### PR TITLE
Fix StreamJsonRpc dependency to be transitive for consumers

### DIFF
--- a/dotnet/src/GitHub.Copilot.SDK.csproj
+++ b/dotnet/src/GitHub.Copilot.SDK.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-    <PackageReference Include="StreamJsonRpc" Version="2.22.23" PrivateAssets="all" />
+    <PackageReference Include="StreamJsonRpc" Version="2.22.23" PrivateAssets="compile" />
     <PackageReference Include="System.Text.Json" Version="10.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Changed PrivateAssets=all to PrivateAssets=compile for StreamJsonRpc. This ensures runtime assets flow to package consumers (StreamJsonRpc will be installed automatically) while compile-time assets remain private (the API won't be exposed to consumers).