### PR TITLE
Correct backtick code block formatting

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -151,7 +151,7 @@ session = await client.create_session({
         )
     ],
 })
-````
+```
 
 The SDK automatically handles `tool.call`, executes your handler (sync or async), and responds with the final result when the tool completes.
 


### PR DESCRIPTION
This PR removes a pesky extra <kbd>`</kbd> closing a code block.