### PR TITLE
Fix timeout handling in CopilotSession

### DIFF
--- a/nodejs/src/session.ts
+++ b/nodejs/src/session.ts
@@ -161,10 +161,14 @@ export class CopilotSession {
                 );
             });
 
-            await Promise.race([idlePromise, timeoutPromise]);
+            try {
+                await Promise.race([idlePromise, timeoutPromise]);
+            } finally {
+                // Clear timeout immediately after race completes to prevent memory leaks
+                if (timeoutId) clearTimeout(timeoutId);
+            }
             return lastAssistantMessage;
         } finally {
-            if (timeoutId) clearTimeout(timeoutId);
             unsubscribe();
         }
     }


### PR DESCRIPTION
Ensure proper timeout management in the CopilotSession class to confirm the process exists upon closure. Clear the timeout immediately after race completes.