### PR TITLE
fix: remove temporary README.md replacement step from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,8 +96,6 @@ jobs:
         run: node scripts/set-version.js
         env:
           VERSION: ${{ needs.version.outputs.version }}
-      - name: Temporarily replace README.md
-        run: echo "Coming soon" > README.md
       - name: Build
         run: npm run build
       - name: Pack


### PR DESCRIPTION
The README.md file was being replaced by the actions pipeline pre-launch. Updating to include the nodejs README.md.