### PR TITLE
Remove duplicate typing-extensions from dev dependencies

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -43,7 +43,6 @@ dev = [
     "ty>=0.0.2",
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
-    "typing-extensions>=4.0.0",
     "httpx>=0.24.0",
 ]
 


### PR DESCRIPTION
## Summary
- Remove `typing-extensions` from dev dependencies as it is already listed in the main `dependencies`

## Test plan
- [ ] Verify dev environment installs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)