### PR TITLE
Simplify Node.js example

### DIFF
--- a/nodejs/examples/basic-example.ts
+++ b/nodejs/examples/basic-example.ts
@@ -32,11 +32,13 @@ session.on((event) => {
 
 // Send a simple message
 console.log("💬 Sending message...");
-await session.sendAndWait({ prompt: "Tell me 2+2" });
+const result1 = await session.sendAndWait({ prompt: "Tell me 2+2" });
+console.log("📝 Response:", result1?.data.content);
 
 // Send another message that uses the tool
 console.log("💬 Sending follow-up message...");
-await session.sendAndWait({ prompt: "Now use lookup_fact to tell me something about Node.js." });
+const result2 = await session.sendAndWait({ prompt: "Use lookup_fact to tell me about 'node'" });
+console.log("📝 Response:", result2?.data.content);
 
 // Clean up
 await session.destroy();


### PR DESCRIPTION
Reduces the Node.js "simple" example from 124 lines to 46 lines just by using the updated APIs and eliminating some unnecessary CLI arg parsing logic.

 We don't necessarily need to have this example, but if we are going to have it, we should make it use current APIs and look nice.