### PR TITLE
Fixes #158 - Setup copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@
 ## Big picture 🔧
 
 - The repo implements language SDKs (Node/TS, Python, Go, .NET) that speak to the **Copilot CLI** via **JSON‑RPC** (see `README.md` and `nodejs/src/client.ts`).
-- Typical flow: your App → SDK client → JSON-RPC → Copilot CLI (server mode). The CLI must be installed or you can connect to an external CLI server via `cli_url`.
+- Typical flow: your App → SDK client → JSON-RPC → Copilot CLI (server mode). The CLI must be installed or you can connect to an external CLI server via the `CLI URL option (language-specific casing)` (Node: `cliUrl`, Go: `CLIUrl`, .NET: `CliUrl`, Python: `cli_url`).
 
 ## Most important files to read first 📚
 
@@ -22,14 +22,14 @@
   - Format all: `just format` | Lint all: `just lint` | Test all: `just test`
 - Per-language:
   - Node: `cd nodejs && npm ci` → `npm test` (Vitest), `npm run generate:session-types` to regenerate session-event types
-  - Python: `cd python && uv pip install -e "[dev]"` → `uv run pytest` (E2E tests use the test harness)
+  - Python: `cd python && uv pip install -e ".[dev]"` → `uv run pytest` (E2E tests use the test harness)
   - Go: `cd go && go test ./...`
   - .NET: `cd dotnet && dotnet test test/GitHub.Copilot.SDK.Test.csproj`
 
 ## Testing & E2E tips ⚙️
 
 - E2E runs against a local **replaying CAPI proxy** (see `test/harness/server.ts`). Most language E2E harnesses spawn that server automatically (see `python/e2e/testharness/proxy.py`).
-- Tests rely on YAML snapshot exchanges under `test/snapshots/` — to add/testing scenarios add or edit appropriate YAML files and update tests.
+- Tests rely on YAML snapshot exchanges under `test/snapshots/` — to add test scenarios, add or edit the appropriate YAML files and update tests.
 - The harness prints `Listening: http://...` — tests parse this URL to configure CLI or proxy.
 
 ## Project-specific conventions & patterns ✅
@@ -41,8 +41,8 @@
 
 ## Integration & environment notes ⚠️
 
-- The SDK requires a Copilot CLI installation or an external server reachable via `cli_url`/`COPILOT_CLI_PATH`.
-- Some scripts (typegen, formatting) call external tools: `go fmt`, `dotnet format`, `npx/tsx`, `quicktype`, `prettier`. Ensure these are available in CI / developer machines.
+- The SDK requires a Copilot CLI installation or an external server reachable via the `CLI URL option (language-specific casing)` (Node: `cliUrl`, Go: `CLIUrl`, .NET: `CliUrl`, Python: `cli_url`) or `COPILOT_CLI_PATH`.
+- Some scripts (typegen, formatting) call external tools: `gofmt`, `dotnet format`, `tsx` (available via npm), `quicktype`/`quicktype-core` (used by the Node typegen script), and `prettier` (provided as an npm devDependency). Most of these are available through the repo's package scripts or devDependencies—run `just install` (and `cd nodejs && npm ci`) to install them. Ensure the required tools are available in CI / developer machines.
 - Tests may assume `node >= 18`, `python >= 3.9`, platform differences handled (Windows uses `shell=True` for npx in harness).
 
 ## Where to add new code or tests 🧭


### PR DESCRIPTION
This fixes #158 to give a good starting point for Github Copilot when it works on this codebase.