### PR TITLE
Fixes #227 - Premium requests consumed while running py dev test

### DIFF
--- a/python/e2e/test_session.py
+++ b/python/e2e/test_session.py
@@ -330,7 +330,12 @@ class TestSessions:
 
         # Send a message that will trigger a long-running shell command
         await session.send(
-            {"prompt": "run the shell command 'sleep 100' (note this works on both bash and PowerShell)"}
+            {
+                "prompt": (
+                    "run the shell command 'sleep 100' "
+                    "(note this works on both bash and PowerShell)"
+                )
+            }
         )
 
         # Wait for the tool to start executing


### PR DESCRIPTION
Root cause : `test_session.py` uses a prompt that is not there in the harness.  It misses a string "note this", compared to other language SDKs.