### PR TITLE
feat(nodejs): add typed event filtering to session.on()

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -240,7 +240,7 @@ Right now, you wait for the complete response before seeing anything. Let's make
 Update `index.ts`:
 
 ```typescript
-import { CopilotClient, SessionEvent } from "@github/copilot-sdk";
+import { CopilotClient } from "@github/copilot-sdk";
 
 const client = new CopilotClient();
 const session = await client.createSession({
@@ -249,13 +249,11 @@ const session = await client.createSession({
 });
 
 // Listen for response chunks
-session.on((event: SessionEvent) => {
-    if (event.type === "assistant.message_delta") {
-        process.stdout.write(event.data.deltaContent);
-    }
-    if (event.type === "session.idle") {
-        console.log(); // New line when done
-    }
+session.on("assistant.message_delta", (event) => {
+    process.stdout.write(event.data.deltaContent);
+});
+session.on("session.idle", () => {
+    console.log(); // New line when done
 });
 
 await session.sendAndWait({ prompt: "Tell me a short joke" });
@@ -401,7 +399,7 @@ Now for the powerful part. Let's give Copilot the ability to call your code by d
 Update `index.ts`:
 
 ```typescript
-import { CopilotClient, defineTool, SessionEvent } from "@github/copilot-sdk";
+import { CopilotClient, defineTool } from "@github/copilot-sdk";
 
 // Define a tool that Copilot can call
 const getWeather = defineTool("get_weather", {
@@ -430,10 +428,8 @@ const session = await client.createSession({
     tools: [getWeather],
 });
 
-session.on((event: SessionEvent) => {
-    if (event.type === "assistant.message_delta") {
-        process.stdout.write(event.data.deltaContent);
-    }
+session.on("assistant.message_delta", (event) => {
+    process.stdout.write(event.data.deltaContent);
 });
 
 await session.sendAndWait({
@@ -650,7 +646,7 @@ Let's put it all together into a useful interactive assistant:
 <summary><strong>Node.js / TypeScript</strong></summary>
 
 ```typescript
-import { CopilotClient, defineTool, SessionEvent } from "@github/copilot-sdk";
+import { CopilotClient, defineTool } from "@github/copilot-sdk";
 import * as readline from "readline";
 
 const getWeather = defineTool("get_weather", {
@@ -677,10 +673,8 @@ const session = await client.createSession({
     tools: [getWeather],
 });
 
-session.on((event: SessionEvent) => {
-    if (event.type === "assistant.message_delta") {
-        process.stdout.write(event.data.deltaContent);
-    }
+session.on("assistant.message_delta", (event) => {
+    process.stdout.write(event.data.deltaContent);
 });
 
 const rl = readline.createInterface({

--- a/nodejs/src/index.ts
+++ b/nodejs/src/index.ts
@@ -33,6 +33,8 @@ export type {
     SessionConfig,
     SessionEvent,
     SessionEventHandler,
+    SessionEventPayload,
+    SessionEventType,
     SessionMetadata,
     SystemMessageAppendConfig,
     SystemMessageConfig,
@@ -41,5 +43,6 @@ export type {
     ToolHandler,
     ToolInvocation,
     ToolResultObject,
+    TypedSessionEventHandler,
     ZodSchema,
 } from "./types.js";

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -807,7 +807,24 @@ export interface MessageOptions {
 }
 
 /**
- * Event handler callback type
+ * All possible event type strings from SessionEvent
+ */
+export type SessionEventType = SessionEvent["type"];
+
+/**
+ * Extract the specific event payload for a given event type
+ */
+export type SessionEventPayload<T extends SessionEventType> = Extract<SessionEvent, { type: T }>;
+
+/**
+ * Event handler for a specific event type
+ */
+export type TypedSessionEventHandler<T extends SessionEventType> = (
+    event: SessionEventPayload<T>
+) => void;
+
+/**
+ * Event handler callback type (for all events)
  */
 export type SessionEventHandler = (event: SessionEvent) => void;
 


### PR DESCRIPTION
Add overloaded on() method that accepts an event type string as the first argument, enabling type-safe event subscriptions:

```
  session.on('assistant.message', (event) => {
    // event is typed as SessionEventPayload<'assistant.message'>
    console.log(event.data.content);
  });
```

The original on(handler) signature remains supported for wildcard subscriptions.

Changes:
- Add SessionEventType, SessionEventPayload, TypedSessionEventHandler types
- Update CopilotSession.on() with typed overload
- Update _dispatchEvent() to dispatch to typed handlers
- Export new types from index.ts
- Update documentation with new usage patterns