### PR TITLE
Set default vscode formatter for Go

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,8 @@
   "python.testing.pytestArgs": ["python"],
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff"
+  },
+  "[go]": {
+    "editor.defaultFormatter": "golang.go"
   }
 }


### PR DESCRIPTION
The default formatter doesn't work for Go. Override it.