### PR TITLE
Add a new line after model generating final response when tool call completes

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -432,6 +432,10 @@ session.on("assistant.message_delta", (event) => {
     process.stdout.write(event.data.deltaContent);
 });
 
+session.on("session.idle", () => {
+    console.log(); // New line when done
+});
+
 await session.sendAndWait({
     prompt: "What's the weather like in Seattle and Tokyo?",
 });


### PR DESCRIPTION
Without the session.idle event generating new line after the full tool-call cycle completes  users couldn't see the output returned by the model because without the trailing newline, the terminal prompt overwrote the response.