### PR TITLE
fix: clear timeout timer in sendAndWait to prevent process hang

### DIFF
--- a/nodejs/src/session.ts
+++ b/nodejs/src/session.ts
@@ -167,11 +167,12 @@ export class CopilotSession {
             }
         });
 
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
         try {
             await this.send(options);
 
             const timeoutPromise = new Promise<never>((_, reject) => {
-                setTimeout(
+                timeoutId = setTimeout(
                     () =>
                         reject(
                             new Error(
@@ -185,6 +186,9 @@ export class CopilotSession {
 
             return lastAssistantMessage;
         } finally {
+            if (timeoutId !== undefined) {
+                clearTimeout(timeoutId);
+            }
             unsubscribe();
         }
     }


### PR DESCRIPTION
When idlePromise resolved first (successful response), the setTimeout timer kept running in the background, preventing Node.js from exiting until the timer fired.

Fixes #136