### PR TITLE
Fix ObjectDisposedException when disposing session after client.StopAsync()

### DIFF
--- a/dotnet/test/ClientTests.cs
+++ b/dotnet/test/ClientTests.cs
@@ -243,4 +243,13 @@ public class ClientTests : IAsyncLifetime
             });
         });
     }
+
+    [Fact]
+    public async Task Should_Not_Throw_When_Disposing_Session_After_Stopping_Client()
+    {
+        await using var client = new CopilotClient(new CopilotClientOptions { CliPath = _cliPath });
+        await using var session = await client.CreateSessionAsync();
+
+        await client.StopAsync();
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #306

When `await client.StopAsync()` is called before the `await using var session` goes out of scope, `session.DisposeAsync()` is called twice:
1. First by `StopAsync()` (while connection is alive) ✓
2. Second by `await using` cleanup (connection is now disposed) ✗ → `ObjectDisposedException`

## Repro (from issue)
```csharp
using GitHub.Copilot.SDK;

await using var client = new CopilotClient();
await using var session = await client.CreateSessionAsync();

await client.StopAsync();
// When method exits, 'await using var session' tries to dispose → CRASH
```

## Solution

Make `CopilotSession.DisposeAsync()` idempotent and tolerant to already-disposed connections:

1. **Added `_isDisposed` flag** - Thread-safe using `Interlocked.Exchange`
2. **Made `DisposeAsync` idempotent** - Returns immediately if already disposed (required by `IAsyncDisposable` contract)
3. **Handle connection failures gracefully** - Catches `ObjectDisposedException` and `IOException` since dispose methods should never throw

This follows the same pattern already used in `CopilotClient.DisposeAsync()`.

## Changes
- `dotnet/src/Session.cs`: Add idempotency and exception handling to `DisposeAsync()`
- `dotnet/test/ClientTests.cs`: Add regression test

## Testing
- All 13 ClientTests pass including the new regression test
- Build passes with no errors