### PR TITLE
Run SDK tests on push to main branch

### DIFF
--- a/.github/workflows/dotnet-sdk-tests.yml
+++ b/.github/workflows/dotnet-sdk-tests.yml
@@ -1,6 +1,9 @@
 name: ".NET SDK Tests"
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     paths:
       - 'dotnet/**'

--- a/.github/workflows/go-sdk-tests.yml
+++ b/.github/workflows/go-sdk-tests.yml
@@ -1,6 +1,9 @@
 name: "Go SDK Tests"
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     paths:
       - 'go/**'

--- a/.github/workflows/nodejs-sdk-tests.yml
+++ b/.github/workflows/nodejs-sdk-tests.yml
@@ -4,6 +4,9 @@ env:
   HUSKY: 0
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     paths:
       - 'nodejs/**'

--- a/.github/workflows/python-sdk-tests.yml
+++ b/.github/workflows/python-sdk-tests.yml
@@ -4,6 +4,9 @@ env:
   PYTHONUTF8: 1
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     paths:
       - 'python/**'


### PR DESCRIPTION
All SDK test workflows were only running on pull requests, not on merges to main. This adds \push\ triggers for the \main\ branch so tests run after PRs are merged.