### PR TITLE
Fix Python E2E test flakiness and missing pytest-timeout

### DIFF
--- a/python/e2e/testharness/context.py
+++ b/python/e2e/testharness/context.py
@@ -100,16 +100,18 @@ class E2ETestContext:
             await self._proxy.configure(abs_snapshot_path, self.work_dir)
 
         # Clear temp directories between tests (but leave them in place)
+        # Use ignore_errors=True to handle race conditions where files may still
+        # be written by background processes during cleanup
         for item in Path(self.home_dir).iterdir():
             if item.is_dir():
-                shutil.rmtree(item)
+                shutil.rmtree(item, ignore_errors=True)
             else:
-                item.unlink()
+                item.unlink(missing_ok=True)
         for item in Path(self.work_dir).iterdir():
             if item.is_dir():
-                shutil.rmtree(item)
+                shutil.rmtree(item, ignore_errors=True)
             else:
-                item.unlink()
+                item.unlink(missing_ok=True)
 
     def get_env(self) -> dict:
         """Return environment variables configured for isolated testing."""

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "ty>=0.0.2",
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
+    "pytest-timeout>=2.0.0",
     "httpx>=0.24.0",
 ]
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -85,6 +85,7 @@ dev = [
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-asyncio", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest-asyncio", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -95,6 +96,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.2" },
@@ -419,6 +421,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes the Python E2E test failure in CI: https://github.com/github/copilot-sdk/actions/runs/21746470248/job/62733447842

## Changes

### 1. Fix race condition in test cleanup (context.py)
The test fixture cleanup was failing with OSError: Directory not empty when shutil.rmtree() tried to delete session-state directories while background processes were still writing files.

**Fix:** Added ignore_errors=True to shutil.rmtree() and missing_ok=True to unlink() to gracefully handle these race conditions.

### 2. Add missing pytest-timeout dependency (pyproject.toml)
The test_compaction.py test uses @pytest.mark.timeout(120) but the pytest-timeout plugin was not installed, causing the warning: Unknown pytest.mark.timeout

**Fix:** Added pytest-timeout>=2.0.0 to dev dependencies.