### PR TITLE
docs: add Foundry Local as a BYOK provider

### DIFF
--- a/docs/auth/byok.md
+++ b/docs/auth/byok.md
@@ -262,7 +262,7 @@ Use the [Foundry Local SDK](https://github.com/microsoft/Foundry-Local#-integrat
 // Bootstrap: npm install foundry-local-sdk
 // import { FoundryLocalManager } from "foundry-local-sdk";
 // const manager = new FoundryLocalManager();
-// const modelInfo = await manager.init("gpt-oss-20b");
+// const modelInfo = await manager.init("phi-4-mini");
 
 provider: {
     type: "openai",
@@ -272,7 +272,7 @@ provider: {
 }
 ```
 
-> **Note:** Foundry Local must be [installed separately](https://github.com/microsoft/Foundry-Local#installing). Run `foundry model run gpt-oss-20b` to download and start a model.
+> **Note:** Foundry Local must be [installed separately](https://github.com/microsoft/Foundry-Local#installing). Run `foundry model run phi-4-mini` to download and start a model.
 
 For a complete walkthrough including tool calling, streaming, and multi-turn conversations, see the [Foundry Local Copilot SDK integration guide](https://github.com/microsoft/Foundry-Local/blob/main/docs/copilot-sdk-integration.md) and the [working Node.js sample](https://github.com/microsoft/Foundry-Local/tree/main/samples/js/copilot-sdk-foundry-local).
 
@@ -403,7 +403,7 @@ foundry --version
 foundry model ls
 
 # Start a model (downloads if not cached)
-foundry model run gpt-oss-20b
+foundry model run phi-4-mini
 
 # Check the service endpoint
 curl http://localhost:5272/v1/models


### PR DESCRIPTION
Adds [Foundry Local](https://github.com/microsoft/Foundry-Local) (Microsoft on-device inference) as a documented BYOK provider in `docs/auth/byok.md`.

Foundry Local exposes an OpenAI-compatible API locally — the same pattern as the existing Ollama entry. Four insertions, zero deletions:
- **Supported Providers table** — new row for Foundry Local (`type: "openai"`)
- **Example configuration section** — `### Foundry Local (On-Device)` with SDK bootstrap snippet and endpoint config
- **Provider-Specific Limitations table** — new row noting local-only, install requirement, and preview status
- **Troubleshooting section** — `### Connection Refused (Foundry Local)` with install and diagnostic commands

## Details
Foundry Local facilitates running AI models on-device without an Azure subscription. It serves an OpenAI-compatible REST API at `http://localhost:5272/v1`, making it a natural fit alongside the existing Ollama documentation.

The new sections cover:
1. **Provider table entry** — identifies Foundry Local as `type: "openai"` with a brief description
2. **Configuration example** — shows how to bootstrap the service using `foundry-local-sdk` and configure the Copilot SDK provider block, including the default endpoint and SDK-provided API key
3. **Limitations** — local-only, requires separate install, model catalog scoped to Foundry Local models, REST API in preview
4. **Troubleshooting** — `foundry --version`, `foundry model ls`, `foundry model run`, `curl` health check, and install commands for Windows (`winget`) and macOS (`brew`)

## Changes
- `docs/auth/byok.md` — 45 lines added, 0 lines removed, no existing content modified
- No other files changed