### PR TITLE
feat(python): add cli_args support to CopilotClientOptions for parity with Node.js SDK

### DIFF
--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -175,6 +175,7 @@ class CopilotClient:
 
         self.options: CopilotClientOptions = {
             "cli_path": default_cli_path,
+            "cli_args": opts.get("cli_args", []),
             "cwd": opts.get("cwd", os.getcwd()),
             "port": opts.get("port", 0),
             "use_stdio": False if opts.get("cli_url") else opts.get("use_stdio", True),
@@ -1116,7 +1117,9 @@ class CopilotClient:
         if not os.path.exists(cli_path):
             raise RuntimeError(f"Copilot CLI not found at {cli_path}")
 
-        args = ["--headless", "--no-auto-update", "--log-level", self.options["log_level"]]
+        # Insert user-provided cli_args before SDK-managed args (matches Node.js SDK behavior)
+        cli_args = list(self.options.get("cli_args") or [])
+        args = [*cli_args, "--headless", "--no-auto-update", "--log-level", self.options["log_level"]]
 
         # Add auth-related flags
         if self.options.get("github_token"):

--- a/python/copilot/types.py
+++ b/python/copilot/types.py
@@ -73,6 +73,8 @@ class CopilotClientOptions(TypedDict, total=False):
     """Options for creating a CopilotClient"""
 
     cli_path: str  # Path to the Copilot CLI executable (default: "copilot")
+    # Extra arguments to pass to the CLI executable (inserted before SDK-managed args)
+    cli_args: list[str]
     # Working directory for the CLI process (default: current process's cwd)
     cwd: str
     port: int  # Port for the CLI server (TCP mode only, default: 0)

--- a/python/test_client.py
+++ b/python/test_client.py
@@ -147,3 +147,27 @@ class TestAuthOptions:
             CopilotClient(
                 {"cli_url": "localhost:8080", "use_logged_in_user": False, "log_level": "error"}
             )
+
+
+class TestCliArgs:
+    def test_cli_args_defaults_to_empty_list(self):
+        client = CopilotClient({"cli_path": CLI_PATH, "log_level": "error"})
+        assert client.options.get("cli_args") == []
+
+    def test_cli_args_stored_in_options(self):
+        client = CopilotClient(
+            {"cli_path": CLI_PATH, "cli_args": ["--verbose", "--debug"], "log_level": "error"}
+        )
+        assert client.options.get("cli_args") == ["--verbose", "--debug"]
+
+    def test_cli_args_empty_list(self):
+        client = CopilotClient(
+            {"cli_path": CLI_PATH, "cli_args": [], "log_level": "error"}
+        )
+        assert client.options.get("cli_args") == []
+
+    def test_cli_args_single_arg(self):
+        client = CopilotClient(
+            {"cli_path": CLI_PATH, "cli_args": ["--custom-flag"], "log_level": "error"}
+        )
+        assert client.options.get("cli_args") == ["--custom-flag"]


### PR DESCRIPTION
## Summary

This PR adds `cli_args` support to the Python SDK's `CopilotClientOptions`, resolving the cross-SDK feature inconsistency reported in #381.

## Problem

The Node.js SDK's `CopilotClientOptions` includes a `cliArgs?: string[]` field that allows users to pass extra arguments to the CLI executable. The Python SDK was missing this corresponding `cli_args` field, making it impossible to pass custom CLI arguments when using the Python SDK.

## Changes

### `python/copilot/types.py`
- Added `cli_args: list[str]` field to `CopilotClientOptions` TypedDict

### `python/copilot/client.py`
- Store `cli_args` in client options (defaults to `[]`)
- Insert user-provided `cli_args` before SDK-managed args in `_start_cli_server()`, matching the Node.js SDK behavior where `cliArgs` are spread before `--headless`, `--no-auto-update`, etc.

### `python/test_client.py`
- Added `TestCliArgs` test class with 4 unit tests:
  - `test_cli_args_defaults_to_empty_list`
  - `test_cli_args_stored_in_options`
  - `test_cli_args_empty_list`
  - `test_cli_args_single_arg`

## Node.js SDK Reference

The implementation mirrors the Node.js SDK behavior:
```typescript
// nodejs/src/client.ts
const args = [
    ...this.options.cliArgs,  // user args first
    "--headless",
    "--no-auto-update",
    "--log-level",
    this.options.logLevel,
];
```

Closes #381