### PR TITLE
fix: set executable permission on CLI binary in Python wheel

### DIFF
--- a/python/scripts/build-wheels.mjs
+++ b/python/scripts/build-wheels.mjs
@@ -240,7 +240,6 @@ async function repackWheelWithPlatform(srcWheel, destWheel, platformTag) {
 import sys
 import zipfile
 import tempfile
-import os
 from pathlib import Path
 
 src_wheel = Path(sys.argv[1])


### PR DESCRIPTION
## Problem

When installing the Python SDK via pip/uv, the bundled CLI binary at copilot/bin/copilot is installed without the Unix executable bit, requiring users to manually chmod it.

## Root Cause

setuptools strips the executable bit when packaging data files. The repack step in build-wheels.mjs then captures this 0o644 permission into the wheel ZIP.

## Fix

After extracting the wheel for repack, restore chmod 0o755 on the CLI binary so zf.write() captures the correct permissions.