### PR TITLE
Bump manylinux tag to glibc 2.28 for Node 24.11

### DIFF
--- a/python/scripts/build-wheels.mjs
+++ b/python/scripts/build-wheels.mjs
@@ -36,6 +36,7 @@ const pythonDir = dirname(__dirname);
 const repoRoot = dirname(pythonDir);
 
 // Platform mappings: npm package suffix -> [wheel platform tag, binary name]
+// Based on Node 24.11 binaries being included in the wheels
 const PLATFORMS = {
     "linux-x64": ["manylinux_2_28_x86_64", "copilot"],
     "linux-arm64": ["manylinux_2_28_aarch64", "copilot"],


### PR DESCRIPTION
Node 24.11 requires glibc 2.28, so bundled CLI binaries in the Python wheels won't run on systems with only glibc 2.17.

- Update `manylinux_2_17` → `manylinux_2_28` for `linux-x64` and `linux-arm64` platform tags in `python/scripts/build-wheels.mjs`
- Add comment documenting the Node version dependency for the platform tags