### PR TITLE
fix(python): always use fake token in E2E tests to prevent hang

### DIFF
--- a/python/e2e/test_session.py
+++ b/python/e2e/test_session.py
@@ -7,7 +7,7 @@ import pytest
 from copilot import CopilotClient
 from copilot.types import Tool
 
-from .testharness import E2ETestContext, get_final_assistant_message, get_next_event_of_type
+from .testharness import E2E_FAKE_GITHUB_TOKEN, E2ETestContext, get_final_assistant_message, get_next_event_of_type
 
 pytestmark = pytest.mark.asyncio(loop_scope="module")
 
@@ -160,13 +160,12 @@ class TestSessions:
         assert "2" in answer.data.content
 
         # Resume using a new client
-        github_token = "fake-token-for-e2e-tests" if os.environ.get("CI") == "true" else None
         new_client = CopilotClient(
             {
                 "cli_path": ctx.cli_path,
                 "cwd": ctx.work_dir,
                 "env": ctx.get_env(),
-                "github_token": github_token,
+                "github_token": E2E_FAKE_GITHUB_TOKEN,
             }
         )
 

--- a/python/e2e/testharness/__init__.py
+++ b/python/e2e/testharness/__init__.py
@@ -1,11 +1,12 @@
 """Test harness for E2E tests."""
 
-from .context import CLI_PATH, E2ETestContext
+from .context import CLI_PATH, E2E_FAKE_GITHUB_TOKEN, E2ETestContext
 from .helper import get_final_assistant_message, get_next_event_of_type
 from .proxy import CapiProxy
 
 __all__ = [
     "CLI_PATH",
+    "E2E_FAKE_GITHUB_TOKEN",
     "E2ETestContext",
     "CapiProxy",
     "get_final_assistant_message",


### PR DESCRIPTION
## Problem

When running Python E2E tests locally (outside CI), they hang indefinitely on any test that sends a message via `send_and_wait()`.

## Root Cause

The E2E test harness overrides `XDG_CONFIG_HOME` to an isolated temp directory for test isolation. When not in CI, `github_token` was `None`, so the CLI defaulted to `use_logged_in_user=True` — but found no credentials in the empty temp dir.

The CLI logged `Error: Session was not created with authentication info or custom provider` but **never emitted a `session.error` event** back to the SDK, so `send_and_wait()` blocked forever waiting for a `session.idle` that would never come.

## Fix

Always pass `github_token="fake-token-for-e2e-tests"` in the test harness and in the one test that creates its own client. Since E2E tests use a replaying proxy with canned responses, real auth is never needed.

## Verification

All 74 Python E2E tests pass (2 pre-existing skips for known unrelated issues).