### PR TITLE
Allow custom npm registry URL for downloading Copilot from dotnet SDK

### DIFF
--- a/dotnet/src/build/GitHub.Copilot.SDK.targets
+++ b/dotnet/src/build/GitHub.Copilot.SDK.targets
@@ -26,7 +26,13 @@
     <_CopilotBinary Condition="'$(_CopilotBinary)' == ''">copilot</_CopilotBinary>
   </PropertyGroup>
 
-  <!-- Allow customization of npm registry URL via project property -->
+  <!-- Allow customization of the npm registry URL used to download the Copilot CLI.
+       This is primarily for organizations using private or mirrored npm registries.
+       Set CopilotNpmRegistryUrl in your .csproj or Directory.Build.props, for example:
+       <PropertyGroup>
+         <CopilotNpmRegistryUrl>https://your-private-registry.example.com</CopilotNpmRegistryUrl>
+       </PropertyGroup>
+       If not set, this defaults to https://registry.npmjs.org. -->
   <PropertyGroup>
     <CopilotNpmRegistryUrl Condition="'$(CopilotNpmRegistryUrl)' == ''">https://registry.npmjs.org</CopilotNpmRegistryUrl>
   </PropertyGroup>


### PR DESCRIPTION
Our repos enforce using private feeds and npm registry to fetch packages. But the .NET SDK attempts to download Copilot package from public npm registry. 

This change allows customizing the registry url by defined a MSBuild property in the csproj or props file - `CopilotNpmRegistryUrl`.

Note: an improvement could be attempting to find and parse any existing `.npmrc` files in any parent directories, but that ends up complicating this target a bit, so skipping for now