### PR TITLE
Fix ObjectDisposedException when disposing session after client.StopAsync()

### DIFF
--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -54,6 +54,7 @@ public partial class CopilotSession : IAsyncDisposable
     private SessionHooks? _hooks;
     private readonly SemaphoreSlim _hooksLock = new(1, 1);
     private SessionRpc? _sessionRpc;
+    private int _isDisposed;
 
     /// <summary>
     /// Gets the unique identifier for this session.
@@ -560,8 +561,24 @@ public partial class CopilotSession : IAsyncDisposable
     /// </example>
     public async ValueTask DisposeAsync()
     {
-        await InvokeRpcAsync<object>(
-            "session.destroy", [new SessionDestroyRequest() { SessionId = SessionId }], CancellationToken.None);
+        if (Interlocked.Exchange(ref _isDisposed, 1) == 1)
+        {
+            return;
+        }
+
+        try
+        {
+            await InvokeRpcAsync<object>(
+                "session.destroy", [new SessionDestroyRequest() { SessionId = SessionId }], CancellationToken.None);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Connection was already disposed (e.g., client.StopAsync() was called first)
+        }
+        catch (IOException)
+        {
+            // Connection is broken or closed
+        }
 
         _eventHandlers.Clear();
         _toolHandlers.Clear();

--- a/dotnet/test/ClientTests.cs
+++ b/dotnet/test/ClientTests.cs
@@ -215,4 +215,13 @@ public class ClientTests
             });
         });
     }
+
+    [Fact]
+    public async Task Should_Not_Throw_When_Disposing_Session_After_Stopping_Client()
+    {
+        await using var client = new CopilotClient(new CopilotClientOptions());
+        await using var session = await client.CreateSessionAsync();
+
+        await client.StopAsync();
+    }
 }


### PR DESCRIPTION
## Summary

Supersedes #371 (resolves merge conflicts against current main).
Fixes #306

When `await client.StopAsync()` is called before the `await using var session` goes out of scope, `session.DisposeAsync()` is called twice:
1. First by `StopAsync()` (while connection is alive) ✓
2. Second by `await using` cleanup (connection is now disposed) ✗ → `ObjectDisposedException`

## Solution

Make `CopilotSession.DisposeAsync()` idempotent and tolerant to already-disposed connections:

1. **Added `_isDisposed` flag** - Thread-safe using `Interlocked.Exchange`
2. **Made `DisposeAsync` idempotent** - Returns immediately if already disposed (required by `IAsyncDisposable` contract)
3. **Handle connection failures gracefully** - Catches `ObjectDisposedException` and `IOException` since dispose methods should never throw

This follows the same pattern already used in `CopilotClient.DisposeAsync()`.

## Changes
- `dotnet/src/Session.cs`: Add idempotency and exception handling to `DisposeAsync()`
- `dotnet/test/ClientTests.cs`: Add regression test

Credit to @parthtrivedi2492 for the original PR #371.