### PR TITLE
Fix ObjectDisposedException when disposing session after client.StopAsync()

### DIFF
--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -54,6 +54,7 @@ public partial class CopilotSession : IAsyncDisposable
     private SessionHooks? _hooks;
     private readonly SemaphoreSlim _hooksLock = new(1, 1);
     private SessionRpc? _sessionRpc;
+    private int _isDisposed;
 
     /// <summary>
     /// Gets the unique identifier for this session.
@@ -560,8 +561,24 @@ public partial class CopilotSession : IAsyncDisposable
     /// </example>
     public async ValueTask DisposeAsync()
     {
-        await InvokeRpcAsync<object>(
-            "session.destroy", [new SessionDestroyRequest() { SessionId = SessionId }], CancellationToken.None);
+        if (Interlocked.Exchange(ref _isDisposed, 1) == 1)
+        {
+            return;
+        }
+
+        try
+        {
+            await InvokeRpcAsync<object>(
+                "session.destroy", [new SessionDestroyRequest() { SessionId = SessionId }], CancellationToken.None);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Connection was already disposed (e.g., client.StopAsync() was called first)
+        }
+        catch (IOException)
+        {
+            // Connection is broken or closed
+        }
 
         _eventHandlers.Clear();
         _toolHandlers.Clear();

--- a/dotnet/test/ClientTests.cs
+++ b/dotnet/test/ClientTests.cs
@@ -215,4 +215,13 @@ public class ClientTests
             });
         });
     }
+
+    [Fact]
+    public async Task Should_Not_Throw_When_Disposing_Session_After_Stopping_Client()
+    {
+        await using var client = new CopilotClient(new CopilotClientOptions());
+        await using var session = await client.CreateSessionAsync();
+
+        await client.StopAsync();
+    }
 }


### PR DESCRIPTION
## Summary

Cherry-picked from #371 with merge conflicts resolved. Closes #306.

Original author: @parthtrivedi2492

When `await client.StopAsync()` is called before `await using var session` goes out of scope, `session.DisposeAsync()` is called twice — the second call throws `ObjectDisposedException`.

## Solution

Make `CopilotSession.DisposeAsync()` idempotent and tolerant to already-disposed connections:

1. **Added `_isDisposed` flag** — Thread-safe using `Interlocked.Exchange`
2. **Made `DisposeAsync` idempotent** — Returns immediately if already disposed
3. **Handle connection failures gracefully** — Catches `ObjectDisposedException` and `IOException`

## Changes
- `dotnet/src/Session.cs`: Add idempotency and exception handling to `DisposeAsync()`
- `dotnet/test/ClientTests.cs`: Add regression test

## Conflict resolution
- `Session.cs`: Both this PR and main added fields at the same location — kept both `_sessionRpc` (from main's RPC codegen) and `_isDisposed`
- `ClientTests.cs`: Adapted test to use `new CopilotClientOptions()` since `_cliPath` was removed on main