### PR TITLE
fix: fall back to portable RID for bundled CLI lookup on Linux

### DIFF
--- a/dotnet/src/build/GitHub.Copilot.SDK.targets
+++ b/dotnet/src/build/GitHub.Copilot.SDK.targets
@@ -3,16 +3,26 @@
   <!-- CopilotCliVersion is imported from GitHub.Copilot.SDK.props (generated at SDK build time, packaged alongside) -->
   <Import Project="$(MSBuildThisFileDirectory)GitHub.Copilot.SDK.props" Condition="'$(CopilotCliVersion)' == '' And Exists('$(MSBuildThisFileDirectory)GitHub.Copilot.SDK.props')" />
 
-  <!-- Resolve RID: use explicit RuntimeIdentifier, or infer from current machine -->
+  <!-- Resolve portable RID from explicit RuntimeIdentifier or build host -->
   <PropertyGroup>
-    <_CopilotRid Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</_CopilotRid>
-    <_CopilotRid Condition="'$(_CopilotRid)' == '' And $([MSBuild]::IsOSPlatform('Windows')) And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64'">win-x64</_CopilotRid>
-    <_CopilotRid Condition="'$(_CopilotRid)' == '' And $([MSBuild]::IsOSPlatform('Windows')) And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">win-arm64</_CopilotRid>
-    <_CopilotRid Condition="'$(_CopilotRid)' == '' And $([MSBuild]::IsOSPlatform('Linux')) And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64'">linux-x64</_CopilotRid>
-    <_CopilotRid Condition="'$(_CopilotRid)' == '' And $([MSBuild]::IsOSPlatform('Linux')) And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">linux-arm64</_CopilotRid>
-    <_CopilotRid Condition="'$(_CopilotRid)' == '' And $([MSBuild]::IsOSPlatform('OSX')) And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64'">osx-x64</_CopilotRid>
-    <_CopilotRid Condition="'$(_CopilotRid)' == '' And $([MSBuild]::IsOSPlatform('OSX')) And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">osx-arm64</_CopilotRid>
+    <!-- Determine OS: from RID prefix if set, otherwise from build host -->
+    <_CopilotOs Condition="'$(RuntimeIdentifier)' != '' And $(RuntimeIdentifier.StartsWith('win'))">win</_CopilotOs>
+    <_CopilotOs Condition="'$(_CopilotOs)' == '' And '$(RuntimeIdentifier)' != '' And $(RuntimeIdentifier.StartsWith('osx'))">osx</_CopilotOs>
+    <_CopilotOs Condition="'$(_CopilotOs)' == '' And '$(RuntimeIdentifier)' != ''">linux</_CopilotOs>
+
+    <!-- Determine arch: from RID suffix if set, otherwise from build host -->
+    <_CopilotArch Condition="'$(RuntimeIdentifier)' != '' And $(RuntimeIdentifier.EndsWith('-x64'))">x64</_CopilotArch>
+    <_CopilotArch Condition="'$(_CopilotArch)' == '' And '$(RuntimeIdentifier)' != '' And $(RuntimeIdentifier.EndsWith('-arm64'))">arm64</_CopilotArch>
+
+    <!-- When no RuntimeIdentifier is set, use the SDK's portable RID for the build host -->
+    <_CopilotRid Condition="'$(_CopilotOs)' != '' And '$(_CopilotArch)' != ''">$(_CopilotOs)-$(_CopilotArch)</_CopilotRid>
+    <_CopilotRid Condition="'$(_CopilotRid)' == '' And '$(RuntimeIdentifier)' == ''">$(NETCoreSdkPortableRuntimeIdentifier)</_CopilotRid>
   </PropertyGroup>
+
+  <!-- Fail if we couldn't determine a portable RID from the given RuntimeIdentifier -->
+  <Target Name="_ValidateCopilotRid" BeforeTargets="BeforeBuild" Condition="'$(RuntimeIdentifier)' != '' And '$(_CopilotRid)' == ''">
+    <Error Text="Could not determine a supported portable RID from RuntimeIdentifier '$(RuntimeIdentifier)'. Supported RIDs: win-x64, win-arm64, linux-x64, linux-arm64, osx-x64, osx-arm64." />
+  </Target>
 
   <!-- Map RID to platform name used in npm packages -->
   <PropertyGroup>


### PR DESCRIPTION
## Problem

On Linux distros that install .NET from distribution packages (Ubuntu, Fedora, RHEL, etc.), `RuntimeInformation.RuntimeIdentifier` returns distro-specific RIDs like `ubuntu.24.04-x64` instead of the portable `linux-x64`. The bundled CLI is placed under `runtimes/linux-x64/native/`, so the runtime lookup fails and throws an `InvalidOperationException`.

This is a regression from v0.1.23 where the bundled CLI feature was introduced.

## Fix

**Runtime (`Client.cs`):** `GetBundledCliPath` now tries the distro-specific RID first, then falls back to the portable RID (e.g., `linux-x64`) computed from OS/architecture detection.

**Build time (`GitHub.Copilot.SDK.targets`):** Always use portable RIDs derived from OS/architecture detection instead of the project's `$(RuntimeIdentifier)`, which may be distro-specific when .NET is installed via distro packages.

Fixes #424