### PR TITLE
Fix maccatalyst RID detection in SDK targets

### DIFF
--- a/dotnet/src/build/GitHub.Copilot.SDK.targets
+++ b/dotnet/src/build/GitHub.Copilot.SDK.targets
@@ -8,6 +8,7 @@
     <!-- Determine OS: from RID prefix if set, otherwise from build host -->
     <_CopilotOs Condition="'$(RuntimeIdentifier)' != '' And $(RuntimeIdentifier.StartsWith('win'))">win</_CopilotOs>
     <_CopilotOs Condition="'$(_CopilotOs)' == '' And '$(RuntimeIdentifier)' != '' And $(RuntimeIdentifier.StartsWith('osx'))">osx</_CopilotOs>
+    <_CopilotOs Condition="'$(_CopilotOs)' == '' And '$(RuntimeIdentifier)' != '' And $(RuntimeIdentifier.StartsWith('maccatalyst'))">osx</_CopilotOs>
     <_CopilotOs Condition="'$(_CopilotOs)' == '' And '$(RuntimeIdentifier)' != ''">linux</_CopilotOs>
 
     <!-- Determine arch: from RID suffix if set, otherwise from build host -->


### PR DESCRIPTION
The OS detection logic in \GitHub.Copilot.SDK.targets\ falls through to \linux\ for \maccatalyst-*\ RIDs since they don't start with \win\ or \osx\. This means passing \-r maccatalyst-x64\ or \-r maccatalyst-arm64\ downloads the **Linux** CLI binary instead of the Darwin one.

This adds explicit handling for the \maccatalyst\ prefix to map it to \osx\, so \_CopilotRid\ resolves to \osx-x64\ / \osx-arm64\ and the correct Darwin CLI binary is downloaded.

Relates to #454, improves on #467 which added \_CopilotPlatform\ mappings but missed the upstream OS detection.