### PR TITLE
Fix empty list handling for tool filters in session methods

### DIFF
--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -630,11 +630,11 @@ class CopilotClient:
 
         # Add available/excluded tools if provided
         available_tools = cfg.get("available_tools")
-        if available_tools:
+        if available_tools is not None:
             payload["availableTools"] = available_tools
 
         excluded_tools = cfg.get("excluded_tools")
-        if excluded_tools:
+        if excluded_tools is not None:
             payload["excludedTools"] = excluded_tools
 
         provider = cfg.get("provider")


### PR DESCRIPTION
Fix null checks for available_tools and excluded_tools in create_session and resume_session

Both create_session and resume_session use truthy checks for the available_tools and  config options:
_if available_tools:_ 
_if excluded_tools:_

For available_tools this silently drops empty lists ([]), which prevents callers from explicitly clearing the default 14 built-in CLI tools to make toolless calls.

**Changes**

python/copilot/client.py: Change available_tools and excluded_tools in create_session and resume_session to
_if available_tools **is not None**: 
_if excluded_tools **is not None**:__ 

**Test results**

pytest: 111 passed, 5 skipped
ruff check: all checks passed
