### PR TITLE
Fix .NET SDK CLI download timeout

### DIFF
--- a/dotnet/src/build/GitHub.Copilot.SDK.targets
+++ b/dotnet/src/build/GitHub.Copilot.SDK.targets
@@ -48,6 +48,13 @@
     <CopilotNpmRegistryUrl Condition="'$(CopilotNpmRegistryUrl)' == ''">https://registry.npmjs.org</CopilotNpmRegistryUrl>
   </PropertyGroup>
 
+  <!-- Timeout in seconds for downloading the Copilot CLI tarball.
+       Override CopilotCliDownloadTimeout in your .csproj or Directory.Build.props if needed.
+       Default is 600 seconds (10 minutes) to handle slow or unreliable network conditions. -->
+  <PropertyGroup>
+    <CopilotCliDownloadTimeout Condition="'$(CopilotCliDownloadTimeout)' == ''">600</CopilotCliDownloadTimeout>
+  </PropertyGroup>
+
   <!-- Download and extract CLI binary -->
   <Target Name="_DownloadCopilotCli" BeforeTargets="BeforeBuild" Condition="'$(_CopilotPlatform)' != ''">
     <Error Condition="'$(CopilotCliVersion)' == ''" Text="CopilotCliVersion is not set. The GitHub.Copilot.SDK.props file may be missing from the NuGet package." />
@@ -68,6 +75,7 @@
     <MakeDir Directories="$(_CopilotCacheDir)" Condition="!Exists('$(_CopilotCliBinaryPath)')" />
     <Message Importance="high" Text="Downloading Copilot CLI $(CopilotCliVersion) for $(_CopilotPlatform)..." Condition="!Exists('$(_CopilotCliBinaryPath)')" />
     <DownloadFile SourceUrl="$(_CopilotDownloadUrl)" DestinationFolder="$(_CopilotCacheDir)" DestinationFileName="copilot.tgz"
+                  Timeout="$([System.Int32]::Parse('$(CopilotCliDownloadTimeout)'))"
                   Condition="!Exists('$(_CopilotCliBinaryPath)')" />
 
     <!-- Extract using tar (use Windows system tar explicitly to avoid Git bash tar issues) -->


### PR DESCRIPTION
## Summary
Fixes #451.

The \DownloadFile\ MSBuild task defaults to 100s timeout (the .NET HttpClient default), which can cause downloads to fail on slow or unreliable networks.

## Changes
- Set an explicit 600-second (10 minute) timeout on the CLI tarball download
- Made the timeout configurable via the \CopilotCliDownloadTimeout\ MSBuild property, allowing users to override it in their \.csproj\ or \Directory.Build.props\ if needed

## Testing
Verified the file still parses as valid XML and the timeout property is correctly applied to the \DownloadFile\ task.