### PR TITLE
feat: Support overriding built-in tools

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -415,6 +415,19 @@ var session = await client.CreateSessionAsync(new SessionConfig
 
 When Copilot invokes `lookup_issue`, the client automatically runs your handler and responds to the CLI. Handlers can return any JSON-serializable value (automatically wrapped), or a `ToolResultAIContent` wrapping a `ToolResultObject` for full control over result metadata.
 
+#### Overriding Built-in Tools
+
+If you register a tool with the same name as a built-in CLI tool (e.g. `edit_file`, `read_file`), your tool takes precedence. The SDK automatically adds the tool name to `ExcludedTools`, so the built-in is disabled and your handler is called instead. This is useful when you need custom behavior for built-in operations.
+
+```csharp
+AIFunctionFactory.Create(
+    async ([Description("File path")] string path, [Description("New content")] string content) => {
+        // your logic
+    },
+    "edit_file",
+    "Custom file editor with project-specific validation")
+```
+
 ### System Message Customization
 
 Control the system prompt using `SystemMessage` in session config:

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -382,7 +382,7 @@ public partial class CopilotClient : IDisposable, IAsyncDisposable
             config?.Tools?.Select(ToolDefinition.FromAIFunction).ToList(),
             config?.SystemMessage,
             config?.AvailableTools,
-            config?.ExcludedTools,
+            MergeExcludedTools(config?.ExcludedTools, config?.Tools),
             config?.Provider,
             (bool?)true,
             config?.OnUserInputRequest != null ? true : null,
@@ -467,7 +467,7 @@ public partial class CopilotClient : IDisposable, IAsyncDisposable
             config?.Tools?.Select(ToolDefinition.FromAIFunction).ToList(),
             config?.SystemMessage,
             config?.AvailableTools,
-            config?.ExcludedTools,
+            MergeExcludedTools(config?.ExcludedTools, config?.Tools),
             config?.Provider,
             (bool?)true,
             config?.OnUserInputRequest != null ? true : null,
@@ -850,6 +850,14 @@ public partial class CopilotClient : IDisposable, IAsyncDisposable
         {
             try { handler(evt); } catch { /* Ignore handler errors */ }
         }
+    }
+
+    internal static List<string>? MergeExcludedTools(List<string>? excludedTools, ICollection<AIFunction>? tools)
+    {
+        var toolNames = tools?.Select(t => t.Name).ToList();
+        if (toolNames is null or { Count: 0 }) return excludedTools;
+        if (excludedTools is null or { Count: 0 }) return toolNames;
+        return excludedTools.Union(toolNames).ToList();
     }
 
     internal static async Task<T> InvokeRpcAsync<T>(JsonRpc rpc, string method, object?[]? args, CancellationToken cancellationToken)

--- a/dotnet/src/GitHub.Copilot.SDK.csproj
+++ b/dotnet/src/GitHub.Copilot.SDK.csproj
@@ -18,6 +18,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="GitHub.Copilot.SDK.Test" />
+    </ItemGroup>
+
+    <ItemGroup>
         <None Include="../README.md" Pack="true" PackagePath="/" />
     </ItemGroup>
 

--- a/dotnet/test/MergeExcludedToolsTests.cs
+++ b/dotnet/test/MergeExcludedToolsTests.cs
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+using Microsoft.Extensions.AI;
+using System.ComponentModel;
+using Xunit;
+
+namespace GitHub.Copilot.SDK.Test;
+
+public class MergeExcludedToolsTests
+{
+    [Fact]
+    public void Tool_Names_Are_Added_To_ExcludedTools()
+    {
+        var tools = new List<AIFunction>
+        {
+            AIFunctionFactory.Create(Noop, "my_tool"),
+        };
+
+        var result = CopilotClient.MergeExcludedTools(null, tools);
+
+        Assert.NotNull(result);
+        Assert.Contains("my_tool", result!);
+    }
+
+    [Fact]
+    public void Merges_With_Existing_ExcludedTools_And_Deduplicates()
+    {
+        var existing = new List<string> { "view", "my_tool" };
+        var tools = new List<AIFunction>
+        {
+            AIFunctionFactory.Create(Noop, "my_tool"),
+            AIFunctionFactory.Create(Noop, "another_tool"),
+        };
+
+        var result = CopilotClient.MergeExcludedTools(existing, tools);
+
+        Assert.NotNull(result);
+        Assert.Equal(3, result!.Count);
+        Assert.Contains("view", result);
+        Assert.Contains("my_tool", result);
+        Assert.Contains("another_tool", result);
+    }
+
+    [Fact]
+    public void Returns_Null_When_No_Tools_Provided()
+    {
+        var result = CopilotClient.MergeExcludedTools(null, null);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Returns_ExcludedTools_Unchanged_When_Tools_Empty()
+    {
+        var existing = new List<string> { "view" };
+        var result = CopilotClient.MergeExcludedTools(existing, new List<AIFunction>());
+
+        Assert.Same(existing, result);
+    }
+
+    [Fact]
+    public void Returns_Tool_Names_When_ExcludedTools_Null()
+    {
+        var tools = new List<AIFunction>
+        {
+            AIFunctionFactory.Create(Noop, "my_tool"),
+        };
+
+        var result = CopilotClient.MergeExcludedTools(null, tools);
+
+        Assert.NotNull(result);
+        Assert.Single(result!);
+        Assert.Equal("my_tool", result[0]);
+    }
+
+    [Description("No-op")]
+    static string Noop() => "";
+}

--- a/go/README.md
+++ b/go/README.md
@@ -266,6 +266,17 @@ session, _ := client.CreateSession(context.Background(), &copilot.SessionConfig{
 
 When the model selects a tool, the SDK automatically runs your handler (in parallel with other calls) and responds to the CLI's `tool.call` with the handler's result.
 
+#### Overriding Built-in Tools
+
+If you register a tool with the same name as a built-in CLI tool (e.g. `edit_file`, `read_file`), your tool takes precedence. The SDK automatically adds the tool name to `ExcludedTools`, so the built-in is disabled and your handler is called instead. This is useful when you need custom behavior for built-in operations.
+
+```go
+editFile := copilot.DefineTool("edit_file", "Custom file editor with project-specific validation",
+    func(params EditFileParams, inv copilot.ToolInvocation) (any, error) {
+        // your logic
+    })
+```
+
 ## Streaming
 
 Enable streaming to receive assistant response chunks as they're generated:

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -444,3 +444,39 @@ func TestResumeSessionRequest_ClientName(t *testing.T) {
 		}
 	})
 }
+
+func TestMergeExcludedTools(t *testing.T) {
+	t.Run("adds tool names to excluded tools", func(t *testing.T) {
+		tools := []Tool{{Name: "edit_file"}, {Name: "read_file"}}
+		got := mergeExcludedTools(nil, tools)
+		want := []string{"edit_file", "read_file"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("deduplicates with existing excluded tools", func(t *testing.T) {
+		excluded := []string{"edit_file", "run_shell"}
+		tools := []Tool{{Name: "edit_file"}, {Name: "read_file"}}
+		got := mergeExcludedTools(excluded, tools)
+		want := []string{"edit_file", "run_shell", "read_file"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("returns original list when no tools provided", func(t *testing.T) {
+		excluded := []string{"edit_file"}
+		got := mergeExcludedTools(excluded, nil)
+		if !reflect.DeepEqual(got, excluded) {
+			t.Errorf("got %v, want %v", got, excluded)
+		}
+	})
+
+	t.Run("returns nil when both inputs are empty", func(t *testing.T) {
+		got := mergeExcludedTools(nil, nil)
+		if got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+}

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -402,6 +402,18 @@ const session = await client.createSession({
 
 When Copilot invokes `lookup_issue`, the client automatically runs your handler and responds to the CLI. Handlers can return any JSON-serializable value (automatically wrapped), a simple string, or a `ToolResultObject` for full control over result metadata. Raw JSON schemas are also supported if Zod isn't desired.
 
+#### Overriding Built-in Tools
+
+If you register a tool with the same name as a built-in CLI tool (e.g. `edit_file`, `read_file`), your tool takes precedence. The SDK automatically adds the tool name to `excludedTools`, so the built-in is disabled and your handler is called instead. This is useful when you need custom behavior for built-in operations.
+
+```ts
+defineTool("edit_file", {
+    description: "Custom file editor with project-specific validation",
+    parameters: z.object({ path: z.string(), content: z.string() }),
+    handler: async ({ path, content }) => { /* your logic */ },
+})
+```
+
 ### System Message Customization
 
 Control the system prompt using `systemMessage` in session config:

--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -51,6 +51,19 @@ import type {
 } from "./types.js";
 
 /**
+ * Merge user-provided excludedTools with tool names from config.tools so that
+ * SDK-registered tools automatically override built-in CLI tools.
+ */
+function mergeExcludedTools(
+    excludedTools: string[] | undefined,
+    tools: Tool[] | undefined
+): string[] | undefined {
+    const toolNames = tools?.map((t) => t.name);
+    if (!excludedTools?.length && !toolNames?.length) return excludedTools;
+    return [...new Set([...(excludedTools ?? []), ...(toolNames ?? [])])];
+}
+
+/**
  * Check if value is a Zod schema (has toJSONSchema method)
  */
 function isZodSchema(value: unknown): value is { toJSONSchema(): Record<string, unknown> } {
@@ -529,7 +542,7 @@ export class CopilotClient {
             })),
             systemMessage: config.systemMessage,
             availableTools: config.availableTools,
-            excludedTools: config.excludedTools,
+            excludedTools: mergeExcludedTools(config.excludedTools, config.tools),
             provider: config.provider,
             requestPermission: true,
             requestUserInput: !!config.onUserInputRequest,
@@ -607,7 +620,7 @@ export class CopilotClient {
             reasoningEffort: config.reasoningEffort,
             systemMessage: config.systemMessage,
             availableTools: config.availableTools,
-            excludedTools: config.excludedTools,
+            excludedTools: mergeExcludedTools(config.excludedTools, config.tools),
             tools: config.tools?.map((tool) => ({
                 name: tool.name,
                 description: tool.description,

--- a/python/README.md
+++ b/python/README.md
@@ -210,6 +210,20 @@ session = await client.create_session({
 
 The SDK automatically handles `tool.call`, executes your handler (sync or async), and responds with the final result when the tool completes.
 
+#### Overriding Built-in Tools
+
+If you register a tool with the same name as a built-in CLI tool (e.g. `edit_file`, `read_file`), your tool takes precedence. The SDK automatically adds the tool name to `excluded_tools`, so the built-in is disabled and your handler is called instead. This is useful when you need custom behavior for built-in operations.
+
+```python
+class EditFileParams(BaseModel):
+    path: str = Field(description="File path")
+    content: str = Field(description="New file content")
+
+@define_tool(name="edit_file", description="Custom file editor with project-specific validation")
+async def edit_file(params: EditFileParams) -> str:
+    # your logic
+```
+
 ## Image Support
 
 The SDK supports image attachments via the `attachments` parameter. You can attach images by providing their file path:

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -483,7 +483,10 @@ class CopilotClient:
         available_tools = cfg.get("available_tools")
         if available_tools is not None:
             payload["availableTools"] = available_tools
-        excluded_tools = cfg.get("excluded_tools")
+        excluded_tools = list(cfg.get("excluded_tools") or [])
+        if tools:
+            tool_names = [t.name for t in tools]
+            excluded_tools = list(dict.fromkeys(excluded_tools + tool_names))
         if excluded_tools:
             payload["excludedTools"] = excluded_tools
 
@@ -655,7 +658,10 @@ class CopilotClient:
         if available_tools is not None:
             payload["availableTools"] = available_tools
 
-        excluded_tools = cfg.get("excluded_tools")
+        excluded_tools = list(cfg.get("excluded_tools") or [])
+        if tools:
+            tool_names = [t.name for t in tools]
+            excluded_tools = list(dict.fromkeys(excluded_tools + tool_names))
         if excluded_tools:
             payload["excludedTools"] = excluded_tools
 


### PR DESCRIPTION
## Summary

Closes #411

When users register tools via `SessionConfig.tools` with names matching built-in CLI tools (e.g., `edit_file`, `read_file`), the CLI previously handled them itself instead of dispatching to the user's handler.

This PR makes user-registered tools automatically take precedence by adding their names to `excludedTools` in the RPC payload, so the CLI's built-in version is excluded and the SDK's local dispatch handles the call instead.

## Changes

Implemented consistently across all 4 SDKs:

| SDK | Code | Tests | Docs |
|-----|------|-------|------|
| **Node.js** | `mergeExcludedTools()` helper in `client.ts` | 4 tests in `client.test.ts` | README updated |
| **Python** | Inline merge in `client.py` | 4 tests in `test_client.py` | README updated |
| **Go** | `mergeExcludedTools()` helper in `client.go` | 4 tests in `client_test.go` | README updated |
| **.NET** | `MergeExcludedTools()` helper in `Client.cs` | 5 tests in `MergeExcludedToolsTests.cs` | README updated |

## How it works

1. Before sending `session.create` / `session.resume` RPC, collect tool names from user-registered tools
2. Merge them into `excludedTools` (with deduplication)
3. CLI receives the merged list and won't handle those tools itself
4. SDK dispatches tool calls to the user's local handler

## Backward compatibility

- Fully backward-compatible: users who don't name tools after built-ins see no behavior change
- If a user already explicitly lists a tool in `excludedTools`, deduplication avoids issues