### PR TITLE
chore(nodejs): bump @github/copilot from ^0.0.411 to ^0.0.414

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^0.0.411",
+        "@github/copilot": "^0.0.414",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },
@@ -662,26 +662,26 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "0.0.411",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-0.0.411.tgz",
-      "integrity": "sha512-I3/7gw40Iu1O+kTyNPKJHNqDRyOebjsUW6wJsvSVrOpT0TNa3/lfm8xdS2XUuJWkp+PgEG/PRwF7u3DVNdP7bQ==",
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-0.0.414.tgz",
+      "integrity": "sha512-jseJ2S02CLWrFks5QK22zzq7as2ErY5m1wMCFBOE6sro1uACq1kvqqM1LwM4qy58YSZFrM1ZAn1s7UOVd9zhIA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "0.0.411",
-        "@github/copilot-darwin-x64": "0.0.411",
-        "@github/copilot-linux-arm64": "0.0.411",
-        "@github/copilot-linux-x64": "0.0.411",
-        "@github/copilot-win32-arm64": "0.0.411",
-        "@github/copilot-win32-x64": "0.0.411"
+        "@github/copilot-darwin-arm64": "0.0.414",
+        "@github/copilot-darwin-x64": "0.0.414",
+        "@github/copilot-linux-arm64": "0.0.414",
+        "@github/copilot-linux-x64": "0.0.414",
+        "@github/copilot-win32-arm64": "0.0.414",
+        "@github/copilot-win32-x64": "0.0.414"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "0.0.411",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-0.0.411.tgz",
-      "integrity": "sha512-dtr+iHxTS4f8HlV2JT9Fp0FFoxuiPWCnU3XGmrHK+rY6bX5okPC2daU5idvs77WKUGcH8yHTZtfbKYUiMxKosw==",
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-0.0.414.tgz",
+      "integrity": "sha512-PW4v89v41i4Mg/NYl4+gEhwnDaVz+olNL+RbqtiQI3IV89gZdS+RZQbUEJfOwMaFcT2GfiUK1OuB+YDv5GrkBg==",
       "cpu": [
         "arm64"
       ],
@@ -695,9 +695,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "0.0.411",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-0.0.411.tgz",
-      "integrity": "sha512-zhdbQCbPi1L4iHClackSLx8POfklA+NX9RQLuS48HlKi/0KI/JlaDA/bdbIeMR79wjif5t9gnc/m+RTVmHlRtA==",
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-0.0.414.tgz",
+      "integrity": "sha512-NyPYm0NovQTwtuI42WJIi4cjYd2z0wBHEvWlUSczRsSuYEyImAClmZmBPegUU63e5JdZd1PdQkQ7FqrrfL2fZQ==",
       "cpu": [
         "x64"
       ],
@@ -711,9 +711,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "0.0.411",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-0.0.411.tgz",
-      "integrity": "sha512-oZYZ7oX/7O+jzdTUcHkfD1A8YnNRW6mlUgdPjUg+5rXC43bwIdyatAnc0ObY21m9h8ghxGqholoLhm5WnGv1LQ==",
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-0.0.414.tgz",
+      "integrity": "sha512-VgdRsvA1FiZ1lcU/AscSvyJWEUWZzoXv2tSZ6WV3NE0uUTuO1Qoq4xuqbKZ/+vKJmn1b8afe7sxAAOtCoWPBHQ==",
       "cpu": [
         "arm64"
       ],
@@ -727,9 +727,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "0.0.411",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-0.0.411.tgz",
-      "integrity": "sha512-nnXrKANmmGnkwa3ROlKdAhVNOx8daeMSE8Xh0o3ybKckFv4s38blhKdcxs0RJQRxgAk4p7XXGlDDKNRhurqF1g==",
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-0.0.414.tgz",
+      "integrity": "sha512-3HyZsbZqYTF5jcT7/e+nDIYBCQXo8UCVWjBI3raOE4lzAw9b2ucL290IhtA23s1+EiquMxJ4m3FnjwFmwlQ12A==",
       "cpu": [
         "x64"
       ],
@@ -743,9 +743,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "0.0.411",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-0.0.411.tgz",
-      "integrity": "sha512-h+Bovb2YVCQSeELZOO7zxv8uht45XHcvAkFbRsc1gf9dl109sSUJIcB4KAhs8Aznk28qksxz7kvdSgUWyQBlIA==",
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-0.0.414.tgz",
+      "integrity": "sha512-8gdaoF4MPpeV0h8UnCZ8TKI5l274EP0fvAaV9BGjsdyEydDcEb+DHqQiXgitWVKKiHAAaPi12aH8P5OsEDUneQ==",
       "cpu": [
         "arm64"
       ],
@@ -759,9 +759,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "0.0.411",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-0.0.411.tgz",
-      "integrity": "sha512-xmOgi1lGvUBHQJWmq5AK1EP95+Y8xR4TFoK9OCSOaGbQ+LFcX2jF7iavnMolfWwddabew/AMQjsEHlXvbgMG8Q==",
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-0.0.414.tgz",
+      "integrity": "sha512-E1Oq1jXHaL1oWNsmmiCd4G30/CfgVdswg/T5oDFUxx3Ri+6uBekciIzdyCDelsP1kn2+fC1EYz2AerQ6F+huzg==",
       "cpu": [
         "x64"
       ],

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -40,7 +40,7 @@
   "author": "GitHub",
   "license": "MIT",
   "dependencies": {
-    "@github/copilot": "^0.0.411",
+    "@github/copilot": "^0.0.414",
     "vscode-jsonrpc": "^8.2.1",
     "zod": "^4.3.6"
   },


### PR DESCRIPTION
Update the Copilot CLI dependency in the Node.js SDK to the latest version (0.0.414).

## Changes
- Updated \@github/copilot\ from \^0.0.411\ to \^0.0.414\ in \
odejs/package.json\
- Updated \
odejs/package-lock.json\

## Verification
- Build passes (\
pm run build\)
- Typecheck passes (\
pm run typecheck\)
- Unit tests pass (22/22)
- E2E tests pass (session, tools, rpc test suites)
- The \--headless\ and \--stdio\ CLI flags are still functional in 0.0.414 (hidden from \--help\ but not removed), so no SDK code changes were needed.