### PR TITLE
fix(python): add timeout parameter to FleetApi.start()

### DIFF
--- a/python/copilot/generated/rpc.py
+++ b/python/copilot/generated/rpc.py
@@ -1015,10 +1015,23 @@ class FleetApi:
         self._client = client
         self._session_id = session_id
 
-    async def start(self, params: SessionFleetStartParams) -> SessionFleetStartResult:
+    async def start(
+        self, params: SessionFleetStartParams, *, timeout: float = 600.0
+    ) -> SessionFleetStartResult:
+        """Start a fleet.
+
+        Args:
+            params: Fleet start parameters.
+            timeout: Request timeout in seconds. Defaults to 600s (10 min)
+                because fleet.start blocks until the fleet completes and
+                the session goes idle, which routinely exceeds the default
+                30s JSON-RPC timeout.
+        """
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
-        return SessionFleetStartResult.from_dict(await self._client.request("session.fleet.start", params_dict))
+        return SessionFleetStartResult.from_dict(
+            await self._client.request("session.fleet.start", params_dict, timeout=timeout)
+        )
 
 
 class SessionRpc:


### PR DESCRIPTION
## Problem

`FleetApi.start()` inherits the default 30s timeout from `JsonRpcClient.request()`, but `session.fleet.start` is a blocking RPC that only responds once the fleet completes. Any workload taking more than 30s raises `asyncio.TimeoutError` (#539).

## Fix

Add an explicit `timeout` keyword parameter to `FleetApi.start()` (default: 600s) and pass it through to `self._client.request()`.

```python
# Before
await session.rpc.fleet.start(params)  # always 30s timeout

# After
await session.rpc.fleet.start(params)  # 600s default
await session.rpc.fleet.start(params, timeout=1800)  # custom
```

Fixes #539