### PR TITLE
docs(go): add missing context package in sample code

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -25,6 +25,7 @@ go run chat.go
 package main
 
 import (
+	"context"
     "fmt"
     "log"
 
@@ -274,6 +275,7 @@ Enable streaming to receive assistant response chunks as they're generated:
 package main
 
 import (
+	"context"
     "fmt"
     "log"
 


### PR DESCRIPTION
Add the missing `context` package in the sample code of Go SDK README.