### PR TITLE
Consolidate schedule for Dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,34 +1,31 @@
 version: 2
+multi-ecosystem-groups:
+  all:
+    schedule:
+      interval: 'weekly'
 updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
-    schedule:
-      interval: 'weekly'
+    multi-ecosystem-group: 'all'
   - package-ecosystem: 'devcontainers'
     directory: '/'
-    schedule:
-      interval: 'weekly'
+    multi-ecosystem-group: 'all'
   # Node.js dependencies
   - package-ecosystem: 'npm'
     directory: '/nodejs'
-    schedule:
-      interval: 'weekly'
+    multi-ecosystem-group: 'all'
   - package-ecosystem: 'npm'
     directory: '/test/harness'
-    schedule:
-      interval: 'weekly'
+    multi-ecosystem-group: 'all'
   # Python dependencies
   - package-ecosystem: 'pip'
     directory: '/python'
-    schedule:
-      interval: 'weekly'
+    multi-ecosystem-group: 'all'
   # Go dependencies
   - package-ecosystem: 'gomod'
     directory: '/go'
-    schedule:
-      interval: 'weekly'
+    multi-ecosystem-group: 'all'
   # .NET dependencies
   - package-ecosystem: 'nuget'
     directory: '/dotnet'
-    schedule:
-      interval: 'weekly'
+    multi-ecosystem-group: 'all'


### PR DESCRIPTION
We just got dozens of PRs from Dependabot. This should reduce it to one per week.