### PR TITLE
fix(python): use 'is not None' check for excluded_tools in session methods

### DIFF
--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -497,7 +497,7 @@ class CopilotClient:
         if available_tools is not None:
             payload["availableTools"] = available_tools
         excluded_tools = cfg.get("excluded_tools")
-        if excluded_tools:
+        if excluded_tools is not None:
             payload["excludedTools"] = excluded_tools
 
         # Always enable permission request callback (deny by default if no handler provided)
@@ -675,7 +675,7 @@ class CopilotClient:
             payload["availableTools"] = available_tools
 
         excluded_tools = cfg.get("excluded_tools")
-        if excluded_tools:
+        if excluded_tools is not None:
             payload["excludedTools"] = excluded_tools
 
         provider = cfg.get("provider")


### PR DESCRIPTION
Fix truthy check for `excluded_tools` in `create_session` and `resume_session` that silently dropped empty lists (`[]`), preventing callers from explicitly clearing excluded tools.

This is the remaining half of #487 — `available_tools` was already fixed on main.

Closes #487