### PR TITLE
Add hidden block directive to validate partial code snippets in docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -426,7 +426,32 @@ unsubscribeIdle();
 <details>
 <summary><strong>Python</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```python
+from copilot import CopilotClient
+from copilot.generated.session_events import SessionEvent, SessionEventType
+
+client = CopilotClient()
+
+session = client.create_session({"on_permission_request": lambda req, inv: {"kind": "approved"}})
+
+# Subscribe to all events
+unsubscribe = session.on(lambda event: print(f"Event: {event.type}"))
+
+# Filter by event type in your handler
+def handle_event(event: SessionEvent) -> None:
+    if event.type == SessionEventType.SESSION_IDLE:
+        print("Session is idle")
+    elif event.type == SessionEventType.ASSISTANT_MESSAGE:
+        print(f"Message: {event.data.content}")
+
+unsubscribe = session.on(handle_event)
+
+# Later, to unsubscribe:
+unsubscribe()
+```
+<!-- /docs-validate: hidden -->
+
 ```python
 # Subscribe to all events
 unsubscribe = session.on(lambda event: print(f"Event: {event.type}"))
@@ -449,7 +474,39 @@ unsubscribe()
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"fmt"
+
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func main() {
+	session := &copilot.Session{}
+
+	// Subscribe to all events
+	unsubscribe := session.On(func(event copilot.SessionEvent) {
+		fmt.Println("Event:", event.Type)
+	})
+
+	// Filter by event type in your handler
+	session.On(func(event copilot.SessionEvent) {
+		if event.Type == "session.idle" {
+			fmt.Println("Session is idle")
+		} else if event.Type == "assistant.message" {
+			fmt.Println("Message:", *event.Data.Content)
+		}
+	})
+
+	// Later, to unsubscribe:
+	unsubscribe()
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 // Subscribe to all events
 unsubscribe := session.On(func(event copilot.SessionEvent) {
@@ -474,7 +531,38 @@ unsubscribe()
 <details>
 <summary><strong>.NET</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public static class EventSubscriptionExample
+{
+    public static void Example(CopilotSession session)
+    {
+        // Subscribe to all events
+        var unsubscribe = session.On(ev => Console.WriteLine($"Event: {ev.Type}"));
+
+        // Filter by event type using pattern matching
+        session.On(ev =>
+        {
+            switch (ev)
+            {
+                case SessionIdleEvent:
+                    Console.WriteLine("Session is idle");
+                    break;
+                case AssistantMessageEvent msg:
+                    Console.WriteLine($"Message: {msg.Data.Content}");
+                    break;
+            }
+        });
+
+        // Later, to unsubscribe:
+        unsubscribe.Dispose();
+    }
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```csharp
 // Subscribe to all events
 var unsubscribe = session.On(ev => Console.WriteLine($"Event: {ev.Type}"));
@@ -1227,7 +1315,37 @@ session = await client.create_session({"on_permission_request": PermissionHandle
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func main() {
+	ctx := context.Background()
+
+	client := copilot.NewClient(&copilot.ClientOptions{
+		CLIUrl: "localhost:4321",
+	})
+
+	if err := client.Start(ctx); err != nil {
+		log.Fatal(err)
+	}
+	defer client.Stop()
+
+	// Use the client normally
+	_, _ = client.CreateSession(ctx, &copilot.SessionConfig{
+		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+	})
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 import copilot "github.com/github/copilot-sdk/go"
 

--- a/scripts/docs-validation/validate.ts
+++ b/scripts/docs-validation/validate.ts
@@ -465,6 +465,15 @@ async function main() {
     console.log("  3. Re-run: npm run validate");
     console.log("\nTo skip a code block, add before it:");
     console.log("  <!-- docs-validate: skip -->");
+    console.log("\nTo validate a complete version while showing a snippet:");
+    console.log("  <!-- docs-validate: hidden -->");
+    console.log("  ```lang");
+    console.log("  // full compilable code");
+    console.log("  ```");
+    console.log("  <!-- /docs-validate: hidden -->");
+    console.log("  ```lang");
+    console.log("  // visible snippet (auto-skipped)");
+    console.log("  ```");
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary


### Changes

**New directive in `extract.ts`:**
- The next visible code block after the closing tag is auto-skipped (no manual `skip` needed)
- Summary output now reports a `Hidden` count

**Converted 4 samples in `getting-started.md`:**
- Python event subscription example
- Go event subscription example  
- C# event subscription example
- Go CLI server connection example

### Impact

- Validated code blocks: 182 → **186** (+4)
- All 186 blocks pass validation locally (TS ✅ Python ✅ Go ✅ C# ✅)

### Usage

```markdown
\`\`\`go
package main
import copilot "github.com/github/copilot-sdk/go"
func main() {
    client := copilot.NewClient(nil)
}
\`\`\`

\`\`\`go
client := copilot.NewClient(nil)
\`\`\`
```

The hidden block compiles in CI; readers see only the clean snippet.