### PR TITLE
fix(python): restore package discovery for platform wheel builds

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -41,8 +41,11 @@ dev = [
     "httpx>=0.24.0",
 ]
 
-[tool.setuptools]
-packages = ["copilot"]
+# Use find with a glob so that the copilot.bin subpackage (created dynamically
+# by scripts/build-wheels.mjs during publishing) is included in platform wheels.
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["copilot*"]
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
The explicit `packages = ["copilot"]` setting in `pyproject.toml` excluded the `copilot.bin` subpackage that `scripts/build-wheels.mjs` creates dynamically at publish time (containing the bundled CLI binary). This caused the publish workflow to fail with a `FileNotFoundError` on `copilot/bin` when repacking wheels.

Switch back to `packages.find` with `include = ["copilot*"]` so `copilot.bin` is discovered during wheel builds while still being safely skipped during normal dev installs (where the directory doesn't exist).

Fixes the failure in https://github.com/github/copilot-sdk/actions/runs/22484209474/job/65129708048