### PR TITLE
Have `CopilotClient.stop()` raise an exception group instead of returning a list of exceptions

### DIFF
--- a/python/copilot/types.py
+++ b/python/copilot/types.py
@@ -619,10 +619,13 @@ class PingResponse:
 
 # Error information from client stop
 @dataclass
-class StopError:
-    """Error information from client stop"""
+class StopError(Exception):
+    """Error that occurred during client stop cleanup."""
 
     message: str  # Error message describing what failed during cleanup
+
+    def __post_init__(self) -> None:
+        Exception.__init__(self, self.message)
 
     @staticmethod
     def from_dict(obj: Any) -> StopError:

--- a/python/e2e/test_client.py
+++ b/python/e2e/test_client.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from copilot import CopilotClient, PermissionHandler
+from copilot import CopilotClient, PermissionHandler, StopError
 
 from .testharness import CLI_PATH
 
@@ -20,8 +20,7 @@ class TestClient:
             assert pong.message == "pong: test message"
             assert pong.timestamp >= 0
 
-            errors = await client.stop()
-            assert len(errors) == 0
+            await client.stop()
             assert client.get_state() == "disconnected"
         finally:
             await client.force_stop()
@@ -38,14 +37,13 @@ class TestClient:
             assert pong.message == "pong: test message"
             assert pong.timestamp >= 0
 
-            errors = await client.stop()
-            assert len(errors) == 0
+            await client.stop()
             assert client.get_state() == "disconnected"
         finally:
             await client.force_stop()
 
     @pytest.mark.asyncio
-    async def test_should_return_errors_on_failed_cleanup(self):
+    async def test_should_raise_exception_group_on_failed_cleanup(self):
         import asyncio
 
         client = CopilotClient({"cli_path": CLI_PATH})
@@ -59,9 +57,11 @@ class TestClient:
             process.kill()
             await asyncio.sleep(0.1)
 
-            errors = await client.stop()
-            assert len(errors) > 0
-            assert "Failed to destroy session" in errors[0].message
+            with pytest.raises(ExceptionGroup) as exc_info:
+                await client.stop()
+            assert len(exc_info.value.exceptions) > 0
+            assert isinstance(exc_info.value.exceptions[0], StopError)
+            assert "Failed to destroy session" in exc_info.value.exceptions[0].message
         finally:
             await client.force_stop()
 

--- a/python/e2e/testharness/context.py
+++ b/python/e2e/testharness/context.py
@@ -77,7 +77,10 @@ class E2ETestContext:
             test_failed: If True, skip writing snapshots to avoid corruption.
         """
         if self._client:
-            await self._client.stop()
+            try:
+                await self._client.stop()
+            except ExceptionGroup:
+                pass  # stop() completes all cleanup before raising; safe to ignore in teardown
             self._client = None
 
         if self._proxy:


### PR DESCRIPTION
As the Zen of Python says, "Errors should never pass silently".