### PR TITLE
Go: stop RPC client logging expected errors

### DIFF
--- a/go/internal/jsonrpc2/jsonrpc2.go
+++ b/go/internal/jsonrpc2/jsonrpc2.go
@@ -333,7 +333,10 @@ func (c *Client) readLoop() {
 		// Read message body
 		body := make([]byte, contentLength)
 		if _, err := io.ReadFull(reader, body); err != nil {
-			fmt.Printf("Error reading body: %v\n", err)
+			// Only log unexpected errors (not EOF or closed pipe during shutdown)
+			if err != io.EOF && !errors.Is(err, os.ErrClosed) && c.running.Load() {
+				fmt.Printf("Error reading body: %v\n", err)
+			}
 			return
 		}
 


### PR DESCRIPTION
You might see `Error reading header: read |0: file already closed` printed during client shutdown on Linux. This happens because `copilot.Client` kills the CLI subprocess and calls the RPC client's `Stop` method, which closes the subprocess's stdout. Meanwhile, the RPC client has a read loop blocked on a pipe connected to the subprocess's stdout. That loop breaks with an error: `io.EOF` if the process teardown wins the race, `os.ErrClosed` if the pipe close does. The comment anticipates this but the guard around printing the error expects only `io.EOF`. So, simple fix to avoid logging the expected error condition is to add `os.ErrClosed` to the guard.