### PR TITLE
fix(python): correct PermissionHandler.approve_all type annotations

### DIFF
--- a/python/copilot/types.py
+++ b/python/copilot/types.py
@@ -192,8 +192,10 @@ _PermissionHandlerFn = Callable[
 
 class PermissionHandler:
     @staticmethod
-    def approve_all(request: Any, invocation: Any) -> dict:
-        return {"kind": "approved"}
+    def approve_all(
+        request: PermissionRequest, invocation: dict[str, str]
+    ) -> PermissionRequestResult:
+        return PermissionRequestResult(kind="approved")
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Fixes #612

`PermissionHandler.approve_all` used `Any` parameter types and returned a plain `dict`, conflicting with the `_PermissionHandlerFn` signature:

```python
_PermissionHandlerFn = Callable[
    [PermissionRequest, dict[str, str]],
    PermissionRequestResult | Awaitable[PermissionRequestResult],
]
```

## Changes

- Replace parameter types: `Any` → `PermissionRequest`, `dict[str, str]`
- Replace return type: `dict` → `PermissionRequestResult`
- Use `PermissionRequestResult()` constructor instead of dict literal

## Before
```python
def approve_all(request: Any, invocation: Any) -> dict:
    return {"kind": "approved"}
```

## After
```python
def approve_all(
    request: PermissionRequest, invocation: dict[str, str]
) -> PermissionRequestResult:
    return PermissionRequestResult(kind="approved")
```

## Tests

- 15 unit tests passed
- ruff check clean
- 2 consecutive review runs with 0 errors