### PR TITLE
Improve changelog agent: prerelease support, formatting fixes, publish trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ on:
 permissions:
   contents: write
   id-token: write # Required for OIDC
+  actions: write # Required to trigger changelog workflow
 
 concurrency:
   group: publish
@@ -211,6 +212,10 @@ jobs:
             --title "v${{ needs.version.outputs.version }}" \
             --generate-notes $NOTES_FLAG \
             --target ${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Trigger changelog generation
+        run: gh workflow run release-changelog.lock.yml -f tag="v${{ needs.version.outputs.version }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Tag Go SDK submodule

--- a/.github/workflows/release-changelog.lock.yml
+++ b/.github/workflows/release-changelog.lock.yml
@@ -21,15 +21,12 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Generates a changelog from merged PRs/commits when a stable release is published, and opens a PR to update CHANGELOG.md
+# Generates release notes from merged PRs/commits. Triggered by the publish workflow or manually via workflow_dispatch.
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"14c83637f3833e511979886eb24004402e15a29d5563e46c966b010678875b9e","compiler_version":"v0.52.1"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"c06cce5802b74e1280963eef2e92515d84870d76d9cfdefa84b56c038e2b8da1","compiler_version":"v0.52.1"}
 
 name: "Release Changelog Generator"
 "on":
-  release:
-    types:
-    - published
   workflow_dispatch:
     inputs:
       tag:
@@ -46,9 +43,6 @@ run-name: "Release Changelog Generator"
 
 jobs:
   activation:
-    needs: pre_activation
-    if: >
-      (needs.pre_activation.outputs.activated == 'true') && (github.event.release.prerelease == false || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -113,11 +107,10 @@ jobs:
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_SAFE_OUTPUTS: ${{ env.GH_AW_SAFE_OUTPUTS }}
-          GH_AW_EXPR_5E147A2A: ${{ github.event.release.tag_name || inputs.tag }}
-          GH_AW_EXPR_611D9200: ${{ github.event.release.name || inputs.tag }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
+          GH_AW_GITHUB_EVENT_INPUTS_TAG: ${{ github.event.inputs.tag }}
           GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
           GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
@@ -180,8 +173,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_EXPR_611D9200: ${{ github.event.release.name || inputs.tag }}
-          GH_AW_EXPR_5E147A2A: ${{ github.event.release.tag_name || inputs.tag }}
+          GH_AW_GITHUB_EVENT_INPUTS_TAG: ${{ github.event.inputs.tag }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
         with:
           script: |
@@ -193,17 +185,15 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_EXPR_5E147A2A: ${{ github.event.release.tag_name || inputs.tag }}
-          GH_AW_EXPR_611D9200: ${{ github.event.release.name || inputs.tag }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
+          GH_AW_GITHUB_EVENT_INPUTS_TAG: ${{ github.event.inputs.tag }}
           GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
           GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
-          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
@@ -215,17 +205,15 @@ jobs:
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
               substitutions: {
-                GH_AW_EXPR_5E147A2A: process.env.GH_AW_EXPR_5E147A2A,
-                GH_AW_EXPR_611D9200: process.env.GH_AW_EXPR_611D9200,
                 GH_AW_GITHUB_ACTOR: process.env.GH_AW_GITHUB_ACTOR,
                 GH_AW_GITHUB_EVENT_COMMENT_ID: process.env.GH_AW_GITHUB_EVENT_COMMENT_ID,
                 GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: process.env.GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER,
+                GH_AW_GITHUB_EVENT_INPUTS_TAG: process.env.GH_AW_GITHUB_EVENT_INPUTS_TAG,
                 GH_AW_GITHUB_EVENT_ISSUE_NUMBER: process.env.GH_AW_GITHUB_EVENT_ISSUE_NUMBER,
                 GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: process.env.GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER,
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
-                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
+                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE
               }
             });
       - name: Validate prompt placeholders
@@ -254,8 +242,6 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
-    concurrency:
-      group: "gh-aw-copilot-${{ github.workflow }}"
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -910,7 +896,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           WORKFLOW_NAME: "Release Changelog Generator"
-          WORKFLOW_DESCRIPTION: "Generates a changelog from merged PRs/commits when a stable release is published, and opens a PR to update CHANGELOG.md"
+          WORKFLOW_DESCRIPTION: "Generates release notes from merged PRs/commits. Triggered by the publish workflow or manually via workflow_dispatch."
           HAS_PATCH: ${{ steps.collect_output.outputs.has_patch }}
         with:
           script: |
@@ -1101,30 +1087,6 @@ jobs:
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
             const { main } = require('/opt/gh-aw/actions/handle_create_pr_error.cjs');
-            await main();
-
-  pre_activation:
-    if: ${{ github.event.release.prerelease == false || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-slim
-    outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
-      matched_command: ''
-    steps:
-      - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@a86e657586e4ac5f549a790628971ec02f6a4a8f # v0.52.1
-        with:
-          destination: /opt/gh-aw/actions
-      - name: Check team membership for workflow
-        id: check_membership
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          GH_AW_REQUIRED_ROLES: admin,maintainer,write
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io);
-            const { main } = require('/opt/gh-aw/actions/check_membership.cjs');
             await main();
 
   safe_outputs:

--- a/.github/workflows/release-changelog.md
+++ b/.github/workflows/release-changelog.md
@@ -1,15 +1,12 @@
 ---
-description: Generates a changelog from merged PRs/commits when a stable release is published, and opens a PR to update CHANGELOG.md
+description: Generates release notes from merged PRs/commits. Triggered by the publish workflow or manually via workflow_dispatch.
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       tag:
         description: "Release tag to generate changelog for (e.g., v0.1.30)"
         required: true
         type: string
-if: ${{ github.event.release.prerelease == false || github.event_name == 'workflow_dispatch' }}
 permissions:
   contents: read
   actions: read
@@ -31,23 +28,30 @@ timeout-minutes: 15
 
 # Release Changelog Generator
 
-You are an AI agent that generates a well-formatted changelog when a new stable release of the Copilot SDK is published. You update `CHANGELOG.md` in the repository and create a PR with the changes.
+You are an AI agent that generates well-formatted release notes when a release of the Copilot SDK is published.
+
+- **For stable releases** (tag has no prerelease suffix like `-preview`): update `CHANGELOG.md` via a PR AND update the GitHub Release notes.
+- **For prerelease releases** (tag contains `-preview` or similar suffix): update the GitHub Release notes ONLY. Do NOT modify `CHANGELOG.md` or create a PR.
+
+Determine which type of release this is by inspecting the tag or fetching the release metadata.
 
 ## Context
 
 - Repository: ${{ github.repository }}
-- Release tag: ${{ github.event.release.tag_name || inputs.tag }}
-- Release name: ${{ github.event.release.name || inputs.tag }}
+- Release tag: ${{ github.event.inputs.tag }}
 
-For `workflow_dispatch` runs, the `github.event.release.*` fields will be empty. In that case, use the GitHub API to fetch the release corresponding to `inputs.tag` to get its name, publish date, and other metadata.
+Use the GitHub API to fetch the release corresponding to `${{ github.event.inputs.tag }}` to get its name, publish date, prerelease status, and other metadata.
 
 ## Your Task
 
 ### Step 1: Identify the version range
 
-1. The **new version** is the release tag: `${{ github.event.release.tag_name || inputs.tag }}`
-2. Read `CHANGELOG.md` and find the **most recent version heading** (a line matching `## [vX.Y.Z](...)`). Extract that version tag — this is the last documented release.
-3. If `CHANGELOG.md` has no version entries yet, find the previous stable release by listing releases and picking the most recent non-prerelease release before this one. If none exist, use the first commit in the repo as the starting point.
+1. The **new version** is the release tag: `${{ github.event.inputs.tag }}`
+2. Fetch the release metadata to determine if this is a **stable** or **prerelease** release.
+3. Determine the **previous version** to diff against:
+   - **For stable releases**: find the previous **stable** release (skip prereleases). Check `CHANGELOG.md` for the most recent version heading (`## [vX.Y.Z](...)`), or fall back to listing releases via the API. This means stable changelogs include ALL changes since the last stable release, even if some were already mentioned in prerelease notes.
+   - **For prerelease releases**: find the most recent release of **any kind** (stable or prerelease) that precedes this one. This way prerelease notes only cover what's new since the last release.
+4. If no previous release exists at all, use the first commit in the repo as the starting point.
 
 ### Step 2: Gather changes
 
@@ -72,7 +76,9 @@ Only include changes that are **user-visible in the published SDK packages**. Sk
 
 Additionally, identify **new contributors** — anyone whose first merged PR to this repo falls within this release range. You can determine this by checking whether the author has any earlier merged PRs in the repository.
 
-### Step 4: Update CHANGELOG.md
+### Step 4: Update CHANGELOG.md (stable releases only)
+
+**Skip this step entirely for prerelease releases.**
 
 1. Read the current `CHANGELOG.md` file.
 2. Add the new version entry **at the top** of the file, right after the title/header.
@@ -90,7 +96,9 @@ Additionally, identify **new contributors** — anyone whose first merged PR to 
    Omit this section if there are no new contributors.
 5. Make sure the existing content below is preserved exactly as-is.
 
-### Step 5: Create a Pull Request
+### Step 5: Create a Pull Request (stable releases only)
+
+**Skip this step entirely for prerelease releases.**
 
 Use the `create-pull-request` output to submit your changes. The PR should:
 - Have a clear title like "Add changelog for vX.Y.Z"


### PR DESCRIPTION
Follow-up improvements to the release changelog agent:

### Prerelease support
- Agent now handles both stable and prerelease releases
- **Stable releases**: update GitHub Release notes AND open a PR to update CHANGELOG.md
- **Prerelease releases**: update GitHub Release notes ONLY (no CHANGELOG.md changes)

### Formatting fixes (from test run feedback)
- Don't include version heading in GitHub Release notes (redundant with release title)
- Omit `### Other changes` subheading when there are no highlighted features above it
- Add `### New contributors` section listing first-time contributors with their PR link

### Trigger fix
- Publish workflow now explicitly triggers the changelog agent via `workflow_dispatch` for both `latest` and `prerelease` (replaces `release: published` trigger which doesn't fire from `GITHUB_TOKEN` events)

Supersedes #640.