### PR TITLE
feat(python): forward `enable_github_mcp_tools` in session.create/resume

### DIFF
--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -537,6 +537,18 @@ class CopilotClient:
             payload["mcpServers"] = mcp_servers
         payload["envValueMode"] = "direct"
 
+        # Enable GitHub MCP tools if requested via session config or CLI args.
+        # This forwards the flag in the session.create payload so the CLI's
+        # headless mode can set up the GitHub MCP server for this session.
+        # See: https://github.com/github/copilot-sdk/issues/128
+        enable_github_mcp = cfg.get("enable_github_mcp_tools", False)
+        if not enable_github_mcp:
+            cli_args = self.options.get("cli_args") or []
+            if "--enable-all-github-mcp-tools" in cli_args:
+                enable_github_mcp = True
+        if enable_github_mcp:
+            payload["enableGithubMcpTools"] = True
+
         # Add custom agents configuration if provided
         custom_agents = cfg.get("custom_agents")
         if custom_agents:
@@ -725,6 +737,16 @@ class CopilotClient:
         if mcp_servers:
             payload["mcpServers"] = mcp_servers
         payload["envValueMode"] = "direct"
+
+        # Enable GitHub MCP tools if requested via session config or CLI args.
+        # See: https://github.com/github/copilot-sdk/issues/128
+        enable_github_mcp = cfg.get("enable_github_mcp_tools", False)
+        if not enable_github_mcp:
+            cli_args = self.options.get("cli_args") or []
+            if "--enable-all-github-mcp-tools" in cli_args:
+                enable_github_mcp = True
+        if enable_github_mcp:
+            payload["enableGithubMcpTools"] = True
 
         # Add custom agents configuration if provided
         custom_agents = cfg.get("custom_agents")

--- a/python/copilot/types.py
+++ b/python/copilot/types.py
@@ -507,6 +507,11 @@ class SessionConfig(TypedDict, total=False):
     # When enabled (default), sessions automatically manage context limits and persist state.
     # Set to {"enabled": False} to disable.
     infinite_sessions: InfiniteSessionConfig
+    # Enable GitHub MCP tools for this session.
+    # When True, the session is configured with the GitHub MCP server so that
+    # GitHub-related tools (issue management, PR operations, etc.) are available.
+    # This is the session-level equivalent of the CLI's --enable-all-github-mcp-tools flag.
+    enable_github_mcp_tools: bool
 
 
 # Azure-specific provider options
@@ -573,6 +578,11 @@ class ResumeSessionConfig(TypedDict, total=False):
     # When True, skips emitting the session.resume event.
     # Useful for reconnecting to a session without triggering resume-related side effects.
     disable_resume: bool
+    # Enable GitHub MCP tools for this session.
+    # When True, the session is configured with the GitHub MCP server so that
+    # GitHub-related tools (issue management, PR operations, etc.) are available.
+    # This is the session-level equivalent of the CLI's --enable-all-github-mcp-tools flag.
+    enable_github_mcp_tools: bool
 
 
 # Options for sending a message to a session

--- a/python/test_client.py
+++ b/python/test_client.py
@@ -316,3 +316,139 @@ class TestSessionConfigForwarding:
             assert captured["session.model.switchTo"]["modelId"] == "gpt-4.1"
         finally:
             await client.force_stop()
+
+
+class TestEnableGithubMcpTools:
+    @pytest.mark.asyncio
+    async def test_create_session_forwards_enable_github_mcp_tools(self):
+        """enable_github_mcp_tools in session config is forwarded as enableGithubMcpTools."""
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            await client.create_session(
+                {
+                    "enable_github_mcp_tools": True,
+                    "on_permission_request": PermissionHandler.approve_all,
+                }
+            )
+            assert captured["session.create"]["enableGithubMcpTools"] is True
+        finally:
+            await client.force_stop()
+
+    @pytest.mark.asyncio
+    async def test_create_session_omits_field_when_not_set(self):
+        """enableGithubMcpTools is omitted from payload when not requested."""
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            await client.create_session(
+                {"on_permission_request": PermissionHandler.approve_all}
+            )
+            assert "enableGithubMcpTools" not in captured["session.create"]
+        finally:
+            await client.force_stop()
+
+    @pytest.mark.asyncio
+    async def test_create_session_detects_cli_args_flag(self):
+        """--enable-all-github-mcp-tools in cli_args is auto-forwarded to session payload."""
+        client = CopilotClient(
+            {"cli_path": CLI_PATH, "cli_args": ["--enable-all-github-mcp-tools"]}
+        )
+        await client.start()
+
+        try:
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            await client.create_session(
+                {"on_permission_request": PermissionHandler.approve_all}
+            )
+            assert captured["session.create"]["enableGithubMcpTools"] is True
+        finally:
+            await client.force_stop()
+
+    @pytest.mark.asyncio
+    async def test_resume_session_forwards_enable_github_mcp_tools(self):
+        """enable_github_mcp_tools is forwarded in resume_session payload."""
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            session = await client.create_session(
+                {"on_permission_request": PermissionHandler.approve_all}
+            )
+
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "session.resume":
+                    return {"sessionId": session.session_id}
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            await client.resume_session(
+                session.session_id,
+                {
+                    "enable_github_mcp_tools": True,
+                    "on_permission_request": PermissionHandler.approve_all,
+                },
+            )
+            assert captured["session.resume"]["enableGithubMcpTools"] is True
+        finally:
+            await client.force_stop()
+
+    @pytest.mark.asyncio
+    async def test_resume_session_detects_cli_args_flag(self):
+        """--enable-all-github-mcp-tools in cli_args is auto-forwarded for resume too."""
+        client = CopilotClient(
+            {"cli_path": CLI_PATH, "cli_args": ["--enable-all-github-mcp-tools"]}
+        )
+        await client.start()
+
+        try:
+            session = await client.create_session(
+                {"on_permission_request": PermissionHandler.approve_all}
+            )
+
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "session.resume":
+                    return {"sessionId": session.session_id}
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            await client.resume_session(
+                session.session_id,
+                {"on_permission_request": PermissionHandler.approve_all},
+            )
+            assert captured["session.resume"]["enableGithubMcpTools"] is True
+        finally:
+            await client.force_stop()


### PR DESCRIPTION
## Problem

Fixes #128.

When using the Python SDK in headless mode, the built-in GitHub MCP server tools are unavailable even when `--enable-all-github-mcp-tools` is passed via `cli_args`. This is because `startServerMode()` in the CLI never receives the flag — it's only wired into the interactive CLI path.

## Root Cause

The `session.create` JSON-RPC payload has no field to request GitHub MCP tools. The `--enable-all-github-mcp-tools` CLI flag is consumed by the interactive `McpManager` + `createGitHubServerConfig()` flow, but when the SDK spawns the CLI in server mode via `startServerMode()`, that flag is never forwarded to the session creation path.

## Solution

1. **New `SessionConfig` / `ResumeSessionConfig` field**: `enable_github_mcp_tools: bool` — when set to `True`, the SDK includes `enableGithubMcpTools: true` in the `session.create` / `session.resume` JSON-RPC payload.

2. **Auto-detection from `cli_args`**: As a convenience, if `--enable-all-github-mcp-tools` is present in the client's `cli_args`, the SDK automatically sets `enableGithubMcpTools: true` in the payload — no explicit session config needed.

This provides a protocol-level mechanism for the CLI's headless path to know that GitHub MCP tools should be enabled for a given session.

## Changes

- **`python/copilot/types.py`**: Added `enable_github_mcp_tools` field to both `SessionConfig` and `ResumeSessionConfig`
- **`python/copilot/client.py`**: Propagation logic in `create_session()` and `resume_session()` — checks session config then falls back to `cli_args` detection
- **`python/test_client.py`**: 5 new unit tests covering explicit config, omission, cli_args detection for both `create_session` and `resume_session`

## Testing

- All 32 tests pass (27 existing + 5 new)
- `ruff check .` — all checks passed
- No regressions

## Note for CLI team

This PR adds the SDK-side plumbing. The CLI's `startServerMode()` / session handler will need a corresponding change to read `enableGithubMcpTools` from the `session.create` params and wire up the GitHub MCP server accordingly (similar to how the interactive path already does it via `McpManager`).