### PR TITLE
Fix Python permission handler in custom agents guide

### DIFF
--- a/docs/guides/custom-agents.md
+++ b/docs/guides/custom-agents.md
@@ -87,7 +87,7 @@ session = await client.create_session({
             "prompt": "You are a code editor. Make minimal, surgical changes to files as requested.",
         },
     ],
-    "on_permission_request": lambda req: {"kind": "approved"},
+    "on_permission_request": lambda req, inv: {"kind": "approved"},
 })
 ```
 


### PR DESCRIPTION
The Python `on_permission_request` lambda only accepted one argument (`lambda req:`), but the handler signature requires two positional arguments `(request, invocation)`. This would cause a `TypeError` at runtime.

**Before:** `"on_permission_request": lambda req: {"kind": "approved"}`
**After:** `"on_permission_request": lambda req, inv: {"kind": "approved"}`