### PR TITLE
docs: add custom agents & sub-agent orchestration guide

### DIFF
--- a/docs/guides/custom-agents.md
+++ b/docs/guides/custom-agents.md
@@ -313,6 +313,44 @@ _, err := session.SendAndWait(ctx, copilot.MessageOptions{
 <details>
 <summary><strong>.NET</strong></summary>
 
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public static class SubAgentEventsExample
+{
+    public static async Task Example(CopilotSession session)
+    {
+        using var subscription = session.On(evt =>
+        {
+            switch (evt)
+            {
+                case SubagentStartedEvent started:
+                    Console.WriteLine($"▶ Sub-agent started: {started.Data.AgentDisplayName}");
+                    Console.WriteLine($"  Description: {started.Data.AgentDescription}");
+                    Console.WriteLine($"  Tool call ID: {started.Data.ToolCallId}");
+                    break;
+                case SubagentCompletedEvent completed:
+                    Console.WriteLine($"✅ Sub-agent completed: {completed.Data.AgentDisplayName}");
+                    break;
+                case SubagentFailedEvent failed:
+                    Console.WriteLine($"❌ Sub-agent failed: {failed.Data.AgentDisplayName} — {failed.Data.Error}");
+                    break;
+                case SubagentSelectedEvent selected:
+                    Console.WriteLine($"🎯 Agent selected: {selected.Data.AgentDisplayName}");
+                    break;
+            }
+        });
+
+        await session.SendAndWaitAsync(new MessageOptions
+        {
+            Prompt = "Research how authentication works in this codebase"
+        });
+    }
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```csharp
 using var subscription = session.On(evt =>
 {


### PR DESCRIPTION
Add comprehensive documentation for custom agents covering:
- Defining custom agents with scoped tools and prompts
- Configuration reference for all CustomAgentConfig properties
- How sub-agent delegation and inference work
- Listening to sub-agent lifecycle events (started/completed/failed/selected)
- Building agent tree UIs from event data
- Attaching MCP servers to agents
- Best practices and common patterns

Code examples provided for all four SDK languages (TypeScript, Python, Go, .NET).

Also fixes C# docs validation failure (`CS0103: 'session' does not exist`) by adding a hidden validation block with the full compilable wrapper, matching the pattern used elsewhere in the docs.

Addresses #619 and #301.