### PR TITLE
fix(go): remove hand-written PermissionRequest that conflicts with generated type

### DIFF
--- a/go/internal/e2e/tools_test.go
+++ b/go/internal/e2e/tools_test.go
@@ -350,8 +350,8 @@ func TestTools(t *testing.T) {
 		for _, req := range permissionRequests {
 			if req.Kind == "custom-tool" {
 				customToolReqs++
-				if toolName, ok := req.Extra["toolName"].(string); !ok || toolName != "encrypt_string" {
-					t.Errorf("Expected toolName 'encrypt_string', got '%v'", req.Extra["toolName"])
+				if req.ToolName == nil || *req.ToolName != "encrypt_string" {
+					t.Errorf("Expected toolName 'encrypt_string', got '%v'", req.ToolName)
 				}
 			}
 		}

--- a/go/types.go
+++ b/go/types.go
@@ -99,39 +99,6 @@ type SystemMessageConfig struct {
 	Content string `json:"content,omitempty"`
 }
 
-// PermissionRequest represents a permission request from the server
-type PermissionRequest struct {
-	Kind       string         `json:"kind"`
-	ToolCallID string         `json:"toolCallId,omitempty"`
-	Extra      map[string]any `json:"-"` // Additional fields vary by kind
-}
-
-// UnmarshalJSON implements custom JSON unmarshaling for PermissionRequest
-// to capture additional fields (varying by kind) into the Extra map.
-func (p *PermissionRequest) UnmarshalJSON(data []byte) error {
-	// Unmarshal known fields via an alias to avoid infinite recursion
-	type Alias PermissionRequest
-	var alias Alias
-	if err := json.Unmarshal(data, &alias); err != nil {
-		return err
-	}
-	*p = PermissionRequest(alias)
-
-	// Unmarshal all fields into a generic map
-	var raw map[string]any
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-
-	// Remove known fields, keep the rest as Extra
-	delete(raw, "kind")
-	delete(raw, "toolCallId")
-	if len(raw) > 0 {
-		p.Extra = raw
-	}
-	return nil
-}
-
 // PermissionRequestResultKind represents the kind of a permission request result.
 type PermissionRequestResultKind string
 

--- a/test/scenarios/callbacks/permissions/go/main.go
+++ b/test/scenarios/callbacks/permissions/go/main.go
@@ -30,7 +30,10 @@ func main() {
 		Model: "claude-haiku-4.5",
 		OnPermissionRequest: func(req copilot.PermissionRequest, inv copilot.PermissionInvocation) (copilot.PermissionRequestResult, error) {
 			permissionLogMu.Lock()
-			toolName, _ := req.Extra["toolName"].(string)
+			toolName := ""
+			if req.ToolName != nil {
+				toolName = *req.ToolName
+			}
 			permissionLog = append(permissionLog, fmt.Sprintf("approved:%s", toolName))
 			permissionLogMu.Unlock()
 			return copilot.PermissionRequestResult{Kind: "approved"}, nil


### PR DESCRIPTION
## Problem

The `@github/copilot` 0.0.421 schema update (#684) caused quicktype to generate a `PermissionRequest` struct in `generated_session_events.go` that conflicts with the hand-written one in `types.go`, breaking the Go build.

## Fix

Remove the hand-written `PermissionRequest` type (and its custom `UnmarshalJSON`) in favor of the generated one. The generated type has all 23+ typed fields (`ToolName`, `Diff`, `Path`, etc.) while the hand-written one was a simplified wrapper with a generic `Extra map[string]any` catch-all.

### Changes
- **`go/types.go`**: Remove `PermissionRequest` struct and `UnmarshalJSON` method (-33 lines)
- **`go/internal/e2e/tools_test.go`**: Update test to use typed `req.ToolName` field instead of `req.Extra["toolName"]`

### Why not a subpackage?
Other SDKs avoid this collision because generated code lives in separate modules (`generated/`). We considered moving Go's generated events to a `go/events/` subpackage, but that would split the public API across two imports for every user (`copilot.SessionEventHandler` takes `events.SessionEvent`). Since the hand-written type was planned for removal anyway, deleting it is the simplest fix.
