### PR TITLE
docs: replace 72 skip directives with hidden compilable blocks

### DIFF
--- a/docs/auth/byok.md
+++ b/docs/auth/byok.md
@@ -363,7 +363,21 @@ const session = await client.createSession({
 
 For Azure OpenAI endpoints (`*.openai.azure.com`), use the correct type:
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```typescript
+import { CopilotClient } from "@github/copilot-sdk";
+
+const client = new CopilotClient();
+const session = await client.createSession({
+    model: "gpt-4.1",
+    provider: {
+        type: "azure",
+        baseUrl: "https://my-resource.openai.azure.com",
+    },
+});
+```
+<!-- /docs-validate: hidden -->
+
 ```typescript
 // ❌ Wrong: Using "openai" type with native Azure endpoint
 provider: {
@@ -380,7 +394,21 @@ provider: {
 
 However, if your Azure AI Foundry deployment provides an OpenAI-compatible endpoint path (e.g., `/openai/v1/`), use `type: "openai"`:
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```typescript
+import { CopilotClient } from "@github/copilot-sdk";
+
+const client = new CopilotClient();
+const session = await client.createSession({
+    model: "gpt-4.1",
+    provider: {
+        type: "openai",
+        baseUrl: "https://your-resource.openai.azure.com/openai/v1/",
+    },
+});
+```
+<!-- /docs-validate: hidden -->
+
 ```typescript
 // ✅ Correct: OpenAI-compatible Azure AI Foundry endpoint
 provider: {

--- a/docs/auth/index.md
+++ b/docs/auth/index.md
@@ -50,7 +50,20 @@ await client.start()
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import copilot "github.com/github/copilot-sdk/go"
+
+func main() {
+	// Default: uses logged-in user credentials
+	client := copilot.NewClient(nil)
+	_ = client
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 import copilot "github.com/github/copilot-sdk/go"
 
@@ -120,7 +133,23 @@ await client.start()
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import copilot "github.com/github/copilot-sdk/go"
+
+func main() {
+	userAccessToken := "token"
+	client := copilot.NewClient(&copilot.ClientOptions{
+		GitHubToken:     userAccessToken,
+		UseLoggedInUser: copilot.Bool(false),
+	})
+	_ = client
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 import copilot "github.com/github/copilot-sdk/go"
 
@@ -135,7 +164,19 @@ client := copilot.NewClient(&copilot.ClientOptions{
 <details>
 <summary><strong>.NET</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+var userAccessToken = "token";
+await using var client = new CopilotClient(new CopilotClientOptions
+{
+    GithubToken = userAccessToken,
+    UseLoggedInUser = false,
+});
+```
+<!-- /docs-validate: hidden -->
+
 ```csharp
 using GitHub.Copilot.SDK;
 
@@ -254,7 +295,16 @@ const client = new CopilotClient({
 <details>
 <summary><strong>Python</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```python
+from copilot import CopilotClient
+
+client = CopilotClient({
+    "use_logged_in_user": False,
+})
+```
+<!-- /docs-validate: hidden -->
+
 ```python
 client = CopilotClient({
     "use_logged_in_user": False,  # Only use explicit tokens
@@ -266,7 +316,21 @@ client = CopilotClient({
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import copilot "github.com/github/copilot-sdk/go"
+
+func main() {
+	client := copilot.NewClient(&copilot.ClientOptions{
+		UseLoggedInUser: copilot.Bool(false),
+	})
+	_ = client
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 client := copilot.NewClient(&copilot.ClientOptions{
     UseLoggedInUser: copilot.Bool(false),  // Only use explicit tokens

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -44,7 +44,21 @@ client = CopilotClient({"log_level": "debug"})
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import copilot "github.com/github/copilot-sdk/go"
+
+func main() {
+	client := copilot.NewClient(&copilot.ClientOptions{
+		LogLevel: "debug",
+	})
+	_ = client
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 import copilot "github.com/github/copilot-sdk/go"
 
@@ -59,6 +73,7 @@ client := copilot.NewClient(&copilot.ClientOptions{
 <summary><strong>.NET</strong></summary>
 
 <!-- docs-validate: skip -->
+
 ```csharp
 using GitHub.Copilot.SDK;
 using Microsoft.Extensions.Logging;
@@ -110,7 +125,18 @@ const client = new CopilotClient({
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+func main() {
+	// The Go SDK does not currently support passing extra CLI arguments.
+	// For custom log directories, run the CLI manually with --log-dir
+	// and connect via CLIUrl option.
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 // The Go SDK does not currently support passing extra CLI arguments.
 // For custom log directories, run the CLI manually with --log-dir

--- a/docs/guides/custom-agents.md
+++ b/docs/guides/custom-agents.md
@@ -97,7 +97,47 @@ session = await client.create_session({
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func main() {
+	ctx := context.Background()
+	client := copilot.NewClient(nil)
+	client.Start(ctx)
+
+	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
+		Model: "gpt-4.1",
+		CustomAgents: []copilot.CustomAgentConfig{
+			{
+				Name:        "researcher",
+				DisplayName: "Research Agent",
+				Description: "Explores codebases and answers questions using read-only tools",
+				Tools:       []string{"grep", "glob", "view"},
+				Prompt:      "You are a research assistant. Analyze code and answer questions. Do not modify any files.",
+			},
+			{
+				Name:        "editor",
+				DisplayName: "Editor Agent",
+				Description: "Makes targeted code changes",
+				Tools:       []string{"view", "edit", "bash"},
+				Prompt:      "You are a code editor. Make minimal, surgical changes to files as requested.",
+			},
+		},
+		OnPermissionRequest: func(req copilot.PermissionRequest, inv copilot.PermissionInvocation) (copilot.PermissionRequestResult, error) {
+			return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindApproved}, nil
+		},
+	})
+	_ = session
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 ctx := context.Background()
 client := copilot.NewClient(nil)
@@ -287,7 +327,51 @@ response = await session.send_and_wait({
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func main() {
+	ctx := context.Background()
+	client := copilot.NewClient(nil)
+	client.Start(ctx)
+
+	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
+		Model: "gpt-4.1",
+		OnPermissionRequest: func(req copilot.PermissionRequest, inv copilot.PermissionInvocation) (copilot.PermissionRequestResult, error) {
+			return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindApproved}, nil
+		},
+	})
+
+	session.On(func(event copilot.SessionEvent) {
+		switch event.Type {
+		case "subagent.started":
+			fmt.Printf("▶ Sub-agent started: %s\n", *event.Data.AgentDisplayName)
+			fmt.Printf("  Description: %s\n", *event.Data.AgentDescription)
+			fmt.Printf("  Tool call ID: %s\n", *event.Data.ToolCallID)
+		case "subagent.completed":
+			fmt.Printf("✅ Sub-agent completed: %s\n", *event.Data.AgentDisplayName)
+		case "subagent.failed":
+			fmt.Printf("❌ Sub-agent failed: %s — %v\n", *event.Data.AgentDisplayName, event.Data.Error)
+		case "subagent.selected":
+			fmt.Printf("🎯 Agent selected: %s\n", *event.Data.AgentDisplayName)
+		}
+	})
+
+	_, err := session.SendAndWait(ctx, copilot.MessageOptions{
+		Prompt: "Research how authentication works in this codebase",
+	})
+	_ = err
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 session.On(func(event copilot.SessionEvent) {
     switch event.Type {

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -81,7 +81,47 @@ session = await client.create_session({
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func onSessionStart(input copilot.SessionStartHookInput, inv copilot.HookInvocation) (*copilot.SessionStartHookOutput, error) {
+	return nil, nil
+}
+
+func onPreToolUse(input copilot.PreToolUseHookInput, inv copilot.HookInvocation) (*copilot.PreToolUseHookOutput, error) {
+	return nil, nil
+}
+
+func onPostToolUse(input copilot.PostToolUseHookInput, inv copilot.HookInvocation) (*copilot.PostToolUseHookOutput, error) {
+	return nil, nil
+}
+
+func main() {
+	ctx := context.Background()
+	client := copilot.NewClient(nil)
+
+	session, err := client.CreateSession(ctx, &copilot.SessionConfig{
+		Hooks: &copilot.SessionHooks{
+			OnSessionStart: onSessionStart,
+			OnPreToolUse:   onPreToolUse,
+			OnPostToolUse:  onPostToolUse,
+		},
+		OnPermissionRequest: func(req copilot.PermissionRequest, inv copilot.PermissionInvocation) (copilot.PermissionRequestResult, error) {
+			return copilot.PermissionRequestResult{Kind: "approved"}, nil
+		},
+	})
+	_ = session
+	_ = err
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 client := copilot.NewClient(nil)
 
@@ -103,7 +143,39 @@ session, err := client.CreateSession(ctx, &copilot.SessionConfig{
 <details>
 <summary><strong>.NET</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public static class HooksExample
+{
+    static Task<SessionStartHookOutput?> onSessionStart(SessionStartHookInput input, HookInvocation invocation) =>
+        Task.FromResult<SessionStartHookOutput?>(null);
+    static Task<PreToolUseHookOutput?> onPreToolUse(PreToolUseHookInput input, HookInvocation invocation) =>
+        Task.FromResult<PreToolUseHookOutput?>(null);
+    static Task<PostToolUseHookOutput?> onPostToolUse(PostToolUseHookInput input, HookInvocation invocation) =>
+        Task.FromResult<PostToolUseHookOutput?>(null);
+
+    public static async Task Main()
+    {
+        var client = new CopilotClient();
+
+        var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            Hooks = new SessionHooks
+            {
+                OnSessionStart = onSessionStart,
+                OnPreToolUse   = onPreToolUse,
+                OnPostToolUse  = onPostToolUse,
+            },
+            OnPermissionRequest = (req, inv) =>
+                Task.FromResult(new PermissionRequestResult { Kind = PermissionRequestResultKind.Approved }),
+        });
+    }
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```csharp
 var client = new CopilotClient();
 
@@ -184,7 +256,43 @@ session = await client.create_session({
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func main() {
+	ctx := context.Background()
+	client := copilot.NewClient(nil)
+
+	readOnlyTools := map[string]bool{"read_file": true, "glob": true, "grep": true, "view": true}
+
+	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
+		Hooks: &copilot.SessionHooks{
+			OnPreToolUse: func(input copilot.PreToolUseHookInput, inv copilot.HookInvocation) (*copilot.PreToolUseHookOutput, error) {
+				if !readOnlyTools[input.ToolName] {
+					return &copilot.PreToolUseHookOutput{
+						PermissionDecision:       "deny",
+						PermissionDecisionReason: fmt.Sprintf("Only read-only tools are allowed. %q was blocked.", input.ToolName),
+					}, nil
+				}
+				return &copilot.PreToolUseHookOutput{PermissionDecision: "allow"}, nil
+			},
+		},
+		OnPermissionRequest: func(req copilot.PermissionRequest, inv copilot.PermissionInvocation) (copilot.PermissionRequestResult, error) {
+			return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindApproved}, nil
+		},
+	})
+	_ = session
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 readOnlyTools := map[string]bool{"read_file": true, "glob": true, "grep": true, "view": true}
 
@@ -208,7 +316,44 @@ session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
 <details>
 <summary><strong>.NET</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public static class PermissionControlExample
+{
+    public static async Task Main()
+    {
+        await using var client = new CopilotClient();
+
+        var readOnlyTools = new HashSet<string> { "read_file", "glob", "grep", "view" };
+
+        var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            Hooks = new SessionHooks
+            {
+                OnPreToolUse = (input, invocation) =>
+                {
+                    if (!readOnlyTools.Contains(input.ToolName))
+                    {
+                        return Task.FromResult<PreToolUseHookOutput?>(new PreToolUseHookOutput
+                        {
+                            PermissionDecision = "deny",
+                            PermissionDecisionReason = $"Only read-only tools are allowed. \"{input.ToolName}\" was blocked.",
+                        });
+                    }
+                    return Task.FromResult<PreToolUseHookOutput?>(
+                        new PreToolUseHookOutput { PermissionDecision = "allow" });
+                },
+            },
+            OnPermissionRequest = (req, inv) =>
+                Task.FromResult(new PermissionRequestResult { Kind = PermissionRequestResultKind.Approved }),
+        });
+    }
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```csharp
 var readOnlyTools = new HashSet<string> { "read_file", "glob", "grep", "view" };
 

--- a/docs/guides/image-input.md
+++ b/docs/guides/image-input.md
@@ -91,7 +91,41 @@ await session.send({
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func main() {
+	ctx := context.Background()
+	client := copilot.NewClient(nil)
+	client.Start(ctx)
+
+	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
+		Model: "gpt-4.1",
+		OnPermissionRequest: func(req copilot.PermissionRequest, inv copilot.PermissionInvocation) (copilot.PermissionRequestResult, error) {
+			return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindApproved}, nil
+		},
+	})
+
+	path := "/absolute/path/to/screenshot.png"
+	session.Send(ctx, copilot.MessageOptions{
+		Prompt: "Describe what you see in this image",
+		Attachments: []copilot.Attachment{
+			{
+				Type: copilot.File,
+				Path: &path,
+			},
+		},
+	})
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 ctx := context.Background()
 client := copilot.NewClient(nil)
@@ -121,7 +155,39 @@ session.Send(ctx, copilot.MessageOptions{
 <details>
 <summary><strong>.NET</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public static class ImageInputExample
+{
+    public static async Task Main()
+    {
+        await using var client = new CopilotClient();
+        await using var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            Model = "gpt-4.1",
+            OnPermissionRequest = (req, inv) =>
+                Task.FromResult(new PermissionRequestResult { Kind = PermissionRequestResultKind.Approved }),
+        });
+
+        await session.SendAsync(new MessageOptions
+        {
+            Prompt = "Describe what you see in this image",
+            Attachments = new List<UserMessageDataAttachmentsItem>
+            {
+                new UserMessageDataAttachmentsItemFile
+                {
+                    Path = "/absolute/path/to/screenshot.png",
+                    DisplayName = "screenshot.png",
+                },
+            },
+        });
+    }
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```csharp
 using GitHub.Copilot.SDK;
 
@@ -180,7 +246,17 @@ Not all models support vision. Check the model's capabilities before sending ima
 
 ### Vision limits type
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```typescript
+interface VisionCapabilities {
+    vision?: {
+        supported_media_types: string[];
+        max_prompt_images: number;
+        max_prompt_image_size: number; // bytes
+    };
+}
+```
+<!-- /docs-validate: hidden -->
 ```typescript
 vision?: {
     supported_media_types: string[];

--- a/docs/guides/session-persistence.md
+++ b/docs/guides/session-persistence.md
@@ -65,7 +65,33 @@ await session.send_and_wait({"prompt": "Analyze my codebase"})
 
 ### Go
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func main() {
+	ctx := context.Background()
+	client := copilot.NewClient(nil)
+
+	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
+		SessionID: "user-123-task-456",
+		Model:     "gpt-5.2-codex",
+		OnPermissionRequest: func(req copilot.PermissionRequest, inv copilot.PermissionInvocation) (copilot.PermissionRequestResult, error) {
+			return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindApproved}, nil
+		},
+	})
+
+	session.SendAndWait(ctx, copilot.MessageOptions{Prompt: "Analyze my codebase"})
+	_ = session
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 ctx := context.Background()
 client := copilot.NewClient(nil)
@@ -142,7 +168,27 @@ await session.send_and_wait({"prompt": "What did we discuss earlier?"})
 
 ### Go
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func main() {
+	ctx := context.Background()
+	client := copilot.NewClient(nil)
+
+	session, _ := client.ResumeSession(ctx, "user-123-task-456", nil)
+
+	session.SendAndWait(ctx, copilot.MessageOptions{Prompt: "What did we discuss earlier?"})
+	_ = session
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 ctx := context.Background()
 
@@ -155,7 +201,28 @@ session.SendAndWait(ctx, copilot.MessageOptions{Prompt: "What did we discuss ear
 
 ### C# (.NET)
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public static class ResumeSessionExample
+{
+    public static async Task Main()
+    {
+        await using var client = new CopilotClient();
+
+        var session = await client.ResumeSessionAsync("user-123-task-456", new ResumeSessionConfig
+        {
+            OnPermissionRequest = (req, inv) =>
+                Task.FromResult(new PermissionRequestResult { Kind = PermissionRequestResultKind.Approved }),
+        });
+
+        await session.SendAndWaitAsync(new MessageOptions { Prompt = "What did we discuss earlier?" });
+    }
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```csharp
 // Resume from a different client instance (or after restart)
 var session = await client.ResumeSessionAsync("user-123-task-456");

--- a/docs/guides/setup/backend-services.md
+++ b/docs/guides/setup/backend-services.md
@@ -131,7 +131,39 @@ response = await session.send_and_wait({"prompt": message})
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func main() {
+	ctx := context.Background()
+	userID := "user1"
+	message := "Hello"
+
+	client := copilot.NewClient(&copilot.ClientOptions{
+		CLIUrl: "localhost:4321",
+	})
+	client.Start(ctx)
+	defer client.Stop()
+
+	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
+		SessionID: fmt.Sprintf("user-%s-%d", userID, time.Now().Unix()),
+		Model:     "gpt-4.1",
+	})
+
+	response, _ := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: message})
+	_ = response
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 client := copilot.NewClient(&copilot.ClientOptions{
     CLIUrl:"localhost:4321",
@@ -152,7 +184,30 @@ response, _ := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: message})
 <details>
 <summary><strong>.NET</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+var userId = "user1";
+var message = "Hello";
+
+var client = new CopilotClient(new CopilotClientOptions
+{
+    CliUrl = "localhost:4321",
+    UseStdio = false,
+});
+
+await using var session = await client.CreateSessionAsync(new SessionConfig
+{
+    SessionId = $"user-{userId}-{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}",
+    Model = "gpt-4.1",
+});
+
+var response = await session.SendAndWaitAsync(
+    new MessageOptions { Prompt = message });
+```
+<!-- /docs-validate: hidden -->
+
 ```csharp
 var client = new CopilotClient(new CopilotClientOptions
 {

--- a/docs/guides/setup/bundled-cli.md
+++ b/docs/guides/setup/bundled-cli.md
@@ -105,7 +105,35 @@ await client.stop()
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func main() {
+	ctx := context.Background()
+
+	client := copilot.NewClient(&copilot.ClientOptions{
+		CLIPath: "./vendor/copilot",
+	})
+	if err := client.Start(ctx); err != nil {
+		log.Fatal(err)
+	}
+	defer client.Stop()
+
+	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{Model: "gpt-4.1"})
+	response, _ := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: "Hello!"})
+	fmt.Println(*response.Data.Content)
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 client := copilot.NewClient(&copilot.ClientOptions{
     CLIPath:"./vendor/copilot",

--- a/docs/guides/setup/byok.md
+++ b/docs/guides/setup/byok.md
@@ -118,7 +118,39 @@ await client.stop()
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func main() {
+	ctx := context.Background()
+
+	client := copilot.NewClient(nil)
+	client.Start(ctx)
+	defer client.Stop()
+
+	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
+		Model: "gpt-4.1",
+		Provider: &copilot.ProviderConfig{
+			Type:    "openai",
+			BaseURL: "https://api.openai.com/v1",
+			APIKey:  os.Getenv("OPENAI_API_KEY"),
+		},
+	})
+
+	response, _ := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: "Hello!"})
+	fmt.Println(*response.Data.Content)
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 client := copilot.NewClient(nil)
 client.Start(ctx)

--- a/docs/guides/setup/github-oauth.md
+++ b/docs/guides/setup/github-oauth.md
@@ -170,7 +170,41 @@ response = await session.send_and_wait({"prompt": "Hello!"})
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func createClientForUser(userToken string) *copilot.Client {
+	return copilot.NewClient(&copilot.ClientOptions{
+		GitHubToken:     userToken,
+		UseLoggedInUser: copilot.Bool(false),
+	})
+}
+
+func main() {
+	ctx := context.Background()
+	userID := "user1"
+
+	client := createClientForUser("gho_user_access_token")
+	client.Start(ctx)
+	defer client.Stop()
+
+	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
+		SessionID: fmt.Sprintf("user-%s-session", userID),
+		Model:     "gpt-4.1",
+	})
+	response, _ := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: "Hello!"})
+	_ = response
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 func createClientForUser(userToken string) *copilot.Client {
     return copilot.NewClient(&copilot.ClientOptions{
@@ -196,7 +230,31 @@ response, _ := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: "Hello!"}
 <details>
 <summary><strong>.NET</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+CopilotClient CreateClientForUser(string userToken) =>
+    new CopilotClient(new CopilotClientOptions
+    {
+        GithubToken = userToken,
+        UseLoggedInUser = false,
+    });
+
+var userId = "user1";
+
+await using var client = CreateClientForUser("gho_user_access_token");
+await using var session = await client.CreateSessionAsync(new SessionConfig
+{
+    SessionId = $"user-{userId}-session",
+    Model = "gpt-4.1",
+});
+
+var response = await session.SendAndWaitAsync(
+    new MessageOptions { Prompt = "Hello!" });
+```
+<!-- /docs-validate: hidden -->
+
 ```csharp
 CopilotClient CreateClientForUser(string userToken) =>
     new CopilotClient(new CopilotClientOptions

--- a/docs/guides/setup/local-cli.md
+++ b/docs/guides/setup/local-cli.md
@@ -68,7 +68,33 @@ await client.stop()
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func main() {
+	ctx := context.Background()
+
+	client := copilot.NewClient(nil)
+	if err := client.Start(ctx); err != nil {
+		log.Fatal(err)
+	}
+	defer client.Stop()
+
+	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{Model: "gpt-4.1"})
+	response, _ := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: "Hello!"})
+	fmt.Println(*response.Data.Content)
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 client := copilot.NewClient(nil)
 if err := client.Start(ctx); err != nil {

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -171,7 +171,31 @@ session = await client.create_session({
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func main() {
+	ctx := context.Background()
+	client := copilot.NewClient(nil)
+
+	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
+		SkillDirectories: []string{"./skills"},
+		DisabledSkills:   []string{"experimental-feature", "deprecated-tool"},
+		OnPermissionRequest: func(req copilot.PermissionRequest, inv copilot.PermissionInvocation) (copilot.PermissionRequestResult, error) {
+			return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindApproved}, nil
+		},
+	})
+	_ = session
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 session, _ := client.CreateSession(context.Background(), &copilot.SessionConfig{
     SkillDirectories: []string{"./skills"},
@@ -184,7 +208,28 @@ session, _ := client.CreateSession(context.Background(), &copilot.SessionConfig{
 <details>
 <summary><strong>.NET</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public static class SkillsExample
+{
+    public static async Task Main()
+    {
+        await using var client = new CopilotClient();
+
+        var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            SkillDirectories = new List<string> { "./skills" },
+            DisabledSkills = new List<string> { "experimental-feature", "deprecated-tool" },
+            OnPermissionRequest = (req, inv) =>
+                Task.FromResult(new PermissionRequestResult { Kind = PermissionRequestResultKind.Approved }),
+        });
+    }
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```csharp
 var session = await client.CreateSessionAsync(new SessionConfig
 {

--- a/docs/guides/steering-and-queueing.md
+++ b/docs/guides/steering-and-queueing.md
@@ -263,7 +263,44 @@ async def main():
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func main() {
+	ctx := context.Background()
+	client := copilot.NewClient(nil)
+	client.Start(ctx)
+
+	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
+		Model: "gpt-4.1",
+		OnPermissionRequest: func(req copilot.PermissionRequest, inv copilot.PermissionInvocation) (copilot.PermissionRequestResult, error) {
+			return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindApproved}, nil
+		},
+	})
+
+	session.Send(ctx, copilot.MessageOptions{
+		Prompt: "Set up the project structure",
+	})
+
+	session.Send(ctx, copilot.MessageOptions{
+		Prompt: "Add unit tests for the auth module",
+		Mode:   "enqueue",
+	})
+
+	session.Send(ctx, copilot.MessageOptions{
+		Prompt: "Update the README with setup instructions",
+		Mode:   "enqueue",
+	})
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 // Send an initial task
 session.Send(ctx, copilot.MessageOptions{
@@ -289,7 +326,43 @@ session.Send(ctx, copilot.MessageOptions{
 <details>
 <summary><strong>.NET</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public static class QueueingExample
+{
+    public static async Task Main()
+    {
+        await using var client = new CopilotClient();
+        await using var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            Model = "gpt-4.1",
+            OnPermissionRequest = (req, inv) =>
+                Task.FromResult(new PermissionRequestResult { Kind = PermissionRequestResultKind.Approved }),
+        });
+
+        await session.SendAsync(new MessageOptions
+        {
+            Prompt = "Set up the project structure"
+        });
+
+        await session.SendAsync(new MessageOptions
+        {
+            Prompt = "Add unit tests for the auth module",
+            Mode = "enqueue"
+        });
+
+        await session.SendAsync(new MessageOptions
+        {
+            Prompt = "Update the README with setup instructions",
+            Mode = "enqueue"
+        });
+    }
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```csharp
 // Send an initial task
 await session.SendAsync(new MessageOptions

--- a/docs/guides/streaming-events.md
+++ b/docs/guides/streaming-events.md
@@ -82,7 +82,23 @@ session.on("assistant.message_delta", (event) => {
 <details>
 <summary><strong>Python</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```python
+from copilot import CopilotClient
+from copilot.generated.session_events import SessionEventType
+
+client = CopilotClient()
+
+session = None  # assume session is created elsewhere
+
+def handle(event):
+    if event.type == SessionEventType.ASSISTANT_MESSAGE_DELTA:
+        print(event.data.delta_content, end="", flush=True)
+
+# session.on(handle)
+```
+<!-- /docs-validate: hidden -->
+
 ```python
 from copilot.generated.session_events import SessionEventType
 
@@ -98,7 +114,38 @@ session.on(handle)
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func main() {
+	ctx := context.Background()
+	client := copilot.NewClient(nil)
+
+	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
+		Model:     "gpt-4.1",
+		Streaming: true,
+		OnPermissionRequest: func(req copilot.PermissionRequest, inv copilot.PermissionInvocation) (copilot.PermissionRequestResult, error) {
+			return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindApproved}, nil
+		},
+	})
+
+	session.On(func(event copilot.SessionEvent) {
+		if event.Type == "assistant.message_delta" {
+			fmt.Print(*event.Data.DeltaContent)
+		}
+	})
+	_ = session
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```go
 session.On(func(event copilot.SessionEvent) {
     if event.Type == "assistant.message_delta" {
@@ -112,7 +159,26 @@ session.On(func(event copilot.SessionEvent) {
 <details>
 <summary><strong>.NET</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public static class StreamingEventsExample
+{
+    public static async Task Example(CopilotSession session)
+    {
+        session.On(evt =>
+        {
+            if (evt is AssistantMessageDeltaEvent delta)
+            {
+                Console.Write(delta.Data.DeltaContent);
+            }
+        });
+    }
+}
+```
+<!-- /docs-validate: hidden -->
+
 ```csharp
 session.On(evt =>
 {

--- a/docs/hooks/error-handling.md
+++ b/docs/hooks/error-handling.md
@@ -12,7 +12,15 @@ The `onErrorOccurred` hook is called when errors occur during session execution.
 <details open>
 <summary><strong>Node.js / TypeScript</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```ts
+import type { ErrorOccurredHookInput, HookInvocation, ErrorOccurredHookOutput } from "@github/copilot-sdk";
+type ErrorOccurredHandler = (
+  input: ErrorOccurredHookInput,
+  invocation: HookInvocation
+) => Promise<ErrorOccurredHookOutput | null | undefined>;
+```
+<!-- /docs-validate: hidden -->
 ```typescript
 type ErrorOccurredHandler = (
   input: ErrorOccurredHookInput,
@@ -25,7 +33,17 @@ type ErrorOccurredHandler = (
 <details>
 <summary><strong>Python</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```python
+from copilot.types import ErrorOccurredHookInput, HookInvocation, ErrorOccurredHookOutput
+from typing import Callable, Awaitable
+
+ErrorOccurredHandler = Callable[
+    [ErrorOccurredHookInput, HookInvocation],
+    Awaitable[ErrorOccurredHookOutput | None]
+]
+```
+<!-- /docs-validate: hidden -->
 ```python
 ErrorOccurredHandler = Callable[
     [ErrorOccurredHookInput, HookInvocation],
@@ -38,7 +56,20 @@ ErrorOccurredHandler = Callable[
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import copilot "github.com/github/copilot-sdk/go"
+
+type ErrorOccurredHandler func(
+    input copilot.ErrorOccurredHookInput,
+    invocation copilot.HookInvocation,
+) (*copilot.ErrorOccurredHookOutput, error)
+
+func main() {}
+```
+<!-- /docs-validate: hidden -->
 ```go
 type ErrorOccurredHandler func(
     input ErrorOccurredHookInput,
@@ -51,7 +82,15 @@ type ErrorOccurredHandler func(
 <details>
 <summary><strong>.NET</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public delegate Task<ErrorOccurredHookOutput?> ErrorOccurredHandler(
+    ErrorOccurredHookInput input,
+    HookInvocation invocation);
+```
+<!-- /docs-validate: hidden -->
 ```csharp
 public delegate Task<ErrorOccurredHookOutput?> ErrorOccurredHandler(
     ErrorOccurredHookInput input,
@@ -123,7 +162,33 @@ session = await client.create_session({
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func main() {
+	client := copilot.NewClient(nil)
+	session, _ := client.CreateSession(context.Background(), &copilot.SessionConfig{
+		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+		Hooks: &copilot.SessionHooks{
+			OnErrorOccurred: func(input copilot.ErrorOccurredHookInput, inv copilot.HookInvocation) (*copilot.ErrorOccurredHookOutput, error) {
+				fmt.Printf("[%s] Error: %s\n", inv.SessionID, input.Error)
+				fmt.Printf("  Context: %s\n", input.ErrorContext)
+				fmt.Printf("  Recoverable: %v\n", input.Recoverable)
+				return nil, nil
+			},
+		},
+	})
+	_ = session
+}
+```
+<!-- /docs-validate: hidden -->
 ```go
 session, _ := client.CreateSession(context.Background(), &copilot.SessionConfig{
     Hooks: &copilot.SessionHooks{
@@ -142,7 +207,32 @@ session, _ := client.CreateSession(context.Background(), &copilot.SessionConfig{
 <details>
 <summary><strong>.NET</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public static class ErrorHandlingExample
+{
+    public static async Task Main()
+    {
+        await using var client = new CopilotClient();
+        var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            Hooks = new SessionHooks
+            {
+                OnErrorOccurred = (input, invocation) =>
+                {
+                    Console.Error.WriteLine($"[{invocation.SessionId}] Error: {input.Error}");
+                    Console.Error.WriteLine($"  Context: {input.ErrorContext}");
+                    Console.Error.WriteLine($"  Recoverable: {input.Recoverable}");
+                    return Task.FromResult<ErrorOccurredHookOutput?>(null);
+                },
+            },
+        });
+    }
+}
+```
+<!-- /docs-validate: hidden -->
 ```csharp
 var session = await client.CreateSessionAsync(new SessionConfig
 {

--- a/docs/hooks/post-tool-use.md
+++ b/docs/hooks/post-tool-use.md
@@ -12,7 +12,15 @@ The `onPostToolUse` hook is called **after** a tool executes. Use it to:
 <details open>
 <summary><strong>Node.js / TypeScript</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```ts
+import type { PostToolUseHookInput, HookInvocation, PostToolUseHookOutput } from "@github/copilot-sdk";
+type PostToolUseHandler = (
+  input: PostToolUseHookInput,
+  invocation: HookInvocation
+) => Promise<PostToolUseHookOutput | null | undefined>;
+```
+<!-- /docs-validate: hidden -->
 ```typescript
 type PostToolUseHandler = (
   input: PostToolUseHookInput,
@@ -25,7 +33,17 @@ type PostToolUseHandler = (
 <details>
 <summary><strong>Python</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```python
+from copilot.types import PostToolUseHookInput, HookInvocation, PostToolUseHookOutput
+from typing import Callable, Awaitable
+
+PostToolUseHandler = Callable[
+    [PostToolUseHookInput, HookInvocation],
+    Awaitable[PostToolUseHookOutput | None]
+]
+```
+<!-- /docs-validate: hidden -->
 ```python
 PostToolUseHandler = Callable[
     [PostToolUseHookInput, HookInvocation],
@@ -38,7 +56,20 @@ PostToolUseHandler = Callable[
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import copilot "github.com/github/copilot-sdk/go"
+
+type PostToolUseHandler func(
+    input copilot.PostToolUseHookInput,
+    invocation copilot.HookInvocation,
+) (*copilot.PostToolUseHookOutput, error)
+
+func main() {}
+```
+<!-- /docs-validate: hidden -->
 ```go
 type PostToolUseHandler func(
     input PostToolUseHookInput,
@@ -51,7 +82,15 @@ type PostToolUseHandler func(
 <details>
 <summary><strong>.NET</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public delegate Task<PostToolUseHookOutput?> PostToolUseHandler(
+    PostToolUseHookInput input,
+    HookInvocation invocation);
+```
+<!-- /docs-validate: hidden -->
 ```csharp
 public delegate Task<PostToolUseHookOutput?> PostToolUseHandler(
     PostToolUseHookInput input,
@@ -122,7 +161,33 @@ session = await client.create_session({
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func main() {
+	client := copilot.NewClient(nil)
+	session, _ := client.CreateSession(context.Background(), &copilot.SessionConfig{
+		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+		Hooks: &copilot.SessionHooks{
+			OnPostToolUse: func(input copilot.PostToolUseHookInput, inv copilot.HookInvocation) (*copilot.PostToolUseHookOutput, error) {
+				fmt.Printf("[%s] Tool: %s\n", inv.SessionID, input.ToolName)
+				fmt.Printf("  Args: %v\n", input.ToolArgs)
+				fmt.Printf("  Result: %v\n", input.ToolResult)
+				return nil, nil
+			},
+		},
+	})
+	_ = session
+}
+```
+<!-- /docs-validate: hidden -->
 ```go
 session, _ := client.CreateSession(context.Background(), &copilot.SessionConfig{
     Hooks: &copilot.SessionHooks{
@@ -141,7 +206,32 @@ session, _ := client.CreateSession(context.Background(), &copilot.SessionConfig{
 <details>
 <summary><strong>.NET</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public static class PostToolUseExample
+{
+    public static async Task Main()
+    {
+        await using var client = new CopilotClient();
+        var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            Hooks = new SessionHooks
+            {
+                OnPostToolUse = (input, invocation) =>
+                {
+                    Console.WriteLine($"[{invocation.SessionId}] Tool: {input.ToolName}");
+                    Console.WriteLine($"  Args: {input.ToolArgs}");
+                    Console.WriteLine($"  Result: {input.ToolResult}");
+                    return Task.FromResult<PostToolUseHookOutput?>(null);
+                },
+            },
+        });
+    }
+}
+```
+<!-- /docs-validate: hidden -->
 ```csharp
 var session = await client.CreateSessionAsync(new SessionConfig
 {

--- a/docs/hooks/pre-tool-use.md
+++ b/docs/hooks/pre-tool-use.md
@@ -12,7 +12,15 @@ The `onPreToolUse` hook is called **before** a tool executes. Use it to:
 <details open>
 <summary><strong>Node.js / TypeScript</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```ts
+import type { PreToolUseHookInput, HookInvocation, PreToolUseHookOutput } from "@github/copilot-sdk";
+type PreToolUseHandler = (
+  input: PreToolUseHookInput,
+  invocation: HookInvocation
+) => Promise<PreToolUseHookOutput | null | undefined>;
+```
+<!-- /docs-validate: hidden -->
 ```typescript
 type PreToolUseHandler = (
   input: PreToolUseHookInput,
@@ -25,7 +33,17 @@ type PreToolUseHandler = (
 <details>
 <summary><strong>Python</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```python
+from copilot.types import PreToolUseHookInput, HookInvocation, PreToolUseHookOutput
+from typing import Callable, Awaitable
+
+PreToolUseHandler = Callable[
+    [PreToolUseHookInput, HookInvocation],
+    Awaitable[PreToolUseHookOutput | None]
+]
+```
+<!-- /docs-validate: hidden -->
 ```python
 PreToolUseHandler = Callable[
     [PreToolUseHookInput, HookInvocation],
@@ -38,7 +56,20 @@ PreToolUseHandler = Callable[
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import copilot "github.com/github/copilot-sdk/go"
+
+type PreToolUseHandler func(
+    input copilot.PreToolUseHookInput,
+    invocation copilot.HookInvocation,
+) (*copilot.PreToolUseHookOutput, error)
+
+func main() {}
+```
+<!-- /docs-validate: hidden -->
 ```go
 type PreToolUseHandler func(
     input PreToolUseHookInput,
@@ -51,7 +82,15 @@ type PreToolUseHandler func(
 <details>
 <summary><strong>.NET</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public delegate Task<PreToolUseHookOutput?> PreToolUseHandler(
+    PreToolUseHookInput input,
+    HookInvocation invocation);
+```
+<!-- /docs-validate: hidden -->
 ```csharp
 public delegate Task<PreToolUseHookOutput?> PreToolUseHandler(
     PreToolUseHookInput input,
@@ -129,7 +168,34 @@ session = await client.create_session({
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func main() {
+	client := copilot.NewClient(nil)
+	session, _ := client.CreateSession(context.Background(), &copilot.SessionConfig{
+		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+		Hooks: &copilot.SessionHooks{
+			OnPreToolUse: func(input copilot.PreToolUseHookInput, inv copilot.HookInvocation) (*copilot.PreToolUseHookOutput, error) {
+				fmt.Printf("[%s] Calling %s\n", inv.SessionID, input.ToolName)
+				fmt.Printf("  Args: %v\n", input.ToolArgs)
+				return &copilot.PreToolUseHookOutput{
+					PermissionDecision: "allow",
+				}, nil
+			},
+		},
+	})
+	_ = session
+}
+```
+<!-- /docs-validate: hidden -->
 ```go
 session, _ := client.CreateSession(context.Background(), &copilot.SessionConfig{
     Hooks: &copilot.SessionHooks{
@@ -149,7 +215,33 @@ session, _ := client.CreateSession(context.Background(), &copilot.SessionConfig{
 <details>
 <summary><strong>.NET</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public static class PreToolUseExample
+{
+    public static async Task Main()
+    {
+        await using var client = new CopilotClient();
+        var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            Hooks = new SessionHooks
+            {
+                OnPreToolUse = (input, invocation) =>
+                {
+                    Console.WriteLine($"[{invocation.SessionId}] Calling {input.ToolName}");
+                    Console.WriteLine($"  Args: {input.ToolArgs}");
+                    return Task.FromResult<PreToolUseHookOutput?>(
+                        new PreToolUseHookOutput { PermissionDecision = "allow" }
+                    );
+                },
+            },
+        });
+    }
+}
+```
+<!-- /docs-validate: hidden -->
 ```csharp
 var session = await client.CreateSessionAsync(new SessionConfig
 {

--- a/docs/hooks/session-lifecycle.md
+++ b/docs/hooks/session-lifecycle.md
@@ -16,7 +16,15 @@ The `onSessionStart` hook is called when a session begins (new or resumed).
 <details open>
 <summary><strong>Node.js / TypeScript</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```ts
+import type { SessionStartHookInput, HookInvocation, SessionStartHookOutput } from "@github/copilot-sdk";
+type SessionStartHandler = (
+  input: SessionStartHookInput,
+  invocation: HookInvocation
+) => Promise<SessionStartHookOutput | null | undefined>;
+```
+<!-- /docs-validate: hidden -->
 ```typescript
 type SessionStartHandler = (
   input: SessionStartHookInput,
@@ -29,7 +37,17 @@ type SessionStartHandler = (
 <details>
 <summary><strong>Python</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```python
+from copilot.types import SessionStartHookInput, HookInvocation, SessionStartHookOutput
+from typing import Callable, Awaitable
+
+SessionStartHandler = Callable[
+    [SessionStartHookInput, HookInvocation],
+    Awaitable[SessionStartHookOutput | None]
+]
+```
+<!-- /docs-validate: hidden -->
 ```python
 SessionStartHandler = Callable[
     [SessionStartHookInput, HookInvocation],
@@ -42,7 +60,20 @@ SessionStartHandler = Callable[
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import copilot "github.com/github/copilot-sdk/go"
+
+type SessionStartHandler func(
+    input copilot.SessionStartHookInput,
+    invocation copilot.HookInvocation,
+) (*copilot.SessionStartHookOutput, error)
+
+func main() {}
+```
+<!-- /docs-validate: hidden -->
 ```go
 type SessionStartHandler func(
     input SessionStartHookInput,
@@ -55,7 +86,15 @@ type SessionStartHandler func(
 <details>
 <summary><strong>.NET</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public delegate Task<SessionStartHookOutput?> SessionStartHandler(
+    SessionStartHookInput input,
+    HookInvocation invocation);
+```
+<!-- /docs-validate: hidden -->
 ```csharp
 public delegate Task<SessionStartHookOutput?> SessionStartHandler(
     SessionStartHookInput input,
@@ -208,7 +247,17 @@ type SessionEndHandler = (
 <details>
 <summary><strong>Python</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```python
+from copilot.types import SessionEndHookInput, HookInvocation
+from typing import Callable, Awaitable
+
+SessionEndHandler = Callable[
+    [SessionEndHookInput, HookInvocation],
+    Awaitable[None]
+]
+```
+<!-- /docs-validate: hidden -->
 ```python
 SessionEndHandler = Callable[
     [SessionEndHookInput, HookInvocation],
@@ -221,7 +270,20 @@ SessionEndHandler = Callable[
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import copilot "github.com/github/copilot-sdk/go"
+
+type SessionEndHandler func(
+    input copilot.SessionEndHookInput,
+    invocation copilot.HookInvocation,
+) error
+
+func main() {}
+```
+<!-- /docs-validate: hidden -->
 ```go
 type SessionEndHandler func(
     input SessionEndHookInput,

--- a/docs/hooks/user-prompt-submitted.md
+++ b/docs/hooks/user-prompt-submitted.md
@@ -12,7 +12,15 @@ The `onUserPromptSubmitted` hook is called when a user submits a message. Use it
 <details open>
 <summary><strong>Node.js / TypeScript</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```ts
+import type { UserPromptSubmittedHookInput, HookInvocation, UserPromptSubmittedHookOutput } from "@github/copilot-sdk";
+type UserPromptSubmittedHandler = (
+  input: UserPromptSubmittedHookInput,
+  invocation: HookInvocation
+) => Promise<UserPromptSubmittedHookOutput | null | undefined>;
+```
+<!-- /docs-validate: hidden -->
 ```typescript
 type UserPromptSubmittedHandler = (
   input: UserPromptSubmittedHookInput,
@@ -25,7 +33,17 @@ type UserPromptSubmittedHandler = (
 <details>
 <summary><strong>Python</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```python
+from copilot.types import UserPromptSubmittedHookInput, HookInvocation, UserPromptSubmittedHookOutput
+from typing import Callable, Awaitable
+
+UserPromptSubmittedHandler = Callable[
+    [UserPromptSubmittedHookInput, HookInvocation],
+    Awaitable[UserPromptSubmittedHookOutput | None]
+]
+```
+<!-- /docs-validate: hidden -->
 ```python
 UserPromptSubmittedHandler = Callable[
     [UserPromptSubmittedHookInput, HookInvocation],
@@ -38,7 +56,20 @@ UserPromptSubmittedHandler = Callable[
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import copilot "github.com/github/copilot-sdk/go"
+
+type UserPromptSubmittedHandler func(
+    input copilot.UserPromptSubmittedHookInput,
+    invocation copilot.HookInvocation,
+) (*copilot.UserPromptSubmittedHookOutput, error)
+
+func main() {}
+```
+<!-- /docs-validate: hidden -->
 ```go
 type UserPromptSubmittedHandler func(
     input UserPromptSubmittedHookInput,
@@ -51,7 +82,15 @@ type UserPromptSubmittedHandler func(
 <details>
 <summary><strong>.NET</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public delegate Task<UserPromptSubmittedHookOutput?> UserPromptSubmittedHandler(
+    UserPromptSubmittedHookInput input,
+    HookInvocation invocation);
+```
+<!-- /docs-validate: hidden -->
 ```csharp
 public delegate Task<UserPromptSubmittedHookOutput?> UserPromptSubmittedHandler(
     UserPromptSubmittedHookInput input,
@@ -116,7 +155,31 @@ session = await client.create_session({
 <details>
 <summary><strong>Go</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func main() {
+	client := copilot.NewClient(nil)
+	session, _ := client.CreateSession(context.Background(), &copilot.SessionConfig{
+		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+		Hooks: &copilot.SessionHooks{
+			OnUserPromptSubmitted: func(input copilot.UserPromptSubmittedHookInput, inv copilot.HookInvocation) (*copilot.UserPromptSubmittedHookOutput, error) {
+				fmt.Printf("[%s] User: %s\n", inv.SessionID, input.Prompt)
+				return nil, nil
+			},
+		},
+	})
+	_ = session
+}
+```
+<!-- /docs-validate: hidden -->
 ```go
 session, _ := client.CreateSession(context.Background(), &copilot.SessionConfig{
     Hooks: &copilot.SessionHooks{
@@ -133,7 +196,30 @@ session, _ := client.CreateSession(context.Background(), &copilot.SessionConfig{
 <details>
 <summary><strong>.NET</strong></summary>
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public static class UserPromptSubmittedExample
+{
+    public static async Task Main()
+    {
+        await using var client = new CopilotClient();
+        var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            Hooks = new SessionHooks
+            {
+                OnUserPromptSubmitted = (input, invocation) =>
+                {
+                    Console.WriteLine($"[{invocation.SessionId}] User: {input.Prompt}");
+                    return Task.FromResult<UserPromptSubmittedHookOutput?>(null);
+                },
+            },
+        });
+    }
+}
+```
+<!-- /docs-validate: hidden -->
 ```csharp
 var session = await client.CreateSessionAsync(new SessionConfig
 {

--- a/docs/mcp/debugging.md
+++ b/docs/mcp/debugging.md
@@ -242,7 +242,37 @@ cd /expected/working/dir
 
 #### .NET Console Apps / Tools
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public static class McpDotnetConfigExample
+{
+    public static void Main()
+    {
+        var servers = new Dictionary<string, McpLocalServerConfig>
+        {
+            ["my-dotnet-server"] = new McpLocalServerConfig
+            {
+                Type = "local",
+                Command = @"C:\Tools\MyServer\MyServer.exe",
+                Args = new List<string>(),
+                Cwd = @"C:\Tools\MyServer",
+                Tools = new List<string> { "*" },
+            },
+            ["my-dotnet-tool"] = new McpLocalServerConfig
+            {
+                Type = "local",
+                Command = "dotnet",
+                Args = new List<string> { @"C:\Tools\MyTool\MyTool.dll" },
+                Cwd = @"C:\Tools\MyTool",
+                Tools = new List<string> { "*" },
+            }
+        };
+    }
+}
+```
+<!-- /docs-validate: hidden -->
 ```csharp
 // Correct configuration for .NET exe
 ["my-dotnet-server"] = new McpLocalServerConfig
@@ -267,7 +297,28 @@ cd /expected/working/dir
 
 #### NPX Commands
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot.SDK;
+
+public static class McpNpxConfigExample
+{
+    public static void Main()
+    {
+        var servers = new Dictionary<string, McpLocalServerConfig>
+        {
+            ["filesystem"] = new McpLocalServerConfig
+            {
+                Type = "local",
+                Command = "cmd",
+                Args = new List<string> { "/c", "npx", "-y", "@modelcontextprotocol/server-filesystem", "C:\\allowed\\path" },
+                Tools = new List<string> { "*" },
+            }
+        };
+    }
+}
+```
+<!-- /docs-validate: hidden -->
 ```csharp
 // Windows needs cmd /c for npx
 ["filesystem"] = new McpLocalServerConfig
@@ -304,7 +355,19 @@ xattr -d com.apple.quarantine /path/to/mcp-server
 
 #### Homebrew Paths
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```typescript
+import { MCPLocalServerConfig } from "@github/copilot-sdk";
+
+const mcpServers: Record<string, MCPLocalServerConfig> = {
+  "my-server": {
+    command: "/opt/homebrew/bin/node",
+    args: ["/path/to/server.js"],
+    tools: ["*"],
+  },
+};
+```
+<!-- /docs-validate: hidden -->
 ```typescript
 // GUI apps may not have /opt/homebrew in PATH
 mcpServers: {

--- a/docs/opentelemetry-instrumentation.md
+++ b/docs/opentelemetry-instrumentation.md
@@ -165,7 +165,18 @@ await session.send({"prompt": "Hello"})
 ```
 
 **Event Data Structure:**
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```python
+from dataclasses import dataclass
+
+@dataclass
+class Usage:
+    input_tokens: float
+    output_tokens: float
+    cache_read_tokens: float
+    cache_write_tokens: float
+```
+<!-- /docs-validate: hidden -->
 ```python
 @dataclass
 class Usage:
@@ -431,7 +442,21 @@ export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
 
 ### Checking at Runtime
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```python
+import os
+from typing import Any
+
+span: Any = None
+event: Any = None
+
+def should_record_content():
+    return os.getenv("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "false").lower() == "true"
+
+if should_record_content() and event.data.content:
+    span.add_event("gen_ai.output.messages", ...)
+```
+<!-- /docs-validate: hidden -->
 ```python
 import os
 
@@ -447,7 +472,23 @@ if should_record_content() and event.data.content:
 
 For MCP-based tools, add these additional attributes following the [OpenTelemetry MCP semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/):
 
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```python
+from typing import Any
+
+data: Any = None
+session: Any = None
+
+tool_attrs = {
+    "mcp.method.name": "tools/call",
+    "mcp.server.name": data.mcp_server_name,
+    "mcp.session.id": session.session_id,
+    "gen_ai.tool.name": data.mcp_tool_name,
+    "gen_ai.operation.name": "execute_tool",
+    "network.transport": "pipe",
+}
+```
+<!-- /docs-validate: hidden -->
 ```python
 tool_attrs = {
     # Required
@@ -552,7 +593,16 @@ View traces in the Azure Portal under your Application Insights resource → Tra
 ### Tool spans not showing as children
 
 Make sure to attach the tool span to the parent context:
-<!-- docs-validate: skip -->
+<!-- docs-validate: hidden -->
+```python
+from opentelemetry import trace, context
+from opentelemetry.trace import SpanKind
+
+tracer = trace.get_tracer(__name__)
+tool_span = tracer.start_span("test", kind=SpanKind.CLIENT)
+tool_token = context.attach(trace.set_span_in_context(tool_span))
+```
+<!-- /docs-validate: hidden -->
 ```python
 tool_token = context.attach(trace.set_span_in_context(tool_span))
 ```


### PR DESCRIPTION
## Summary


## Changes across 22 markdown files

| Category | Skips removed |
|----------|--------------|
| Hook type signatures (5 files × 4 langs) | 20 |
| Hook Go/C# implementations (4 files) | 10 |
| Guide Go/C#/Py snippets (8 files) | 21 |
| Setup/auth snippets (7 files) | 11 |
| OpenTelemetry Python (1 file) | 4 |
| Misc snippets (2 files) | 4 |
| **Total removed** | **72** |

## Remaining 14 skips

All due to external package dependencies not available to the validator:
- `Microsoft.Agents.AI` (10 — MAF guide)
- `@azure/identity` / `Azure.Identity` (2 — Azure managed identity guide)
- `aiofiles` (1 — hooks guide)
- `Microsoft.Extensions.Logging` (1 — debugging guide)

## Validation

All 305 extracted code blocks pass: TypeScript (160), Python (62), Go (41), C# (42).