### PR TITLE
Emit XML doc comments from schema descriptions in C# codegen

### DIFF
--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -5,245 +5,281 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 // Generated from: api.schema.json
 
-// Generated code does not have XML doc comments; suppress CS1591 to avoid warnings.
-#pragma warning disable CS1591
-
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using StreamJsonRpc;
 
 namespace GitHub.Copilot.SDK.Rpc;
 
+/// <summary>RPC data type for Ping operations.</summary>
 public class PingResult
 {
-    /// <summary>Echoed message (or default greeting)</summary>
+    /// <summary>Echoed message (or default greeting).</summary>
     [JsonPropertyName("message")]
     public string Message { get; set; } = string.Empty;
 
-    /// <summary>Server timestamp in milliseconds</summary>
+    /// <summary>Server timestamp in milliseconds.</summary>
     [JsonPropertyName("timestamp")]
     public double Timestamp { get; set; }
 
-    /// <summary>Server protocol version number</summary>
+    /// <summary>Server protocol version number.</summary>
     [JsonPropertyName("protocolVersion")]
     public double ProtocolVersion { get; set; }
 }
 
+/// <summary>RPC data type for Ping operations.</summary>
 internal class PingRequest
 {
+    /// <summary>Optional message to echo back.</summary>
     [JsonPropertyName("message")]
     public string? Message { get; set; }
 }
 
+/// <summary>RPC data type for ModelCapabilitiesSupports operations.</summary>
 public class ModelCapabilitiesSupports
 {
+    /// <summary>Gets or sets the <c>vision</c> value.</summary>
     [JsonPropertyName("vision")]
     public bool? Vision { get; set; }
 
-    /// <summary>Whether this model supports reasoning effort configuration</summary>
+    /// <summary>Whether this model supports reasoning effort configuration.</summary>
     [JsonPropertyName("reasoningEffort")]
     public bool? ReasoningEffort { get; set; }
 }
 
+/// <summary>RPC data type for ModelCapabilitiesLimits operations.</summary>
 public class ModelCapabilitiesLimits
 {
+    /// <summary>Gets or sets the <c>max_prompt_tokens</c> value.</summary>
     [JsonPropertyName("max_prompt_tokens")]
     public double? MaxPromptTokens { get; set; }
 
+    /// <summary>Gets or sets the <c>max_output_tokens</c> value.</summary>
     [JsonPropertyName("max_output_tokens")]
     public double? MaxOutputTokens { get; set; }
 
+    /// <summary>Gets or sets the <c>max_context_window_tokens</c> value.</summary>
     [JsonPropertyName("max_context_window_tokens")]
     public double MaxContextWindowTokens { get; set; }
 }
 
-/// <summary>Model capabilities and limits</summary>
+/// <summary>Model capabilities and limits.</summary>
 public class ModelCapabilities
 {
+    /// <summary>Gets or sets the <c>supports</c> value.</summary>
     [JsonPropertyName("supports")]
     public ModelCapabilitiesSupports Supports { get; set; } = new();
 
+    /// <summary>Gets or sets the <c>limits</c> value.</summary>
     [JsonPropertyName("limits")]
     public ModelCapabilitiesLimits Limits { get; set; } = new();
 }
 
-/// <summary>Policy state (if applicable)</summary>
+/// <summary>Policy state (if applicable).</summary>
 public class ModelPolicy
 {
+    /// <summary>Gets or sets the <c>state</c> value.</summary>
     [JsonPropertyName("state")]
     public string State { get; set; } = string.Empty;
 
+    /// <summary>Gets or sets the <c>terms</c> value.</summary>
     [JsonPropertyName("terms")]
     public string Terms { get; set; } = string.Empty;
 }
 
-/// <summary>Billing information</summary>
+/// <summary>Billing information.</summary>
 public class ModelBilling
 {
+    /// <summary>Gets or sets the <c>multiplier</c> value.</summary>
     [JsonPropertyName("multiplier")]
     public double Multiplier { get; set; }
 }
 
+/// <summary>RPC data type for Model operations.</summary>
 public class Model
 {
-    /// <summary>Model identifier (e.g., "claude-sonnet-4.5")</summary>
+    /// <summary>Model identifier (e.g., "claude-sonnet-4.5").</summary>
     [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
 
-    /// <summary>Display name</summary>
+    /// <summary>Display name.</summary>
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
-    /// <summary>Model capabilities and limits</summary>
+    /// <summary>Model capabilities and limits.</summary>
     [JsonPropertyName("capabilities")]
     public ModelCapabilities Capabilities { get; set; } = new();
 
-    /// <summary>Policy state (if applicable)</summary>
+    /// <summary>Policy state (if applicable).</summary>
     [JsonPropertyName("policy")]
     public ModelPolicy? Policy { get; set; }
 
-    /// <summary>Billing information</summary>
+    /// <summary>Billing information.</summary>
     [JsonPropertyName("billing")]
     public ModelBilling? Billing { get; set; }
 
-    /// <summary>Supported reasoning effort levels (only present if model supports reasoning effort)</summary>
+    /// <summary>Supported reasoning effort levels (only present if model supports reasoning effort).</summary>
     [JsonPropertyName("supportedReasoningEfforts")]
     public List<string>? SupportedReasoningEfforts { get; set; }
 
-    /// <summary>Default reasoning effort level (only present if model supports reasoning effort)</summary>
+    /// <summary>Default reasoning effort level (only present if model supports reasoning effort).</summary>
     [JsonPropertyName("defaultReasoningEffort")]
     public string? DefaultReasoningEffort { get; set; }
 }
 
+/// <summary>RPC data type for ModelsList operations.</summary>
 public class ModelsListResult
 {
-    /// <summary>List of available models with full metadata</summary>
+    /// <summary>List of available models with full metadata.</summary>
     [JsonPropertyName("models")]
     public List<Model> Models { get; set; } = [];
 }
 
+/// <summary>RPC data type for Tool operations.</summary>
 public class Tool
 {
-    /// <summary>Tool identifier (e.g., "bash", "grep", "str_replace_editor")</summary>
+    /// <summary>Tool identifier (e.g., "bash", "grep", "str_replace_editor").</summary>
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
-    /// <summary>Optional namespaced name for declarative filtering (e.g., "playwright/navigate" for MCP tools)</summary>
+    /// <summary>Optional namespaced name for declarative filtering (e.g., "playwright/navigate" for MCP tools).</summary>
     [JsonPropertyName("namespacedName")]
     public string? NamespacedName { get; set; }
 
-    /// <summary>Description of what the tool does</summary>
+    /// <summary>Description of what the tool does.</summary>
     [JsonPropertyName("description")]
     public string Description { get; set; } = string.Empty;
 
-    /// <summary>JSON Schema for the tool's input parameters</summary>
+    /// <summary>JSON Schema for the tool's input parameters.</summary>
     [JsonPropertyName("parameters")]
     public Dictionary<string, object>? Parameters { get; set; }
 
-    /// <summary>Optional instructions for how to use this tool effectively</summary>
+    /// <summary>Optional instructions for how to use this tool effectively.</summary>
     [JsonPropertyName("instructions")]
     public string? Instructions { get; set; }
 }
 
+/// <summary>RPC data type for ToolsList operations.</summary>
 public class ToolsListResult
 {
-    /// <summary>List of available built-in tools with metadata</summary>
+    /// <summary>List of available built-in tools with metadata.</summary>
     [JsonPropertyName("tools")]
     public List<Tool> Tools { get; set; } = [];
 }
 
+/// <summary>RPC data type for ToolsList operations.</summary>
 internal class ToolsListRequest
 {
+    /// <summary>Optional model ID — when provided, the returned tool list reflects model-specific overrides.</summary>
     [JsonPropertyName("model")]
     public string? Model { get; set; }
 }
 
+/// <summary>RPC data type for AccountGetQuotaResultQuotaSnapshotsValue operations.</summary>
 public class AccountGetQuotaResultQuotaSnapshotsValue
 {
-    /// <summary>Number of requests included in the entitlement</summary>
+    /// <summary>Number of requests included in the entitlement.</summary>
     [JsonPropertyName("entitlementRequests")]
     public double EntitlementRequests { get; set; }
 
-    /// <summary>Number of requests used so far this period</summary>
+    /// <summary>Number of requests used so far this period.</summary>
     [JsonPropertyName("usedRequests")]
     public double UsedRequests { get; set; }
 
-    /// <summary>Percentage of entitlement remaining</summary>
+    /// <summary>Percentage of entitlement remaining.</summary>
     [JsonPropertyName("remainingPercentage")]
     public double RemainingPercentage { get; set; }
 
-    /// <summary>Number of overage requests made this period</summary>
+    /// <summary>Number of overage requests made this period.</summary>
     [JsonPropertyName("overage")]
     public double Overage { get; set; }
 
-    /// <summary>Whether pay-per-request usage is allowed when quota is exhausted</summary>
+    /// <summary>Whether pay-per-request usage is allowed when quota is exhausted.</summary>
     [JsonPropertyName("overageAllowedWithExhaustedQuota")]
     public bool OverageAllowedWithExhaustedQuota { get; set; }
 
-    /// <summary>Date when the quota resets (ISO 8601)</summary>
+    /// <summary>Date when the quota resets (ISO 8601).</summary>
     [JsonPropertyName("resetDate")]
     public string? ResetDate { get; set; }
 }
 
+/// <summary>RPC data type for AccountGetQuota operations.</summary>
 public class AccountGetQuotaResult
 {
-    /// <summary>Quota snapshots keyed by type (e.g., chat, completions, premium_interactions)</summary>
+    /// <summary>Quota snapshots keyed by type (e.g., chat, completions, premium_interactions).</summary>
     [JsonPropertyName("quotaSnapshots")]
     public Dictionary<string, AccountGetQuotaResultQuotaSnapshotsValue> QuotaSnapshots { get; set; } = [];
 }
 
+/// <summary>RPC data type for SessionLog operations.</summary>
 public class SessionLogResult
 {
-    /// <summary>The unique identifier of the emitted session event</summary>
+    /// <summary>The unique identifier of the emitted session event.</summary>
     [JsonPropertyName("eventId")]
     public Guid EventId { get; set; }
 }
 
+/// <summary>RPC data type for SessionLog operations.</summary>
 internal class SessionLogRequest
 {
+    /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 
+    /// <summary>Human-readable message.</summary>
     [JsonPropertyName("message")]
     public string Message { get; set; } = string.Empty;
 
+    /// <summary>Log severity level. Determines how the message is displayed in the timeline. Defaults to "info".</summary>
     [JsonPropertyName("level")]
     public SessionLogRequestLevel? Level { get; set; }
 
+    /// <summary>When true, the message is transient and not persisted to the session event log on disk.</summary>
     [JsonPropertyName("ephemeral")]
     public bool? Ephemeral { get; set; }
 }
 
+/// <summary>RPC data type for SessionModelGetCurrent operations.</summary>
 public class SessionModelGetCurrentResult
 {
+    /// <summary>Gets or sets the <c>modelId</c> value.</summary>
     [JsonPropertyName("modelId")]
     public string? ModelId { get; set; }
 }
 
+/// <summary>RPC data type for SessionModelGetCurrent operations.</summary>
 internal class SessionModelGetCurrentRequest
 {
+    /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 }
 
+/// <summary>RPC data type for SessionModelSwitchTo operations.</summary>
 public class SessionModelSwitchToResult
 {
+    /// <summary>Gets or sets the <c>modelId</c> value.</summary>
     [JsonPropertyName("modelId")]
     public string? ModelId { get; set; }
 }
 
+/// <summary>RPC data type for SessionModelSwitchTo operations.</summary>
 internal class SessionModelSwitchToRequest
 {
+    /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 
+    /// <summary>Gets or sets the <c>modelId</c> value.</summary>
     [JsonPropertyName("modelId")]
     public string ModelId { get; set; } = string.Empty;
 
+    /// <summary>Gets or sets the <c>reasoningEffort</c> value.</summary>
     [JsonPropertyName("reasoningEffort")]
     public SessionModelSwitchToRequestReasoningEffort? ReasoningEffort { get; set; }
 }
 
+/// <summary>RPC data type for SessionModeGet operations.</summary>
 public class SessionModeGetResult
 {
     /// <summary>The current agent mode.</summary>
@@ -251,12 +287,15 @@ public class SessionModeGetResult
     public SessionModeGetResultMode Mode { get; set; }
 }
 
+/// <summary>RPC data type for SessionModeGet operations.</summary>
 internal class SessionModeGetRequest
 {
+    /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 }
 
+/// <summary>RPC data type for SessionModeSet operations.</summary>
 public class SessionModeSetResult
 {
     /// <summary>The agent mode after switching.</summary>
@@ -264,317 +303,390 @@ public class SessionModeSetResult
     public SessionModeGetResultMode Mode { get; set; }
 }
 
+/// <summary>RPC data type for SessionModeSet operations.</summary>
 internal class SessionModeSetRequest
 {
+    /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 
+    /// <summary>The mode to switch to. Valid values: "interactive", "plan", "autopilot".</summary>
     [JsonPropertyName("mode")]
     public SessionModeGetResultMode Mode { get; set; }
 }
 
+/// <summary>RPC data type for SessionPlanRead operations.</summary>
 public class SessionPlanReadResult
 {
-    /// <summary>Whether the plan file exists in the workspace</summary>
+    /// <summary>Whether the plan file exists in the workspace.</summary>
     [JsonPropertyName("exists")]
     public bool Exists { get; set; }
 
-    /// <summary>The content of the plan file, or null if it does not exist</summary>
+    /// <summary>The content of the plan file, or null if it does not exist.</summary>
     [JsonPropertyName("content")]
     public string? Content { get; set; }
 
-    /// <summary>Absolute file path of the plan file, or null if workspace is not enabled</summary>
+    /// <summary>Absolute file path of the plan file, or null if workspace is not enabled.</summary>
     [JsonPropertyName("path")]
     public string? Path { get; set; }
 }
 
+/// <summary>RPC data type for SessionPlanRead operations.</summary>
 internal class SessionPlanReadRequest
 {
+    /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 }
 
+/// <summary>RPC data type for SessionPlanUpdate operations.</summary>
 public class SessionPlanUpdateResult
 {
 }
 
+/// <summary>RPC data type for SessionPlanUpdate operations.</summary>
 internal class SessionPlanUpdateRequest
 {
+    /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 
+    /// <summary>The new content for the plan file.</summary>
     [JsonPropertyName("content")]
     public string Content { get; set; } = string.Empty;
 }
 
+/// <summary>RPC data type for SessionPlanDelete operations.</summary>
 public class SessionPlanDeleteResult
 {
 }
 
+/// <summary>RPC data type for SessionPlanDelete operations.</summary>
 internal class SessionPlanDeleteRequest
 {
+    /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 }
 
+/// <summary>RPC data type for SessionWorkspaceListFiles operations.</summary>
 public class SessionWorkspaceListFilesResult
 {
-    /// <summary>Relative file paths in the workspace files directory</summary>
+    /// <summary>Relative file paths in the workspace files directory.</summary>
     [JsonPropertyName("files")]
     public List<string> Files { get; set; } = [];
 }
 
+/// <summary>RPC data type for SessionWorkspaceListFiles operations.</summary>
 internal class SessionWorkspaceListFilesRequest
 {
+    /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 }
 
+/// <summary>RPC data type for SessionWorkspaceReadFile operations.</summary>
 public class SessionWorkspaceReadFileResult
 {
-    /// <summary>File content as a UTF-8 string</summary>
+    /// <summary>File content as a UTF-8 string.</summary>
     [JsonPropertyName("content")]
     public string Content { get; set; } = string.Empty;
 }
 
+/// <summary>RPC data type for SessionWorkspaceReadFile operations.</summary>
 internal class SessionWorkspaceReadFileRequest
 {
+    /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 
+    /// <summary>Relative path within the workspace files directory.</summary>
     [JsonPropertyName("path")]
     public string Path { get; set; } = string.Empty;
 }
 
+/// <summary>RPC data type for SessionWorkspaceCreateFile operations.</summary>
 public class SessionWorkspaceCreateFileResult
 {
 }
 
+/// <summary>RPC data type for SessionWorkspaceCreateFile operations.</summary>
 internal class SessionWorkspaceCreateFileRequest
 {
+    /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 
+    /// <summary>Relative path within the workspace files directory.</summary>
     [JsonPropertyName("path")]
     public string Path { get; set; } = string.Empty;
 
+    /// <summary>File content to write as a UTF-8 string.</summary>
     [JsonPropertyName("content")]
     public string Content { get; set; } = string.Empty;
 }
 
+/// <summary>RPC data type for SessionFleetStart operations.</summary>
 public class SessionFleetStartResult
 {
-    /// <summary>Whether fleet mode was successfully activated</summary>
+    /// <summary>Whether fleet mode was successfully activated.</summary>
     [JsonPropertyName("started")]
     public bool Started { get; set; }
 }
 
+/// <summary>RPC data type for SessionFleetStart operations.</summary>
 internal class SessionFleetStartRequest
 {
+    /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 
+    /// <summary>Optional user prompt to combine with fleet instructions.</summary>
     [JsonPropertyName("prompt")]
     public string? Prompt { get; set; }
 }
 
+/// <summary>RPC data type for Agent operations.</summary>
 public class Agent
 {
-    /// <summary>Unique identifier of the custom agent</summary>
+    /// <summary>Unique identifier of the custom agent.</summary>
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
-    /// <summary>Human-readable display name</summary>
+    /// <summary>Human-readable display name.</summary>
     [JsonPropertyName("displayName")]
     public string DisplayName { get; set; } = string.Empty;
 
-    /// <summary>Description of the agent's purpose</summary>
+    /// <summary>Description of the agent's purpose.</summary>
     [JsonPropertyName("description")]
     public string Description { get; set; } = string.Empty;
 }
 
+/// <summary>RPC data type for SessionAgentList operations.</summary>
 public class SessionAgentListResult
 {
-    /// <summary>Available custom agents</summary>
+    /// <summary>Available custom agents.</summary>
     [JsonPropertyName("agents")]
     public List<Agent> Agents { get; set; } = [];
 }
 
+/// <summary>RPC data type for SessionAgentList operations.</summary>
 internal class SessionAgentListRequest
 {
+    /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 }
 
+/// <summary>RPC data type for SessionAgentGetCurrentResultAgent operations.</summary>
 public class SessionAgentGetCurrentResultAgent
 {
-    /// <summary>Unique identifier of the custom agent</summary>
+    /// <summary>Unique identifier of the custom agent.</summary>
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
-    /// <summary>Human-readable display name</summary>
+    /// <summary>Human-readable display name.</summary>
     [JsonPropertyName("displayName")]
     public string DisplayName { get; set; } = string.Empty;
 
-    /// <summary>Description of the agent's purpose</summary>
+    /// <summary>Description of the agent's purpose.</summary>
     [JsonPropertyName("description")]
     public string Description { get; set; } = string.Empty;
 }
 
+/// <summary>RPC data type for SessionAgentGetCurrent operations.</summary>
 public class SessionAgentGetCurrentResult
 {
-    /// <summary>Currently selected custom agent, or null if using the default agent</summary>
+    /// <summary>Currently selected custom agent, or null if using the default agent.</summary>
     [JsonPropertyName("agent")]
     public SessionAgentGetCurrentResultAgent? Agent { get; set; }
 }
 
+/// <summary>RPC data type for SessionAgentGetCurrent operations.</summary>
 internal class SessionAgentGetCurrentRequest
 {
+    /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 }
 
-/// <summary>The newly selected custom agent</summary>
+/// <summary>The newly selected custom agent.</summary>
 public class SessionAgentSelectResultAgent
 {
-    /// <summary>Unique identifier of the custom agent</summary>
+    /// <summary>Unique identifier of the custom agent.</summary>
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
-    /// <summary>Human-readable display name</summary>
+    /// <summary>Human-readable display name.</summary>
     [JsonPropertyName("displayName")]
     public string DisplayName { get; set; } = string.Empty;
 
-    /// <summary>Description of the agent's purpose</summary>
+    /// <summary>Description of the agent's purpose.</summary>
     [JsonPropertyName("description")]
     public string Description { get; set; } = string.Empty;
 }
 
+/// <summary>RPC data type for SessionAgentSelect operations.</summary>
 public class SessionAgentSelectResult
 {
-    /// <summary>The newly selected custom agent</summary>
+    /// <summary>The newly selected custom agent.</summary>
     [JsonPropertyName("agent")]
     public SessionAgentSelectResultAgent Agent { get; set; } = new();
 }
 
+/// <summary>RPC data type for SessionAgentSelect operations.</summary>
 internal class SessionAgentSelectRequest
 {
+    /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 
+    /// <summary>Name of the custom agent to select.</summary>
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 }
 
+/// <summary>RPC data type for SessionAgentDeselect operations.</summary>
 public class SessionAgentDeselectResult
 {
 }
 
+/// <summary>RPC data type for SessionAgentDeselect operations.</summary>
 internal class SessionAgentDeselectRequest
 {
+    /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 }
 
+/// <summary>RPC data type for SessionCompactionCompact operations.</summary>
 public class SessionCompactionCompactResult
 {
-    /// <summary>Whether compaction completed successfully</summary>
+    /// <summary>Whether compaction completed successfully.</summary>
     [JsonPropertyName("success")]
     public bool Success { get; set; }
 
-    /// <summary>Number of tokens freed by compaction</summary>
+    /// <summary>Number of tokens freed by compaction.</summary>
     [JsonPropertyName("tokensRemoved")]
     public double TokensRemoved { get; set; }
 
-    /// <summary>Number of messages removed during compaction</summary>
+    /// <summary>Number of messages removed during compaction.</summary>
     [JsonPropertyName("messagesRemoved")]
     public double MessagesRemoved { get; set; }
 }
 
+/// <summary>RPC data type for SessionCompactionCompact operations.</summary>
 internal class SessionCompactionCompactRequest
 {
+    /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 }
 
+/// <summary>RPC data type for SessionToolsHandlePendingToolCall operations.</summary>
 public class SessionToolsHandlePendingToolCallResult
 {
+    /// <summary>Gets or sets the <c>success</c> value.</summary>
     [JsonPropertyName("success")]
     public bool Success { get; set; }
 }
 
+/// <summary>RPC data type for SessionToolsHandlePendingToolCall operations.</summary>
 internal class SessionToolsHandlePendingToolCallRequest
 {
+    /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 
+    /// <summary>Gets or sets the <c>requestId</c> value.</summary>
     [JsonPropertyName("requestId")]
     public string RequestId { get; set; } = string.Empty;
 
+    /// <summary>Gets or sets the <c>result</c> value.</summary>
     [JsonPropertyName("result")]
     public object? Result { get; set; }
 
+    /// <summary>Gets or sets the <c>error</c> value.</summary>
     [JsonPropertyName("error")]
     public string? Error { get; set; }
 }
 
+/// <summary>RPC data type for SessionPermissionsHandlePendingPermissionRequest operations.</summary>
 public class SessionPermissionsHandlePendingPermissionRequestResult
 {
+    /// <summary>Gets or sets the <c>success</c> value.</summary>
     [JsonPropertyName("success")]
     public bool Success { get; set; }
 }
 
+/// <summary>RPC data type for SessionPermissionsHandlePendingPermissionRequest operations.</summary>
 internal class SessionPermissionsHandlePendingPermissionRequestRequest
 {
+    /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 
+    /// <summary>Gets or sets the <c>requestId</c> value.</summary>
     [JsonPropertyName("requestId")]
     public string RequestId { get; set; } = string.Empty;
 
+    /// <summary>Gets or sets the <c>result</c> value.</summary>
     [JsonPropertyName("result")]
     public object Result { get; set; } = null!;
 }
 
+/// <summary>Log severity level. Determines how the message is displayed in the timeline. Defaults to "info".</summary>
 [JsonConverter(typeof(JsonStringEnumConverter<SessionLogRequestLevel>))]
 public enum SessionLogRequestLevel
 {
+    /// <summary>The <c>info</c> variant.</summary>
     [JsonStringEnumMemberName("info")]
     Info,
+    /// <summary>The <c>warning</c> variant.</summary>
     [JsonStringEnumMemberName("warning")]
     Warning,
+    /// <summary>The <c>error</c> variant.</summary>
     [JsonStringEnumMemberName("error")]
     Error,
 }
 
 
+/// <summary>Defines the allowed values.</summary>
 [JsonConverter(typeof(JsonStringEnumConverter<SessionModelSwitchToRequestReasoningEffort>))]
 public enum SessionModelSwitchToRequestReasoningEffort
 {
+    /// <summary>The <c>low</c> variant.</summary>
     [JsonStringEnumMemberName("low")]
     Low,
+    /// <summary>The <c>medium</c> variant.</summary>
     [JsonStringEnumMemberName("medium")]
     Medium,
+    /// <summary>The <c>high</c> variant.</summary>
     [JsonStringEnumMemberName("high")]
     High,
+    /// <summary>The <c>xhigh</c> variant.</summary>
     [JsonStringEnumMemberName("xhigh")]
     Xhigh,
 }
 
 
+/// <summary>The current agent mode.</summary>
 [JsonConverter(typeof(JsonStringEnumConverter<SessionModeGetResultMode>))]
 public enum SessionModeGetResultMode
 {
+    /// <summary>The <c>interactive</c> variant.</summary>
     [JsonStringEnumMemberName("interactive")]
     Interactive,
+    /// <summary>The <c>plan</c> variant.</summary>
     [JsonStringEnumMemberName("plan")]
     Plan,
+    /// <summary>The <c>autopilot</c> variant.</summary>
     [JsonStringEnumMemberName("autopilot")]
     Autopilot,
 }
 
 
-/// <summary>Typed server-scoped RPC methods (no session required).</summary>
+/// <summary>Provides server-scoped RPC methods (no session required).</summary>
 public class ServerRpc
 {
     private readonly JsonRpc _rpc;
@@ -604,7 +716,7 @@ public class ServerRpc
     public ServerAccountApi Account { get; }
 }
 
-/// <summary>Server-scoped Models APIs.</summary>
+/// <summary>Provides server-scoped Models APIs.</summary>
 public class ServerModelsApi
 {
     private readonly JsonRpc _rpc;
@@ -621,7 +733,7 @@ public class ServerModelsApi
     }
 }
 
-/// <summary>Server-scoped Tools APIs.</summary>
+/// <summary>Provides server-scoped Tools APIs.</summary>
 public class ServerToolsApi
 {
     private readonly JsonRpc _rpc;
@@ -639,7 +751,7 @@ public class ServerToolsApi
     }
 }
 
-/// <summary>Server-scoped Account APIs.</summary>
+/// <summary>Provides server-scoped Account APIs.</summary>
 public class ServerAccountApi
 {
     private readonly JsonRpc _rpc;
@@ -656,7 +768,7 @@ public class ServerAccountApi
     }
 }
 
-/// <summary>Typed session-scoped RPC methods.</summary>
+/// <summary>Provides typed session-scoped RPC methods.</summary>
 public class SessionRpc
 {
     private readonly JsonRpc _rpc;
@@ -677,22 +789,31 @@ public class SessionRpc
         Permissions = new PermissionsApi(rpc, sessionId);
     }
 
+    /// <summary>Model APIs.</summary>
     public ModelApi Model { get; }
 
+    /// <summary>Mode APIs.</summary>
     public ModeApi Mode { get; }
 
+    /// <summary>Plan APIs.</summary>
     public PlanApi Plan { get; }
 
+    /// <summary>Workspace APIs.</summary>
     public WorkspaceApi Workspace { get; }
 
+    /// <summary>Fleet APIs.</summary>
     public FleetApi Fleet { get; }
 
+    /// <summary>Agent APIs.</summary>
     public AgentApi Agent { get; }
 
+    /// <summary>Compaction APIs.</summary>
     public CompactionApi Compaction { get; }
 
+    /// <summary>Tools APIs.</summary>
     public ToolsApi Tools { get; }
 
+    /// <summary>Permissions APIs.</summary>
     public PermissionsApi Permissions { get; }
 
     /// <summary>Calls "session.log".</summary>
@@ -703,6 +824,7 @@ public class SessionRpc
     }
 }
 
+/// <summary>Provides session-scoped Model APIs.</summary>
 public class ModelApi
 {
     private readonly JsonRpc _rpc;
@@ -729,6 +851,7 @@ public class ModelApi
     }
 }
 
+/// <summary>Provides session-scoped Mode APIs.</summary>
 public class ModeApi
 {
     private readonly JsonRpc _rpc;
@@ -755,6 +878,7 @@ public class ModeApi
     }
 }
 
+/// <summary>Provides session-scoped Plan APIs.</summary>
 public class PlanApi
 {
     private readonly JsonRpc _rpc;
@@ -788,6 +912,7 @@ public class PlanApi
     }
 }
 
+/// <summary>Provides session-scoped Workspace APIs.</summary>
 public class WorkspaceApi
 {
     private readonly JsonRpc _rpc;
@@ -821,6 +946,7 @@ public class WorkspaceApi
     }
 }
 
+/// <summary>Provides session-scoped Fleet APIs.</summary>
 public class FleetApi
 {
     private readonly JsonRpc _rpc;
@@ -840,6 +966,7 @@ public class FleetApi
     }
 }
 
+/// <summary>Provides session-scoped Agent APIs.</summary>
 public class AgentApi
 {
     private readonly JsonRpc _rpc;
@@ -880,6 +1007,7 @@ public class AgentApi
     }
 }
 
+/// <summary>Provides session-scoped Compaction APIs.</summary>
 public class CompactionApi
 {
     private readonly JsonRpc _rpc;
@@ -899,6 +1027,7 @@ public class CompactionApi
     }
 }
 
+/// <summary>Provides session-scoped Tools APIs.</summary>
 public class ToolsApi
 {
     private readonly JsonRpc _rpc;
@@ -918,6 +1047,7 @@ public class ToolsApi
     }
 }
 
+/// <summary>Provides session-scoped Permissions APIs.</summary>
 public class PermissionsApi
 {
     private readonly JsonRpc _rpc;

--- a/dotnet/src/Generated/SessionEvents.cs
+++ b/dotnet/src/Generated/SessionEvents.cs
@@ -5,16 +5,13 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 // Generated from: session-events.schema.json
 
-// Generated code does not have XML doc comments; suppress CS1591 to avoid warnings.
-#pragma warning disable CS1591
-
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace GitHub.Copilot.SDK;
 
 /// <summary>
-/// Base class for all session events with polymorphic JSON serialization.
+/// Provides the base class from which all session events derive.
 /// </summary>
 [JsonPolymorphic(
     TypeDiscriminatorPropertyName = "type",
@@ -80,15 +77,19 @@ namespace GitHub.Copilot.SDK;
 [JsonDerivedType(typeof(UserMessageEvent), "user.message")]
 public abstract partial class SessionEvent
 {
+    /// <summary>Unique event identifier (UUID v4), generated when the event is emitted.</summary>
     [JsonPropertyName("id")]
     public Guid Id { get; set; }
 
+    /// <summary>ISO 8601 timestamp when the event was created.</summary>
     [JsonPropertyName("timestamp")]
     public DateTimeOffset Timestamp { get; set; }
 
+    /// <summary>ID of the chronologically preceding event in the session, forming a linked chain. Null for the first event.</summary>
     [JsonPropertyName("parentId")]
     public Guid? ParentId { get; set; }
 
+    /// <summary>When true, the event is transient and not persisted to the session event log on disk.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("ephemeral")]
     public bool? Ephemeral { get; set; }
@@ -99,1807 +100,2153 @@ public abstract partial class SessionEvent
     [JsonIgnore]
     public abstract string Type { get; }
 
+    /// <summary>Deserializes a JSON string into a <see cref="SessionEvent"/>.</summary>
     public static SessionEvent FromJson(string json) =>
         JsonSerializer.Deserialize(json, SessionEventsJsonContext.Default.SessionEvent)!;
 
+    /// <summary>Serializes this event to a JSON string.</summary>
     public string ToJson() =>
         JsonSerializer.Serialize(this, SessionEventsJsonContext.Default.SessionEvent);
 }
 
-/// <summary>
-/// Event: session.start
-/// </summary>
+/// <summary>Represents the <c>session.start</c> event.</summary>
 public partial class SessionStartEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.start";
 
+    /// <summary>The <c>session.start</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionStartData Data { get; set; }
 }
 
-/// <summary>
-/// Event: session.resume
-/// </summary>
+/// <summary>Represents the <c>session.resume</c> event.</summary>
 public partial class SessionResumeEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.resume";
 
+    /// <summary>The <c>session.resume</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionResumeData Data { get; set; }
 }
 
-/// <summary>
-/// Event: session.error
-/// </summary>
+/// <summary>Represents the <c>session.error</c> event.</summary>
 public partial class SessionErrorEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.error";
 
+    /// <summary>The <c>session.error</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionErrorData Data { get; set; }
 }
 
-/// <summary>
-/// Event: session.idle
-/// </summary>
+/// <summary>Payload indicating the agent is idle; includes any background tasks still in flight.</summary>
+/// <remarks>Represents the <c>session.idle</c> event.</remarks>
 public partial class SessionIdleEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.idle";
 
+    /// <summary>The <c>session.idle</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionIdleData Data { get; set; }
 }
 
-/// <summary>
-/// Event: session.title_changed
-/// </summary>
+/// <summary>Represents the <c>session.title_changed</c> event.</summary>
 public partial class SessionTitleChangedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.title_changed";
 
+    /// <summary>The <c>session.title_changed</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionTitleChangedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: session.info
-/// </summary>
+/// <summary>Represents the <c>session.info</c> event.</summary>
 public partial class SessionInfoEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.info";
 
+    /// <summary>The <c>session.info</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionInfoData Data { get; set; }
 }
 
-/// <summary>
-/// Event: session.warning
-/// </summary>
+/// <summary>Represents the <c>session.warning</c> event.</summary>
 public partial class SessionWarningEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.warning";
 
+    /// <summary>The <c>session.warning</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionWarningData Data { get; set; }
 }
 
-/// <summary>
-/// Event: session.model_change
-/// </summary>
+/// <summary>Represents the <c>session.model_change</c> event.</summary>
 public partial class SessionModelChangeEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.model_change";
 
+    /// <summary>The <c>session.model_change</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionModelChangeData Data { get; set; }
 }
 
-/// <summary>
-/// Event: session.mode_changed
-/// </summary>
+/// <summary>Represents the <c>session.mode_changed</c> event.</summary>
 public partial class SessionModeChangedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.mode_changed";
 
+    /// <summary>The <c>session.mode_changed</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionModeChangedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: session.plan_changed
-/// </summary>
+/// <summary>Represents the <c>session.plan_changed</c> event.</summary>
 public partial class SessionPlanChangedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.plan_changed";
 
+    /// <summary>The <c>session.plan_changed</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionPlanChangedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: session.workspace_file_changed
-/// </summary>
+/// <summary>Represents the <c>session.workspace_file_changed</c> event.</summary>
 public partial class SessionWorkspaceFileChangedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.workspace_file_changed";
 
+    /// <summary>The <c>session.workspace_file_changed</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionWorkspaceFileChangedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: session.handoff
-/// </summary>
+/// <summary>Represents the <c>session.handoff</c> event.</summary>
 public partial class SessionHandoffEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.handoff";
 
+    /// <summary>The <c>session.handoff</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionHandoffData Data { get; set; }
 }
 
-/// <summary>
-/// Event: session.truncation
-/// </summary>
+/// <summary>Represents the <c>session.truncation</c> event.</summary>
 public partial class SessionTruncationEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.truncation";
 
+    /// <summary>The <c>session.truncation</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionTruncationData Data { get; set; }
 }
 
-/// <summary>
-/// Event: session.snapshot_rewind
-/// </summary>
+/// <summary>Represents the <c>session.snapshot_rewind</c> event.</summary>
 public partial class SessionSnapshotRewindEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.snapshot_rewind";
 
+    /// <summary>The <c>session.snapshot_rewind</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionSnapshotRewindData Data { get; set; }
 }
 
-/// <summary>
-/// Event: session.shutdown
-/// </summary>
+/// <summary>Represents the <c>session.shutdown</c> event.</summary>
 public partial class SessionShutdownEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.shutdown";
 
+    /// <summary>The <c>session.shutdown</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionShutdownData Data { get; set; }
 }
 
-/// <summary>
-/// Event: session.context_changed
-/// </summary>
+/// <summary>Represents the <c>session.context_changed</c> event.</summary>
 public partial class SessionContextChangedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.context_changed";
 
+    /// <summary>The <c>session.context_changed</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionContextChangedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: session.usage_info
-/// </summary>
+/// <summary>Represents the <c>session.usage_info</c> event.</summary>
 public partial class SessionUsageInfoEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.usage_info";
 
+    /// <summary>The <c>session.usage_info</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionUsageInfoData Data { get; set; }
 }
 
-/// <summary>
-/// Event: session.compaction_start
-/// </summary>
+/// <summary>Empty payload; the event signals that LLM-powered conversation compaction has begun.</summary>
+/// <remarks>Represents the <c>session.compaction_start</c> event.</remarks>
 public partial class SessionCompactionStartEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.compaction_start";
 
+    /// <summary>The <c>session.compaction_start</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionCompactionStartData Data { get; set; }
 }
 
-/// <summary>
-/// Event: session.compaction_complete
-/// </summary>
+/// <summary>Represents the <c>session.compaction_complete</c> event.</summary>
 public partial class SessionCompactionCompleteEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.compaction_complete";
 
+    /// <summary>The <c>session.compaction_complete</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionCompactionCompleteData Data { get; set; }
 }
 
-/// <summary>
-/// Event: session.task_complete
-/// </summary>
+/// <summary>Represents the <c>session.task_complete</c> event.</summary>
 public partial class SessionTaskCompleteEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "session.task_complete";
 
+    /// <summary>The <c>session.task_complete</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SessionTaskCompleteData Data { get; set; }
 }
 
-/// <summary>
-/// Event: user.message
-/// </summary>
+/// <summary>Represents the <c>user.message</c> event.</summary>
 public partial class UserMessageEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "user.message";
 
+    /// <summary>The <c>user.message</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required UserMessageData Data { get; set; }
 }
 
-/// <summary>
-/// Event: pending_messages.modified
-/// </summary>
+/// <summary>Empty payload; the event signals that the pending message queue has changed.</summary>
+/// <remarks>Represents the <c>pending_messages.modified</c> event.</remarks>
 public partial class PendingMessagesModifiedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "pending_messages.modified";
 
+    /// <summary>The <c>pending_messages.modified</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required PendingMessagesModifiedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: assistant.turn_start
-/// </summary>
+/// <summary>Represents the <c>assistant.turn_start</c> event.</summary>
 public partial class AssistantTurnStartEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "assistant.turn_start";
 
+    /// <summary>The <c>assistant.turn_start</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required AssistantTurnStartData Data { get; set; }
 }
 
-/// <summary>
-/// Event: assistant.intent
-/// </summary>
+/// <summary>Represents the <c>assistant.intent</c> event.</summary>
 public partial class AssistantIntentEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "assistant.intent";
 
+    /// <summary>The <c>assistant.intent</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required AssistantIntentData Data { get; set; }
 }
 
-/// <summary>
-/// Event: assistant.reasoning
-/// </summary>
+/// <summary>Represents the <c>assistant.reasoning</c> event.</summary>
 public partial class AssistantReasoningEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "assistant.reasoning";
 
+    /// <summary>The <c>assistant.reasoning</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required AssistantReasoningData Data { get; set; }
 }
 
-/// <summary>
-/// Event: assistant.reasoning_delta
-/// </summary>
+/// <summary>Represents the <c>assistant.reasoning_delta</c> event.</summary>
 public partial class AssistantReasoningDeltaEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "assistant.reasoning_delta";
 
+    /// <summary>The <c>assistant.reasoning_delta</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required AssistantReasoningDeltaData Data { get; set; }
 }
 
-/// <summary>
-/// Event: assistant.streaming_delta
-/// </summary>
+/// <summary>Represents the <c>assistant.streaming_delta</c> event.</summary>
 public partial class AssistantStreamingDeltaEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "assistant.streaming_delta";
 
+    /// <summary>The <c>assistant.streaming_delta</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required AssistantStreamingDeltaData Data { get; set; }
 }
 
-/// <summary>
-/// Event: assistant.message
-/// </summary>
+/// <summary>Represents the <c>assistant.message</c> event.</summary>
 public partial class AssistantMessageEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "assistant.message";
 
+    /// <summary>The <c>assistant.message</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required AssistantMessageData Data { get; set; }
 }
 
-/// <summary>
-/// Event: assistant.message_delta
-/// </summary>
+/// <summary>Represents the <c>assistant.message_delta</c> event.</summary>
 public partial class AssistantMessageDeltaEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "assistant.message_delta";
 
+    /// <summary>The <c>assistant.message_delta</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required AssistantMessageDeltaData Data { get; set; }
 }
 
-/// <summary>
-/// Event: assistant.turn_end
-/// </summary>
+/// <summary>Represents the <c>assistant.turn_end</c> event.</summary>
 public partial class AssistantTurnEndEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "assistant.turn_end";
 
+    /// <summary>The <c>assistant.turn_end</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required AssistantTurnEndData Data { get; set; }
 }
 
-/// <summary>
-/// Event: assistant.usage
-/// </summary>
+/// <summary>Represents the <c>assistant.usage</c> event.</summary>
 public partial class AssistantUsageEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "assistant.usage";
 
+    /// <summary>The <c>assistant.usage</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required AssistantUsageData Data { get; set; }
 }
 
-/// <summary>
-/// Event: abort
-/// </summary>
+/// <summary>Represents the <c>abort</c> event.</summary>
 public partial class AbortEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "abort";
 
+    /// <summary>The <c>abort</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required AbortData Data { get; set; }
 }
 
-/// <summary>
-/// Event: tool.user_requested
-/// </summary>
+/// <summary>Represents the <c>tool.user_requested</c> event.</summary>
 public partial class ToolUserRequestedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "tool.user_requested";
 
+    /// <summary>The <c>tool.user_requested</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required ToolUserRequestedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: tool.execution_start
-/// </summary>
+/// <summary>Represents the <c>tool.execution_start</c> event.</summary>
 public partial class ToolExecutionStartEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "tool.execution_start";
 
+    /// <summary>The <c>tool.execution_start</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required ToolExecutionStartData Data { get; set; }
 }
 
-/// <summary>
-/// Event: tool.execution_partial_result
-/// </summary>
+/// <summary>Represents the <c>tool.execution_partial_result</c> event.</summary>
 public partial class ToolExecutionPartialResultEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "tool.execution_partial_result";
 
+    /// <summary>The <c>tool.execution_partial_result</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required ToolExecutionPartialResultData Data { get; set; }
 }
 
-/// <summary>
-/// Event: tool.execution_progress
-/// </summary>
+/// <summary>Represents the <c>tool.execution_progress</c> event.</summary>
 public partial class ToolExecutionProgressEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "tool.execution_progress";
 
+    /// <summary>The <c>tool.execution_progress</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required ToolExecutionProgressData Data { get; set; }
 }
 
-/// <summary>
-/// Event: tool.execution_complete
-/// </summary>
+/// <summary>Represents the <c>tool.execution_complete</c> event.</summary>
 public partial class ToolExecutionCompleteEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "tool.execution_complete";
 
+    /// <summary>The <c>tool.execution_complete</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required ToolExecutionCompleteData Data { get; set; }
 }
 
-/// <summary>
-/// Event: skill.invoked
-/// </summary>
+/// <summary>Represents the <c>skill.invoked</c> event.</summary>
 public partial class SkillInvokedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "skill.invoked";
 
+    /// <summary>The <c>skill.invoked</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SkillInvokedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: subagent.started
-/// </summary>
+/// <summary>Represents the <c>subagent.started</c> event.</summary>
 public partial class SubagentStartedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "subagent.started";
 
+    /// <summary>The <c>subagent.started</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SubagentStartedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: subagent.completed
-/// </summary>
+/// <summary>Represents the <c>subagent.completed</c> event.</summary>
 public partial class SubagentCompletedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "subagent.completed";
 
+    /// <summary>The <c>subagent.completed</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SubagentCompletedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: subagent.failed
-/// </summary>
+/// <summary>Represents the <c>subagent.failed</c> event.</summary>
 public partial class SubagentFailedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "subagent.failed";
 
+    /// <summary>The <c>subagent.failed</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SubagentFailedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: subagent.selected
-/// </summary>
+/// <summary>Represents the <c>subagent.selected</c> event.</summary>
 public partial class SubagentSelectedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "subagent.selected";
 
+    /// <summary>The <c>subagent.selected</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SubagentSelectedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: subagent.deselected
-/// </summary>
+/// <summary>Empty payload; the event signals that the custom agent was deselected, returning to the default agent.</summary>
+/// <remarks>Represents the <c>subagent.deselected</c> event.</remarks>
 public partial class SubagentDeselectedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "subagent.deselected";
 
+    /// <summary>The <c>subagent.deselected</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SubagentDeselectedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: hook.start
-/// </summary>
+/// <summary>Represents the <c>hook.start</c> event.</summary>
 public partial class HookStartEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "hook.start";
 
+    /// <summary>The <c>hook.start</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required HookStartData Data { get; set; }
 }
 
-/// <summary>
-/// Event: hook.end
-/// </summary>
+/// <summary>Represents the <c>hook.end</c> event.</summary>
 public partial class HookEndEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "hook.end";
 
+    /// <summary>The <c>hook.end</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required HookEndData Data { get; set; }
 }
 
-/// <summary>
-/// Event: system.message
-/// </summary>
+/// <summary>Represents the <c>system.message</c> event.</summary>
 public partial class SystemMessageEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "system.message";
 
+    /// <summary>The <c>system.message</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SystemMessageData Data { get; set; }
 }
 
-/// <summary>
-/// Event: system.notification
-/// </summary>
+/// <summary>Represents the <c>system.notification</c> event.</summary>
 public partial class SystemNotificationEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "system.notification";
 
+    /// <summary>The <c>system.notification</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required SystemNotificationData Data { get; set; }
 }
 
-/// <summary>
-/// Event: permission.requested
-/// </summary>
+/// <summary>Represents the <c>permission.requested</c> event.</summary>
 public partial class PermissionRequestedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "permission.requested";
 
+    /// <summary>The <c>permission.requested</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required PermissionRequestedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: permission.completed
-/// </summary>
+/// <summary>Represents the <c>permission.completed</c> event.</summary>
 public partial class PermissionCompletedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "permission.completed";
 
+    /// <summary>The <c>permission.completed</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required PermissionCompletedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: user_input.requested
-/// </summary>
+/// <summary>Represents the <c>user_input.requested</c> event.</summary>
 public partial class UserInputRequestedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "user_input.requested";
 
+    /// <summary>The <c>user_input.requested</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required UserInputRequestedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: user_input.completed
-/// </summary>
+/// <summary>Represents the <c>user_input.completed</c> event.</summary>
 public partial class UserInputCompletedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "user_input.completed";
 
+    /// <summary>The <c>user_input.completed</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required UserInputCompletedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: elicitation.requested
-/// </summary>
+/// <summary>Represents the <c>elicitation.requested</c> event.</summary>
 public partial class ElicitationRequestedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "elicitation.requested";
 
+    /// <summary>The <c>elicitation.requested</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required ElicitationRequestedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: elicitation.completed
-/// </summary>
+/// <summary>Represents the <c>elicitation.completed</c> event.</summary>
 public partial class ElicitationCompletedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "elicitation.completed";
 
+    /// <summary>The <c>elicitation.completed</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required ElicitationCompletedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: external_tool.requested
-/// </summary>
+/// <summary>Represents the <c>external_tool.requested</c> event.</summary>
 public partial class ExternalToolRequestedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "external_tool.requested";
 
+    /// <summary>The <c>external_tool.requested</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required ExternalToolRequestedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: external_tool.completed
-/// </summary>
+/// <summary>Represents the <c>external_tool.completed</c> event.</summary>
 public partial class ExternalToolCompletedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "external_tool.completed";
 
+    /// <summary>The <c>external_tool.completed</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required ExternalToolCompletedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: command.queued
-/// </summary>
+/// <summary>Represents the <c>command.queued</c> event.</summary>
 public partial class CommandQueuedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "command.queued";
 
+    /// <summary>The <c>command.queued</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required CommandQueuedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: command.completed
-/// </summary>
+/// <summary>Represents the <c>command.completed</c> event.</summary>
 public partial class CommandCompletedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "command.completed";
 
+    /// <summary>The <c>command.completed</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required CommandCompletedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: exit_plan_mode.requested
-/// </summary>
+/// <summary>Represents the <c>exit_plan_mode.requested</c> event.</summary>
 public partial class ExitPlanModeRequestedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "exit_plan_mode.requested";
 
+    /// <summary>The <c>exit_plan_mode.requested</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required ExitPlanModeRequestedData Data { get; set; }
 }
 
-/// <summary>
-/// Event: exit_plan_mode.completed
-/// </summary>
+/// <summary>Represents the <c>exit_plan_mode.completed</c> event.</summary>
 public partial class ExitPlanModeCompletedEvent : SessionEvent
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "exit_plan_mode.completed";
 
+    /// <summary>The <c>exit_plan_mode.completed</c> event payload.</summary>
     [JsonPropertyName("data")]
     public required ExitPlanModeCompletedData Data { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SessionStartEvent"/>.</summary>
 public partial class SessionStartData
 {
+    /// <summary>Unique identifier for the session.</summary>
     [JsonPropertyName("sessionId")]
     public required string SessionId { get; set; }
 
+    /// <summary>Schema version number for the session event format.</summary>
     [JsonPropertyName("version")]
     public required double Version { get; set; }
 
+    /// <summary>Identifier of the software producing the events (e.g., "copilot-agent").</summary>
     [JsonPropertyName("producer")]
     public required string Producer { get; set; }
 
+    /// <summary>Version string of the Copilot application.</summary>
     [JsonPropertyName("copilotVersion")]
     public required string CopilotVersion { get; set; }
 
+    /// <summary>ISO 8601 timestamp when the session was created.</summary>
     [JsonPropertyName("startTime")]
     public required DateTimeOffset StartTime { get; set; }
 
+    /// <summary>Model selected at session creation time, if any.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("selectedModel")]
     public string? SelectedModel { get; set; }
 
+    /// <summary>Working directory and git context at session start.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("context")]
     public SessionStartDataContext? Context { get; set; }
 
+    /// <summary>Gets or sets the <c>alreadyInUse</c> value.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("alreadyInUse")]
     public bool? AlreadyInUse { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SessionResumeEvent"/>.</summary>
 public partial class SessionResumeData
 {
+    /// <summary>ISO 8601 timestamp when the session was resumed.</summary>
     [JsonPropertyName("resumeTime")]
     public required DateTimeOffset ResumeTime { get; set; }
 
+    /// <summary>Total number of persisted events in the session at the time of resume.</summary>
     [JsonPropertyName("eventCount")]
     public required double EventCount { get; set; }
 
+    /// <summary>Updated working directory and git context at resume time.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("context")]
     public SessionResumeDataContext? Context { get; set; }
 
+    /// <summary>Gets or sets the <c>alreadyInUse</c> value.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("alreadyInUse")]
     public bool? AlreadyInUse { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SessionErrorEvent"/>.</summary>
 public partial class SessionErrorData
 {
+    /// <summary>Category of error (e.g., "authentication", "authorization", "quota", "rate_limit", "query").</summary>
     [JsonPropertyName("errorType")]
     public required string ErrorType { get; set; }
 
+    /// <summary>Human-readable error message.</summary>
     [JsonPropertyName("message")]
     public required string Message { get; set; }
 
+    /// <summary>Error stack trace, when available.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("stack")]
     public string? Stack { get; set; }
 
+    /// <summary>HTTP status code from the upstream request, if applicable.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("statusCode")]
     public double? StatusCode { get; set; }
 
+    /// <summary>GitHub request tracing ID (x-github-request-id header) for correlating with server-side logs.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("providerCallId")]
     public string? ProviderCallId { get; set; }
 }
 
+/// <summary>Payload indicating the agent is idle; includes any background tasks still in flight.</summary>
 public partial class SessionIdleData
 {
+    /// <summary>Background tasks still running when the agent became idle.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("backgroundTasks")]
     public SessionIdleDataBackgroundTasks? BackgroundTasks { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SessionTitleChangedEvent"/>.</summary>
 public partial class SessionTitleChangedData
 {
+    /// <summary>The new display title for the session.</summary>
     [JsonPropertyName("title")]
     public required string Title { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SessionInfoEvent"/>.</summary>
 public partial class SessionInfoData
 {
+    /// <summary>Category of informational message (e.g., "notification", "timing", "context_window", "mcp", "snapshot", "configuration", "authentication", "model").</summary>
     [JsonPropertyName("infoType")]
     public required string InfoType { get; set; }
 
+    /// <summary>Human-readable informational message for display in the timeline.</summary>
     [JsonPropertyName("message")]
     public required string Message { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SessionWarningEvent"/>.</summary>
 public partial class SessionWarningData
 {
+    /// <summary>Category of warning (e.g., "subscription", "policy", "mcp").</summary>
     [JsonPropertyName("warningType")]
     public required string WarningType { get; set; }
 
+    /// <summary>Human-readable warning message for display in the timeline.</summary>
     [JsonPropertyName("message")]
     public required string Message { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SessionModelChangeEvent"/>.</summary>
 public partial class SessionModelChangeData
 {
+    /// <summary>Model that was previously selected, if any.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("previousModel")]
     public string? PreviousModel { get; set; }
 
+    /// <summary>Newly selected model identifier.</summary>
     [JsonPropertyName("newModel")]
     public required string NewModel { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SessionModeChangedEvent"/>.</summary>
 public partial class SessionModeChangedData
 {
+    /// <summary>Agent mode before the change (e.g., "interactive", "plan", "autopilot").</summary>
     [JsonPropertyName("previousMode")]
     public required string PreviousMode { get; set; }
 
+    /// <summary>Agent mode after the change (e.g., "interactive", "plan", "autopilot").</summary>
     [JsonPropertyName("newMode")]
     public required string NewMode { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SessionPlanChangedEvent"/>.</summary>
 public partial class SessionPlanChangedData
 {
+    /// <summary>The type of operation performed on the plan file.</summary>
     [JsonPropertyName("operation")]
     public required SessionPlanChangedDataOperation Operation { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SessionWorkspaceFileChangedEvent"/>.</summary>
 public partial class SessionWorkspaceFileChangedData
 {
+    /// <summary>Relative path within the session workspace files directory.</summary>
     [JsonPropertyName("path")]
     public required string Path { get; set; }
 
+    /// <summary>Whether the file was newly created or updated.</summary>
     [JsonPropertyName("operation")]
     public required SessionWorkspaceFileChangedDataOperation Operation { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SessionHandoffEvent"/>.</summary>
 public partial class SessionHandoffData
 {
+    /// <summary>ISO 8601 timestamp when the handoff occurred.</summary>
     [JsonPropertyName("handoffTime")]
     public required DateTimeOffset HandoffTime { get; set; }
 
+    /// <summary>Origin type of the session being handed off.</summary>
     [JsonPropertyName("sourceType")]
     public required SessionHandoffDataSourceType SourceType { get; set; }
 
+    /// <summary>Repository context for the handed-off session.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("repository")]
     public SessionHandoffDataRepository? Repository { get; set; }
 
+    /// <summary>Additional context information for the handoff.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("context")]
     public string? Context { get; set; }
 
+    /// <summary>Summary of the work done in the source session.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("summary")]
     public string? Summary { get; set; }
 
+    /// <summary>Session ID of the remote session being handed off.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("remoteSessionId")]
     public string? RemoteSessionId { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SessionTruncationEvent"/>.</summary>
 public partial class SessionTruncationData
 {
+    /// <summary>Maximum token count for the model's context window.</summary>
     [JsonPropertyName("tokenLimit")]
     public required double TokenLimit { get; set; }
 
+    /// <summary>Total tokens in conversation messages before truncation.</summary>
     [JsonPropertyName("preTruncationTokensInMessages")]
     public required double PreTruncationTokensInMessages { get; set; }
 
+    /// <summary>Number of conversation messages before truncation.</summary>
     [JsonPropertyName("preTruncationMessagesLength")]
     public required double PreTruncationMessagesLength { get; set; }
 
+    /// <summary>Total tokens in conversation messages after truncation.</summary>
     [JsonPropertyName("postTruncationTokensInMessages")]
     public required double PostTruncationTokensInMessages { get; set; }
 
+    /// <summary>Number of conversation messages after truncation.</summary>
     [JsonPropertyName("postTruncationMessagesLength")]
     public required double PostTruncationMessagesLength { get; set; }
 
+    /// <summary>Number of tokens removed by truncation.</summary>
     [JsonPropertyName("tokensRemovedDuringTruncation")]
     public required double TokensRemovedDuringTruncation { get; set; }
 
+    /// <summary>Number of messages removed by truncation.</summary>
     [JsonPropertyName("messagesRemovedDuringTruncation")]
     public required double MessagesRemovedDuringTruncation { get; set; }
 
+    /// <summary>Identifier of the component that performed truncation (e.g., "BasicTruncator").</summary>
     [JsonPropertyName("performedBy")]
     public required string PerformedBy { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SessionSnapshotRewindEvent"/>.</summary>
 public partial class SessionSnapshotRewindData
 {
+    /// <summary>Event ID that was rewound to; all events after this one were removed.</summary>
     [JsonPropertyName("upToEventId")]
     public required string UpToEventId { get; set; }
 
+    /// <summary>Number of events that were removed by the rewind.</summary>
     [JsonPropertyName("eventsRemoved")]
     public required double EventsRemoved { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SessionShutdownEvent"/>.</summary>
 public partial class SessionShutdownData
 {
+    /// <summary>Whether the session ended normally ("routine") or due to a crash/fatal error ("error").</summary>
     [JsonPropertyName("shutdownType")]
     public required SessionShutdownDataShutdownType ShutdownType { get; set; }
 
+    /// <summary>Error description when shutdownType is "error".</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("errorReason")]
     public string? ErrorReason { get; set; }
 
+    /// <summary>Total number of premium API requests used during the session.</summary>
     [JsonPropertyName("totalPremiumRequests")]
     public required double TotalPremiumRequests { get; set; }
 
+    /// <summary>Cumulative time spent in API calls during the session, in milliseconds.</summary>
     [JsonPropertyName("totalApiDurationMs")]
     public required double TotalApiDurationMs { get; set; }
 
+    /// <summary>Unix timestamp (milliseconds) when the session started.</summary>
     [JsonPropertyName("sessionStartTime")]
     public required double SessionStartTime { get; set; }
 
+    /// <summary>Aggregate code change metrics for the session.</summary>
     [JsonPropertyName("codeChanges")]
     public required SessionShutdownDataCodeChanges CodeChanges { get; set; }
 
+    /// <summary>Per-model usage breakdown, keyed by model identifier.</summary>
     [JsonPropertyName("modelMetrics")]
     public required Dictionary<string, object> ModelMetrics { get; set; }
 
+    /// <summary>Model that was selected at the time of shutdown.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("currentModel")]
     public string? CurrentModel { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SessionContextChangedEvent"/>.</summary>
 public partial class SessionContextChangedData
 {
+    /// <summary>Current working directory path.</summary>
     [JsonPropertyName("cwd")]
     public required string Cwd { get; set; }
 
+    /// <summary>Root directory of the git repository, resolved via git rev-parse.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("gitRoot")]
     public string? GitRoot { get; set; }
 
+    /// <summary>Repository identifier in "owner/name" format, derived from the git remote URL.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("repository")]
     public string? Repository { get; set; }
 
+    /// <summary>Current git branch name.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("branch")]
     public string? Branch { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SessionUsageInfoEvent"/>.</summary>
 public partial class SessionUsageInfoData
 {
+    /// <summary>Maximum token count for the model's context window.</summary>
     [JsonPropertyName("tokenLimit")]
     public required double TokenLimit { get; set; }
 
+    /// <summary>Current number of tokens in the context window.</summary>
     [JsonPropertyName("currentTokens")]
     public required double CurrentTokens { get; set; }
 
+    /// <summary>Current number of messages in the conversation.</summary>
     [JsonPropertyName("messagesLength")]
     public required double MessagesLength { get; set; }
 }
 
+/// <summary>Empty payload; the event signals that LLM-powered conversation compaction has begun.</summary>
 public partial class SessionCompactionStartData
 {
 }
 
+/// <summary>Event payload for <see cref="SessionCompactionCompleteEvent"/>.</summary>
 public partial class SessionCompactionCompleteData
 {
+    /// <summary>Whether compaction completed successfully.</summary>
     [JsonPropertyName("success")]
     public required bool Success { get; set; }
 
+    /// <summary>Error message if compaction failed.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("error")]
     public string? Error { get; set; }
 
+    /// <summary>Total tokens in conversation before compaction.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("preCompactionTokens")]
     public double? PreCompactionTokens { get; set; }
 
+    /// <summary>Total tokens in conversation after compaction.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("postCompactionTokens")]
     public double? PostCompactionTokens { get; set; }
 
+    /// <summary>Number of messages before compaction.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("preCompactionMessagesLength")]
     public double? PreCompactionMessagesLength { get; set; }
 
+    /// <summary>Number of messages removed during compaction.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("messagesRemoved")]
     public double? MessagesRemoved { get; set; }
 
+    /// <summary>Number of tokens removed during compaction.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("tokensRemoved")]
     public double? TokensRemoved { get; set; }
 
+    /// <summary>LLM-generated summary of the compacted conversation history.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("summaryContent")]
     public string? SummaryContent { get; set; }
 
+    /// <summary>Checkpoint snapshot number created for recovery.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("checkpointNumber")]
     public double? CheckpointNumber { get; set; }
 
+    /// <summary>File path where the checkpoint was stored.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("checkpointPath")]
     public string? CheckpointPath { get; set; }
 
+    /// <summary>Token usage breakdown for the compaction LLM call.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("compactionTokensUsed")]
     public SessionCompactionCompleteDataCompactionTokensUsed? CompactionTokensUsed { get; set; }
 
+    /// <summary>GitHub request tracing ID (x-github-request-id header) for the compaction LLM call.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("requestId")]
     public string? RequestId { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SessionTaskCompleteEvent"/>.</summary>
 public partial class SessionTaskCompleteData
 {
+    /// <summary>Optional summary of the completed task, provided by the agent.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("summary")]
     public string? Summary { get; set; }
 }
 
+/// <summary>Event payload for <see cref="UserMessageEvent"/>.</summary>
 public partial class UserMessageData
 {
+    /// <summary>The user's message text as displayed in the timeline.</summary>
     [JsonPropertyName("content")]
     public required string Content { get; set; }
 
+    /// <summary>Transformed version of the message sent to the model, with XML wrapping, timestamps, and other augmentations for prompt caching.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("transformedContent")]
     public string? TransformedContent { get; set; }
 
+    /// <summary>Files, selections, or GitHub references attached to the message.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("attachments")]
     public UserMessageDataAttachmentsItem[]? Attachments { get; set; }
 
+    /// <summary>Origin of this message, used for timeline filtering (e.g., "skill-pdf" for skill-injected messages that should be hidden from the user).</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("source")]
     public string? Source { get; set; }
 
+    /// <summary>The agent mode that was active when this message was sent.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("agentMode")]
     public UserMessageDataAgentMode? AgentMode { get; set; }
 
+    /// <summary>CAPI interaction ID for correlating this user message with its turn.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("interactionId")]
     public string? InteractionId { get; set; }
 }
 
+/// <summary>Empty payload; the event signals that the pending message queue has changed.</summary>
 public partial class PendingMessagesModifiedData
 {
 }
 
+/// <summary>Event payload for <see cref="AssistantTurnStartEvent"/>.</summary>
 public partial class AssistantTurnStartData
 {
+    /// <summary>Identifier for this turn within the agentic loop, typically a stringified turn number.</summary>
     [JsonPropertyName("turnId")]
     public required string TurnId { get; set; }
 
+    /// <summary>CAPI interaction ID for correlating this turn with upstream telemetry.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("interactionId")]
     public string? InteractionId { get; set; }
 }
 
+/// <summary>Event payload for <see cref="AssistantIntentEvent"/>.</summary>
 public partial class AssistantIntentData
 {
+    /// <summary>Short description of what the agent is currently doing or planning to do.</summary>
     [JsonPropertyName("intent")]
     public required string Intent { get; set; }
 }
 
+/// <summary>Event payload for <see cref="AssistantReasoningEvent"/>.</summary>
 public partial class AssistantReasoningData
 {
+    /// <summary>Unique identifier for this reasoning block.</summary>
     [JsonPropertyName("reasoningId")]
     public required string ReasoningId { get; set; }
 
+    /// <summary>The complete extended thinking text from the model.</summary>
     [JsonPropertyName("content")]
     public required string Content { get; set; }
 }
 
+/// <summary>Event payload for <see cref="AssistantReasoningDeltaEvent"/>.</summary>
 public partial class AssistantReasoningDeltaData
 {
+    /// <summary>Reasoning block ID this delta belongs to, matching the corresponding assistant.reasoning event.</summary>
     [JsonPropertyName("reasoningId")]
     public required string ReasoningId { get; set; }
 
+    /// <summary>Incremental text chunk to append to the reasoning content.</summary>
     [JsonPropertyName("deltaContent")]
     public required string DeltaContent { get; set; }
 }
 
+/// <summary>Event payload for <see cref="AssistantStreamingDeltaEvent"/>.</summary>
 public partial class AssistantStreamingDeltaData
 {
+    /// <summary>Cumulative total bytes received from the streaming response so far.</summary>
     [JsonPropertyName("totalResponseSizeBytes")]
     public required double TotalResponseSizeBytes { get; set; }
 }
 
+/// <summary>Event payload for <see cref="AssistantMessageEvent"/>.</summary>
 public partial class AssistantMessageData
 {
+    /// <summary>Unique identifier for this assistant message.</summary>
     [JsonPropertyName("messageId")]
     public required string MessageId { get; set; }
 
+    /// <summary>The assistant's text response content.</summary>
     [JsonPropertyName("content")]
     public required string Content { get; set; }
 
+    /// <summary>Tool invocations requested by the assistant in this message.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("toolRequests")]
     public AssistantMessageDataToolRequestsItem[]? ToolRequests { get; set; }
 
+    /// <summary>Opaque/encrypted extended thinking data from Anthropic models. Session-bound and stripped on resume.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("reasoningOpaque")]
     public string? ReasoningOpaque { get; set; }
 
+    /// <summary>Readable reasoning text from the model's extended thinking.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("reasoningText")]
     public string? ReasoningText { get; set; }
 
+    /// <summary>Encrypted reasoning content from OpenAI models. Session-bound and stripped on resume.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("encryptedContent")]
     public string? EncryptedContent { get; set; }
 
+    /// <summary>Generation phase for phased-output models (e.g., thinking vs. response phases).</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("phase")]
     public string? Phase { get; set; }
 
+    /// <summary>Actual output token count from the API response (completion_tokens), used for accurate token accounting.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("outputTokens")]
     public double? OutputTokens { get; set; }
 
+    /// <summary>CAPI interaction ID for correlating this message with upstream telemetry.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("interactionId")]
     public string? InteractionId { get; set; }
 
+    /// <summary>Tool call ID of the parent tool invocation when this event originates from a sub-agent.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("parentToolCallId")]
     public string? ParentToolCallId { get; set; }
 }
 
+/// <summary>Event payload for <see cref="AssistantMessageDeltaEvent"/>.</summary>
 public partial class AssistantMessageDeltaData
 {
+    /// <summary>Message ID this delta belongs to, matching the corresponding assistant.message event.</summary>
     [JsonPropertyName("messageId")]
     public required string MessageId { get; set; }
 
+    /// <summary>Incremental text chunk to append to the message content.</summary>
     [JsonPropertyName("deltaContent")]
     public required string DeltaContent { get; set; }
 
+    /// <summary>Tool call ID of the parent tool invocation when this event originates from a sub-agent.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("parentToolCallId")]
     public string? ParentToolCallId { get; set; }
 }
 
+/// <summary>Event payload for <see cref="AssistantTurnEndEvent"/>.</summary>
 public partial class AssistantTurnEndData
 {
+    /// <summary>Identifier of the turn that has ended, matching the corresponding assistant.turn_start event.</summary>
     [JsonPropertyName("turnId")]
     public required string TurnId { get; set; }
 }
 
+/// <summary>Event payload for <see cref="AssistantUsageEvent"/>.</summary>
 public partial class AssistantUsageData
 {
+    /// <summary>Model identifier used for this API call.</summary>
     [JsonPropertyName("model")]
     public required string Model { get; set; }
 
+    /// <summary>Number of input tokens consumed.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("inputTokens")]
     public double? InputTokens { get; set; }
 
+    /// <summary>Number of output tokens produced.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("outputTokens")]
     public double? OutputTokens { get; set; }
 
+    /// <summary>Number of tokens read from prompt cache.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("cacheReadTokens")]
     public double? CacheReadTokens { get; set; }
 
+    /// <summary>Number of tokens written to prompt cache.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("cacheWriteTokens")]
     public double? CacheWriteTokens { get; set; }
 
+    /// <summary>Model multiplier cost for billing purposes.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("cost")]
     public double? Cost { get; set; }
 
+    /// <summary>Duration of the API call in milliseconds.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("duration")]
     public double? Duration { get; set; }
 
+    /// <summary>What initiated this API call (e.g., "sub-agent"); absent for user-initiated calls.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("initiator")]
     public string? Initiator { get; set; }
 
+    /// <summary>Completion ID from the model provider (e.g., chatcmpl-abc123).</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("apiCallId")]
     public string? ApiCallId { get; set; }
 
+    /// <summary>GitHub request tracing ID (x-github-request-id header) for server-side log correlation.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("providerCallId")]
     public string? ProviderCallId { get; set; }
 
+    /// <summary>Parent tool call ID when this usage originates from a sub-agent.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("parentToolCallId")]
     public string? ParentToolCallId { get; set; }
 
+    /// <summary>Per-quota resource usage snapshots, keyed by quota identifier.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("quotaSnapshots")]
     public Dictionary<string, object>? QuotaSnapshots { get; set; }
 
+    /// <summary>Per-request cost and usage data from the CAPI copilot_usage response field.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("copilotUsage")]
     public AssistantUsageDataCopilotUsage? CopilotUsage { get; set; }
 }
 
+/// <summary>Event payload for <see cref="AbortEvent"/>.</summary>
 public partial class AbortData
 {
+    /// <summary>Reason the current turn was aborted (e.g., "user initiated").</summary>
     [JsonPropertyName("reason")]
     public required string Reason { get; set; }
 }
 
+/// <summary>Event payload for <see cref="ToolUserRequestedEvent"/>.</summary>
 public partial class ToolUserRequestedData
 {
+    /// <summary>Unique identifier for this tool call.</summary>
     [JsonPropertyName("toolCallId")]
     public required string ToolCallId { get; set; }
 
+    /// <summary>Name of the tool the user wants to invoke.</summary>
     [JsonPropertyName("toolName")]
     public required string ToolName { get; set; }
 
+    /// <summary>Arguments for the tool invocation.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("arguments")]
     public object? Arguments { get; set; }
 }
 
+/// <summary>Event payload for <see cref="ToolExecutionStartEvent"/>.</summary>
 public partial class ToolExecutionStartData
 {
+    /// <summary>Unique identifier for this tool call.</summary>
     [JsonPropertyName("toolCallId")]
     public required string ToolCallId { get; set; }
 
+    /// <summary>Name of the tool being executed.</summary>
     [JsonPropertyName("toolName")]
     public required string ToolName { get; set; }
 
+    /// <summary>Arguments passed to the tool.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("arguments")]
     public object? Arguments { get; set; }
 
+    /// <summary>Name of the MCP server hosting this tool, when the tool is an MCP tool.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("mcpServerName")]
     public string? McpServerName { get; set; }
 
+    /// <summary>Original tool name on the MCP server, when the tool is an MCP tool.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("mcpToolName")]
     public string? McpToolName { get; set; }
 
+    /// <summary>Tool call ID of the parent tool invocation when this event originates from a sub-agent.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("parentToolCallId")]
     public string? ParentToolCallId { get; set; }
 }
 
+/// <summary>Event payload for <see cref="ToolExecutionPartialResultEvent"/>.</summary>
 public partial class ToolExecutionPartialResultData
 {
+    /// <summary>Tool call ID this partial result belongs to.</summary>
     [JsonPropertyName("toolCallId")]
     public required string ToolCallId { get; set; }
 
+    /// <summary>Incremental output chunk from the running tool.</summary>
     [JsonPropertyName("partialOutput")]
     public required string PartialOutput { get; set; }
 }
 
+/// <summary>Event payload for <see cref="ToolExecutionProgressEvent"/>.</summary>
 public partial class ToolExecutionProgressData
 {
+    /// <summary>Tool call ID this progress notification belongs to.</summary>
     [JsonPropertyName("toolCallId")]
     public required string ToolCallId { get; set; }
 
+    /// <summary>Human-readable progress status message (e.g., from an MCP server).</summary>
     [JsonPropertyName("progressMessage")]
     public required string ProgressMessage { get; set; }
 }
 
+/// <summary>Event payload for <see cref="ToolExecutionCompleteEvent"/>.</summary>
 public partial class ToolExecutionCompleteData
 {
+    /// <summary>Unique identifier for the completed tool call.</summary>
     [JsonPropertyName("toolCallId")]
     public required string ToolCallId { get; set; }
 
+    /// <summary>Whether the tool execution completed successfully.</summary>
     [JsonPropertyName("success")]
     public required bool Success { get; set; }
 
+    /// <summary>Model identifier that generated this tool call.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("model")]
     public string? Model { get; set; }
 
+    /// <summary>CAPI interaction ID for correlating this tool execution with upstream telemetry.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("interactionId")]
     public string? InteractionId { get; set; }
 
+    /// <summary>Whether this tool call was explicitly requested by the user rather than the assistant.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("isUserRequested")]
     public bool? IsUserRequested { get; set; }
 
+    /// <summary>Tool execution result on success.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("result")]
     public ToolExecutionCompleteDataResult? Result { get; set; }
 
+    /// <summary>Error details when the tool execution failed.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("error")]
     public ToolExecutionCompleteDataError? Error { get; set; }
 
+    /// <summary>Tool-specific telemetry data (e.g., CodeQL check counts, grep match counts).</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("toolTelemetry")]
     public Dictionary<string, object>? ToolTelemetry { get; set; }
 
+    /// <summary>Tool call ID of the parent tool invocation when this event originates from a sub-agent.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("parentToolCallId")]
     public string? ParentToolCallId { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SkillInvokedEvent"/>.</summary>
 public partial class SkillInvokedData
 {
+    /// <summary>Name of the invoked skill.</summary>
     [JsonPropertyName("name")]
     public required string Name { get; set; }
 
+    /// <summary>File path to the SKILL.md definition.</summary>
     [JsonPropertyName("path")]
     public required string Path { get; set; }
 
+    /// <summary>Full content of the skill file, injected into the conversation for the model.</summary>
     [JsonPropertyName("content")]
     public required string Content { get; set; }
 
+    /// <summary>Tool names that should be auto-approved when this skill is active.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("allowedTools")]
     public string[]? AllowedTools { get; set; }
 
+    /// <summary>Name of the plugin this skill originated from, when applicable.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("pluginName")]
     public string? PluginName { get; set; }
 
+    /// <summary>Version of the plugin this skill originated from, when applicable.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("pluginVersion")]
     public string? PluginVersion { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SubagentStartedEvent"/>.</summary>
 public partial class SubagentStartedData
 {
+    /// <summary>Tool call ID of the parent tool invocation that spawned this sub-agent.</summary>
     [JsonPropertyName("toolCallId")]
     public required string ToolCallId { get; set; }
 
+    /// <summary>Internal name of the sub-agent.</summary>
     [JsonPropertyName("agentName")]
     public required string AgentName { get; set; }
 
+    /// <summary>Human-readable display name of the sub-agent.</summary>
     [JsonPropertyName("agentDisplayName")]
     public required string AgentDisplayName { get; set; }
 
+    /// <summary>Description of what the sub-agent does.</summary>
     [JsonPropertyName("agentDescription")]
     public required string AgentDescription { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SubagentCompletedEvent"/>.</summary>
 public partial class SubagentCompletedData
 {
+    /// <summary>Tool call ID of the parent tool invocation that spawned this sub-agent.</summary>
     [JsonPropertyName("toolCallId")]
     public required string ToolCallId { get; set; }
 
+    /// <summary>Internal name of the sub-agent.</summary>
     [JsonPropertyName("agentName")]
     public required string AgentName { get; set; }
 
+    /// <summary>Human-readable display name of the sub-agent.</summary>
     [JsonPropertyName("agentDisplayName")]
     public required string AgentDisplayName { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SubagentFailedEvent"/>.</summary>
 public partial class SubagentFailedData
 {
+    /// <summary>Tool call ID of the parent tool invocation that spawned this sub-agent.</summary>
     [JsonPropertyName("toolCallId")]
     public required string ToolCallId { get; set; }
 
+    /// <summary>Internal name of the sub-agent.</summary>
     [JsonPropertyName("agentName")]
     public required string AgentName { get; set; }
 
+    /// <summary>Human-readable display name of the sub-agent.</summary>
     [JsonPropertyName("agentDisplayName")]
     public required string AgentDisplayName { get; set; }
 
+    /// <summary>Error message describing why the sub-agent failed.</summary>
     [JsonPropertyName("error")]
     public required string Error { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SubagentSelectedEvent"/>.</summary>
 public partial class SubagentSelectedData
 {
+    /// <summary>Internal name of the selected custom agent.</summary>
     [JsonPropertyName("agentName")]
     public required string AgentName { get; set; }
 
+    /// <summary>Human-readable display name of the selected custom agent.</summary>
     [JsonPropertyName("agentDisplayName")]
     public required string AgentDisplayName { get; set; }
 
+    /// <summary>List of tool names available to this agent, or null for all tools.</summary>
     [JsonPropertyName("tools")]
     public string[]? Tools { get; set; }
 }
 
+/// <summary>Empty payload; the event signals that the custom agent was deselected, returning to the default agent.</summary>
 public partial class SubagentDeselectedData
 {
 }
 
+/// <summary>Event payload for <see cref="HookStartEvent"/>.</summary>
 public partial class HookStartData
 {
+    /// <summary>Unique identifier for this hook invocation.</summary>
     [JsonPropertyName("hookInvocationId")]
     public required string HookInvocationId { get; set; }
 
+    /// <summary>Type of hook being invoked (e.g., "preToolUse", "postToolUse", "sessionStart").</summary>
     [JsonPropertyName("hookType")]
     public required string HookType { get; set; }
 
+    /// <summary>Input data passed to the hook.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("input")]
     public object? Input { get; set; }
 }
 
+/// <summary>Event payload for <see cref="HookEndEvent"/>.</summary>
 public partial class HookEndData
 {
+    /// <summary>Identifier matching the corresponding hook.start event.</summary>
     [JsonPropertyName("hookInvocationId")]
     public required string HookInvocationId { get; set; }
 
+    /// <summary>Type of hook that was invoked (e.g., "preToolUse", "postToolUse", "sessionStart").</summary>
     [JsonPropertyName("hookType")]
     public required string HookType { get; set; }
 
+    /// <summary>Output data produced by the hook.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("output")]
     public object? Output { get; set; }
 
+    /// <summary>Whether the hook completed successfully.</summary>
     [JsonPropertyName("success")]
     public required bool Success { get; set; }
 
+    /// <summary>Error details when the hook failed.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("error")]
     public HookEndDataError? Error { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SystemMessageEvent"/>.</summary>
 public partial class SystemMessageData
 {
+    /// <summary>The system or developer prompt text.</summary>
     [JsonPropertyName("content")]
     public required string Content { get; set; }
 
+    /// <summary>Message role: "system" for system prompts, "developer" for developer-injected instructions.</summary>
     [JsonPropertyName("role")]
     public required SystemMessageDataRole Role { get; set; }
 
+    /// <summary>Optional name identifier for the message source.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("name")]
     public string? Name { get; set; }
 
+    /// <summary>Metadata about the prompt template and its construction.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("metadata")]
     public SystemMessageDataMetadata? Metadata { get; set; }
 }
 
+/// <summary>Event payload for <see cref="SystemNotificationEvent"/>.</summary>
 public partial class SystemNotificationData
 {
+    /// <summary>The notification text, typically wrapped in &lt;system_notification&gt; XML tags.</summary>
     [JsonPropertyName("content")]
     public required string Content { get; set; }
 
+    /// <summary>Structured metadata identifying what triggered this notification.</summary>
     [JsonPropertyName("kind")]
     public required SystemNotificationDataKind Kind { get; set; }
 }
 
+/// <summary>Event payload for <see cref="PermissionRequestedEvent"/>.</summary>
 public partial class PermissionRequestedData
 {
+    /// <summary>Unique identifier for this permission request; used to respond via session.respondToPermission().</summary>
     [JsonPropertyName("requestId")]
     public required string RequestId { get; set; }
 
+    /// <summary>Details of the permission being requested.</summary>
     [JsonPropertyName("permissionRequest")]
     public required PermissionRequest PermissionRequest { get; set; }
 }
 
+/// <summary>Event payload for <see cref="PermissionCompletedEvent"/>.</summary>
 public partial class PermissionCompletedData
 {
+    /// <summary>Request ID of the resolved permission request; clients should dismiss any UI for this request.</summary>
     [JsonPropertyName("requestId")]
     public required string RequestId { get; set; }
 
+    /// <summary>The result of the permission request.</summary>
     [JsonPropertyName("result")]
     public required PermissionCompletedDataResult Result { get; set; }
 }
 
+/// <summary>Event payload for <see cref="UserInputRequestedEvent"/>.</summary>
 public partial class UserInputRequestedData
 {
+    /// <summary>Unique identifier for this input request; used to respond via session.respondToUserInput().</summary>
     [JsonPropertyName("requestId")]
     public required string RequestId { get; set; }
 
+    /// <summary>The question or prompt to present to the user.</summary>
     [JsonPropertyName("question")]
     public required string Question { get; set; }
 
+    /// <summary>Predefined choices for the user to select from, if applicable.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("choices")]
     public string[]? Choices { get; set; }
 
+    /// <summary>Whether the user can provide a free-form text response in addition to predefined choices.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("allowFreeform")]
     public bool? AllowFreeform { get; set; }
 }
 
+/// <summary>Event payload for <see cref="UserInputCompletedEvent"/>.</summary>
 public partial class UserInputCompletedData
 {
+    /// <summary>Request ID of the resolved user input request; clients should dismiss any UI for this request.</summary>
     [JsonPropertyName("requestId")]
     public required string RequestId { get; set; }
 }
 
+/// <summary>Event payload for <see cref="ElicitationRequestedEvent"/>.</summary>
 public partial class ElicitationRequestedData
 {
+    /// <summary>Unique identifier for this elicitation request; used to respond via session.respondToElicitation().</summary>
     [JsonPropertyName("requestId")]
     public required string RequestId { get; set; }
 
+    /// <summary>Message describing what information is needed from the user.</summary>
     [JsonPropertyName("message")]
     public required string Message { get; set; }
 
+    /// <summary>Elicitation mode; currently only "form" is supported. Defaults to "form" when absent.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("mode")]
     public string? Mode { get; set; }
 
+    /// <summary>JSON Schema describing the form fields to present to the user.</summary>
     [JsonPropertyName("requestedSchema")]
     public required ElicitationRequestedDataRequestedSchema RequestedSchema { get; set; }
 }
 
+/// <summary>Event payload for <see cref="ElicitationCompletedEvent"/>.</summary>
 public partial class ElicitationCompletedData
 {
+    /// <summary>Request ID of the resolved elicitation request; clients should dismiss any UI for this request.</summary>
     [JsonPropertyName("requestId")]
     public required string RequestId { get; set; }
 }
 
+/// <summary>Event payload for <see cref="ExternalToolRequestedEvent"/>.</summary>
 public partial class ExternalToolRequestedData
 {
+    /// <summary>Unique identifier for this request; used to respond via session.respondToExternalTool().</summary>
     [JsonPropertyName("requestId")]
     public required string RequestId { get; set; }
 
+    /// <summary>Session ID that this external tool request belongs to.</summary>
     [JsonPropertyName("sessionId")]
     public required string SessionId { get; set; }
 
+    /// <summary>Tool call ID assigned to this external tool invocation.</summary>
     [JsonPropertyName("toolCallId")]
     public required string ToolCallId { get; set; }
 
+    /// <summary>Name of the external tool to invoke.</summary>
     [JsonPropertyName("toolName")]
     public required string ToolName { get; set; }
 
+    /// <summary>Arguments to pass to the external tool.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("arguments")]
     public object? Arguments { get; set; }
 }
 
+/// <summary>Event payload for <see cref="ExternalToolCompletedEvent"/>.</summary>
 public partial class ExternalToolCompletedData
 {
+    /// <summary>Request ID of the resolved external tool request; clients should dismiss any UI for this request.</summary>
     [JsonPropertyName("requestId")]
     public required string RequestId { get; set; }
 }
 
+/// <summary>Event payload for <see cref="CommandQueuedEvent"/>.</summary>
 public partial class CommandQueuedData
 {
+    /// <summary>Unique identifier for this request; used to respond via session.respondToQueuedCommand().</summary>
     [JsonPropertyName("requestId")]
     public required string RequestId { get; set; }
 
+    /// <summary>The slash command text to be executed (e.g., /help, /clear).</summary>
     [JsonPropertyName("command")]
     public required string Command { get; set; }
 }
 
+/// <summary>Event payload for <see cref="CommandCompletedEvent"/>.</summary>
 public partial class CommandCompletedData
 {
+    /// <summary>Request ID of the resolved command request; clients should dismiss any UI for this request.</summary>
     [JsonPropertyName("requestId")]
     public required string RequestId { get; set; }
 }
 
+/// <summary>Event payload for <see cref="ExitPlanModeRequestedEvent"/>.</summary>
 public partial class ExitPlanModeRequestedData
 {
+    /// <summary>Unique identifier for this request; used to respond via session.respondToExitPlanMode().</summary>
     [JsonPropertyName("requestId")]
     public required string RequestId { get; set; }
 
+    /// <summary>Summary of the plan that was created.</summary>
     [JsonPropertyName("summary")]
     public required string Summary { get; set; }
 
+    /// <summary>Full content of the plan file.</summary>
     [JsonPropertyName("planContent")]
     public required string PlanContent { get; set; }
 
+    /// <summary>Available actions the user can take (e.g., approve, edit, reject).</summary>
     [JsonPropertyName("actions")]
     public required string[] Actions { get; set; }
 
+    /// <summary>The recommended action for the user to take.</summary>
     [JsonPropertyName("recommendedAction")]
     public required string RecommendedAction { get; set; }
 }
 
+/// <summary>Event payload for <see cref="ExitPlanModeCompletedEvent"/>.</summary>
 public partial class ExitPlanModeCompletedData
 {
+    /// <summary>Request ID of the resolved exit plan mode request; clients should dismiss any UI for this request.</summary>
     [JsonPropertyName("requestId")]
     public required string RequestId { get; set; }
 }
 
+/// <summary>Working directory and git context at session start.</summary>
+/// <remarks>Nested data type for <c>SessionStartDataContext</c>.</remarks>
 public partial class SessionStartDataContext
 {
+    /// <summary>Current working directory path.</summary>
     [JsonPropertyName("cwd")]
     public required string Cwd { get; set; }
 
+    /// <summary>Root directory of the git repository, resolved via git rev-parse.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("gitRoot")]
     public string? GitRoot { get; set; }
 
+    /// <summary>Repository identifier in "owner/name" format, derived from the git remote URL.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("repository")]
     public string? Repository { get; set; }
 
+    /// <summary>Current git branch name.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("branch")]
     public string? Branch { get; set; }
 }
 
+/// <summary>Updated working directory and git context at resume time.</summary>
+/// <remarks>Nested data type for <c>SessionResumeDataContext</c>.</remarks>
 public partial class SessionResumeDataContext
 {
+    /// <summary>Current working directory path.</summary>
     [JsonPropertyName("cwd")]
     public required string Cwd { get; set; }
 
+    /// <summary>Root directory of the git repository, resolved via git rev-parse.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("gitRoot")]
     public string? GitRoot { get; set; }
 
+    /// <summary>Repository identifier in "owner/name" format, derived from the git remote URL.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("repository")]
     public string? Repository { get; set; }
 
+    /// <summary>Current git branch name.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("branch")]
     public string? Branch { get; set; }
 }
 
+/// <summary>Nested data type for <c>SessionIdleDataBackgroundTasksAgentsItem</c>.</summary>
 public partial class SessionIdleDataBackgroundTasksAgentsItem
 {
+    /// <summary>Unique identifier of the background agent.</summary>
     [JsonPropertyName("agentId")]
     public required string AgentId { get; set; }
 
+    /// <summary>Type of the background agent.</summary>
     [JsonPropertyName("agentType")]
     public required string AgentType { get; set; }
 
+    /// <summary>Human-readable description of the agent task.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("description")]
     public string? Description { get; set; }
 }
 
+/// <summary>Nested data type for <c>SessionIdleDataBackgroundTasksShellsItem</c>.</summary>
 public partial class SessionIdleDataBackgroundTasksShellsItem
 {
+    /// <summary>Unique identifier of the background shell.</summary>
     [JsonPropertyName("shellId")]
     public required string ShellId { get; set; }
 
+    /// <summary>Human-readable description of the shell command.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("description")]
     public string? Description { get; set; }
 }
 
+/// <summary>Background tasks still running when the agent became idle.</summary>
+/// <remarks>Nested data type for <c>SessionIdleDataBackgroundTasks</c>.</remarks>
 public partial class SessionIdleDataBackgroundTasks
 {
+    /// <summary>Currently running background agents.</summary>
     [JsonPropertyName("agents")]
     public required SessionIdleDataBackgroundTasksAgentsItem[] Agents { get; set; }
 
+    /// <summary>Currently running background shell commands.</summary>
     [JsonPropertyName("shells")]
     public required SessionIdleDataBackgroundTasksShellsItem[] Shells { get; set; }
 }
 
+/// <summary>Repository context for the handed-off session.</summary>
+/// <remarks>Nested data type for <c>SessionHandoffDataRepository</c>.</remarks>
 public partial class SessionHandoffDataRepository
 {
+    /// <summary>Repository owner (user or organization).</summary>
     [JsonPropertyName("owner")]
     public required string Owner { get; set; }
 
+    /// <summary>Repository name.</summary>
     [JsonPropertyName("name")]
     public required string Name { get; set; }
 
+    /// <summary>Git branch name, if applicable.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("branch")]
     public string? Branch { get; set; }
 }
 
+/// <summary>Aggregate code change metrics for the session.</summary>
+/// <remarks>Nested data type for <c>SessionShutdownDataCodeChanges</c>.</remarks>
 public partial class SessionShutdownDataCodeChanges
 {
+    /// <summary>Total number of lines added during the session.</summary>
     [JsonPropertyName("linesAdded")]
     public required double LinesAdded { get; set; }
 
+    /// <summary>Total number of lines removed during the session.</summary>
     [JsonPropertyName("linesRemoved")]
     public required double LinesRemoved { get; set; }
 
+    /// <summary>List of file paths that were modified during the session.</summary>
     [JsonPropertyName("filesModified")]
     public required string[] FilesModified { get; set; }
 }
 
+/// <summary>Token usage breakdown for the compaction LLM call.</summary>
+/// <remarks>Nested data type for <c>SessionCompactionCompleteDataCompactionTokensUsed</c>.</remarks>
 public partial class SessionCompactionCompleteDataCompactionTokensUsed
 {
+    /// <summary>Input tokens consumed by the compaction LLM call.</summary>
     [JsonPropertyName("input")]
     public required double Input { get; set; }
 
+    /// <summary>Output tokens produced by the compaction LLM call.</summary>
     [JsonPropertyName("output")]
     public required double Output { get; set; }
 
+    /// <summary>Cached input tokens reused in the compaction LLM call.</summary>
     [JsonPropertyName("cachedInput")]
     public required double CachedInput { get; set; }
 }
 
+/// <summary>Optional line range to scope the attachment to a specific section of the file.</summary>
+/// <remarks>Nested data type for <c>UserMessageDataAttachmentsItemFileLineRange</c>.</remarks>
 public partial class UserMessageDataAttachmentsItemFileLineRange
 {
+    /// <summary>Start line number (1-based).</summary>
     [JsonPropertyName("start")]
     public required double Start { get; set; }
 
+    /// <summary>End line number (1-based, inclusive).</summary>
     [JsonPropertyName("end")]
     public required double End { get; set; }
 }
 
+/// <summary>The <c>file</c> variant of <see cref="UserMessageDataAttachmentsItem"/>.</summary>
 public partial class UserMessageDataAttachmentsItemFile : UserMessageDataAttachmentsItem
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "file";
 
+    /// <summary>Absolute file or directory path.</summary>
     [JsonPropertyName("path")]
     public required string Path { get; set; }
 
+    /// <summary>User-facing display name for the attachment.</summary>
     [JsonPropertyName("displayName")]
     public required string DisplayName { get; set; }
 
+    /// <summary>Optional line range to scope the attachment to a specific section of the file.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("lineRange")]
     public UserMessageDataAttachmentsItemFileLineRange? LineRange { get; set; }
 }
 
+/// <summary>Optional line range to scope the attachment to a specific section of the file.</summary>
+/// <remarks>Nested data type for <c>UserMessageDataAttachmentsItemDirectoryLineRange</c>.</remarks>
 public partial class UserMessageDataAttachmentsItemDirectoryLineRange
 {
+    /// <summary>Start line number (1-based).</summary>
     [JsonPropertyName("start")]
     public required double Start { get; set; }
 
+    /// <summary>End line number (1-based, inclusive).</summary>
     [JsonPropertyName("end")]
     public required double End { get; set; }
 }
 
+/// <summary>The <c>directory</c> variant of <see cref="UserMessageDataAttachmentsItem"/>.</summary>
 public partial class UserMessageDataAttachmentsItemDirectory : UserMessageDataAttachmentsItem
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "directory";
 
+    /// <summary>Absolute file or directory path.</summary>
     [JsonPropertyName("path")]
     public required string Path { get; set; }
 
+    /// <summary>User-facing display name for the attachment.</summary>
     [JsonPropertyName("displayName")]
     public required string DisplayName { get; set; }
 
+    /// <summary>Optional line range to scope the attachment to a specific section of the file.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("lineRange")]
     public UserMessageDataAttachmentsItemDirectoryLineRange? LineRange { get; set; }
 }
 
+/// <summary>Nested data type for <c>UserMessageDataAttachmentsItemSelectionSelectionStart</c>.</summary>
 public partial class UserMessageDataAttachmentsItemSelectionSelectionStart
 {
+    /// <summary>Start line number (0-based).</summary>
     [JsonPropertyName("line")]
     public required double Line { get; set; }
 
+    /// <summary>Start character offset within the line (0-based).</summary>
     [JsonPropertyName("character")]
     public required double Character { get; set; }
 }
 
+/// <summary>Nested data type for <c>UserMessageDataAttachmentsItemSelectionSelectionEnd</c>.</summary>
 public partial class UserMessageDataAttachmentsItemSelectionSelectionEnd
 {
+    /// <summary>End line number (0-based).</summary>
     [JsonPropertyName("line")]
     public required double Line { get; set; }
 
+    /// <summary>End character offset within the line (0-based).</summary>
     [JsonPropertyName("character")]
     public required double Character { get; set; }
 }
 
+/// <summary>Position range of the selection within the file.</summary>
+/// <remarks>Nested data type for <c>UserMessageDataAttachmentsItemSelectionSelection</c>.</remarks>
 public partial class UserMessageDataAttachmentsItemSelectionSelection
 {
+    /// <summary>Gets or sets the <c>start</c> value.</summary>
     [JsonPropertyName("start")]
     public required UserMessageDataAttachmentsItemSelectionSelectionStart Start { get; set; }
 
+    /// <summary>Gets or sets the <c>end</c> value.</summary>
     [JsonPropertyName("end")]
     public required UserMessageDataAttachmentsItemSelectionSelectionEnd End { get; set; }
 }
 
+/// <summary>The <c>selection</c> variant of <see cref="UserMessageDataAttachmentsItem"/>.</summary>
 public partial class UserMessageDataAttachmentsItemSelection : UserMessageDataAttachmentsItem
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "selection";
 
+    /// <summary>Absolute path to the file containing the selection.</summary>
     [JsonPropertyName("filePath")]
     public required string FilePath { get; set; }
 
+    /// <summary>User-facing display name for the selection.</summary>
     [JsonPropertyName("displayName")]
     public required string DisplayName { get; set; }
 
+    /// <summary>The selected text content.</summary>
     [JsonPropertyName("text")]
     public required string Text { get; set; }
 
+    /// <summary>Position range of the selection within the file.</summary>
     [JsonPropertyName("selection")]
     public required UserMessageDataAttachmentsItemSelectionSelection Selection { get; set; }
 }
 
+/// <summary>The <c>github_reference</c> variant of <see cref="UserMessageDataAttachmentsItem"/>.</summary>
 public partial class UserMessageDataAttachmentsItemGithubReference : UserMessageDataAttachmentsItem
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "github_reference";
 
+    /// <summary>Issue, pull request, or discussion number.</summary>
     [JsonPropertyName("number")]
     public required double Number { get; set; }
 
+    /// <summary>Title of the referenced item.</summary>
     [JsonPropertyName("title")]
     public required string Title { get; set; }
 
+    /// <summary>Type of GitHub reference.</summary>
     [JsonPropertyName("referenceType")]
     public required UserMessageDataAttachmentsItemGithubReferenceReferenceType ReferenceType { get; set; }
 
+    /// <summary>Current state of the referenced item (e.g., open, closed, merged).</summary>
     [JsonPropertyName("state")]
     public required string State { get; set; }
 
+    /// <summary>URL to the referenced item on GitHub.</summary>
     [JsonPropertyName("url")]
     public required string Url { get; set; }
 }
 
+/// <summary>Polymorphic base type discriminated by <c>type</c>.</summary>
 [JsonPolymorphic(
     TypeDiscriminatorPropertyName = "type",
     UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType)]
@@ -1909,161 +2256,210 @@ public partial class UserMessageDataAttachmentsItemGithubReference : UserMessage
 [JsonDerivedType(typeof(UserMessageDataAttachmentsItemGithubReference), "github_reference")]
 public partial class UserMessageDataAttachmentsItem
 {
+    /// <summary>The type discriminator.</summary>
     [JsonPropertyName("type")]
     public virtual string Type { get; set; } = string.Empty;
 }
 
 
+/// <summary>Nested data type for <c>AssistantMessageDataToolRequestsItem</c>.</summary>
 public partial class AssistantMessageDataToolRequestsItem
 {
+    /// <summary>Unique identifier for this tool call.</summary>
     [JsonPropertyName("toolCallId")]
     public required string ToolCallId { get; set; }
 
+    /// <summary>Name of the tool being invoked.</summary>
     [JsonPropertyName("name")]
     public required string Name { get; set; }
 
+    /// <summary>Arguments to pass to the tool, format depends on the tool.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("arguments")]
     public object? Arguments { get; set; }
 
+    /// <summary>Tool call type: "function" for standard tool calls, "custom" for grammar-based tool calls. Defaults to "function" when absent.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("type")]
     public AssistantMessageDataToolRequestsItemType? Type { get; set; }
 }
 
+/// <summary>Nested data type for <c>AssistantUsageDataCopilotUsageTokenDetailsItem</c>.</summary>
 public partial class AssistantUsageDataCopilotUsageTokenDetailsItem
 {
+    /// <summary>Number of tokens in this billing batch.</summary>
     [JsonPropertyName("batchSize")]
     public required double BatchSize { get; set; }
 
+    /// <summary>Cost per batch of tokens.</summary>
     [JsonPropertyName("costPerBatch")]
     public required double CostPerBatch { get; set; }
 
+    /// <summary>Total token count for this entry.</summary>
     [JsonPropertyName("tokenCount")]
     public required double TokenCount { get; set; }
 
+    /// <summary>Token category (e.g., "input", "output").</summary>
     [JsonPropertyName("tokenType")]
     public required string TokenType { get; set; }
 }
 
+/// <summary>Per-request cost and usage data from the CAPI copilot_usage response field.</summary>
+/// <remarks>Nested data type for <c>AssistantUsageDataCopilotUsage</c>.</remarks>
 public partial class AssistantUsageDataCopilotUsage
 {
+    /// <summary>Itemized token usage breakdown.</summary>
     [JsonPropertyName("tokenDetails")]
     public required AssistantUsageDataCopilotUsageTokenDetailsItem[] TokenDetails { get; set; }
 
+    /// <summary>Total cost in nano-AIU (AI Units) for this request.</summary>
     [JsonPropertyName("totalNanoAiu")]
     public required double TotalNanoAiu { get; set; }
 }
 
+/// <summary>The <c>text</c> variant of <see cref="ToolExecutionCompleteDataResultContentsItem"/>.</summary>
 public partial class ToolExecutionCompleteDataResultContentsItemText : ToolExecutionCompleteDataResultContentsItem
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "text";
 
+    /// <summary>The text content.</summary>
     [JsonPropertyName("text")]
     public required string Text { get; set; }
 }
 
+/// <summary>The <c>terminal</c> variant of <see cref="ToolExecutionCompleteDataResultContentsItem"/>.</summary>
 public partial class ToolExecutionCompleteDataResultContentsItemTerminal : ToolExecutionCompleteDataResultContentsItem
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "terminal";
 
+    /// <summary>Terminal/shell output text.</summary>
     [JsonPropertyName("text")]
     public required string Text { get; set; }
 
+    /// <summary>Process exit code, if the command has completed.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("exitCode")]
     public double? ExitCode { get; set; }
 
+    /// <summary>Working directory where the command was executed.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("cwd")]
     public string? Cwd { get; set; }
 }
 
+/// <summary>The <c>image</c> variant of <see cref="ToolExecutionCompleteDataResultContentsItem"/>.</summary>
 public partial class ToolExecutionCompleteDataResultContentsItemImage : ToolExecutionCompleteDataResultContentsItem
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "image";
 
+    /// <summary>Base64-encoded image data.</summary>
     [JsonPropertyName("data")]
     public required string Data { get; set; }
 
+    /// <summary>MIME type of the image (e.g., image/png, image/jpeg).</summary>
     [JsonPropertyName("mimeType")]
     public required string MimeType { get; set; }
 }
 
+/// <summary>The <c>audio</c> variant of <see cref="ToolExecutionCompleteDataResultContentsItem"/>.</summary>
 public partial class ToolExecutionCompleteDataResultContentsItemAudio : ToolExecutionCompleteDataResultContentsItem
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "audio";
 
+    /// <summary>Base64-encoded audio data.</summary>
     [JsonPropertyName("data")]
     public required string Data { get; set; }
 
+    /// <summary>MIME type of the audio (e.g., audio/wav, audio/mpeg).</summary>
     [JsonPropertyName("mimeType")]
     public required string MimeType { get; set; }
 }
 
+/// <summary>Nested data type for <c>ToolExecutionCompleteDataResultContentsItemResourceLinkIconsItem</c>.</summary>
 public partial class ToolExecutionCompleteDataResultContentsItemResourceLinkIconsItem
 {
+    /// <summary>URL or path to the icon image.</summary>
     [JsonPropertyName("src")]
     public required string Src { get; set; }
 
+    /// <summary>MIME type of the icon image.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("mimeType")]
     public string? MimeType { get; set; }
 
+    /// <summary>Available icon sizes (e.g., ['16x16', '32x32']).</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("sizes")]
     public string[]? Sizes { get; set; }
 
+    /// <summary>Theme variant this icon is intended for.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("theme")]
     public ToolExecutionCompleteDataResultContentsItemResourceLinkIconsItemTheme? Theme { get; set; }
 }
 
+/// <summary>The <c>resource_link</c> variant of <see cref="ToolExecutionCompleteDataResultContentsItem"/>.</summary>
 public partial class ToolExecutionCompleteDataResultContentsItemResourceLink : ToolExecutionCompleteDataResultContentsItem
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "resource_link";
 
+    /// <summary>Icons associated with this resource.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("icons")]
     public ToolExecutionCompleteDataResultContentsItemResourceLinkIconsItem[]? Icons { get; set; }
 
+    /// <summary>Resource name identifier.</summary>
     [JsonPropertyName("name")]
     public required string Name { get; set; }
 
+    /// <summary>Human-readable display title for the resource.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("title")]
     public string? Title { get; set; }
 
+    /// <summary>URI identifying the resource.</summary>
     [JsonPropertyName("uri")]
     public required string Uri { get; set; }
 
+    /// <summary>Human-readable description of the resource.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("description")]
     public string? Description { get; set; }
 
+    /// <summary>MIME type of the resource content.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("mimeType")]
     public string? MimeType { get; set; }
 
+    /// <summary>Size of the resource in bytes.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("size")]
     public double? Size { get; set; }
 }
 
+/// <summary>The <c>resource</c> variant of <see cref="ToolExecutionCompleteDataResultContentsItem"/>.</summary>
 public partial class ToolExecutionCompleteDataResultContentsItemResource : ToolExecutionCompleteDataResultContentsItem
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "resource";
 
+    /// <summary>The embedded resource contents, either text or base64-encoded binary.</summary>
     [JsonPropertyName("resource")]
     public required object Resource { get; set; }
 }
 
+/// <summary>Polymorphic base type discriminated by <c>type</c>.</summary>
 [JsonPolymorphic(
     TypeDiscriminatorPropertyName = "type",
     UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType)]
@@ -2075,109 +2471,145 @@ public partial class ToolExecutionCompleteDataResultContentsItemResource : ToolE
 [JsonDerivedType(typeof(ToolExecutionCompleteDataResultContentsItemResource), "resource")]
 public partial class ToolExecutionCompleteDataResultContentsItem
 {
+    /// <summary>The type discriminator.</summary>
     [JsonPropertyName("type")]
     public virtual string Type { get; set; } = string.Empty;
 }
 
 
+/// <summary>Tool execution result on success.</summary>
+/// <remarks>Nested data type for <c>ToolExecutionCompleteDataResult</c>.</remarks>
 public partial class ToolExecutionCompleteDataResult
 {
+    /// <summary>Concise tool result text sent to the LLM for chat completion, potentially truncated for token efficiency.</summary>
     [JsonPropertyName("content")]
     public required string Content { get; set; }
 
+    /// <summary>Full detailed tool result for UI/timeline display, preserving complete content such as diffs. Falls back to content when absent.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("detailedContent")]
     public string? DetailedContent { get; set; }
 
+    /// <summary>Structured content blocks (text, images, audio, resources) returned by the tool in their native format.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("contents")]
     public ToolExecutionCompleteDataResultContentsItem[]? Contents { get; set; }
 }
 
+/// <summary>Error details when the tool execution failed.</summary>
+/// <remarks>Nested data type for <c>ToolExecutionCompleteDataError</c>.</remarks>
 public partial class ToolExecutionCompleteDataError
 {
+    /// <summary>Human-readable error message.</summary>
     [JsonPropertyName("message")]
     public required string Message { get; set; }
 
+    /// <summary>Machine-readable error code.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("code")]
     public string? Code { get; set; }
 }
 
+/// <summary>Error details when the hook failed.</summary>
+/// <remarks>Nested data type for <c>HookEndDataError</c>.</remarks>
 public partial class HookEndDataError
 {
+    /// <summary>Human-readable error message.</summary>
     [JsonPropertyName("message")]
     public required string Message { get; set; }
 
+    /// <summary>Error stack trace, when available.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("stack")]
     public string? Stack { get; set; }
 }
 
+/// <summary>Metadata about the prompt template and its construction.</summary>
+/// <remarks>Nested data type for <c>SystemMessageDataMetadata</c>.</remarks>
 public partial class SystemMessageDataMetadata
 {
+    /// <summary>Version identifier of the prompt template used.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("promptVersion")]
     public string? PromptVersion { get; set; }
 
+    /// <summary>Template variables used when constructing the prompt.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("variables")]
     public Dictionary<string, object>? Variables { get; set; }
 }
 
+/// <summary>The <c>agent_completed</c> variant of <see cref="SystemNotificationDataKind"/>.</summary>
 public partial class SystemNotificationDataKindAgentCompleted : SystemNotificationDataKind
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "agent_completed";
 
+    /// <summary>Unique identifier of the background agent.</summary>
     [JsonPropertyName("agentId")]
     public required string AgentId { get; set; }
 
+    /// <summary>Type of the agent (e.g., explore, task, general-purpose).</summary>
     [JsonPropertyName("agentType")]
     public required string AgentType { get; set; }
 
+    /// <summary>Whether the agent completed successfully or failed.</summary>
     [JsonPropertyName("status")]
     public required SystemNotificationDataKindAgentCompletedStatus Status { get; set; }
 
+    /// <summary>Human-readable description of the agent task.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("description")]
     public string? Description { get; set; }
 
+    /// <summary>The full prompt given to the background agent.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("prompt")]
     public string? Prompt { get; set; }
 }
 
+/// <summary>The <c>shell_completed</c> variant of <see cref="SystemNotificationDataKind"/>.</summary>
 public partial class SystemNotificationDataKindShellCompleted : SystemNotificationDataKind
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "shell_completed";
 
+    /// <summary>Unique identifier of the shell session.</summary>
     [JsonPropertyName("shellId")]
     public required string ShellId { get; set; }
 
+    /// <summary>Exit code of the shell command, if available.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("exitCode")]
     public double? ExitCode { get; set; }
 
+    /// <summary>Human-readable description of the command.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("description")]
     public string? Description { get; set; }
 }
 
+/// <summary>The <c>shell_detached_completed</c> variant of <see cref="SystemNotificationDataKind"/>.</summary>
 public partial class SystemNotificationDataKindShellDetachedCompleted : SystemNotificationDataKind
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Type => "shell_detached_completed";
 
+    /// <summary>Unique identifier of the detached shell session.</summary>
     [JsonPropertyName("shellId")]
     public required string ShellId { get; set; }
 
+    /// <summary>Human-readable description of the command.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("description")]
     public string? Description { get; set; }
 }
 
+/// <summary>Structured metadata identifying what triggered this notification.</summary>
+/// <remarks>Polymorphic base type discriminated by <c>type</c>.</remarks>
 [JsonPolymorphic(
     TypeDiscriminatorPropertyName = "type",
     UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType)]
@@ -2186,181 +2618,237 @@ public partial class SystemNotificationDataKindShellDetachedCompleted : SystemNo
 [JsonDerivedType(typeof(SystemNotificationDataKindShellDetachedCompleted), "shell_detached_completed")]
 public partial class SystemNotificationDataKind
 {
+    /// <summary>The type discriminator.</summary>
     [JsonPropertyName("type")]
     public virtual string Type { get; set; } = string.Empty;
 }
 
 
+/// <summary>Nested data type for <c>PermissionRequestShellCommandsItem</c>.</summary>
 public partial class PermissionRequestShellCommandsItem
 {
+    /// <summary>Command identifier (e.g., executable name).</summary>
     [JsonPropertyName("identifier")]
     public required string Identifier { get; set; }
 
+    /// <summary>Whether this command is read-only (no side effects).</summary>
     [JsonPropertyName("readOnly")]
     public required bool ReadOnly { get; set; }
 }
 
+/// <summary>Nested data type for <c>PermissionRequestShellPossibleUrlsItem</c>.</summary>
 public partial class PermissionRequestShellPossibleUrlsItem
 {
+    /// <summary>URL that may be accessed by the command.</summary>
     [JsonPropertyName("url")]
     public required string Url { get; set; }
 }
 
+/// <summary>The <c>shell</c> variant of <see cref="PermissionRequest"/>.</summary>
 public partial class PermissionRequestShell : PermissionRequest
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Kind => "shell";
 
+    /// <summary>Tool call ID that triggered this permission request.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("toolCallId")]
     public string? ToolCallId { get; set; }
 
+    /// <summary>The complete shell command text to be executed.</summary>
     [JsonPropertyName("fullCommandText")]
     public required string FullCommandText { get; set; }
 
+    /// <summary>Human-readable description of what the command intends to do.</summary>
     [JsonPropertyName("intention")]
     public required string Intention { get; set; }
 
+    /// <summary>Parsed command identifiers found in the command text.</summary>
     [JsonPropertyName("commands")]
     public required PermissionRequestShellCommandsItem[] Commands { get; set; }
 
+    /// <summary>File paths that may be read or written by the command.</summary>
     [JsonPropertyName("possiblePaths")]
     public required string[] PossiblePaths { get; set; }
 
+    /// <summary>URLs that may be accessed by the command.</summary>
     [JsonPropertyName("possibleUrls")]
     public required PermissionRequestShellPossibleUrlsItem[] PossibleUrls { get; set; }
 
+    /// <summary>Whether the command includes a file write redirection (e.g., &gt; or &gt;&gt;).</summary>
     [JsonPropertyName("hasWriteFileRedirection")]
     public required bool HasWriteFileRedirection { get; set; }
 
+    /// <summary>Whether the UI can offer session-wide approval for this command pattern.</summary>
     [JsonPropertyName("canOfferSessionApproval")]
     public required bool CanOfferSessionApproval { get; set; }
 
+    /// <summary>Optional warning message about risks of running this command.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("warning")]
     public string? Warning { get; set; }
 }
 
+/// <summary>The <c>write</c> variant of <see cref="PermissionRequest"/>.</summary>
 public partial class PermissionRequestWrite : PermissionRequest
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Kind => "write";
 
+    /// <summary>Tool call ID that triggered this permission request.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("toolCallId")]
     public string? ToolCallId { get; set; }
 
+    /// <summary>Human-readable description of the intended file change.</summary>
     [JsonPropertyName("intention")]
     public required string Intention { get; set; }
 
+    /// <summary>Path of the file being written to.</summary>
     [JsonPropertyName("fileName")]
     public required string FileName { get; set; }
 
+    /// <summary>Unified diff showing the proposed changes.</summary>
     [JsonPropertyName("diff")]
     public required string Diff { get; set; }
 
+    /// <summary>Complete new file contents for newly created files.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("newFileContents")]
     public string? NewFileContents { get; set; }
 }
 
+/// <summary>The <c>read</c> variant of <see cref="PermissionRequest"/>.</summary>
 public partial class PermissionRequestRead : PermissionRequest
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Kind => "read";
 
+    /// <summary>Tool call ID that triggered this permission request.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("toolCallId")]
     public string? ToolCallId { get; set; }
 
+    /// <summary>Human-readable description of why the file is being read.</summary>
     [JsonPropertyName("intention")]
     public required string Intention { get; set; }
 
+    /// <summary>Path of the file or directory being read.</summary>
     [JsonPropertyName("path")]
     public required string Path { get; set; }
 }
 
+/// <summary>The <c>mcp</c> variant of <see cref="PermissionRequest"/>.</summary>
 public partial class PermissionRequestMcp : PermissionRequest
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Kind => "mcp";
 
+    /// <summary>Tool call ID that triggered this permission request.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("toolCallId")]
     public string? ToolCallId { get; set; }
 
+    /// <summary>Name of the MCP server providing the tool.</summary>
     [JsonPropertyName("serverName")]
     public required string ServerName { get; set; }
 
+    /// <summary>Internal name of the MCP tool.</summary>
     [JsonPropertyName("toolName")]
     public required string ToolName { get; set; }
 
+    /// <summary>Human-readable title of the MCP tool.</summary>
     [JsonPropertyName("toolTitle")]
     public required string ToolTitle { get; set; }
 
+    /// <summary>Arguments to pass to the MCP tool.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("args")]
     public object? Args { get; set; }
 
+    /// <summary>Whether this MCP tool is read-only (no side effects).</summary>
     [JsonPropertyName("readOnly")]
     public required bool ReadOnly { get; set; }
 }
 
+/// <summary>The <c>url</c> variant of <see cref="PermissionRequest"/>.</summary>
 public partial class PermissionRequestUrl : PermissionRequest
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Kind => "url";
 
+    /// <summary>Tool call ID that triggered this permission request.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("toolCallId")]
     public string? ToolCallId { get; set; }
 
+    /// <summary>Human-readable description of why the URL is being accessed.</summary>
     [JsonPropertyName("intention")]
     public required string Intention { get; set; }
 
+    /// <summary>URL to be fetched.</summary>
     [JsonPropertyName("url")]
     public required string Url { get; set; }
 }
 
+/// <summary>The <c>memory</c> variant of <see cref="PermissionRequest"/>.</summary>
 public partial class PermissionRequestMemory : PermissionRequest
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Kind => "memory";
 
+    /// <summary>Tool call ID that triggered this permission request.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("toolCallId")]
     public string? ToolCallId { get; set; }
 
+    /// <summary>Topic or subject of the memory being stored.</summary>
     [JsonPropertyName("subject")]
     public required string Subject { get; set; }
 
+    /// <summary>The fact or convention being stored.</summary>
     [JsonPropertyName("fact")]
     public required string Fact { get; set; }
 
+    /// <summary>Source references for the stored fact.</summary>
     [JsonPropertyName("citations")]
     public required string Citations { get; set; }
 }
 
+/// <summary>The <c>custom-tool</c> variant of <see cref="PermissionRequest"/>.</summary>
 public partial class PermissionRequestCustomTool : PermissionRequest
 {
+    /// <inheritdoc />
     [JsonIgnore]
     public override string Kind => "custom-tool";
 
+    /// <summary>Tool call ID that triggered this permission request.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("toolCallId")]
     public string? ToolCallId { get; set; }
 
+    /// <summary>Name of the custom tool.</summary>
     [JsonPropertyName("toolName")]
     public required string ToolName { get; set; }
 
+    /// <summary>Description of what the custom tool does.</summary>
     [JsonPropertyName("toolDescription")]
     public required string ToolDescription { get; set; }
 
+    /// <summary>Arguments to pass to the custom tool.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("args")]
     public object? Args { get; set; }
 }
 
+/// <summary>Details of the permission being requested.</summary>
+/// <remarks>Polymorphic base type discriminated by <c>kind</c>.</remarks>
 [JsonPolymorphic(
     TypeDiscriminatorPropertyName = "kind",
     UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType)]
@@ -2373,139 +2861,188 @@ public partial class PermissionRequestCustomTool : PermissionRequest
 [JsonDerivedType(typeof(PermissionRequestCustomTool), "custom-tool")]
 public partial class PermissionRequest
 {
+    /// <summary>The type discriminator.</summary>
     [JsonPropertyName("kind")]
     public virtual string Kind { get; set; } = string.Empty;
 }
 
 
+/// <summary>The result of the permission request.</summary>
+/// <remarks>Nested data type for <c>PermissionCompletedDataResult</c>.</remarks>
 public partial class PermissionCompletedDataResult
 {
+    /// <summary>The outcome of the permission request.</summary>
     [JsonPropertyName("kind")]
     public required PermissionCompletedDataResultKind Kind { get; set; }
 }
 
+/// <summary>JSON Schema describing the form fields to present to the user.</summary>
+/// <remarks>Nested data type for <c>ElicitationRequestedDataRequestedSchema</c>.</remarks>
 public partial class ElicitationRequestedDataRequestedSchema
 {
+    /// <summary>Gets or sets the <c>type</c> value.</summary>
     [JsonPropertyName("type")]
     public required string Type { get; set; }
 
+    /// <summary>Form field definitions, keyed by field name.</summary>
     [JsonPropertyName("properties")]
     public required Dictionary<string, object> Properties { get; set; }
 
+    /// <summary>List of required field names.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("required")]
     public string[]? Required { get; set; }
 }
 
+/// <summary>The type of operation performed on the plan file.</summary>
 [JsonConverter(typeof(JsonStringEnumConverter<SessionPlanChangedDataOperation>))]
 public enum SessionPlanChangedDataOperation
 {
+    /// <summary>The <c>create</c> variant.</summary>
     [JsonStringEnumMemberName("create")]
     Create,
+    /// <summary>The <c>update</c> variant.</summary>
     [JsonStringEnumMemberName("update")]
     Update,
+    /// <summary>The <c>delete</c> variant.</summary>
     [JsonStringEnumMemberName("delete")]
     Delete,
 }
 
+/// <summary>Whether the file was newly created or updated.</summary>
 [JsonConverter(typeof(JsonStringEnumConverter<SessionWorkspaceFileChangedDataOperation>))]
 public enum SessionWorkspaceFileChangedDataOperation
 {
+    /// <summary>The <c>create</c> variant.</summary>
     [JsonStringEnumMemberName("create")]
     Create,
+    /// <summary>The <c>update</c> variant.</summary>
     [JsonStringEnumMemberName("update")]
     Update,
 }
 
+/// <summary>Origin type of the session being handed off.</summary>
 [JsonConverter(typeof(JsonStringEnumConverter<SessionHandoffDataSourceType>))]
 public enum SessionHandoffDataSourceType
 {
+    /// <summary>The <c>remote</c> variant.</summary>
     [JsonStringEnumMemberName("remote")]
     Remote,
+    /// <summary>The <c>local</c> variant.</summary>
     [JsonStringEnumMemberName("local")]
     Local,
 }
 
+/// <summary>Whether the session ended normally ("routine") or due to a crash/fatal error ("error").</summary>
 [JsonConverter(typeof(JsonStringEnumConverter<SessionShutdownDataShutdownType>))]
 public enum SessionShutdownDataShutdownType
 {
+    /// <summary>The <c>routine</c> variant.</summary>
     [JsonStringEnumMemberName("routine")]
     Routine,
+    /// <summary>The <c>error</c> variant.</summary>
     [JsonStringEnumMemberName("error")]
     Error,
 }
 
+/// <summary>Type of GitHub reference.</summary>
 [JsonConverter(typeof(JsonStringEnumConverter<UserMessageDataAttachmentsItemGithubReferenceReferenceType>))]
 public enum UserMessageDataAttachmentsItemGithubReferenceReferenceType
 {
+    /// <summary>The <c>issue</c> variant.</summary>
     [JsonStringEnumMemberName("issue")]
     Issue,
+    /// <summary>The <c>pr</c> variant.</summary>
     [JsonStringEnumMemberName("pr")]
     Pr,
+    /// <summary>The <c>discussion</c> variant.</summary>
     [JsonStringEnumMemberName("discussion")]
     Discussion,
 }
 
+/// <summary>The agent mode that was active when this message was sent.</summary>
 [JsonConverter(typeof(JsonStringEnumConverter<UserMessageDataAgentMode>))]
 public enum UserMessageDataAgentMode
 {
+    /// <summary>The <c>interactive</c> variant.</summary>
     [JsonStringEnumMemberName("interactive")]
     Interactive,
+    /// <summary>The <c>plan</c> variant.</summary>
     [JsonStringEnumMemberName("plan")]
     Plan,
+    /// <summary>The <c>autopilot</c> variant.</summary>
     [JsonStringEnumMemberName("autopilot")]
     Autopilot,
+    /// <summary>The <c>shell</c> variant.</summary>
     [JsonStringEnumMemberName("shell")]
     Shell,
 }
 
+/// <summary>Tool call type: "function" for standard tool calls, "custom" for grammar-based tool calls. Defaults to "function" when absent.</summary>
 [JsonConverter(typeof(JsonStringEnumConverter<AssistantMessageDataToolRequestsItemType>))]
 public enum AssistantMessageDataToolRequestsItemType
 {
+    /// <summary>The <c>function</c> variant.</summary>
     [JsonStringEnumMemberName("function")]
     Function,
+    /// <summary>The <c>custom</c> variant.</summary>
     [JsonStringEnumMemberName("custom")]
     Custom,
 }
 
+/// <summary>Theme variant this icon is intended for.</summary>
 [JsonConverter(typeof(JsonStringEnumConverter<ToolExecutionCompleteDataResultContentsItemResourceLinkIconsItemTheme>))]
 public enum ToolExecutionCompleteDataResultContentsItemResourceLinkIconsItemTheme
 {
+    /// <summary>The <c>light</c> variant.</summary>
     [JsonStringEnumMemberName("light")]
     Light,
+    /// <summary>The <c>dark</c> variant.</summary>
     [JsonStringEnumMemberName("dark")]
     Dark,
 }
 
+/// <summary>Message role: "system" for system prompts, "developer" for developer-injected instructions.</summary>
 [JsonConverter(typeof(JsonStringEnumConverter<SystemMessageDataRole>))]
 public enum SystemMessageDataRole
 {
+    /// <summary>The <c>system</c> variant.</summary>
     [JsonStringEnumMemberName("system")]
     System,
+    /// <summary>The <c>developer</c> variant.</summary>
     [JsonStringEnumMemberName("developer")]
     Developer,
 }
 
+/// <summary>Whether the agent completed successfully or failed.</summary>
 [JsonConverter(typeof(JsonStringEnumConverter<SystemNotificationDataKindAgentCompletedStatus>))]
 public enum SystemNotificationDataKindAgentCompletedStatus
 {
+    /// <summary>The <c>completed</c> variant.</summary>
     [JsonStringEnumMemberName("completed")]
     Completed,
+    /// <summary>The <c>failed</c> variant.</summary>
     [JsonStringEnumMemberName("failed")]
     Failed,
 }
 
+/// <summary>The outcome of the permission request.</summary>
 [JsonConverter(typeof(JsonStringEnumConverter<PermissionCompletedDataResultKind>))]
 public enum PermissionCompletedDataResultKind
 {
+    /// <summary>The <c>approved</c> variant.</summary>
     [JsonStringEnumMemberName("approved")]
     Approved,
+    /// <summary>The <c>denied-by-rules</c> variant.</summary>
     [JsonStringEnumMemberName("denied-by-rules")]
     DeniedByRules,
+    /// <summary>The <c>denied-no-approval-rule-and-could-not-request-from-user</c> variant.</summary>
     [JsonStringEnumMemberName("denied-no-approval-rule-and-could-not-request-from-user")]
     DeniedNoApprovalRuleAndCouldNotRequestFromUser,
+    /// <summary>The <c>denied-interactively-by-user</c> variant.</summary>
     [JsonStringEnumMemberName("denied-interactively-by-user")]
     DeniedInteractivelyByUser,
+    /// <summary>The <c>denied-by-content-exclusion-policy</c> variant.</summary>
     [JsonStringEnumMemberName("denied-by-content-exclusion-policy")]
     DeniedByContentExclusionPolicy,
 }

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -44,6 +44,60 @@ function applyTypeRename(className: string): string {
 
 // ── C# utilities ────────────────────────────────────────────────────────────
 
+function escapeXml(text: string): string {
+    return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** Ensures text ends with sentence-ending punctuation. */
+function ensureTrailingPunctuation(text: string): string {
+    const trimmed = text.trimEnd();
+    if (/[.!?]$/.test(trimmed)) return trimmed;
+    return `${trimmed}.`;
+}
+
+function xmlDocComment(description: string | undefined, indent: string): string[] {
+    if (!description) return [];
+    const escaped = ensureTrailingPunctuation(escapeXml(description.trim()));
+    const lines = escaped.split(/\r?\n/);
+    if (lines.length === 1) {
+        return [`${indent}/// <summary>${lines[0]}</summary>`];
+    }
+    return [
+        `${indent}/// <summary>`,
+        ...lines.map((l) => `${indent}/// ${l}`),
+        `${indent}/// </summary>`,
+    ];
+}
+
+/** Like xmlDocComment but skips XML escaping — use only for codegen-controlled strings that already contain valid XML tags. */
+function rawXmlDocSummary(text: string, indent: string): string[] {
+    const line = ensureTrailingPunctuation(text.trim());
+    return [`${indent}/// <summary>${line}</summary>`];
+}
+
+/** Emits a summary (from description or fallback) and, when a real description exists, a remarks line with the fallback. */
+function xmlDocCommentWithFallback(description: string | undefined, fallback: string, indent: string): string[] {
+    if (description) {
+        return [
+            ...xmlDocComment(description, indent),
+            `${indent}/// <remarks>${ensureTrailingPunctuation(fallback)}</remarks>`,
+        ];
+    }
+    return rawXmlDocSummary(fallback, indent);
+}
+
+/** Emits a summary from the schema description, or a fallback naming the property by its JSON key. */
+function xmlDocPropertyComment(description: string | undefined, jsonPropName: string, indent: string): string[] {
+    if (description) return xmlDocComment(description, indent);
+    return rawXmlDocSummary(`Gets or sets the <c>${escapeXml(jsonPropName)}</c> value.`, indent);
+}
+
+/** Emits a summary from the schema description, or a generic fallback. */
+function xmlDocEnumComment(description: string | undefined, indent: string): string[] {
+    if (description) return xmlDocComment(description, indent);
+    return rawXmlDocSummary(`Defines the allowed values.`, indent);
+}
+
 function toPascalCase(name: string): string {
     if (name.includes("_") || name.includes("-")) {
         return name.split(/[-_]/).map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join("");
@@ -139,11 +193,12 @@ interface EventVariant {
     className: string;
     dataClassName: string;
     dataSchema: JSONSchema7;
+    dataDescription?: string;
 }
 
 let generatedEnums = new Map<string, { enumName: string; values: string[] }>();
 
-function getOrCreateEnum(parentClassName: string, propName: string, values: string[], enumOutput: string[]): string {
+function getOrCreateEnum(parentClassName: string, propName: string, values: string[], enumOutput: string[], description?: string): string {
     const valuesKey = [...values].sort().join("|");
     for (const [, existing] of generatedEnums) {
         if ([...existing.values].sort().join("|") === valuesKey) return existing.enumName;
@@ -151,8 +206,11 @@ function getOrCreateEnum(parentClassName: string, propName: string, values: stri
     const enumName = `${parentClassName}${propName}`;
     generatedEnums.set(enumName, { enumName, values });
 
-    const lines = [`[JsonConverter(typeof(JsonStringEnumConverter<${enumName}>))]`, `public enum ${enumName}`, `{`];
+    const lines: string[] = [];
+    lines.push(...xmlDocEnumComment(description, ""));
+    lines.push(`[JsonConverter(typeof(JsonStringEnumConverter<${enumName}>))]`, `public enum ${enumName}`, `{`);
     for (const value of values) {
+        lines.push(`    /// <summary>The <c>${escapeXml(value)}</c> variant.</summary>`);
         lines.push(`    [JsonStringEnumMemberName("${value}")]`, `    ${toPascalCaseEnumMember(value)},`);
     }
     lines.push(`}`, "");
@@ -171,11 +229,13 @@ function extractEventVariants(schema: JSONSchema7): EventVariant[] {
             const typeName = typeSchema?.const as string;
             if (!typeName) throw new Error("Variant must have type.const");
             const baseName = typeToClassName(typeName);
+            const dataSchema = variant.properties.data as JSONSchema7;
             return {
                 typeName,
                 className: `${baseName}Event`,
                 dataClassName: `${baseName}Data`,
-                dataSchema: variant.properties.data as JSONSchema7,
+                dataSchema,
+                dataDescription: dataSchema?.description,
             };
         })
         .filter((v) => !EXCLUDED_EVENT_TYPES.has(v.typeName));
@@ -222,12 +282,14 @@ function generatePolymorphicClasses(
     variants: JSONSchema7[],
     knownTypes: Map<string, string>,
     nestedClasses: Map<string, string>,
-    enumOutput: string[]
+    enumOutput: string[],
+    description?: string
 ): string {
     const lines: string[] = [];
     const discriminatorInfo = findDiscriminator(variants)!;
     const renamedBase = applyTypeRename(baseClassName);
 
+    lines.push(...xmlDocCommentWithFallback(description, `Polymorphic base type discriminated by <c>${escapeXml(discriminatorProperty)}</c>.`, ""));
     lines.push(`[JsonPolymorphic(`);
     lines.push(`    TypeDiscriminatorPropertyName = "${discriminatorProperty}",`);
     lines.push(`    UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType)]`);
@@ -239,6 +301,7 @@ function generatePolymorphicClasses(
 
     lines.push(`public partial class ${renamedBase}`);
     lines.push(`{`);
+    lines.push(`    /// <summary>The type discriminator.</summary>`);
     lines.push(`    [JsonPropertyName("${discriminatorProperty}")]`);
     lines.push(`    public virtual string ${toPascalCase(discriminatorProperty)} { get; set; } = string.Empty;`);
     lines.push(`}`);
@@ -269,8 +332,10 @@ function generateDerivedClass(
     const lines: string[] = [];
     const required = new Set(schema.required || []);
 
+    lines.push(...xmlDocCommentWithFallback(schema.description, `The <c>${escapeXml(discriminatorValue)}</c> variant of <see cref="${baseClassName}"/>.`, ""));
     lines.push(`public partial class ${className} : ${baseClassName}`);
     lines.push(`{`);
+    lines.push(`    /// <inheritdoc />`);
     lines.push(`    [JsonIgnore]`);
     lines.push(`    public override string ${toPascalCase(discriminatorProperty)} => "${discriminatorValue}";`);
     lines.push("");
@@ -284,6 +349,7 @@ function generateDerivedClass(
             const csharpName = toPascalCase(propName);
             const csharpType = resolveSessionPropertyType(propSchema as JSONSchema7, className, csharpName, isReq, knownTypes, nestedClasses, enumOutput);
 
+            lines.push(...xmlDocPropertyComment((propSchema as JSONSchema7).description, propName, "    "));
             if (!isReq) lines.push(`    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`);
             lines.push(`    [JsonPropertyName("${propName}")]`);
             const reqMod = isReq && !csharpType.endsWith("?") ? "required " : "";
@@ -304,7 +370,9 @@ function generateNestedClass(
     enumOutput: string[]
 ): string {
     const required = new Set(schema.required || []);
-    const lines = [`public partial class ${className}`, `{`];
+    const lines: string[] = [];
+    lines.push(...xmlDocCommentWithFallback(schema.description, `Nested data type for <c>${className}</c>.`, ""));
+    lines.push(`public partial class ${className}`, `{`);
 
     for (const [propName, propSchema] of Object.entries(schema.properties || {})) {
         if (typeof propSchema !== "object") continue;
@@ -313,6 +381,7 @@ function generateNestedClass(
         const csharpName = toPascalCase(propName);
         const csharpType = resolveSessionPropertyType(prop, className, csharpName, isReq, knownTypes, nestedClasses, enumOutput);
 
+        lines.push(...xmlDocPropertyComment(prop.description, propName, "    "));
         if (!isReq) lines.push(`    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`);
         lines.push(`    [JsonPropertyName("${propName}")]`);
         const reqMod = isReq && !csharpType.endsWith("?") ? "required " : "";
@@ -345,7 +414,7 @@ function resolveSessionPropertyType(
             if (discriminatorInfo) {
                 const baseClassName = `${parentClassName}${propName}`;
                 const renamedBase = applyTypeRename(baseClassName);
-                const polymorphicCode = generatePolymorphicClasses(baseClassName, discriminatorInfo.property, variants, knownTypes, nestedClasses, enumOutput);
+                const polymorphicCode = generatePolymorphicClasses(baseClassName, discriminatorInfo.property, variants, knownTypes, nestedClasses, enumOutput, propSchema.description);
                 nestedClasses.set(renamedBase, polymorphicCode);
                 return isRequired && !hasNull ? renamedBase : `${renamedBase}?`;
             }
@@ -353,7 +422,7 @@ function resolveSessionPropertyType(
         return hasNull || !isRequired ? "object?" : "object";
     }
     if (propSchema.enum && Array.isArray(propSchema.enum)) {
-        const enumName = getOrCreateEnum(parentClassName, propName, propSchema.enum as string[], enumOutput);
+        const enumName = getOrCreateEnum(parentClassName, propName, propSchema.enum as string[], enumOutput, propSchema.description);
         return isRequired ? enumName : `${enumName}?`;
     }
     if (propSchema.type === "object" && propSchema.properties) {
@@ -370,7 +439,7 @@ function resolveSessionPropertyType(
             if (discriminatorInfo) {
                 const baseClassName = `${parentClassName}${propName}Item`;
                 const renamedBase = applyTypeRename(baseClassName);
-                const polymorphicCode = generatePolymorphicClasses(baseClassName, discriminatorInfo.property, variants, knownTypes, nestedClasses, enumOutput);
+                const polymorphicCode = generatePolymorphicClasses(baseClassName, discriminatorInfo.property, variants, knownTypes, nestedClasses, enumOutput, items.description);
                 nestedClasses.set(renamedBase, polymorphicCode);
                 return isRequired ? `${renamedBase}[]` : `${renamedBase}[]?`;
             }
@@ -381,7 +450,7 @@ function resolveSessionPropertyType(
             return isRequired ? `${itemClassName}[]` : `${itemClassName}[]?`;
         }
         if (items.enum && Array.isArray(items.enum)) {
-            const enumName = getOrCreateEnum(parentClassName, `${propName}Item`, items.enum as string[], enumOutput);
+            const enumName = getOrCreateEnum(parentClassName, `${propName}Item`, items.enum as string[], enumOutput, items.description);
             return isRequired ? `${enumName}[]` : `${enumName}[]?`;
         }
         const itemType = schemaTypeToCSharp(items, true, knownTypes);
@@ -394,7 +463,13 @@ function generateDataClass(variant: EventVariant, knownTypes: Map<string, string
     if (!variant.dataSchema?.properties) return `public partial class ${variant.dataClassName} { }`;
 
     const required = new Set(variant.dataSchema.required || []);
-    const lines = [`public partial class ${variant.dataClassName}`, `{`];
+    const lines: string[] = [];
+    if (variant.dataDescription) {
+        lines.push(...xmlDocComment(variant.dataDescription, ""));
+    } else {
+        lines.push(...rawXmlDocSummary(`Event payload for <see cref="${variant.className}"/>.`, ""));
+    }
+    lines.push(`public partial class ${variant.dataClassName}`, `{`);
 
     for (const [propName, propSchema] of Object.entries(variant.dataSchema.properties)) {
         if (typeof propSchema !== "object") continue;
@@ -402,6 +477,7 @@ function generateDataClass(variant: EventVariant, knownTypes: Map<string, string
         const csharpName = toPascalCase(propName);
         const csharpType = resolveSessionPropertyType(propSchema as JSONSchema7, variant.dataClassName, csharpName, isReq, knownTypes, nestedClasses, enumOutput);
 
+        lines.push(...xmlDocPropertyComment((propSchema as JSONSchema7).description, propName, "    "));
         if (!isReq) lines.push(`    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`);
         lines.push(`    [JsonPropertyName("${propName}")]`);
         const reqMod = isReq && !csharpType.endsWith("?") ? "required " : "";
@@ -419,14 +495,19 @@ function generateSessionEventsCode(schema: JSONSchema7): string {
     const nestedClasses = new Map<string, string>();
     const enumOutput: string[] = [];
 
+    // Extract descriptions for base class properties from the first variant
+    const firstVariant = (schema.definitions?.SessionEvent as JSONSchema7)?.anyOf?.[0];
+    const baseProps = typeof firstVariant === "object" && firstVariant?.properties ? firstVariant.properties : {};
+    const baseDesc = (name: string) => {
+        const prop = baseProps[name];
+        return typeof prop === "object" ? (prop as JSONSchema7).description : undefined;
+    };
+
     const lines: string[] = [];
     lines.push(`${COPYRIGHT}
 
 // AUTO-GENERATED FILE - DO NOT EDIT
 // Generated from: session-events.schema.json
-
-// Generated code does not have XML doc comments; suppress CS1591 to avoid warnings.
-#pragma warning disable CS1591
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -436,25 +517,41 @@ namespace GitHub.Copilot.SDK;
 
     // Base class with XML doc
     lines.push(`/// <summary>`);
-    lines.push(`/// Base class for all session events with polymorphic JSON serialization.`);
+    lines.push(`/// Provides the base class from which all session events derive.`);
     lines.push(`/// </summary>`);
     lines.push(`[JsonPolymorphic(`, `    TypeDiscriminatorPropertyName = "type",`, `    UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FailSerialization)]`);
     for (const variant of [...variants].sort((a, b) => a.typeName.localeCompare(b.typeName))) {
         lines.push(`[JsonDerivedType(typeof(${variant.className}), "${variant.typeName}")]`);
     }
-    lines.push(`public abstract partial class SessionEvent`, `{`, `    [JsonPropertyName("id")]`, `    public Guid Id { get; set; }`, "");
+    lines.push(`public abstract partial class SessionEvent`, `{`);
+    lines.push(...xmlDocComment(baseDesc("id"), "    "));
+    lines.push(`    [JsonPropertyName("id")]`, `    public Guid Id { get; set; }`, "");
+    lines.push(...xmlDocComment(baseDesc("timestamp"), "    "));
     lines.push(`    [JsonPropertyName("timestamp")]`, `    public DateTimeOffset Timestamp { get; set; }`, "");
+    lines.push(...xmlDocComment(baseDesc("parentId"), "    "));
     lines.push(`    [JsonPropertyName("parentId")]`, `    public Guid? ParentId { get; set; }`, "");
+    lines.push(...xmlDocComment(baseDesc("ephemeral"), "    "));
     lines.push(`    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`, `    [JsonPropertyName("ephemeral")]`, `    public bool? Ephemeral { get; set; }`, "");
     lines.push(`    /// <summary>`, `    /// The event type discriminator.`, `    /// </summary>`);
     lines.push(`    [JsonIgnore]`, `    public abstract string Type { get; }`, "");
+    lines.push(`    /// <summary>Deserializes a JSON string into a <see cref="SessionEvent"/>.</summary>`);
     lines.push(`    public static SessionEvent FromJson(string json) =>`, `        JsonSerializer.Deserialize(json, SessionEventsJsonContext.Default.SessionEvent)!;`, "");
+    lines.push(`    /// <summary>Serializes this event to a JSON string.</summary>`);
     lines.push(`    public string ToJson() =>`, `        JsonSerializer.Serialize(this, SessionEventsJsonContext.Default.SessionEvent);`, `}`, "");
 
     // Event classes with XML docs
     for (const variant of variants) {
-        lines.push(`/// <summary>`, `/// Event: ${variant.typeName}`, `/// </summary>`);
-        lines.push(`public partial class ${variant.className} : SessionEvent`, `{`, `    [JsonIgnore]`, `    public override string Type => "${variant.typeName}";`, "");
+        const remarksLine = `/// <remarks>Represents the <c>${escapeXml(variant.typeName)}</c> event.</remarks>`;
+        if (variant.dataDescription) {
+            lines.push(...xmlDocComment(variant.dataDescription, ""));
+            lines.push(remarksLine);
+        } else {
+            lines.push(`/// <summary>Represents the <c>${escapeXml(variant.typeName)}</c> event.</summary>`);
+        }
+        lines.push(`public partial class ${variant.className} : SessionEvent`, `{`);
+        lines.push(`    /// <inheritdoc />`);
+        lines.push(`    [JsonIgnore]`, `    public override string Type => "${variant.typeName}";`, "");
+        lines.push(`    /// <summary>The <c>${escapeXml(variant.typeName)}</c> event payload.</summary>`);
         lines.push(`    [JsonPropertyName("data")]`, `    public required ${variant.dataClassName} Data { get; set; }`, `}`, "");
     }
 
@@ -512,7 +609,7 @@ function resolveRpcType(schema: JSONSchema7, isRequired: boolean, parentClassNam
     }
     // Handle enums (string unions like "interactive" | "plan" | "autopilot")
     if (schema.enum && Array.isArray(schema.enum)) {
-        const enumName = getOrCreateEnum(parentClassName, propName, schema.enum as string[], rpcEnumOutput);
+        const enumName = getOrCreateEnum(parentClassName, propName, schema.enum as string[], rpcEnumOutput, schema.description);
         return isRequired ? enumName : `${enumName}?`;
     }
     if (schema.type === "object" && schema.properties) {
@@ -549,7 +646,7 @@ function emitRpcClass(className: string, schema: JSONSchema7, visibility: "publi
 
     const requiredSet = new Set(schema.required || []);
     const lines: string[] = [];
-    if (schema.description) lines.push(`/// <summary>${schema.description}</summary>`);
+    lines.push(...xmlDocComment(schema.description || `RPC data type for ${className.replace(/Request$/, "").replace(/Result$/, "")} operations.`, ""));
     lines.push(`${visibility} class ${className}`, `{`);
 
     const props = Object.entries(schema.properties || {});
@@ -561,7 +658,7 @@ function emitRpcClass(className: string, schema: JSONSchema7, visibility: "publi
         const csharpName = toPascalCase(propName);
         const csharpType = resolveRpcType(prop, isReq, className, csharpName, extraClasses);
 
-        if (prop.description && visibility === "public") lines.push(`    /// <summary>${prop.description}</summary>`);
+        lines.push(...xmlDocPropertyComment(prop.description, propName, "    "));
         lines.push(`    [JsonPropertyName("${propName}")]`);
 
         let defaultVal = "";
@@ -591,7 +688,7 @@ function emitServerRpcClasses(node: Record<string, unknown>, classes: string[]):
 
     // ServerRpc class
     const srLines: string[] = [];
-    srLines.push(`/// <summary>Typed server-scoped RPC methods (no session required).</summary>`);
+    srLines.push(`/// <summary>Provides server-scoped RPC methods (no session required).</summary>`);
     srLines.push(`public class ServerRpc`);
     srLines.push(`{`);
     srLines.push(`    private readonly JsonRpc _rpc;`);
@@ -631,7 +728,7 @@ function emitServerRpcClasses(node: Record<string, unknown>, classes: string[]):
 function emitServerApiClass(className: string, node: Record<string, unknown>, classes: string[]): string {
     const lines: string[] = [];
     const displayName = className.replace(/^Server/, "").replace(/Api$/, "");
-    lines.push(`/// <summary>Server-scoped ${displayName} APIs.</summary>`);
+    lines.push(`/// <summary>Provides server-scoped ${displayName} APIs.</summary>`);
     lines.push(`public class ${className}`);
     lines.push(`{`);
     lines.push(`    private readonly JsonRpc _rpc;`);
@@ -703,11 +800,11 @@ function emitSessionRpcClasses(node: Record<string, unknown>, classes: string[])
     const groups = Object.entries(node).filter(([, v]) => typeof v === "object" && v !== null && !isRpcMethod(v));
     const topLevelMethods = Object.entries(node).filter(([, v]) => isRpcMethod(v));
 
-    const srLines = [`/// <summary>Typed session-scoped RPC methods.</summary>`, `public class SessionRpc`, `{`, `    private readonly JsonRpc _rpc;`, `    private readonly string _sessionId;`, ""];
+    const srLines = [`/// <summary>Provides typed session-scoped RPC methods.</summary>`, `public class SessionRpc`, `{`, `    private readonly JsonRpc _rpc;`, `    private readonly string _sessionId;`, ""];
     srLines.push(`    internal SessionRpc(JsonRpc rpc, string sessionId)`, `    {`, `        _rpc = rpc;`, `        _sessionId = sessionId;`);
     for (const [groupName] of groups) srLines.push(`        ${toPascalCase(groupName)} = new ${toPascalCase(groupName)}Api(rpc, sessionId);`);
     srLines.push(`    }`);
-    for (const [groupName] of groups) srLines.push("", `    public ${toPascalCase(groupName)}Api ${toPascalCase(groupName)} { get; }`);
+    for (const [groupName] of groups) srLines.push("", `    /// <summary>${toPascalCase(groupName)} APIs.</summary>`, `    public ${toPascalCase(groupName)}Api ${toPascalCase(groupName)} { get; }`);
 
     // Emit top-level session RPC methods directly on the SessionRpc class
     const topLevelLines: string[] = [];
@@ -766,7 +863,8 @@ function emitSessionMethod(key: string, method: RpcMethod, lines: string[], clas
 }
 
 function emitSessionApiClass(className: string, node: Record<string, unknown>, classes: string[]): string {
-    const lines = [`public class ${className}`, `{`, `    private readonly JsonRpc _rpc;`, `    private readonly string _sessionId;`, ""];
+    const displayName = className.replace(/Api$/, "");
+    const lines = [`/// <summary>Provides session-scoped ${displayName} APIs.</summary>`, `public class ${className}`, `{`, `    private readonly JsonRpc _rpc;`, `    private readonly string _sessionId;`, ""];
     lines.push(`    internal ${className}(JsonRpc rpc, string sessionId)`, `    {`, `        _rpc = rpc;`, `        _sessionId = sessionId;`, `    }`);
 
     for (const [key, value] of Object.entries(node)) {
@@ -795,9 +893,6 @@ function generateRpcCode(schema: ApiSchema): string {
 
 // AUTO-GENERATED FILE - DO NOT EDIT
 // Generated from: api.schema.json
-
-// Generated code does not have XML doc comments; suppress CS1591 to avoid warnings.
-#pragma warning disable CS1591
 
 using System.Text.Json;
 using System.Text.Json.Serialization;


### PR DESCRIPTION
## Summary

Updates the C# code generator to emit `/// <summary>` \ XML doc comments on all generated types and members, sourced from JSON Schema \description\ annotations. This enables IntelliSense documentation for .NET SDK consumers.

## Changes

### \scripts/codegen/csharp.ts\
- **New helpers**: \escapeXml()\, \ensureTrailingPunctuation()\, \xmlDocComment()\, \
awXmlDocSummary()\, \xmlDocCommentWithFallback()\
- **Session event classes**: \<summary>\ from schema description (or synthetic fallback with \<c>\ tag), \<remarks>\ with event type name when a real description exists
- **Data classes**: \<summary>\ from schema, fallback uses \<see cref>\ to link to the parent event class
- **Nested/polymorphic classes**: \<summary>\ from schema with synthetic fallbacks for derived classes and nested types
- **Enum types and members**: Type-level \<summary>\ from schema, per-member \<summary>\ with \<c>\ variant name
- **Properties**: \<summary>\ from schema descriptions with XML escaping
- **Override properties**: \<inheritdoc />\ on all \override string Type\ properties
- **RPC types**: Class-level and property-level docs with fallback summaries
- **Punctuation**: All comments normalized to end with \.\, \!\, or \?\

### Generated output (from published \@github/copilot\ v1.0.2)
- \SessionEvents.cs\: ~525 \<summary>\ + 69 \<inheritdoc>\ doc comments
- \Rpc.cs\: Full class-level and property-level documentation with fallbacks
- Both files build with 0 errors, 0 warnings

## Notes
- The \#pragma warning disable CS1591\ remains in both generated files for members whose upstream schema definitions don't yet include descriptions. Once the upstream Zod schemas are enriched with \.describe()\ calls and published, the pragmas can be removed.
- A companion PR will be opened in \copilot-agent-runtime\ to add ~80 additional \.describe()\ calls to the Zod source schemas.