### PR TITLE
Use lazy property initialization in generated C# RPC classes

### DIFF
--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -61,10 +61,10 @@ public class ModelCapabilitiesLimits
 public class ModelCapabilities
 {
     [JsonPropertyName("supports")]
-    public ModelCapabilitiesSupports Supports { get; set; } = new();
+    public ModelCapabilitiesSupports Supports { get => field ??= new(); set; }
 
     [JsonPropertyName("limits")]
-    public ModelCapabilitiesLimits Limits { get; set; } = new();
+    public ModelCapabilitiesLimits Limits { get => field ??= new(); set; }
 }
 
 /// <summary>Policy state (if applicable)</summary>
@@ -96,7 +96,7 @@ public class Model
 
     /// <summary>Model capabilities and limits</summary>
     [JsonPropertyName("capabilities")]
-    public ModelCapabilities Capabilities { get; set; } = new();
+    public ModelCapabilities Capabilities { get => field ??= new(); set; }
 
     /// <summary>Policy state (if applicable)</summary>
     [JsonPropertyName("policy")]
@@ -119,7 +119,7 @@ public class ModelsListResult
 {
     /// <summary>List of available models with full metadata</summary>
     [JsonPropertyName("models")]
-    public List<Model> Models { get; set; } = [];
+    public List<Model> Models { get => field ??= []; set; }
 }
 
 public class Tool
@@ -149,7 +149,7 @@ public class ToolsListResult
 {
     /// <summary>List of available built-in tools with metadata</summary>
     [JsonPropertyName("tools")]
-    public List<Tool> Tools { get; set; } = [];
+    public List<Tool> Tools { get => field ??= []; set; }
 }
 
 internal class ToolsListRequest
@@ -189,7 +189,7 @@ public class AccountGetQuotaResult
 {
     /// <summary>Quota snapshots keyed by type (e.g., chat, completions, premium_interactions)</summary>
     [JsonPropertyName("quotaSnapshots")]
-    public Dictionary<string, AccountGetQuotaResultQuotaSnapshotsValue> QuotaSnapshots { get; set; } = [];
+    public Dictionary<string, AccountGetQuotaResultQuotaSnapshotsValue> QuotaSnapshots { get => field ??= []; set; }
 }
 
 public class SessionLogResult
@@ -321,7 +321,7 @@ public class SessionWorkspaceListFilesResult
 {
     /// <summary>Relative file paths in the workspace files directory</summary>
     [JsonPropertyName("files")]
-    public List<string> Files { get; set; } = [];
+    public List<string> Files { get => field ??= []; set; }
 }
 
 internal class SessionWorkspaceListFilesRequest
@@ -397,7 +397,7 @@ public class SessionAgentListResult
 {
     /// <summary>Available custom agents</summary>
     [JsonPropertyName("agents")]
-    public List<Agent> Agents { get; set; } = [];
+    public List<Agent> Agents { get => field ??= []; set; }
 }
 
 internal class SessionAgentListRequest
@@ -454,7 +454,7 @@ public class SessionAgentSelectResult
 {
     /// <summary>The newly selected custom agent</summary>
     [JsonPropertyName("agent")]
-    public SessionAgentSelectResultAgent Agent { get; set; } = new();
+    public SessionAgentSelectResultAgent Agent { get => field ??= new(); set; }
 }
 
 internal class SessionAgentSelectRequest

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -565,13 +565,17 @@ function emitRpcClass(className: string, schema: JSONSchema7, visibility: "publi
         lines.push(`    [JsonPropertyName("${propName}")]`);
 
         let defaultVal = "";
+        let propAccessors = "{ get; set; }";
         if (isReq && !csharpType.endsWith("?")) {
             if (csharpType === "string") defaultVal = " = string.Empty;";
             else if (csharpType === "object") defaultVal = " = null!;";
-            else if (csharpType.startsWith("List<") || csharpType.startsWith("Dictionary<")) defaultVal = " = [];";
-            else if (emittedRpcClasses.has(csharpType)) defaultVal = " = new();";
+            else if (csharpType.startsWith("List<") || csharpType.startsWith("Dictionary<")) {
+                propAccessors = "{ get => field ??= []; set; }";
+            } else if (emittedRpcClasses.has(csharpType)) {
+                propAccessors = "{ get => field ??= new(); set; }";
+            }
         }
-        lines.push(`    public ${csharpType} ${csharpName} { get; set; }${defaultVal}`);
+        lines.push(`    public ${csharpType} ${csharpName} ${propAccessors}${defaultVal}`);
         if (i < props.length - 1) lines.push("");
     }
     lines.push(`}`);


### PR DESCRIPTION
The C# codegen was emitting eager initialization for collection and nested-class properties:

```csharp
public List<Tool> Tools { get; set; } = [];
public ModelCapabilities Capabilities { get; set; } = new();
```

During deserialization, this allocates an empty collection/object only to immediately overwrite it. This PR changes the codegen to use lazy initialization via `field` keyword instead:

```csharp
public List<Tool> Tools { get => field ??= []; set; }
public ModelCapabilities Capabilities { get => field ??= new(); set; }
```

This avoids unnecessary allocations when the property is set by the deserializer, while still ensuring a non-null default when accessed without prior assignment.

### Changes
- **\scripts/codegen/csharp.ts\**: Updated property emission for \List<>\/\Dictionary<>\ and nested RPC class types to use field ??=\ lazy init.
- **\dotnet/src/Generated/Rpc.cs\**: Regenerated with the new pattern.