### PR TITLE
Add DebuggerDisplay to SessionEvent for better debugging

### DIFF
--- a/dotnet/src/Generated/SessionEvents.cs
+++ b/dotnet/src/Generated/SessionEvents.cs
@@ -5,6 +5,7 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 // Generated from: session-events.schema.json
 
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -13,6 +14,7 @@ namespace GitHub.Copilot.SDK;
 /// <summary>
 /// Provides the base class from which all session events derive.
 /// </summary>
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
 [JsonPolymorphic(
     TypeDiscriminatorPropertyName = "type",
     UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FailSerialization)]
@@ -107,6 +109,9 @@ public abstract partial class SessionEvent
     /// <summary>Serializes this event to a JSON string.</summary>
     public string ToJson() =>
         JsonSerializer.Serialize(this, SessionEventsJsonContext.Default.SessionEvent);
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private string DebuggerDisplay => ToJson();
 }
 
 /// <summary>Represents the <c>session.start</c> event.</summary>

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -509,6 +509,7 @@ function generateSessionEventsCode(schema: JSONSchema7): string {
 // AUTO-GENERATED FILE - DO NOT EDIT
 // Generated from: session-events.schema.json
 
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -519,6 +520,7 @@ namespace GitHub.Copilot.SDK;
     lines.push(`/// <summary>`);
     lines.push(`/// Provides the base class from which all session events derive.`);
     lines.push(`/// </summary>`);
+    lines.push(`[DebuggerDisplay("{DebuggerDisplay,nq}")]`);
     lines.push(`[JsonPolymorphic(`, `    TypeDiscriminatorPropertyName = "type",`, `    UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FailSerialization)]`);
     for (const variant of [...variants].sort((a, b) => a.typeName.localeCompare(b.typeName))) {
         lines.push(`[JsonDerivedType(typeof(${variant.className}), "${variant.typeName}")]`);
@@ -537,7 +539,9 @@ namespace GitHub.Copilot.SDK;
     lines.push(`    /// <summary>Deserializes a JSON string into a <see cref="SessionEvent"/>.</summary>`);
     lines.push(`    public static SessionEvent FromJson(string json) =>`, `        JsonSerializer.Deserialize(json, SessionEventsJsonContext.Default.SessionEvent)!;`, "");
     lines.push(`    /// <summary>Serializes this event to a JSON string.</summary>`);
-    lines.push(`    public string ToJson() =>`, `        JsonSerializer.Serialize(this, SessionEventsJsonContext.Default.SessionEvent);`, `}`, "");
+    lines.push(`    public string ToJson() =>`, `        JsonSerializer.Serialize(this, SessionEventsJsonContext.Default.SessionEvent);`, "");
+    lines.push(`    [DebuggerBrowsable(DebuggerBrowsableState.Never)]`, `    private string DebuggerDisplay => ToJson();`);
+    lines.push(`}`, "");
 
     // Event classes with XML docs
     for (const variant of variants) {


### PR DESCRIPTION
Adds `[DebuggerDisplay]` to the generated `SessionEvent` base class so that hovering over an event in the debugger shows its JSON representation.

**Changes:**
- **scripts/codegen/csharp.ts**: Updated the C# code generator to emit `using System.Diagnostics;`, the `[DebuggerDisplay]` attribute, and a `DebuggerDisplay` property on the `SessionEvent` base class.
- **dotnet/src/Generated/SessionEvents.cs**: Regenerated output reflecting the generator changes.

Before:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/b9f6eba6-d983-486d-8ba5-ebf63536ed54" />

After:
<img width="2836" height="79" alt="image" src="https://github.com/user-attachments/assets/de6f542a-f2ca-480e-a519-f9bc50ef8ff1" />

