### PR TITLE
In C# codegen, represent optional RPC params as optional C# method params, not just nullable values

### DIFF
--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -775,7 +775,7 @@ public class FleetApi
     }
 
     /// <summary>Calls "session.fleet.start".</summary>
-    public async Task<SessionFleetStartResult> StartAsync(string? prompt, CancellationToken cancellationToken = default)
+    public async Task<SessionFleetStartResult> StartAsync(string? prompt = null, CancellationToken cancellationToken = default)
     {
         var request = new SessionFleetStartRequest { SessionId = _sessionId, Prompt = prompt };
         return await CopilotClient.InvokeRpcAsync<SessionFleetStartResult>(_rpc, "session.fleet.start", [request], cancellationToken);
@@ -853,7 +853,7 @@ public class ToolsApi
     }
 
     /// <summary>Calls "session.tools.handlePendingToolCall".</summary>
-    public async Task<SessionToolsHandlePendingToolCallResult> HandlePendingToolCallAsync(string requestId, object? result, string? error, CancellationToken cancellationToken = default)
+    public async Task<SessionToolsHandlePendingToolCallResult> HandlePendingToolCallAsync(string requestId, object? result = null, string? error = null, CancellationToken cancellationToken = default)
     {
         var request = new SessionToolsHandlePendingToolCallRequest { SessionId = _sessionId, RequestId = requestId, Result = result, Error = error };
         return await CopilotClient.InvokeRpcAsync<SessionToolsHandlePendingToolCallResult>(_rpc, "session.tools.handlePendingToolCall", [request], cancellationToken);

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -699,6 +699,13 @@ function emitSessionApiClass(className: string, node: Record<string, unknown>, c
         const paramEntries = (method.params?.properties ? Object.entries(method.params.properties) : []).filter(([k]) => k !== "sessionId");
         const requiredSet = new Set(method.params?.required || []);
 
+        // Sort so required params come before optional (C# requires defaults at end)
+        paramEntries.sort((a, b) => {
+            const aReq = requiredSet.has(a[0]) ? 0 : 1;
+            const bReq = requiredSet.has(b[0]) ? 0 : 1;
+            return aReq - bReq;
+        });
+
         const requestClassName = `${typeToClassName(method.rpcMethod)}Request`;
         if (method.params) {
             const reqClass = emitRpcClass(requestClassName, method.params, "internal", classes);
@@ -711,8 +718,9 @@ function emitSessionApiClass(className: string, node: Record<string, unknown>, c
 
         for (const [pName, pSchema] of paramEntries) {
             if (typeof pSchema !== "object") continue;
-            const csType = resolveRpcType(pSchema as JSONSchema7, requiredSet.has(pName), requestClassName, toPascalCase(pName), classes);
-            sigParams.push(`${csType} ${pName}`);
+            const isReq = requiredSet.has(pName);
+            const csType = resolveRpcType(pSchema as JSONSchema7, isReq, requestClassName, toPascalCase(pName), classes);
+            sigParams.push(`${csType} ${pName}${isReq ? "" : " = null"}`);
             bodyAssignments.push(`${toPascalCase(pName)} = ${pName}`);
         }
         sigParams.push("CancellationToken cancellationToken = default");


### PR DESCRIPTION
Otherwise adding a new optional RPC param will be a source-breaking change in all usages.

Note that even with this improvement, adding a new optional RPC param will still be a binary-breaking change for C#. At the moment I think that's not an issue based on our usage model, but if this changes, things will get a lot more complex as codegen would have to keep track of historical overloads we need to preserve.

Also note that even with this improvement, adding a new optional RPC param will be source-breaking if people are already passing positional args as optional params.

cc @stephentoub in case you have any thoughts on how to handle this better. What comes to mind for me is hand-authoring partial class methods that act as back-compat overloads. It does complicate the codegen approach though.

The other main thing we could do is not have positional method parameters at all, and instead represent everything as options objects like we do in other languages. That feels slightly cumbersome for callers in C# but is more faithful to the RPC contract. Obviously it would also be a one-time breaking change too.