### PR TITLE
fix(nodejs): add .js extension to vscode-jsonrpc/node import in session.ts

### DIFF
--- a/nodejs/src/session.ts
+++ b/nodejs/src/session.ts
@@ -7,8 +7,8 @@
  * @module session
  */
 
-import type { MessageConnection } from "vscode-jsonrpc/node";
-import { ConnectionError, ResponseError } from "vscode-jsonrpc/node";
+import type { MessageConnection } from "vscode-jsonrpc/node.js";
+import { ConnectionError, ResponseError } from "vscode-jsonrpc/node.js";
 import { createSessionRpc } from "./generated/rpc.js";
 import type {
     MessageOptions,


### PR DESCRIPTION
## Summary

- Add missing `.js` file extension to `vscode-jsonrpc/node` imports in `nodejs/src/session.ts`
- Matches the existing correct pattern in `client.ts` (`from "vscode-jsonrpc/node.js"`)
- Same class of fix as #8

## Problem

SDK 0.1.31 added a new import to `session.ts`:
```ts
import { ConnectionError, ResponseError } from "vscode-jsonrpc/node";
```

Since the SDK declares `"type": "module"` (ESM) and `vscode-jsonrpc@8.2.1` has no `exports` map, Node.js ESM resolution cannot resolve the bare subpath without the `.js` extension.

**Error:**
```
ERR_MODULE_NOT_FOUND: Cannot find module 'vscode-jsonrpc/node' imported from @github/copilot-sdk/dist/session.js
```

## Fix

```diff
-import type { MessageConnection } from "vscode-jsonrpc/node";
-import { ConnectionError, ResponseError } from "vscode-jsonrpc/node";
+import type { MessageConnection } from "vscode-jsonrpc/node.js";
+import { ConnectionError, ResponseError } from "vscode-jsonrpc/node.js";
```

Fixes #707