### PR TITLE
Remove PR creation from cross-repo issue analysis workflow

### DIFF
--- a/.github/workflows/cross-repo-issue-analysis.md
+++ b/.github/workflows/cross-repo-issue-analysis.md
@@ -1,5 +1,5 @@
 ---
-description: Analyzes copilot-sdk issues to determine if a fix is needed in copilot-agent-runtime, then opens a linked issue and suggested-fix PR there
+description: Analyzes copilot-sdk issues to determine if a fix is needed in copilot-agent-runtime, then opens a linked issue there
 on:
   issues:
     types: [labeled]
@@ -13,7 +13,6 @@ if: "github.event_name == 'workflow_dispatch' || github.event.label.name == 'run
 permissions:
   contents: read
   issues: read
-  pull-requests: read
 steps:
   - name: Clone copilot-agent-runtime
     run: git clone --depth 1 https://x-access-token:${{ secrets.RUNTIME_TRIAGE_TOKEN }}@github.com/github/copilot-agent-runtime.git ${{ github.workspace }}/copilot-agent-runtime
@@ -21,7 +20,6 @@ tools:
   github:
     toolsets: [default]
     github-token: ${{ secrets.RUNTIME_TRIAGE_TOKEN }}
-  edit:
   bash:
     - "grep:*"
     - "find:*"
@@ -42,12 +40,6 @@ safe-outputs:
     labels: [upstream-from-sdk, ai-triaged]
     target-repo: "github/copilot-agent-runtime"
     max: 1
-  create-pull-request:
-    title-prefix: "[copilot-sdk] "
-    labels: [upstream-from-sdk, ai-suggested-fix]
-    draft: true
-    target-repo: "github/copilot-agent-runtime"
-
 timeout-minutes: 20
 ---
 
@@ -106,10 +98,6 @@ Classify the issue into one of these categories:
      - References the original SDK issue (e.g., `github/copilot-sdk#123`)
      - Includes the specific files and code paths involved
      - Suggests a fix approach
-   - Create a draft PR in `github/copilot-agent-runtime` with a suggested fix:
-     - Make the minimal, targeted code changes needed
-     - Include a clear PR description linking back to both issues
-     - If you're uncertain about the fix, still create the PR as a starting point for discussion
 
 3. **Needs-investigation**: You cannot confidently determine the root cause. Label the issue `needs-investigation`.
 
@@ -117,7 +105,6 @@ Classify the issue into one of these categories:
 
 1. **Be thorough but focused**: Read enough code to be confident in your analysis, but don't read every file in both repos
 2. **Err on the side of creating the runtime issue**: If there's a reasonable chance the fix is in the runtime, create the issue. False positives are better than missed upstream bugs.
-3. **Make actionable PRs**: Even if the fix isn't perfect, a draft PR with a concrete starting point is more useful than just an issue description
-4. **Link everything**: Always cross-reference between the SDK issue, runtime issue, and runtime PR so maintainers can follow the trail
-5. **Be specific**: When describing the root cause, point to specific files, functions, and line numbers in both repos
-6. **Don't duplicate**: Before creating a runtime issue, search existing open issues in `github/copilot-agent-runtime` to avoid duplicates. If a related issue exists, reference it instead of creating a new one.
+3. **Link everything**: Always cross-reference between the SDK issue and runtime issue so maintainers can follow the trail
+4. **Be specific**: When describing the root cause, point to specific files, functions, and line numbers in both repos
+5. **Don't duplicate**: Before creating a runtime issue, search existing open issues in `github/copilot-agent-runtime` to avoid duplicates. If a related issue exists, reference it instead of creating a new one.


### PR DESCRIPTION
Simplifies the cross-repo issue analysis workflow to only open linked issues in copilot-agent-runtime instead of also creating draft PRs with suggested fixes.

### Changes
- Remove `pull-requests` permission (no longer needed)
- Remove `edit` tool and `create-pull-request` safe-output config
- Remove PR creation instructions from the agent prompt
- Update guidelines to reflect issue-only workflow

### Motivation
Automated draft PRs from the triage workflow can be noisy and low-signal. Focusing on issue creation keeps the workflow targeted — maintainers can decide whether/how to fix upstream.