### PR TITLE
fix(devcontainer): bump to v3 Python image to fix Yarn GPG key failure

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
   "name": "Python 3",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/python:2-3.14-trixie",
+  "image": "mcr.microsoft.com/devcontainers/python:3-3.14-trixie",
   "features": {
     "ghcr.io/devcontainers/features/copilot-cli:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},


### PR DESCRIPTION
The v2 base image (`mcr.microsoft.com/devcontainers/python:2-3.14-trixie`) ships with a Yarn Classic APT repository whose GPG key has expired, causing `apt-get update` to fail during feature installation and breaking the entire devcontainer build.

Bumps to the v3 image (`python:3-3.14-trixie`, published 2026-01-30) which no longer includes the Yarn APT repo, resolving the issue without any additional workarounds.

Ref: devcontainers/images#1797