### PR TITLE
fix(dotnet): add AOT-safe RequestId serialization for StreamJsonRpc

### DIFF
--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -14,6 +14,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using System.Text.RegularExpressions;
 using GitHub.Copilot.SDK.Rpc;
 using System.Globalization;
@@ -1226,6 +1227,12 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         options.TypeInfoResolverChain.Add(SessionEventsJsonContext.Default);
         options.TypeInfoResolverChain.Add(SDK.Rpc.RpcJsonContext.Default);
 
+        // StreamJsonRpc's RequestId needs serialization when CancellationToken fires during
+        // JSON-RPC operations. Its built-in converter (RequestIdSTJsonConverter) is internal,
+        // and [JsonSerializable] can't source-gen for it (SYSLIB1220), so we provide our own
+        // AOT-safe resolver + converter.
+        options.TypeInfoResolverChain.Add(new RequestIdTypeInfoResolver());
+
         options.MakeReadOnly();
 
         return options;
@@ -1639,6 +1646,50 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     [JsonSerializable(typeof(UserInputRequest))]
     [JsonSerializable(typeof(UserInputResponse))]
     internal partial class ClientJsonContext : JsonSerializerContext;
+
+    /// <summary>
+    /// AOT-safe type info resolver for <see cref="RequestId"/>.
+    /// StreamJsonRpc's own RequestIdSTJsonConverter is internal (SYSLIB1220/CS0122),
+    /// so we provide our own converter and wire it through <see cref="JsonMetadataServices.CreateValueInfo{T}"/>
+    /// to stay fully AOT/trimming-compatible.
+    /// </summary>
+    private sealed class RequestIdTypeInfoResolver : IJsonTypeInfoResolver
+    {
+        public JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options)
+        {
+            if (type == typeof(RequestId))
+                return JsonMetadataServices.CreateValueInfo<RequestId>(options, new RequestIdJsonConverter());
+            return null;
+        }
+    }
+
+    private sealed class RequestIdJsonConverter : JsonConverter<RequestId>
+    {
+        public override RequestId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return reader.TokenType switch
+            {
+                JsonTokenType.Number => reader.TryGetInt64(out long val)
+                    ? new RequestId(val)
+                    : new RequestId(reader.HasValueSequence
+                        ? Encoding.UTF8.GetString(reader.ValueSequence)
+                        : Encoding.UTF8.GetString(reader.ValueSpan)),
+                JsonTokenType.String => new RequestId(reader.GetString()!),
+                JsonTokenType.Null => RequestId.Null,
+                _ => throw new JsonException($"Unexpected token type for RequestId: {reader.TokenType}"),
+            };
+        }
+
+        public override void Write(Utf8JsonWriter writer, RequestId value, JsonSerializerOptions options)
+        {
+            if (value.Number.HasValue)
+                writer.WriteNumberValue(value.Number.Value);
+            else if (value.String is not null)
+                writer.WriteStringValue(value.String);
+            else
+                writer.WriteNullValue();
+        }
+    }
 
     [GeneratedRegex(@"listening on port ([0-9]+)", RegexOptions.IgnoreCase)]
     private static partial Regex ListeningOnPortRegex();

--- a/dotnet/test/SerializationTests.cs
+++ b/dotnet/test/SerializationTests.cs
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+using Xunit;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using StreamJsonRpc;
+
+namespace GitHub.Copilot.SDK.Test;
+
+/// <summary>
+/// Tests for JSON serialization compatibility, particularly for StreamJsonRpc types
+/// that are needed when CancellationTokens fire during JSON-RPC operations.
+/// This test suite verifies the fix for https://github.com/PureWeen/PolyPilot/issues/319
+/// </summary>
+public class SerializationTests
+{
+    /// <summary>
+    /// Verifies that StreamJsonRpc.RequestId can be round-tripped using the SDK's configured
+    /// JsonSerializerOptions. This is critical for preventing NotSupportedException when
+    /// StandardCancellationStrategy fires during JSON-RPC operations.
+    /// </summary>
+    [Fact]
+    public void RequestId_CanBeSerializedAndDeserialized_WithSdkOptions()
+    {
+        var options = GetSerializerOptions();
+
+        // Long id
+        var jsonLong = JsonSerializer.Serialize(new RequestId(42L), options);
+        Assert.Equal("42", jsonLong);
+        Assert.Equal(new RequestId(42L), JsonSerializer.Deserialize<RequestId>(jsonLong, options));
+
+        // String id
+        var jsonStr = JsonSerializer.Serialize(new RequestId("req-1"), options);
+        Assert.Equal("\"req-1\"", jsonStr);
+        Assert.Equal(new RequestId("req-1"), JsonSerializer.Deserialize<RequestId>(jsonStr, options));
+
+        // Null id
+        var jsonNull = JsonSerializer.Serialize(RequestId.Null, options);
+        Assert.Equal("null", jsonNull);
+        Assert.Equal(RequestId.Null, JsonSerializer.Deserialize<RequestId>(jsonNull, options));
+    }
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(-1L)]
+    [InlineData(long.MaxValue)]
+    public void RequestId_NumericEdgeCases_RoundTrip(long id)
+    {
+        var options = GetSerializerOptions();
+        var requestId = new RequestId(id);
+        var json = JsonSerializer.Serialize(requestId, options);
+        Assert.Equal(requestId, JsonSerializer.Deserialize<RequestId>(json, options));
+    }
+
+    /// <summary>
+    /// Verifies the SDK's options can resolve type info for RequestId,
+    /// ensuring AOT-safe serialization without falling back to reflection.
+    /// </summary>
+    [Fact]
+    public void SerializerOptions_CanResolveRequestIdTypeInfo()
+    {
+        var options = GetSerializerOptions();
+        var typeInfo = options.GetTypeInfo(typeof(RequestId));
+        Assert.NotNull(typeInfo);
+        Assert.Equal(typeof(RequestId), typeInfo.Type);
+    }
+
+    private static JsonSerializerOptions GetSerializerOptions()
+    {
+        var prop = typeof(CopilotClient)
+            .GetProperty("SerializerOptionsForMessageFormatter",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        var options = (JsonSerializerOptions?)prop?.GetValue(null);
+        Assert.NotNull(options);
+        return options;
+    }
+}


### PR DESCRIPTION
## Problem

When `CancellationToken` fires during a JSON-RPC operation, StreamJsonRpc's `StandardCancellationStrategy` sends a `$/cancelRequest` notification containing a `RequestId`. The SDK's AOT serialization setup (source-generated contexts + `MakeReadOnly()`) has no type info for `RequestId`, causing a `NotSupportedException` that silently kills the JSON-RPC connection.

Fixes: https://github.com/PureWeen/PolyPilot/issues/319

## Root Cause

Commit 4e7319e locked serialization to source-generated contexts only. `RequestId` couldn't be added via `[JsonSerializable]` because it has `[JsonConverter(typeof(RequestIdSTJsonConverter))]` and that converter is `internal` to StreamJsonRpc (SYSLIB1220). The converter also can't be used directly (CS0122).

## Solution

Add AOT-safe `RequestIdTypeInfoResolver` + `RequestIdJsonConverter`:

- **`RequestIdJsonConverter`** — hand-written converter using `RequestId`'s public API (`Number`, `String`, constructors). Uses `TryGetInt64()` with string fallback for overflow/decimal safety.
- **`RequestIdTypeInfoResolver`** — `IJsonTypeInfoResolver` that returns type info via `JsonMetadataServices.CreateValueInfo<T>()` (the same API the source generator uses internally). Zero reflection.

This follows the existing converter pattern in the SDK (see `PermissionRequestResultKind.Converter` in Types.cs).

## Tests

- `RequestId_CanBeSerializedAndDeserialized_WithSdkOptions` — round-trips long, string, and null RequestIds
- `SerializerOptions_CanResolveRequestIdTypeInfo` — verifies the resolver chain produces type info
- `RequestId_NumericEdgeCases_RoundTrip` — `[Theory]` covering 0, -1, `long.MaxValue`

All 5 tests fail without the fix (`NotSupportedException`) and pass with it.
