### PR TITLE
fix: update Python examples to work OOTB

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -286,7 +286,7 @@ async def main():
 
     session = await client.create_session({
         "model": "gpt-4.1",
-		"on_permission_request": PermissionHandler.approve_all,
+        "on_permission_request": PermissionHandler.approve_all,
         "streaming": True,
     })
 


### PR DESCRIPTION
The Python examples were not working OOTB giving the following error:

```bash
ValueError: An on_permission_request handler is required when creating a session. For example, to allow all permissions, use {"on_permission_request": PermissionHandler.approve_all}.
```

However upon adding the `on_permission_request` they work as expected.