### PR TITLE
[Python] Set default value for ephemeral parameter in log_message method to `False`

### DIFF
--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -770,6 +770,6 @@ class CopilotSession:
         params = SessionLogParams(
             message=message,
             level=Level(level) if level is not None else None,
-            ephemeral=ephemeral,
+            ephemeral=ephemeral or None,
         )
         await self.rpc.log(params)


### PR DESCRIPTION
Also narrow the parameter's type along the way.