### PR TITLE
test: cover python session workspace and destroy APIs

### DIFF
--- a/python/test_client.py
+++ b/python/test_client.py
@@ -480,3 +480,44 @@ class TestSessionConfigForwarding:
             assert captured["session.model.switchTo"]["modelId"] == "gpt-4.1"
         finally:
             await client.force_stop()
+
+    @pytest.mark.asyncio
+    async def test_create_session_exposes_workspace_path(self):
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            session = await client.create_session(
+                {"on_permission_request": PermissionHandler.approve_all}
+            )
+            assert session.workspace_path is not None
+            assert session.workspace_path.endswith(session.session_id)
+        finally:
+            await client.force_stop()
+
+    @pytest.mark.asyncio
+    async def test_destroy_warns_and_disconnects_session(self):
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            session = await client.create_session(
+                {"on_permission_request": PermissionHandler.approve_all}
+            )
+
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "session.destroy":
+                    return {}
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            with pytest.deprecated_call(match=r"destroy\(\) is deprecated, use disconnect\(\) instead"):
+                await session.destroy()
+
+            assert captured["session.destroy"] == {"sessionId": session.session_id}
+        finally:
+            await client.force_stop()


### PR DESCRIPTION
## Summary
- add a Python client test that asserts `create_session()` exposes `session.workspace_path`
- add a Python client test that verifies deprecated `session.destroy()` warns and forwards to `session.destroy` RPC cleanup

## Why
Issue #809 calls out three public `CopilotSession` APIs that were effectively unused in tests. `set_model()` already had request-shape coverage, but `workspace_path` and deprecated `destroy()` still had no client-level validation. This PR closes that gap without changing runtime behavior.

## Validation
- `python -m pytest -q python/test_client.py -k 'workspace_path or destroy_warns'`
- `git diff --check`
