### PR TITLE
fix: default python session.log level to info

### DIFF
--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -768,7 +768,7 @@ class CopilotSession:
         """
         params = SessionLogParams(
             message=message,
-            level=Level(level) if level is not None else None,
+            level=Level(level) if level is not None else Level("info"),
             ephemeral=ephemeral,
         )
         await self.rpc.log(params)

--- a/python/test_client.py
+++ b/python/test_client.py
@@ -480,3 +480,33 @@ class TestSessionConfigForwarding:
             assert captured["session.model.switchTo"]["modelId"] == "gpt-4.1"
         finally:
             await client.force_stop()
+
+    @pytest.mark.asyncio
+    async def test_log_uses_info_level_by_default(self):
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            session = await client.create_session(
+                {"on_permission_request": PermissionHandler.approve_all}
+            )
+
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "session.log":
+                    return {"eventId": "12345678-1234-5678-1234-567812345678"}
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            await session.log("hello from test")
+
+            assert captured["session.log"] == {
+                "sessionId": session.session_id,
+                "message": "hello from test",
+                "level": "info",
+            }
+        finally:
+            await client.force_stop()


### PR DESCRIPTION
## Summary
- make Python `CopilotSession.log()` send `level="info"` when callers omit the `level` argument
- add a focused client test that locks the default request shape in place

## Why
Fixes #810. The public Python API documents `level` as defaulting to `"info"`, but the current implementation omits `level` from the RPC entirely when the caller does not pass it. This PR aligns the implementation with the documented/default API contract.

## Validation
- `python -m pytest -q python/test_client.py -k 'log_uses_info_level_by_default'`
- `git diff --check`
