### PR TITLE
test: cover python delete_session contract

### DIFF
--- a/python/test_client.py
+++ b/python/test_client.py
@@ -480,3 +480,33 @@ class TestSessionConfigForwarding:
             assert captured["session.model.switchTo"]["modelId"] == "gpt-4.1"
         finally:
             await client.force_stop()
+
+
+class TestSessionManagementApis:
+    @pytest.mark.asyncio
+    async def test_delete_session_sends_rpc_and_clears_local_cache(self):
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            session = await client.create_session(
+                {"on_permission_request": PermissionHandler.approve_all}
+            )
+            assert session.session_id in client._sessions
+
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "session.delete":
+                    return {"success": True}
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            await client.delete_session(session.session_id)
+
+            assert captured["session.delete"] == {"sessionId": session.session_id}
+            assert session.session_id not in client._sessions
+        finally:
+            await client.force_stop()


### PR DESCRIPTION
## Summary
- add a Python client test for `delete_session()`
- verify the client sends the expected `session.delete` RPC payload
- verify successful deletion also clears the local session cache entry

## Why
`CopilotClient.delete_session()` is part of the public Python API, but it had no focused contract test covering either the request shape or the local `_sessions` cleanup behavior. This PR locks both in place so regressions are caught in CI.

## Validation
- `python -m pytest -q python/test_client.py -k 'delete_session_sends_rpc_and_clears_local_cache'`
- `git diff --check`
