### PR TITLE
test: cover python delete_session failure path

### DIFF
--- a/python/test_client.py
+++ b/python/test_client.py
@@ -480,3 +480,29 @@ class TestSessionConfigForwarding:
             assert captured["session.model.switchTo"]["modelId"] == "gpt-4.1"
         finally:
             await client.force_stop()
+
+
+class TestSessionManagementApis:
+    @pytest.mark.asyncio
+    async def test_delete_session_raises_on_failed_response(self):
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "session.delete":
+                    return {"success": False, "error": "permission denied"}
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+
+            with pytest.raises(RuntimeError, match="Failed to delete session session-123: permission denied"):
+                await client.delete_session("session-123")
+
+            assert captured["session.delete"] == {"sessionId": "session-123"}
+        finally:
+            await client.force_stop()


### PR DESCRIPTION
## Summary
- add a focused Python client test for the `delete_session()` failure path
- verify the expected `session.delete` RPC payload is sent
- verify an unsuccessful response raises a descriptive `RuntimeError`

## Why
The Python client already had coverage for the happy path of deleting sessions, but not for the server-declared failure case. This PR locks down the error contract so regressions in exception behavior or wire payload shape are caught in CI.

## Validation
- `python -m pytest -q python/test_client.py -k 'delete_session_raises_on_failed_response'`
- `git diff --check`
