### PR TITLE
test: cover python list_sessions empty filter

### DIFF
--- a/python/test_client.py
+++ b/python/test_client.py
@@ -480,3 +480,26 @@ class TestSessionConfigForwarding:
             assert captured["session.model.switchTo"]["modelId"] == "gpt-4.1"
         finally:
             await client.force_stop()
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_sends_empty_payload_without_filter(self):
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "session.list":
+                    return {"sessions": []}
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            sessions = await client.list_sessions()
+
+            assert captured["session.list"] == {}
+            assert sessions == []
+        finally:
+            await client.force_stop()


### PR DESCRIPTION
## Summary
- add a focused Python client test for `list_sessions()` without a filter
- verify the client sends an empty payload when no `SessionListFilter` is provided
- verify the empty server response is returned as an empty list

## Why
The Python client now has targeted coverage for filtered `list_sessions()` calls, but not for the no-filter default path. This PR locks down the default wire contract so regressions in payload shape or empty-response handling are caught in CI.

## Validation
- `python -m pytest -q python/test_client.py -k 'list_sessions_sends_empty_payload_without_filter'`
- `git diff --check`
