### PR TITLE
test: cover python get_last_session_id none case

### DIFF
--- a/python/test_client.py
+++ b/python/test_client.py
@@ -480,3 +480,26 @@ class TestSessionConfigForwarding:
             assert captured["session.model.switchTo"]["modelId"] == "gpt-4.1"
         finally:
             await client.force_stop()
+
+    @pytest.mark.asyncio
+    async def test_get_last_session_id_returns_none_when_absent(self):
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "session.getLastId":
+                    return {}
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            session_id = await client.get_last_session_id()
+
+            assert captured["session.getLastId"] == {}
+            assert session_id is None
+        finally:
+            await client.force_stop()


### PR DESCRIPTION
## Summary
- add a focused Python client test for `get_last_session_id()` when the server returns no session id
- verify the client still sends the expected empty payload to `session.getLastId`
- verify the Python API returns `None` for the no-session case

## Why
The happy path for `get_last_session_id()` is now covered, but the default/no-session path was still untested. This PR locks down that behavior so regressions in payload shape or `None` handling are caught in CI.

## Validation
- `python -m pytest -q python/test_client.py -k 'get_last_session_id_returns_none_when_absent'`
- `git diff --check`
