### PR TITLE
test: cover python list_sessions missing field

### DIFF
--- a/python/test_client.py
+++ b/python/test_client.py
@@ -480,3 +480,26 @@ class TestSessionConfigForwarding:
             assert captured["session.model.switchTo"]["modelId"] == "gpt-4.1"
         finally:
             await client.force_stop()
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_returns_empty_list_when_sessions_field_missing(self):
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "session.list":
+                    return {}
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            sessions = await client.list_sessions()
+
+            assert captured["session.list"] == {}
+            assert sessions == []
+        finally:
+            await client.force_stop()


### PR DESCRIPTION
## Summary
- add a focused Python client test for `list_sessions()` when the server omits the `sessions` field entirely
- verify the client still sends the expected empty payload
- verify the Python API returns an empty list for the missing-field default case

## Why
`list_sessions()` already had targeted coverage for filtered calls and explicit empty arrays, but not for the server default-path where the `sessions` field is absent altogether. This PR locks down that fallback behavior so regressions in empty-response handling are caught in CI.

## Validation
- `python -m pytest -q python/test_client.py -k 'list_sessions_returns_empty_list_when_sessions_field_missing'`
- `git diff --check`
