### PR TITLE
go: change LogOptions.Ephemeral from bool to *bool

### DIFF
--- a/go/internal/e2e/session_test.go
+++ b/go/internal/e2e/session_test.go
@@ -981,7 +981,7 @@ func TestSessionLog(t *testing.T) {
 	})
 
 	t.Run("should log ephemeral message", func(t *testing.T) {
-		if err := session.Log(t.Context(), "Ephemeral message", &copilot.LogOptions{Ephemeral: true}); err != nil {
+		if err := session.Log(t.Context(), "Ephemeral message", &copilot.LogOptions{Ephemeral: copilot.Bool(true)}); err != nil {
 			t.Fatalf("Log failed: %v", err)
 		}
 

--- a/go/session.go
+++ b/go/session.go
@@ -711,8 +711,9 @@ type LogOptions struct {
 	// [rpc.Warning], and [rpc.Error].
 	Level rpc.Level
 	// Ephemeral marks the message as transient so it is not persisted
-	// to the session event log on disk.
-	Ephemeral bool
+	// to the session event log on disk. When nil the server decides the
+	// default; set to a non-nil value to explicitly control persistence.
+	Ephemeral *bool
 }
 
 // Log sends a log message to the session timeline.
@@ -730,7 +731,7 @@ type LogOptions struct {
 //	session.Log(ctx, "Rate limit approaching", &copilot.LogOptions{Level: rpc.Warning})
 //
 //	// Ephemeral message (not persisted)
-//	session.Log(ctx, "Working...", &copilot.LogOptions{Ephemeral: true})
+//	session.Log(ctx, "Working...", &copilot.LogOptions{Ephemeral: copilot.Bool(true)})
 func (s *Session) Log(ctx context.Context, message string, opts *LogOptions) error {
 	params := &rpc.SessionLogParams{Message: message}
 
@@ -738,8 +739,8 @@ func (s *Session) Log(ctx context.Context, message string, opts *LogOptions) err
 		if opts.Level != "" {
 			params.Level = &opts.Level
 		}
-		if opts.Ephemeral {
-			params.Ephemeral = &opts.Ephemeral
+		if opts.Ephemeral != nil {
+			params.Ephemeral = opts.Ephemeral
 		}
 	}
 

--- a/go/types.go
+++ b/go/types.go
@@ -64,7 +64,10 @@ type ClientOptions struct {
 }
 
 // Bool returns a pointer to the given bool value.
-// Use for setting AutoStart: AutoStart: Bool(false)
+// Use for option fields such as AutoStart, AutoRestart, or LogOptions.Ephemeral:
+//
+//	AutoStart: Bool(false)
+//	Ephemeral: Bool(true)
 func Bool(v bool) *bool {
 	return &v
 }


### PR DESCRIPTION
## Summary

`LogOptions.Ephemeral` was a plain `bool`, making it impossible for callers to distinguish between "not set" (zero-value `false`) and an explicit `false`. The SDK only sent `ephemeral` on the wire when the value was `true`, so callers could never explicitly request non-ephemeral logging.

## Changes

- **go/session.go** - Change `Ephemeral` from `bool` to `*bool`. The `Log` method now checks `opts.Ephemeral != nil` and passes the pointer through directly.
- **go/types.go** - Updated `Bool` helper doc to mention `LogOptions.Ephemeral`.
- **go/internal/e2e/session_test.go** - Updated test to use `copilot.Bool(true)`.

## Breaking change

Callers must now write `Ephemeral: copilot.Bool(true)` instead of `Ephemeral: true`.

This aligns the Go SDK with how the other three SDKs (Node, Python, .NET) handle the field - all use nullable types that omit the field from the JSON-RPC payload when not set.
