### PR TITLE
test: cover python get_foreground_session_id none case

### DIFF
--- a/python/test_client.py
+++ b/python/test_client.py
@@ -480,3 +480,27 @@ class TestSessionConfigForwarding:
             assert captured["session.model.switchTo"]["modelId"] == "gpt-4.1"
         finally:
             await client.force_stop()
+
+
+class TestForegroundSessionApis:
+    @pytest.mark.asyncio
+    async def test_get_foreground_session_id_returns_none_when_absent(self):
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "session.getForeground":
+                    return {}
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            result = await client.get_foreground_session_id()
+            assert captured["session.getForeground"] == {}
+            assert result is None
+        finally:
+            await client.force_stop()


### PR DESCRIPTION
## Summary
- add a focused Python client test for `get_foreground_session_id()` when the server omits `sessionId`
- verify the client still sends the exact `session.getForeground` RPC payload `{}`
- lock in the public API behavior of returning `None` for the no-foreground-session case

## Validation
- `python -m pytest -q python/test_client.py -k 'get_foreground_session_id_returns_none_when_absent'`
- `git diff --check`
