### PR TITLE
test: cover python get_foreground_session_id contract

### DIFF
--- a/python/test_client.py
+++ b/python/test_client.py
@@ -480,3 +480,26 @@ class TestSessionConfigForwarding:
             assert captured["session.model.switchTo"]["modelId"] == "gpt-4.1"
         finally:
             await client.force_stop()
+
+class TestForegroundSessionGetSuccess:
+    @pytest.mark.asyncio
+    async def test_get_foreground_session_id_sends_correct_rpc(self):
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "session.getForeground":
+                    return {"sessionId": "session-123"}
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            result = await client.get_foreground_session_id()
+            assert captured["session.getForeground"] == {}
+            assert result == "session-123"
+        finally:
+            await client.force_stop()


### PR DESCRIPTION
## Summary
- add a focused Python client test for the successful `get_foreground_session_id()` path
- verify the client sends the exact `session.getForeground` RPC payload `{}`
- lock in parsing of the returned `sessionId`

## Validation
- `python -m pytest -q python/test_client.py -k 'test_get_foreground_session_id_sends_correct_rpc'`
- `git diff --check`
