### PR TITLE
test: cover python set_foreground unknown error

### DIFF
--- a/python/test_client.py
+++ b/python/test_client.py
@@ -480,3 +480,26 @@ class TestSessionConfigForwarding:
             assert captured["session.model.switchTo"]["modelId"] == "gpt-4.1"
         finally:
             await client.force_stop()
+
+class TestForegroundSessionFailureFallback:
+    @pytest.mark.asyncio
+    async def test_set_foreground_session_id_uses_unknown_error_fallback(self):
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "session.setForeground":
+                    return {"success": False}
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            with pytest.raises(RuntimeError, match="Failed to set foreground session: Unknown error"):
+                await client.set_foreground_session_id("session-123")
+            assert captured["session.setForeground"] == {"sessionId": "session-123"}
+        finally:
+            await client.force_stop()


### PR DESCRIPTION
## Summary
- add a focused Python client test for `set_foreground_session_id()` when the server returns `{success: false}` without an explicit `error`
- verify the client still sends the exact `session.setForeground` payload
- lock in the fallback error message `Unknown error`

## Validation
- `python -m pytest -q python/test_client.py -k 'test_set_foreground_session_id_uses_unknown_error_fallback'`
- `git diff --check`
