### PR TITLE
test: cover python get_status contract

### DIFF
--- a/python/test_client.py
+++ b/python/test_client.py
@@ -480,3 +480,27 @@ class TestSessionConfigForwarding:
             assert captured["session.model.switchTo"]["modelId"] == "gpt-4.1"
         finally:
             await client.force_stop()
+
+class TestStatusApi:
+    @pytest.mark.asyncio
+    async def test_get_status_sends_correct_rpc(self):
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "status.get":
+                    return {"version": "1.0.0", "protocolVersion": 2}
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            result = await client.get_status()
+            assert captured["status.get"] == {}
+            assert result.version == "1.0.0"
+            assert result.protocolVersion == 2
+        finally:
+            await client.force_stop()


### PR DESCRIPTION
## Summary
- add a focused Python client test for `get_status()`
- verify the client sends the exact `status.get` RPC payload `{}`
- lock in parsing of `version` and `protocolVersion`

## Validation
- `python -m pytest -q python/test_client.py -k 'test_get_status_sends_correct_rpc'`
- `git diff --check`
