### PR TITLE
test: cover python list_models contract

### DIFF
--- a/python/test_client.py
+++ b/python/test_client.py
@@ -480,3 +480,39 @@ class TestSessionConfigForwarding:
             assert captured["session.model.switchTo"]["modelId"] == "gpt-4.1"
         finally:
             await client.force_stop()
+
+class TestListModelsApi:
+    @pytest.mark.asyncio
+    async def test_list_models_sends_correct_rpc(self):
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "models.list":
+                    return {
+                        "models": [
+                            {
+                                "id": "gpt-4.1",
+                                "name": "GPT-4.1",
+                                "capabilities": {
+                                    "supports": {"vision": True},
+                                    "limits": {"max_prompt_tokens": 8192}
+                                }
+                            }
+                        ]
+                    }
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            result = await client.list_models()
+            assert captured["models.list"] == {}
+            assert len(result) == 1
+            assert result[0].id == "gpt-4.1"
+            assert result[0].name == "GPT-4.1"
+        finally:
+            await client.force_stop()


### PR DESCRIPTION
## Summary
- add a focused Python client test for `list_models()`
- verify the client sends the exact `models.list` RPC payload `{}`
- lock in parsing of the `models` array and `ModelInfo` fields

## Validation
- `python -m pytest -q python/test_client.py -k 'test_list_models_sends_correct_rpc'`
- `git diff --check`
