### PR TITLE
test: cover python abort contract

### DIFF
--- a/python/test_client.py
+++ b/python/test_client.py
@@ -480,3 +480,32 @@ class TestSessionConfigForwarding:
             assert captured["session.model.switchTo"]["modelId"] == "gpt-4.1"
         finally:
             await client.force_stop()
+
+class TestAbortApi:
+    @pytest.mark.asyncio
+    async def test_abort_sends_correct_rpc(self):
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "session.create":
+                    return {
+                        "sessionId": "session-abort",
+                        "workspacePath": "/tmp/test",
+                        "latestCheckpoint": {"checkpointId": "cp-1"}
+                    }
+                if method == "session.abort":
+                    return {}
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            session = await client.create_session({"on_permission_request": PermissionHandler.approve_all})
+            await session.abort()
+            assert captured["session.abort"]["sessionId"] == session.session_id
+        finally:
+            await client.force_stop()


### PR DESCRIPTION
## Summary
- add a focused Python client test for `session.abort()`
- verify the session sends the exact `session.abort` RPC payload with correct `sessionId`

## Validation
- `python -m pytest -q python/test_client.py -k 'test_abort_sends_correct_rpc'`
- `git diff --check`
