### PR TITLE
test: cover python get_status protocol coercion

### DIFF
--- a/python/test_client.py
+++ b/python/test_client.py
@@ -480,3 +480,28 @@ class TestSessionConfigForwarding:
             assert captured["session.model.switchTo"]["modelId"] == "gpt-4.1"
         finally:
             await client.force_stop()
+
+class TestStatusApi:
+    @pytest.mark.asyncio
+    async def test_get_status_coerces_protocol_version_to_int(self):
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "status.get":
+                    return {"version": "1.2.3", "protocolVersion": "2"}
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            result = await client.get_status()
+            assert captured["status.get"] == {}
+            assert result.version == "1.2.3"
+            assert result.protocolVersion == 2
+            assert isinstance(result.protocolVersion, int)
+        finally:
+            await client.force_stop()


### PR DESCRIPTION
## Summary
- add a focused Python client test for `get_status()` response coercion
- verify the client still sends the exact `status.get` RPC payload `{}`
- lock in coercion of `protocolVersion` from string to integer

## Validation
- `python -m pytest -q python/test_client.py -k 'test_get_status_coerces_protocol_version_to_int'`
- `git diff --check`
