### PR TITLE
test: cover python get_auth_status bool coercion

### DIFF
--- a/python/test_client.py
+++ b/python/test_client.py
@@ -480,3 +480,28 @@ class TestSessionConfigForwarding:
             assert captured["session.model.switchTo"]["modelId"] == "gpt-4.1"
         finally:
             await client.force_stop()
+
+class TestAuthStatusApi:
+    @pytest.mark.asyncio
+    async def test_get_auth_status_coerces_bool_flag(self):
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "auth.getStatus":
+                    return {"isAuthenticated": 1, "login": "octocat"}
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            result = await client.get_auth_status()
+            assert captured["auth.getStatus"] == {}
+            assert result.isAuthenticated is True
+            assert isinstance(result.isAuthenticated, bool)
+            assert result.login == "octocat"
+        finally:
+            await client.force_stop()


### PR DESCRIPTION
## Summary
- add a focused Python client test for `get_auth_status()` boolean coercion
- verify the client still sends the exact `auth.getStatus` payload `{}`
- lock in coercion of `isAuthenticated` to a real Python bool

## Validation
- `python -m pytest -q python/test_client.py -k 'test_get_auth_status_coerces_bool_flag'`
- `git diff --check`
