### PR TITLE
test: cover python get_auth_status status message

### DIFF
--- a/python/test_client.py
+++ b/python/test_client.py
@@ -480,3 +480,31 @@ class TestSessionConfigForwarding:
             assert captured["session.model.switchTo"]["modelId"] == "gpt-4.1"
         finally:
             await client.force_stop()
+
+class TestAuthStatusApi:
+    @pytest.mark.asyncio
+    async def test_get_auth_status_parses_status_message(self):
+        client = CopilotClient({"cli_path": CLI_PATH})
+        await client.start()
+
+        try:
+            captured = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "auth.getStatus":
+                    return {
+                        "isAuthenticated": False,
+                        "statusMessage": "Authentication required",
+                    }
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            result = await client.get_auth_status()
+            assert captured["auth.getStatus"] == {}
+            assert result.isAuthenticated is False
+            assert result.statusMessage == "Authentication required"
+            assert result.login is None
+        finally:
+            await client.force_stop()


### PR DESCRIPTION
## Summary
- add a focused Python client test for `get_auth_status()` status message parsing
- verify the client still sends the exact `auth.getStatus` payload `{}`
- lock in parsing of optional `statusMessage`

## Validation
- `python -m pytest -q python/test_client.py -k 'test_get_auth_status_parses_status_message'`
- `git diff --check`
