### PR TITLE
Add Permission Handling documentation to all language READMEs

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -607,19 +607,21 @@ var session = await client.CreateSessionAsync(new SessionConfig
     Model = "gpt-5",
     OnPermissionRequest = async (request, invocation) =>
     {
-        // request.Kind — what type of operation is being requested:
-        //   PermissionRequestKind.Shell      — executing a shell command
-        //   PermissionRequestKind.Write      — writing or editing a file
-        //   PermissionRequestKind.Read       — reading a file
-        //   PermissionRequestKind.Mcp        — calling an MCP tool
-        //   PermissionRequestKind.CustomTool — calling one of your registered tools
-        //   PermissionRequestKind.Url        — fetching a URL
-        // request.ToolCallId  — the tool call that triggered this request
-        // request.ToolName    — name of the tool (for custom-tool / mcp)
-        // request.FileName    — file being written (for write)
+        // request.Kind — string discriminator for the type of operation being requested:
+        //   "shell"       — executing a shell command
+        //   "write"       — writing or editing a file
+        //   "read"        — reading a file
+        //   "mcp"         — calling an MCP tool
+        //   "custom_tool" — calling one of your registered tools
+        //   "url"         — fetching a URL
+        //   "memory"      — accessing or modifying assistant memory
+        //   "hook"        — invoking a registered hook
+        // request.ToolCallId      — the tool call that triggered this request
+        // request.ToolName        — name of the tool (for custom-tool / mcp)
+        // request.FileName        — file being written (for write)
         // request.FullCommandText — full shell command text (for shell)
 
-        if (request.Kind == PermissionRequestKind.Shell)
+        if (request.Kind == "shell")
         {
             // Deny shell commands
             return new PermissionRequestResult { Kind = PermissionRequestResultKind.DeniedInteractivelyByUser };
@@ -638,7 +640,7 @@ var session = await client.CreateSessionAsync(new SessionConfig
 | `PermissionRequestResultKind.DeniedInteractivelyByUser` | User explicitly denied the request |
 | `PermissionRequestResultKind.DeniedCouldNotRequestFromUser` | No approval rule matched and user could not be asked |
 | `PermissionRequestResultKind.DeniedByRules` | Denied by a policy rule |
-| `PermissionRequestResultKind.NoResult` | No decision (treated as denied) |
+| `PermissionRequestResultKind.NoResult` | Leave the permission request unanswered (the SDK returns without calling the RPC). Not allowed for protocol v2 permission requests (will be rejected). |
 
 ### Resuming Sessions
 

--- a/go/README.md
+++ b/go/README.md
@@ -532,6 +532,8 @@ session, err := client.CreateSession(context.Background(), &copilot.SessionConfi
         //   copilot.MCP        — calling an MCP tool
         //   copilot.CustomTool — calling one of your registered tools
         //   copilot.URL        — fetching a URL
+        //   copilot.Memory     — accessing or updating Copilot-managed memory
+        //   copilot.Hook       — invoking a registered hook
         // request.ToolCallID  — pointer to the tool call that triggered this request
         // request.ToolName    — pointer to the name of the tool (for custom-tool / mcp)
         // request.FileName    — pointer to the file being written (for write)
@@ -555,7 +557,7 @@ session, err := client.CreateSession(context.Background(), &copilot.SessionConfi
 | `PermissionRequestResultKindDeniedInteractivelyByUser` | User explicitly denied the request |
 | `PermissionRequestResultKindDeniedCouldNotRequestFromUser` | No approval rule matched and user could not be asked |
 | `PermissionRequestResultKindDeniedByRules` | Denied by a policy rule |
-| `PermissionRequestResultKindNoResult` | No decision (treated as denied) |
+| `PermissionRequestResultKindNoResult` | Leave the permission request unanswered (protocol v1 only; not allowed for protocol v2) |
 
 ### Resuming Sessions
 

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -684,6 +684,9 @@ const session = await client.createSession({
         //   "mcp"         — calling an MCP tool
         //   "custom-tool" — calling one of your registered tools
         //   "url"         — fetching a URL
+        //   "memory"      — storing or retrieving persistent session memory
+        //   "hook"        — invoking a server-side hook or integration
+        //   (additional kinds may be added; include a default case in handlers)
         // request.toolCallId — the tool call that triggered this request
         // request.toolName   — name of the tool (for custom-tool / mcp)
         // request.fileName   — file being written (for write)
@@ -708,7 +711,7 @@ const session = await client.createSession({
 | `"denied-no-approval-rule-and-could-not-request-from-user"` | No approval rule matched and user could not be asked |
 | `"denied-by-rules"` | Denied by a policy rule |
 | `"denied-by-content-exclusion-policy"` | Denied due to a content exclusion policy |
-
+| `"no-result"` | Leave the request unanswered (only valid with protocol v1; rejected by protocol v2 servers) |
 ### Resuming Sessions
 
 Pass `onPermissionRequest` when resuming a session too — it is required:

--- a/python/README.md
+++ b/python/README.md
@@ -508,6 +508,8 @@ def on_permission_request(request: PermissionRequest, invocation: dict) -> Permi
     #   "mcp"         — calling an MCP tool
     #   "custom-tool" — calling one of your registered tools
     #   "url"         — fetching a URL
+    #   "memory"      — accessing or updating session/workspace memory
+    #   "hook"        — invoking a registered hook
     # request.tool_call_id  — the tool call that triggered this request
     # request.tool_name     — name of the tool (for custom-tool / mcp)
     # request.file_name     — file being written (for write)
@@ -543,6 +545,7 @@ async def on_permission_request(request: PermissionRequest, invocation: dict) ->
 | `"denied-no-approval-rule-and-could-not-request-from-user"` | No approval rule matched and user could not be asked (default when no kind is specified) |
 | `"denied-by-rules"` | Denied by a policy rule |
 | `"denied-by-content-exclusion-policy"` | Denied due to a content exclusion policy |
+| `"no-result"` | Leave the request unanswered (not allowed for protocol v2 permission requests) |
 
 ### Resuming Sessions
 


### PR DESCRIPTION
This pull request updates the documentation for all SDKs (Node.js, Python, Go, .NET) to clarify that a permission handler is now required when creating or resuming a Copilot session. It adds detailed sections and examples for "Permission Handling", including how to use built-in helpers or provide custom logic to approve or deny tool executions. The changes also update all code samples, quick starts, and configuration references to include the required permission handler.