### PR TITLE
Fix Python resume_session override test to not require auth

### DIFF
--- a/python/test_client.py
+++ b/python/test_client.py
@@ -213,11 +213,12 @@ class TestOverridesBuiltInTool:
             )
 
             captured = {}
-            original_request = client._client.request
 
             async def mock_request(method, params):
                 captured[method] = params
-                return await original_request(method, params)
+                # Return a fake response instead of calling the real CLI,
+                # which would fail without auth credentials.
+                return {"sessionId": params["sessionId"]}
 
             client._client.request = mock_request
 


### PR DESCRIPTION
## Problem

`test_resume_session_sends_overrides_built_in_tool` fails on CI runs that don't have access to the Copilot token because it makes a real network call, unlike all the other tests. Fails with:

```
copilot._jsonrpc.JsonRpcError: JSON-RPC Error -32603: Request session.resume failed with message: No authentication info available
```

## Root cause

The test mock interceptor captured the `session.resume` params but then **passed through to the real CLI**, which needs auth credentials. This fails in CI environments without Copilot auth.

Other resume tests in the same file (e.g. `test_resume_session_forwards_client_name`, `test_resume_session_forwards_agent`) already handled this correctly by returning a fake response for `session.resume`. This test was simply missed.

The Node.js equivalent also mocks the response rather than calling through.

## Fix

Return a fake response from the mock instead of calling the real CLI, consistent with the other resume tests.
