### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![NPM Downloads](https://img.shields.io/npm/dm/%40github%2Fcopilot-sdk?label=npm)](https://www.npmjs.com/package/@github/copilot-sdk)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/github-copilot-sdk?label=PyPI)](https://pypi.org/project/github-copilot-sdk/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/GitHub.Copilot.SDK?label=NuGet)](https://www.nuget.org/packages/GitHub.Copilot.SDK)
+[![gitcgr](https://gitcgr.com/badge/github/copilot-sdk.svg)](https://gitcgr.com/github/copilot-sdk)
 
 Agents for every app.
 


### PR DESCRIPTION
Someone visualized your repository on [gitcgr.com](https://gitcgr.com/github/copilot-sdk)! This badge lets visitors explore your codebase as an interactive graph.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/github/copilot-sdk.svg)](https://gitcgr.com/github/copilot-sdk)

Clicking the badge takes users to an interactive visualization of your code structure — functions, classes, modules, and their relationships.