### PR TITLE
fix: update runtime to 1.0.15-2, re-enable postToolUse hook tests

### DIFF
--- a/dotnet/test/HooksTests.cs
+++ b/dotnet/test/HooksTests.cs
@@ -46,8 +46,7 @@ public class HooksTests(E2ETestFixture fixture, ITestOutputHelper output) : E2ET
         Assert.Contains(preToolUseInputs, i => !string.IsNullOrEmpty(i.ToolName));
     }
 
-    // TODO: Re-enable once runtime postToolUse hooks are fixed (https://github.com/github/copilot-sdk/issues/972)
-    [Fact(Skip = "Runtime postToolUse hooks broken")]
+    [Fact]
     public async Task Should_Invoke_PostToolUse_Hook_After_Model_Runs_A_Tool()
     {
         var postToolUseInputs = new List<PostToolUseHookInput>();
@@ -84,8 +83,7 @@ public class HooksTests(E2ETestFixture fixture, ITestOutputHelper output) : E2ET
         Assert.Contains(postToolUseInputs, i => i.ToolResult != null);
     }
 
-    // TODO: Re-enable once runtime postToolUse hooks are fixed (https://github.com/github/copilot-sdk/issues/972)
-    [Fact(Skip = "Runtime postToolUse hooks broken")]
+    [Fact]
     public async Task Should_Invoke_Both_PreToolUse_And_PostToolUse_Hooks_For_Single_Tool_Call()
     {
         var preToolUseInputs = new List<PreToolUseHookInput>();

--- a/go/internal/e2e/hooks_test.go
+++ b/go/internal/e2e/hooks_test.go
@@ -74,9 +74,7 @@ func TestHooks(t *testing.T) {
 		}
 	})
 
-	// TODO: Re-enable once runtime postToolUse hooks are fixed (https://github.com/github/copilot-sdk/issues/972)
 	t.Run("should invoke postToolUse hook after model runs a tool", func(t *testing.T) {
-		t.Skip("Runtime postToolUse hooks broken")
 		ctx.ConfigureForTest(t)
 
 		var postToolUseInputs []copilot.PostToolUseHookInput
@@ -141,9 +139,7 @@ func TestHooks(t *testing.T) {
 		}
 	})
 
-	// TODO: Re-enable once runtime postToolUse hooks are fixed (https://github.com/github/copilot-sdk/issues/972)
 	t.Run("should invoke both preToolUse and postToolUse hooks for a single tool call", func(t *testing.T) {
-		t.Skip("Runtime postToolUse hooks broken")
 		ctx.ConfigureForTest(t)
 
 		var preToolUseInputs []copilot.PreToolUseHookInput

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^1.0.15-1",
+        "@github/copilot": "^1.0.15-2",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },
@@ -663,26 +663,26 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.15-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.15-1.tgz",
-      "integrity": "sha512-H5I7CXJpOj+nUD1+0VQzawhV86X9Nb2m4fU0h70KDk+LDWRGhWvOlhK/bfFTVj6TPQbjBaOU4n2QJ+zKv48fGw==",
+      "version": "1.0.15-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.15-2.tgz",
+      "integrity": "sha512-ZVwGAH9u55CbGsM2fbZr9yL7oML5NZxfMbATBU9hWY8yEjiaSj+9WkRPxCSxGsd2cu4tw3OcHhFkDvxvWd2QpQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.15-1",
-        "@github/copilot-darwin-x64": "1.0.15-1",
-        "@github/copilot-linux-arm64": "1.0.15-1",
-        "@github/copilot-linux-x64": "1.0.15-1",
-        "@github/copilot-win32-arm64": "1.0.15-1",
-        "@github/copilot-win32-x64": "1.0.15-1"
+        "@github/copilot-darwin-arm64": "1.0.15-2",
+        "@github/copilot-darwin-x64": "1.0.15-2",
+        "@github/copilot-linux-arm64": "1.0.15-2",
+        "@github/copilot-linux-x64": "1.0.15-2",
+        "@github/copilot-win32-arm64": "1.0.15-2",
+        "@github/copilot-win32-x64": "1.0.15-2"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.15-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.15-1.tgz",
-      "integrity": "sha512-xo3yBGtzEliSnKZ+5RLBS94PxXpDkeNEf/dqi9/EtMjWTA8Zr6Zc318XDMG+7R/PwwiGdDNHa2+41/ffQ5ek4A==",
+      "version": "1.0.15-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.15-2.tgz",
+      "integrity": "sha512-J2kvPBbNC636z3YdFdg2uK8YAF0o1ktss4Cmz+WVi5+5rNzscty3GmUoWBgw1AtPRNSeFT8amMVZ9xBvkpzA/A==",
       "cpu": [
         "arm64"
       ],
@@ -696,9 +696,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.15-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.15-1.tgz",
-      "integrity": "sha512-gJ4uVuETqHSdvz+XD65F7MJqojU8Nthoi4+10549jPNhn29rAk6huZSJHg7DzK9K/bSlKEXKDziOE+p799EF8g==",
+      "version": "1.0.15-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.15-2.tgz",
+      "integrity": "sha512-utoHP7RyJXasNVQtpAhkDfp4jTLiNwJf5ZFjOkb9XMASre0+i4CfsokuXb1yPXczXFnrLcreVWQ2wtSuRiyV3A==",
       "cpu": [
         "x64"
       ],
@@ -712,9 +712,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.15-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.15-1.tgz",
-      "integrity": "sha512-j0a+rAopJxV1NaA4VJElHMsA7x7ICD3+vkhb/1tOW1mfRQSg9OMegajidA0UvnMBAgQrOODUm8CAXc2ko1QMNw==",
+      "version": "1.0.15-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.15-2.tgz",
+      "integrity": "sha512-tkqt6W+3VhZRvTMQoNj80s5JWNu5TXPYnNQkrPzAviqTsd8BRXOSGnqcIL7DvU+Y0z4pY5IS0ZECByB0IsRSHw==",
       "cpu": [
         "arm64"
       ],
@@ -728,9 +728,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.15-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.15-1.tgz",
-      "integrity": "sha512-K0UAkXKHlKU2wPgafO6mNl6xF5EoJ8xRBbXgJZOQZZtuJVHxGrVmmQWMdvz7bixrL+F1eB35jMYexupXS3C4Vw==",
+      "version": "1.0.15-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.15-2.tgz",
+      "integrity": "sha512-svGfox/x8pNzrxcTAkpbqyWzaeQiJaRj6ZuQzzGJGi5+G6kAok3iqIInO+QYNB6fozW8oLnR8QJigAoj8Ldzbw==",
       "cpu": [
         "x64"
       ],
@@ -744,9 +744,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.15-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.15-1.tgz",
-      "integrity": "sha512-BKMqmsZ/EKSJZZ3M2HHcVLOxFvqcwO4ZtpEQPsXqPpbjyRRZCfbVr0fwb9ltZmiNP8rKMtEAO8yxYStiYHXjgw==",
+      "version": "1.0.15-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.15-2.tgz",
+      "integrity": "sha512-ZM/cmICtOOknMLkN42OvCRaLp5qJPBN9GAKkwTWCrhBmFpAIjC9O679AQA6KiCNj4OUzL6Hi5mSl9ufdUzPwkw==",
       "cpu": [
         "arm64"
       ],
@@ -760,9 +760,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.15-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.15-1.tgz",
-      "integrity": "sha512-qdOefGZzDq9V9BxRDCx45FtWBy2epmPYtAG4icGzjqJQnl5+D//SjMbfpcYPYopBgAywgH7tEVxvWcvJINA23w==",
+      "version": "1.0.15-2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.15-2.tgz",
+      "integrity": "sha512-tAyd3Fzta6XJoH5MZ3yaw4H8i92C6k0zVkLKzL5zhrm4YEGWyQMcGB7NlLcvcmKewx49smCjbWtO/TIcVWJrrA==",
       "cpu": [
         "x64"
       ],

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -56,7 +56,7 @@
   "author": "GitHub",
   "license": "MIT",
   "dependencies": {
-    "@github/copilot": "^1.0.15-1",
+    "@github/copilot": "^1.0.15-2",
     "vscode-jsonrpc": "^8.2.1",
     "zod": "^4.3.6"
   },

--- a/nodejs/test/e2e/hooks.test.ts
+++ b/nodejs/test/e2e/hooks.test.ts
@@ -48,8 +48,7 @@ describe("Session hooks", async () => {
         await session.disconnect();
     });
 
-    // TODO: Re-enable once runtime postToolUse hooks are fixed (https://github.com/github/copilot-sdk/issues/972)
-    it.skip("should invoke postToolUse hook after model runs a tool", async () => {
+    it("should invoke postToolUse hook after model runs a tool", async () => {
         const postToolUseInputs: PostToolUseHookInput[] = [];
 
         const session = await client.createSession({
@@ -80,8 +79,7 @@ describe("Session hooks", async () => {
         await session.disconnect();
     });
 
-    // TODO: Re-enable once runtime postToolUse hooks are fixed (https://github.com/github/copilot-sdk/issues/972)
-    it.skip("should invoke both preToolUse and postToolUse hooks for a single tool call", async () => {
+    it("should invoke both preToolUse and postToolUse hooks for a single tool call", async () => {
         const preToolUseInputs: PreToolUseHookInput[] = [];
         const postToolUseInputs: PostToolUseHookInput[] = [];
 

--- a/python/e2e/test_hooks.py
+++ b/python/e2e/test_hooks.py
@@ -41,8 +41,6 @@ class TestHooks:
 
         await session.disconnect()
 
-    # TODO: Re-enable once runtime postToolUse hooks are fixed (https://github.com/github/copilot-sdk/issues/972)
-    @pytest.mark.skip(reason="Runtime postToolUse hooks broken")
     async def test_should_invoke_posttooluse_hook_after_model_runs_a_tool(
         self, ctx: E2ETestContext
     ):
@@ -73,8 +71,6 @@ class TestHooks:
 
         await session.disconnect()
 
-    # TODO: Re-enable once runtime postToolUse hooks are fixed (https://github.com/github/copilot-sdk/issues/972)
-    @pytest.mark.skip(reason="Runtime postToolUse hooks broken")
     async def test_should_invoke_both_pretooluse_and_posttooluse_hooks_for_a_single_tool_call(
         self, ctx: E2ETestContext
     ):


### PR DESCRIPTION
The postToolUse hook regression (#972) was fixed in the runtime. Updates @github/copilot to 1.0.15-2 and re-enables all skipped postToolUse hook tests across all 4 languages.

Closes #972