### PR TITLE
Clear the CLI startup timeout when we are told to stop

### DIFF
--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -199,6 +199,7 @@ function getBundledCliPath(): string {
  * ```
  */
 export class CopilotClient {
+    private cliStartTimeout: ReturnType<typeof setTimeout> | null = null;
     private cliProcess: ChildProcess | null = null;
     private connection: MessageConnection | null = null;
     private socket: Socket | null = null;
@@ -540,6 +541,10 @@ export class CopilotClient {
             }
             this.cliProcess = null;
         }
+        if (this.cliStartTimeout) {
+            clearTimeout(this.cliStartTimeout);
+            this.cliStartTimeout = null;
+        }
 
         this.state = "disconnected";
         this.actualPort = null;
@@ -611,6 +616,11 @@ export class CopilotClient {
                 // Ignore errors
             }
             this.cliProcess = null;
+        }
+
+        if (this.cliStartTimeout) {
+            clearTimeout(this.cliStartTimeout);
+            this.cliStartTimeout = null;
         }
 
         this.state = "disconnected";
@@ -1522,7 +1532,7 @@ export class CopilotClient {
             });
 
             // Timeout after 10 seconds
-            setTimeout(() => {
+            this.cliStartTimeout = setTimeout(() => {
                 if (!resolved) {
                     resolved = true;
                     reject(new Error("Timeout waiting for CLI server to start"));


### PR DESCRIPTION
With `index.ts` as
```
import { CopilotClient } from "@github/copilot-sdk";

const client = new CopilotClient();
await client.start();
await client.stop();
```
running `npx tsx index.ts` takes more than 10 seconds. This is problematic for scripts that run quick queries, or even decide to run no queries after starting a client.

This is due to the 10 second timeout that is used to declare the CLI server failed to start.

With this PR, the above takes less than a second.

I can't run the `npm test` tests locally on main; I get as far as
```
 Test Files 3 passed (30)
      Tests 72 passed (72)
   Start at 17:36:49
   Duration 624.16s
```
and then it seemingly makes no further progress. But I get the same on my branch, and I assume that CI has run them.