### PR TITLE
[Node] Set `requestPermission` False If Using Default Permission Handler

### DIFF
--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -869,7 +869,8 @@ export class CopilotClient {
                 })),
                 provider: config.provider,
                 modelCapabilities: config.modelCapabilities,
-                requestPermission: config.onPermissionRequest !== defaultJoinSessionPermissionHandler,
+                requestPermission:
+                    config.onPermissionRequest !== defaultJoinSessionPermissionHandler,
                 requestUserInput: !!config.onUserInputRequest,
                 requestElicitation: !!config.onElicitationRequest,
                 hooks: !!(config.hooks && Object.values(config.hooks).some(Boolean)),

--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -55,6 +55,7 @@ import type {
     TraceContextProvider,
     TypedSessionLifecycleHandler,
 } from "./types.js";
+import { defaultJoinSessionPermissionHandler } from "./types.js";
 
 /**
  * Minimum protocol version this SDK can communicate with.
@@ -868,7 +869,7 @@ export class CopilotClient {
                 })),
                 provider: config.provider,
                 modelCapabilities: config.modelCapabilities,
-                requestPermission: true,
+                requestPermission: config.onPermissionRequest !== defaultJoinSessionPermissionHandler,
                 requestUserInput: !!config.onUserInputRequest,
                 requestElicitation: !!config.onElicitationRequest,
                 hooks: !!(config.hooks && Object.values(config.hooks).some(Boolean)),

--- a/nodejs/src/extension.ts
+++ b/nodejs/src/extension.ts
@@ -4,7 +4,7 @@
 
 import { CopilotClient } from "./client.js";
 import type { CopilotSession } from "./session.js";
-import { defaultJoinSessionPermissionHandler, type PermissionHandler, type PermissionRequestResult, type ResumeSessionConfig } from "./types.js";
+import { defaultJoinSessionPermissionHandler, type PermissionHandler, type ResumeSessionConfig } from "./types.js";
 
 export type JoinSessionConfig = Omit<ResumeSessionConfig, "onPermissionRequest"> & {
     onPermissionRequest?: PermissionHandler;

--- a/nodejs/src/extension.ts
+++ b/nodejs/src/extension.ts
@@ -4,7 +4,11 @@
 
 import { CopilotClient } from "./client.js";
 import type { CopilotSession } from "./session.js";
-import { defaultJoinSessionPermissionHandler, type PermissionHandler, type ResumeSessionConfig } from "./types.js";
+import {
+    defaultJoinSessionPermissionHandler,
+    type PermissionHandler,
+    type ResumeSessionConfig,
+} from "./types.js";
 
 export type JoinSessionConfig = Omit<ResumeSessionConfig, "onPermissionRequest"> & {
     onPermissionRequest?: PermissionHandler;

--- a/nodejs/src/extension.ts
+++ b/nodejs/src/extension.ts
@@ -4,11 +4,7 @@
 
 import { CopilotClient } from "./client.js";
 import type { CopilotSession } from "./session.js";
-import type { PermissionHandler, PermissionRequestResult, ResumeSessionConfig } from "./types.js";
-
-const defaultJoinSessionPermissionHandler: PermissionHandler = (): PermissionRequestResult => ({
-    kind: "no-result",
-});
+import { defaultJoinSessionPermissionHandler, type PermissionHandler, type PermissionRequestResult, type ResumeSessionConfig } from "./types.js";
 
 export type JoinSessionConfig = Omit<ResumeSessionConfig, "onPermissionRequest"> & {
     onPermissionRequest?: PermissionHandler;

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -662,6 +662,10 @@ export type PermissionHandler = (
 
 export const approveAll: PermissionHandler = () => ({ kind: "approved" });
 
+export const defaultJoinSessionPermissionHandler: PermissionHandler = (): PermissionRequestResult => ({
+    kind: "no-result",
+});
+
 // ============================================================================
 // User Input Request Types
 // ============================================================================

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -662,9 +662,10 @@ export type PermissionHandler = (
 
 export const approveAll: PermissionHandler = () => ({ kind: "approved" });
 
-export const defaultJoinSessionPermissionHandler: PermissionHandler = (): PermissionRequestResult => ({
-    kind: "no-result",
-});
+export const defaultJoinSessionPermissionHandler: PermissionHandler =
+    (): PermissionRequestResult => ({
+        kind: "no-result",
+    });
 
 // ============================================================================
 // User Input Request Types

--- a/nodejs/test/client.test.ts
+++ b/nodejs/test/client.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { approveAll, CopilotClient, type ModelInfo } from "../src/index.js";
+import { defaultJoinSessionPermissionHandler } from "../src/types.js";
 
 // This file is for unit tests. Where relevant, prefer to add e2e tests in e2e/*.test.ts instead
 
@@ -93,6 +94,60 @@ describe("CopilotClient", () => {
         expect(spy).toHaveBeenCalledWith(
             "session.resume",
             expect.objectContaining({ clientName: "my-app", sessionId: session.sessionId })
+        );
+        spy.mockRestore();
+    });
+
+    it("does not request permissions on session.resume when using the default joinSession handler", async () => {
+        const client = new CopilotClient();
+        await client.start();
+        onTestFinished(() => client.forceStop());
+
+        const session = await client.createSession({ onPermissionRequest: approveAll });
+        const spy = vi
+            .spyOn((client as any).connection!, "sendRequest")
+            .mockImplementation(async (method: string, params: any) => {
+                if (method === "session.resume") return { sessionId: params.sessionId };
+                throw new Error(`Unexpected method: ${method}`);
+            });
+
+        await client.resumeSession(session.sessionId, {
+            onPermissionRequest: defaultJoinSessionPermissionHandler,
+        });
+
+        expect(spy).toHaveBeenCalledWith(
+            "session.resume",
+            expect.objectContaining({
+                sessionId: session.sessionId,
+                requestPermission: false,
+            })
+        );
+        spy.mockRestore();
+    });
+
+    it("requests permissions on session.resume when using an explicit handler", async () => {
+        const client = new CopilotClient();
+        await client.start();
+        onTestFinished(() => client.forceStop());
+
+        const session = await client.createSession({ onPermissionRequest: approveAll });
+        const spy = vi
+            .spyOn((client as any).connection!, "sendRequest")
+            .mockImplementation(async (method: string, params: any) => {
+                if (method === "session.resume") return { sessionId: params.sessionId };
+                throw new Error(`Unexpected method: ${method}`);
+            });
+
+        await client.resumeSession(session.sessionId, {
+            onPermissionRequest: approveAll,
+        });
+
+        expect(spy).toHaveBeenCalledWith(
+            "session.resume",
+            expect.objectContaining({
+                sessionId: session.sessionId,
+                requestPermission: true,
+            })
         );
         spy.mockRestore();
     });

--- a/nodejs/test/extension.test.ts
+++ b/nodejs/test/extension.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { CopilotClient } from "../src/client.js";
 import { approveAll } from "../src/index.js";
 import { joinSession } from "../src/extension.js";
+import { defaultJoinSessionPermissionHandler } from "../src/types.js";
 
 describe("joinSession", () => {
     const originalSessionId = process.env.SESSION_ID;
@@ -25,6 +26,7 @@ describe("joinSession", () => {
 
         const [, config] = resumeSession.mock.calls[0]!;
         expect(config.onPermissionRequest).toBeDefined();
+        expect(config.onPermissionRequest).toBe(defaultJoinSessionPermissionHandler);
         const result = await Promise.resolve(
             config.onPermissionRequest!({ kind: "write" }, { sessionId: "session-123" })
         );


### PR DESCRIPTION
Needed for extensions security work. We want to detect if an extension is trying to setup a permission handler.