### PR TITLE
Add $ref support to all four language code generators

### DIFF
--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -13,19 +13,10 @@ import type { MessageConnection } from "vscode-jsonrpc/node.js";
  */
 export type SessionMode = "interactive" | "plan" | "autopilot";
 /**
- * The agent mode. Valid values: "interactive", "plan", "autopilot".
- */
-export type SessionMode1 = "interactive" | "plan" | "autopilot";
-/**
  * The user's response: accept (submitted), decline (rejected), or cancel (dismissed)
  */
 export type UIElicitationResponseAction = "accept" | "decline" | "cancel";
 export type UIElicitationFieldValue = string | number | boolean | string[];
-/**
- * The user's response: accept (submitted), decline (rejected), or cancel (dismissed)
- */
-export type UIElicitationResponseAction1 = "accept" | "decline" | "cancel";
-export type UIElicitationFieldValue1 = string | number | boolean | string[];
 export type PermissionDecision =
   | {
       /**
@@ -601,7 +592,7 @@ export interface ModelCapabilitiesOverride {
 }
 
 export interface ModeSetRequest {
-  mode: SessionMode1;
+  mode: SessionMode;
 }
 
 export interface PlanReadResult {
@@ -1102,20 +1093,7 @@ export interface UIHandlePendingElicitationRequest {
    * The unique request ID from the elicitation.requested event
    */
   requestId: string;
-  result: UIElicitationResponse1;
-}
-/**
- * The elicitation response (accept with form values, decline, or cancel)
- */
-export interface UIElicitationResponse1 {
-  action: UIElicitationResponseAction1;
-  content?: UIElicitationResponseContent1;
-}
-/**
- * The form values submitted by the user (present when action is 'accept')
- */
-export interface UIElicitationResponseContent1 {
-  [k: string]: UIElicitationFieldValue1;
+  result: UIElicitationResponse;
 }
 
 export interface PermissionRequestResult {

--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -5,6 +5,93 @@
 
 import type { MessageConnection } from "vscode-jsonrpc/node.js";
 
+/**
+ * The agent mode. Valid values: "interactive", "plan", "autopilot".
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionMode".
+ */
+export type SessionMode = "interactive" | "plan" | "autopilot";
+/**
+ * The agent mode. Valid values: "interactive", "plan", "autopilot".
+ */
+export type SessionMode1 = "interactive" | "plan" | "autopilot";
+/**
+ * The user's response: accept (submitted), decline (rejected), or cancel (dismissed)
+ */
+export type UIElicitationResponseAction = "accept" | "decline" | "cancel";
+export type UIElicitationFieldValue = string | number | boolean | string[];
+/**
+ * The user's response: accept (submitted), decline (rejected), or cancel (dismissed)
+ */
+export type UIElicitationResponseAction1 = "accept" | "decline" | "cancel";
+export type UIElicitationFieldValue1 = string | number | boolean | string[];
+export type PermissionDecision =
+  | {
+      /**
+       * The permission request was approved
+       */
+      kind: "approved";
+    }
+  | {
+      /**
+       * Denied because approval rules explicitly blocked it
+       */
+      kind: "denied-by-rules";
+      /**
+       * Rules that denied the request
+       */
+      rules: unknown[];
+    }
+  | {
+      /**
+       * Denied because no approval rule matched and user confirmation was unavailable
+       */
+      kind: "denied-no-approval-rule-and-could-not-request-from-user";
+    }
+  | {
+      /**
+       * Denied by the user during an interactive prompt
+       */
+      kind: "denied-interactively-by-user";
+      /**
+       * Optional feedback from the user explaining the denial
+       */
+      feedback?: string;
+    }
+  | {
+      /**
+       * Denied by the organization's content exclusion policy
+       */
+      kind: "denied-by-content-exclusion-policy";
+      /**
+       * File path that triggered the exclusion
+       */
+      path: string;
+      /**
+       * Human-readable explanation of why the path was excluded
+       */
+      message: string;
+    }
+  | {
+      /**
+       * Denied by a permission request hook registered by an extension or plugin
+       */
+      kind: "denied-by-permission-request-hook";
+      /**
+       * Optional message from the hook explaining the denial
+       */
+      message?: string;
+      /**
+       * Whether to interrupt the current agent turn
+       */
+      interrupt?: boolean;
+    };
+/**
+ * Log severity level. Determines how the message is displayed in the timeline. Defaults to "info".
+ */
+export type SessionLogLevel = "info" | "warning" | "error";
+
 export interface PingResult {
   /**
    * Echoed message (or default greeting)
@@ -457,13 +544,6 @@ export interface CurrentModel {
   modelId?: string;
 }
 
-export interface SessionModelGetCurrentRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
-}
-
 export interface ModelSwitchToResult {
   /**
    * Currently active model identifier after the switch
@@ -472,10 +552,6 @@ export interface ModelSwitchToResult {
 }
 
 export interface ModelSwitchToRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
   /**
    * Model identifier to switch to
    */
@@ -524,24 +600,8 @@ export interface ModelCapabilitiesOverride {
   };
 }
 
-/**
- * The agent mode. Valid values: "interactive", "plan", "autopilot".
- */
-export type SessionMode = "interactive" | "plan" | "autopilot";
-
-export interface SessionModeGetRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
-}
-
 export interface ModeSetRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
-  mode: SessionMode;
+  mode: SessionMode1;
 }
 
 export interface PlanReadResult {
@@ -559,29 +619,11 @@ export interface PlanReadResult {
   path: string | null;
 }
 
-export interface SessionPlanReadRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
-}
-
 export interface PlanUpdateRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
   /**
    * The new content for the plan file
    */
   content: string;
-}
-
-export interface SessionPlanDeleteRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
 }
 
 export interface WorkspaceListFilesResult {
@@ -589,13 +631,6 @@ export interface WorkspaceListFilesResult {
    * Relative file paths in the workspace files directory
    */
   files: string[];
-}
-
-export interface SessionWorkspaceListFilesRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
 }
 
 export interface WorkspaceReadFileResult {
@@ -607,20 +642,12 @@ export interface WorkspaceReadFileResult {
 
 export interface WorkspaceReadFileRequest {
   /**
-   * Target session identifier
-   */
-  sessionId: string;
-  /**
    * Relative path within the workspace files directory
    */
   path: string;
 }
 
 export interface WorkspaceCreateFileRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
   /**
    * Relative path within the workspace files directory
    */
@@ -641,10 +668,6 @@ export interface FleetStartResult {
 
 /** @experimental */
 export interface FleetStartRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
   /**
    * Optional user prompt to combine with fleet instructions
    */
@@ -673,14 +696,6 @@ export interface AgentList {
 }
 
 /** @experimental */
-export interface SessionAgentListRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
-}
-
-/** @experimental */
 export interface AgentGetCurrentResult {
   /**
    * Currently selected custom agent, or null if using the default agent
@@ -699,14 +714,6 @@ export interface AgentGetCurrentResult {
      */
     description: string;
   } | null;
-}
-
-/** @experimental */
-export interface SessionAgentGetCurrentRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
 }
 
 /** @experimental */
@@ -733,21 +740,9 @@ export interface AgentSelectResult {
 /** @experimental */
 export interface AgentSelectRequest {
   /**
-   * Target session identifier
-   */
-  sessionId: string;
-  /**
    * Name of the custom agent to select
    */
   name: string;
-}
-
-/** @experimental */
-export interface SessionAgentDeselectRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
 }
 
 /** @experimental */
@@ -769,14 +764,6 @@ export interface AgentReloadResult {
      */
     description: string;
   }[];
-}
-
-/** @experimental */
-export interface SessionAgentReloadRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
 }
 
 /** @experimental */
@@ -813,19 +800,7 @@ export interface SkillList {
 }
 
 /** @experimental */
-export interface SessionSkillsListRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
-}
-
-/** @experimental */
 export interface SkillsEnableRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
   /**
    * Name of the skill to enable
    */
@@ -835,21 +810,9 @@ export interface SkillsEnableRequest {
 /** @experimental */
 export interface SkillsDisableRequest {
   /**
-   * Target session identifier
-   */
-  sessionId: string;
-  /**
    * Name of the skill to disable
    */
   name: string;
-}
-
-/** @experimental */
-export interface SessionSkillsReloadRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
 }
 
 /** @experimental */
@@ -878,19 +841,7 @@ export interface McpServerList {
 }
 
 /** @experimental */
-export interface SessionMcpListRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
-}
-
-/** @experimental */
 export interface McpEnableRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
   /**
    * Name of the MCP server to enable
    */
@@ -900,21 +851,9 @@ export interface McpEnableRequest {
 /** @experimental */
 export interface McpDisableRequest {
   /**
-   * Target session identifier
-   */
-  sessionId: string;
-  /**
    * Name of the MCP server to disable
    */
   serverName: string;
-}
-
-/** @experimental */
-export interface SessionMcpReloadRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
 }
 
 /** @experimental */
@@ -940,14 +879,6 @@ export interface PluginList {
      */
     enabled: boolean;
   }[];
-}
-
-/** @experimental */
-export interface SessionPluginsListRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
 }
 
 /** @experimental */
@@ -980,19 +911,7 @@ export interface ExtensionList {
 }
 
 /** @experimental */
-export interface SessionExtensionsListRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
-}
-
-/** @experimental */
 export interface ExtensionsEnableRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
   /**
    * Source-qualified extension ID to enable
    */
@@ -1002,21 +921,9 @@ export interface ExtensionsEnableRequest {
 /** @experimental */
 export interface ExtensionsDisableRequest {
   /**
-   * Target session identifier
-   */
-  sessionId: string;
-  /**
    * Source-qualified extension ID to disable
    */
   id: string;
-}
-
-/** @experimental */
-export interface SessionExtensionsReloadRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
 }
 
 export interface HandleToolCallResult {
@@ -1027,10 +934,6 @@ export interface HandleToolCallResult {
 }
 
 export interface ToolsHandlePendingToolCallRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
   /**
    * Request ID of the pending tool call
    */
@@ -1074,10 +977,6 @@ export interface CommandsHandlePendingCommandResult {
 
 export interface CommandsHandlePendingCommandRequest {
   /**
-   * Target session identifier
-   */
-  sessionId: string;
-  /**
    * Request ID from the command invocation event
    */
   requestId: string;
@@ -1086,14 +985,11 @@ export interface CommandsHandlePendingCommandRequest {
    */
   error?: string;
 }
-
-/**
- * The user's response: accept (submitted), decline (rejected), or cancel (dismissed)
- */
-export type UIElicitationResponseAction = "accept" | "decline" | "cancel";
-export type UIElicitationFieldValue = string | number | boolean | string[];
 /**
  * The elicitation response (accept with form values, decline, or cancel)
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "UIElicitationResponse".
  */
 export interface UIElicitationResponse {
   action: UIElicitationResponseAction;
@@ -1107,10 +1003,6 @@ export interface UIElicitationResponseContent {
 }
 
 export interface UIElicitationRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
   /**
    * Message describing what information is needed from the user
    */
@@ -1207,14 +1099,23 @@ export interface UIElicitationResult {
 
 export interface UIHandlePendingElicitationRequest {
   /**
-   * Target session identifier
-   */
-  sessionId: string;
-  /**
    * The unique request ID from the elicitation.requested event
    */
   requestId: string;
-  result: UIElicitationResponse;
+  result: UIElicitationResponse1;
+}
+/**
+ * The elicitation response (accept with form values, decline, or cancel)
+ */
+export interface UIElicitationResponse1 {
+  action: UIElicitationResponseAction1;
+  content?: UIElicitationResponseContent1;
+}
+/**
+ * The form values submitted by the user (present when action is 'accept')
+ */
+export interface UIElicitationResponseContent1 {
+  [k: string]: UIElicitationFieldValue1;
 }
 
 export interface PermissionRequestResult {
@@ -1224,73 +1125,7 @@ export interface PermissionRequestResult {
   success: boolean;
 }
 
-export type PermissionDecision =
-  | {
-      /**
-       * The permission request was approved
-       */
-      kind: "approved";
-    }
-| {
-      /**
-       * Denied because approval rules explicitly blocked it
-       */
-      kind: "denied-by-rules";
-      /**
-       * Rules that denied the request
-       */
-      rules: unknown[];
-    }
-  | {
-      /**
-       * Denied because no approval rule matched and user confirmation was unavailable
-       */
-      kind: "denied-no-approval-rule-and-could-not-request-from-user";
-    }
-  | {
-      /**
-       * Denied by the user during an interactive prompt
-       */
-      kind: "denied-interactively-by-user";
-      /**
-       * Optional feedback from the user explaining the denial
-       */
-      feedback?: string;
-    }
-  | {
-      /**
-       * Denied by the organization's content exclusion policy
-       */
-      kind: "denied-by-content-exclusion-policy";
-      /**
-       * File path that triggered the exclusion
-       */
-      path: string;
-      /**
-       * Human-readable explanation of why the path was excluded
-       */
-      message: string;
-    }
-  | {
-      /**
-       * Denied by a permission request hook registered by an extension or plugin
-       */
-      kind: "denied-by-permission-request-hook";
-      /**
-       * Optional message from the hook explaining the denial
-       */
-      message?: string;
-      /**
-       * Whether to interrupt the current agent turn
-       */
-      interrupt?: boolean;
-    };
-
 export interface PermissionDecisionRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
   /**
    * Request ID of the pending permission request
    */
@@ -1305,15 +1140,7 @@ export interface LogResult {
   eventId: string;
 }
 
-/**
- * Log severity level. Determines how the message is displayed in the timeline. Defaults to "info".
- */
-export type SessionLogLevel = "info" | "warning" | "error";
 export interface LogRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
   /**
    * Human-readable message
    */
@@ -1338,10 +1165,6 @@ export interface ShellExecResult {
 
 export interface ShellExecRequest {
   /**
-   * Target session identifier
-   */
-  sessionId: string;
-  /**
    * Shell command to execute
    */
   command: string;
@@ -1363,10 +1186,6 @@ export interface ShellKillResult {
 }
 
 export interface ShellKillRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
   /**
    * Process identifier returned by shell.exec
    */
@@ -1423,14 +1242,6 @@ export interface HistoryCompactResult {
 }
 
 /** @experimental */
-export interface SessionHistoryCompactRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
-}
-
-/** @experimental */
 export interface HistoryTruncateResult {
   /**
    * Number of events that were removed
@@ -1440,10 +1251,6 @@ export interface HistoryTruncateResult {
 
 /** @experimental */
 export interface HistoryTruncateRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
   /**
    * Event ID to truncate to. This event and all events after it are removed from the session.
    */
@@ -1542,14 +1349,6 @@ export interface UsageGetMetricsResult {
    * Output tokens from the most recent main-agent API call
    */
   lastCallOutputTokens: number;
-}
-
-/** @experimental */
-export interface SessionUsageGetMetricsRequest {
-  /**
-   * Target session identifier
-   */
-  sessionId: string;
 }
 
 export interface SessionFsReadFileResult {

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -326,7 +326,7 @@ let sessionDefinitions: Record<string, JSONSchema7Definition> = {};
 }
 
 function extractEventVariants(schema: JSONSchema7): EventVariant[] {
-    const sessionEvent = schema.definitions?.SessionEvent as JSONSchema7;
+    const sessionEvent = collectDefinitions(schema as Record<string, unknown>).SessionEvent as JSONSchema7;
     if (!sessionEvent?.anyOf) throw new Error("Schema must have SessionEvent definition with anyOf");
 
     return sessionEvent.anyOf
@@ -611,14 +611,15 @@ function generateDataClass(variant: EventVariant, knownTypes: Map<string, string
 
 function generateSessionEventsCode(schema: JSONSchema7): string {
     generatedEnums.clear();
-    sessionDefinitions = schema.definitions as Record<string, JSONSchema7Definition> || {};
+    sessionDefinitions = collectDefinitions(schema as Record<string, unknown>);
     const variants = extractEventVariants(schema);
     const knownTypes = new Map<string, string>();
     const nestedClasses = new Map<string, string>();
     const enumOutput: string[] = [];
 
     // Extract descriptions for base class properties from the first variant
-    const firstVariant = (schema.definitions?.SessionEvent as JSONSchema7)?.anyOf?.[0];
+    const sessionEventDefinition = sessionDefinitions.SessionEvent;
+    const firstVariant = typeof sessionEventDefinition === "object" ? (sessionEventDefinition as JSONSchema7).anyOf?.[0] : undefined;
     const baseProps = typeof firstVariant === "object" && firstVariant?.properties ? firstVariant.properties : {};
     const baseDesc = (name: string) => {
         const prop = baseProps[name];

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -10,18 +10,21 @@ import { execFile } from "child_process";
 import fs from "fs/promises";
 import path from "path";
 import { promisify } from "util";
-import type { JSONSchema7 } from "json-schema";
+import type { JSONSchema7, JSONSchema7Definition } from "json-schema";
 import {
     cloneSchemaForCodegen,
     getApiSchemaPath,
     getRpcSchemaTypeName,
     getSessionEventsSchemaPath,
+    writeGeneratedFile,
+    collectDefinitions,
+    resolveRef,
+    refTypeName,
+    isRpcMethod,
     isNodeFullyExperimental,
     isObjectSchema,
     isVoidSchema,
-    isRpcMethod,
     REPO_ROOT,
-    writeGeneratedFile,
     type ApiSchema,
     type RpcMethod,
 } from "./utils.js";
@@ -305,6 +308,8 @@ function getOrCreateEnum(parentClassName: string, propName: string, values: stri
     const enumName = explicitName ?? `${parentClassName}${propName}`;
     const existing = generatedEnums.get(enumName);
     if (existing) return existing.enumName;
+/** Schema definitions available during session event generation (for $ref resolution). */
+let sessionDefinitions: Record<string, JSONSchema7Definition> = {};
     generatedEnums.set(enumName, { enumName, values });
 
     const lines: string[] = [];
@@ -505,6 +510,21 @@ function resolveSessionPropertyType(
     nestedClasses: Map<string, string>,
     enumOutput: string[]
 ): string {
+    // Handle $ref by resolving against schema definitions
+    if (propSchema.$ref) {
+        const typeName = refTypeName(propSchema.$ref);
+        const className = typeToClassName(typeName);
+        if (!nestedClasses.has(className)) {
+            const refSchema = resolveRef(propSchema.$ref, sessionDefinitions);
+            if (refSchema) {
+                if (refSchema.enum && Array.isArray(refSchema.enum)) {
+                    return getOrCreateEnum(className, "", refSchema.enum as string[], enumOutput);
+                }
+                nestedClasses.set(className, generateNestedClass(className, refSchema, knownTypes, nestedClasses, enumOutput));
+            }
+        }
+        return isRequired ? className : `${className}?`;
+    }
     if (propSchema.anyOf) {
         const hasNull = propSchema.anyOf.some((s) => typeof s === "object" && (s as JSONSchema7).type === "null");
         const nonNull = propSchema.anyOf.filter((s) => typeof s === "object" && (s as JSONSchema7).type !== "null");
@@ -536,6 +556,18 @@ function resolveSessionPropertyType(
     }
     if (propSchema.type === "array" && propSchema.items) {
         const items = propSchema.items as JSONSchema7;
+        // Handle $ref in array items
+        if (items.$ref) {
+            const typeName = refTypeName(items.$ref);
+            const className = typeToClassName(typeName);
+            if (!nestedClasses.has(className)) {
+                const refSchema = resolveRef(items.$ref, sessionDefinitions);
+                if (refSchema) {
+                    nestedClasses.set(className, generateNestedClass(className, refSchema, knownTypes, nestedClasses, enumOutput));
+                }
+            }
+            return isRequired ? `${className}[]` : `${className}[]?`;
+        }
         // Array of discriminated union (anyOf with shared discriminator)
         if (items.anyOf && Array.isArray(items.anyOf)) {
             const variants = items.anyOf.filter((v): v is JSONSchema7 => typeof v === "object");
@@ -596,6 +628,7 @@ function generateDataClass(variant: EventVariant, knownTypes: Map<string, string
 
 function generateSessionEventsCode(schema: JSONSchema7): string {
     generatedEnums.clear();
+    sessionDefinitions = schema.definitions as Record<string, JSONSchema7Definition> || {};
     const variants = extractEventVariants(schema);
     const knownTypes = new Map<string, string>();
     const nestedClasses = new Map<string, string>();
@@ -708,6 +741,9 @@ let experimentalRpcTypes = new Set<string>();
 let rpcKnownTypes = new Map<string, string>();
 let rpcEnumOutput: string[] = [];
 
+/** Schema definitions available during RPC generation (for $ref resolution). */
+let rpcDefinitions: Record<string, JSONSchema7Definition> = {};
+
 function singularPascal(s: string): string {
     const p = toPascalCase(s);
     if (p.endsWith("ies")) return `${p.slice(0, -3)}y`;
@@ -736,6 +772,16 @@ function stableStringify(value: unknown): string {
 }
 
 function resolveRpcType(schema: JSONSchema7, isRequired: boolean, parentClassName: string, propName: string, classes: string[]): string {
+    // Handle $ref by resolving against schema definitions and generating the referenced class
+    if (schema.$ref) {
+        const typeName = refTypeName(schema.$ref);
+        const refSchema = resolveRef(schema.$ref, rpcDefinitions);
+        if (refSchema && !emittedRpcClasses.has(typeName)) {
+            const cls = emitRpcClass(typeName, refSchema, "public", classes);
+            if (cls) classes.push(cls);
+        }
+        return isRequired ? typeName : `${typeName}?`;
+    }
     // Handle anyOf: [T, null] → T? (nullable typed property)
     if (schema.anyOf) {
         const hasNull = schema.anyOf.some((s) => typeof s === "object" && (s as JSONSchema7).type === "null");
@@ -763,6 +809,16 @@ function resolveRpcType(schema: JSONSchema7, isRequired: boolean, parentClassNam
     }
     if (schema.type === "array" && schema.items) {
         const items = schema.items as JSONSchema7;
+        // Handle $ref in array items
+        if (items.$ref) {
+            const typeName = refTypeName(items.$ref);
+            const refSchema = resolveRef(items.$ref, rpcDefinitions);
+            if (refSchema && !emittedRpcClasses.has(typeName)) {
+                const cls = emitRpcClass(typeName, refSchema, "public", classes);
+                if (cls) classes.push(cls);
+            }
+            return isRequired ? `List<${typeName}>` : `List<${typeName}>?`;
+        }
         if (items.type === "object" && items.properties) {
             const itemClass = (items.title as string) ?? singularPascal(propName);
             classes.push(emitRpcClass(itemClass, items, "public", classes));
@@ -1259,6 +1315,7 @@ function generateRpcCode(schema: ApiSchema): string {
     rpcKnownTypes.clear();
     rpcEnumOutput = [];
     generatedEnums.clear(); // Clear shared enum deduplication map
+    rpcDefinitions = collectDefinitions(schema as Record<string, unknown>);
     const classes: string[] = [];
 
     let serverRpcParts: string[] = [];

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -18,6 +18,7 @@ import {
     getSessionEventsSchemaPath,
     writeGeneratedFile,
     collectDefinitions,
+    postProcessSchema,
     resolveRef,
     refTypeName,
     isRpcMethod,
@@ -512,18 +513,25 @@ function resolveSessionPropertyType(
 ): string {
     // Handle $ref by resolving against schema definitions
     if (propSchema.$ref) {
-        const typeName = refTypeName(propSchema.$ref);
-        const className = typeToClassName(typeName);
-        if (!nestedClasses.has(className)) {
-            const refSchema = resolveRef(propSchema.$ref, sessionDefinitions);
-            if (refSchema) {
-                if (refSchema.enum && Array.isArray(refSchema.enum)) {
-                    return getOrCreateEnum(className, "", refSchema.enum as string[], enumOutput);
-                }
+        const className = typeToClassName(refTypeName(propSchema.$ref));
+        const refSchema = resolveRef(propSchema.$ref, sessionDefinitions);
+        if (!refSchema) {
+            return isRequired ? className : `${className}?`;
+        }
+
+        if (refSchema.enum && Array.isArray(refSchema.enum)) {
+            const enumName = getOrCreateEnum(className, "", refSchema.enum as string[], enumOutput, refSchema.description);
+            return isRequired ? enumName : `${enumName}?`;
+        }
+
+        if (refSchema.type === "object" && refSchema.properties) {
+            if (!nestedClasses.has(className)) {
                 nestedClasses.set(className, generateNestedClass(className, refSchema, knownTypes, nestedClasses, enumOutput));
             }
+            return isRequired ? className : `${className}?`;
         }
-        return isRequired ? className : `${className}?`;
+
+        return resolveSessionPropertyType(refSchema, parentClassName, propName, isRequired, knownTypes, nestedClasses, enumOutput);
     }
     if (propSchema.anyOf) {
         const hasNull = propSchema.anyOf.some((s) => typeof s === "object" && (s as JSONSchema7).type === "null");
@@ -556,40 +564,15 @@ function resolveSessionPropertyType(
     }
     if (propSchema.type === "array" && propSchema.items) {
         const items = propSchema.items as JSONSchema7;
-        // Handle $ref in array items
-        if (items.$ref) {
-            const typeName = refTypeName(items.$ref);
-            const className = typeToClassName(typeName);
-            if (!nestedClasses.has(className)) {
-                const refSchema = resolveRef(items.$ref, sessionDefinitions);
-                if (refSchema) {
-                    nestedClasses.set(className, generateNestedClass(className, refSchema, knownTypes, nestedClasses, enumOutput));
-                }
-            }
-            return isRequired ? `${className}[]` : `${className}[]?`;
-        }
-        // Array of discriminated union (anyOf with shared discriminator)
-        if (items.anyOf && Array.isArray(items.anyOf)) {
-            const variants = items.anyOf.filter((v): v is JSONSchema7 => typeof v === "object");
-            const discriminatorInfo = findDiscriminator(variants);
-            if (discriminatorInfo) {
-                const baseClassName = (items.title as string) ?? `${parentClassName}${propName}Item`;
-                const renamedBase = applyTypeRename(baseClassName);
-                const polymorphicCode = generatePolymorphicClasses(baseClassName, discriminatorInfo.property, variants, knownTypes, nestedClasses, enumOutput, items.description);
-                nestedClasses.set(renamedBase, polymorphicCode);
-                return isRequired ? `${renamedBase}[]` : `${renamedBase}[]?`;
-            }
-        }
-        if (items.type === "object" && items.properties) {
-            const itemClassName = (items.title as string) ?? `${parentClassName}${propName}Item`;
-            nestedClasses.set(itemClassName, generateNestedClass(itemClassName, items, knownTypes, nestedClasses, enumOutput));
-            return isRequired ? `${itemClassName}[]` : `${itemClassName}[]?`;
-        }
-        if (items.enum && Array.isArray(items.enum)) {
-            const enumName = getOrCreateEnum(parentClassName, `${propName}Item`, items.enum as string[], enumOutput, items.description, items.title as string | undefined);
-            return isRequired ? `${enumName}[]` : `${enumName}[]?`;
-        }
-        const itemType = schemaTypeToCSharp(items, true, knownTypes);
+        const itemType = resolveSessionPropertyType(
+            items,
+            parentClassName,
+            `${propName}Item`,
+            true,
+            knownTypes,
+            nestedClasses,
+            enumOutput
+        );
         return isRequired ? `${itemType}[]` : `${itemType}[]?`;
     }
     return schemaTypeToCSharp(propSchema, isRequired, knownTypes);
@@ -725,7 +708,8 @@ export async function generateSessionEvents(schemaPath?: string): Promise<void> 
     console.log("C#: generating session-events...");
     const resolvedPath = schemaPath ?? (await getSessionEventsSchemaPath());
     const schema = cloneSchemaForCodegen(JSON.parse(await fs.readFile(resolvedPath, "utf-8")) as JSONSchema7);
-    const code = generateSessionEventsCode(schema);
+    const processed = postProcessSchema(schema);
+    const code = generateSessionEventsCode(processed);
     const outPath = await writeGeneratedFile("dotnet/src/Generated/SessionEvents.cs", code);
     console.log(`  ✓ ${outPath}`);
     await formatCSharpFile(outPath);
@@ -774,13 +758,24 @@ function stableStringify(value: unknown): string {
 function resolveRpcType(schema: JSONSchema7, isRequired: boolean, parentClassName: string, propName: string, classes: string[]): string {
     // Handle $ref by resolving against schema definitions and generating the referenced class
     if (schema.$ref) {
-        const typeName = refTypeName(schema.$ref);
+        const typeName = typeToClassName(refTypeName(schema.$ref));
         const refSchema = resolveRef(schema.$ref, rpcDefinitions);
-        if (refSchema && !emittedRpcClasses.has(typeName)) {
+        if (!refSchema) {
+            return isRequired ? typeName : `${typeName}?`;
+        }
+
+        if (refSchema.enum && Array.isArray(refSchema.enum)) {
+            const enumName = getOrCreateEnum(typeName, "", refSchema.enum as string[], rpcEnumOutput, refSchema.description);
+            return isRequired ? enumName : `${enumName}?`;
+        }
+
+        if (refSchema.type === "object" && refSchema.properties) {
             const cls = emitRpcClass(typeName, refSchema, "public", classes);
             if (cls) classes.push(cls);
+            return isRequired ? typeName : `${typeName}?`;
         }
-        return isRequired ? typeName : `${typeName}?`;
+
+        return resolveRpcType(refSchema, isRequired, parentClassName, propName, classes);
     }
     // Handle anyOf: [T, null] → T? (nullable typed property)
     if (schema.anyOf) {
@@ -809,43 +804,17 @@ function resolveRpcType(schema: JSONSchema7, isRequired: boolean, parentClassNam
     }
     if (schema.type === "array" && schema.items) {
         const items = schema.items as JSONSchema7;
-        // Handle $ref in array items
-        if (items.$ref) {
-            const typeName = refTypeName(items.$ref);
-            const refSchema = resolveRef(items.$ref, rpcDefinitions);
-            if (refSchema && !emittedRpcClasses.has(typeName)) {
-                const cls = emitRpcClass(typeName, refSchema, "public", classes);
-                if (cls) classes.push(cls);
-            }
-            return isRequired ? `List<${typeName}>` : `List<${typeName}>?`;
-        }
         if (items.type === "object" && items.properties) {
             const itemClass = (items.title as string) ?? singularPascal(propName);
             classes.push(emitRpcClass(itemClass, items, "public", classes));
             return isRequired ? `IList<${itemClass}>` : `IList<${itemClass}>?`;
         }
-        if (items.enum && Array.isArray(items.enum)) {
-            const itemEnum = getOrCreateEnum(
-                parentClassName,
-                `${propName}Item`,
-                items.enum as string[],
-                rpcEnumOutput,
-                items.description,
-                items.title as string | undefined,
-            );
-            return isRequired ? `IList<${itemEnum}>` : `IList<${itemEnum}>?`;
-        }
-        const itemType = schemaTypeToCSharp(items, true, rpcKnownTypes);
+        const itemType = resolveRpcType(items, true, parentClassName, `${propName}Item`, classes);
         return isRequired ? `IList<${itemType}>` : `IList<${itemType}>?`;
     }
     if (schema.type === "object" && schema.additionalProperties && typeof schema.additionalProperties === "object") {
         const vs = schema.additionalProperties as JSONSchema7;
-        if (vs.type === "object" && vs.properties) {
-            const valClass = (vs.title as string) ?? `${parentClassName}${propName}Value`;
-            classes.push(emitRpcClass(valClass, vs, "public", classes));
-            return isRequired ? `IDictionary<string, ${valClass}>` : `IDictionary<string, ${valClass}>?`;
-        }
-        const valueType = schemaTypeToCSharp(vs, true, rpcKnownTypes);
+        const valueType = resolveRpcType(vs, true, parentClassName, `${propName}Value`, classes);
         return isRequired ? `IDictionary<string, ${valueType}>` : `IDictionary<string, ${valueType}>?`;
     }
     return schemaTypeToCSharp(schema, isRequired, rpcKnownTypes);
@@ -1045,15 +1014,9 @@ function emitServerInstanceMethod(
         if (typeof pSchema !== "object") continue;
         const isReq = requiredSet.has(pName);
         const jsonSchema = pSchema as JSONSchema7;
-        let csType: string;
-        // If the property has an enum, resolve to the generated enum type by title
-        if (jsonSchema.enum && Array.isArray(jsonSchema.enum) && requestClassName) {
-            const enumTitle = (jsonSchema.title as string) ?? `${requestClassName}${toPascalCase(pName)}`;
-            const match = generatedEnums.get(enumTitle);
-            csType = match ? (isReq ? match.enumName : `${match.enumName}?`) : schemaTypeToCSharp(jsonSchema, isReq, rpcKnownTypes);
-        } else {
-            csType = schemaTypeToCSharp(jsonSchema, isReq, rpcKnownTypes);
-        }
+        const csType = requestClassName
+            ? resolveRpcType(jsonSchema, isReq, requestClassName, toPascalCase(pName), classes)
+            : schemaTypeToCSharp(jsonSchema, isReq, rpcKnownTypes);
         sigParams.push(`${csType} ${pName}${isReq ? "" : " = null"}`);
         bodyAssignments.push(`${toPascalCase(pName)} = ${pName}`);
     }

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -10,16 +10,18 @@ import { execFile } from "child_process";
 import fs from "fs/promises";
 import path from "path";
 import { promisify } from "util";
-import type { JSONSchema7, JSONSchema7Definition } from "json-schema";
+import type { JSONSchema7 } from "json-schema";
 import {
     cloneSchemaForCodegen,
     getApiSchemaPath,
     getRpcSchemaTypeName,
     getSessionEventsSchemaPath,
     writeGeneratedFile,
-    collectDefinitions,
+    collectDefinitionCollections,
     postProcessSchema,
     resolveRef,
+    resolveObjectSchema,
+    resolveSchema,
     refTypeName,
     isRpcMethod,
     isNodeFullyExperimental,
@@ -27,6 +29,7 @@ import {
     isVoidSchema,
     REPO_ROOT,
     type ApiSchema,
+    type DefinitionCollections,
     type RpcMethod,
 } from "./utils.js";
 
@@ -305,12 +308,13 @@ interface EventVariant {
 
 let generatedEnums = new Map<string, { enumName: string; values: string[] }>();
 
+/** Schema definitions available during session event generation (for $ref resolution). */
+let sessionDefinitions: DefinitionCollections = { definitions: {}, $defs: {} };
+
 function getOrCreateEnum(parentClassName: string, propName: string, values: string[], enumOutput: string[], description?: string, explicitName?: string): string {
     const enumName = explicitName ?? `${parentClassName}${propName}`;
     const existing = generatedEnums.get(enumName);
     if (existing) return existing.enumName;
-/** Schema definitions available during session event generation (for $ref resolution). */
-let sessionDefinitions: Record<string, JSONSchema7Definition> = {};
     generatedEnums.set(enumName, { enumName, values });
 
     const lines: string[] = [];
@@ -326,17 +330,27 @@ let sessionDefinitions: Record<string, JSONSchema7Definition> = {};
 }
 
 function extractEventVariants(schema: JSONSchema7): EventVariant[] {
-    const sessionEvent = collectDefinitions(schema as Record<string, unknown>).SessionEvent as JSONSchema7;
+    const definitionCollections = collectDefinitionCollections(schema as Record<string, unknown>);
+    const sessionEvent =
+        resolveSchema({ $ref: "#/definitions/SessionEvent" }, definitionCollections) ??
+        resolveSchema({ $ref: "#/$defs/SessionEvent" }, definitionCollections);
     if (!sessionEvent?.anyOf) throw new Error("Schema must have SessionEvent definition with anyOf");
 
     return sessionEvent.anyOf
         .map((variant) => {
-            if (typeof variant !== "object" || !variant.properties) throw new Error("Invalid variant");
-            const typeSchema = variant.properties.type as JSONSchema7;
+            const resolvedVariant =
+                resolveObjectSchema(variant as JSONSchema7, definitionCollections) ??
+                resolveSchema(variant as JSONSchema7, definitionCollections) ??
+                (variant as JSONSchema7);
+            if (typeof resolvedVariant !== "object" || !resolvedVariant.properties) throw new Error("Invalid variant");
+            const typeSchema = resolvedVariant.properties.type as JSONSchema7;
             const typeName = typeSchema?.const as string;
             if (!typeName) throw new Error("Variant must have type.const");
             const baseName = typeToClassName(typeName);
-            const dataSchema = variant.properties.data as JSONSchema7;
+            const dataSchema =
+                resolveObjectSchema(resolvedVariant.properties.data as JSONSchema7, definitionCollections) ??
+                resolveSchema(resolvedVariant.properties.data as JSONSchema7, definitionCollections) ??
+                (resolvedVariant.properties.data as JSONSchema7);
             return {
                 typeName,
                 className: `${baseName}Event`,
@@ -513,7 +527,7 @@ function resolveSessionPropertyType(
 ): string {
     // Handle $ref by resolving against schema definitions
     if (propSchema.$ref) {
-        const className = typeToClassName(refTypeName(propSchema.$ref));
+        const className = typeToClassName(refTypeName(propSchema.$ref, sessionDefinitions));
         const refSchema = resolveRef(propSchema.$ref, sessionDefinitions);
         if (!refSchema) {
             return isRequired ? className : `${className}?`;
@@ -611,16 +625,24 @@ function generateDataClass(variant: EventVariant, knownTypes: Map<string, string
 
 function generateSessionEventsCode(schema: JSONSchema7): string {
     generatedEnums.clear();
-    sessionDefinitions = collectDefinitions(schema as Record<string, unknown>);
+    sessionDefinitions = collectDefinitionCollections(schema as Record<string, unknown>);
     const variants = extractEventVariants(schema);
     const knownTypes = new Map<string, string>();
     const nestedClasses = new Map<string, string>();
     const enumOutput: string[] = [];
 
     // Extract descriptions for base class properties from the first variant
-    const sessionEventDefinition = sessionDefinitions.SessionEvent;
-    const firstVariant = typeof sessionEventDefinition === "object" ? (sessionEventDefinition as JSONSchema7).anyOf?.[0] : undefined;
-    const baseProps = typeof firstVariant === "object" && firstVariant?.properties ? firstVariant.properties : {};
+    const sessionEventDefinition =
+        resolveSchema({ $ref: "#/definitions/SessionEvent" }, sessionDefinitions) ??
+        resolveSchema({ $ref: "#/$defs/SessionEvent" }, sessionDefinitions);
+    const firstVariant =
+        typeof sessionEventDefinition === "object" ? (sessionEventDefinition.anyOf?.[0] as JSONSchema7 | undefined) : undefined;
+    const resolvedFirstVariant =
+        resolveObjectSchema(firstVariant, sessionDefinitions) ??
+        resolveSchema(firstVariant, sessionDefinitions) ??
+        firstVariant;
+    const baseProps =
+        typeof resolvedFirstVariant === "object" && resolvedFirstVariant?.properties ? resolvedFirstVariant.properties : {};
     const baseDesc = (name: string) => {
         const prop = baseProps[name];
         return typeof prop === "object" ? (prop as JSONSchema7).description : undefined;
@@ -727,7 +749,7 @@ let rpcKnownTypes = new Map<string, string>();
 let rpcEnumOutput: string[] = [];
 
 /** Schema definitions available during RPC generation (for $ref resolution). */
-let rpcDefinitions: Record<string, JSONSchema7Definition> = {};
+let rpcDefinitions: DefinitionCollections = { definitions: {}, $defs: {} };
 
 function singularPascal(s: string): string {
     const p = toPascalCase(s);
@@ -737,12 +759,25 @@ function singularPascal(s: string): string {
     return p;
 }
 
+function getMethodResultSchema(method: RpcMethod): JSONSchema7 | undefined {
+    return resolveSchema(method.result, rpcDefinitions) ?? method.result ?? undefined;
+}
+
 function resultTypeName(method: RpcMethod): string {
-    return getRpcSchemaTypeName(method.result, `${typeToClassName(method.rpcMethod)}Result`);
+    return getRpcSchemaTypeName(getMethodResultSchema(method), `${typeToClassName(method.rpcMethod)}Result`);
 }
 
 function paramsTypeName(method: RpcMethod): string {
-    return getRpcSchemaTypeName(method.params, `${typeToClassName(method.rpcMethod)}Request`);
+    return getRpcSchemaTypeName(resolveMethodParamsSchema(method), `${typeToClassName(method.rpcMethod)}Request`);
+}
+
+function resolveMethodParamsSchema(method: RpcMethod): JSONSchema7 | undefined {
+    return (
+        resolveObjectSchema(method.params, rpcDefinitions) ??
+        resolveSchema(method.params, rpcDefinitions) ??
+        method.params ??
+        undefined
+    );
 }
 
 function stableStringify(value: unknown): string {
@@ -759,7 +794,7 @@ function stableStringify(value: unknown): string {
 function resolveRpcType(schema: JSONSchema7, isRequired: boolean, parentClassName: string, propName: string, classes: string[]): string {
     // Handle $ref by resolving against schema definitions and generating the referenced class
     if (schema.$ref) {
-        const typeName = typeToClassName(refTypeName(schema.$ref));
+        const typeName = typeToClassName(refTypeName(schema.$ref, rpcDefinitions));
         const refSchema = resolveRef(schema.$ref, rpcDefinitions);
         if (!refSchema) {
             return isRequired ? typeName : `${typeName}?`;
@@ -806,7 +841,7 @@ function resolveRpcType(schema: JSONSchema7, isRequired: boolean, parentClassNam
     if (schema.type === "array" && schema.items) {
         const items = schema.items as JSONSchema7;
         if (items.type === "object" && items.properties) {
-            const itemClass = (items.title as string) ?? singularPascal(propName);
+            const itemClass = (items.title as string) ?? `${parentClassName}${singularPascal(propName)}`;
             classes.push(emitRpcClass(itemClass, items, "public", classes));
             return isRequired ? `IList<${itemClass}>` : `IList<${itemClass}>?`;
         }
@@ -821,8 +856,17 @@ function resolveRpcType(schema: JSONSchema7, isRequired: boolean, parentClassNam
     return schemaTypeToCSharp(schema, isRequired, rpcKnownTypes);
 }
 
-function emitRpcClass(className: string, schema: JSONSchema7, visibility: "public" | "internal", extraClasses: string[]): string {
-    const schemaKey = stableStringify(schema);
+function emitRpcClass(
+    className: string,
+    schema: JSONSchema7,
+    visibility: "public" | "internal",
+    extraClasses: string[]
+): string {
+    const effectiveSchema =
+        resolveObjectSchema(schema, rpcDefinitions) ??
+        resolveSchema(schema, rpcDefinitions) ??
+        schema;
+    const schemaKey = stableStringify(effectiveSchema);
     const existingSchema = emittedRpcClassSchemas.get(className);
     if (existingSchema) {
         if (existingSchema !== schemaKey) {
@@ -835,15 +879,15 @@ function emitRpcClass(className: string, schema: JSONSchema7, visibility: "publi
 
     emittedRpcClassSchemas.set(className, schemaKey);
 
-    const requiredSet = new Set(schema.required || []);
+    const requiredSet = new Set(effectiveSchema.required || []);
     const lines: string[] = [];
-    lines.push(...xmlDocComment(schema.description || `RPC data type for ${className.replace(/(Request|Result|Params)$/, "")} operations.`, ""));
+    lines.push(...xmlDocComment(schema.description || effectiveSchema.description || `RPC data type for ${className.replace(/(Request|Result|Params)$/, "")} operations.`, ""));
     if (experimentalRpcTypes.has(className)) {
         lines.push(`[Experimental(Diagnostics.Experimental)]`);
     }
     lines.push(`${visibility} sealed class ${className}`, `{`);
 
-    const props = Object.entries(schema.properties || {});
+    const props = Object.entries(effectiveSchema.properties || {});
     for (let i = 0; i < props.length; i++) {
         const [propName, propSchema] = props[i];
         if (typeof propSchema !== "object") continue;
@@ -978,19 +1022,21 @@ function emitServerInstanceMethod(
     groupExperimental: boolean
 ): void {
     const methodName = toPascalCase(name);
-    let resultClassName = !isVoidSchema(method.result) ? resultTypeName(method) : "";
-    if (!isVoidSchema(method.result) && method.stability === "experimental") {
+    const resultSchema = getMethodResultSchema(method);
+    let resultClassName = !isVoidSchema(resultSchema) ? resultTypeName(method) : "";
+    if (!isVoidSchema(resultSchema) && method.stability === "experimental") {
         experimentalRpcTypes.add(resultClassName);
     }
-    if (isObjectSchema(method.result)) {
-        const resultClass = emitRpcClass(resultClassName, method.result, "public", classes);
+    if (isObjectSchema(resultSchema)) {
+        const resultClass = emitRpcClass(resultClassName, resultSchema!, "public", classes);
         if (resultClass) classes.push(resultClass);
-    } else if (!isVoidSchema(method.result)) {
-        resultClassName = emitNonObjectResultType(resultClassName, method.result, classes);
+    } else if (!isVoidSchema(resultSchema)) {
+        resultClassName = emitNonObjectResultType(resultClassName, resultSchema!, classes);
     }
 
-    const paramEntries = method.params?.properties ? Object.entries(method.params.properties) : [];
-    const requiredSet = new Set(method.params?.required || []);
+    const effectiveParams = resolveMethodParamsSchema(method);
+    const paramEntries = effectiveParams?.properties ? Object.entries(effectiveParams.properties) : [];
+    const requiredSet = new Set(effectiveParams?.required || []);
 
     let requestClassName: string | null = null;
     if (paramEntries.length > 0) {
@@ -998,7 +1044,7 @@ function emitServerInstanceMethod(
         if (method.stability === "experimental") {
             experimentalRpcTypes.add(requestClassName);
         }
-        const reqClass = emitRpcClass(requestClassName, method.params!, "internal", classes);
+        const reqClass = emitRpcClass(requestClassName, effectiveParams!, "internal", classes);
         if (reqClass) classes.push(reqClass);
     }
 
@@ -1023,18 +1069,18 @@ function emitServerInstanceMethod(
     }
     sigParams.push("CancellationToken cancellationToken = default");
 
-    const taskType = !isVoidSchema(method.result) ? `Task<${resultClassName}>` : "Task";
+    const taskType = !isVoidSchema(resultSchema) ? `Task<${resultClassName}>` : "Task";
     lines.push(`${indent}public async ${taskType} ${methodName}Async(${sigParams.join(", ")})`);
     lines.push(`${indent}{`);
     if (requestClassName && bodyAssignments.length > 0) {
         lines.push(`${indent}    var request = new ${requestClassName} { ${bodyAssignments.join(", ")} };`);
-        if (!isVoidSchema(method.result)) {
+        if (!isVoidSchema(resultSchema)) {
             lines.push(`${indent}    return await CopilotClient.InvokeRpcAsync<${resultClassName}>(_rpc, "${method.rpcMethod}", [request], cancellationToken);`);
         } else {
             lines.push(`${indent}    await CopilotClient.InvokeRpcAsync(_rpc, "${method.rpcMethod}", [request], cancellationToken);`);
         }
     } else {
-        if (!isVoidSchema(method.result)) {
+        if (!isVoidSchema(resultSchema)) {
             lines.push(`${indent}    return await CopilotClient.InvokeRpcAsync<${resultClassName}>(_rpc, "${method.rpcMethod}", [], cancellationToken);`);
         } else {
             lines.push(`${indent}    await CopilotClient.InvokeRpcAsync(_rpc, "${method.rpcMethod}", [], cancellationToken);`);
@@ -1072,19 +1118,21 @@ function emitSessionRpcClasses(node: Record<string, unknown>, classes: string[])
 
 function emitSessionMethod(key: string, method: RpcMethod, lines: string[], classes: string[], indent: string, groupExperimental: boolean): void {
     const methodName = toPascalCase(key);
-    let resultClassName = !isVoidSchema(method.result) ? resultTypeName(method) : "";
-    if (!isVoidSchema(method.result) && method.stability === "experimental") {
+    const resultSchema = getMethodResultSchema(method);
+    let resultClassName = !isVoidSchema(resultSchema) ? resultTypeName(method) : "";
+    if (!isVoidSchema(resultSchema) && method.stability === "experimental") {
         experimentalRpcTypes.add(resultClassName);
     }
-    if (isObjectSchema(method.result)) {
-        const resultClass = emitRpcClass(resultClassName, method.result, "public", classes);
+    if (isObjectSchema(resultSchema)) {
+        const resultClass = emitRpcClass(resultClassName, resultSchema!, "public", classes);
         if (resultClass) classes.push(resultClass);
-    } else if (!isVoidSchema(method.result)) {
-        resultClassName = emitNonObjectResultType(resultClassName, method.result, classes);
+    } else if (!isVoidSchema(resultSchema)) {
+        resultClassName = emitNonObjectResultType(resultClassName, resultSchema!, classes);
     }
 
-    const paramEntries = (method.params?.properties ? Object.entries(method.params.properties) : []).filter(([k]) => k !== "sessionId");
-    const requiredSet = new Set(method.params?.required || []);
+    const effectiveParams = resolveMethodParamsSchema(method);
+    const paramEntries = (effectiveParams?.properties ? Object.entries(effectiveParams.properties) : []).filter(([k]) => k !== "sessionId");
+    const requiredSet = new Set(effectiveParams?.required || []);
 
     // Sort so required params come before optional (C# requires defaults at end)
     paramEntries.sort((a, b) => {
@@ -1097,8 +1145,8 @@ function emitSessionMethod(key: string, method: RpcMethod, lines: string[], clas
     if (method.stability === "experimental") {
         experimentalRpcTypes.add(requestClassName);
     }
-    if (method.params) {
-        const reqClass = emitRpcClass(requestClassName, method.params, "internal", classes);
+    if (effectiveParams?.properties && Object.keys(effectiveParams.properties).length > 0) {
+        const reqClass = emitRpcClass(requestClassName, effectiveParams, "internal", classes);
         if (reqClass) classes.push(reqClass);
     }
 
@@ -1118,10 +1166,10 @@ function emitSessionMethod(key: string, method: RpcMethod, lines: string[], clas
     }
     sigParams.push("CancellationToken cancellationToken = default");
 
-    const taskType = !isVoidSchema(method.result) ? `Task<${resultClassName}>` : "Task";
+    const taskType = !isVoidSchema(resultSchema) ? `Task<${resultClassName}>` : "Task";
     lines.push(`${indent}public async ${taskType} ${methodName}Async(${sigParams.join(", ")})`);
     lines.push(`${indent}{`, `${indent}    var request = new ${requestClassName} { ${bodyAssignments.join(", ")} };`);
-    if (!isVoidSchema(method.result)) {
+    if (!isVoidSchema(resultSchema)) {
         lines.push(`${indent}    return await CopilotClient.InvokeRpcAsync<${resultClassName}>(_rpc, "${method.rpcMethod}", [request], cancellationToken);`, `${indent}}`);
     } else {
         lines.push(`${indent}    await CopilotClient.InvokeRpcAsync(_rpc, "${method.rpcMethod}", [request], cancellationToken);`, `${indent}}`);
@@ -1172,17 +1220,19 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>,
 
     for (const { methods } of groups) {
         for (const method of methods) {
-            if (!isVoidSchema(method.result)) {
-                if (isObjectSchema(method.result)) {
-                    const resultClass = emitRpcClass(resultTypeName(method), method.result, "public", classes);
+            const resultSchema = getMethodResultSchema(method);
+            if (!isVoidSchema(resultSchema)) {
+                if (isObjectSchema(resultSchema)) {
+                    const resultClass = emitRpcClass(resultTypeName(method), resultSchema!, "public", classes);
                     if (resultClass) classes.push(resultClass);
                 } else {
-                    emitNonObjectResultType(resultTypeName(method), method.result, classes);
+                    emitNonObjectResultType(resultTypeName(method), resultSchema!, classes);
                 }
             }
 
-            if (method.params?.properties && Object.keys(method.params.properties).length > 0) {
-                const paramsClass = emitRpcClass(paramsTypeName(method), method.params, "public", classes);
+            const effectiveParams = resolveMethodParamsSchema(method);
+            if (effectiveParams?.properties && Object.keys(effectiveParams.properties).length > 0) {
+                const paramsClass = emitRpcClass(paramsTypeName(method), effectiveParams, "public", classes);
                 if (paramsClass) classes.push(paramsClass);
             }
         }
@@ -1198,8 +1248,10 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>,
         lines.push(`public interface ${interfaceName}`);
         lines.push(`{`);
         for (const method of methods) {
-            const hasParams = method.params?.properties && Object.keys(method.params.properties).length > 0;
-            const taskType = !isVoidSchema(method.result) ? `Task<${resultTypeName(method)}>` : "Task";
+            const effectiveParams = resolveMethodParamsSchema(method);
+            const hasParams = !!effectiveParams?.properties && Object.keys(effectiveParams.properties).length > 0;
+            const resultSchema = getMethodResultSchema(method);
+            const taskType = !isVoidSchema(resultSchema) ? `Task<${resultTypeName(method)}>` : "Task";
             lines.push(`    /// <summary>Handles "${method.rpcMethod}".</summary>`);
             if (method.stability === "experimental" && !groupExperimental) {
                 lines.push(`    [Experimental(Diagnostics.Experimental)]`);
@@ -1240,9 +1292,11 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>,
         for (const method of methods) {
             const handlerProperty = toPascalCase(groupName);
             const handlerMethod = clientHandlerMethodName(method.rpcMethod);
-            const hasParams = method.params?.properties && Object.keys(method.params.properties).length > 0;
+            const effectiveParams = resolveMethodParamsSchema(method);
+            const hasParams = !!effectiveParams?.properties && Object.keys(effectiveParams.properties).length > 0;
+            const resultSchema = getMethodResultSchema(method);
             const paramsClass = paramsTypeName(method);
-            const taskType = !isVoidSchema(method.result) ? `Task<${resultTypeName(method)}>` : "Task";
+            const taskType = !isVoidSchema(resultSchema) ? `Task<${resultTypeName(method)}>` : "Task";
             const registrationVar = `register${typeToClassName(method.rpcMethod)}Method`;
 
             if (hasParams) {
@@ -1250,7 +1304,7 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>,
                 lines.push(`        {`);
                 lines.push(`            var handler = getHandlers(request.SessionId).${handlerProperty};`);
                 lines.push(`            if (handler is null) throw new InvalidOperationException($"No ${groupName} handler registered for session: {request.SessionId}");`);
-                if (!isVoidSchema(method.result)) {
+                if (!isVoidSchema(resultSchema)) {
                     lines.push(`            return await handler.${handlerMethod}(request, cancellationToken);`);
                 } else {
                     lines.push(`            await handler.${handlerMethod}(request, cancellationToken);`);
@@ -1279,7 +1333,7 @@ function generateRpcCode(schema: ApiSchema): string {
     rpcKnownTypes.clear();
     rpcEnumOutput = [];
     generatedEnums.clear(); // Clear shared enum deduplication map
-    rpcDefinitions = collectDefinitions(schema as Record<string, unknown>);
+    rpcDefinitions = collectDefinitionCollections(schema as Record<string, unknown>);
     const classes: string[] = [];
 
     let serverRpcParts: string[] = [];

--- a/scripts/codegen/go.ts
+++ b/scripts/codegen/go.ts
@@ -8,7 +8,7 @@
 
 import { execFile } from "child_process";
 import fs from "fs/promises";
-import type { JSONSchema7, JSONSchema7Definition } from "json-schema";
+import type { JSONSchema7 } from "json-schema";
 import { FetchingJSONSchemaStore, InputData, JSONSchemaInput, quicktype } from "quicktype-core";
 import { promisify } from "util";
 import {
@@ -17,16 +17,20 @@ import {
     getRpcSchemaTypeName,
     getSessionEventsSchemaPath,
     hoistTitledSchemas,
+    hasSchemaPayload,
     isNodeFullyExperimental,
     isVoidSchema,
     isRpcMethod,
     postProcessSchema,
     writeGeneratedFile,
-    collectDefinitions,
+    collectDefinitionCollections,
+    resolveObjectSchema,
+    resolveSchema,
     withSharedDefinitions,
     refTypeName,
     resolveRef,
     type ApiSchema,
+    type DefinitionCollections,
     type RpcMethod,
 } from "./utils.js";
 
@@ -177,12 +181,24 @@ function extractFieldNames(qtCode: string): Map<string, Map<string, string>> {
     return result;
 }
 
-function goResultTypeName(method: RpcMethod): string {
-    return getRpcSchemaTypeName(method.result, toPascalCase(method.rpcMethod) + "Result");
-}
+function extractQuicktypeImports(qtCode: string): { code: string; imports: string[] } {
+    const collectedImports: string[] = [];
+    let code = qtCode.replace(/^import \(\n([\s\S]*?)^\)\n+/m, (_match, block: string) => {
+        for (const line of block.split(/\r?\n/)) {
+            const trimmed = line.trim();
+            if (trimmed.length > 0) {
+                collectedImports.push(trimmed);
+            }
+        }
+        return "";
+    });
 
-function goParamsTypeName(method: RpcMethod): string {
-    return getRpcSchemaTypeName(method.params, toPascalCase(method.rpcMethod) + "Request");
+    code = code.replace(/^import ("[^"]+")\n+/m, (_match, singleImport: string) => {
+        collectedImports.push(singleImport.trim());
+        return "";
+    });
+
+    return { code, imports: collectedImports };
 }
 
 async function formatGoFile(filePath: string): Promise<void> {
@@ -206,6 +222,33 @@ function collectRpcMethods(node: Record<string, unknown>): RpcMethod[] {
     return results;
 }
 
+let rpcDefinitions: DefinitionCollections = { definitions: {}, $defs: {} };
+
+function withRootTitle(schema: JSONSchema7, title: string): JSONSchema7 {
+    return { ...schema, title };
+}
+
+function getMethodResultSchema(method: RpcMethod): JSONSchema7 | undefined {
+    return resolveSchema(method.result, rpcDefinitions) ?? method.result ?? undefined;
+}
+
+function getMethodParamsSchema(method: RpcMethod): JSONSchema7 | undefined {
+    return (
+        resolveObjectSchema(method.params, rpcDefinitions) ??
+        resolveSchema(method.params, rpcDefinitions) ??
+        method.params ??
+        undefined
+    );
+}
+
+function goResultTypeName(method: RpcMethod): string {
+    return getRpcSchemaTypeName(getMethodResultSchema(method), toPascalCase(method.rpcMethod) + "Result");
+}
+
+function goParamsTypeName(method: RpcMethod): string {
+    return getRpcSchemaTypeName(getMethodParamsSchema(method), toPascalCase(method.rpcMethod) + "Request");
+}
+
 // ── Session Events (custom codegen — per-event-type data structs) ───────────
 
 interface GoEventVariant {
@@ -220,20 +263,30 @@ interface GoCodegenCtx {
     enums: string[];
     enumsByName: Map<string, string>; // enumName → enumName (dedup by type name, not values)
     generatedNames: Set<string>;
-    definitions?: Record<string, JSONSchema7Definition>;
+    definitions?: DefinitionCollections;
 }
 
 function extractGoEventVariants(schema: JSONSchema7): GoEventVariant[] {
-    const sessionEvent = schema.definitions?.SessionEvent as JSONSchema7;
+    const definitionCollections = collectDefinitionCollections(schema as Record<string, unknown>);
+    const sessionEvent =
+        resolveSchema({ $ref: "#/definitions/SessionEvent" }, definitionCollections) ??
+        resolveSchema({ $ref: "#/$defs/SessionEvent" }, definitionCollections);
     if (!sessionEvent?.anyOf) throw new Error("Schema must have SessionEvent definition with anyOf");
 
     return (sessionEvent.anyOf as JSONSchema7[])
         .map((variant) => {
-            if (typeof variant !== "object" || !variant.properties) throw new Error("Invalid variant");
-            const typeSchema = variant.properties.type as JSONSchema7;
+            const resolvedVariant =
+                resolveObjectSchema(variant as JSONSchema7, definitionCollections) ??
+                resolveSchema(variant as JSONSchema7, definitionCollections) ??
+                (variant as JSONSchema7);
+            if (typeof resolvedVariant !== "object" || !resolvedVariant.properties) throw new Error("Invalid variant");
+            const typeSchema = resolvedVariant.properties.type as JSONSchema7;
             const typeName = typeSchema?.const as string;
             if (!typeName) throw new Error("Variant must have type.const");
-            const dataSchema = (variant.properties.data as JSONSchema7) || {};
+            const dataSchema =
+                resolveObjectSchema(resolvedVariant.properties.data as JSONSchema7, definitionCollections) ??
+                resolveSchema(resolvedVariant.properties.data as JSONSchema7, definitionCollections) ??
+                ((resolvedVariant.properties.data as JSONSchema7) || {});
             return {
                 typeName,
                 dataClassName: `${toPascalCase(typeName)}Data`,
@@ -327,14 +380,18 @@ function resolveGoPropertyType(
 
     // Handle $ref — resolve the reference and generate the referenced type
     if (propSchema.$ref && typeof propSchema.$ref === "string") {
-        const typeName = toGoFieldName(refTypeName(propSchema.$ref));
+        const typeName = toGoFieldName(refTypeName(propSchema.$ref, ctx.definitions));
         const resolved = resolveRef(propSchema.$ref, ctx.definitions);
         if (resolved) {
             if (resolved.enum) {
-                return getOrCreateGoEnum(typeName, resolved.enum as string[], ctx, resolved.description);
+                const enumType = getOrCreateGoEnum(typeName, resolved.enum as string[], ctx, resolved.description);
+                return isRequired ? enumType : `*${enumType}`;
             }
-            emitGoStruct(typeName, resolved, ctx);
-            return isRequired ? typeName : `*${typeName}`;
+            if (resolved.properties && Object.keys(resolved.properties).length > 0) {
+                emitGoStruct(typeName, resolved, ctx);
+                return isRequired ? typeName : `*${typeName}`;
+            }
+            return resolveGoPropertyType(resolved, parentTypeName, jsonPropName, isRequired, ctx);
         }
         // Fallback: use the type name directly
         return isRequired ? typeName : `*${typeName}`;
@@ -600,7 +657,7 @@ function generateGoSessionEventsCode(schema: JSONSchema7): string {
         enums: [],
         enumsByName: new Map(),
         generatedNames: new Set(),
-        definitions: schema.definitions as Record<string, JSONSchema7Definition> | undefined,
+        definitions: collectDefinitionCollections(schema as Record<string, unknown>),
     };
 
     // Generate per-event data structs
@@ -881,49 +938,69 @@ async function generateRpc(schemaPath?: string): Promise<void> {
 
     // Build a combined schema for quicktype — prefix types to avoid conflicts.
     // Include shared definitions from the API schema for $ref resolution.
-    const sharedDefs = collectDefinitions(schema as Record<string, unknown>);
+    rpcDefinitions = collectDefinitionCollections(schema as Record<string, unknown>);
     const combinedSchema = withSharedDefinitions(
         {
             $schema: "http://json-schema.org/draft-07/schema#",
         },
-        sharedDefs
+        rpcDefinitions
     );
 
     for (const method of allMethods) {
-        if (isVoidSchema(method.result)) {
+        const resultSchema = getMethodResultSchema(method);
+        if (isVoidSchema(resultSchema)) {
             // Emit an empty struct for void results (forward-compatible with adding fields later)
-            combinedSchema.definitions![goResultTypeName(method)] = { type: "object", properties: {}, additionalProperties: false };
-        } else {
-            combinedSchema.definitions![goResultTypeName(method)] = method.result;
+            combinedSchema.definitions![goResultTypeName(method)] = {
+                title: goResultTypeName(method),
+                type: "object",
+                properties: {},
+                additionalProperties: false,
+            };
+        } else if (method.result) {
+            combinedSchema.definitions![goResultTypeName(method)] = withRootTitle(
+                method.result,
+                goResultTypeName(method)
+            );
         }
-        if (method.params?.properties && Object.keys(method.params.properties).length > 0) {
+        const resolvedParams = getMethodParamsSchema(method);
+        if (method.params && hasSchemaPayload(resolvedParams)) {
             // For session methods, filter out sessionId from params type
-            if (method.rpcMethod.startsWith("session.")) {
+            if (method.rpcMethod.startsWith("session.") && resolvedParams?.properties) {
                 const filtered: JSONSchema7 = {
-                    ...method.params,
+                    ...resolvedParams,
                     properties: Object.fromEntries(
-                        Object.entries(method.params.properties).filter(([k]) => k !== "sessionId")
+                        Object.entries(resolvedParams.properties).filter(([k]) => k !== "sessionId")
                     ),
-                    required: method.params.required?.filter((r) => r !== "sessionId"),
+                    required: resolvedParams.required?.filter((r) => r !== "sessionId"),
                 };
-                if (Object.keys(filtered.properties!).length > 0) {
-                    combinedSchema.definitions![goParamsTypeName(method)] = filtered;
+                if (hasSchemaPayload(filtered)) {
+                    combinedSchema.definitions![goParamsTypeName(method)] = withRootTitle(
+                        filtered,
+                        goParamsTypeName(method)
+                    );
                 }
             } else {
-                combinedSchema.definitions![goParamsTypeName(method)] = method.params;
+                combinedSchema.definitions![goParamsTypeName(method)] = withRootTitle(
+                    method.params,
+                    goParamsTypeName(method)
+                );
             }
         }
     }
 
     const { rootDefinitions, sharedDefinitions } = hoistTitledSchemas(combinedSchema.definitions! as Record<string, JSONSchema7>);
     const allDefinitions = { ...rootDefinitions, ...sharedDefinitions };
+    const allDefinitionCollections: DefinitionCollections = {
+        definitions: { ...(combinedSchema.$defs ?? {}), ...allDefinitions },
+        $defs: { ...allDefinitions, ...(combinedSchema.$defs ?? {}) },
+    };
 
     // Generate types via quicktype
     const schemaInput = new JSONSchemaInput(new FetchingJSONSchemaStore());
     for (const [name, def] of Object.entries(rootDefinitions)) {
         const schemaWithDefs = withSharedDefinitions(
             typeof def === "object" ? (def as JSONSchema7) : {},
-            allDefinitions
+            allDefinitionCollections
         );
         await schemaInput.addSource({ name, schema: JSON.stringify(schemaWithDefs) });
     }
@@ -937,21 +1014,10 @@ async function generateRpc(schemaPath?: string): Promise<void> {
         rendererOptions: { package: "copilot", "just-types": "true" },
     });
 
-    // Post-process quicktype output: fix enum constant names
+    // Post-process quicktype output: hoist quicktype's imports into the file-level import block
     let qtCode = qtResult.lines.filter((l) => !l.startsWith("package ")).join("\n");
-    // Extract any imports quicktype emitted (e.g., "time") and hoist them
-    const qtImports: string[] = [];
-    qtCode = qtCode.replace(/^import\s+"([^"]+)"\s*$/gm, (_match, imp) => {
-        qtImports.push(`"${imp}"`);
-        return "";
-    });
-    qtCode = qtCode.replace(/^import\s+\(([^)]*)\)\s*$/gm, (_match, block) => {
-        for (const line of block.split("\n")) {
-            const trimmed = line.trim();
-            if (trimmed) qtImports.push(trimmed);
-        }
-        return "";
-    });
+    const quicktypeImports = extractQuicktypeImports(qtCode);
+    qtCode = quicktypeImports.code;
     qtCode = postProcessEnumConstants(qtCode);
     qtCode = collapsePlaceholderGoStructs(qtCode);
     // Strip trailing whitespace from quicktype output (gofmt requirement)
@@ -959,7 +1025,7 @@ async function generateRpc(schemaPath?: string): Promise<void> {
 
     // Extract actual type names generated by quicktype (may differ from toPascalCase)
     const actualTypeNames = new Map<string, string>();
-    const typeRe = /^type\s+(\w+)\s+/gm;
+    const typeRe = /^type\s+(\w+)\b/gm;
     let sm;
     while ((sm = typeRe.exec(qtCode)) !== null) {
         actualTypeNames.set(sm[1].toLowerCase(), sm[1]);
@@ -998,14 +1064,15 @@ async function generateRpc(schemaPath?: string): Promise<void> {
     lines.push(`package rpc`);
     lines.push(``);
     const imports = [`"context"`, `"encoding/json"`];
+    for (const imp of quicktypeImports.imports) {
+        if (!imports.includes(imp)) {
+            imports.push(imp);
+        }
+    }
     if (schema.clientSession) {
         imports.push(`"errors"`, `"fmt"`);
     }
     imports.push(`"github.com/github/copilot-sdk/go/internal/jsonrpc2"`);
-    // Add any imports hoisted from quicktype output
-    for (const qi of qtImports) {
-        if (!imports.includes(qi)) imports.push(qi);
-    }
 
     lines.push(`import (`);
     for (const imp of imports) {
@@ -1114,10 +1181,11 @@ function emitMethod(lines: string[], receiver: string, name: string, method: Rpc
     const methodName = toPascalCase(name);
     const resultType = resolveType(goResultTypeName(method));
 
-    const paramProps = method.params?.properties || {};
-    const requiredParams = new Set(method.params?.required || []);
+    const effectiveParams = getMethodParamsSchema(method);
+    const paramProps = effectiveParams?.properties || {};
+    const requiredParams = new Set(effectiveParams?.required || []);
     const nonSessionParams = Object.keys(paramProps).filter((k) => k !== "sessionId");
-    const hasParams = isSession ? nonSessionParams.length > 0 : Object.keys(paramProps).length > 0;
+    const hasParams = isSession ? nonSessionParams.length > 0 : hasSchemaPayload(effectiveParams);
     const paramsType = hasParams ? resolveType(goParamsTypeName(method)) : "";
 
     // For wrapper-level methods, access fields through a.common; for service type aliases, use a directly

--- a/scripts/codegen/go.ts
+++ b/scripts/codegen/go.ts
@@ -8,7 +8,7 @@
 
 import { execFile } from "child_process";
 import fs from "fs/promises";
-import type { JSONSchema7 } from "json-schema";
+import type { JSONSchema7, JSONSchema7Definition } from "json-schema";
 import { FetchingJSONSchemaStore, InputData, JSONSchemaInput, quicktype } from "quicktype-core";
 import { promisify } from "util";
 import {
@@ -22,6 +22,9 @@ import {
     isRpcMethod,
     postProcessSchema,
     writeGeneratedFile,
+    collectDefinitions,
+    refTypeName,
+    resolveRef,
     type ApiSchema,
     type RpcMethod,
 } from "./utils.js";
@@ -216,6 +219,7 @@ interface GoCodegenCtx {
     enums: string[];
     enumsByName: Map<string, string>; // enumName → enumName (dedup by type name, not values)
     generatedNames: Set<string>;
+    definitions?: Record<string, JSONSchema7Definition>;
 }
 
 function extractGoEventVariants(schema: JSONSchema7): GoEventVariant[] {
@@ -319,6 +323,21 @@ function resolveGoPropertyType(
     ctx: GoCodegenCtx
 ): string {
     const nestedName = parentTypeName + toGoFieldName(jsonPropName);
+
+    // Handle $ref — resolve the reference and generate the referenced type
+    if (propSchema.$ref && typeof propSchema.$ref === "string") {
+        const typeName = toGoFieldName(refTypeName(propSchema.$ref));
+        const resolved = resolveRef(propSchema.$ref, ctx.definitions);
+        if (resolved) {
+            if (resolved.enum) {
+                return getOrCreateGoEnum(typeName, resolved.enum as string[], ctx, resolved.description);
+            }
+            emitGoStruct(typeName, resolved, ctx);
+            return isRequired ? typeName : `*${typeName}`;
+        }
+        // Fallback: use the type name directly
+        return isRequired ? typeName : `*${typeName}`;
+    }
 
     // Handle anyOf
     if (propSchema.anyOf) {
@@ -580,6 +599,7 @@ function generateGoSessionEventsCode(schema: JSONSchema7): string {
         enums: [],
         enumsByName: new Map(),
         generatedNames: new Set(),
+        definitions: schema.definitions as Record<string, JSONSchema7Definition> | undefined,
     };
 
     // Generate per-event data structs
@@ -858,10 +878,12 @@ async function generateRpc(schemaPath?: string): Promise<void> {
         ...collectRpcMethods(schema.clientSession || {}),
     ];
 
-    // Build a combined schema for quicktype - prefix types to avoid conflicts
+    // Build a combined schema for quicktype — prefix types to avoid conflicts.
+    // Include shared definitions from the API schema for $ref resolution.
+    const sharedDefs = collectDefinitions(schema as Record<string, unknown>);
     const combinedSchema: JSONSchema7 = {
         $schema: "http://json-schema.org/draft-07/schema#",
-        definitions: {},
+        definitions: { ...sharedDefs },
     };
 
     for (const method of allMethods) {
@@ -891,6 +913,7 @@ async function generateRpc(schemaPath?: string): Promise<void> {
     }
 
     const { rootDefinitions, sharedDefinitions } = hoistTitledSchemas(combinedSchema.definitions! as Record<string, JSONSchema7>);
+    const allDefinitions = { ...rootDefinitions, ...sharedDefinitions };
 
     // Generate types via quicktype
     const schemaInput = new JSONSchemaInput(new FetchingJSONSchemaStore());
@@ -899,7 +922,7 @@ async function generateRpc(schemaPath?: string): Promise<void> {
             name,
             schema: JSON.stringify({
                 ...def,
-                definitions: sharedDefinitions,
+                definitions: allDefinitions,
             }),
         });
     }

--- a/scripts/codegen/go.ts
+++ b/scripts/codegen/go.ts
@@ -228,6 +228,24 @@ function withRootTitle(schema: JSONSchema7, title: string): JSONSchema7 {
     return { ...schema, title };
 }
 
+function goRequestFallbackName(method: RpcMethod): string {
+    return toPascalCase(method.rpcMethod) + "Request";
+}
+
+function schemaSourceForNamedDefinition(
+    schema: JSONSchema7 | null | undefined,
+    resolvedSchema: JSONSchema7 | undefined
+): JSONSchema7 {
+    if (schema?.$ref && resolvedSchema) {
+        return resolvedSchema;
+    }
+    return schema ?? resolvedSchema ?? { type: "object" };
+}
+
+function isNamedGoObjectSchema(schema: JSONSchema7 | undefined): schema is JSONSchema7 {
+    return !!schema && schema.type === "object" && (schema.properties !== undefined || schema.additionalProperties === false);
+}
+
 function getMethodResultSchema(method: RpcMethod): JSONSchema7 | undefined {
     return resolveSchema(method.result, rpcDefinitions) ?? method.result ?? undefined;
 }
@@ -246,7 +264,11 @@ function goResultTypeName(method: RpcMethod): string {
 }
 
 function goParamsTypeName(method: RpcMethod): string {
-    return getRpcSchemaTypeName(getMethodParamsSchema(method), toPascalCase(method.rpcMethod) + "Request");
+    const fallback = goRequestFallbackName(method);
+    if (method.rpcMethod.startsWith("session.") && method.params?.$ref) {
+        return fallback;
+    }
+    return getRpcSchemaTypeName(getMethodParamsSchema(method), fallback);
 }
 
 // ── Session Events (custom codegen — per-event-type data structs) ───────────
@@ -387,7 +409,7 @@ function resolveGoPropertyType(
                 const enumType = getOrCreateGoEnum(typeName, resolved.enum as string[], ctx, resolved.description);
                 return isRequired ? enumType : `*${enumType}`;
             }
-            if (resolved.properties && Object.keys(resolved.properties).length > 0) {
+            if (isNamedGoObjectSchema(resolved)) {
                 emitGoStruct(typeName, resolved, ctx);
                 return isRequired ? typeName : `*${typeName}`;
             }
@@ -958,7 +980,7 @@ async function generateRpc(schemaPath?: string): Promise<void> {
             };
         } else if (method.result) {
             combinedSchema.definitions![goResultTypeName(method)] = withRootTitle(
-                method.result,
+                schemaSourceForNamedDefinition(method.result, resultSchema),
                 goResultTypeName(method)
             );
         }
@@ -981,7 +1003,7 @@ async function generateRpc(schemaPath?: string): Promise<void> {
                 }
             } else {
                 combinedSchema.definitions![goParamsTypeName(method)] = withRootTitle(
-                    method.params,
+                    schemaSourceForNamedDefinition(method.params, resolvedParams),
                     goParamsTypeName(method)
                 );
             }

--- a/scripts/codegen/go.ts
+++ b/scripts/codegen/go.ts
@@ -23,6 +23,7 @@ import {
     postProcessSchema,
     writeGeneratedFile,
     collectDefinitions,
+    withSharedDefinitions,
     refTypeName,
     resolveRef,
     type ApiSchema,
@@ -881,10 +882,12 @@ async function generateRpc(schemaPath?: string): Promise<void> {
     // Build a combined schema for quicktype — prefix types to avoid conflicts.
     // Include shared definitions from the API schema for $ref resolution.
     const sharedDefs = collectDefinitions(schema as Record<string, unknown>);
-    const combinedSchema: JSONSchema7 = {
-        $schema: "http://json-schema.org/draft-07/schema#",
-        definitions: { ...sharedDefs },
-    };
+    const combinedSchema = withSharedDefinitions(
+        {
+            $schema: "http://json-schema.org/draft-07/schema#",
+        },
+        sharedDefs
+    );
 
     for (const method of allMethods) {
         if (isVoidSchema(method.result)) {
@@ -918,13 +921,11 @@ async function generateRpc(schemaPath?: string): Promise<void> {
     // Generate types via quicktype
     const schemaInput = new JSONSchemaInput(new FetchingJSONSchemaStore());
     for (const [name, def] of Object.entries(rootDefinitions)) {
-        await schemaInput.addSource({
-            name,
-            schema: JSON.stringify({
-                ...def,
-                definitions: allDefinitions,
-            }),
-        });
+        const schemaWithDefs = withSharedDefinitions(
+            typeof def === "object" ? (def as JSONSchema7) : {},
+            allDefinitions
+        );
+        await schemaInput.addSource({ name, schema: JSON.stringify(schemaWithDefs) });
     }
 
     const inputData = new InputData();

--- a/scripts/codegen/python.ts
+++ b/scripts/codegen/python.ts
@@ -1273,10 +1273,11 @@ async function generateRpc(schemaPath?: string): Promise<void> {
         ...collectRpcMethods(schema.clientSession || {}),
     ];
 
-    // Build a combined schema for quicktype
+    // Build a combined schema for quicktype, including shared definitions from the API schema
+    const sharedDefs = collectDefinitions(schema as Record<string, unknown>);
     const combinedSchema: JSONSchema7 = {
         $schema: "http://json-schema.org/draft-07/schema#",
-        definitions: {},
+        definitions: { ...sharedDefs },
     };
 
     for (const method of allMethods) {
@@ -1302,6 +1303,7 @@ async function generateRpc(schemaPath?: string): Promise<void> {
     }
 
     const { rootDefinitions, sharedDefinitions } = hoistTitledSchemas(combinedSchema.definitions! as Record<string, JSONSchema7>);
+    const allDefinitions = { ...rootDefinitions, ...sharedDefinitions };
 
     // Generate types via quicktype
     const schemaInput = new JSONSchemaInput(new FetchingJSONSchemaStore());
@@ -1310,7 +1312,7 @@ async function generateRpc(schemaPath?: string): Promise<void> {
             name,
             schema: JSON.stringify({
                 ...def,
-                definitions: sharedDefinitions,
+                definitions: allDefinitions,
             }),
         });
     }

--- a/scripts/codegen/python.ts
+++ b/scripts/codegen/python.ts
@@ -22,9 +22,14 @@ import {
     isNodeFullyExperimental,
     postProcessSchema,
     writeGeneratedFile,
-    collectDefinitions,
+    collectDefinitionCollections,
+    hasSchemaPayload,
+    refTypeName,
+    resolveObjectSchema,
+    resolveSchema,
     withSharedDefinitions,
     type ApiSchema,
+    type DefinitionCollections,
     type RpcMethod,
 } from "./utils.js";
 
@@ -212,12 +217,31 @@ function collectRpcMethods(node: Record<string, unknown>): RpcMethod[] {
     return results;
 }
 
+let rpcDefinitions: DefinitionCollections = { definitions: {}, $defs: {} };
+
+function withRootTitle(schema: JSONSchema7, title: string): JSONSchema7 {
+    return { ...schema, title };
+}
+
+function getMethodResultSchema(method: RpcMethod): JSONSchema7 | undefined {
+    return resolveSchema(method.result, rpcDefinitions) ?? method.result ?? undefined;
+}
+
+function getMethodParamsSchema(method: RpcMethod): JSONSchema7 | undefined {
+    return (
+        resolveObjectSchema(method.params, rpcDefinitions) ??
+        resolveSchema(method.params, rpcDefinitions) ??
+        method.params ??
+        undefined
+    );
+}
+
 function pythonResultTypeName(method: RpcMethod): string {
-    return getRpcSchemaTypeName(method.result, toPascalCase(method.rpcMethod) + "Result");
+    return getRpcSchemaTypeName(getMethodResultSchema(method), toPascalCase(method.rpcMethod) + "Result");
 }
 
 function pythonParamsTypeName(method: RpcMethod): string {
-    return getRpcSchemaTypeName(method.params, toPascalCase(method.rpcMethod) + "Request");
+    return getRpcSchemaTypeName(getMethodParamsSchema(method), toPascalCase(method.rpcMethod) + "Request");
 }
 
 // ── Session Events ──────────────────────────────────────────────────────────
@@ -243,6 +267,7 @@ interface PyCodegenCtx {
     generatedNames: Set<string>;
     usesTimedelta: boolean;
     usesIntegerTimedelta: boolean;
+    definitions: DefinitionCollections;
 }
 
 function toEnumMemberName(value: string): string {
@@ -374,24 +399,34 @@ function toPythonLiteral(value: unknown): string | undefined {
 }
 
 function extractPyEventVariants(schema: JSONSchema7): PyEventVariant[] {
-    const sessionEvent = schema.definitions?.SessionEvent as JSONSchema7;
+    const definitionCollections = collectDefinitionCollections(schema as Record<string, unknown>);
+    const sessionEvent =
+        resolveSchema({ $ref: "#/definitions/SessionEvent" }, definitionCollections) ??
+        resolveSchema({ $ref: "#/$defs/SessionEvent" }, definitionCollections);
     if (!sessionEvent?.anyOf) {
         throw new Error("Schema must have SessionEvent definition with anyOf");
     }
 
     return (sessionEvent.anyOf as JSONSchema7[])
         .map((variant) => {
-            if (typeof variant !== "object" || !variant.properties) {
+            const resolvedVariant =
+                resolveObjectSchema(variant as JSONSchema7, definitionCollections) ??
+                resolveSchema(variant as JSONSchema7, definitionCollections) ??
+                (variant as JSONSchema7);
+            if (typeof resolvedVariant !== "object" || !resolvedVariant.properties) {
                 throw new Error("Invalid event variant");
             }
 
-            const typeSchema = variant.properties.type as JSONSchema7;
+            const typeSchema = resolvedVariant.properties.type as JSONSchema7;
             const typeName = typeSchema?.const as string;
             if (!typeName) {
                 throw new Error("Event variant must define type.const");
             }
 
-            const dataSchema = (variant.properties.data as JSONSchema7) || {};
+            const dataSchema =
+                resolveObjectSchema(resolvedVariant.properties.data as JSONSchema7, definitionCollections) ??
+                resolveSchema(resolvedVariant.properties.data as JSONSchema7, definitionCollections) ??
+                ((resolvedVariant.properties.data as JSONSchema7) || {});
             return {
                 typeName,
                 dataClassName: `${toPascalCase(typeName)}Data`,
@@ -481,6 +516,35 @@ function resolvePyPropertyType(
 ): PyResolvedType {
     const nestedName = parentTypeName + toPascalCase(jsonPropName);
 
+    if (propSchema.$ref && typeof propSchema.$ref === "string") {
+        const typeName = toPascalCase(refTypeName(propSchema.$ref, ctx.definitions));
+        const resolved = resolveSchema(propSchema, ctx.definitions);
+        if (resolved && resolved !== propSchema) {
+            if (resolved.enum && Array.isArray(resolved.enum) && resolved.enum.every((value) => typeof value === "string")) {
+                const enumType = getOrCreatePyEnum(typeName, resolved.enum as string[], ctx, resolved.description);
+                const enumResolved: PyResolvedType = {
+                    annotation: enumType,
+                    fromExpr: (expr) => `parse_enum(${enumType}, ${expr})`,
+                    toExpr: (expr) => `to_enum(${enumType}, ${expr})`,
+                };
+                return isRequired ? enumResolved : pyOptionalResolvedType(enumResolved);
+            }
+
+            const resolvedObject = resolveObjectSchema(propSchema, ctx.definitions);
+            if (resolvedObject?.properties && Object.keys(resolvedObject.properties).length > 0) {
+                emitPyClass(typeName, resolvedObject, ctx, resolvedObject.description);
+                const objectResolved: PyResolvedType = {
+                    annotation: typeName,
+                    fromExpr: (expr) => `${typeName}.from_dict(${expr})`,
+                    toExpr: (expr) => `to_class(${typeName}, ${expr})`,
+                };
+                return isRequired ? objectResolved : pyOptionalResolvedType(objectResolved);
+            }
+
+            return resolvePyPropertyType(resolved, parentTypeName, jsonPropName, isRequired, ctx);
+        }
+    }
+
     if (propSchema.allOf && propSchema.allOf.length === 1 && typeof propSchema.allOf[0] === "object") {
         return resolvePyPropertyType(
             propSchema.allOf[0] as JSONSchema7,
@@ -492,7 +556,14 @@ function resolvePyPropertyType(
     }
 
     if (propSchema.anyOf) {
-        const variants = (propSchema.anyOf as JSONSchema7[]).filter((item) => typeof item === "object");
+        const variants = (propSchema.anyOf as JSONSchema7[])
+            .filter((item) => typeof item === "object")
+            .map(
+                (item) =>
+                    resolveObjectSchema(item as JSONSchema7, ctx.definitions) ??
+                    resolveSchema(item as JSONSchema7, ctx.definitions) ??
+                    (item as JSONSchema7)
+            );
         const nonNull = variants.filter((item) => item.type !== "null");
         const hasNull = variants.length !== nonNull.length;
 
@@ -636,6 +707,12 @@ function resolvePyPropertyType(
         if (items.anyOf) {
             const itemVariants = (items.anyOf as JSONSchema7[])
                 .filter((variant) => typeof variant === "object")
+                .map(
+                    (variant) =>
+                        resolveObjectSchema(variant as JSONSchema7, ctx.definitions) ??
+                        resolveSchema(variant as JSONSchema7, ctx.definitions) ??
+                        (variant as JSONSchema7)
+                )
                 .filter((variant) => variant.type !== "null");
             const discriminator = findPyDiscriminator(itemVariants);
             if (discriminator) {
@@ -943,6 +1020,7 @@ export function generatePythonSessionEventsCode(schema: JSONSchema7): string {
         generatedNames: new Set(),
         usesTimedelta: false,
         usesIntegerTimedelta: false,
+        definitions: collectDefinitionCollections(schema as Record<string, unknown>),
     };
 
     for (const variant of variants) {
@@ -1276,45 +1354,60 @@ async function generateRpc(schemaPath?: string): Promise<void> {
     ];
 
     // Build a combined schema for quicktype, including shared definitions from the API schema
-    const sharedDefs = collectDefinitions(schema as Record<string, unknown>);
+    rpcDefinitions = collectDefinitionCollections(schema as Record<string, unknown>);
     const combinedSchema = withSharedDefinitions(
         {
             $schema: "http://json-schema.org/draft-07/schema#",
         },
-        sharedDefs
+        rpcDefinitions
     );
 
     for (const method of allMethods) {
-        if (!isVoidSchema(method.result)) {
-            combinedSchema.definitions![pythonResultTypeName(method)] = method.result;
+        const resultSchema = getMethodResultSchema(method);
+        if (!isVoidSchema(resultSchema)) {
+            combinedSchema.definitions![pythonResultTypeName(method)] = withRootTitle(
+                method.result ?? resultSchema ?? { type: "object" },
+                pythonResultTypeName(method)
+            );
         }
-        if (method.params?.properties && Object.keys(method.params.properties).length > 0) {
-            if (method.rpcMethod.startsWith("session.")) {
+        const resolvedParams = getMethodParamsSchema(method);
+        if (method.params && hasSchemaPayload(resolvedParams)) {
+            if (method.rpcMethod.startsWith("session.") && resolvedParams?.properties) {
                 const filtered: JSONSchema7 = {
-                    ...method.params,
+                    ...resolvedParams,
                     properties: Object.fromEntries(
-                        Object.entries(method.params.properties).filter(([k]) => k !== "sessionId")
+                        Object.entries(resolvedParams.properties).filter(([k]) => k !== "sessionId")
                     ),
-                    required: method.params.required?.filter((r) => r !== "sessionId"),
+                    required: resolvedParams.required?.filter((r) => r !== "sessionId"),
                 };
-                if (Object.keys(filtered.properties!).length > 0) {
-                    combinedSchema.definitions![pythonParamsTypeName(method)] = filtered;
+                if (hasSchemaPayload(filtered)) {
+                    combinedSchema.definitions![pythonParamsTypeName(method)] = withRootTitle(
+                        filtered,
+                        pythonParamsTypeName(method)
+                    );
                 }
             } else {
-                combinedSchema.definitions![pythonParamsTypeName(method)] = method.params;
+                combinedSchema.definitions![pythonParamsTypeName(method)] = withRootTitle(
+                    method.params,
+                    pythonParamsTypeName(method)
+                );
             }
         }
     }
 
     const { rootDefinitions, sharedDefinitions } = hoistTitledSchemas(combinedSchema.definitions! as Record<string, JSONSchema7>);
     const allDefinitions = { ...rootDefinitions, ...sharedDefinitions };
+    const allDefinitionCollections: DefinitionCollections = {
+        definitions: { ...(combinedSchema.$defs ?? {}), ...allDefinitions },
+        $defs: { ...allDefinitions, ...(combinedSchema.$defs ?? {}) },
+    };
 
     // Generate types via quicktype
     const schemaInput = new JSONSchemaInput(new FetchingJSONSchemaStore());
     for (const [name, def] of Object.entries(rootDefinitions)) {
         const schemaWithDefs = withSharedDefinitions(
             typeof def === "object" ? (def as JSONSchema7) : {},
-            allDefinitions
+            allDefinitionCollections
         );
         await schemaInput.addSource({ name, schema: JSON.stringify(schemaWithDefs) });
     }
@@ -1506,13 +1599,15 @@ function emitRpcWrapper(lines: string[], node: Record<string, unknown>, isSessio
 
 function emitMethod(lines: string[], name: string, method: RpcMethod, isSession: boolean, resolveType: (name: string) => string, groupExperimental = false): void {
     const methodName = toSnakeCase(name);
-    const hasResult = !isVoidSchema(method.result);
+    const resultSchema = getMethodResultSchema(method);
+    const hasResult = !isVoidSchema(resultSchema);
     const resultType = hasResult ? resolveType(pythonResultTypeName(method)) : "None";
-    const resultIsObject = isObjectSchema(method.result);
+    const resultIsObject = isObjectSchema(resultSchema);
 
-    const paramProps = method.params?.properties || {};
+    const effectiveParams = getMethodParamsSchema(method);
+    const paramProps = effectiveParams?.properties || {};
     const nonSessionParams = Object.keys(paramProps).filter((k) => k !== "sessionId");
-    const hasParams = isSession ? nonSessionParams.length > 0 : Object.keys(paramProps).length > 0;
+    const hasParams = isSession ? nonSessionParams.length > 0 : hasSchemaPayload(effectiveParams);
     const paramsType = resolveType(pythonParamsTypeName(method));
 
     // Build signature with typed params + optional timeout
@@ -1629,7 +1724,8 @@ function emitClientSessionHandlerMethod(
     groupExperimental = false
 ): void {
     const paramsType = resolveType(pythonParamsTypeName(method));
-    const resultType = !isVoidSchema(method.result) ? resolveType(pythonResultTypeName(method)) : "None";
+    const resultSchema = getMethodResultSchema(method);
+    const resultType = !isVoidSchema(resultSchema) ? resolveType(pythonResultTypeName(method)) : "None";
     lines.push(`    async def ${toSnakeCase(name)}(self, params: ${paramsType}) -> ${resultType}:`);
     if (method.stability === "experimental" && !groupExperimental) {
         lines.push(`        """.. warning:: This API is experimental and may change or be removed in future versions."""`);
@@ -1646,7 +1742,8 @@ function emitClientSessionRegistrationMethod(
 ): void {
     const handlerVariableName = `handle_${toSnakeCase(groupName)}_${toSnakeCase(methodName)}`;
     const paramsType = resolveType(pythonParamsTypeName(method));
-    const resultType = !isVoidSchema(method.result) ? resolveType(pythonResultTypeName(method)) : null;
+    const resultSchema = getMethodResultSchema(method);
+    const resultType = !isVoidSchema(resultSchema) ? resolveType(pythonResultTypeName(method)) : null;
     const handlerField = toSnakeCase(groupName);
     const handlerMethod = toSnakeCase(methodName);
 
@@ -1658,7 +1755,7 @@ function emitClientSessionRegistrationMethod(
     );
     if (resultType) {
         lines.push(`        result = await handler.${handlerMethod}(request)`);
-        if (isObjectSchema(method.result)) {
+        if (isObjectSchema(resultSchema)) {
             lines.push(`        return result.to_dict()`);
         } else {
             lines.push(`        return result.value if hasattr(result, 'value') else result`);

--- a/scripts/codegen/python.ts
+++ b/scripts/codegen/python.ts
@@ -223,6 +223,24 @@ function withRootTitle(schema: JSONSchema7, title: string): JSONSchema7 {
     return { ...schema, title };
 }
 
+function pythonRequestFallbackName(method: RpcMethod): string {
+    return toPascalCase(method.rpcMethod) + "Request";
+}
+
+function schemaSourceForNamedDefinition(
+    schema: JSONSchema7 | null | undefined,
+    resolvedSchema: JSONSchema7 | undefined
+): JSONSchema7 {
+    if (schema?.$ref && resolvedSchema) {
+        return resolvedSchema;
+    }
+    return schema ?? resolvedSchema ?? { type: "object" };
+}
+
+function isNamedPyObjectSchema(schema: JSONSchema7 | undefined): schema is JSONSchema7 {
+    return !!schema && schema.type === "object" && (schema.properties !== undefined || schema.additionalProperties === false);
+}
+
 function getMethodResultSchema(method: RpcMethod): JSONSchema7 | undefined {
     return resolveSchema(method.result, rpcDefinitions) ?? method.result ?? undefined;
 }
@@ -241,7 +259,11 @@ function pythonResultTypeName(method: RpcMethod): string {
 }
 
 function pythonParamsTypeName(method: RpcMethod): string {
-    return getRpcSchemaTypeName(getMethodParamsSchema(method), toPascalCase(method.rpcMethod) + "Request");
+    const fallback = pythonRequestFallbackName(method);
+    if (method.rpcMethod.startsWith("session.") && method.params?.$ref) {
+        return fallback;
+    }
+    return getRpcSchemaTypeName(getMethodParamsSchema(method), fallback);
 }
 
 // ── Session Events ──────────────────────────────────────────────────────────
@@ -531,7 +553,7 @@ function resolvePyPropertyType(
             }
 
             const resolvedObject = resolveObjectSchema(propSchema, ctx.definitions);
-            if (resolvedObject?.properties && Object.keys(resolvedObject.properties).length > 0) {
+            if (isNamedPyObjectSchema(resolvedObject)) {
                 emitPyClass(typeName, resolvedObject, ctx, resolvedObject.description);
                 const objectResolved: PyResolvedType = {
                     annotation: typeName,
@@ -1366,7 +1388,7 @@ async function generateRpc(schemaPath?: string): Promise<void> {
         const resultSchema = getMethodResultSchema(method);
         if (!isVoidSchema(resultSchema)) {
             combinedSchema.definitions![pythonResultTypeName(method)] = withRootTitle(
-                method.result ?? resultSchema ?? { type: "object" },
+                schemaSourceForNamedDefinition(method.result, resultSchema),
                 pythonResultTypeName(method)
             );
         }
@@ -1388,7 +1410,7 @@ async function generateRpc(schemaPath?: string): Promise<void> {
                 }
             } else {
                 combinedSchema.definitions![pythonParamsTypeName(method)] = withRootTitle(
-                    method.params,
+                    schemaSourceForNamedDefinition(method.params, resolvedParams),
                     pythonParamsTypeName(method)
                 );
             }

--- a/scripts/codegen/python.ts
+++ b/scripts/codegen/python.ts
@@ -22,6 +22,8 @@ import {
     isNodeFullyExperimental,
     postProcessSchema,
     writeGeneratedFile,
+    collectDefinitions,
+    withSharedDefinitions,
     type ApiSchema,
     type RpcMethod,
 } from "./utils.js";
@@ -1275,10 +1277,12 @@ async function generateRpc(schemaPath?: string): Promise<void> {
 
     // Build a combined schema for quicktype, including shared definitions from the API schema
     const sharedDefs = collectDefinitions(schema as Record<string, unknown>);
-    const combinedSchema: JSONSchema7 = {
-        $schema: "http://json-schema.org/draft-07/schema#",
-        definitions: { ...sharedDefs },
-    };
+    const combinedSchema = withSharedDefinitions(
+        {
+            $schema: "http://json-schema.org/draft-07/schema#",
+        },
+        sharedDefs
+    );
 
     for (const method of allMethods) {
         if (!isVoidSchema(method.result)) {
@@ -1308,13 +1312,11 @@ async function generateRpc(schemaPath?: string): Promise<void> {
     // Generate types via quicktype
     const schemaInput = new JSONSchemaInput(new FetchingJSONSchemaStore());
     for (const [name, def] of Object.entries(rootDefinitions)) {
-        await schemaInput.addSource({
-            name,
-            schema: JSON.stringify({
-                ...def,
-                definitions: allDefinitions,
-            }),
-        });
+        const schemaWithDefs = withSharedDefinitions(
+            typeof def === "object" ? (def as JSONSchema7) : {},
+            allDefinitions
+        );
+        await schemaInput.addSource({ name, schema: JSON.stringify(schemaWithDefs) });
     }
 
     const inputData = new InputData();

--- a/scripts/codegen/typescript.ts
+++ b/scripts/codegen/typescript.ts
@@ -15,13 +15,17 @@ import {
     getSessionEventsSchemaPath,
     postProcessSchema,
     writeGeneratedFile,
-    collectDefinitions,
+    collectDefinitionCollections,
+    hasSchemaPayload,
+    resolveObjectSchema,
+    resolveSchema,
     withSharedDefinitions,
     isRpcMethod,
     isNodeFullyExperimental,
     isVoidSchema,
     stripNonAnnotationTitles,
     type ApiSchema,
+    type DefinitionCollections,
     type RpcMethod,
 } from "./utils.js";
 
@@ -127,6 +131,52 @@ function collectRpcMethods(node: Record<string, unknown>): RpcMethod[] {
     return results;
 }
 
+function normalizeSchemaForTypeScript(schema: JSONSchema7): JSONSchema7 {
+    const root = structuredClone(schema) as JSONSchema7 & {
+        definitions?: Record<string, unknown>;
+        $defs?: Record<string, unknown>;
+    };
+    const definitions = { ...(root.definitions ?? {}) };
+    const draftDefinitionAliases = new Map<string, string>();
+
+    for (const [key, value] of Object.entries(root.$defs ?? {})) {
+        let alias = key;
+        if (alias in definitions) {
+            alias = `$defs_${key}`;
+            while (alias in definitions) {
+                alias = `$defs_${alias}`;
+            }
+        }
+        draftDefinitionAliases.set(key, alias);
+        definitions[alias] = value;
+    }
+
+    root.definitions = definitions;
+    delete root.$defs;
+
+    const rewrite = (value: unknown): unknown => {
+        if (Array.isArray(value)) {
+            return value.map(rewrite);
+        }
+        if (!value || typeof value !== "object") {
+            return value;
+        }
+
+        const rewritten = Object.fromEntries(
+            Object.entries(value as Record<string, unknown>).map(([key, child]) => [key, rewrite(child)])
+        ) as Record<string, unknown>;
+
+        if (typeof rewritten.$ref === "string" && rewritten.$ref.startsWith("#/$defs/")) {
+            const definitionName = rewritten.$ref.slice("#/$defs/".length);
+            rewritten.$ref = `#/definitions/${draftDefinitionAliases.get(definitionName) ?? definitionName}`;
+        }
+
+        return rewritten;
+    };
+
+    return rewrite(root) as JSONSchema7;
+}
+
 // ── Session Events ──────────────────────────────────────────────────────────
 
 async function generateSessionEvents(schemaPath?: string): Promise<void> {
@@ -135,8 +185,14 @@ async function generateSessionEvents(schemaPath?: string): Promise<void> {
     const resolvedPath = schemaPath ?? (await getSessionEventsSchemaPath());
     const schema = JSON.parse(await fs.readFile(resolvedPath, "utf-8")) as JSONSchema7;
     const processed = postProcessSchema(stripNonAnnotationTitles(schema));
+    const definitionCollections = collectDefinitionCollections(processed as Record<string, unknown>);
+    const sessionEvent =
+        resolveSchema({ $ref: "#/definitions/SessionEvent" }, definitionCollections) ??
+        resolveSchema({ $ref: "#/$defs/SessionEvent" }, definitionCollections) ??
+        processed;
+    const schemaForCompile = withSharedDefinitions(sessionEvent, definitionCollections);
 
-    const ts = await compile(processed, "SessionEvent", {
+    const ts = await compile(normalizeSchemaForTypeScript(schemaForCompile), "SessionEvent", {
         bannerComment: `/**
  * AUTO-GENERATED FILE - DO NOT EDIT
  * Generated from: session-events.schema.json
@@ -151,12 +207,37 @@ async function generateSessionEvents(schemaPath?: string): Promise<void> {
 
 // ── RPC Types ───────────────────────────────────────────────────────────────
 
+let rpcDefinitions: DefinitionCollections = { definitions: {}, $defs: {} };
+
+function withRootTitle(schema: JSONSchema7, title: string): JSONSchema7 {
+    return { ...schema, title };
+}
+
+function getMethodResultSchema(method: RpcMethod): JSONSchema7 | undefined {
+    return resolveSchema(method.result, rpcDefinitions) ?? method.result ?? undefined;
+}
+
+function getMethodParamsSchema(method: RpcMethod): JSONSchema7 | undefined {
+    return (
+        resolveObjectSchema(method.params, rpcDefinitions) ??
+        resolveSchema(method.params, rpcDefinitions) ??
+        method.params ??
+        undefined
+    );
+}
+
 function resultTypeName(method: RpcMethod): string {
-    return getRpcSchemaTypeName(method.result, method.rpcMethod.split(".").map(toPascalCase).join("") + "Result");
+    return getRpcSchemaTypeName(
+        getMethodResultSchema(method),
+        method.rpcMethod.split(".").map(toPascalCase).join("") + "Result"
+    );
 }
 
 function paramsTypeName(method: RpcMethod): string {
-    return getRpcSchemaTypeName(method.params, method.rpcMethod.split(".").map(toPascalCase).join("") + "Request");
+    return getRpcSchemaTypeName(
+        getMethodParamsSchema(method),
+        method.rpcMethod.split(".").map(toPascalCase).join("") + "Request"
+    );
 }
 
 async function generateRpc(schemaPath?: string): Promise<void> {
@@ -180,35 +261,62 @@ import type { MessageConnection } from "vscode-jsonrpc/node.js";
 
     // Build a single combined schema with shared definitions and all method types.
     // This ensures $ref-referenced types are generated exactly once.
-    const sharedDefs = collectDefinitions(schema as Record<string, unknown>);
+    rpcDefinitions = collectDefinitionCollections(schema as Record<string, unknown>);
     const combinedSchema = withSharedDefinitions(
         {
             $schema: "http://json-schema.org/draft-07/schema#",
             type: "object",
         },
-        sharedDefs
+        rpcDefinitions
     );
 
     // Track which type names come from experimental methods for JSDoc annotations.
     const experimentalTypes = new Set<string>();
 
     for (const method of [...allMethods, ...clientSessionMethods]) {
-        if (!isVoidSchema(method.result)) {
-            combinedSchema.definitions![resultTypeName(method)] = method.result;
+        const resultSchema = getMethodResultSchema(method);
+        if (!isVoidSchema(resultSchema)) {
+            combinedSchema.definitions![resultTypeName(method)] = withRootTitle(
+                method.result ?? resultSchema ?? { type: "object" },
+                resultTypeName(method)
+            );
             if (method.stability === "experimental") {
                 experimentalTypes.add(resultTypeName(method));
             }
         }
 
-        if (method.params?.properties && Object.keys(method.params.properties).length > 0) {
-            combinedSchema.definitions![paramsTypeName(method)] = method.params;
-            if (method.stability === "experimental") {
-                experimentalTypes.add(paramsTypeName(method));
+        const resolvedParams = getMethodParamsSchema(method);
+        if (method.params && hasSchemaPayload(resolvedParams)) {
+            if (method.rpcMethod.startsWith("session.") && resolvedParams?.properties) {
+                const filtered: JSONSchema7 = {
+                    ...resolvedParams,
+                    properties: Object.fromEntries(
+                        Object.entries(resolvedParams.properties).filter(([k]) => k !== "sessionId")
+                    ),
+                    required: resolvedParams.required?.filter((r) => r !== "sessionId"),
+                };
+                if (hasSchemaPayload(filtered)) {
+                    combinedSchema.definitions![paramsTypeName(method)] = withRootTitle(
+                        filtered,
+                        paramsTypeName(method)
+                    );
+                    if (method.stability === "experimental") {
+                        experimentalTypes.add(paramsTypeName(method));
+                    }
+                }
+            } else {
+                combinedSchema.definitions![paramsTypeName(method)] = withRootTitle(
+                    method.params,
+                    paramsTypeName(method)
+                );
+                if (method.stability === "experimental") {
+                    experimentalTypes.add(paramsTypeName(method));
+                }
             }
         }
     }
 
-    const compiled = await compile(stripNonAnnotationTitles(combinedSchema), "_RpcSchemaRoot", {
+    const compiled = await compile(normalizeSchemaForTypeScript(stripNonAnnotationTitles(combinedSchema)), "_RpcSchemaRoot", {
         bannerComment: "",
         additionalProperties: false,
         unreachableDefinitions: true,
@@ -272,11 +380,14 @@ function emitGroup(node: Record<string, unknown>, indent: string, isSession: boo
     for (const [key, value] of Object.entries(node)) {
         if (isRpcMethod(value)) {
             const { rpcMethod, params } = value;
-            const resultType = !isVoidSchema(value.result) ? resultTypeName(value) : "void";
+            const resultType = !isVoidSchema(getMethodResultSchema(value)) ? resultTypeName(value) : "void";
             const paramsType = paramsTypeName(value);
+            const effectiveParams = getMethodParamsSchema(value);
 
-            const paramEntries = params?.properties ? Object.entries(params.properties).filter(([k]) => k !== "sessionId") : [];
-            const hasParams = params?.properties && Object.keys(params.properties).length > 0;
+            const paramEntries = effectiveParams?.properties
+                ? Object.entries(effectiveParams.properties).filter(([k]) => k !== "sessionId")
+                : [];
+            const hasParams = hasSchemaPayload(effectiveParams);
             const hasNonSessionParams = paramEntries.length > 0;
 
             const sigParams: string[] = [];
@@ -360,9 +471,9 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>)
         lines.push(`export interface ${interfaceName} {`);
         for (const method of methods) {
             const name = handlerMethodName(method.rpcMethod);
-            const hasParams = method.params?.properties && Object.keys(method.params.properties).length > 0;
+            const hasParams = hasSchemaPayload(getMethodParamsSchema(method));
             const pType = hasParams ? paramsTypeName(method) : "";
-            const rType = !isVoidSchema(method.result) ? resultTypeName(method) : "void";
+            const rType = !isVoidSchema(getMethodResultSchema(method)) ? resultTypeName(method) : "void";
 
             if (hasParams) {
                 lines.push(`    ${name}(params: ${pType}): Promise<${rType}>;`);
@@ -400,7 +511,7 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>)
         for (const method of methods) {
             const name = handlerMethodName(method.rpcMethod);
             const pType = paramsTypeName(method);
-            const hasParams = method.params?.properties && Object.keys(method.params.properties).length > 0;
+            const hasParams = hasSchemaPayload(getMethodParamsSchema(method));
 
             if (hasParams) {
                 lines.push(`    connection.onRequest("${method.rpcMethod}", async (params: ${pType}) => {`);

--- a/scripts/codegen/typescript.ts
+++ b/scripts/codegen/typescript.ts
@@ -213,7 +213,12 @@ import type { MessageConnection } from "vscode-jsonrpc/node.js";
 
     // Strip the placeholder root type and keep only the definition-generated types
     const strippedTs = compiled
+        .replace(
+            /\/\*\*\n \* This (?:interface|type) was referenced by `_RpcSchemaRoot`'s JSON-Schema\n \* via the `definition` "[^"]+"\.\n \*\/\n/g,
+            "\n"
+        )
         .replace(/export interface _RpcSchemaRoot\s*\{[^}]*\}\s*/g, "")
+        .replace(/export type _RpcSchemaRoot = [^;]+;\s*/g, "")
         .trim();
 
     if (strippedTs) {

--- a/scripts/codegen/typescript.ts
+++ b/scripts/codegen/typescript.ts
@@ -13,12 +13,13 @@ import {
     getApiSchemaPath,
     getRpcSchemaTypeName,
     getSessionEventsSchemaPath,
-    isNodeFullyExperimental,
-    isRpcMethod,
-    isVoidSchema,
     postProcessSchema,
-    stripNonAnnotationTitles,
     writeGeneratedFile,
+    collectDefinitions,
+    isRpcMethod,
+    isNodeFullyExperimental,
+    isVoidSchema,
+    stripNonAnnotationTitles,
     type ApiSchema,
     type RpcMethod,
 } from "./utils.js";
@@ -176,30 +177,56 @@ import type { MessageConnection } from "vscode-jsonrpc/node.js";
     const clientSessionMethods = collectRpcMethods(schema.clientSession || {});
     const seenBlocks = new Map<string, string>();
 
+    // Build a single combined schema with shared definitions and all method types.
+    // This ensures $ref-referenced types are generated exactly once.
+    const sharedDefs = collectDefinitions(schema as Record<string, unknown>);
+    const combinedSchema: JSONSchema7 = {
+        $schema: "http://json-schema.org/draft-07/schema#",
+        type: "object",
+        definitions: { ...sharedDefs },
+    };
+
+    // Track which type names come from experimental methods for JSDoc annotations.
+    const experimentalTypes = new Set<string>();
+
     for (const method of [...allMethods, ...clientSessionMethods]) {
         if (!isVoidSchema(method.result)) {
-            const compiled = await compile(stripNonAnnotationTitles(method.result), resultTypeName(method), {
-                bannerComment: "",
-                additionalProperties: false,
-            });
+            combinedSchema.definitions![resultTypeName(method)] = method.result;
             if (method.stability === "experimental") {
-                lines.push("/** @experimental */");
+                experimentalTypes.add(resultTypeName(method));
             }
-            appendUniqueExportBlocks(lines, compiled, seenBlocks);
-            lines.push("");
         }
 
         if (method.params?.properties && Object.keys(method.params.properties).length > 0) {
-            const paramsCompiled = await compile(stripNonAnnotationTitles(method.params), paramsTypeName(method), {
-                bannerComment: "",
-                additionalProperties: false,
-            });
+            combinedSchema.definitions![paramsTypeName(method)] = method.params;
             if (method.stability === "experimental") {
-                lines.push("/** @experimental */");
+                experimentalTypes.add(paramsTypeName(method));
             }
-            appendUniqueExportBlocks(lines, paramsCompiled, seenBlocks);
-            lines.push("");
         }
+    }
+
+    const compiled = await compile(stripNonAnnotationTitles(combinedSchema), "_RpcSchemaRoot", {
+        bannerComment: "",
+        additionalProperties: false,
+        unreachableDefinitions: true,
+    });
+
+    // Strip the placeholder root type and keep only the definition-generated types
+    const strippedTs = compiled
+        .replace(/export interface _RpcSchemaRoot\s*\{[^}]*\}\s*/g, "")
+        .trim();
+
+    if (strippedTs) {
+        // Add @experimental JSDoc annotations for types from experimental methods
+        let annotatedTs = strippedTs;
+        for (const expType of experimentalTypes) {
+            annotatedTs = annotatedTs.replace(
+                new RegExp(`(^|\\n)(export (?:interface|type) ${expType}\\b)`, "m"),
+                `$1/** @experimental */\n$2`
+            );
+        }
+        lines.push(annotatedTs);
+        lines.push("");
     }
 
     // Generate factory functions

--- a/scripts/codegen/typescript.ts
+++ b/scripts/codegen/typescript.ts
@@ -13,6 +13,7 @@ import {
     getApiSchemaPath,
     getRpcSchemaTypeName,
     getSessionEventsSchemaPath,
+    normalizeSchemaTitles,
     postProcessSchema,
     writeGeneratedFile,
     collectDefinitionCollections,
@@ -177,6 +178,65 @@ function normalizeSchemaForTypeScript(schema: JSONSchema7): JSONSchema7 {
     return rewrite(root) as JSONSchema7;
 }
 
+function stableStringify(value: unknown): string {
+    if (Array.isArray(value)) {
+        return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+    }
+    if (value && typeof value === "object") {
+        const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b));
+        return `{${entries.map(([key, child]) => `${JSON.stringify(key)}:${stableStringify(child)}`).join(",")}}`;
+    }
+    return JSON.stringify(value);
+}
+
+function replaceDuplicateTitledSchemasWithRefs(
+    value: unknown,
+    definitions: Record<string, unknown>,
+    isRoot = false
+): unknown {
+    if (Array.isArray(value)) {
+        return value.map((item) => replaceDuplicateTitledSchemasWithRefs(item, definitions));
+    }
+    if (!value || typeof value !== "object") {
+        return value;
+    }
+
+    const rewritten = Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).map(([key, child]) => [
+            key,
+            replaceDuplicateTitledSchemasWithRefs(child, definitions),
+        ])
+    ) as Record<string, unknown>;
+
+    if (!isRoot && typeof rewritten.title === "string") {
+        const sharedSchema = definitions[rewritten.title];
+        if (
+            sharedSchema &&
+            typeof sharedSchema === "object" &&
+            stableStringify(normalizeSchemaTitles(rewritten as JSONSchema7)) ===
+                stableStringify(normalizeSchemaTitles(sharedSchema as JSONSchema7))
+        ) {
+            return { $ref: `#/definitions/${rewritten.title}` };
+        }
+    }
+
+    return rewritten;
+}
+
+function reuseSharedTitledSchemas(schema: JSONSchema7): JSONSchema7 {
+    const definitions = { ...((schema.definitions ?? {}) as Record<string, unknown>) };
+
+    return {
+        ...schema,
+        definitions: Object.fromEntries(
+            Object.entries(definitions).map(([name, definition]) => [
+                name,
+                replaceDuplicateTitledSchemasWithRefs(definition, definitions, true),
+            ])
+        ),
+    };
+}
+
 // ── Session Events ──────────────────────────────────────────────────────────
 
 async function generateSessionEvents(schemaPath?: string): Promise<void> {
@@ -213,6 +273,20 @@ function withRootTitle(schema: JSONSchema7, title: string): JSONSchema7 {
     return { ...schema, title };
 }
 
+function rpcRequestFallbackName(method: RpcMethod): string {
+    return method.rpcMethod.split(".").map(toPascalCase).join("") + "Request";
+}
+
+function schemaSourceForNamedDefinition(
+    schema: JSONSchema7 | null | undefined,
+    resolvedSchema: JSONSchema7 | undefined
+): JSONSchema7 {
+    if (schema?.$ref && resolvedSchema) {
+        return resolvedSchema;
+    }
+    return schema ?? resolvedSchema ?? { type: "object" };
+}
+
 function getMethodResultSchema(method: RpcMethod): JSONSchema7 | undefined {
     return resolveSchema(method.result, rpcDefinitions) ?? method.result ?? undefined;
 }
@@ -234,10 +308,11 @@ function resultTypeName(method: RpcMethod): string {
 }
 
 function paramsTypeName(method: RpcMethod): string {
-    return getRpcSchemaTypeName(
-        getMethodParamsSchema(method),
-        method.rpcMethod.split(".").map(toPascalCase).join("") + "Request"
-    );
+    const fallback = rpcRequestFallbackName(method);
+    if (method.rpcMethod.startsWith("session.") && method.params?.$ref) {
+        return fallback;
+    }
+    return getRpcSchemaTypeName(getMethodParamsSchema(method), fallback);
 }
 
 async function generateRpc(schemaPath?: string): Promise<void> {
@@ -277,7 +352,7 @@ import type { MessageConnection } from "vscode-jsonrpc/node.js";
         const resultSchema = getMethodResultSchema(method);
         if (!isVoidSchema(resultSchema)) {
             combinedSchema.definitions![resultTypeName(method)] = withRootTitle(
-                method.result ?? resultSchema ?? { type: "object" },
+                schemaSourceForNamedDefinition(method.result, resultSchema),
                 resultTypeName(method)
             );
             if (method.stability === "experimental") {
@@ -306,7 +381,7 @@ import type { MessageConnection } from "vscode-jsonrpc/node.js";
                 }
             } else {
                 combinedSchema.definitions![paramsTypeName(method)] = withRootTitle(
-                    method.params,
+                    schemaSourceForNamedDefinition(method.params, resolvedParams),
                     paramsTypeName(method)
                 );
                 if (method.stability === "experimental") {
@@ -316,7 +391,9 @@ import type { MessageConnection } from "vscode-jsonrpc/node.js";
         }
     }
 
-    const compiled = await compile(normalizeSchemaForTypeScript(stripNonAnnotationTitles(combinedSchema)), "_RpcSchemaRoot", {
+    const schemaForCompile = reuseSharedTitledSchemas(stripNonAnnotationTitles(combinedSchema));
+
+    const compiled = await compile(normalizeSchemaForTypeScript(schemaForCompile), "_RpcSchemaRoot", {
         bannerComment: "",
         additionalProperties: false,
         unreachableDefinitions: true,

--- a/scripts/codegen/typescript.ts
+++ b/scripts/codegen/typescript.ts
@@ -16,6 +16,7 @@ import {
     postProcessSchema,
     writeGeneratedFile,
     collectDefinitions,
+    withSharedDefinitions,
     isRpcMethod,
     isNodeFullyExperimental,
     isVoidSchema,
@@ -180,11 +181,13 @@ import type { MessageConnection } from "vscode-jsonrpc/node.js";
     // Build a single combined schema with shared definitions and all method types.
     // This ensures $ref-referenced types are generated exactly once.
     const sharedDefs = collectDefinitions(schema as Record<string, unknown>);
-    const combinedSchema: JSONSchema7 = {
-        $schema: "http://json-schema.org/draft-07/schema#",
-        type: "object",
-        definitions: { ...sharedDefs },
-    };
+    const combinedSchema = withSharedDefinitions(
+        {
+            $schema: "http://json-schema.org/draft-07/schema#",
+            type: "object",
+        },
+        sharedDefs
+    );
 
     // Track which type names come from experimental methods for JSDoc annotations.
     const experimentalTypes = new Set<string>();

--- a/scripts/codegen/utils.ts
+++ b/scripts/codegen/utils.ts
@@ -21,6 +21,17 @@ const __dirname = path.dirname(__filename);
 /** Root of the copilot-sdk repo */
 export const REPO_ROOT = path.resolve(__dirname, "../..");
 
+/** Event types to exclude from generation (internal/legacy types) */
+export const EXCLUDED_EVENT_TYPES = new Set(["session.import_legacy"]);
+
+export interface JSONSchema7WithDefs extends JSONSchema7 {
+    $defs?: Record<string, JSONSchema7Definition>;
+}
+
+export type SchemaWithSharedDefinitions<T extends JSONSchema7 = JSONSchema7> = T & {
+    definitions: Record<string, JSONSchema7Definition>;
+    $defs: Record<string, JSONSchema7Definition>;
+};
 // ── Schema paths ────────────────────────────────────────────────────────────
 
 export async function getSessionEventsSchemaPath(): Promise<string> {
@@ -51,16 +62,7 @@ export async function getApiSchemaPath(cliArg?: string): Promise<string> {
 export function postProcessSchema(schema: JSONSchema7): JSONSchema7 {
     if (typeof schema !== "object" || schema === null) return schema;
 
-    const processed: JSONSchema7 = { ...schema };
-
-    // Normalize $defs → definitions for draft 2019+ compatibility
-    if ("$defs" in processed && !processed.definitions) {
-        processed.definitions = (processed as Record<string, unknown>).$defs as Record<
-            string,
-            JSONSchema7Definition
-        >;
-        delete (processed as Record<string, unknown>).$defs;
-    }
+    const processed = { ...schema } as JSONSchema7WithDefs;
 
     if ("const" in processed && typeof processed.const === "boolean") {
         processed.enum = [processed.const];
@@ -93,12 +95,14 @@ export function postProcessSchema(schema: JSONSchema7): JSONSchema7 {
         }
     }
 
-    if (processed.definitions) {
+    const definitions = collectDefinitions(processed as Record<string, unknown>);
+    if (Object.keys(definitions).length > 0) {
         const newDefs: Record<string, JSONSchema7Definition> = {};
-        for (const [key, value] of Object.entries(processed.definitions)) {
+        for (const [key, value] of Object.entries(definitions)) {
             newDefs[key] = typeof value === "object" ? postProcessSchema(value as JSONSchema7) : value;
         }
         processed.definitions = newDefs;
+        processed.$defs = newDefs;
     }
 
     if (typeof processed.additionalProperties === "object") {
@@ -339,6 +343,19 @@ export function resolveRef(
 export function collectDefinitions(
     schema: Record<string, unknown>
 ): Record<string, JSONSchema7Definition> {
-    const defs = (schema.definitions ?? schema.$defs ?? {}) as Record<string, JSONSchema7Definition>;
-    return { ...defs }
+    const legacyDefinitions = (schema.definitions ?? {}) as Record<string, JSONSchema7Definition>;
+    const draft2019Definitions = (schema.$defs ?? {}) as Record<string, JSONSchema7Definition>;
+    return { ...draft2019Definitions, ...legacyDefinitions };
+}
+
+export function withSharedDefinitions<T extends JSONSchema7>(
+    schema: T,
+    definitions: Record<string, JSONSchema7Definition>
+): SchemaWithSharedDefinitions<T> {
+    const sharedDefinitions = { ...definitions };
+    return {
+        ...schema,
+        definitions: sharedDefinitions,
+        $defs: sharedDefinitions,
+    };
 }

--- a/scripts/codegen/utils.ts
+++ b/scripts/codegen/utils.ts
@@ -24,9 +24,12 @@ export const REPO_ROOT = path.resolve(__dirname, "../..");
 /** Event types to exclude from generation (internal/legacy types) */
 export const EXCLUDED_EVENT_TYPES = new Set(["session.import_legacy"]);
 
-export interface JSONSchema7WithDefs extends JSONSchema7 {
+export interface DefinitionCollections {
+    definitions?: Record<string, JSONSchema7Definition>;
     $defs?: Record<string, JSONSchema7Definition>;
 }
+
+export interface JSONSchema7WithDefs extends JSONSchema7, DefinitionCollections {}
 
 export type SchemaWithSharedDefinitions<T extends JSONSchema7 = JSONSchema7> = T & {
     definitions: Record<string, JSONSchema7Definition>;
@@ -95,14 +98,27 @@ export function postProcessSchema(schema: JSONSchema7): JSONSchema7 {
         }
     }
 
-    const definitions = collectDefinitions(processed as Record<string, unknown>);
+    const { definitions, $defs } = collectDefinitionCollections(processed as Record<string, unknown>);
+    let newDefs: Record<string, JSONSchema7Definition> | undefined;
     if (Object.keys(definitions).length > 0) {
-        const newDefs: Record<string, JSONSchema7Definition> = {};
+        newDefs = {};
         for (const [key, value] of Object.entries(definitions)) {
             newDefs[key] = typeof value === "object" ? postProcessSchema(value as JSONSchema7) : value;
         }
         processed.definitions = newDefs;
-        processed.$defs = newDefs;
+    }
+    let newDraftDefs: Record<string, JSONSchema7Definition> | undefined;
+    if (Object.keys($defs).length > 0) {
+        newDraftDefs = {};
+        for (const [key, value] of Object.entries($defs)) {
+            newDraftDefs[key] = typeof value === "object" ? postProcessSchema(value as JSONSchema7) : value;
+        }
+        processed.$defs = newDraftDefs;
+    }
+    if (processed.definitions && !processed.$defs) {
+        processed.$defs = { ...(newDefs ?? processed.definitions) };
+    } else if (processed.$defs && !processed.definitions) {
+        processed.definitions = { ...processed.$defs };
     }
 
     if (typeof processed.additionalProperties === "object") {
@@ -306,6 +322,135 @@ export function isRpcMethod(node: unknown): node is RpcMethod {
     return typeof node === "object" && node !== null && "rpcMethod" in node;
 }
 
+function normalizeSchemaDefinitionTitles(definition: JSONSchema7Definition): JSONSchema7Definition {
+    return typeof definition === "object" && definition !== null
+        ? normalizeSchemaTitles(definition as JSONSchema7)
+        : definition;
+}
+
+export function normalizeSchemaTitles(schema: JSONSchema7): JSONSchema7 {
+    if (typeof schema !== "object" || schema === null) return schema;
+
+    const normalized = { ...schema } as JSONSchema7WithDefs & Record<string, unknown>;
+    delete normalized.title;
+    delete normalized.titleSource;
+
+    if (normalized.properties) {
+        const newProps: Record<string, JSONSchema7Definition> = {};
+        for (const [key, value] of Object.entries(normalized.properties)) {
+            newProps[key] = normalizeSchemaDefinitionTitles(value);
+        }
+        normalized.properties = newProps;
+    }
+
+    if (normalized.items) {
+        if (typeof normalized.items === "object" && !Array.isArray(normalized.items)) {
+            normalized.items = normalizeSchemaTitles(normalized.items as JSONSchema7);
+        } else if (Array.isArray(normalized.items)) {
+            normalized.items = normalized.items.map((item) => normalizeSchemaDefinitionTitles(item)) as JSONSchema7Definition[];
+        }
+    }
+
+    for (const combiner of ["anyOf", "allOf", "oneOf"] as const) {
+        if (normalized[combiner]) {
+            normalized[combiner] = normalized[combiner]!.map((item) => normalizeSchemaDefinitionTitles(item)) as JSONSchema7Definition[];
+        }
+    }
+
+    if (normalized.additionalProperties && typeof normalized.additionalProperties === "object") {
+        normalized.additionalProperties = normalizeSchemaTitles(normalized.additionalProperties as JSONSchema7);
+    }
+
+    if (normalized.propertyNames && typeof normalized.propertyNames === "object" && !Array.isArray(normalized.propertyNames)) {
+        normalized.propertyNames = normalizeSchemaTitles(normalized.propertyNames as JSONSchema7);
+    }
+
+    if (normalized.contains && typeof normalized.contains === "object" && !Array.isArray(normalized.contains)) {
+        normalized.contains = normalizeSchemaTitles(normalized.contains as JSONSchema7);
+    }
+
+    if (normalized.not && typeof normalized.not === "object" && !Array.isArray(normalized.not)) {
+        normalized.not = normalizeSchemaTitles(normalized.not as JSONSchema7);
+    }
+
+    if (normalized.if && typeof normalized.if === "object" && !Array.isArray(normalized.if)) {
+        normalized.if = normalizeSchemaTitles(normalized.if as JSONSchema7);
+    }
+    if (normalized.then && typeof normalized.then === "object" && !Array.isArray(normalized.then)) {
+        normalized.then = normalizeSchemaTitles(normalized.then as JSONSchema7);
+    }
+    if (normalized.else && typeof normalized.else === "object" && !Array.isArray(normalized.else)) {
+        normalized.else = normalizeSchemaTitles(normalized.else as JSONSchema7);
+    }
+
+    if (normalized.patternProperties) {
+        const newPatternProps: Record<string, JSONSchema7Definition> = {};
+        for (const [key, value] of Object.entries(normalized.patternProperties)) {
+            newPatternProps[key] = normalizeSchemaDefinitionTitles(value);
+        }
+        normalized.patternProperties = newPatternProps;
+    }
+
+    const { definitions, $defs } = collectDefinitionCollections(normalized as Record<string, unknown>);
+    if (Object.keys(definitions).length > 0) {
+        const newDefs: Record<string, JSONSchema7Definition> = {};
+        for (const [key, value] of Object.entries(definitions)) {
+            newDefs[key] = normalizeSchemaDefinitionTitles(value);
+        }
+        normalized.definitions = newDefs;
+    }
+    if (Object.keys($defs).length > 0) {
+        const newDraftDefs: Record<string, JSONSchema7Definition> = {};
+        for (const [key, value] of Object.entries($defs)) {
+            newDraftDefs[key] = normalizeSchemaDefinitionTitles(value);
+        }
+        normalized.$defs = newDraftDefs;
+    }
+
+    return normalized;
+}
+
+function normalizeApiNode(node: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+    if (!node) return undefined;
+
+    const normalizedNode: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(node)) {
+        if (isRpcMethod(value)) {
+            const method = value as RpcMethod;
+            normalizedNode[key] = {
+                ...method,
+                params: method.params ? normalizeSchemaTitles(method.params) : method.params,
+                result: method.result ? normalizeSchemaTitles(method.result) : method.result,
+            };
+        } else if (typeof value === "object" && value !== null) {
+            normalizedNode[key] = normalizeApiNode(value as Record<string, unknown>);
+        } else {
+            normalizedNode[key] = value;
+        }
+    }
+
+    return normalizedNode;
+}
+
+export function normalizeApiSchema(schema: ApiSchema): ApiSchema {
+    return {
+        ...schema,
+        definitions: schema.definitions
+            ? Object.fromEntries(
+                  Object.entries(schema.definitions).map(([key, value]) => [key, normalizeSchemaDefinitionTitles(value)])
+              )
+            : schema.definitions,
+        $defs: schema.$defs
+            ? Object.fromEntries(
+                  Object.entries(schema.$defs).map(([key, value]) => [key, normalizeSchemaDefinitionTitles(value)])
+              )
+            : schema.$defs,
+        server: normalizeApiNode(schema.server),
+        session: normalizeApiNode(schema.session),
+        clientSession: normalizeApiNode(schema.clientSession),
+    };
+}
+
 /** Returns true when every leaf RPC method inside `node` is marked experimental. */
 export function isNodeFullyExperimental(node: Record<string, unknown>): boolean {
     const methods: RpcMethod[] = [];
@@ -323,39 +468,160 @@ export function isNodeFullyExperimental(node: Record<string, unknown>): boolean 
 
 // ── $ref resolution ─────────────────────────────────────────────────────────
 
-/** Extract the type name from a `$ref` path (e.g. "#/definitions/Model" → "Model"). */
-export function refTypeName(ref: string): string {
-    return ref.split("/").pop()!;
+/** Extract the generated type name from a `$ref` path (e.g. "#/definitions/Model" → "Model"). */
+export function refTypeName(ref: string, definitions?: DefinitionCollections): string {
+    const baseName = ref.split("/").pop()!;
+    const match = ref.match(/^#\/(definitions|\$defs)\/(.+)$/);
+    if (!match || match[1] !== "$defs" || !definitions) return baseName;
+
+    const key = match[2];
+    const legacyDefinition = definitions.definitions?.[key];
+    const draftDefinition = definitions.$defs?.[key];
+    if (
+        legacyDefinition !== undefined &&
+        draftDefinition !== undefined &&
+        stableStringify(legacyDefinition) !== stableStringify(draftDefinition)
+    ) {
+        return `Draft${baseName}`;
+    }
+
+    return baseName;
 }
 
 /** Resolve a `$ref` path against a definitions map, returning the referenced schema. */
 export function resolveRef(
     ref: string,
-    definitions: Record<string, JSONSchema7Definition> | undefined
+    definitions: DefinitionCollections | undefined
 ): JSONSchema7 | undefined {
     const match = ref.match(/^#\/(definitions|\$defs)\/(.+)$/);
     if (!match || !definitions) return undefined;
-    const def = definitions[match[2]];
+    const [, namespace, key] = match;
+    const primary = namespace === "$defs" ? definitions.$defs : definitions.definitions;
+    const fallback = namespace === "$defs" ? definitions.definitions : definitions.$defs;
+    const def = primary?.[key] ?? fallback?.[key];
     return typeof def === "object" ? (def as JSONSchema7) : undefined;
+}
+
+export function resolveSchema(
+    schema: JSONSchema7 | null | undefined,
+    definitions: DefinitionCollections | undefined
+): JSONSchema7 | undefined {
+    let current = schema ?? undefined;
+    const seenRefs = new Set<string>();
+    while (current?.$ref) {
+        if (seenRefs.has(current.$ref)) break;
+        seenRefs.add(current.$ref);
+        const resolved = resolveRef(current.$ref, definitions);
+        if (!resolved) break;
+        current = resolved;
+    }
+    return current;
+}
+
+export function resolveObjectSchema(
+    schema: JSONSchema7 | null | undefined,
+    definitions: DefinitionCollections | undefined
+): JSONSchema7 | undefined {
+    const resolved = resolveSchema(schema, definitions) ?? schema ?? undefined;
+    if (!resolved) return undefined;
+    if (resolved.properties || resolved.additionalProperties || resolved.type === "object") return resolved;
+
+    if (resolved.allOf) {
+        const mergedProperties: Record<string, JSONSchema7Definition> = {};
+        const mergedRequired = new Set<string>();
+        const merged: JSONSchema7 = {
+            type: "object",
+            description: resolved.description,
+        };
+        let hasObjectShape = false;
+
+        for (const item of resolved.allOf) {
+            if (typeof item !== "object") continue;
+            const objectSchema = resolveObjectSchema(item as JSONSchema7, definitions);
+            if (!objectSchema) continue;
+
+            if (objectSchema.properties) {
+                Object.assign(mergedProperties, objectSchema.properties);
+                hasObjectShape = true;
+            }
+            if (objectSchema.required) {
+                for (const name of objectSchema.required) {
+                    mergedRequired.add(name);
+                }
+            }
+            if (objectSchema.additionalProperties !== undefined) {
+                merged.additionalProperties = objectSchema.additionalProperties;
+                hasObjectShape = true;
+            }
+            if (!merged.description && objectSchema.description) {
+                merged.description = objectSchema.description;
+            }
+        }
+
+        if (!hasObjectShape) return resolved;
+        if (Object.keys(mergedProperties).length > 0) {
+            merged.properties = mergedProperties;
+        }
+        if (mergedRequired.size > 0) {
+            merged.required = [...mergedRequired];
+        }
+        return merged;
+    }
+
+    const singleBranch = (resolved.anyOf ?? resolved.oneOf)
+        ?.filter((item): item is JSONSchema7 => typeof item === "object" && (item as JSONSchema7).type !== "null");
+    if (singleBranch && singleBranch.length === 1) {
+        return resolveObjectSchema(singleBranch[0], definitions);
+    }
+
+    return resolved;
+}
+
+export function hasSchemaPayload(schema: JSONSchema7 | null | undefined): boolean {
+    if (!schema) return false;
+    if (schema.properties) return Object.keys(schema.properties).length > 0;
+    if (schema.additionalProperties) return true;
+    if (schema.items) return true;
+    if (schema.anyOf || schema.oneOf || schema.allOf) return true;
+    if (schema.enum && schema.enum.length > 0) return true;
+    if (schema.const !== undefined) return true;
+    if (schema.$ref) return true;
+    if (Array.isArray(schema.type)) return schema.type.length > 0 && !(schema.type.length === 1 && schema.type[0] === "object");
+    return schema.type !== undefined && schema.type !== "object";
+}
+
+export function collectDefinitionCollections(
+    schema: Record<string, unknown>
+): Required<DefinitionCollections> {
+    return {
+        definitions: { ...((schema.definitions ?? {}) as Record<string, JSONSchema7Definition>) },
+        $defs: { ...((schema.$defs ?? {}) as Record<string, JSONSchema7Definition>) },
+    };
 }
 
 /** Collect the shared definitions from a schema (handles both `definitions` and `$defs`). */
 export function collectDefinitions(
     schema: Record<string, unknown>
 ): Record<string, JSONSchema7Definition> {
-    const legacyDefinitions = (schema.definitions ?? {}) as Record<string, JSONSchema7Definition>;
-    const draft2019Definitions = (schema.$defs ?? {}) as Record<string, JSONSchema7Definition>;
-    return { ...draft2019Definitions, ...legacyDefinitions };
+    const { definitions, $defs } = collectDefinitionCollections(schema);
+    return { ...$defs, ...definitions };
 }
 
 export function withSharedDefinitions<T extends JSONSchema7>(
     schema: T,
-    definitions: Record<string, JSONSchema7Definition>
+    definitions: DefinitionCollections
 ): SchemaWithSharedDefinitions<T> {
-    const sharedDefinitions = { ...definitions };
+    const legacyDefinitions = { ...(definitions.definitions ?? {}) };
+    const draft2019Definitions = { ...(definitions.$defs ?? {}) };
+
+    const sharedLegacyDefinitions =
+        Object.keys(legacyDefinitions).length > 0 ? legacyDefinitions : { ...draft2019Definitions };
+    const sharedDraftDefinitions =
+        Object.keys(draft2019Definitions).length > 0 ? draft2019Definitions : { ...legacyDefinitions };
+
     return {
         ...schema,
-        definitions: sharedDefinitions,
-        $defs: sharedDefinitions,
+        definitions: sharedLegacyDefinitions,
+        $defs: sharedDraftDefinitions,
     };
 }

--- a/scripts/codegen/utils.ts
+++ b/scripts/codegen/utils.ts
@@ -53,6 +53,15 @@ export function postProcessSchema(schema: JSONSchema7): JSONSchema7 {
 
     const processed: JSONSchema7 = { ...schema };
 
+    // Normalize $defs → definitions for draft 2019+ compatibility
+    if ("$defs" in processed && !processed.definitions) {
+        processed.definitions = (processed as Record<string, unknown>).$defs as Record<
+            string,
+            JSONSchema7Definition
+        >;
+        delete (processed as Record<string, unknown>).$defs;
+    }
+
     if ("const" in processed && typeof processed.const === "boolean") {
         processed.enum = [processed.const];
         delete processed.const;
@@ -282,6 +291,8 @@ function sortJsonValue(value: unknown): unknown {
 }
 
 export interface ApiSchema {
+    definitions?: Record<string, JSONSchema7Definition>;
+    $defs?: Record<string, JSONSchema7Definition>;
     server?: Record<string, unknown>;
     session?: Record<string, unknown>;
     clientSession?: Record<string, unknown>;
@@ -304,4 +315,30 @@ export function isNodeFullyExperimental(node: Record<string, unknown>): boolean 
         }
     })(node);
     return methods.length > 0 && methods.every(m => m.stability === "experimental");
+}
+
+// ── $ref resolution ─────────────────────────────────────────────────────────
+
+/** Extract the type name from a `$ref` path (e.g. "#/definitions/Model" → "Model"). */
+export function refTypeName(ref: string): string {
+    return ref.split("/").pop()!;
+}
+
+/** Resolve a `$ref` path against a definitions map, returning the referenced schema. */
+export function resolveRef(
+    ref: string,
+    definitions: Record<string, JSONSchema7Definition> | undefined
+): JSONSchema7 | undefined {
+    const match = ref.match(/^#\/(definitions|\$defs)\/(.+)$/);
+    if (!match || !definitions) return undefined;
+    const def = definitions[match[2]];
+    return typeof def === "object" ? (def as JSONSchema7) : undefined;
+}
+
+/** Collect the shared definitions from a schema (handles both `definitions` and `$defs`). */
+export function collectDefinitions(
+    schema: Record<string, unknown>
+): Record<string, JSONSchema7Definition> {
+    const defs = (schema.definitions ?? schema.$defs ?? {}) as Record<string, JSONSchema7Definition>;
+    return { ...defs }
 }


### PR DESCRIPTION
## Summary

Enable JSON Schema `$ref` for type deduplication across all SDK code generators (TypeScript, Python, Go, C#). This allows the runtime to declare a shared type once using `$`ref and have each generator produce a single deduplicated type per language.

## Changes

### `scripts/codegen/utils.ts`
- Add `resolveRef()`, `refTypeName()`, `collectDefinitions()` helpers
- Normalize `$`defs to `definitions` in `postProcessSchema` for cross-draft compatibility
- Add `definitions`/`$`defs fields to `ApiSchema` interface

### `scripts/codegen/typescript.ts`
- Build a single combined schema with shared definitions and compile once via `unreachableDefinitions`, instead of per-method compilation
- Preserves `@experimental` JSDoc annotations via post-processing

### `scripts/codegen/python.ts`
- Include all definitions alongside `SessionEvent` for quicktype `$`ref resolution
- Include shared API definitions in each RPC `addSource` call

### `scripts/codegen/go.ts`
- Add `$`ref handling to the custom Go session events generator (`resolveGoPropertyType`) with `definitions` on `GoCodegenCtx`
- Include shared API definitions in RPC combined schema for quicktype `$`ref resolution

### `scripts/codegen/csharp.ts`
- Add `$`ref handling to `resolveSessionPropertyType` and `resolveRpcType`
- Generate classes for referenced types on demand using module-level `sessionDefinitions`/`rpcDefinitions` state
- Handle `$`ref in array items

## Motivation

The copilot-agent-runtime is moving to use `$`ref for type deduplication in tool schemas. Without this change, generators would either fail to resolve `$`ref pointers or inline duplicate type definitions.