### PR TITLE
Enhance C# generator with richer typing and data annotations

### DIFF
--- a/docs/auth/byok.md
+++ b/docs/auth/byok.md
@@ -426,7 +426,7 @@ using GitHub.Copilot.SDK;
 
 var client = new CopilotClient(new CopilotClientOptions
 {
-    OnListModels = (ct) => Task.FromResult(new List<ModelInfo>
+    OnListModels = (ct) => Task.FromResult<IList<ModelInfo>>(new List<ModelInfo>
     {
         new()
         {

--- a/docs/setup/local-cli.md
+++ b/docs/setup/local-cli.md
@@ -99,7 +99,9 @@ func main() {
 
 	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{Model: "gpt-4.1"})
 	response, _ := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: "Hello!"})
-	fmt.Println(*response.Data.Content)
+	if d, ok := response.Data.(*copilot.AssistantMessageData); ok {
+		fmt.Println(d.Content)
+	}
 }
 ```
 <!-- /docs-validate: hidden -->
@@ -115,7 +117,9 @@ defer client.Stop()
 
 session, _ := client.CreateSession(ctx, &copilot.SessionConfig{Model: "gpt-4.1"})
 response, _ := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: "Hello!"})
-fmt.Println(*response.Data.Content)
+if d, ok := response.Data.(*copilot.AssistantMessageData); ok {
+    fmt.Println(d.Content)
+}
 ```
 
 </details>

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -131,7 +131,7 @@ Ping the server to check connectivity.
 
 Get current connection state.
 
-##### `ListSessionsAsync(): Task<List<SessionMetadata>>`
+##### `ListSessionsAsync(): Task<IList<SessionMetadata>>`
 
 List all available sessions.
 

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -75,7 +75,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     private int? _negotiatedProtocolVersion;
     private List<ModelInfo>? _modelsCache;
     private readonly SemaphoreSlim _modelsCacheLock = new(1, 1);
-    private readonly Func<CancellationToken, Task<List<ModelInfo>>>? _onListModels;
+    private readonly Func<CancellationToken, Task<IList<ModelInfo>>>? _onListModels;
     private readonly List<Action<SessionLifecycleEvent>> _lifecycleHandlers = [];
     private readonly Dictionary<string, List<Action<SessionLifecycleEvent>>> _typedLifecycleHandlers = [];
     private readonly object _lifecycleHandlersLock = new();
@@ -735,7 +735,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     /// The cache is cleared when the client disconnects.
     /// </remarks>
     /// <exception cref="InvalidOperationException">Thrown when the client is not connected or not authenticated.</exception>
-    public async Task<List<ModelInfo>> ListModelsAsync(CancellationToken cancellationToken = default)
+    public async Task<IList<ModelInfo>> ListModelsAsync(CancellationToken cancellationToken = default)
     {
         await _modelsCacheLock.WaitAsync(cancellationToken);
         try
@@ -746,7 +746,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 return [.. _modelsCache]; // Return a copy to prevent cache mutation
             }
 
-            List<ModelInfo> models;
+            IList<ModelInfo> models;
             if (_onListModels is not null)
             {
                 // Use custom handler instead of CLI RPC
@@ -847,7 +847,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     /// }
     /// </code>
     /// </example>
-    public async Task<List<SessionMetadata>> ListSessionsAsync(SessionListFilter? filter = null, CancellationToken cancellationToken = default)
+    public async Task<IList<SessionMetadata>> ListSessionsAsync(SessionListFilter? filter = null, CancellationToken cancellationToken = default)
     {
         var connection = await EnsureConnectedAsync(cancellationToken);
 
@@ -1467,7 +1467,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             client.DispatchLifecycleEvent(evt);
         }
 
-        public async Task<UserInputRequestResponse> OnUserInputRequest(string sessionId, string question, List<string>? choices = null, bool? allowFreeform = null)
+        public async Task<UserInputRequestResponse> OnUserInputRequest(string sessionId, string question, IList<string>? choices = null, bool? allowFreeform = null)
         {
             var session = client.GetSession(sessionId) ?? throw new ArgumentException($"Unknown session {sessionId}");
             var request = new UserInputRequest
@@ -1621,26 +1621,26 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         string? SessionId,
         string? ClientName,
         string? ReasoningEffort,
-        List<ToolDefinition>? Tools,
+        IList<ToolDefinition>? Tools,
         SystemMessageConfig? SystemMessage,
-        List<string>? AvailableTools,
-        List<string>? ExcludedTools,
+        IList<string>? AvailableTools,
+        IList<string>? ExcludedTools,
         ProviderConfig? Provider,
         bool? RequestPermission,
         bool? RequestUserInput,
         bool? Hooks,
         string? WorkingDirectory,
         bool? Streaming,
-        Dictionary<string, McpServerConfig>? McpServers,
+        IDictionary<string, McpServerConfig>? McpServers,
         string? EnvValueMode,
-        List<CustomAgentConfig>? CustomAgents,
+        IList<CustomAgentConfig>? CustomAgents,
         string? Agent,
         string? ConfigDir,
         bool? EnableConfigDiscovery,
-        List<string>? SkillDirectories,
-        List<string>? DisabledSkills,
+        IList<string>? SkillDirectories,
+        IList<string>? DisabledSkills,
         InfiniteSessionConfig? InfiniteSessions,
-        List<CommandWireDefinition>? Commands = null,
+        IList<CommandWireDefinition>? Commands = null,
         bool? RequestElicitation = null,
         string? Traceparent = null,
         string? Tracestate = null,
@@ -1673,10 +1673,10 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         string? ClientName,
         string? Model,
         string? ReasoningEffort,
-        List<ToolDefinition>? Tools,
+        IList<ToolDefinition>? Tools,
         SystemMessageConfig? SystemMessage,
-        List<string>? AvailableTools,
-        List<string>? ExcludedTools,
+        IList<string>? AvailableTools,
+        IList<string>? ExcludedTools,
         ProviderConfig? Provider,
         bool? RequestPermission,
         bool? RequestUserInput,
@@ -1686,14 +1686,14 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         bool? EnableConfigDiscovery,
         bool? DisableResume,
         bool? Streaming,
-        Dictionary<string, McpServerConfig>? McpServers,
+        IDictionary<string, McpServerConfig>? McpServers,
         string? EnvValueMode,
-        List<CustomAgentConfig>? CustomAgents,
+        IList<CustomAgentConfig>? CustomAgents,
         string? Agent,
-        List<string>? SkillDirectories,
-        List<string>? DisabledSkills,
+        IList<string>? SkillDirectories,
+        IList<string>? DisabledSkills,
         InfiniteSessionConfig? InfiniteSessions,
-        List<CommandWireDefinition>? Commands = null,
+        IList<CommandWireDefinition>? Commands = null,
         bool? RequestElicitation = null,
         string? Traceparent = null,
         string? Tracestate = null,

--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -9,6 +9,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using GitHub.Copilot.SDK;
 using StreamJsonRpc;
 
 namespace GitHub.Copilot.SDK.Rpc;

--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -5,6 +5,7 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 // Generated from: api.schema.json
 
+using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -60,7 +61,7 @@ public class ModelCapabilitiesLimitsVision
 {
     /// <summary>MIME types the model accepts.</summary>
     [JsonPropertyName("supported_media_types")]
-    public List<string> SupportedMediaTypes { get => field ??= []; set; }
+    public IList<string> SupportedMediaTypes { get => field ??= []; set; }
 
     /// <summary>Maximum number of images per prompt.</summary>
     [JsonPropertyName("max_prompt_images")]
@@ -148,7 +149,7 @@ public class Model
 
     /// <summary>Supported reasoning effort levels (only present if model supports reasoning effort).</summary>
     [JsonPropertyName("supportedReasoningEfforts")]
-    public List<string>? SupportedReasoningEfforts { get; set; }
+    public IList<string>? SupportedReasoningEfforts { get; set; }
 
     /// <summary>Default reasoning effort level (only present if model supports reasoning effort).</summary>
     [JsonPropertyName("defaultReasoningEffort")]
@@ -160,7 +161,7 @@ public class ModelsListResult
 {
     /// <summary>List of available models with full metadata.</summary>
     [JsonPropertyName("models")]
-    public List<Model> Models { get => field ??= []; set; }
+    public IList<Model> Models { get => field ??= []; set; }
 }
 
 /// <summary>RPC data type for Tool operations.</summary>
@@ -180,7 +181,7 @@ public class Tool
 
     /// <summary>JSON Schema for the tool's input parameters.</summary>
     [JsonPropertyName("parameters")]
-    public Dictionary<string, object>? Parameters { get; set; }
+    public IDictionary<string, object>? Parameters { get; set; }
 
     /// <summary>Optional instructions for how to use this tool effectively.</summary>
     [JsonPropertyName("instructions")]
@@ -192,7 +193,7 @@ public class ToolsListResult
 {
     /// <summary>List of available built-in tools with metadata.</summary>
     [JsonPropertyName("tools")]
-    public List<Tool> Tools { get => field ??= []; set; }
+    public IList<Tool> Tools { get => field ??= []; set; }
 }
 
 /// <summary>RPC data type for ToolsList operations.</summary>
@@ -236,7 +237,7 @@ public class AccountGetQuotaResult
 {
     /// <summary>Quota snapshots keyed by type (e.g., chat, completions, premium_interactions).</summary>
     [JsonPropertyName("quotaSnapshots")]
-    public Dictionary<string, AccountGetQuotaResultQuotaSnapshotsValue> QuotaSnapshots { get => field ??= []; set; }
+    public IDictionary<string, AccountGetQuotaResultQuotaSnapshotsValue> QuotaSnapshots { get => field ??= new Dictionary<string, AccountGetQuotaResultQuotaSnapshotsValue>(); set; }
 }
 
 /// <summary>RPC data type for SessionFsSetProvider operations.</summary>
@@ -313,6 +314,8 @@ internal class SessionLogRequest
     public bool? Ephemeral { get; set; }
 
     /// <summary>Optional URL the user can open in their browser for more details.</summary>
+    [Url]
+    [StringSyntax(StringSyntaxAttribute.Uri)]
     [JsonPropertyName("url")]
     public string? Url { get; set; }
 }
@@ -358,7 +361,7 @@ public class ModelCapabilitiesOverrideLimitsVision
 {
     /// <summary>MIME types the model accepts.</summary>
     [JsonPropertyName("supported_media_types")]
-    public List<string>? SupportedMediaTypes { get; set; }
+    public IList<string>? SupportedMediaTypes { get; set; }
 
     /// <summary>Maximum number of images per prompt.</summary>
     [JsonPropertyName("max_prompt_images")]
@@ -516,7 +519,7 @@ public class SessionWorkspaceListFilesResult
 {
     /// <summary>Relative file paths in the workspace files directory.</summary>
     [JsonPropertyName("files")]
-    public List<string> Files { get => field ??= []; set; }
+    public IList<string> Files { get => field ??= []; set; }
 }
 
 /// <summary>RPC data type for SessionWorkspaceListFiles operations.</summary>
@@ -612,7 +615,7 @@ public class SessionAgentListResult
 {
     /// <summary>Available custom agents.</summary>
     [JsonPropertyName("agents")]
-    public List<Agent> Agents { get => field ??= []; set; }
+    public IList<Agent> Agents { get => field ??= []; set; }
 }
 
 /// <summary>RPC data type for SessionAgentList operations.</summary>
@@ -717,7 +720,7 @@ public class SessionAgentReloadResult
 {
     /// <summary>Reloaded custom agents.</summary>
     [JsonPropertyName("agents")]
-    public List<Agent> Agents { get => field ??= []; set; }
+    public IList<Agent> Agents { get => field ??= []; set; }
 }
 
 /// <summary>RPC data type for SessionAgentReload operations.</summary>
@@ -763,7 +766,7 @@ public class SessionSkillsListResult
 {
     /// <summary>Available skills.</summary>
     [JsonPropertyName("skills")]
-    public List<Skill> Skills { get => field ??= []; set; }
+    public IList<Skill> Skills { get => field ??= []; set; }
 }
 
 /// <summary>RPC data type for SessionSkillsList operations.</summary>
@@ -854,7 +857,7 @@ public class SessionMcpListResult
 {
     /// <summary>Configured MCP servers.</summary>
     [JsonPropertyName("servers")]
-    public List<Server> Servers { get => field ??= []; set; }
+    public IList<Server> Servers { get => field ??= []; set; }
 }
 
 /// <summary>RPC data type for SessionMcpList operations.</summary>
@@ -945,7 +948,7 @@ public class SessionPluginsListResult
 {
     /// <summary>Installed plugins.</summary>
     [JsonPropertyName("plugins")]
-    public List<Plugin> Plugins { get => field ??= []; set; }
+    public IList<Plugin> Plugins { get => field ??= []; set; }
 }
 
 /// <summary>RPC data type for SessionPluginsList operations.</summary>
@@ -978,7 +981,7 @@ public class Extension
 
     /// <summary>Process ID if the extension is running.</summary>
     [JsonPropertyName("pid")]
-    public double? Pid { get; set; }
+    public long? Pid { get; set; }
 }
 
 /// <summary>RPC data type for SessionExtensionsList operations.</summary>
@@ -987,7 +990,7 @@ public class SessionExtensionsListResult
 {
     /// <summary>Discovered extensions and their current status.</summary>
     [JsonPropertyName("extensions")]
-    public List<Extension> Extensions { get => field ??= []; set; }
+    public IList<Extension> Extensions { get => field ??= []; set; }
 }
 
 /// <summary>RPC data type for SessionExtensionsList operations.</summary>
@@ -1113,7 +1116,7 @@ public class SessionUiElicitationResult
 
     /// <summary>The form values submitted by the user (present when action is 'accept').</summary>
     [JsonPropertyName("content")]
-    public Dictionary<string, object>? Content { get; set; }
+    public IDictionary<string, object>? Content { get; set; }
 }
 
 /// <summary>JSON Schema describing the form fields to present to the user.</summary>
@@ -1125,11 +1128,11 @@ public class SessionUiElicitationRequestRequestedSchema
 
     /// <summary>Form field definitions, keyed by field name.</summary>
     [JsonPropertyName("properties")]
-    public Dictionary<string, object> Properties { get => field ??= []; set; }
+    public IDictionary<string, object> Properties { get => field ??= new Dictionary<string, object>(); set; }
 
     /// <summary>List of required field names.</summary>
     [JsonPropertyName("required")]
-    public List<string>? Required { get; set; }
+    public IList<string>? Required { get; set; }
 }
 
 /// <summary>RPC data type for SessionUiElicitation operations.</summary>
@@ -1165,7 +1168,7 @@ public class SessionUiHandlePendingElicitationRequestResult
 
     /// <summary>The form values submitted by the user (present when action is 'accept').</summary>
     [JsonPropertyName("content")]
-    public Dictionary<string, object>? Content { get; set; }
+    public IDictionary<string, object>? Content { get; set; }
 }
 
 /// <summary>RPC data type for SessionUiHandlePendingElicitation operations.</summary>
@@ -1449,7 +1452,7 @@ public class SessionFsReaddirResult
 {
     /// <summary>Entry names in the directory.</summary>
     [JsonPropertyName("entries")]
-    public List<string> Entries { get => field ??= []; set; }
+    public IList<string> Entries { get => field ??= []; set; }
 }
 
 /// <summary>RPC data type for SessionFsReaddir operations.</summary>
@@ -1481,7 +1484,7 @@ public class SessionFsReaddirWithTypesResult
 {
     /// <summary>Directory entries with type information.</summary>
     [JsonPropertyName("entries")]
-    public List<Entry> Entries { get => field ??= []; set; }
+    public IList<Entry> Entries { get => field ??= []; set; }
 }
 
 /// <summary>RPC data type for SessionFsReaddirWithTypes operations.</summary>

--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -9,7 +9,6 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using GitHub.Copilot.SDK;
 using StreamJsonRpc;
 
 namespace GitHub.Copilot.SDK.Rpc;

--- a/dotnet/src/Generated/SessionEvents.cs
+++ b/dotnet/src/Generated/SessionEvents.cs
@@ -5,7 +5,9 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 // Generated from: session-events.schema.json
 
+using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -1196,7 +1198,7 @@ public partial class SessionErrorData
     /// <summary>HTTP status code from the upstream request, if applicable.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("statusCode")]
-    public double? StatusCode { get; set; }
+    public long? StatusCode { get; set; }
 
     /// <summary>GitHub request tracing ID (x-github-request-id header) for correlating with server-side logs.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -1204,6 +1206,8 @@ public partial class SessionErrorData
     public string? ProviderCallId { get; set; }
 
     /// <summary>Optional URL associated with this error that the user can open in a browser.</summary>
+    [Url]
+    [StringSyntax(StringSyntaxAttribute.Uri)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("url")]
     public string? Url { get; set; }
@@ -1238,6 +1242,8 @@ public partial class SessionInfoData
     public required string Message { get; set; }
 
     /// <summary>Optional URL associated with this message that the user can open in a browser.</summary>
+    [Url]
+    [StringSyntax(StringSyntaxAttribute.Uri)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("url")]
     public string? Url { get; set; }
@@ -1255,6 +1261,8 @@ public partial class SessionWarningData
     public required string Message { get; set; }
 
     /// <summary>Optional URL associated with this warning that the user can open in a browser.</summary>
+    [Url]
+    [StringSyntax(StringSyntaxAttribute.Uri)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("url")]
     public string? Url { get; set; }
@@ -1430,7 +1438,7 @@ public partial class SessionShutdownData
 
     /// <summary>Per-model usage breakdown, keyed by model identifier.</summary>
     [JsonPropertyName("modelMetrics")]
-    public required Dictionary<string, object> ModelMetrics { get; set; }
+    public required IDictionary<string, object> ModelMetrics { get; set; }
 
     /// <summary>Model that was selected at the time of shutdown.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -1886,7 +1894,7 @@ public partial class AssistantUsageData
     /// <summary>Per-quota resource usage snapshots, keyed by quota identifier.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("quotaSnapshots")]
-    public Dictionary<string, object>? QuotaSnapshots { get; set; }
+    public IDictionary<string, object>? QuotaSnapshots { get; set; }
 
     /// <summary>Per-request cost and usage data from the CAPI copilot_usage response field.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -2019,7 +2027,7 @@ public partial class ToolExecutionCompleteData
     /// <summary>Tool-specific telemetry data (e.g., CodeQL check counts, grep match counts).</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("toolTelemetry")]
-    public Dictionary<string, object>? ToolTelemetry { get; set; }
+    public IDictionary<string, object>? ToolTelemetry { get; set; }
 
     /// <summary>Tool call ID of the parent tool invocation when this event originates from a sub-agent.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -2383,7 +2391,7 @@ public partial class ElicitationCompletedData
     /// <summary>The submitted form data when action is 'accept'; keys match the requested schema fields.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("content")]
-    public Dictionary<string, object>? Content { get; set; }
+    public IDictionary<string, object>? Content { get; set; }
 }
 
 /// <summary>Sampling request from an MCP server; contains the server name and a requestId for correlation.</summary>
@@ -3270,7 +3278,7 @@ public partial class SystemMessageDataMetadata
     /// <summary>Template variables used when constructing the prompt.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("variables")]
-    public Dictionary<string, object>? Variables { get; set; }
+    public IDictionary<string, object>? Variables { get; set; }
 }
 
 /// <summary>The <c>agent_completed</c> variant of <see cref="SystemNotificationDataKind"/>.</summary>
@@ -3678,7 +3686,7 @@ public partial class ElicitationRequestedDataRequestedSchema
 
     /// <summary>Form field definitions, keyed by field name.</summary>
     [JsonPropertyName("properties")]
-    public required Dictionary<string, object> Properties { get; set; }
+    public required IDictionary<string, object> Properties { get; set; }
 
     /// <summary>List of required field names.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/dotnet/src/MillisecondsTimeSpanConverter.cs
+++ b/dotnet/src/MillisecondsTimeSpanConverter.cs
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GitHub.Copilot.SDK;
+
+/// <summary>Converts between JSON numeric milliseconds and <see cref="TimeSpan"/>.</summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public sealed class MillisecondsTimeSpanConverter : JsonConverter<TimeSpan>
+{
+    /// <inheritdoc />
+    public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        TimeSpan.FromMilliseconds(reader.GetDouble());
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options) =>
+        writer.WriteNumberValue(value.TotalMilliseconds);
+}

--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -1219,7 +1219,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
     {
         public string SessionId { get; init; } = string.Empty;
         public string Prompt { get; init; } = string.Empty;
-        public List<UserMessageDataAttachmentsItem>? Attachments { get; init; }
+        public IList<UserMessageDataAttachmentsItem>? Attachments { get; init; }
         public string? Mode { get; init; }
         public string? Traceparent { get; init; }
         public string? Tracestate { get; init; }
@@ -1237,7 +1237,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
 
     internal record GetMessagesResponse
     {
-        public List<JsonObject> Events { get; init; } = [];
+        public IList<JsonObject> Events { get => field ??= []; init; }
     }
 
     internal record SessionAbortRequest

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -1700,7 +1700,9 @@ public class SessionConfig
         Hooks = other.Hooks;
         InfiniteSessions = other.InfiniteSessions;
         McpServers = other.McpServers is not null
-            ? new Dictionary<string, McpServerConfig>(other.McpServers)
+            ? (other.McpServers is Dictionary<string, McpServerConfig> dict
+                ? new Dictionary<string, McpServerConfig>(dict, dict.Comparer)
+                : new Dictionary<string, McpServerConfig>(other.McpServers))
             : null;
         Model = other.Model;
         ModelCapabilities = other.ModelCapabilities;
@@ -1928,7 +1930,9 @@ public class ResumeSessionConfig
         Hooks = other.Hooks;
         InfiniteSessions = other.InfiniteSessions;
         McpServers = other.McpServers is not null
-            ? new Dictionary<string, McpServerConfig>(other.McpServers)
+            ? (other.McpServers is Dictionary<string, McpServerConfig> dict
+                ? new Dictionary<string, McpServerConfig>(dict, dict.Comparer)
+                : new Dictionary<string, McpServerConfig>(other.McpServers))
             : null;
         Model = other.Model;
         ModelCapabilities = other.ModelCapabilities;

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -149,7 +149,7 @@ public class CopilotClientOptions
     /// querying the CLI server. Useful in BYOK mode to return models
     /// available from your custom provider.
     /// </summary>
-    public Func<CancellationToken, Task<List<ModelInfo>>>? OnListModels { get; set; }
+    public Func<CancellationToken, Task<IList<ModelInfo>>>? OnListModels { get; set; }
 
     /// <summary>
     /// Custom session filesystem provider configuration.
@@ -293,7 +293,7 @@ public class ToolResultObject
     /// Binary results (e.g., images) to be consumed by the language model.
     /// </summary>
     [JsonPropertyName("binaryResultsForLlm")]
-    public List<ToolBinaryResult>? BinaryResultsForLlm { get; set; }
+    public IList<ToolBinaryResult>? BinaryResultsForLlm { get; set; }
 
     /// <summary>
     /// Result type indicator.
@@ -323,7 +323,7 @@ public class ToolResultObject
     /// Custom telemetry data associated with the tool execution.
     /// </summary>
     [JsonPropertyName("toolTelemetry")]
-    public Dictionary<string, object>? ToolTelemetry { get; set; }
+    public IDictionary<string, object>? ToolTelemetry { get; set; }
 
     /// <summary>
     /// Converts the result of an <see cref="AIFunction"/> invocation into a
@@ -540,7 +540,7 @@ public class PermissionRequestResult
     /// Permission rules to apply for the decision.
     /// </summary>
     [JsonPropertyName("rules")]
-    public List<object>? Rules { get; set; }
+    public IList<object>? Rules { get; set; }
 }
 
 /// <summary>
@@ -578,7 +578,7 @@ public class UserInputRequest
     /// Optional choices for multiple choice questions.
     /// </summary>
     [JsonPropertyName("choices")]
-    public List<string>? Choices { get; set; }
+    public IList<string>? Choices { get; set; }
 
     /// <summary>
     /// Whether freeform text input is allowed.
@@ -696,13 +696,13 @@ public class ElicitationSchema
     /// Form field definitions, keyed by field name.
     /// </summary>
     [JsonPropertyName("properties")]
-    public Dictionary<string, object> Properties { get; set; } = [];
+    public IDictionary<string, object> Properties { get => field ??= new Dictionary<string, object>(); set; }
 
     /// <summary>
     /// List of required field names.
     /// </summary>
     [JsonPropertyName("required")]
-    public List<string>? Required { get; set; }
+    public IList<string>? Required { get; set; }
 }
 
 /// <summary>
@@ -734,7 +734,7 @@ public class ElicitationResult
     /// <summary>
     /// Form values submitted by the user (present when <see cref="Action"/> is <c>Accept</c>).
     /// </summary>
-    public Dictionary<string, object>? Content { get; set; }
+    public IDictionary<string, object>? Content { get; set; }
 }
 
 /// <summary>
@@ -1127,7 +1127,7 @@ public class SessionStartHookOutput
     /// Modified session configuration to apply at startup.
     /// </summary>
     [JsonPropertyName("modifiedConfig")]
-    public Dictionary<string, object>? ModifiedConfig { get; set; }
+    public IDictionary<string, object>? ModifiedConfig { get; set; }
 }
 
 /// <summary>
@@ -1193,7 +1193,7 @@ public class SessionEndHookOutput
     /// List of cleanup action identifiers to execute after the session ends.
     /// </summary>
     [JsonPropertyName("cleanupActions")]
-    public List<string>? CleanupActions { get; set; }
+    public IList<string>? CleanupActions { get; set; }
 
     /// <summary>
     /// Summary of the session to persist for future reference.
@@ -1438,7 +1438,7 @@ public class SystemMessageConfig
     /// Section-level overrides for customize mode.
     /// Keys are section identifiers (see <see cref="SystemPromptSections"/>).
     /// </summary>
-    public Dictionary<string, SectionOverride>? Sections { get; set; }
+    public IDictionary<string, SectionOverride>? Sections { get; set; }
 }
 
 /// <summary>
@@ -1517,7 +1517,7 @@ public abstract class McpServerConfig
     /// List of tools to include from this server. Empty list means none. Use "*" for all.
     /// </summary>
     [JsonPropertyName("tools")]
-    public List<string> Tools { get; set; } = [];
+    public IList<string> Tools { get => field ??= []; set; }
 
     /// <summary>
     /// The server type discriminator.
@@ -1551,13 +1551,13 @@ public sealed class McpStdioServerConfig : McpServerConfig
     /// Arguments to pass to the command.
     /// </summary>
     [JsonPropertyName("args")]
-    public List<string> Args { get; set; } = [];
+    public IList<string> Args { get => field ??= []; set; }
 
     /// <summary>
     /// Environment variables to pass to the server.
     /// </summary>
     [JsonPropertyName("env")]
-    public Dictionary<string, string>? Env { get; set; }
+    public IDictionary<string, string>? Env { get; set; }
 
     /// <summary>
     /// Working directory for the server process.
@@ -1585,7 +1585,7 @@ public sealed class McpHttpServerConfig : McpServerConfig
     /// Optional HTTP headers to include in requests.
     /// </summary>
     [JsonPropertyName("headers")]
-    public Dictionary<string, string>? Headers { get; set; }
+    public IDictionary<string, string>? Headers { get; set; }
 }
 
 // ============================================================================
@@ -1619,7 +1619,7 @@ public class CustomAgentConfig
     /// List of tool names the agent can use. Null for all tools.
     /// </summary>
     [JsonPropertyName("tools")]
-    public List<string>? Tools { get; set; }
+    public IList<string>? Tools { get; set; }
 
     /// <summary>
     /// The prompt content for the agent.
@@ -1631,7 +1631,7 @@ public class CustomAgentConfig
     /// MCP servers specific to this agent.
     /// </summary>
     [JsonPropertyName("mcpServers")]
-    public Dictionary<string, McpServerConfig>? McpServers { get; set; }
+    public IDictionary<string, McpServerConfig>? McpServers { get; set; }
 
     /// <summary>
     /// Whether the agent should be available for model inference.
@@ -1700,7 +1700,7 @@ public class SessionConfig
         Hooks = other.Hooks;
         InfiniteSessions = other.InfiniteSessions;
         McpServers = other.McpServers is not null
-            ? new Dictionary<string, McpServerConfig>(other.McpServers, other.McpServers.Comparer)
+            ? new Dictionary<string, McpServerConfig>(other.McpServers)
             : null;
         Model = other.Model;
         ModelCapabilities = other.ModelCapabilities;
@@ -1777,11 +1777,11 @@ public class SessionConfig
     /// <summary>
     /// List of tool names to allow; only these tools will be available when specified.
     /// </summary>
-    public List<string>? AvailableTools { get; set; }
+    public IList<string>? AvailableTools { get; set; }
     /// <summary>
     /// List of tool names to exclude from the session.
     /// </summary>
-    public List<string>? ExcludedTools { get; set; }
+    public IList<string>? ExcludedTools { get; set; }
     /// <summary>
     /// Custom model provider configuration for the session.
     /// </summary>
@@ -1804,7 +1804,7 @@ public class SessionConfig
     /// When the CLI has a TUI, each command appears as <c>/name</c> for the user to invoke.
     /// The handler is called when the user executes the command.
     /// </summary>
-    public List<CommandDefinition>? Commands { get; set; }
+    public IList<CommandDefinition>? Commands { get; set; }
 
     /// <summary>
     /// Handler for elicitation requests from the server or MCP tools.
@@ -1834,12 +1834,12 @@ public class SessionConfig
     /// MCP server configurations for the session.
     /// Keys are server names, values are server configurations (<see cref="McpStdioServerConfig"/> or <see cref="McpHttpServerConfig"/>).
     /// </summary>
-    public Dictionary<string, McpServerConfig>? McpServers { get; set; }
+    public IDictionary<string, McpServerConfig>? McpServers { get; set; }
 
     /// <summary>
     /// Custom agent configurations for the session.
     /// </summary>
-    public List<CustomAgentConfig>? CustomAgents { get; set; }
+    public IList<CustomAgentConfig>? CustomAgents { get; set; }
 
     /// <summary>
     /// Name of the custom agent to activate when the session starts.
@@ -1850,12 +1850,12 @@ public class SessionConfig
     /// <summary>
     /// Directories to load skills from.
     /// </summary>
-    public List<string>? SkillDirectories { get; set; }
+    public IList<string>? SkillDirectories { get; set; }
 
     /// <summary>
     /// List of skill names to disable.
     /// </summary>
-    public List<string>? DisabledSkills { get; set; }
+    public IList<string>? DisabledSkills { get; set; }
 
     /// <summary>
     /// Infinite session configuration for persistent workspaces and automatic compaction.
@@ -1928,7 +1928,7 @@ public class ResumeSessionConfig
         Hooks = other.Hooks;
         InfiniteSessions = other.InfiniteSessions;
         McpServers = other.McpServers is not null
-            ? new Dictionary<string, McpServerConfig>(other.McpServers, other.McpServers.Comparer)
+            ? new Dictionary<string, McpServerConfig>(other.McpServers)
             : null;
         Model = other.Model;
         ModelCapabilities = other.ModelCapabilities;
@@ -1971,13 +1971,13 @@ public class ResumeSessionConfig
     /// List of tool names to allow. When specified, only these tools will be available.
     /// Takes precedence over ExcludedTools.
     /// </summary>
-    public List<string>? AvailableTools { get; set; }
+    public IList<string>? AvailableTools { get; set; }
 
     /// <summary>
     /// List of tool names to disable. All other tools remain available.
     /// Ignored if AvailableTools is specified.
     /// </summary>
-    public List<string>? ExcludedTools { get; set; }
+    public IList<string>? ExcludedTools { get; set; }
 
     /// <summary>
     /// Custom model provider configuration for the resumed session.
@@ -2012,7 +2012,7 @@ public class ResumeSessionConfig
     /// When the CLI has a TUI, each command appears as <c>/name</c> for the user to invoke.
     /// The handler is called when the user executes the command.
     /// </summary>
-    public List<CommandDefinition>? Commands { get; set; }
+    public IList<CommandDefinition>? Commands { get; set; }
 
     /// <summary>
     /// Handler for elicitation requests from the server or MCP tools.
@@ -2066,12 +2066,12 @@ public class ResumeSessionConfig
     /// MCP server configurations for the session.
     /// Keys are server names, values are server configurations (<see cref="McpStdioServerConfig"/> or <see cref="McpHttpServerConfig"/>).
     /// </summary>
-    public Dictionary<string, McpServerConfig>? McpServers { get; set; }
+    public IDictionary<string, McpServerConfig>? McpServers { get; set; }
 
     /// <summary>
     /// Custom agent configurations for the session.
     /// </summary>
-    public List<CustomAgentConfig>? CustomAgents { get; set; }
+    public IList<CustomAgentConfig>? CustomAgents { get; set; }
 
     /// <summary>
     /// Name of the custom agent to activate when the session starts.
@@ -2082,12 +2082,12 @@ public class ResumeSessionConfig
     /// <summary>
     /// Directories to load skills from.
     /// </summary>
-    public List<string>? SkillDirectories { get; set; }
+    public IList<string>? SkillDirectories { get; set; }
 
     /// <summary>
     /// List of skill names to disable.
     /// </summary>
-    public List<string>? DisabledSkills { get; set; }
+    public IList<string>? DisabledSkills { get; set; }
 
     /// <summary>
     /// Infinite session configuration for persistent workspaces and automatic compaction.
@@ -2152,7 +2152,7 @@ public class MessageOptions
     /// <summary>
     /// File or data attachments to include with the message.
     /// </summary>
-    public List<UserMessageDataAttachmentsItem>? Attachments { get; set; }
+    public IList<UserMessageDataAttachmentsItem>? Attachments { get; set; }
     /// <summary>
     /// Interaction mode for the message (e.g., "plan", "edit").
     /// </summary>
@@ -2320,7 +2320,7 @@ public class ModelVisionLimits
     /// List of supported image MIME types (e.g., "image/png", "image/jpeg").
     /// </summary>
     [JsonPropertyName("supported_media_types")]
-    public List<string> SupportedMediaTypes { get; set; } = [];
+    public IList<string> SupportedMediaTypes { get => field ??= []; set; }
 
     /// <summary>
     /// Maximum number of images allowed in a single prompt.
@@ -2452,7 +2452,7 @@ public class ModelInfo
 
     /// <summary>Supported reasoning effort levels (only present if model supports reasoning effort)</summary>
     [JsonPropertyName("supportedReasoningEfforts")]
-    public List<string>? SupportedReasoningEfforts { get; set; }
+    public IList<string>? SupportedReasoningEfforts { get; set; }
 
     /// <summary>Default reasoning effort level (only present if model supports reasoning effort)</summary>
     [JsonPropertyName("defaultReasoningEffort")]
@@ -2468,7 +2468,7 @@ public class GetModelsResponse
     /// List of available models.
     /// </summary>
     [JsonPropertyName("models")]
-    public List<ModelInfo> Models { get; set; } = [];
+    public IList<ModelInfo> Models { get => field ??= []; set; }
 }
 
 // ============================================================================
@@ -2597,7 +2597,7 @@ public class SystemMessageTransformRpcResponse
     /// The transformed sections keyed by section identifier.
     /// </summary>
     [JsonPropertyName("sections")]
-    public Dictionary<string, SystemMessageTransformSection>? Sections { get; set; }
+    public IDictionary<string, SystemMessageTransformSection>? Sections { get; set; }
 }
 
 [JsonSourceGenerationOptions(

--- a/dotnet/test/ClientTests.cs
+++ b/dotnet/test/ClientTests.cs
@@ -278,7 +278,7 @@ public class ClientTests
     [Fact]
     public async Task ListModels_WithCustomHandler_CallsHandler()
     {
-        var customModels = new List<ModelInfo>
+        IList<ModelInfo> customModels = new List<ModelInfo>
         {
             new()
             {
@@ -312,7 +312,7 @@ public class ClientTests
     [Fact]
     public async Task ListModels_WithCustomHandler_CachesResults()
     {
-        var customModels = new List<ModelInfo>
+        IList<ModelInfo> customModels = new List<ModelInfo>
         {
             new()
             {
@@ -345,7 +345,7 @@ public class ClientTests
     [Fact]
     public async Task ListModels_WithCustomHandler_WorksWithoutStart()
     {
-        var customModels = new List<ModelInfo>
+        IList<ModelInfo> customModels = new List<ModelInfo>
         {
             new()
             {

--- a/dotnet/test/ElicitationTests.cs
+++ b/dotnet/test/ElicitationTests.cs
@@ -62,7 +62,7 @@ public class ElicitationTests(E2ETestFixture fixture, ITestOutputHelper output)
                 Message = "Enter name",
                 RequestedSchema = new ElicitationSchema
                 {
-                    Properties = new() { ["name"] = new Dictionary<string, object> { ["type"] = "string" } },
+                    Properties = new Dictionary<string, object>() { ["name"] = new Dictionary<string, object> { ["type"] = "string" } },
                     Required = ["name"],
                 },
             });

--- a/dotnet/test/SessionTests.cs
+++ b/dotnet/test/SessionTests.cs
@@ -397,7 +397,7 @@ public class SessionTests(E2ETestFixture fixture, ITestOutputHelper output) : E2
         var sessions = await Client.ListSessionsAsync();
         Assert.NotEmpty(sessions);
 
-        var ourSession = sessions.Find(s => s.SessionId == session.SessionId);
+        var ourSession = sessions.FirstOrDefault(s => s.SessionId == session.SessionId);
         Assert.NotNull(ourSession);
 
         // Context may be present on sessions that have been persisted with workspace.yaml

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -158,13 +158,25 @@ function schemaTypeToCSharp(schema: JSONSchema7, required: boolean, knownTypes: 
             if (format === "date-time") return "DateTimeOffset?";
             return "string?";
         }
+        if (nonNullTypes.length === 1 && (nonNullTypes[0] === "number" || nonNullTypes[0] === "integer")) {
+            if (format === "duration") {
+                return "TimeSpan?";
+            }
+            return nonNullTypes[0] === "integer" ? "long?" : "double?";
+        }
     }
     if (type === "string") {
         if (format === "uuid") return required ? "Guid" : "Guid?";
         if (format === "date-time") return required ? "DateTimeOffset" : "DateTimeOffset?";
         return required ? "string" : "string?";
     }
-    if (type === "number" || type === "integer") return required ? "double" : "double?";
+    if (type === "number" || type === "integer") {
+        if (format === "duration") {
+            return required ? "TimeSpan" : "TimeSpan?";
+        }
+        if (type === "integer") return required ? "long" : "long?";
+        return required ? "double" : "double?";
+    }
     if (type === "boolean") return required ? "bool" : "bool?";
     if (type === "array") {
         const items = schema.items as JSONSchema7 | undefined;
@@ -174,12 +186,91 @@ function schemaTypeToCSharp(schema: JSONSchema7, required: boolean, knownTypes: 
     if (type === "object") {
         if (schema.additionalProperties && typeof schema.additionalProperties === "object") {
             const valueType = schemaTypeToCSharp(schema.additionalProperties as JSONSchema7, true, knownTypes);
-            return required ? `Dictionary<string, ${valueType}>` : `Dictionary<string, ${valueType}>?`;
+            return required ? `IDictionary<string, ${valueType}>` : `IDictionary<string, ${valueType}>?`;
         }
         return required ? "object" : "object?";
     }
     return required ? "object" : "object?";
 }
+
+/** Tracks whether any TimeSpan property was emitted so the converter can be generated. */
+
+
+/**
+ * Emit C# data-annotation attributes for a JSON Schema property.
+ * Returns an array of attribute lines (without trailing newlines).
+ */
+function emitDataAnnotations(schema: JSONSchema7, indent: string): string[] {
+    const attrs: string[] = [];
+    const format = schema.format;
+
+    // [Url] + [StringSyntax(StringSyntaxAttribute.Uri)] for format: "uri"
+    if (format === "uri") {
+        attrs.push(`${indent}[Url]`);
+        attrs.push(`${indent}[StringSyntax(StringSyntaxAttribute.Uri)]`);
+    }
+
+    // [StringSyntax(StringSyntaxAttribute.Regex)] for format: "regex"
+    if (format === "regex") {
+        attrs.push(`${indent}[StringSyntax(StringSyntaxAttribute.Regex)]`);
+    }
+
+    // [Base64String] for base64-encoded string properties
+    if (format === "byte" || (schema as Record<string, unknown>).contentEncoding === "base64") {
+        attrs.push(`${indent}[Base64String]`);
+    }
+
+    // [Range]for minimum/maximum
+    const hasMin = typeof schema.minimum === "number";
+    const hasMax = typeof schema.maximum === "number";
+    if (hasMin || hasMax) {
+        const min = hasMin ? String(schema.minimum) : (schema.type === "integer" ? "long.MinValue" : "double.MinValue");
+        const max = hasMax ? String(schema.maximum) : (schema.type === "integer" ? "long.MaxValue" : "double.MaxValue");
+        const namedArgs: string[] = [];
+        if (schema.exclusiveMinimum === true) namedArgs.push("MinimumIsExclusive = true");
+        if (schema.exclusiveMaximum === true) namedArgs.push("MaximumIsExclusive = true");
+        const namedSuffix = namedArgs.length > 0 ? `, ${namedArgs.join(", ")}` : "";
+        attrs.push(`${indent}[Range(${min}, ${max}${namedSuffix})]`);
+    }
+
+    // [RegularExpression] for pattern
+    if (typeof schema.pattern === "string") {
+        const escaped = schema.pattern.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+        attrs.push(`${indent}[RegularExpression("${escaped}")]`);
+    }
+
+    // [MinLength] / [MaxLength] for string constraints
+    if (typeof schema.minLength === "number") {
+        attrs.push(`${indent}[MinLength(${schema.minLength})]`);
+    }
+    if (typeof schema.maxLength === "number") {
+        attrs.push(`${indent}[MaxLength(${schema.maxLength})]`);
+    }
+
+    return attrs;
+}
+
+/**
+ * Returns true when a TimeSpan-typed property needs a [JsonConverter] attribute.
+ *
+ * NOTE: The runtime schema uses `format: "duration"` on numeric (integer/number) fields
+ * to mean "a duration value expressed in milliseconds". This differs from the JSON Schema
+ * spec, where `format: "duration"` denotes an ISO 8601 duration string (e.g. "PT1H30M").
+ * The generator and runtime agree on this convention, so we map these to TimeSpan with a
+ * milliseconds-based JSON converter rather than expecting ISO 8601 strings.
+ */
+function isDurationProperty(schema: JSONSchema7): boolean {
+    if (schema.format === "duration") {
+        const t = schema.type;
+        if (t === "number" || t === "integer") return true;
+        if (Array.isArray(t)) {
+            const nonNull = (t as string[]).filter((x) => x !== "null");
+            if (nonNull.length === 1 && (nonNull[0] === "number" || nonNull[0] === "integer")) return true;
+        }
+    }
+    return false;
+}
+
 
 const COPYRIGHT = `/*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
@@ -351,6 +442,8 @@ function generateDerivedClass(
             const csharpType = resolveSessionPropertyType(propSchema as JSONSchema7, className, csharpName, isReq, knownTypes, nestedClasses, enumOutput);
 
             lines.push(...xmlDocPropertyComment((propSchema as JSONSchema7).description, propName, "    "));
+            lines.push(...emitDataAnnotations(propSchema as JSONSchema7, "    "));
+            if (isDurationProperty(propSchema as JSONSchema7)) lines.push(`    [JsonConverter(typeof(MillisecondsTimeSpanConverter))]`);
             if (!isReq) lines.push(`    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`);
             lines.push(`    [JsonPropertyName("${propName}")]`);
             const reqMod = isReq && !csharpType.endsWith("?") ? "required " : "";
@@ -383,6 +476,8 @@ function generateNestedClass(
         const csharpType = resolveSessionPropertyType(prop, className, csharpName, isReq, knownTypes, nestedClasses, enumOutput);
 
         lines.push(...xmlDocPropertyComment(prop.description, propName, "    "));
+        lines.push(...emitDataAnnotations(prop, "    "));
+        if (isDurationProperty(prop)) lines.push(`    [JsonConverter(typeof(MillisecondsTimeSpanConverter))]`);
         if (!isReq) lines.push(`    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`);
         lines.push(`    [JsonPropertyName("${propName}")]`);
         const reqMod = isReq && !csharpType.endsWith("?") ? "required " : "";
@@ -479,6 +574,8 @@ function generateDataClass(variant: EventVariant, knownTypes: Map<string, string
         const csharpType = resolveSessionPropertyType(propSchema as JSONSchema7, variant.dataClassName, csharpName, isReq, knownTypes, nestedClasses, enumOutput);
 
         lines.push(...xmlDocPropertyComment((propSchema as JSONSchema7).description, propName, "    "));
+        lines.push(...emitDataAnnotations(propSchema as JSONSchema7, "    "));
+        if (isDurationProperty(propSchema as JSONSchema7)) lines.push(`    [JsonConverter(typeof(MillisecondsTimeSpanConverter))]`);
         if (!isReq) lines.push(`    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`);
         lines.push(`    [JsonPropertyName("${propName}")]`);
         const reqMod = isReq && !csharpType.endsWith("?") ? "required " : "";
@@ -510,7 +607,9 @@ function generateSessionEventsCode(schema: JSONSchema7): string {
 // AUTO-GENERATED FILE - DO NOT EDIT
 // Generated from: session-events.schema.json
 
+using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -640,20 +739,20 @@ function resolveRpcType(schema: JSONSchema7, isRequired: boolean, parentClassNam
         if (items.type === "object" && items.properties) {
             const itemClass = singularPascal(propName);
             if (!emittedRpcClasses.has(itemClass)) classes.push(emitRpcClass(itemClass, items, "public", classes));
-            return isRequired ? `List<${itemClass}>` : `List<${itemClass}>?`;
+            return isRequired ? `IList<${itemClass}>` : `IList<${itemClass}>?`;
         }
         const itemType = schemaTypeToCSharp(items, true, rpcKnownTypes);
-        return isRequired ? `List<${itemType}>` : `List<${itemType}>?`;
+        return isRequired ? `IList<${itemType}>` : `IList<${itemType}>?`;
     }
     if (schema.type === "object" && schema.additionalProperties && typeof schema.additionalProperties === "object") {
         const vs = schema.additionalProperties as JSONSchema7;
         if (vs.type === "object" && vs.properties) {
             const valClass = `${parentClassName}${propName}Value`;
             classes.push(emitRpcClass(valClass, vs, "public", classes));
-            return isRequired ? `Dictionary<string, ${valClass}>` : `Dictionary<string, ${valClass}>?`;
+            return isRequired ? `IDictionary<string, ${valClass}>` : `IDictionary<string, ${valClass}>?`;
         }
         const valueType = schemaTypeToCSharp(vs, true, rpcKnownTypes);
-        return isRequired ? `Dictionary<string, ${valueType}>` : `Dictionary<string, ${valueType}>?`;
+        return isRequired ? `IDictionary<string, ${valueType}>` : `IDictionary<string, ${valueType}>?`;
     }
     return schemaTypeToCSharp(schema, isRequired, rpcKnownTypes);
 }
@@ -680,6 +779,8 @@ function emitRpcClass(className: string, schema: JSONSchema7, visibility: "publi
         const csharpType = resolveRpcType(prop, isReq, className, csharpName, extraClasses);
 
         lines.push(...xmlDocPropertyComment(prop.description, propName, "    "));
+        lines.push(...emitDataAnnotations(prop, "    "));
+        if (isDurationProperty(prop)) lines.push(`    [JsonConverter(typeof(MillisecondsTimeSpanConverter))]`);
         lines.push(`    [JsonPropertyName("${propName}")]`);
 
         let defaultVal = "";
@@ -687,8 +788,11 @@ function emitRpcClass(className: string, schema: JSONSchema7, visibility: "publi
         if (isReq && !csharpType.endsWith("?")) {
             if (csharpType === "string") defaultVal = " = string.Empty;";
             else if (csharpType === "object") defaultVal = " = null!;";
-            else if (csharpType.startsWith("List<") || csharpType.startsWith("Dictionary<")) {
+            else if (csharpType.startsWith("IList<")) {
                 propAccessors = "{ get => field ??= []; set; }";
+            } else if (csharpType.startsWith("IDictionary<")) {
+                const concreteType = csharpType.replace("IDictionary<", "Dictionary<");
+                propAccessors = `{ get => field ??= new ${concreteType}(); set; }`;
             } else if (emittedRpcClasses.has(csharpType)) {
                 propAccessors = "{ get => field ??= new(); set; }";
             }
@@ -1082,6 +1186,7 @@ function generateRpcCode(schema: ApiSchema): string {
 // AUTO-GENERATED FILE - DO NOT EDIT
 // Generated from: api.schema.json
 
+using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -220,17 +220,24 @@ function emitDataAnnotations(schema: JSONSchema7, indent: string): string[] {
         attrs.push(`${indent}[Base64String]`);
     }
 
-    // [Range]for minimum/maximum
+    // [Range] for minimum/maximum
     const hasMin = typeof schema.minimum === "number";
     const hasMax = typeof schema.maximum === "number";
     if (hasMin || hasMax) {
-        const min = hasMin ? String(schema.minimum) : (schema.type === "integer" ? "long.MinValue" : "double.MinValue");
-        const max = hasMax ? String(schema.maximum) : (schema.type === "integer" ? "long.MaxValue" : "double.MaxValue");
         const namedArgs: string[] = [];
         if (schema.exclusiveMinimum === true) namedArgs.push("MinimumIsExclusive = true");
         if (schema.exclusiveMaximum === true) namedArgs.push("MaximumIsExclusive = true");
         const namedSuffix = namedArgs.length > 0 ? `, ${namedArgs.join(", ")}` : "";
-        attrs.push(`${indent}[Range(${min}, ${max}${namedSuffix})]`);
+        if (schema.type === "integer") {
+            // Use Range(Type, string, string) overload since RangeAttribute has no long constructor
+            const min = hasMin ? String(schema.minimum) : "long.MinValue";
+            const max = hasMax ? String(schema.maximum) : "long.MaxValue";
+            attrs.push(`${indent}[Range(typeof(long), "${min}", "${max}"${namedSuffix})]`);
+        } else {
+            const min = hasMin ? String(schema.minimum) : "double.MinValue";
+            const max = hasMax ? String(schema.maximum) : "double.MaxValue";
+            attrs.push(`${indent}[Range(${min}, ${max}${namedSuffix})]`);
+        }
     }
 
     // [RegularExpression] for pattern
@@ -1190,6 +1197,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using GitHub.Copilot.SDK;
 using StreamJsonRpc;
 
 namespace GitHub.Copilot.SDK.Rpc;

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -1197,7 +1197,6 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using GitHub.Copilot.SDK;
 using StreamJsonRpc;
 
 namespace GitHub.Copilot.SDK.Rpc;


### PR DESCRIPTION
The C# code generator (`scripts/codegen/csharp.ts`) emits types from JSON Schema but was leaving a lot of type information on the table -- using `double` for all numerics, `string` for dates and durations, no validation attributes, and concrete collection types in public APIs. This PR teaches the generator to produce idiomatic, well-annotated C# and applies the same patterns to the hand-written public API surface.

## What changed

**Richer type mappings in the generator:**
- `integer` -> `long` (JSON Schema integers can be up to 2^53, so `int` would be lossy)
- `number` -> `double` (unchanged, but now distinct from integer)
- `format: "date-time"` -> `DateTimeOffset`
- `format: "uuid"` -> `Guid`
- `format: "duration"` on numeric fields -> `TimeSpan` with a `[JsonConverter]` that converts milliseconds (the runtime's convention for duration fields differs from JSON Schema's ISO 8601 string definition -- see comment on `isDurationProperty()`)

**Data annotation attributes:**
- `[Range]` from `minimum`/`maximum`/`exclusiveMinimum`/`exclusiveMaximum`
- `[RegularExpression]` from `pattern`
- `[Url]` and `[StringSyntax(StringSyntaxAttribute.Uri)]` from `format: "uri"`
- `[StringSyntax(StringSyntaxAttribute.Regex)]` from `format: "regex"`
- `[MinLength]`/`[MaxLength]` from `minLength`/`maxLength`
- `[Base64String]` from `contentEncoding: "base64"` or `format: "byte"` (no current schema fields use this yet, but the generator is wired up)

**Collection interfaces in the public API:**
- All `List<T>` properties/returns/parameters -> `IList<T>`
- All `Dictionary<K,V>` -> `IDictionary<K,V>`
- Applied in both generated code and hand-written files (`Types.cs`, `Client.cs`, `Session.cs`)
- Collection properties use lazy initialization (`field ??= []` / `field ??= new Dictionary<>()`) instead of eager allocation

**New file:** `dotnet/src/MillisecondsTimeSpanConverter.cs` -- a standalone `JsonConverter<TimeSpan>` that serializes TimeSpan as milliseconds. Marked `[EditorBrowsable(Never)]` since it's an implementation detail.

## Things to note

- The session-events schema is relatively sparse -- it only has `format: "date-time"` and `format: "uri"`, so `SessionEvents.cs` gets fewer annotations than `Rpc.cs` (which has ranges, patterns, durations, etc.).
- Test changes are mechanical: explicit `IList<T>` types where `Task<T>` invariance requires it, `new Dictionary<>()` where `[]` doesn't work for `IDictionary`, and `.FirstOrDefault()` replacing `List.Find()`.
- The `[DefaultValue]` and `[AllowedValues]` attributes were investigated but not added -- the schemas have almost no `default` values and string enums are already mapped to C# enum types.