### PR TITLE
Add configurable session idle timeout option

### DIFF
--- a/docs/features/session-persistence.md
+++ b/docs/features/session-persistence.md
@@ -441,7 +441,7 @@ const client = new CopilotClient({
 });
 ```
 
-When a timeout is configured, sessions without activity for that duration are automatically cleaned up. The minimum value is 300 seconds (5 minutes). Set to `0` or omit to disable.
+When a timeout is configured, sessions without activity for that duration are automatically cleaned up. Set to `0` or omit to disable.
 
 > **Note:** This option only applies when the SDK spawns the runtime process. When connecting to an existing server via `cliUrl`, the server's own timeout configuration applies.
 

--- a/docs/features/session-persistence.md
+++ b/docs/features/session-persistence.md
@@ -433,15 +433,15 @@ await client.deleteSession("user-123-task-456");
 
 ## Automatic Cleanup: Idle Timeout
 
-By default, sessions have **no idle timeout** and live indefinitely until explicitly disconnected or deleted. You can optionally configure a server-wide idle timeout via `CopilotClientOptions.sessionIdleTimeoutMs`:
+By default, sessions have **no idle timeout** and live indefinitely until explicitly disconnected or deleted. You can optionally configure a server-wide idle timeout via `CopilotClientOptions.sessionIdleTimeoutSeconds`:
 
 ```typescript
 const client = new CopilotClient({
-  sessionIdleTimeoutMs: 30 * 60 * 1000, // 30 minutes
+  sessionIdleTimeoutSeconds: 30 * 60, // 30 minutes
 });
 ```
 
-When a timeout is configured, sessions without activity for that duration are automatically cleaned up. The minimum value is 5 minutes (300,000ms). Set to `0` or omit to disable.
+When a timeout is configured, sessions without activity for that duration are automatically cleaned up. The minimum value is 300 seconds (5 minutes). Set to `0` or omit to disable.
 
 > **Note:** This option only applies when the SDK spawns the runtime process. When connecting to an existing server via `cliUrl`, the server's own timeout configuration applies.
 

--- a/docs/features/session-persistence.md
+++ b/docs/features/session-persistence.md
@@ -433,14 +433,26 @@ await client.deleteSession("user-123-task-456");
 
 ## Automatic Cleanup: Idle Timeout
 
-The CLI has a built-in 30-minute idle timeout. Sessions without activity are automatically cleaned up:
+By default, sessions have **no idle timeout** and live indefinitely until explicitly disconnected or deleted. You can optionally configure a server-wide idle timeout via `CopilotClientOptions.sessionIdleTimeoutMs`:
+
+```typescript
+const client = new CopilotClient({
+  sessionIdleTimeoutMs: 30 * 60 * 1000, // 30 minutes
+});
+```
+
+When a timeout is configured, sessions without activity for that duration are automatically cleaned up. The minimum value is 5 minutes (300,000ms). Set to `0` or omit to disable.
+
+> **Note:** This option only applies when the SDK spawns the runtime process. When connecting to an existing server via `cliUrl`, the server's own timeout configuration applies.
 
 ```mermaid
 flowchart LR
-    A["⚡ Last Activity"] --> B["⏳ 25 min<br/>timeout_warning"] --> C["🧹 30 min<br/>destroyed"]
+    A["⚡ Last Activity"] --> B["⏳ ~5 min before<br/>timeout_warning"] --> C["🧹 Timeout<br/>destroyed"]
 ```
 
-Listen for idle events to know when work completes:
+Sessions with active work (running commands, background agents) are always protected from idle cleanup, regardless of the timeout setting.
+
+Listen for idle events to react to session inactivity:
 
 ```typescript
 session.on("session.idle", (event) => {

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -1190,6 +1190,11 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             args.Add("--no-auto-login");
         }
 
+        if (options.SessionIdleTimeoutSeconds is > 0)
+        {
+            args.AddRange(["--session-idle-timeout", options.SessionIdleTimeoutSeconds.Value.ToString(CultureInfo.InvariantCulture)]);
+        }
+
         var (fileName, processArgs) = ResolveCliCommand(cliPath, args);
 
         var startInfo = new ProcessStartInfo

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -170,7 +170,6 @@ public class CopilotClientOptions
     /// Server-wide idle timeout for sessions in seconds.
     /// Sessions without activity for this duration are automatically cleaned up.
     /// Set to <c>0</c> or leave as <see langword="null"/> to disable (sessions live indefinitely).
-    /// Minimum value: 300 (5 minutes).
     /// This option is only used when the SDK spawns the CLI process; it is ignored
     /// when connecting to an external server via <see cref="CliUrl"/>.
     /// </summary>

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -69,6 +69,7 @@ public class CopilotClientOptions
         UseStdio = other.UseStdio;
         OnListModels = other.OnListModels;
         SessionFs = other.SessionFs;
+        SessionIdleTimeoutSeconds = other.SessionIdleTimeoutSeconds;
     }
 
     /// <summary>
@@ -164,6 +165,16 @@ public class CopilotClientOptions
     /// When set to a non-<see langword="null"/> instance, the CLI server is started with OpenTelemetry instrumentation enabled.
     /// </summary>
     public TelemetryConfig? Telemetry { get; set; }
+
+    /// <summary>
+    /// Server-wide idle timeout for sessions in seconds.
+    /// Sessions without activity for this duration are automatically cleaned up.
+    /// Set to <c>0</c> or leave as <see langword="null"/> to disable (sessions live indefinitely).
+    /// Minimum value: 300 (5 minutes).
+    /// This option is only used when the SDK spawns the CLI process; it is ignored
+    /// when connecting to an external server via <see cref="CliUrl"/>.
+    /// </summary>
+    public int? SessionIdleTimeoutSeconds { get; set; }
 
     /// <summary>
     /// Creates a shallow clone of this <see cref="CopilotClientOptions"/> instance.

--- a/dotnet/test/ClientTests.cs
+++ b/dotnet/test/ClientTests.cs
@@ -217,6 +217,25 @@ public class ClientTests
     }
 
     [Fact]
+    public void Should_Default_SessionIdleTimeoutSeconds_To_Null()
+    {
+        var options = new CopilotClientOptions();
+
+        Assert.Null(options.SessionIdleTimeoutSeconds);
+    }
+
+    [Fact]
+    public void Should_Accept_SessionIdleTimeoutSeconds_Option()
+    {
+        var options = new CopilotClientOptions
+        {
+            SessionIdleTimeoutSeconds = 600
+        };
+
+        Assert.Equal(600, options.SessionIdleTimeoutSeconds);
+    }
+
+    [Fact]
     public async Task Should_Not_Throw_When_Disposing_Session_After_Stopping_Client()
     {
         await using var client = new CopilotClient(new CopilotClientOptions());

--- a/dotnet/test/CloneTests.cs
+++ b/dotnet/test/CloneTests.cs
@@ -26,6 +26,7 @@ public class CloneTests
             Environment = new Dictionary<string, string> { ["KEY"] = "value" },
             GitHubToken = "ghp_test",
             UseLoggedInUser = false,
+            SessionIdleTimeoutSeconds = 600,
         };
 
         var clone = original.Clone();
@@ -42,6 +43,7 @@ public class CloneTests
         Assert.Equal(original.Environment, clone.Environment);
         Assert.Equal(original.GitHubToken, clone.GitHubToken);
         Assert.Equal(original.UseLoggedInUser, clone.UseLoggedInUser);
+        Assert.Equal(original.SessionIdleTimeoutSeconds, clone.SessionIdleTimeoutSeconds);
     }
 
     [Fact]

--- a/go/client.go
+++ b/go/client.go
@@ -218,9 +218,7 @@ func NewClient(options *ClientOptions) *Client {
 		if options.Telemetry != nil {
 			opts.Telemetry = options.Telemetry
 		}
-		if options.SessionIdleTimeoutSeconds > 0 {
-			opts.SessionIdleTimeoutSeconds = options.SessionIdleTimeoutSeconds
-		}
+		opts.SessionIdleTimeoutSeconds = options.SessionIdleTimeoutSeconds
 	}
 
 	// Default Env to current environment if not set

--- a/go/client.go
+++ b/go/client.go
@@ -215,6 +215,12 @@ func NewClient(options *ClientOptions) *Client {
 			sessionFs := *options.SessionFs
 			opts.SessionFs = &sessionFs
 		}
+		if options.Telemetry != nil {
+			opts.Telemetry = options.Telemetry
+		}
+		if options.SessionIdleTimeoutSeconds > 0 {
+			opts.SessionIdleTimeoutSeconds = options.SessionIdleTimeoutSeconds
+		}
 	}
 
 	// Default Env to current environment if not set
@@ -1376,6 +1382,10 @@ func (c *Client) startCLIServer(ctx context.Context) error {
 	}
 	if !useLoggedInUser {
 		args = append(args, "--no-auto-login")
+	}
+
+	if c.options.SessionIdleTimeoutSeconds > 0 {
+		args = append(args, "--session-idle-timeout", strconv.Itoa(c.options.SessionIdleTimeoutSeconds))
 	}
 
 	// If CLIPath is a .js file, run it with node

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -391,6 +391,26 @@ func TestClient_EnvOptions(t *testing.T) {
 	})
 }
 
+func TestClient_SessionIdleTimeoutSeconds(t *testing.T) {
+	t.Run("should store SessionIdleTimeoutSeconds option", func(t *testing.T) {
+		client := NewClient(&ClientOptions{
+			SessionIdleTimeoutSeconds: 600,
+		})
+
+		if client.options.SessionIdleTimeoutSeconds != 600 {
+			t.Errorf("Expected SessionIdleTimeoutSeconds to be 600, got %d", client.options.SessionIdleTimeoutSeconds)
+		}
+	})
+
+	t.Run("should default SessionIdleTimeoutSeconds to zero", func(t *testing.T) {
+		client := NewClient(&ClientOptions{})
+
+		if client.options.SessionIdleTimeoutSeconds != 0 {
+			t.Errorf("Expected SessionIdleTimeoutSeconds to be 0, got %d", client.options.SessionIdleTimeoutSeconds)
+		}
+	})
+}
+
 func findCLIPathForTest() string {
 	abs, _ := filepath.Abs("../nodejs/node_modules/@github/copilot/index.js")
 	if fileExistsForTest(abs) {

--- a/go/types.go
+++ b/go/types.go
@@ -74,7 +74,6 @@ type ClientOptions struct {
 	// SessionIdleTimeoutSeconds configures the server-wide session idle timeout in seconds.
 	// Sessions without activity for this duration are automatically cleaned up.
 	// Set to 0 or leave unset to disable (sessions live indefinitely).
-	// Minimum value: 300 (5 minutes).
 	// This option is only used when the SDK spawns the CLI process; it is ignored
 	// when connecting to an external server via CLIUrl.
 	SessionIdleTimeoutSeconds int

--- a/go/types.go
+++ b/go/types.go
@@ -71,6 +71,13 @@ type ClientOptions struct {
 	// When non-nil, COPILOT_OTEL_ENABLED=true is set and any populated fields
 	// are mapped to the corresponding environment variables.
 	Telemetry *TelemetryConfig
+	// SessionIdleTimeoutSeconds configures the server-wide session idle timeout in seconds.
+	// Sessions without activity for this duration are automatically cleaned up.
+	// Set to 0 or leave unset to disable (sessions live indefinitely).
+	// Minimum value: 300 (5 minutes).
+	// This option is only used when the SDK spawns the CLI process; it is ignored
+	// when connecting to an external server via CLIUrl.
+	SessionIdleTimeoutSeconds int
 }
 
 // TelemetryConfig configures OpenTelemetry integration for the Copilot CLI process.

--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -339,6 +339,7 @@ export class CopilotClient {
             // Default useLoggedInUser to false when githubToken is provided, otherwise true
             useLoggedInUser: options.useLoggedInUser ?? (options.githubToken ? false : true),
             telemetry: options.telemetry,
+            sessionIdleTimeoutMs: options.sessionIdleTimeoutMs ?? 0,
         };
     }
 
@@ -1383,6 +1384,10 @@ export class CopilotClient {
             }
             if (!this.options.useLoggedInUser) {
                 args.push("--no-auto-login");
+            }
+
+            if (this.options.sessionIdleTimeoutMs !== undefined && this.options.sessionIdleTimeoutMs > 0) {
+                args.push("--session-idle-timeout", this.options.sessionIdleTimeoutMs.toString());
             }
 
             // Suppress debug/trace output that might pollute stdout

--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -339,7 +339,7 @@ export class CopilotClient {
             // Default useLoggedInUser to false when githubToken is provided, otherwise true
             useLoggedInUser: options.useLoggedInUser ?? (options.githubToken ? false : true),
             telemetry: options.telemetry,
-            sessionIdleTimeoutMs: options.sessionIdleTimeoutMs ?? 0,
+            sessionIdleTimeoutSeconds: options.sessionIdleTimeoutSeconds ?? 0,
         };
     }
 
@@ -1386,8 +1386,8 @@ export class CopilotClient {
                 args.push("--no-auto-login");
             }
 
-            if (this.options.sessionIdleTimeoutMs !== undefined && this.options.sessionIdleTimeoutMs > 0) {
-                args.push("--session-idle-timeout", this.options.sessionIdleTimeoutMs.toString());
+            if (this.options.sessionIdleTimeoutSeconds !== undefined && this.options.sessionIdleTimeoutSeconds > 0) {
+                args.push("--session-idle-timeout", this.options.sessionIdleTimeoutSeconds.toString());
             }
 
             // Suppress debug/trace output that might pollute stdout

--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -1386,8 +1386,14 @@ export class CopilotClient {
                 args.push("--no-auto-login");
             }
 
-            if (this.options.sessionIdleTimeoutSeconds !== undefined && this.options.sessionIdleTimeoutSeconds > 0) {
-                args.push("--session-idle-timeout", this.options.sessionIdleTimeoutSeconds.toString());
+            if (
+                this.options.sessionIdleTimeoutSeconds !== undefined &&
+                this.options.sessionIdleTimeoutSeconds > 0
+            ) {
+                args.push(
+                    "--session-idle-timeout",
+                    this.options.sessionIdleTimeoutSeconds.toString()
+                );
             }
 
             // Suppress debug/trace output that might pollute stdout

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -190,6 +190,8 @@ export interface CopilotClientOptions {
      * Sessions without activity for this duration are automatically cleaned up.
      * Set to 0 or omit to disable (sessions live indefinitely).
      * Minimum value: 300 (5 minutes).
+     * This option is only used when the SDK spawns the CLI process; it is ignored
+     * when connecting to an external server via {@link cliUrl}.
      * @default undefined (disabled)
      */
     sessionIdleTimeoutSeconds?: number;

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -189,7 +189,6 @@ export interface CopilotClientOptions {
      * Server-wide idle timeout for sessions in seconds.
      * Sessions without activity for this duration are automatically cleaned up.
      * Set to 0 or omit to disable (sessions live indefinitely).
-     * Minimum value: 300 (5 minutes).
      * This option is only used when the SDK spawns the CLI process; it is ignored
      * when connecting to an external server via {@link cliUrl}.
      * @default undefined (disabled)

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -182,6 +182,15 @@ export interface CopilotClientOptions {
      * instead of the server's default local filesystem storage.
      */
     sessionFs?: SessionFsConfig;
+
+    /**
+     * Server-wide idle timeout for sessions in milliseconds.
+     * Sessions without activity for this duration are automatically cleaned up.
+     * Set to 0 or omit to disable (sessions live indefinitely).
+     * Minimum value: 300000 (5 minutes).
+     * @default 0 (disabled)
+     */
+    sessionIdleTimeoutMs?: number;
 }
 
 /**

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -188,7 +188,7 @@ export interface CopilotClientOptions {
      * Sessions without activity for this duration are automatically cleaned up.
      * Set to 0 or omit to disable (sessions live indefinitely).
      * Minimum value: 300 (5 minutes).
-     * @default 0 (disabled)
+     * @default undefined (disabled)
      */
     sessionIdleTimeoutSeconds?: number;
 }

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -184,13 +184,13 @@ export interface CopilotClientOptions {
     sessionFs?: SessionFsConfig;
 
     /**
-     * Server-wide idle timeout for sessions in milliseconds.
+     * Server-wide idle timeout for sessions in seconds.
      * Sessions without activity for this duration are automatically cleaned up.
      * Set to 0 or omit to disable (sessions live indefinitely).
-     * Minimum value: 300000 (5 minutes).
+     * Minimum value: 300 (5 minutes).
      * @default 0 (disabled)
      */
-    sessionIdleTimeoutMs?: number;
+    sessionIdleTimeoutSeconds?: number;
 }
 
 /**

--- a/nodejs/test/client.test.ts
+++ b/nodejs/test/client.test.ts
@@ -1258,4 +1258,23 @@ describe("CopilotClient", () => {
             rpcSpy.mockRestore();
         });
     });
+
+    describe("sessionIdleTimeoutSeconds", () => {
+        it("should default to 0 when not specified", () => {
+            const client = new CopilotClient({
+                logLevel: "error",
+            });
+
+            expect((client as any).options.sessionIdleTimeoutSeconds).toBe(0);
+        });
+
+        it("should store a custom value", () => {
+            const client = new CopilotClient({
+                sessionIdleTimeoutSeconds: 600,
+                logLevel: "error",
+            });
+
+            expect((client as any).options.sessionIdleTimeoutSeconds).toBe(600);
+        });
+    });
 });

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -156,6 +156,7 @@ class SubprocessConfig:
     Sessions without activity for this duration are automatically cleaned up.
     Set to ``None`` or ``0`` to disable (sessions live indefinitely).
     Minimum value: 300 (5 minutes).
+    This option is only used when the SDK spawns the CLI process.
     """
 
 

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -155,7 +155,6 @@ class SubprocessConfig:
 
     Sessions without activity for this duration are automatically cleaned up.
     Set to ``None`` or ``0`` to disable (sessions live indefinitely).
-    Minimum value: 300 (5 minutes).
     This option is only used when the SDK spawns the CLI process.
     """
 

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -150,6 +150,14 @@ class SubprocessConfig:
     session_fs: SessionFsConfig | None = None
     """Connection-level session filesystem provider configuration."""
 
+    session_idle_timeout_seconds: int | None = None
+    """Server-wide session idle timeout in seconds.
+
+    Sessions without activity for this duration are automatically cleaned up.
+    Set to ``None`` or ``0`` to disable (sessions live indefinitely).
+    Minimum value: 300 (5 minutes).
+    """
+
 
 @dataclass
 class ExternalServerConfig:
@@ -2260,6 +2268,9 @@ class CopilotClient:
             args.extend(["--auth-token-env", "COPILOT_SDK_AUTH_TOKEN"])
         if not cfg.use_logged_in_user:
             args.append("--no-auto-login")
+
+        if cfg.session_idle_timeout_seconds is not None and cfg.session_idle_timeout_seconds > 0:
+            args.extend(["--session-idle-timeout", str(cfg.session_idle_timeout_seconds)])
 
         # If cli_path is a .js file, run it with node
         # Note that we can't rely on the shebang as Windows doesn't support it

--- a/python/test_client.py
+++ b/python/test_client.py
@@ -217,9 +217,7 @@ class TestSessionIdleTimeoutSeconds:
         assert client._config.session_idle_timeout_seconds == 600
 
     def test_default_session_idle_timeout_seconds_is_none(self):
-        client = CopilotClient(
-            SubprocessConfig(cli_path=CLI_PATH, log_level="error")
-        )
+        client = CopilotClient(SubprocessConfig(cli_path=CLI_PATH, log_level="error"))
         assert isinstance(client._config, SubprocessConfig)
         assert client._config.session_idle_timeout_seconds is None
 

--- a/python/test_client.py
+++ b/python/test_client.py
@@ -204,6 +204,26 @@ class TestAuthOptions:
         assert client._config.use_logged_in_user is False
 
 
+class TestSessionIdleTimeoutSeconds:
+    def test_accepts_session_idle_timeout_seconds(self):
+        client = CopilotClient(
+            SubprocessConfig(
+                cli_path=CLI_PATH,
+                session_idle_timeout_seconds=600,
+                log_level="error",
+            )
+        )
+        assert isinstance(client._config, SubprocessConfig)
+        assert client._config.session_idle_timeout_seconds == 600
+
+    def test_default_session_idle_timeout_seconds_is_none(self):
+        client = CopilotClient(
+            SubprocessConfig(cli_path=CLI_PATH, log_level="error")
+        )
+        assert isinstance(client._config, SubprocessConfig)
+        assert client._config.session_idle_timeout_seconds is None
+
+
 class TestOverridesBuiltInTool:
     @pytest.mark.asyncio
     async def test_overrides_built_in_tool_sent_in_tool_definition(self):


### PR DESCRIPTION
## Summary

Adds SDK-side support for configurable session idle timeout across all four SDK languages, addressing github/copilot-sdk-partners#28.

The corresponding runtime changes that add the `--session-idle-timeout` CLI arg are in github/copilot-agent-runtime#6414.

## Changes

### Node.js
- **`nodejs/src/types.ts`** -- Added `sessionIdleTimeoutSeconds?: number` to `CopilotClientOptions`.
- **`nodejs/src/client.ts`** -- Defaults to `0` (disabled); passes `--session-idle-timeout <seconds>` to the CLI when positive.
- **`nodejs/test/client.test.ts`** -- Unit tests for default and custom values.

### Go
- **`go/types.go`** -- Added `SessionIdleTimeoutSeconds int` to `ClientOptions`.
- **`go/client.go`** -- Copies the option in `NewClient()` and passes `--session-idle-timeout <seconds>` to the CLI when positive.
- **`go/client_test.go`** -- Unit tests for default and custom values.

### Python
- **`python/copilot/client.py`** -- Added `session_idle_timeout_seconds: int | None = None` to `SubprocessConfig`; passes `--session-idle-timeout <seconds>` to the CLI when positive.
- **`python/test_client.py`** -- Unit tests for default and custom values.

### .NET
- **`dotnet/src/Types.cs`** -- Added `SessionIdleTimeoutSeconds int?` to `CopilotClientOptions` (including copy constructor).
- **`dotnet/src/Client.cs`** -- Passes `--session-idle-timeout <seconds>` to the CLI when positive.
- **`dotnet/test/ClientTests.cs`** -- Unit tests for default and custom values.
- **`dotnet/test/CloneTests.cs`** -- Clone test updated.

### Docs
- **`docs/features/session-persistence.md`** -- Updated the "Automatic Cleanup: Idle Timeout" section to reflect that sessions now have **no idle timeout by default** and document the new option.

## Notes
- This is a `CopilotClientOptions` field (server/process level), not a per-session config.
- The option is only relevant when the SDK spawns the runtime process (not when using `cliUrl` to connect to an existing server).
- Minimum value is 300 seconds (5 minutes); validation is handled by the runtime.
