### PR TITLE
Per-session GitHub authentication for all SDK languages

### DIFF
--- a/docs/auth/index.md
+++ b/docs/auth/index.md
@@ -110,7 +110,7 @@ Use an OAuth GitHub App to authenticate users through your application and pass 
 **How it works:**
 1. User authorizes your OAuth GitHub App
 2. Your app receives a user access token (`gho_` or `ghu_` prefix)
-3. Pass the token to the SDK via `githubToken` option
+3. Pass the token to the SDK via `gitHubToken` option
 
 **SDK Configuration:**
 
@@ -121,7 +121,7 @@ Use an OAuth GitHub App to authenticate users through your application and pass 
 import { CopilotClient } from "@github/copilot-sdk";
 
 const client = new CopilotClient({
-    githubToken: userAccessToken,  // Token from OAuth flow
+    gitHubToken: userAccessToken,  // Token from OAuth flow
     useLoggedInUser: false,        // Don't use stored CLI credentials
 });
 ```
@@ -299,7 +299,7 @@ BYOK allows you to use your own API keys from model providers like Azure AI Foun
 
 When multiple authentication methods are available, the SDK uses them in this priority order:
 
-1. **Explicit `githubToken`** - Token passed directly to SDK constructor
+1. **Explicit `gitHubToken`** - Token passed directly to SDK constructor
 2. **HMAC key** - `CAPI_HMAC_KEY` or `COPILOT_HMAC_KEY` environment variables
 3. **Direct API token** - `GITHUB_COPILOT_API_TOKEN` with `COPILOT_API_URL`
 4. **Environment variable tokens** - `COPILOT_GITHUB_TOKEN` → `GH_TOKEN` → `GITHUB_TOKEN`

--- a/docs/setup/backend-services.md
+++ b/docs/setup/backend-services.md
@@ -290,7 +290,7 @@ Pass individual user tokens when creating sessions. See [GitHub OAuth](./github-
 app.post("/chat", authMiddleware, async (req, res) => {
     const client = new CopilotClient({
         cliUrl: "localhost:4321",
-        githubToken: req.user.githubToken,
+        gitHubToken: req.user.githubToken,
         useLoggedInUser: false,
     });
 

--- a/docs/setup/github-oauth.md
+++ b/docs/setup/github-oauth.md
@@ -26,7 +26,7 @@ sequenceDiagram
     GH-->>App: Access token (gho_xxx)
 
     App->>SDK: Create client with token
-    SDK->>CLI: Start with githubToken
+    SDK->>CLI: Start with gitHubToken
     CLI->>API: Request (as user)
     API-->>CLI: Response
     CLI-->>SDK: Result
@@ -124,7 +124,7 @@ import { CopilotClient } from "@github/copilot-sdk";
 // Create a client for an authenticated user
 function createClientForUser(userToken: string): CopilotClient {
     return new CopilotClient({
-        githubToken: userToken,
+        gitHubToken: userToken,
         useLoggedInUser: false,  // Don't fall back to CLI login
     });
 }
@@ -373,7 +373,7 @@ For GitHub Enterprise Managed Users, the flow is identical — EMU users authent
 // No special SDK configuration needed for EMU
 // Enterprise policies are enforced server-side by GitHub
 const client = new CopilotClient({
-    githubToken: emuUserToken,  // Works the same as regular tokens
+    gitHubToken: emuUserToken,  // Works the same as regular tokens
     useLoggedInUser: false,
 });
 ```
@@ -438,7 +438,7 @@ const clients = new Map<string, CopilotClient>();
 function getClientForUser(userId: string, token: string): CopilotClient {
     if (!clients.has(userId)) {
         clients.set(userId, new CopilotClient({
-            githubToken: token,
+            gitHubToken: token,
             useLoggedInUser: false,
         }));
     }

--- a/docs/troubleshooting/compatibility.md
+++ b/docs/troubleshooting/compatibility.md
@@ -55,7 +55,7 @@ The Copilot SDK communicates with the CLI via JSON-RPC protocol. Features must b
 | Create workspace file | `session.rpc.workspace.createFile()` | Create file in workspace |
 | **Authentication** | | |
 | Get auth status | `getAuthStatus()` | Check login state |
-| Use token | `githubToken` option | Programmatic auth |
+| Use token | `gitHubToken` option | Programmatic auth |
 | **Connectivity** | | |
 | Ping | `client.ping()` | Health check with server timestamp |
 | Get server status | `client.getStatus()` | Protocol version and server info |

--- a/docs/troubleshooting/debugging.md
+++ b/docs/troubleshooting/debugging.md
@@ -268,7 +268,7 @@ var client = new CopilotClient(new CopilotClientOptions
 
    ```typescript
    const client = new CopilotClient({
-     githubToken: process.env.GITHUB_TOKEN,
+     gitHubToken: process.env.GITHUB_TOKEN,
    });
    ```
    </details>

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -1602,7 +1602,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             {
                 return new PermissionRequestResponseV2(new PermissionRequestResult
                 {
-                    Kind = PermissionRequestResultKind.DeniedCouldNotRequestFromUser
+                    Kind = PermissionRequestResultKind.UserNotAvailable
                 });
             }
         }

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -513,7 +513,8 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 RequestElicitation: config.OnElicitationRequest != null,
                 Traceparent: traceparent,
                 Tracestate: tracestate,
-                ModelCapabilities: config.ModelCapabilities);
+                ModelCapabilities: config.ModelCapabilities,
+                GitHubToken: config.GitHubToken);
 
             var response = await InvokeRpcAsync<CreateSessionResponse>(
                 connection.Rpc, "session.create", [request], cancellationToken);
@@ -638,7 +639,8 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 RequestElicitation: config.OnElicitationRequest != null,
                 Traceparent: traceparent,
                 Tracestate: tracestate,
-                ModelCapabilities: config.ModelCapabilities);
+                ModelCapabilities: config.ModelCapabilities,
+                GitHubToken: config.GitHubToken);
 
             var response = await InvokeRpcAsync<ResumeSessionResponse>(
                 connection.Rpc, "session.resume", [request], cancellationToken);
@@ -1661,7 +1663,8 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         bool? RequestElicitation = null,
         string? Traceparent = null,
         string? Tracestate = null,
-        ModelCapabilitiesOverride? ModelCapabilities = null);
+        ModelCapabilitiesOverride? ModelCapabilities = null,
+        string? GitHubToken = null);
 
     internal record ToolDefinition(
         string Name,
@@ -1716,7 +1719,8 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         bool? RequestElicitation = null,
         string? Traceparent = null,
         string? Tracestate = null,
-        ModelCapabilitiesOverride? ModelCapabilities = null);
+        ModelCapabilitiesOverride? ModelCapabilities = null,
+        string? GitHubToken = null);
 
     internal record ResumeSessionResponse(
         string SessionId,

--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -1521,14 +1521,11 @@ public sealed class PermissionRequestResult
 [JsonPolymorphic(
     TypeDiscriminatorPropertyName = "kind",
     UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType)]
-[JsonDerivedType(typeof(PermissionDecisionApproved), "approved")]
-[JsonDerivedType(typeof(PermissionDecisionApprovedForSession), "approved-for-session")]
-[JsonDerivedType(typeof(PermissionDecisionApprovedForLocation), "approved-for-location")]
-[JsonDerivedType(typeof(PermissionDecisionDeniedByRules), "denied-by-rules")]
-[JsonDerivedType(typeof(PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser), "denied-no-approval-rule-and-could-not-request-from-user")]
-[JsonDerivedType(typeof(PermissionDecisionDeniedInteractivelyByUser), "denied-interactively-by-user")]
-[JsonDerivedType(typeof(PermissionDecisionDeniedByContentExclusionPolicy), "denied-by-content-exclusion-policy")]
-[JsonDerivedType(typeof(PermissionDecisionDeniedByPermissionRequestHook), "denied-by-permission-request-hook")]
+[JsonDerivedType(typeof(PermissionDecisionApproveOnce), "approve-once")]
+[JsonDerivedType(typeof(PermissionDecisionApproveForSession), "approve-for-session")]
+[JsonDerivedType(typeof(PermissionDecisionApproveForLocation), "approve-for-location")]
+[JsonDerivedType(typeof(PermissionDecisionReject), "reject")]
+[JsonDerivedType(typeof(PermissionDecisionUserNotAvailable), "user-not-available")]
 public partial class PermissionDecision
 {
     /// <summary>The type discriminator.</summary>
@@ -1537,12 +1534,12 @@ public partial class PermissionDecision
 }
 
 
-/// <summary>The <c>approved</c> variant of <see cref="PermissionDecision"/>.</summary>
-public partial class PermissionDecisionApproved : PermissionDecision
+/// <summary>The <c>approve-once</c> variant of <see cref="PermissionDecision"/>.</summary>
+public partial class PermissionDecisionApproveOnce : PermissionDecision
 {
     /// <inheritdoc />
     [JsonIgnore]
-    public override string Kind => "approved";
+    public override string Kind => "approve-once";
 }
 
 /// <summary>The approval to add as a session-scoped rule.</summary>
@@ -1550,13 +1547,14 @@ public partial class PermissionDecisionApproved : PermissionDecision
 [JsonPolymorphic(
     TypeDiscriminatorPropertyName = "kind",
     UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType)]
-[JsonDerivedType(typeof(PermissionDecisionApprovedForSessionApprovalCommands), "commands")]
-[JsonDerivedType(typeof(PermissionDecisionApprovedForSessionApprovalWrite), "write")]
-[JsonDerivedType(typeof(PermissionDecisionApprovedForSessionApprovalMcp), "mcp")]
-[JsonDerivedType(typeof(PermissionDecisionApprovedForSessionApprovalMcpSampling), "mcp-sampling")]
-[JsonDerivedType(typeof(PermissionDecisionApprovedForSessionApprovalMemory), "memory")]
-[JsonDerivedType(typeof(PermissionDecisionApprovedForSessionApprovalCustomTool), "custom-tool")]
-public partial class PermissionDecisionApprovedForSessionApproval
+[JsonDerivedType(typeof(PermissionDecisionApproveForSessionApprovalCommands), "commands")]
+[JsonDerivedType(typeof(PermissionDecisionApproveForSessionApprovalRead), "read")]
+[JsonDerivedType(typeof(PermissionDecisionApproveForSessionApprovalWrite), "write")]
+[JsonDerivedType(typeof(PermissionDecisionApproveForSessionApprovalMcp), "mcp")]
+[JsonDerivedType(typeof(PermissionDecisionApproveForSessionApprovalMcpSampling), "mcp-sampling")]
+[JsonDerivedType(typeof(PermissionDecisionApproveForSessionApprovalMemory), "memory")]
+[JsonDerivedType(typeof(PermissionDecisionApproveForSessionApprovalCustomTool), "custom-tool")]
+public partial class PermissionDecisionApproveForSessionApproval
 {
     /// <summary>The type discriminator.</summary>
     [JsonPropertyName("kind")]
@@ -1564,8 +1562,8 @@ public partial class PermissionDecisionApprovedForSessionApproval
 }
 
 
-/// <summary>The <c>commands</c> variant of <see cref="PermissionDecisionApprovedForSessionApproval"/>.</summary>
-public partial class PermissionDecisionApprovedForSessionApprovalCommands : PermissionDecisionApprovedForSessionApproval
+/// <summary>The <c>commands</c> variant of <see cref="PermissionDecisionApproveForSessionApproval"/>.</summary>
+public partial class PermissionDecisionApproveForSessionApprovalCommands : PermissionDecisionApproveForSessionApproval
 {
     /// <inheritdoc />
     [JsonIgnore]
@@ -1576,16 +1574,24 @@ public partial class PermissionDecisionApprovedForSessionApprovalCommands : Perm
     public required IList<string> CommandIdentifiers { get; set; }
 }
 
-/// <summary>The <c>write</c> variant of <see cref="PermissionDecisionApprovedForSessionApproval"/>.</summary>
-public partial class PermissionDecisionApprovedForSessionApprovalWrite : PermissionDecisionApprovedForSessionApproval
+/// <summary>The <c>read</c> variant of <see cref="PermissionDecisionApproveForSessionApproval"/>.</summary>
+public partial class PermissionDecisionApproveForSessionApprovalRead : PermissionDecisionApproveForSessionApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "read";
+}
+
+/// <summary>The <c>write</c> variant of <see cref="PermissionDecisionApproveForSessionApproval"/>.</summary>
+public partial class PermissionDecisionApproveForSessionApprovalWrite : PermissionDecisionApproveForSessionApproval
 {
     /// <inheritdoc />
     [JsonIgnore]
     public override string Kind => "write";
 }
 
-/// <summary>The <c>mcp</c> variant of <see cref="PermissionDecisionApprovedForSessionApproval"/>.</summary>
-public partial class PermissionDecisionApprovedForSessionApprovalMcp : PermissionDecisionApprovedForSessionApproval
+/// <summary>The <c>mcp</c> variant of <see cref="PermissionDecisionApproveForSessionApproval"/>.</summary>
+public partial class PermissionDecisionApproveForSessionApprovalMcp : PermissionDecisionApproveForSessionApproval
 {
     /// <inheritdoc />
     [JsonIgnore]
@@ -1600,8 +1606,8 @@ public partial class PermissionDecisionApprovedForSessionApprovalMcp : Permissio
     public string? ToolName { get; set; }
 }
 
-/// <summary>The <c>mcp-sampling</c> variant of <see cref="PermissionDecisionApprovedForSessionApproval"/>.</summary>
-public partial class PermissionDecisionApprovedForSessionApprovalMcpSampling : PermissionDecisionApprovedForSessionApproval
+/// <summary>The <c>mcp-sampling</c> variant of <see cref="PermissionDecisionApproveForSessionApproval"/>.</summary>
+public partial class PermissionDecisionApproveForSessionApprovalMcpSampling : PermissionDecisionApproveForSessionApproval
 {
     /// <inheritdoc />
     [JsonIgnore]
@@ -1612,16 +1618,16 @@ public partial class PermissionDecisionApprovedForSessionApprovalMcpSampling : P
     public required string ServerName { get; set; }
 }
 
-/// <summary>The <c>memory</c> variant of <see cref="PermissionDecisionApprovedForSessionApproval"/>.</summary>
-public partial class PermissionDecisionApprovedForSessionApprovalMemory : PermissionDecisionApprovedForSessionApproval
+/// <summary>The <c>memory</c> variant of <see cref="PermissionDecisionApproveForSessionApproval"/>.</summary>
+public partial class PermissionDecisionApproveForSessionApprovalMemory : PermissionDecisionApproveForSessionApproval
 {
     /// <inheritdoc />
     [JsonIgnore]
     public override string Kind => "memory";
 }
 
-/// <summary>The <c>custom-tool</c> variant of <see cref="PermissionDecisionApprovedForSessionApproval"/>.</summary>
-public partial class PermissionDecisionApprovedForSessionApprovalCustomTool : PermissionDecisionApprovedForSessionApproval
+/// <summary>The <c>custom-tool</c> variant of <see cref="PermissionDecisionApproveForSessionApproval"/>.</summary>
+public partial class PermissionDecisionApproveForSessionApprovalCustomTool : PermissionDecisionApproveForSessionApproval
 {
     /// <inheritdoc />
     [JsonIgnore]
@@ -1632,16 +1638,16 @@ public partial class PermissionDecisionApprovedForSessionApprovalCustomTool : Pe
     public required string ToolName { get; set; }
 }
 
-/// <summary>The <c>approved-for-session</c> variant of <see cref="PermissionDecision"/>.</summary>
-public partial class PermissionDecisionApprovedForSession : PermissionDecision
+/// <summary>The <c>approve-for-session</c> variant of <see cref="PermissionDecision"/>.</summary>
+public partial class PermissionDecisionApproveForSession : PermissionDecision
 {
     /// <inheritdoc />
     [JsonIgnore]
-    public override string Kind => "approved-for-session";
+    public override string Kind => "approve-for-session";
 
     /// <summary>The approval to add as a session-scoped rule.</summary>
     [JsonPropertyName("approval")]
-    public required PermissionDecisionApprovedForSessionApproval Approval { get; set; }
+    public required PermissionDecisionApproveForSessionApproval Approval { get; set; }
 }
 
 /// <summary>The approval to persist for this location.</summary>
@@ -1649,13 +1655,14 @@ public partial class PermissionDecisionApprovedForSession : PermissionDecision
 [JsonPolymorphic(
     TypeDiscriminatorPropertyName = "kind",
     UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType)]
-[JsonDerivedType(typeof(PermissionDecisionApprovedForLocationApprovalCommands), "commands")]
-[JsonDerivedType(typeof(PermissionDecisionApprovedForLocationApprovalWrite), "write")]
-[JsonDerivedType(typeof(PermissionDecisionApprovedForLocationApprovalMcp), "mcp")]
-[JsonDerivedType(typeof(PermissionDecisionApprovedForLocationApprovalMcpSampling), "mcp-sampling")]
-[JsonDerivedType(typeof(PermissionDecisionApprovedForLocationApprovalMemory), "memory")]
-[JsonDerivedType(typeof(PermissionDecisionApprovedForLocationApprovalCustomTool), "custom-tool")]
-public partial class PermissionDecisionApprovedForLocationApproval
+[JsonDerivedType(typeof(PermissionDecisionApproveForLocationApprovalCommands), "commands")]
+[JsonDerivedType(typeof(PermissionDecisionApproveForLocationApprovalRead), "read")]
+[JsonDerivedType(typeof(PermissionDecisionApproveForLocationApprovalWrite), "write")]
+[JsonDerivedType(typeof(PermissionDecisionApproveForLocationApprovalMcp), "mcp")]
+[JsonDerivedType(typeof(PermissionDecisionApproveForLocationApprovalMcpSampling), "mcp-sampling")]
+[JsonDerivedType(typeof(PermissionDecisionApproveForLocationApprovalMemory), "memory")]
+[JsonDerivedType(typeof(PermissionDecisionApproveForLocationApprovalCustomTool), "custom-tool")]
+public partial class PermissionDecisionApproveForLocationApproval
 {
     /// <summary>The type discriminator.</summary>
     [JsonPropertyName("kind")]
@@ -1663,8 +1670,8 @@ public partial class PermissionDecisionApprovedForLocationApproval
 }
 
 
-/// <summary>The <c>commands</c> variant of <see cref="PermissionDecisionApprovedForLocationApproval"/>.</summary>
-public partial class PermissionDecisionApprovedForLocationApprovalCommands : PermissionDecisionApprovedForLocationApproval
+/// <summary>The <c>commands</c> variant of <see cref="PermissionDecisionApproveForLocationApproval"/>.</summary>
+public partial class PermissionDecisionApproveForLocationApprovalCommands : PermissionDecisionApproveForLocationApproval
 {
     /// <inheritdoc />
     [JsonIgnore]
@@ -1675,16 +1682,24 @@ public partial class PermissionDecisionApprovedForLocationApprovalCommands : Per
     public required IList<string> CommandIdentifiers { get; set; }
 }
 
-/// <summary>The <c>write</c> variant of <see cref="PermissionDecisionApprovedForLocationApproval"/>.</summary>
-public partial class PermissionDecisionApprovedForLocationApprovalWrite : PermissionDecisionApprovedForLocationApproval
+/// <summary>The <c>read</c> variant of <see cref="PermissionDecisionApproveForLocationApproval"/>.</summary>
+public partial class PermissionDecisionApproveForLocationApprovalRead : PermissionDecisionApproveForLocationApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "read";
+}
+
+/// <summary>The <c>write</c> variant of <see cref="PermissionDecisionApproveForLocationApproval"/>.</summary>
+public partial class PermissionDecisionApproveForLocationApprovalWrite : PermissionDecisionApproveForLocationApproval
 {
     /// <inheritdoc />
     [JsonIgnore]
     public override string Kind => "write";
 }
 
-/// <summary>The <c>mcp</c> variant of <see cref="PermissionDecisionApprovedForLocationApproval"/>.</summary>
-public partial class PermissionDecisionApprovedForLocationApprovalMcp : PermissionDecisionApprovedForLocationApproval
+/// <summary>The <c>mcp</c> variant of <see cref="PermissionDecisionApproveForLocationApproval"/>.</summary>
+public partial class PermissionDecisionApproveForLocationApprovalMcp : PermissionDecisionApproveForLocationApproval
 {
     /// <inheritdoc />
     [JsonIgnore]
@@ -1699,8 +1714,8 @@ public partial class PermissionDecisionApprovedForLocationApprovalMcp : Permissi
     public string? ToolName { get; set; }
 }
 
-/// <summary>The <c>mcp-sampling</c> variant of <see cref="PermissionDecisionApprovedForLocationApproval"/>.</summary>
-public partial class PermissionDecisionApprovedForLocationApprovalMcpSampling : PermissionDecisionApprovedForLocationApproval
+/// <summary>The <c>mcp-sampling</c> variant of <see cref="PermissionDecisionApproveForLocationApproval"/>.</summary>
+public partial class PermissionDecisionApproveForLocationApprovalMcpSampling : PermissionDecisionApproveForLocationApproval
 {
     /// <inheritdoc />
     [JsonIgnore]
@@ -1711,16 +1726,16 @@ public partial class PermissionDecisionApprovedForLocationApprovalMcpSampling : 
     public required string ServerName { get; set; }
 }
 
-/// <summary>The <c>memory</c> variant of <see cref="PermissionDecisionApprovedForLocationApproval"/>.</summary>
-public partial class PermissionDecisionApprovedForLocationApprovalMemory : PermissionDecisionApprovedForLocationApproval
+/// <summary>The <c>memory</c> variant of <see cref="PermissionDecisionApproveForLocationApproval"/>.</summary>
+public partial class PermissionDecisionApproveForLocationApprovalMemory : PermissionDecisionApproveForLocationApproval
 {
     /// <inheritdoc />
     [JsonIgnore]
     public override string Kind => "memory";
 }
 
-/// <summary>The <c>custom-tool</c> variant of <see cref="PermissionDecisionApprovedForLocationApproval"/>.</summary>
-public partial class PermissionDecisionApprovedForLocationApprovalCustomTool : PermissionDecisionApprovedForLocationApproval
+/// <summary>The <c>custom-tool</c> variant of <see cref="PermissionDecisionApproveForLocationApproval"/>.</summary>
+public partial class PermissionDecisionApproveForLocationApprovalCustomTool : PermissionDecisionApproveForLocationApproval
 {
     /// <inheritdoc />
     [JsonIgnore]
@@ -1731,48 +1746,28 @@ public partial class PermissionDecisionApprovedForLocationApprovalCustomTool : P
     public required string ToolName { get; set; }
 }
 
-/// <summary>The <c>approved-for-location</c> variant of <see cref="PermissionDecision"/>.</summary>
-public partial class PermissionDecisionApprovedForLocation : PermissionDecision
+/// <summary>The <c>approve-for-location</c> variant of <see cref="PermissionDecision"/>.</summary>
+public partial class PermissionDecisionApproveForLocation : PermissionDecision
 {
     /// <inheritdoc />
     [JsonIgnore]
-    public override string Kind => "approved-for-location";
+    public override string Kind => "approve-for-location";
 
     /// <summary>The approval to persist for this location.</summary>
     [JsonPropertyName("approval")]
-    public required PermissionDecisionApprovedForLocationApproval Approval { get; set; }
+    public required PermissionDecisionApproveForLocationApproval Approval { get; set; }
 
     /// <summary>The location key (git root or cwd) to persist the approval to.</summary>
     [JsonPropertyName("locationKey")]
     public required string LocationKey { get; set; }
 }
 
-/// <summary>The <c>denied-by-rules</c> variant of <see cref="PermissionDecision"/>.</summary>
-public partial class PermissionDecisionDeniedByRules : PermissionDecision
+/// <summary>The <c>reject</c> variant of <see cref="PermissionDecision"/>.</summary>
+public partial class PermissionDecisionReject : PermissionDecision
 {
     /// <inheritdoc />
     [JsonIgnore]
-    public override string Kind => "denied-by-rules";
-
-    /// <summary>Rules that denied the request.</summary>
-    [JsonPropertyName("rules")]
-    public required IList<object> Rules { get; set; }
-}
-
-/// <summary>The <c>denied-no-approval-rule-and-could-not-request-from-user</c> variant of <see cref="PermissionDecision"/>.</summary>
-public partial class PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser : PermissionDecision
-{
-    /// <inheritdoc />
-    [JsonIgnore]
-    public override string Kind => "denied-no-approval-rule-and-could-not-request-from-user";
-}
-
-/// <summary>The <c>denied-interactively-by-user</c> variant of <see cref="PermissionDecision"/>.</summary>
-public partial class PermissionDecisionDeniedInteractivelyByUser : PermissionDecision
-{
-    /// <inheritdoc />
-    [JsonIgnore]
-    public override string Kind => "denied-interactively-by-user";
+    public override string Kind => "reject";
 
     /// <summary>Optional feedback from the user explaining the denial.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -1780,38 +1775,12 @@ public partial class PermissionDecisionDeniedInteractivelyByUser : PermissionDec
     public string? Feedback { get; set; }
 }
 
-/// <summary>The <c>denied-by-content-exclusion-policy</c> variant of <see cref="PermissionDecision"/>.</summary>
-public partial class PermissionDecisionDeniedByContentExclusionPolicy : PermissionDecision
+/// <summary>The <c>user-not-available</c> variant of <see cref="PermissionDecision"/>.</summary>
+public partial class PermissionDecisionUserNotAvailable : PermissionDecision
 {
     /// <inheritdoc />
     [JsonIgnore]
-    public override string Kind => "denied-by-content-exclusion-policy";
-
-    /// <summary>Human-readable explanation of why the path was excluded.</summary>
-    [JsonPropertyName("message")]
-    public required string Message { get; set; }
-
-    /// <summary>File path that triggered the exclusion.</summary>
-    [JsonPropertyName("path")]
-    public required string Path { get; set; }
-}
-
-/// <summary>The <c>denied-by-permission-request-hook</c> variant of <see cref="PermissionDecision"/>.</summary>
-public partial class PermissionDecisionDeniedByPermissionRequestHook : PermissionDecision
-{
-    /// <inheritdoc />
-    [JsonIgnore]
-    public override string Kind => "denied-by-permission-request-hook";
-
-    /// <summary>Whether to interrupt the current agent turn.</summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("interrupt")]
-    public bool? Interrupt { get; set; }
-
-    /// <summary>Optional message from the hook explaining the denial.</summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("message")]
-    public string? Message { get; set; }
+    public override string Kind => "user-not-available";
 }
 
 /// <summary>RPC data type for PermissionDecision operations.</summary>
@@ -3880,8 +3849,8 @@ public static class ClientSessionApiRegistration
 [JsonSerializable(typeof(NameGetResult))]
 [JsonSerializable(typeof(NameSetRequest))]
 [JsonSerializable(typeof(PermissionDecision))]
-[JsonSerializable(typeof(PermissionDecisionApprovedForLocationApproval))]
-[JsonSerializable(typeof(PermissionDecisionApprovedForSessionApproval))]
+[JsonSerializable(typeof(PermissionDecisionApproveForLocationApproval))]
+[JsonSerializable(typeof(PermissionDecisionApproveForSessionApproval))]
 [JsonSerializable(typeof(PermissionDecisionRequest))]
 [JsonSerializable(typeof(PermissionRequestResult))]
 [JsonSerializable(typeof(PermissionsResetSessionApprovalsRequest))]

--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -129,7 +129,7 @@ public sealed class ModelPolicy
 
     /// <summary>Usage terms or conditions for this model.</summary>
     [JsonPropertyName("terms")]
-    public string Terms { get; set; } = string.Empty;
+    public string? Terms { get; set; }
 }
 
 /// <summary>RPC data type for Model operations.</summary>
@@ -170,6 +170,14 @@ public sealed class ModelList
     /// <summary>List of available models with full metadata.</summary>
     [JsonPropertyName("models")]
     public IList<Model> Models { get => field ??= []; set; }
+}
+
+/// <summary>RPC data type for ModelsList operations.</summary>
+internal sealed class ModelsListRequest
+{
+    /// <summary>GitHub token for per-user model listing. When provided, resolves this token to determine the user's Copilot plan and available models instead of using the global auth.</summary>
+    [JsonPropertyName("gitHubToken")]
+    public string? GitHubToken { get; set; }
 }
 
 /// <summary>RPC data type for Tool operations.</summary>
@@ -258,6 +266,14 @@ public sealed class AccountGetQuotaResult
     public IDictionary<string, AccountQuotaSnapshot> QuotaSnapshots { get => field ??= new Dictionary<string, AccountQuotaSnapshot>(); set; }
 }
 
+/// <summary>RPC data type for AccountGetQuota operations.</summary>
+internal sealed class AccountGetQuotaRequest
+{
+    /// <summary>GitHub token for per-user quota lookup. When provided, resolves this token to determine the user's quota instead of using the global auth.</summary>
+    [JsonPropertyName("gitHubToken")]
+    public string? GitHubToken { get; set; }
+}
+
 /// <summary>RPC data type for DiscoveredMcpServer operations.</summary>
 public sealed class DiscoveredMcpServer
 {
@@ -266,7 +282,9 @@ public sealed class DiscoveredMcpServer
     public bool Enabled { get; set; }
 
     /// <summary>Server name (config key).</summary>
-    [RegularExpression("^[0-9a-zA-Z_.@-]+(\\/[0-9a-zA-Z_.@-]+)*$")]
+    [RegularExpression("^[^\\x00-\\x1f/\\x7f-\\x9f}]+(?:\\/[^\\x00-\\x1f/\\x7f-\\x9f}]+)*$")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Safe for generated string properties: JSON Schema minLength/maxLength map to string length validation, not reflection over trimmed Count members")]
+    [MinLength(1)]
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
@@ -311,7 +329,9 @@ internal sealed class McpConfigAddRequest
     public object Config { get; set; } = null!;
 
     /// <summary>Unique name for the MCP server.</summary>
-    [RegularExpression("^[0-9a-zA-Z_.@-]+(\\/[0-9a-zA-Z_.@-]+)*$")]
+    [RegularExpression("^[^\\x00-\\x1f/\\x7f-\\x9f}]+(?:\\/[^\\x00-\\x1f/\\x7f-\\x9f}]+)*$")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Safe for generated string properties: JSON Schema minLength/maxLength map to string length validation, not reflection over trimmed Count members")]
+    [MinLength(1)]
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 }
@@ -324,7 +344,9 @@ internal sealed class McpConfigUpdateRequest
     public object Config { get; set; } = null!;
 
     /// <summary>Name of the MCP server to update.</summary>
-    [RegularExpression("^[0-9a-zA-Z_.@-]+(\\/[0-9a-zA-Z_.@-]+)*$")]
+    [RegularExpression("^[^\\x00-\\x1f/\\x7f-\\x9f}]+(?:\\/[^\\x00-\\x1f/\\x7f-\\x9f}]+)*$")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Safe for generated string properties: JSON Schema minLength/maxLength map to string length validation, not reflection over trimmed Count members")]
+    [MinLength(1)]
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 }
@@ -333,9 +355,27 @@ internal sealed class McpConfigUpdateRequest
 internal sealed class McpConfigRemoveRequest
 {
     /// <summary>Name of the MCP server to remove.</summary>
-    [RegularExpression("^[0-9a-zA-Z_.@-]+(\\/[0-9a-zA-Z_.@-]+)*$")]
+    [RegularExpression("^[^\\x00-\\x1f/\\x7f-\\x9f}]+(?:\\/[^\\x00-\\x1f/\\x7f-\\x9f}]+)*$")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Safe for generated string properties: JSON Schema minLength/maxLength map to string length validation, not reflection over trimmed Count members")]
+    [MinLength(1)]
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
+}
+
+/// <summary>RPC data type for McpConfigEnable operations.</summary>
+internal sealed class McpConfigEnableRequest
+{
+    /// <summary>Names of MCP servers to enable. Each server is removed from the persisted disabled list so new sessions spawn it. Unknown or already-enabled names are ignored.</summary>
+    [JsonPropertyName("names")]
+    public IList<string> Names { get => field ??= []; set; }
+}
+
+/// <summary>RPC data type for McpConfigDisable operations.</summary>
+internal sealed class McpConfigDisableRequest
+{
+    /// <summary>Names of MCP servers to disable. Each server is added to the persisted disabled list so new sessions skip it. Already-disabled names are ignored. Active sessions keep their current connections until they end.</summary>
+    [JsonPropertyName("names")]
+    public IList<string> Names { get => field ??= []; set; }
 }
 
 /// <summary>RPC data type for ServerSkill operations.</summary>
@@ -476,6 +516,42 @@ internal sealed class LogRequest
     [StringSyntax(StringSyntaxAttribute.Uri)]
     [JsonPropertyName("url")]
     public string? Url { get; set; }
+}
+
+/// <summary>RPC data type for SessionAuthStatus operations.</summary>
+public sealed class SessionAuthStatus
+{
+    /// <summary>Authentication type.</summary>
+    [JsonPropertyName("authType")]
+    public AuthInfoType? AuthType { get; set; }
+
+    /// <summary>Copilot plan tier (e.g., individual_pro, business).</summary>
+    [JsonPropertyName("copilotPlan")]
+    public string? CopilotPlan { get; set; }
+
+    /// <summary>Authentication host URL.</summary>
+    [JsonPropertyName("host")]
+    public string? Host { get; set; }
+
+    /// <summary>Whether the session has resolved authentication.</summary>
+    [JsonPropertyName("isAuthenticated")]
+    public bool IsAuthenticated { get; set; }
+
+    /// <summary>Authenticated login/username, if available.</summary>
+    [JsonPropertyName("login")]
+    public string? Login { get; set; }
+
+    /// <summary>Human-readable authentication status description.</summary>
+    [JsonPropertyName("statusMessage")]
+    public string? StatusMessage { get; set; }
+}
+
+/// <summary>RPC data type for SessionAuthGetStatus operations.</summary>
+internal sealed class SessionAuthGetStatusRequest
+{
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
 }
 
 /// <summary>RPC data type for CurrentModel operations.</summary>
@@ -1087,7 +1163,9 @@ public sealed class McpServer
     public string? Error { get; set; }
 
     /// <summary>Server name (config key).</summary>
-    [RegularExpression("^[0-9a-zA-Z_.@-]+(\\/[0-9a-zA-Z_.@-]+)*$")]
+    [RegularExpression("^[^\\x00-\\x1f/\\x7f-\\x9f}]+(?:\\/[^\\x00-\\x1f/\\x7f-\\x9f}]+)*$")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Safe for generated string properties: JSON Schema minLength/maxLength map to string length validation, not reflection over trimmed Count members")]
+    [MinLength(1)]
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
@@ -1123,7 +1201,9 @@ internal sealed class SessionMcpListRequest
 internal sealed class McpEnableRequest
 {
     /// <summary>Name of the MCP server to enable.</summary>
-    [RegularExpression("^[0-9a-zA-Z_.@-]+(\\/[0-9a-zA-Z_.@-]+)*$")]
+    [RegularExpression("^[^\\x00-\\x1f/\\x7f-\\x9f}]+(?:\\/[^\\x00-\\x1f/\\x7f-\\x9f}]+)*$")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Safe for generated string properties: JSON Schema minLength/maxLength map to string length validation, not reflection over trimmed Count members")]
+    [MinLength(1)]
     [JsonPropertyName("serverName")]
     public string ServerName { get; set; } = string.Empty;
 
@@ -1137,7 +1217,9 @@ internal sealed class McpEnableRequest
 internal sealed class McpDisableRequest
 {
     /// <summary>Name of the MCP server to disable.</summary>
-    [RegularExpression("^[0-9a-zA-Z_.@-]+(\\/[0-9a-zA-Z_.@-]+)*$")]
+    [RegularExpression("^[^\\x00-\\x1f/\\x7f-\\x9f}]+(?:\\/[^\\x00-\\x1f/\\x7f-\\x9f}]+)*$")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Safe for generated string properties: JSON Schema minLength/maxLength map to string length validation, not reflection over trimmed Count members")]
+    [MinLength(1)]
     [JsonPropertyName("serverName")]
     public string ServerName { get; set; } = string.Empty;
 
@@ -1150,6 +1232,43 @@ internal sealed class McpDisableRequest
 [Experimental(Diagnostics.Experimental)]
 internal sealed class SessionMcpReloadRequest
 {
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>RPC data type for McpOauthLogin operations.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class McpOauthLoginResult
+{
+    /// <summary>URL the caller should open in a browser to complete OAuth. Omitted when cached tokens were still valid and no browser interaction was needed — the server is already reconnected in that case. When present, the runtime starts the callback listener before returning and continues the flow in the background; completion is signaled via session.mcp_server_status_changed.</summary>
+    [JsonPropertyName("authorizationUrl")]
+    public string? AuthorizationUrl { get; set; }
+}
+
+/// <summary>RPC data type for McpOauthLogin operations.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class McpOauthLoginRequest
+{
+    /// <summary>Optional override for the body text shown on the OAuth loopback callback success page. When omitted, the runtime applies a neutral fallback; callers driving interactive auth should pass surface-specific copy telling the user where to return.</summary>
+    [JsonPropertyName("callbackSuccessMessage")]
+    public string? CallbackSuccessMessage { get; set; }
+
+    /// <summary>Optional override for the OAuth client display name shown on the consent screen. Applies to newly registered dynamic clients only — existing registrations keep the name they were created with. When omitted, the runtime applies a neutral fallback; callers driving interactive auth should pass their own surface-specific label so the consent screen matches the product the user sees.</summary>
+    [JsonPropertyName("clientName")]
+    public string? ClientName { get; set; }
+
+    /// <summary>When true, clears any cached OAuth token for the server and runs a full new authorization. Use when the user explicitly wants to switch accounts or believes their session is stuck.</summary>
+    [JsonPropertyName("forceReauth")]
+    public bool? ForceReauth { get; set; }
+
+    /// <summary>Name of the remote MCP server to authenticate.</summary>
+    [RegularExpression("^[^\\x00-\\x1f/\\x7f-\\x9f}]+(?:\\/[^\\x00-\\x1f/\\x7f-\\x9f}]+)*$")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Safe for generated string properties: JSON Schema minLength/maxLength map to string length validation, not reflection over trimmed Count members")]
+    [MinLength(1)]
+    [JsonPropertyName("serverName")]
+    public string ServerName { get; set; } = string.Empty;
+
     /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
@@ -1403,6 +1522,8 @@ public sealed class PermissionRequestResult
     TypeDiscriminatorPropertyName = "kind",
     UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType)]
 [JsonDerivedType(typeof(PermissionDecisionApproved), "approved")]
+[JsonDerivedType(typeof(PermissionDecisionApprovedForSession), "approved-for-session")]
+[JsonDerivedType(typeof(PermissionDecisionApprovedForLocation), "approved-for-location")]
 [JsonDerivedType(typeof(PermissionDecisionDeniedByRules), "denied-by-rules")]
 [JsonDerivedType(typeof(PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser), "denied-no-approval-rule-and-could-not-request-from-user")]
 [JsonDerivedType(typeof(PermissionDecisionDeniedInteractivelyByUser), "denied-interactively-by-user")]
@@ -1424,6 +1545,208 @@ public partial class PermissionDecisionApproved : PermissionDecision
     public override string Kind => "approved";
 }
 
+/// <summary>The approval to add as a session-scoped rule.</summary>
+/// <remarks>Polymorphic base type discriminated by <c>kind</c>.</remarks>
+[JsonPolymorphic(
+    TypeDiscriminatorPropertyName = "kind",
+    UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType)]
+[JsonDerivedType(typeof(PermissionDecisionApprovedForSessionApprovalCommands), "commands")]
+[JsonDerivedType(typeof(PermissionDecisionApprovedForSessionApprovalWrite), "write")]
+[JsonDerivedType(typeof(PermissionDecisionApprovedForSessionApprovalMcp), "mcp")]
+[JsonDerivedType(typeof(PermissionDecisionApprovedForSessionApprovalMcpSampling), "mcp-sampling")]
+[JsonDerivedType(typeof(PermissionDecisionApprovedForSessionApprovalMemory), "memory")]
+[JsonDerivedType(typeof(PermissionDecisionApprovedForSessionApprovalCustomTool), "custom-tool")]
+public partial class PermissionDecisionApprovedForSessionApproval
+{
+    /// <summary>The type discriminator.</summary>
+    [JsonPropertyName("kind")]
+    public virtual string Kind { get; set; } = string.Empty;
+}
+
+
+/// <summary>The <c>commands</c> variant of <see cref="PermissionDecisionApprovedForSessionApproval"/>.</summary>
+public partial class PermissionDecisionApprovedForSessionApprovalCommands : PermissionDecisionApprovedForSessionApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "commands";
+
+    /// <summary>Gets or sets the <c>commandIdentifiers</c> value.</summary>
+    [JsonPropertyName("commandIdentifiers")]
+    public required IList<string> CommandIdentifiers { get; set; }
+}
+
+/// <summary>The <c>write</c> variant of <see cref="PermissionDecisionApprovedForSessionApproval"/>.</summary>
+public partial class PermissionDecisionApprovedForSessionApprovalWrite : PermissionDecisionApprovedForSessionApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "write";
+}
+
+/// <summary>The <c>mcp</c> variant of <see cref="PermissionDecisionApprovedForSessionApproval"/>.</summary>
+public partial class PermissionDecisionApprovedForSessionApprovalMcp : PermissionDecisionApprovedForSessionApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "mcp";
+
+    /// <summary>Gets or sets the <c>serverName</c> value.</summary>
+    [JsonPropertyName("serverName")]
+    public required string ServerName { get; set; }
+
+    /// <summary>Gets or sets the <c>toolName</c> value.</summary>
+    [JsonPropertyName("toolName")]
+    public string? ToolName { get; set; }
+}
+
+/// <summary>The <c>mcp-sampling</c> variant of <see cref="PermissionDecisionApprovedForSessionApproval"/>.</summary>
+public partial class PermissionDecisionApprovedForSessionApprovalMcpSampling : PermissionDecisionApprovedForSessionApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "mcp-sampling";
+
+    /// <summary>Gets or sets the <c>serverName</c> value.</summary>
+    [JsonPropertyName("serverName")]
+    public required string ServerName { get; set; }
+}
+
+/// <summary>The <c>memory</c> variant of <see cref="PermissionDecisionApprovedForSessionApproval"/>.</summary>
+public partial class PermissionDecisionApprovedForSessionApprovalMemory : PermissionDecisionApprovedForSessionApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "memory";
+}
+
+/// <summary>The <c>custom-tool</c> variant of <see cref="PermissionDecisionApprovedForSessionApproval"/>.</summary>
+public partial class PermissionDecisionApprovedForSessionApprovalCustomTool : PermissionDecisionApprovedForSessionApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "custom-tool";
+
+    /// <summary>Gets or sets the <c>toolName</c> value.</summary>
+    [JsonPropertyName("toolName")]
+    public required string ToolName { get; set; }
+}
+
+/// <summary>The <c>approved-for-session</c> variant of <see cref="PermissionDecision"/>.</summary>
+public partial class PermissionDecisionApprovedForSession : PermissionDecision
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "approved-for-session";
+
+    /// <summary>The approval to add as a session-scoped rule.</summary>
+    [JsonPropertyName("approval")]
+    public required PermissionDecisionApprovedForSessionApproval Approval { get; set; }
+}
+
+/// <summary>The approval to persist for this location.</summary>
+/// <remarks>Polymorphic base type discriminated by <c>kind</c>.</remarks>
+[JsonPolymorphic(
+    TypeDiscriminatorPropertyName = "kind",
+    UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType)]
+[JsonDerivedType(typeof(PermissionDecisionApprovedForLocationApprovalCommands), "commands")]
+[JsonDerivedType(typeof(PermissionDecisionApprovedForLocationApprovalWrite), "write")]
+[JsonDerivedType(typeof(PermissionDecisionApprovedForLocationApprovalMcp), "mcp")]
+[JsonDerivedType(typeof(PermissionDecisionApprovedForLocationApprovalMcpSampling), "mcp-sampling")]
+[JsonDerivedType(typeof(PermissionDecisionApprovedForLocationApprovalMemory), "memory")]
+[JsonDerivedType(typeof(PermissionDecisionApprovedForLocationApprovalCustomTool), "custom-tool")]
+public partial class PermissionDecisionApprovedForLocationApproval
+{
+    /// <summary>The type discriminator.</summary>
+    [JsonPropertyName("kind")]
+    public virtual string Kind { get; set; } = string.Empty;
+}
+
+
+/// <summary>The <c>commands</c> variant of <see cref="PermissionDecisionApprovedForLocationApproval"/>.</summary>
+public partial class PermissionDecisionApprovedForLocationApprovalCommands : PermissionDecisionApprovedForLocationApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "commands";
+
+    /// <summary>Gets or sets the <c>commandIdentifiers</c> value.</summary>
+    [JsonPropertyName("commandIdentifiers")]
+    public required IList<string> CommandIdentifiers { get; set; }
+}
+
+/// <summary>The <c>write</c> variant of <see cref="PermissionDecisionApprovedForLocationApproval"/>.</summary>
+public partial class PermissionDecisionApprovedForLocationApprovalWrite : PermissionDecisionApprovedForLocationApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "write";
+}
+
+/// <summary>The <c>mcp</c> variant of <see cref="PermissionDecisionApprovedForLocationApproval"/>.</summary>
+public partial class PermissionDecisionApprovedForLocationApprovalMcp : PermissionDecisionApprovedForLocationApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "mcp";
+
+    /// <summary>Gets or sets the <c>serverName</c> value.</summary>
+    [JsonPropertyName("serverName")]
+    public required string ServerName { get; set; }
+
+    /// <summary>Gets or sets the <c>toolName</c> value.</summary>
+    [JsonPropertyName("toolName")]
+    public string? ToolName { get; set; }
+}
+
+/// <summary>The <c>mcp-sampling</c> variant of <see cref="PermissionDecisionApprovedForLocationApproval"/>.</summary>
+public partial class PermissionDecisionApprovedForLocationApprovalMcpSampling : PermissionDecisionApprovedForLocationApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "mcp-sampling";
+
+    /// <summary>Gets or sets the <c>serverName</c> value.</summary>
+    [JsonPropertyName("serverName")]
+    public required string ServerName { get; set; }
+}
+
+/// <summary>The <c>memory</c> variant of <see cref="PermissionDecisionApprovedForLocationApproval"/>.</summary>
+public partial class PermissionDecisionApprovedForLocationApprovalMemory : PermissionDecisionApprovedForLocationApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "memory";
+}
+
+/// <summary>The <c>custom-tool</c> variant of <see cref="PermissionDecisionApprovedForLocationApproval"/>.</summary>
+public partial class PermissionDecisionApprovedForLocationApprovalCustomTool : PermissionDecisionApprovedForLocationApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "custom-tool";
+
+    /// <summary>Gets or sets the <c>toolName</c> value.</summary>
+    [JsonPropertyName("toolName")]
+    public required string ToolName { get; set; }
+}
+
+/// <summary>The <c>approved-for-location</c> variant of <see cref="PermissionDecision"/>.</summary>
+public partial class PermissionDecisionApprovedForLocation : PermissionDecision
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "approved-for-location";
+
+    /// <summary>The approval to persist for this location.</summary>
+    [JsonPropertyName("approval")]
+    public required PermissionDecisionApprovedForLocationApproval Approval { get; set; }
+
+    /// <summary>The location key (git root or cwd) to persist the approval to.</summary>
+    [JsonPropertyName("locationKey")]
+    public required string LocationKey { get; set; }
+}
+
 /// <summary>The <c>denied-by-rules</c> variant of <see cref="PermissionDecision"/>.</summary>
 public partial class PermissionDecisionDeniedByRules : PermissionDecision
 {
@@ -1433,7 +1756,7 @@ public partial class PermissionDecisionDeniedByRules : PermissionDecision
 
     /// <summary>Rules that denied the request.</summary>
     [JsonPropertyName("rules")]
-    public required object[] Rules { get; set; }
+    public required IList<object> Rules { get; set; }
 }
 
 /// <summary>The <c>denied-no-approval-rule-and-could-not-request-from-user</c> variant of <see cref="PermissionDecision"/>.</summary>
@@ -1502,6 +1825,42 @@ internal sealed class PermissionDecisionRequest
     [JsonPropertyName("result")]
     public PermissionDecision Result { get => field ??= new(); set; }
 
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>RPC data type for PermissionsSetApproveAll operations.</summary>
+public sealed class PermissionsSetApproveAllResult
+{
+    /// <summary>Whether the operation succeeded.</summary>
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+}
+
+/// <summary>RPC data type for PermissionsSetApproveAll operations.</summary>
+internal sealed class PermissionsSetApproveAllRequest
+{
+    /// <summary>Whether to auto-approve all tool permission requests.</summary>
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; }
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>RPC data type for PermissionsResetSessionApprovals operations.</summary>
+public sealed class PermissionsResetSessionApprovalsResult
+{
+    /// <summary>Whether the operation succeeded.</summary>
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+}
+
+/// <summary>RPC data type for PermissionsResetSessionApprovals operations.</summary>
+internal sealed class PermissionsResetSessionApprovalsRequest
+{
     /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
@@ -2097,6 +2456,34 @@ public enum SessionLogLevel
 }
 
 
+/// <summary>Authentication type.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<AuthInfoType>))]
+public enum AuthInfoType
+{
+    /// <summary>The <c>hmac</c> variant.</summary>
+    [JsonStringEnumMemberName("hmac")]
+    Hmac,
+    /// <summary>The <c>env</c> variant.</summary>
+    [JsonStringEnumMemberName("env")]
+    Env,
+    /// <summary>The <c>user</c> variant.</summary>
+    [JsonStringEnumMemberName("user")]
+    User,
+    /// <summary>The <c>gh-cli</c> variant.</summary>
+    [JsonStringEnumMemberName("gh-cli")]
+    GhCli,
+    /// <summary>The <c>api-key</c> variant.</summary>
+    [JsonStringEnumMemberName("api-key")]
+    ApiKey,
+    /// <summary>The <c>token</c> variant.</summary>
+    [JsonStringEnumMemberName("token")]
+    Token,
+    /// <summary>The <c>copilot-api-token</c> variant.</summary>
+    [JsonStringEnumMemberName("copilot-api-token")]
+    CopilotApiToken,
+}
+
+
 /// <summary>The agent mode. Valid values: "interactive", "plan", "autopilot".</summary>
 [JsonConverter(typeof(JsonStringEnumConverter<SessionMode>))]
 public enum SessionMode
@@ -2374,9 +2761,10 @@ public sealed class ServerModelsApi
     }
 
     /// <summary>Calls "models.list".</summary>
-    public async Task<ModelList> ListAsync(CancellationToken cancellationToken = default)
+    public async Task<ModelList> ListAsync(string? gitHubToken = null, CancellationToken cancellationToken = default)
     {
-        return await CopilotClient.InvokeRpcAsync<ModelList>(_rpc, "models.list", [], cancellationToken);
+        var request = new ModelsListRequest { GitHubToken = gitHubToken };
+        return await CopilotClient.InvokeRpcAsync<ModelList>(_rpc, "models.list", [request], cancellationToken);
     }
 }
 
@@ -2409,9 +2797,10 @@ public sealed class ServerAccountApi
     }
 
     /// <summary>Calls "account.getQuota".</summary>
-    public async Task<AccountGetQuotaResult> GetQuotaAsync(CancellationToken cancellationToken = default)
+    public async Task<AccountGetQuotaResult> GetQuotaAsync(string? gitHubToken = null, CancellationToken cancellationToken = default)
     {
-        return await CopilotClient.InvokeRpcAsync<AccountGetQuotaResult>(_rpc, "account.getQuota", [], cancellationToken);
+        var request = new AccountGetQuotaRequest { GitHubToken = gitHubToken };
+        return await CopilotClient.InvokeRpcAsync<AccountGetQuotaResult>(_rpc, "account.getQuota", [request], cancellationToken);
     }
 }
 
@@ -2472,6 +2861,20 @@ public sealed class ServerMcpConfigApi
     {
         var request = new McpConfigRemoveRequest { Name = name };
         await CopilotClient.InvokeRpcAsync(_rpc, "mcp.config.remove", [request], cancellationToken);
+    }
+
+    /// <summary>Calls "mcp.config.enable".</summary>
+    public async Task EnableAsync(IList<string> names, CancellationToken cancellationToken = default)
+    {
+        var request = new McpConfigEnableRequest { Names = names };
+        await CopilotClient.InvokeRpcAsync(_rpc, "mcp.config.enable", [request], cancellationToken);
+    }
+
+    /// <summary>Calls "mcp.config.disable".</summary>
+    public async Task DisableAsync(IList<string> names, CancellationToken cancellationToken = default)
+    {
+        var request = new McpConfigDisableRequest { Names = names };
+        await CopilotClient.InvokeRpcAsync(_rpc, "mcp.config.disable", [request], cancellationToken);
     }
 }
 
@@ -2562,6 +2965,7 @@ public sealed class SessionRpc
     {
         _rpc = rpc;
         _sessionId = sessionId;
+        Auth = new AuthApi(rpc, sessionId);
         Model = new ModelApi(rpc, sessionId);
         Mode = new ModeApi(rpc, sessionId);
         Name = new NameApi(rpc, sessionId);
@@ -2582,6 +2986,9 @@ public sealed class SessionRpc
         History = new HistoryApi(rpc, sessionId);
         Usage = new UsageApi(rpc, sessionId);
     }
+
+    /// <summary>Auth APIs.</summary>
+    public AuthApi Auth { get; }
 
     /// <summary>Model APIs.</summary>
     public ModelApi Model { get; }
@@ -2645,6 +3052,26 @@ public sealed class SessionRpc
     {
         var request = new LogRequest { SessionId = _sessionId, Message = message, Level = level, Ephemeral = ephemeral, Url = url };
         return await CopilotClient.InvokeRpcAsync<LogResult>(_rpc, "session.log", [request], cancellationToken);
+    }
+}
+
+/// <summary>Provides session-scoped Auth APIs.</summary>
+public sealed class AuthApi
+{
+    private readonly JsonRpc _rpc;
+    private readonly string _sessionId;
+
+    internal AuthApi(JsonRpc rpc, string sessionId)
+    {
+        _rpc = rpc;
+        _sessionId = sessionId;
+    }
+
+    /// <summary>Calls "session.auth.getStatus".</summary>
+    public async Task<SessionAuthStatus> GetStatusAsync(CancellationToken cancellationToken = default)
+    {
+        var request = new SessionAuthGetStatusRequest { SessionId = _sessionId };
+        return await CopilotClient.InvokeRpcAsync<SessionAuthStatus>(_rpc, "session.auth.getStatus", [request], cancellationToken);
     }
 }
 
@@ -2947,6 +3374,7 @@ public sealed class McpApi
     {
         _rpc = rpc;
         _sessionId = sessionId;
+        Oauth = new McpOauthApi(rpc, sessionId);
     }
 
     /// <summary>Calls "session.mcp.list".</summary>
@@ -2975,6 +3403,30 @@ public sealed class McpApi
     {
         var request = new SessionMcpReloadRequest { SessionId = _sessionId };
         await CopilotClient.InvokeRpcAsync(_rpc, "session.mcp.reload", [request], cancellationToken);
+    }
+
+    /// <summary>Oauth APIs.</summary>
+    public McpOauthApi Oauth { get; }
+}
+
+/// <summary>Provides session-scoped McpOauth APIs.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class McpOauthApi
+{
+    private readonly JsonRpc _rpc;
+    private readonly string _sessionId;
+
+    internal McpOauthApi(JsonRpc rpc, string sessionId)
+    {
+        _rpc = rpc;
+        _sessionId = sessionId;
+    }
+
+    /// <summary>Calls "session.mcp.oauth.login".</summary>
+    public async Task<McpOauthLoginResult> LoginAsync(string serverName, bool? forceReauth = null, string? clientName = null, string? callbackSuccessMessage = null, CancellationToken cancellationToken = default)
+    {
+        var request = new McpOauthLoginRequest { SessionId = _sessionId, ServerName = serverName, ForceReauth = forceReauth, ClientName = clientName, CallbackSuccessMessage = callbackSuccessMessage };
+        return await CopilotClient.InvokeRpcAsync<McpOauthLoginResult>(_rpc, "session.mcp.oauth.login", [request], cancellationToken);
     }
 }
 
@@ -3125,6 +3577,20 @@ public sealed class PermissionsApi
     {
         var request = new PermissionDecisionRequest { SessionId = _sessionId, RequestId = requestId, Result = result };
         return await CopilotClient.InvokeRpcAsync<PermissionRequestResult>(_rpc, "session.permissions.handlePendingPermissionRequest", [request], cancellationToken);
+    }
+
+    /// <summary>Calls "session.permissions.setApproveAll".</summary>
+    public async Task<PermissionsSetApproveAllResult> SetApproveAllAsync(bool enabled, CancellationToken cancellationToken = default)
+    {
+        var request = new PermissionsSetApproveAllRequest { SessionId = _sessionId, Enabled = enabled };
+        return await CopilotClient.InvokeRpcAsync<PermissionsSetApproveAllResult>(_rpc, "session.permissions.setApproveAll", [request], cancellationToken);
+    }
+
+    /// <summary>Calls "session.permissions.resetSessionApprovals".</summary>
+    public async Task<PermissionsResetSessionApprovalsResult> ResetSessionApprovalsAsync(CancellationToken cancellationToken = default)
+    {
+        var request = new PermissionsResetSessionApprovalsRequest { SessionId = _sessionId };
+        return await CopilotClient.InvokeRpcAsync<PermissionsResetSessionApprovalsResult>(_rpc, "session.permissions.resetSessionApprovals", [request], cancellationToken);
     }
 }
 
@@ -3353,6 +3819,7 @@ public static class ClientSessionApiRegistration
     JsonSerializerDefaults.Web,
     AllowOutOfOrderMetadataProperties = true,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(AccountGetQuotaRequest))]
 [JsonSerializable(typeof(AccountGetQuotaResult))]
 [JsonSerializable(typeof(AccountQuotaSnapshot))]
 [JsonSerializable(typeof(AgentGetCurrentResult))]
@@ -3381,6 +3848,8 @@ public static class ClientSessionApiRegistration
 [JsonSerializable(typeof(LogRequest))]
 [JsonSerializable(typeof(LogResult))]
 [JsonSerializable(typeof(McpConfigAddRequest))]
+[JsonSerializable(typeof(McpConfigDisableRequest))]
+[JsonSerializable(typeof(McpConfigEnableRequest))]
 [JsonSerializable(typeof(McpConfigList))]
 [JsonSerializable(typeof(McpConfigRemoveRequest))]
 [JsonSerializable(typeof(McpConfigUpdateRequest))]
@@ -3388,6 +3857,8 @@ public static class ClientSessionApiRegistration
 [JsonSerializable(typeof(McpDiscoverRequest))]
 [JsonSerializable(typeof(McpDiscoverResult))]
 [JsonSerializable(typeof(McpEnableRequest))]
+[JsonSerializable(typeof(McpOauthLoginRequest))]
+[JsonSerializable(typeof(McpOauthLoginResult))]
 [JsonSerializable(typeof(McpServer))]
 [JsonSerializable(typeof(McpServerList))]
 [JsonSerializable(typeof(ModeSetRequest))]
@@ -3405,11 +3876,18 @@ public static class ClientSessionApiRegistration
 [JsonSerializable(typeof(ModelPolicy))]
 [JsonSerializable(typeof(ModelSwitchToRequest))]
 [JsonSerializable(typeof(ModelSwitchToResult))]
+[JsonSerializable(typeof(ModelsListRequest))]
 [JsonSerializable(typeof(NameGetResult))]
 [JsonSerializable(typeof(NameSetRequest))]
 [JsonSerializable(typeof(PermissionDecision))]
+[JsonSerializable(typeof(PermissionDecisionApprovedForLocationApproval))]
+[JsonSerializable(typeof(PermissionDecisionApprovedForSessionApproval))]
 [JsonSerializable(typeof(PermissionDecisionRequest))]
 [JsonSerializable(typeof(PermissionRequestResult))]
+[JsonSerializable(typeof(PermissionsResetSessionApprovalsRequest))]
+[JsonSerializable(typeof(PermissionsResetSessionApprovalsResult))]
+[JsonSerializable(typeof(PermissionsSetApproveAllRequest))]
+[JsonSerializable(typeof(PermissionsSetApproveAllResult))]
 [JsonSerializable(typeof(PingRequest))]
 [JsonSerializable(typeof(PingResult))]
 [JsonSerializable(typeof(PlanReadResult))]
@@ -3422,6 +3900,8 @@ public static class ClientSessionApiRegistration
 [JsonSerializable(typeof(SessionAgentGetCurrentRequest))]
 [JsonSerializable(typeof(SessionAgentListRequest))]
 [JsonSerializable(typeof(SessionAgentReloadRequest))]
+[JsonSerializable(typeof(SessionAuthGetStatusRequest))]
+[JsonSerializable(typeof(SessionAuthStatus))]
 [JsonSerializable(typeof(SessionExtensionsListRequest))]
 [JsonSerializable(typeof(SessionExtensionsReloadRequest))]
 [JsonSerializable(typeof(SessionFsAppendFileRequest))]

--- a/dotnet/src/Generated/SessionEvents.cs
+++ b/dotnet/src/Generated/SessionEvents.cs
@@ -33,6 +33,8 @@ namespace GitHub.Copilot.SDK;
 [JsonDerivedType(typeof(AssistantTurnEndEvent), "assistant.turn_end")]
 [JsonDerivedType(typeof(AssistantTurnStartEvent), "assistant.turn_start")]
 [JsonDerivedType(typeof(AssistantUsageEvent), "assistant.usage")]
+[JsonDerivedType(typeof(AutoModeSwitchCompletedEvent), "auto_mode_switch.completed")]
+[JsonDerivedType(typeof(AutoModeSwitchRequestedEvent), "auto_mode_switch.requested")]
 [JsonDerivedType(typeof(CapabilitiesChangedEvent), "capabilities.changed")]
 [JsonDerivedType(typeof(CommandCompletedEvent), "command.completed")]
 [JsonDerivedType(typeof(CommandExecuteEvent), "command.execute")]
@@ -952,6 +954,32 @@ public partial class CommandCompletedEvent : SessionEvent
     public required CommandCompletedData Data { get; set; }
 }
 
+/// <summary>Auto mode switch request notification requiring user approval.</summary>
+/// <remarks>Represents the <c>auto_mode_switch.requested</c> event.</remarks>
+public partial class AutoModeSwitchRequestedEvent : SessionEvent
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Type => "auto_mode_switch.requested";
+
+    /// <summary>The <c>auto_mode_switch.requested</c> event payload.</summary>
+    [JsonPropertyName("data")]
+    public required AutoModeSwitchRequestedData Data { get; set; }
+}
+
+/// <summary>Auto mode switch completion notification.</summary>
+/// <remarks>Represents the <c>auto_mode_switch.completed</c> event.</remarks>
+public partial class AutoModeSwitchCompletedEvent : SessionEvent
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Type => "auto_mode_switch.completed";
+
+    /// <summary>The <c>auto_mode_switch.completed</c> event payload.</summary>
+    [JsonPropertyName("data")]
+    public required AutoModeSwitchCompletedData Data { get; set; }
+}
+
 /// <summary>SDK command registration change notification.</summary>
 /// <remarks>Represents the <c>commands.changed</c> event.</remarks>
 public partial class CommandsChangedEvent : SessionEvent
@@ -1580,7 +1608,7 @@ public partial class SessionCompactionCompleteData
     [JsonPropertyName("checkpointPath")]
     public string? CheckpointPath { get; set; }
 
-    /// <summary>Token usage breakdown for the compaction LLM call.</summary>
+    /// <summary>Token usage breakdown for the compaction LLM call (aligned with assistant.usage format).</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("compactionTokensUsed")]
     public CompactionCompleteCompactionTokensUsed? CompactionTokensUsed { get; set; }
@@ -2558,6 +2586,31 @@ public partial class CommandCompletedData
     public required string RequestId { get; set; }
 }
 
+/// <summary>Auto mode switch request notification requiring user approval.</summary>
+public partial class AutoModeSwitchRequestedData
+{
+    /// <summary>The rate limit error code that triggered this request.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("errorCode")]
+    public string? ErrorCode { get; set; }
+
+    /// <summary>Unique identifier for this request; used to respond via session.respondToAutoModeSwitch().</summary>
+    [JsonPropertyName("requestId")]
+    public required string RequestId { get; set; }
+}
+
+/// <summary>Auto mode switch completion notification.</summary>
+public partial class AutoModeSwitchCompletedData
+{
+    /// <summary>Request ID of the resolved request; clients should dismiss any UI for this request.</summary>
+    [JsonPropertyName("requestId")]
+    public required string RequestId { get; set; }
+
+    /// <summary>The user's choice: 'yes', 'yes_always', or 'no'.</summary>
+    [JsonPropertyName("response")]
+    public required string Response { get; set; }
+}
+
 /// <summary>SDK command registration change notification.</summary>
 public partial class CommandsChangedData
 {
@@ -2822,21 +2875,78 @@ public partial class ShutdownModelMetric
     public required ShutdownModelMetricUsage Usage { get; set; }
 }
 
-/// <summary>Token usage breakdown for the compaction LLM call.</summary>
+/// <summary>Token usage detail for a single billing category.</summary>
+/// <remarks>Nested data type for <c>CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail</c>.</remarks>
+public partial class CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail
+{
+    /// <summary>Number of tokens in this billing batch.</summary>
+    [JsonPropertyName("batchSize")]
+    public required double BatchSize { get; set; }
+
+    /// <summary>Cost per batch of tokens.</summary>
+    [JsonPropertyName("costPerBatch")]
+    public required double CostPerBatch { get; set; }
+
+    /// <summary>Total token count for this entry.</summary>
+    [JsonPropertyName("tokenCount")]
+    public required double TokenCount { get; set; }
+
+    /// <summary>Token category (e.g., "input", "output").</summary>
+    [JsonPropertyName("tokenType")]
+    public required string TokenType { get; set; }
+}
+
+/// <summary>Per-request cost and usage data from the CAPI copilot_usage response field.</summary>
+/// <remarks>Nested data type for <c>CompactionCompleteCompactionTokensUsedCopilotUsage</c>.</remarks>
+public partial class CompactionCompleteCompactionTokensUsedCopilotUsage
+{
+    /// <summary>Itemized token usage breakdown.</summary>
+    [JsonPropertyName("tokenDetails")]
+    public required CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail[] TokenDetails { get; set; }
+
+    /// <summary>Total cost in nano-AIU (AI Units) for this request.</summary>
+    [JsonPropertyName("totalNanoAiu")]
+    public required double TotalNanoAiu { get; set; }
+}
+
+/// <summary>Token usage breakdown for the compaction LLM call (aligned with assistant.usage format).</summary>
 /// <remarks>Nested data type for <c>CompactionCompleteCompactionTokensUsed</c>.</remarks>
 public partial class CompactionCompleteCompactionTokensUsed
 {
     /// <summary>Cached input tokens reused in the compaction LLM call.</summary>
-    [JsonPropertyName("cachedInput")]
-    public required double CachedInput { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("cacheReadTokens")]
+    public double? CacheReadTokens { get; set; }
+
+    /// <summary>Tokens written to prompt cache in the compaction LLM call.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("cacheWriteTokens")]
+    public double? CacheWriteTokens { get; set; }
+
+    /// <summary>Per-request cost and usage data from the CAPI copilot_usage response field.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("copilotUsage")]
+    public CompactionCompleteCompactionTokensUsedCopilotUsage? CopilotUsage { get; set; }
+
+    /// <summary>Duration of the compaction LLM call in milliseconds.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("duration")]
+    public double? Duration { get; set; }
 
     /// <summary>Input tokens consumed by the compaction LLM call.</summary>
-    [JsonPropertyName("input")]
-    public required double Input { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("inputTokens")]
+    public double? InputTokens { get; set; }
+
+    /// <summary>Model identifier used for the compaction LLM call.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("model")]
+    public string? Model { get; set; }
 
     /// <summary>Output tokens produced by the compaction LLM call.</summary>
-    [JsonPropertyName("output")]
-    public required double Output { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("outputTokens")]
+    public double? OutputTokens { get; set; }
 }
 
 /// <summary>Optional line range to scope the attachment to a specific section of the file.</summary>
@@ -4145,6 +4255,12 @@ public enum PermissionCompletedKind
     /// <summary>The <c>approved</c> variant.</summary>
     [JsonStringEnumMemberName("approved")]
     Approved,
+    /// <summary>The <c>approved-for-session</c> variant.</summary>
+    [JsonStringEnumMemberName("approved-for-session")]
+    ApprovedForSession,
+    /// <summary>The <c>approved-for-location</c> variant.</summary>
+    [JsonStringEnumMemberName("approved-for-location")]
+    ApprovedForLocation,
     /// <summary>The <c>denied-by-rules</c> variant.</summary>
     [JsonStringEnumMemberName("denied-by-rules")]
     DeniedByRules,
@@ -4296,6 +4412,10 @@ public enum ExtensionsLoadedExtensionStatus
 [JsonSerializable(typeof(AssistantUsageData))]
 [JsonSerializable(typeof(AssistantUsageEvent))]
 [JsonSerializable(typeof(AssistantUsageQuotaSnapshot))]
+[JsonSerializable(typeof(AutoModeSwitchCompletedData))]
+[JsonSerializable(typeof(AutoModeSwitchCompletedEvent))]
+[JsonSerializable(typeof(AutoModeSwitchRequestedData))]
+[JsonSerializable(typeof(AutoModeSwitchRequestedEvent))]
 [JsonSerializable(typeof(CapabilitiesChangedData))]
 [JsonSerializable(typeof(CapabilitiesChangedEvent))]
 [JsonSerializable(typeof(CapabilitiesChangedUI))]
@@ -4309,6 +4429,8 @@ public enum ExtensionsLoadedExtensionStatus
 [JsonSerializable(typeof(CommandsChangedData))]
 [JsonSerializable(typeof(CommandsChangedEvent))]
 [JsonSerializable(typeof(CompactionCompleteCompactionTokensUsed))]
+[JsonSerializable(typeof(CompactionCompleteCompactionTokensUsedCopilotUsage))]
+[JsonSerializable(typeof(CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail))]
 [JsonSerializable(typeof(CustomAgentsUpdatedAgent))]
 [JsonSerializable(typeof(ElicitationCompletedData))]
 [JsonSerializable(typeof(ElicitationCompletedEvent))]

--- a/dotnet/src/Generated/SessionEvents.cs
+++ b/dotnet/src/Generated/SessionEvents.cs
@@ -2328,6 +2328,11 @@ public partial class PermissionRequestedData
     [JsonPropertyName("permissionRequest")]
     public required PermissionRequest PermissionRequest { get; set; }
 
+    /// <summary>Derived user-facing permission prompt details for UI consumers.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("promptRequest")]
+    public PermissionPromptRequest? PromptRequest { get; set; }
+
     /// <summary>Unique identifier for this permission request; used to respond via session.respondToPermission().</summary>
     [JsonPropertyName("requestId")]
     public required string RequestId { get; set; }
@@ -2348,6 +2353,11 @@ public partial class PermissionCompletedData
     /// <summary>The result of the permission request.</summary>
     [JsonPropertyName("result")]
     public required PermissionCompletedResult Result { get; set; }
+
+    /// <summary>Optional tool call ID associated with this permission prompt; clients may use it to correlate UI created from tool-scoped prompts.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("toolCallId")]
+    public string? ToolCallId { get; set; }
 }
 
 /// <summary>User input request notification with question and optional predefined choices.</summary>
@@ -3908,6 +3918,293 @@ public partial class PermissionRequest
 }
 
 
+/// <summary>Shell command permission prompt.</summary>
+/// <remarks>The <c>commands</c> variant of <see cref="PermissionPromptRequest"/>.</remarks>
+public partial class PermissionPromptRequestCommands : PermissionPromptRequest
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "commands";
+
+    /// <summary>Whether the UI can offer session-wide approval for this command pattern.</summary>
+    [JsonPropertyName("canOfferSessionApproval")]
+    public required bool CanOfferSessionApproval { get; set; }
+
+    /// <summary>Command identifiers covered by this approval prompt.</summary>
+    [JsonPropertyName("commandIdentifiers")]
+    public required string[] CommandIdentifiers { get; set; }
+
+    /// <summary>The complete shell command text to be executed.</summary>
+    [JsonPropertyName("fullCommandText")]
+    public required string FullCommandText { get; set; }
+
+    /// <summary>Human-readable description of what the command intends to do.</summary>
+    [JsonPropertyName("intention")]
+    public required string Intention { get; set; }
+
+    /// <summary>Tool call ID that triggered this permission request.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("toolCallId")]
+    public string? ToolCallId { get; set; }
+
+    /// <summary>Optional warning message about risks of running this command.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("warning")]
+    public string? Warning { get; set; }
+}
+
+/// <summary>File write permission prompt.</summary>
+/// <remarks>The <c>write</c> variant of <see cref="PermissionPromptRequest"/>.</remarks>
+public partial class PermissionPromptRequestWrite : PermissionPromptRequest
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "write";
+
+    /// <summary>Whether the UI can offer session-wide approval for file write operations.</summary>
+    [JsonPropertyName("canOfferSessionApproval")]
+    public required bool CanOfferSessionApproval { get; set; }
+
+    /// <summary>Unified diff showing the proposed changes.</summary>
+    [JsonPropertyName("diff")]
+    public required string Diff { get; set; }
+
+    /// <summary>Path of the file being written to.</summary>
+    [JsonPropertyName("fileName")]
+    public required string FileName { get; set; }
+
+    /// <summary>Human-readable description of the intended file change.</summary>
+    [JsonPropertyName("intention")]
+    public required string Intention { get; set; }
+
+    /// <summary>Complete new file contents for newly created files.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("newFileContents")]
+    public string? NewFileContents { get; set; }
+
+    /// <summary>Tool call ID that triggered this permission request.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("toolCallId")]
+    public string? ToolCallId { get; set; }
+}
+
+/// <summary>File read permission prompt.</summary>
+/// <remarks>The <c>read</c> variant of <see cref="PermissionPromptRequest"/>.</remarks>
+public partial class PermissionPromptRequestRead : PermissionPromptRequest
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "read";
+
+    /// <summary>Human-readable description of why the file is being read.</summary>
+    [JsonPropertyName("intention")]
+    public required string Intention { get; set; }
+
+    /// <summary>Path of the file or directory being read.</summary>
+    [JsonPropertyName("path")]
+    public required string Path { get; set; }
+
+    /// <summary>Tool call ID that triggered this permission request.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("toolCallId")]
+    public string? ToolCallId { get; set; }
+}
+
+/// <summary>MCP tool invocation permission prompt.</summary>
+/// <remarks>The <c>mcp</c> variant of <see cref="PermissionPromptRequest"/>.</remarks>
+public partial class PermissionPromptRequestMcp : PermissionPromptRequest
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "mcp";
+
+    /// <summary>Arguments to pass to the MCP tool.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("args")]
+    public object? Args { get; set; }
+
+    /// <summary>Name of the MCP server providing the tool.</summary>
+    [JsonPropertyName("serverName")]
+    public required string ServerName { get; set; }
+
+    /// <summary>Tool call ID that triggered this permission request.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("toolCallId")]
+    public string? ToolCallId { get; set; }
+
+    /// <summary>Internal name of the MCP tool.</summary>
+    [JsonPropertyName("toolName")]
+    public required string ToolName { get; set; }
+
+    /// <summary>Human-readable title of the MCP tool.</summary>
+    [JsonPropertyName("toolTitle")]
+    public required string ToolTitle { get; set; }
+}
+
+/// <summary>URL access permission prompt.</summary>
+/// <remarks>The <c>url</c> variant of <see cref="PermissionPromptRequest"/>.</remarks>
+public partial class PermissionPromptRequestUrl : PermissionPromptRequest
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "url";
+
+    /// <summary>Human-readable description of why the URL is being accessed.</summary>
+    [JsonPropertyName("intention")]
+    public required string Intention { get; set; }
+
+    /// <summary>Tool call ID that triggered this permission request.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("toolCallId")]
+    public string? ToolCallId { get; set; }
+
+    /// <summary>URL to be fetched.</summary>
+    [JsonPropertyName("url")]
+    public required string Url { get; set; }
+}
+
+/// <summary>Memory operation permission prompt.</summary>
+/// <remarks>The <c>memory</c> variant of <see cref="PermissionPromptRequest"/>.</remarks>
+public partial class PermissionPromptRequestMemory : PermissionPromptRequest
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "memory";
+
+    /// <summary>Whether this is a store or vote memory operation.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("action")]
+    public PermissionPromptRequestMemoryAction? Action { get; set; }
+
+    /// <summary>Source references for the stored fact (store only).</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("citations")]
+    public string? Citations { get; set; }
+
+    /// <summary>Vote direction (vote only).</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("direction")]
+    public PermissionPromptRequestMemoryDirection? Direction { get; set; }
+
+    /// <summary>The fact being stored or voted on.</summary>
+    [JsonPropertyName("fact")]
+    public required string Fact { get; set; }
+
+    /// <summary>Reason for the vote (vote only).</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("reason")]
+    public string? Reason { get; set; }
+
+    /// <summary>Topic or subject of the memory (store only).</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("subject")]
+    public string? Subject { get; set; }
+
+    /// <summary>Tool call ID that triggered this permission request.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("toolCallId")]
+    public string? ToolCallId { get; set; }
+}
+
+/// <summary>Custom tool invocation permission prompt.</summary>
+/// <remarks>The <c>custom-tool</c> variant of <see cref="PermissionPromptRequest"/>.</remarks>
+public partial class PermissionPromptRequestCustomTool : PermissionPromptRequest
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "custom-tool";
+
+    /// <summary>Arguments to pass to the custom tool.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("args")]
+    public object? Args { get; set; }
+
+    /// <summary>Tool call ID that triggered this permission request.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("toolCallId")]
+    public string? ToolCallId { get; set; }
+
+    /// <summary>Description of what the custom tool does.</summary>
+    [JsonPropertyName("toolDescription")]
+    public required string ToolDescription { get; set; }
+
+    /// <summary>Name of the custom tool.</summary>
+    [JsonPropertyName("toolName")]
+    public required string ToolName { get; set; }
+}
+
+/// <summary>Path access permission prompt.</summary>
+/// <remarks>The <c>path</c> variant of <see cref="PermissionPromptRequest"/>.</remarks>
+public partial class PermissionPromptRequestPath : PermissionPromptRequest
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "path";
+
+    /// <summary>Underlying permission kind that needs path approval.</summary>
+    [JsonPropertyName("accessKind")]
+    public required PermissionPromptRequestPathAccessKind AccessKind { get; set; }
+
+    /// <summary>File paths that require explicit approval.</summary>
+    [JsonPropertyName("paths")]
+    public required string[] Paths { get; set; }
+
+    /// <summary>Tool call ID that triggered this permission request.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("toolCallId")]
+    public string? ToolCallId { get; set; }
+}
+
+/// <summary>Hook confirmation permission prompt.</summary>
+/// <remarks>The <c>hook</c> variant of <see cref="PermissionPromptRequest"/>.</remarks>
+public partial class PermissionPromptRequestHook : PermissionPromptRequest
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "hook";
+
+    /// <summary>Optional message from the hook explaining why confirmation is needed.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("hookMessage")]
+    public string? HookMessage { get; set; }
+
+    /// <summary>Arguments of the tool call being gated.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("toolArgs")]
+    public object? ToolArgs { get; set; }
+
+    /// <summary>Tool call ID that triggered this permission request.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("toolCallId")]
+    public string? ToolCallId { get; set; }
+
+    /// <summary>Name of the tool the hook is gating.</summary>
+    [JsonPropertyName("toolName")]
+    public required string ToolName { get; set; }
+}
+
+/// <summary>Derived user-facing permission prompt details for UI consumers.</summary>
+/// <remarks>Polymorphic base type discriminated by <c>kind</c>.</remarks>
+[JsonPolymorphic(
+    TypeDiscriminatorPropertyName = "kind",
+    UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType)]
+[JsonDerivedType(typeof(PermissionPromptRequestCommands), "commands")]
+[JsonDerivedType(typeof(PermissionPromptRequestWrite), "write")]
+[JsonDerivedType(typeof(PermissionPromptRequestRead), "read")]
+[JsonDerivedType(typeof(PermissionPromptRequestMcp), "mcp")]
+[JsonDerivedType(typeof(PermissionPromptRequestUrl), "url")]
+[JsonDerivedType(typeof(PermissionPromptRequestMemory), "memory")]
+[JsonDerivedType(typeof(PermissionPromptRequestCustomTool), "custom-tool")]
+[JsonDerivedType(typeof(PermissionPromptRequestPath), "path")]
+[JsonDerivedType(typeof(PermissionPromptRequestHook), "hook")]
+public partial class PermissionPromptRequest
+{
+    /// <summary>The type discriminator.</summary>
+    [JsonPropertyName("kind")]
+    public virtual string Kind { get; set; } = string.Empty;
+}
+
+
 /// <summary>The result of the permission request.</summary>
 /// <remarks>Nested data type for <c>PermissionCompletedResult</c>.</remarks>
 public partial class PermissionCompletedResult
@@ -4248,6 +4545,45 @@ public enum PermissionRequestMemoryDirection
     Downvote,
 }
 
+/// <summary>Whether this is a store or vote memory operation.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<PermissionPromptRequestMemoryAction>))]
+public enum PermissionPromptRequestMemoryAction
+{
+    /// <summary>The <c>store</c> variant.</summary>
+    [JsonStringEnumMemberName("store")]
+    Store,
+    /// <summary>The <c>vote</c> variant.</summary>
+    [JsonStringEnumMemberName("vote")]
+    Vote,
+}
+
+/// <summary>Vote direction (vote only).</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<PermissionPromptRequestMemoryDirection>))]
+public enum PermissionPromptRequestMemoryDirection
+{
+    /// <summary>The <c>upvote</c> variant.</summary>
+    [JsonStringEnumMemberName("upvote")]
+    Upvote,
+    /// <summary>The <c>downvote</c> variant.</summary>
+    [JsonStringEnumMemberName("downvote")]
+    Downvote,
+}
+
+/// <summary>Underlying permission kind that needs path approval.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<PermissionPromptRequestPathAccessKind>))]
+public enum PermissionPromptRequestPathAccessKind
+{
+    /// <summary>The <c>read</c> variant.</summary>
+    [JsonStringEnumMemberName("read")]
+    Read,
+    /// <summary>The <c>shell</c> variant.</summary>
+    [JsonStringEnumMemberName("shell")]
+    Shell,
+    /// <summary>The <c>write</c> variant.</summary>
+    [JsonStringEnumMemberName("write")]
+    Write,
+}
+
 /// <summary>The outcome of the permission request.</summary>
 [JsonConverter(typeof(JsonStringEnumConverter<PermissionCompletedKind>))]
 public enum PermissionCompletedKind
@@ -4463,6 +4799,16 @@ public enum ExtensionsLoadedExtensionStatus
 [JsonSerializable(typeof(PermissionCompletedData))]
 [JsonSerializable(typeof(PermissionCompletedEvent))]
 [JsonSerializable(typeof(PermissionCompletedResult))]
+[JsonSerializable(typeof(PermissionPromptRequest))]
+[JsonSerializable(typeof(PermissionPromptRequestCommands))]
+[JsonSerializable(typeof(PermissionPromptRequestCustomTool))]
+[JsonSerializable(typeof(PermissionPromptRequestHook))]
+[JsonSerializable(typeof(PermissionPromptRequestMcp))]
+[JsonSerializable(typeof(PermissionPromptRequestMemory))]
+[JsonSerializable(typeof(PermissionPromptRequestPath))]
+[JsonSerializable(typeof(PermissionPromptRequestRead))]
+[JsonSerializable(typeof(PermissionPromptRequestUrl))]
+[JsonSerializable(typeof(PermissionPromptRequestWrite))]
 [JsonSerializable(typeof(PermissionRequest))]
 [JsonSerializable(typeof(PermissionRequestCustomTool))]
 [JsonSerializable(typeof(PermissionRequestHook))]

--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -412,7 +412,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
         {
             return new PermissionRequestResult
             {
-                Kind = PermissionRequestResultKind.DeniedCouldNotRequestFromUser
+                Kind = PermissionRequestResultKind.UserNotAvailable
             };
         }
 
@@ -615,7 +615,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
             {
                 await Rpc.Permissions.HandlePendingPermissionRequestAsync(requestId, new PermissionDecision
                 {
-                    Kind = PermissionRequestResultKind.DeniedCouldNotRequestFromUser.Value
+                    Kind = PermissionRequestResultKind.UserNotAvailable.Value
                 });
             }
             catch (IOException)

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -1755,6 +1755,7 @@ public class SessionConfig
         Provider = other.Provider;
         ReasoningEffort = other.ReasoningEffort;
         CreateSessionFsHandler = other.CreateSessionFsHandler;
+        GitHubToken = other.GitHubToken;
         SessionId = other.SessionId;
         SkillDirectories = other.SkillDirectories is not null ? [.. other.SkillDirectories] : null;
         Streaming = other.Streaming;
@@ -1945,6 +1946,13 @@ public class SessionConfig
     public Func<CopilotSession, SessionFsProvider>? CreateSessionFsHandler { get; set; }
 
     /// <summary>
+    /// GitHub token for per-session authentication.
+    /// When provided, the runtime resolves this token into a full GitHub identity
+    /// and stores it on the session for content exclusion, model routing, and quota checks.
+    /// </summary>
+    public string? GitHubToken { get; set; }
+
+    /// <summary>
     /// Creates a shallow clone of this <see cref="SessionConfig"/> instance.
     /// </summary>
     /// <remarks>
@@ -2005,6 +2013,7 @@ public class ResumeSessionConfig
         Provider = other.Provider;
         ReasoningEffort = other.ReasoningEffort;
         CreateSessionFsHandler = other.CreateSessionFsHandler;
+        GitHubToken = other.GitHubToken;
         SkillDirectories = other.SkillDirectories is not null ? [.. other.SkillDirectories] : null;
         Streaming = other.Streaming;
         IncludeSubAgentStreamingEvents = other.IncludeSubAgentStreamingEvents;
@@ -2190,6 +2199,13 @@ public class ResumeSessionConfig
     /// This is used only when <see cref="CopilotClientOptions.SessionFs"/> is configured.
     /// </summary>
     public Func<CopilotSession, SessionFsProvider>? CreateSessionFsHandler { get; set; }
+
+    /// <summary>
+    /// GitHub token for per-session authentication.
+    /// When provided, the runtime resolves this token into a full GitHub identity
+    /// and stores it on the session for content exclusion, model routing, and quota checks.
+    /// </summary>
+    public string? GitHubToken { get; set; }
 
     /// <summary>
     /// Creates a shallow clone of this <see cref="ResumeSessionConfig"/> instance.

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -458,20 +458,29 @@ public delegate Task<object?> ToolHandler(ToolInvocation invocation);
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct PermissionRequestResultKind : IEquatable<PermissionRequestResultKind>
 {
-    /// <summary>Gets the kind indicating the permission was approved.</summary>
-    public static PermissionRequestResultKind Approved { get; } = new("approved");
-
-    /// <summary>Gets the kind indicating the permission was denied by rules.</summary>
-    public static PermissionRequestResultKind DeniedByRules { get; } = new("denied-by-rules");
-
-    /// <summary>Gets the kind indicating the permission was denied because no approval rule was found and the user could not be prompted.</summary>
-    public static PermissionRequestResultKind DeniedCouldNotRequestFromUser { get; } = new("denied-no-approval-rule-and-could-not-request-from-user");
+    /// <summary>Gets the kind indicating the permission was approved for this one instance.</summary>
+    public static PermissionRequestResultKind Approved { get; } = new("approve-once");
 
     /// <summary>Gets the kind indicating the permission was denied interactively by the user.</summary>
-    public static PermissionRequestResultKind DeniedInteractivelyByUser { get; } = new("denied-interactively-by-user");
+    public static PermissionRequestResultKind Rejected { get; } = new("reject");
 
-    /// <summary>Gets the kind indicating the permission was denied interactively by the user.</summary>
+    /// <summary>Gets the kind indicating the permission was denied because user confirmation was unavailable.</summary>
+    public static PermissionRequestResultKind UserNotAvailable { get; } = new("user-not-available");
+
+    /// <summary>Gets the kind indicating no permission decision was made.</summary>
     public static PermissionRequestResultKind NoResult { get; } = new("no-result");
+
+    /// <summary>Deprecated. Use <see cref="Rejected"/> instead.</summary>
+    [Obsolete("Use Rejected instead.")]
+    public static PermissionRequestResultKind DeniedInteractivelyByUser => Rejected;
+
+    /// <summary>Deprecated. Use <see cref="UserNotAvailable"/> instead.</summary>
+    [Obsolete("Use UserNotAvailable instead.")]
+    public static PermissionRequestResultKind DeniedCouldNotRequestFromUser => UserNotAvailable;
+
+    /// <summary>Deprecated. Use <see cref="UserNotAvailable"/> instead.</summary>
+    [Obsolete("Use UserNotAvailable instead.")]
+    public static PermissionRequestResultKind DeniedByRules => UserNotAvailable;
 
     /// <summary>Gets the underlying string value of this <see cref="PermissionRequestResultKind"/>.</summary>
     public string Value => _value ?? string.Empty;

--- a/dotnet/test/Harness/CapiProxy.cs
+++ b/dotnet/test/Harness/CapiProxy.cs
@@ -132,6 +132,16 @@ public sealed partial class CapiProxy : IAsyncDisposable
                ?? [];
     }
 
+    public async Task SetCopilotUserByTokenAsync(string token, CopilotUserConfig response)
+    {
+        var url = await (_startupTask ?? throw new InvalidOperationException("Proxy not started"));
+
+        using var client = new HttpClient();
+        var payload = new CopilotUserByTokenRequest(token, response);
+        var resp = await client.PostAsJsonAsync($"{url}/copilot-user-config", payload, CapiProxyJsonContext.Default.CopilotUserByTokenRequest);
+        resp.EnsureSuccessStatusCode();
+    }
+
     public async ValueTask DisposeAsync()
     {
         await StopAsync();
@@ -152,8 +162,19 @@ public sealed partial class CapiProxy : IAsyncDisposable
     [JsonSourceGenerationOptions(JsonSerializerDefaults.Web)]
     [JsonSerializable(typeof(ConfigureRequest))]
     [JsonSerializable(typeof(List<ParsedHttpExchange>))]
+    [JsonSerializable(typeof(CopilotUserByTokenRequest))]
     private partial class CapiProxyJsonContext : JsonSerializerContext;
 }
+
+public record CopilotUserByTokenRequest(string Token, CopilotUserConfig Response);
+
+public record CopilotUserConfig(
+    string Login,
+    string CopilotPlan,
+    CopilotUserEndpoints Endpoints,
+    string AnalyticsTrackingId);
+
+public record CopilotUserEndpoints(string Api, string Telemetry);
 
 public record ParsedHttpExchange(ChatCompletionRequest Request, ChatCompletionResponse? Response);
 

--- a/dotnet/test/Harness/E2ETestContext.cs
+++ b/dotnet/test/Harness/E2ETestContext.cs
@@ -83,6 +83,11 @@ public sealed class E2ETestContext : IAsyncDisposable
         return _proxy.GetExchangesAsync();
     }
 
+    public Task SetCopilotUserByTokenAsync(string token, CopilotUserConfig response)
+    {
+        return _proxy.SetCopilotUserByTokenAsync(token, response);
+    }
+
     public IReadOnlyDictionary<string, string> GetEnvironment()
     {
         var env = Environment.GetEnvironmentVariables()

--- a/dotnet/test/MultiClientTests.cs
+++ b/dotnet/test/MultiClientTests.cs
@@ -207,7 +207,7 @@ public class MultiClientTests : IClassFixture<MultiClientTestFixture>, IAsyncLif
         {
             OnPermissionRequest = (_, _) => Task.FromResult(new PermissionRequestResult
             {
-                Kind = PermissionRequestResultKind.DeniedInteractivelyByUser,
+                Kind = PermissionRequestResultKind.Rejected,
             }),
         });
 

--- a/dotnet/test/PerSessionAuthTests.cs
+++ b/dotnet/test/PerSessionAuthTests.cs
@@ -1,0 +1,123 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+using GitHub.Copilot.SDK.Test.Harness;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace GitHub.Copilot.SDK.Test;
+
+public class PerSessionAuthTests(E2ETestFixture fixture, ITestOutputHelper output) : E2ETestBase(fixture, "per-session-auth", output)
+{
+    /// <summary>
+    /// Creates a client with COPILOT_DEBUG_GITHUB_API_URL redirected to the proxy
+    /// so per-session auth token resolution (fetchCopilotUser) is intercepted.
+    /// </summary>
+    private CopilotClient CreateAuthTestClient()
+    {
+        var env = new Dictionary<string, string>(Ctx.GetEnvironment())
+        {
+            ["COPILOT_DEBUG_GITHUB_API_URL"] = Ctx.ProxyUrl,
+        };
+        return Ctx.CreateClient(options: new CopilotClientOptions { Environment = env });
+    }
+
+    private async Task SetupCopilotUsersAsync()
+    {
+        await Ctx.SetCopilotUserByTokenAsync("token-alice", new CopilotUserConfig(
+            Login: "alice",
+            CopilotPlan: "individual_pro",
+            Endpoints: new CopilotUserEndpoints(Api: Ctx.ProxyUrl, Telemetry: "https://localhost:1/telemetry"),
+            AnalyticsTrackingId: "alice-tracking-id"
+        ));
+
+        await Ctx.SetCopilotUserByTokenAsync("token-bob", new CopilotUserConfig(
+            Login: "bob",
+            CopilotPlan: "business",
+            Endpoints: new CopilotUserEndpoints(Api: Ctx.ProxyUrl, Telemetry: "https://localhost:1/telemetry"),
+            AnalyticsTrackingId: "bob-tracking-id"
+        ));
+    }
+
+    private CopilotClient? _authClient;
+
+    private CopilotClient AuthClient => _authClient ??= CreateAuthTestClient();
+
+    [Fact]
+    public async Task ShouldAuthenticateWithGitHubToken()
+    {
+        await SetupCopilotUsersAsync();
+
+        await using var session = await AuthClient.CreateSessionAsync(new SessionConfig
+        {
+            GitHubToken = "token-alice",
+            OnPermissionRequest = PermissionHandler.ApproveAll,
+        });
+
+        var authStatus = await session.Rpc.Auth.GetStatusAsync();
+
+        Assert.True(authStatus.IsAuthenticated);
+        Assert.Equal("alice", authStatus.Login);
+    }
+
+    [Fact]
+    public async Task ShouldIsolateAuthBetweenSessions()
+    {
+        await SetupCopilotUsersAsync();
+
+        await using var sessionA = await AuthClient.CreateSessionAsync(new SessionConfig
+        {
+            GitHubToken = "token-alice",
+            OnPermissionRequest = PermissionHandler.ApproveAll,
+        });
+
+        await using var sessionB = await AuthClient.CreateSessionAsync(new SessionConfig
+        {
+            GitHubToken = "token-bob",
+            OnPermissionRequest = PermissionHandler.ApproveAll,
+        });
+
+        var statusA = await sessionA.Rpc.Auth.GetStatusAsync();
+        var statusB = await sessionB.Rpc.Auth.GetStatusAsync();
+
+        Assert.True(statusA.IsAuthenticated);
+        Assert.Equal("alice", statusA.Login);
+
+        Assert.True(statusB.IsAuthenticated);
+        Assert.Equal("bob", statusB.Login);
+    }
+
+    [Fact]
+    public async Task ShouldBeUnauthenticatedWithoutToken()
+    {
+        await using var session = await AuthClient.CreateSessionAsync(new SessionConfig
+        {
+            OnPermissionRequest = PermissionHandler.ApproveAll,
+        });
+
+        var authStatus = await session.Rpc.Auth.GetStatusAsync();
+
+        // Without a per-session token, there is no per-session identity.
+        // In CI the process-level fake token may still authenticate globally,
+        // so we check Login rather than IsAuthenticated.
+        Assert.Null(authStatus.Login);
+    }
+
+    [Fact]
+    public async Task ShouldFailWithInvalidToken()
+    {
+        await SetupCopilotUsersAsync();
+
+        var ex = await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            await using var session = await AuthClient.CreateSessionAsync(new SessionConfig
+            {
+                GitHubToken = "invalid-token",
+                OnPermissionRequest = PermissionHandler.ApproveAll,
+            });
+        });
+
+        Assert.NotNull(ex);
+    }
+}

--- a/dotnet/test/PermissionRequestResultKindTests.cs
+++ b/dotnet/test/PermissionRequestResultKindTests.cs
@@ -17,17 +17,23 @@ public class PermissionRequestResultKindTests
     [Fact]
     public void WellKnownKinds_HaveExpectedValues()
     {
-        Assert.Equal("approved", PermissionRequestResultKind.Approved.Value);
-        Assert.Equal("denied-by-rules", PermissionRequestResultKind.DeniedByRules.Value);
-        Assert.Equal("denied-no-approval-rule-and-could-not-request-from-user", PermissionRequestResultKind.DeniedCouldNotRequestFromUser.Value);
-        Assert.Equal("denied-interactively-by-user", PermissionRequestResultKind.DeniedInteractivelyByUser.Value);
-        Assert.Equal("no-result", new PermissionRequestResultKind("no-result").Value);
+        Assert.Equal("approve-once", PermissionRequestResultKind.Approved.Value);
+        Assert.Equal("reject", PermissionRequestResultKind.Rejected.Value);
+        Assert.Equal("user-not-available", PermissionRequestResultKind.UserNotAvailable.Value);
+        Assert.Equal("no-result", PermissionRequestResultKind.NoResult.Value);
+
+        // Deprecated aliases still resolve
+#pragma warning disable CS0618
+        Assert.Equal(PermissionRequestResultKind.Rejected, PermissionRequestResultKind.DeniedInteractivelyByUser);
+        Assert.Equal(PermissionRequestResultKind.UserNotAvailable, PermissionRequestResultKind.DeniedCouldNotRequestFromUser);
+        Assert.Equal(PermissionRequestResultKind.UserNotAvailable, PermissionRequestResultKind.DeniedByRules);
+#pragma warning restore CS0618
     }
 
     [Fact]
     public void Equals_SameValue_ReturnsTrue()
     {
-        var a = new PermissionRequestResultKind("approved");
+        var a = new PermissionRequestResultKind("approve-once");
         Assert.True(a == PermissionRequestResultKind.Approved);
         Assert.True(a.Equals(PermissionRequestResultKind.Approved));
         Assert.True(a.Equals((object)PermissionRequestResultKind.Approved));
@@ -36,29 +42,29 @@ public class PermissionRequestResultKindTests
     [Fact]
     public void Equals_DifferentValue_ReturnsFalse()
     {
-        Assert.True(PermissionRequestResultKind.Approved != PermissionRequestResultKind.DeniedByRules);
-        Assert.False(PermissionRequestResultKind.Approved.Equals(PermissionRequestResultKind.DeniedByRules));
+        Assert.True(PermissionRequestResultKind.Approved != PermissionRequestResultKind.Rejected);
+        Assert.False(PermissionRequestResultKind.Approved.Equals(PermissionRequestResultKind.Rejected));
     }
 
     [Fact]
     public void Equals_IsCaseInsensitive()
     {
-        var upper = new PermissionRequestResultKind("APPROVED");
+        var upper = new PermissionRequestResultKind("APPROVE-ONCE");
         Assert.Equal(PermissionRequestResultKind.Approved, upper);
     }
 
     [Fact]
     public void GetHashCode_IsCaseInsensitive()
     {
-        var upper = new PermissionRequestResultKind("APPROVED");
+        var upper = new PermissionRequestResultKind("APPROVE-ONCE");
         Assert.Equal(PermissionRequestResultKind.Approved.GetHashCode(), upper.GetHashCode());
     }
 
     [Fact]
     public void ToString_ReturnsValue()
     {
-        Assert.Equal("approved", PermissionRequestResultKind.Approved.ToString());
-        Assert.Equal("denied-by-rules", PermissionRequestResultKind.DeniedByRules.ToString());
+        Assert.Equal("approve-once", PermissionRequestResultKind.Approved.ToString());
+        Assert.Equal("reject", PermissionRequestResultKind.Rejected.ToString());
     }
 
     [Fact]
@@ -88,7 +94,7 @@ public class PermissionRequestResultKindTests
     [Fact]
     public void Equals_NonPermissionRequestResultKindObject_ReturnsFalse()
     {
-        Assert.False(PermissionRequestResultKind.Approved.Equals("approved"));
+        Assert.False(PermissionRequestResultKind.Approved.Equals("approve-once"));
     }
 
     [Fact]
@@ -96,15 +102,15 @@ public class PermissionRequestResultKindTests
     {
         var result = new PermissionRequestResult { Kind = PermissionRequestResultKind.Approved };
         var json = JsonSerializer.Serialize(result, s_jsonOptions);
-        Assert.Contains("\"kind\":\"approved\"", json);
+        Assert.Contains("\"kind\":\"approve-once\"", json);
     }
 
     [Fact]
     public void JsonDeserialize_ReadsStringValue()
     {
-        var json = """{"kind":"denied-by-rules"}""";
+        var json = """{"kind":"reject"}""";
         var result = JsonSerializer.Deserialize<PermissionRequestResult>(json, s_jsonOptions)!;
-        Assert.Equal(PermissionRequestResultKind.DeniedByRules, result.Kind);
+        Assert.Equal(PermissionRequestResultKind.Rejected, result.Kind);
     }
 
     [Fact]
@@ -113,10 +119,9 @@ public class PermissionRequestResultKindTests
         var kinds = new[]
         {
             PermissionRequestResultKind.Approved,
-            PermissionRequestResultKind.DeniedByRules,
-            PermissionRequestResultKind.DeniedCouldNotRequestFromUser,
-            PermissionRequestResultKind.DeniedInteractivelyByUser,
-            new PermissionRequestResultKind("no-result"),
+            PermissionRequestResultKind.Rejected,
+            PermissionRequestResultKind.UserNotAvailable,
+            PermissionRequestResultKind.NoResult,
         };
 
         foreach (var kind in kinds)

--- a/dotnet/test/PermissionTests.cs
+++ b/dotnet/test/PermissionTests.cs
@@ -50,7 +50,7 @@ public class PermissionTests(E2ETestFixture fixture, ITestOutputHelper output) :
             {
                 return Task.FromResult(new PermissionRequestResult
                 {
-                    Kind = PermissionRequestResultKind.DeniedInteractivelyByUser
+                    Kind = PermissionRequestResultKind.Rejected
                 });
             }
         });
@@ -76,7 +76,7 @@ public class PermissionTests(E2ETestFixture fixture, ITestOutputHelper output) :
         var session = await CreateSessionAsync(new SessionConfig
         {
             OnPermissionRequest = (_, _) =>
-                Task.FromResult(new PermissionRequestResult { Kind = PermissionRequestResultKind.DeniedCouldNotRequestFromUser })
+                Task.FromResult(new PermissionRequestResult { Kind = PermissionRequestResultKind.UserNotAvailable })
         });
         var permissionDenied = false;
 
@@ -201,7 +201,7 @@ public class PermissionTests(E2ETestFixture fixture, ITestOutputHelper output) :
         var session2 = await ResumeSessionAsync(sessionId, new ResumeSessionConfig
         {
             OnPermissionRequest = (_, _) =>
-                Task.FromResult(new PermissionRequestResult { Kind = PermissionRequestResultKind.DeniedCouldNotRequestFromUser })
+                Task.FromResult(new PermissionRequestResult { Kind = PermissionRequestResultKind.UserNotAvailable })
         });
         var permissionDenied = false;
 

--- a/dotnet/test/ToolsTests.cs
+++ b/dotnet/test/ToolsTests.cs
@@ -290,7 +290,7 @@ public partial class ToolsTests(E2ETestFixture fixture, ITestOutputHelper output
         var session = await Client.CreateSessionAsync(new SessionConfig
         {
             Tools = [AIFunctionFactory.Create(EncryptStringDenied, "encrypt_string")],
-            OnPermissionRequest = async (request, invocation) => new() { Kind = PermissionRequestResultKind.DeniedInteractivelyByUser },
+            OnPermissionRequest = async (request, invocation) => new() { Kind = PermissionRequestResultKind.Rejected },
         });
 
         await session.SendAsync(new MessageOptions

--- a/go/client.go
+++ b/go/client.go
@@ -601,6 +601,7 @@ func (c *Client) CreateSession(ctx context.Context, config *SessionConfig) (*Ses
 	req.SkillDirectories = config.SkillDirectories
 	req.DisabledSkills = config.DisabledSkills
 	req.InfiniteSessions = config.InfiniteSessions
+	req.GitHubToken = config.GitHubToken
 
 	if len(config.Commands) > 0 {
 		cmds := make([]wireCommand, 0, len(config.Commands))
@@ -786,6 +787,7 @@ func (c *Client) ResumeSessionWithOptions(ctx context.Context, sessionID string,
 	req.SkillDirectories = config.SkillDirectories
 	req.DisabledSkills = config.DisabledSkills
 	req.InfiniteSessions = config.InfiniteSessions
+	req.GitHubToken = config.GitHubToken
 	req.RequestPermission = Bool(true)
 
 	if len(config.Commands) > 0 {

--- a/go/generated_session_events.go
+++ b/go/generated_session_events.go
@@ -449,6 +449,18 @@ func (e *SessionEvent) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		e.Data = &d
+	case SessionEventTypeAutoModeSwitchRequested:
+		var d AutoModeSwitchRequestedData
+		if err := json.Unmarshal(raw.Data, &d); err != nil {
+			return err
+		}
+		e.Data = &d
+	case SessionEventTypeAutoModeSwitchCompleted:
+		var d AutoModeSwitchCompletedData
+		if err := json.Unmarshal(raw.Data, &d); err != nil {
+			return err
+		}
+		e.Data = &d
 	case SessionEventTypeCommandsChanged:
 		var d CommandsChangedData
 		if err := json.Unmarshal(raw.Data, &d); err != nil {
@@ -607,6 +619,8 @@ const (
 	SessionEventTypeCommandQueued                 SessionEventType = "command.queued"
 	SessionEventTypeCommandExecute                SessionEventType = "command.execute"
 	SessionEventTypeCommandCompleted              SessionEventType = "command.completed"
+	SessionEventTypeAutoModeSwitchRequested       SessionEventType = "auto_mode_switch.requested"
+	SessionEventTypeAutoModeSwitchCompleted       SessionEventType = "auto_mode_switch.completed"
 	SessionEventTypeCommandsChanged               SessionEventType = "commands.changed"
 	SessionEventTypeCapabilitiesChanged           SessionEventType = "capabilities.changed"
 	SessionEventTypeExitPlanModeRequested         SessionEventType = "exit_plan_mode.requested"
@@ -677,6 +691,26 @@ type AssistantMessageData struct {
 
 func (*AssistantMessageData) sessionEventData() {}
 
+// Auto mode switch completion notification
+type AutoModeSwitchCompletedData struct {
+	// Request ID of the resolved request; clients should dismiss any UI for this request
+	RequestID string `json:"requestId"`
+	// The user's choice: 'yes', 'yes_always', or 'no'
+	Response string `json:"response"`
+}
+
+func (*AutoModeSwitchCompletedData) sessionEventData() {}
+
+// Auto mode switch request notification requiring user approval
+type AutoModeSwitchRequestedData struct {
+	// The rate limit error code that triggered this request
+	ErrorCode *string `json:"errorCode,omitempty"`
+	// Unique identifier for this request; used to respond via session.respondToAutoModeSwitch()
+	RequestID string `json:"requestId"`
+}
+
+func (*AutoModeSwitchRequestedData) sessionEventData() {}
+
 // Context window breakdown at the start of LLM-powered conversation compaction
 type SessionCompactionStartData struct {
 	// Token count from non-system messages (user, assistant, tool) at compaction start
@@ -695,7 +729,7 @@ type SessionCompactionCompleteData struct {
 	CheckpointNumber *float64 `json:"checkpointNumber,omitempty"`
 	// File path where the checkpoint was stored
 	CheckpointPath *string `json:"checkpointPath,omitempty"`
-	// Token usage breakdown for the compaction LLM call
+	// Token usage breakdown for the compaction LLM call (aligned with assistant.usage format)
 	CompactionTokensUsed *CompactionCompleteCompactionTokensUsed `json:"compactionTokensUsed,omitempty"`
 	// Token count from non-system messages (user, assistant, tool) after compaction
 	ConversationTokens *float64 `json:"conversationTokens,omitempty"`
@@ -1864,6 +1898,14 @@ type AssistantUsageCopilotUsage struct {
 	TotalNanoAiu float64 `json:"totalNanoAiu"`
 }
 
+// Per-request cost and usage data from the CAPI copilot_usage response field
+type CompactionCompleteCompactionTokensUsedCopilotUsage struct {
+	// Itemized token usage breakdown
+	TokenDetails []CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail `json:"tokenDetails"`
+	// Total cost in nano-AIU (AI Units) for this request
+	TotalNanoAiu float64 `json:"totalNanoAiu"`
+}
+
 // Position range of the selection within the file
 type UserMessageAttachmentSelectionDetails struct {
 	// End position of the selection
@@ -1954,18 +1996,38 @@ type ShutdownModelMetricUsage struct {
 	ReasoningTokens *float64 `json:"reasoningTokens,omitempty"`
 }
 
-// Token usage breakdown for the compaction LLM call
+// Token usage breakdown for the compaction LLM call (aligned with assistant.usage format)
 type CompactionCompleteCompactionTokensUsed struct {
 	// Cached input tokens reused in the compaction LLM call
-	CachedInput float64 `json:"cachedInput"`
+	CacheReadTokens *float64 `json:"cacheReadTokens,omitempty"`
+	// Tokens written to prompt cache in the compaction LLM call
+	CacheWriteTokens *float64 `json:"cacheWriteTokens,omitempty"`
+	// Per-request cost and usage data from the CAPI copilot_usage response field
+	CopilotUsage *CompactionCompleteCompactionTokensUsedCopilotUsage `json:"copilotUsage,omitempty"`
+	// Duration of the compaction LLM call in milliseconds
+	Duration *float64 `json:"duration,omitempty"`
 	// Input tokens consumed by the compaction LLM call
-	Input float64 `json:"input"`
+	InputTokens *float64 `json:"inputTokens,omitempty"`
+	// Model identifier used for the compaction LLM call
+	Model *string `json:"model,omitempty"`
 	// Output tokens produced by the compaction LLM call
-	Output float64 `json:"output"`
+	OutputTokens *float64 `json:"outputTokens,omitempty"`
 }
 
 // Token usage detail for a single billing category
 type AssistantUsageCopilotUsageTokenDetail struct {
+	// Number of tokens in this billing batch
+	BatchSize float64 `json:"batchSize"`
+	// Cost per batch of tokens
+	CostPerBatch float64 `json:"costPerBatch"`
+	// Total token count for this entry
+	TokenCount float64 `json:"tokenCount"`
+	// Token category (e.g., "input", "output")
+	TokenType string `json:"tokenType"`
+}
+
+// Token usage detail for a single billing category
+type CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail struct {
 	// Number of tokens in this billing batch
 	BatchSize float64 `json:"batchSize"`
 	// Cost per batch of tokens
@@ -2214,6 +2276,8 @@ type PermissionCompletedKind string
 
 const (
 	PermissionCompletedKindApproved                                       PermissionCompletedKind = "approved"
+	PermissionCompletedKindApprovedForSession                             PermissionCompletedKind = "approved-for-session"
+	PermissionCompletedKindApprovedForLocation                            PermissionCompletedKind = "approved-for-location"
 	PermissionCompletedKindDeniedByRules                                  PermissionCompletedKind = "denied-by-rules"
 	PermissionCompletedKindDeniedNoApprovalRuleAndCouldNotRequestFromUser PermissionCompletedKind = "denied-no-approval-rule-and-could-not-request-from-user"
 	PermissionCompletedKindDeniedInteractivelyByUser                      PermissionCompletedKind = "denied-interactively-by-user"

--- a/go/generated_session_events.go
+++ b/go/generated_session_events.go
@@ -1042,6 +1042,8 @@ type PermissionCompletedData struct {
 	RequestID string `json:"requestId"`
 	// The result of the permission request
 	Result PermissionCompletedResult `json:"result"`
+	// Optional tool call ID associated with this permission prompt; clients may use it to correlate UI created from tool-scoped prompts
+	ToolCallID *string `json:"toolCallId,omitempty"`
 }
 
 func (*PermissionCompletedData) sessionEventData() {}
@@ -1050,6 +1052,8 @@ func (*PermissionCompletedData) sessionEventData() {}
 type PermissionRequestedData struct {
 	// Details of the permission being requested
 	PermissionRequest PermissionRequest `json:"permissionRequest"`
+	// Derived user-facing permission prompt details for UI consumers
+	PromptRequest *PermissionPromptRequest `json:"promptRequest,omitempty"`
 	// Unique identifier for this permission request; used to respond via session.respondToPermission()
 	RequestID string `json:"requestId"`
 	// When true, this permission was already resolved by a permissionRequest hook and requires no client action
@@ -1766,6 +1770,64 @@ type ShutdownCodeChanges struct {
 	LinesRemoved float64 `json:"linesRemoved"`
 }
 
+// Derived user-facing permission prompt details for UI consumers
+type PermissionPromptRequest struct {
+	// Kind discriminator
+	Kind PermissionPromptRequestKind `json:"kind"`
+	// Underlying permission kind that needs path approval
+	AccessKind *PermissionPromptRequestPathAccessKind `json:"accessKind,omitempty"`
+	// Whether this is a store or vote memory operation
+	Action *PermissionPromptRequestMemoryAction `json:"action,omitempty"`
+	// Arguments to pass to the MCP tool
+	Args *any `json:"args,omitempty"`
+	// Whether the UI can offer session-wide approval for this command pattern
+	CanOfferSessionApproval *bool `json:"canOfferSessionApproval,omitempty"`
+	// Source references for the stored fact (store only)
+	Citations *string `json:"citations,omitempty"`
+	// Command identifiers covered by this approval prompt
+	CommandIdentifiers []string `json:"commandIdentifiers,omitempty"`
+	// Unified diff showing the proposed changes
+	Diff *string `json:"diff,omitempty"`
+	// Vote direction (vote only)
+	Direction *PermissionPromptRequestMemoryDirection `json:"direction,omitempty"`
+	// The fact being stored or voted on
+	Fact *string `json:"fact,omitempty"`
+	// Path of the file being written to
+	FileName *string `json:"fileName,omitempty"`
+	// The complete shell command text to be executed
+	FullCommandText *string `json:"fullCommandText,omitempty"`
+	// Optional message from the hook explaining why confirmation is needed
+	HookMessage *string `json:"hookMessage,omitempty"`
+	// Human-readable description of what the command intends to do
+	Intention *string `json:"intention,omitempty"`
+	// Complete new file contents for newly created files
+	NewFileContents *string `json:"newFileContents,omitempty"`
+	// Path of the file or directory being read
+	Path *string `json:"path,omitempty"`
+	// File paths that require explicit approval
+	Paths []string `json:"paths,omitempty"`
+	// Reason for the vote (vote only)
+	Reason *string `json:"reason,omitempty"`
+	// Name of the MCP server providing the tool
+	ServerName *string `json:"serverName,omitempty"`
+	// Topic or subject of the memory (store only)
+	Subject *string `json:"subject,omitempty"`
+	// Arguments of the tool call being gated
+	ToolArgs any `json:"toolArgs,omitempty"`
+	// Tool call ID that triggered this permission request
+	ToolCallID *string `json:"toolCallId,omitempty"`
+	// Description of what the custom tool does
+	ToolDescription *string `json:"toolDescription,omitempty"`
+	// Internal name of the MCP tool
+	ToolName *string `json:"toolName,omitempty"`
+	// Human-readable title of the MCP tool
+	ToolTitle *string `json:"toolTitle,omitempty"`
+	// URL to be fetched
+	URL *string `json:"url,omitempty"`
+	// Optional warning message about risks of running this command
+	Warning *string `json:"warning,omitempty"`
+}
+
 // Details of the permission being requested
 type PermissionRequest struct {
 	// Kind discriminator
@@ -2219,6 +2281,21 @@ const (
 	WorkingDirectoryContextHostTypeAdo    WorkingDirectoryContextHostType = "ado"
 )
 
+// Kind discriminator for PermissionPromptRequest.
+type PermissionPromptRequestKind string
+
+const (
+	PermissionPromptRequestKindCommands   PermissionPromptRequestKind = "commands"
+	PermissionPromptRequestKindWrite      PermissionPromptRequestKind = "write"
+	PermissionPromptRequestKindRead       PermissionPromptRequestKind = "read"
+	PermissionPromptRequestKindMcp        PermissionPromptRequestKind = "mcp"
+	PermissionPromptRequestKindURL        PermissionPromptRequestKind = "url"
+	PermissionPromptRequestKindMemory     PermissionPromptRequestKind = "memory"
+	PermissionPromptRequestKindCustomTool PermissionPromptRequestKind = "custom-tool"
+	PermissionPromptRequestKindPath       PermissionPromptRequestKind = "path"
+	PermissionPromptRequestKindHook       PermissionPromptRequestKind = "hook"
+)
+
 // Kind discriminator for PermissionRequest.
 type PermissionRequestKind string
 
@@ -2362,6 +2439,23 @@ const (
 	UserMessageAttachmentGithubReferenceTypeDiscussion UserMessageAttachmentGithubReferenceType = "discussion"
 )
 
+// Underlying permission kind that needs path approval
+type PermissionPromptRequestPathAccessKind string
+
+const (
+	PermissionPromptRequestPathAccessKindRead  PermissionPromptRequestPathAccessKind = "read"
+	PermissionPromptRequestPathAccessKindShell PermissionPromptRequestPathAccessKind = "shell"
+	PermissionPromptRequestPathAccessKindWrite PermissionPromptRequestPathAccessKind = "write"
+)
+
+// Vote direction (vote only)
+type PermissionPromptRequestMemoryDirection string
+
+const (
+	PermissionPromptRequestMemoryDirectionUpvote   PermissionPromptRequestMemoryDirection = "upvote"
+	PermissionPromptRequestMemoryDirectionDownvote PermissionPromptRequestMemoryDirection = "downvote"
+)
+
 // Vote direction (vote only)
 type PermissionRequestMemoryDirection string
 
@@ -2392,6 +2486,14 @@ type ShutdownType string
 const (
 	ShutdownTypeRoutine ShutdownType = "routine"
 	ShutdownTypeError   ShutdownType = "error"
+)
+
+// Whether this is a store or vote memory operation
+type PermissionPromptRequestMemoryAction string
+
+const (
+	PermissionPromptRequestMemoryActionStore PermissionPromptRequestMemoryAction = "store"
+	PermissionPromptRequestMemoryActionVote  PermissionPromptRequestMemoryAction = "vote"
 )
 
 // Whether this is a store or vote memory operation

--- a/go/internal/e2e/multi_client_test.go
+++ b/go/internal/e2e/multi_client_test.go
@@ -237,7 +237,7 @@ func TestMultiClient(t *testing.T) {
 		// Client 1 creates a session and denies all permission requests
 		session1, err := client1.CreateSession(t.Context(), &copilot.SessionConfig{
 			OnPermissionRequest: func(request copilot.PermissionRequest, invocation copilot.PermissionInvocation) (copilot.PermissionRequestResult, error) {
-				return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindDeniedInteractivelyByUser}, nil
+				return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindRejected}, nil
 			},
 		})
 		if err != nil {

--- a/go/internal/e2e/per_session_auth_test.go
+++ b/go/internal/e2e/per_session_auth_test.go
@@ -1,0 +1,134 @@
+package e2e
+
+import (
+	"testing"
+
+	copilot "github.com/github/copilot-sdk/go"
+	"github.com/github/copilot-sdk/go/internal/e2e/testharness"
+)
+
+func TestPerSessionAuth(t *testing.T) {
+	ctx := testharness.NewTestContext(t)
+
+	// Create client with COPILOT_DEBUG_GITHUB_API_URL redirected to the proxy
+	// so per-session auth token resolution (fetchCopilotUser) is intercepted.
+	client := ctx.NewClient(func(opts *copilot.ClientOptions) {
+		opts.Env = append(opts.Env, "COPILOT_DEBUG_GITHUB_API_URL="+ctx.ProxyURL)
+	})
+	t.Cleanup(func() { client.ForceStop() })
+	// Register per-token user configs on the proxy
+	if err := ctx.SetCopilotUserByToken("token-alice", map[string]interface{}{
+		"login":                 "alice",
+		"copilot_plan":          "individual_pro",
+		"endpoints":             map[string]interface{}{"api": ctx.ProxyURL, "telemetry": "https://localhost:1/telemetry"},
+		"analytics_tracking_id": "alice-tracking-id",
+	}); err != nil {
+		t.Fatalf("Failed to set copilot user for alice: %v", err)
+	}
+
+	if err := ctx.SetCopilotUserByToken("token-bob", map[string]interface{}{
+		"login":                 "bob",
+		"copilot_plan":          "business",
+		"endpoints":             map[string]interface{}{"api": ctx.ProxyURL, "telemetry": "https://localhost:1/telemetry"},
+		"analytics_tracking_id": "bob-tracking-id",
+	}); err != nil {
+		t.Fatalf("Failed to set copilot user for bob: %v", err)
+	}
+
+	t.Run("should authenticate with per-session token", func(t *testing.T) {
+		ctx.ConfigureForTest(t)
+
+		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
+			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+			GitHubToken:         "token-alice",
+		})
+		if err != nil {
+			t.Fatalf("Failed to create session: %v", err)
+		}
+
+		authStatus, err := session.RPC.Auth.GetStatus(t.Context())
+		if err != nil {
+			t.Fatalf("Failed to get auth status: %v", err)
+		}
+
+		if !authStatus.IsAuthenticated {
+			t.Errorf("Expected session to be authenticated")
+		}
+		if authStatus.Login == nil || *authStatus.Login != "alice" {
+			t.Errorf("Expected login to be 'alice', got %v", authStatus.Login)
+		}
+	})
+
+	t.Run("should isolate auth between sessions", func(t *testing.T) {
+		ctx.ConfigureForTest(t)
+
+		sessionA, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
+			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+			GitHubToken:         "token-alice",
+		})
+		if err != nil {
+			t.Fatalf("Failed to create session A: %v", err)
+		}
+
+		sessionB, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
+			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+			GitHubToken:         "token-bob",
+		})
+		if err != nil {
+			t.Fatalf("Failed to create session B: %v", err)
+		}
+
+		statusA, err := sessionA.RPC.Auth.GetStatus(t.Context())
+		if err != nil {
+			t.Fatalf("Failed to get auth status for session A: %v", err)
+		}
+
+		statusB, err := sessionB.RPC.Auth.GetStatus(t.Context())
+		if err != nil {
+			t.Fatalf("Failed to get auth status for session B: %v", err)
+		}
+
+		if statusA.Login == nil || *statusA.Login != "alice" {
+			t.Errorf("Expected session A login to be 'alice', got %v", statusA.Login)
+		}
+		if statusB.Login == nil || *statusB.Login != "bob" {
+			t.Errorf("Expected session B login to be 'bob', got %v", statusB.Login)
+		}
+	})
+
+	t.Run("should be unauthenticated without token", func(t *testing.T) {
+		ctx.ConfigureForTest(t)
+
+		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
+			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create session: %v", err)
+		}
+
+		authStatus, err := session.RPC.Auth.GetStatus(t.Context())
+		if err != nil {
+			t.Fatalf("Failed to get auth status: %v", err)
+		}
+
+		// Without a per-session token, there is no per-session identity.
+		// In CI the process-level fake token may still authenticate globally,
+		// so we check Login rather than IsAuthenticated.
+		if authStatus.Login != nil && *authStatus.Login != "" {
+			t.Errorf("Expected no per-session login without token, got %q", *authStatus.Login)
+		}
+	})
+
+	t.Run("should fail with invalid token", func(t *testing.T) {
+		ctx.ConfigureForTest(t)
+
+		_, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
+			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+			GitHubToken:         "invalid-token",
+		})
+		if err == nil {
+			t.Fatal("Expected session creation to fail with invalid token")
+		}
+		t.Logf("Got expected error: %v", err)
+	})
+}

--- a/go/internal/e2e/permissions_test.go
+++ b/go/internal/e2e/permissions_test.go
@@ -117,7 +117,7 @@ func TestPermissions(t *testing.T) {
 		ctx.ConfigureForTest(t)
 
 		onPermissionRequest := func(request copilot.PermissionRequest, invocation copilot.PermissionInvocation) (copilot.PermissionRequestResult, error) {
-			return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindDeniedInteractivelyByUser}, nil
+			return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindRejected}, nil
 		}
 
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
@@ -162,7 +162,7 @@ func TestPermissions(t *testing.T) {
 
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
 			OnPermissionRequest: func(request copilot.PermissionRequest, invocation copilot.PermissionInvocation) (copilot.PermissionRequestResult, error) {
-				return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindDeniedCouldNotRequestFromUser}, nil
+				return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindUserNotAvailable}, nil
 			},
 		})
 		if err != nil {
@@ -214,7 +214,7 @@ func TestPermissions(t *testing.T) {
 
 		session2, err := client.ResumeSession(t.Context(), sessionID, &copilot.ResumeSessionConfig{
 			OnPermissionRequest: func(request copilot.PermissionRequest, invocation copilot.PermissionInvocation) (copilot.PermissionRequestResult, error) {
-				return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindDeniedCouldNotRequestFromUser}, nil
+				return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindUserNotAvailable}, nil
 			},
 		})
 		if err != nil {

--- a/go/internal/e2e/rpc_test.go
+++ b/go/internal/e2e/rpc_test.go
@@ -64,7 +64,7 @@ func TestRpc(t *testing.T) {
 			t.Skip("Not authenticated - skipping models.list test")
 		}
 
-		result, err := client.RPC.Models.List(t.Context())
+		result, err := client.RPC.Models.List(t.Context(), nil)
 		if err != nil {
 			t.Fatalf("Failed to call RPC.Models.List: %v", err)
 		}
@@ -101,7 +101,7 @@ func TestRpc(t *testing.T) {
 			t.Skip("Not authenticated - skipping account.getQuota test")
 		}
 
-		result, err := client.RPC.Account.GetQuota(t.Context())
+		result, err := client.RPC.Account.GetQuota(t.Context(), nil)
 		if err != nil {
 			t.Fatalf("Failed to call RPC.Account.GetQuota: %v", err)
 		}

--- a/go/internal/e2e/testharness/context.go
+++ b/go/internal/e2e/testharness/context.go
@@ -144,6 +144,11 @@ func (c *TestContext) GetExchanges() ([]ParsedHttpExchange, error) {
 	return c.proxy.GetExchanges()
 }
 
+// SetCopilotUserByToken registers a per-token user configuration on the proxy.
+func (c *TestContext) SetCopilotUserByToken(token string, response map[string]interface{}) error {
+	return c.proxy.SetCopilotUserByToken(token, response)
+}
+
 // Env returns environment variables configured for isolated testing.
 func (c *TestContext) Env() []string {
 	env := os.Environ()

--- a/go/internal/e2e/testharness/proxy.go
+++ b/go/internal/e2e/testharness/proxy.go
@@ -2,6 +2,7 @@ package testharness
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -250,4 +251,33 @@ func (p *CapiProxy) URL() string {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.proxyURL
+}
+
+// SetCopilotUserByToken registers a per-token user configuration on the proxy.
+func (p *CapiProxy) SetCopilotUserByToken(token string, response map[string]interface{}) error {
+	p.mu.Lock()
+	url := p.proxyURL
+	p.mu.Unlock()
+
+	if url == "" {
+		return fmt.Errorf("proxy not started")
+	}
+
+	body := map[string]interface{}{
+		"token":    token,
+		"response": response,
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	resp, err := http.Post(url+"/copilot-user-config", "application/json", bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("setCopilotUserByToken: unexpected status %d", resp.StatusCode)
+	}
+	return nil
 }

--- a/go/internal/e2e/tools_test.go
+++ b/go/internal/e2e/tools_test.go
@@ -429,7 +429,7 @@ func TestTools(t *testing.T) {
 					}),
 			},
 			OnPermissionRequest: func(request copilot.PermissionRequest, invocation copilot.PermissionInvocation) (copilot.PermissionRequestResult, error) {
-				return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindDeniedInteractivelyByUser}, nil
+				return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindRejected}, nil
 			},
 		})
 		if err != nil {

--- a/go/rpc/generated_rpc.go
+++ b/go/rpc/generated_rpc.go
@@ -13,6 +13,7 @@ import (
 )
 
 type RPCTypes struct {
+	AccountGetQuotaRequest                                           AccountGetQuotaRequest                                           `json:"AccountGetQuotaRequest"`
 	AccountGetQuotaResult                                            AccountGetQuotaResult                                            `json:"AccountGetQuotaResult"`
 	AccountQuotaSnapshot                                             AccountQuotaSnapshot                                             `json:"AccountQuotaSnapshot"`
 	AgentDeselectResult                                              AgentDeselectResult                                              `json:"AgentDeselectResult"`
@@ -22,6 +23,7 @@ type RPCTypes struct {
 	AgentReloadResult                                                AgentReloadResult                                                `json:"AgentReloadResult"`
 	AgentSelectRequest                                               AgentSelectRequest                                               `json:"AgentSelectRequest"`
 	AgentSelectResult                                                AgentSelectResult                                                `json:"AgentSelectResult"`
+	AuthInfoType                                                     AuthInfoType                                                     `json:"AuthInfoType"`
 	CommandsHandlePendingCommandRequest                              CommandsHandlePendingCommandRequest                              `json:"CommandsHandlePendingCommandRequest"`
 	CommandsHandlePendingCommandResult                               CommandsHandlePendingCommandResult                               `json:"CommandsHandlePendingCommandResult"`
 	CurrentModel                                                     CurrentModel                                                     `json:"CurrentModel"`
@@ -55,6 +57,10 @@ type RPCTypes struct {
 	LogResult                                                        LogResult                                                        `json:"LogResult"`
 	MCPConfigAddRequest                                              MCPConfigAddRequest                                              `json:"McpConfigAddRequest"`
 	MCPConfigAddResult                                               MCPConfigAddResult                                               `json:"McpConfigAddResult"`
+	MCPConfigDisableRequest                                          MCPConfigDisableRequest                                          `json:"McpConfigDisableRequest"`
+	MCPConfigDisableResult                                           MCPConfigDisableResult                                           `json:"McpConfigDisableResult"`
+	MCPConfigEnableRequest                                           MCPConfigEnableRequest                                           `json:"McpConfigEnableRequest"`
+	MCPConfigEnableResult                                            MCPConfigEnableResult                                            `json:"McpConfigEnableResult"`
 	MCPConfigList                                                    MCPConfigList                                                    `json:"McpConfigList"`
 	MCPConfigRemoveRequest                                           MCPConfigRemoveRequest                                           `json:"McpConfigRemoveRequest"`
 	MCPConfigRemoveResult                                            MCPConfigRemoveResult                                            `json:"McpConfigRemoveResult"`
@@ -66,6 +72,8 @@ type RPCTypes struct {
 	MCPDiscoverResult                                                MCPDiscoverResult                                                `json:"McpDiscoverResult"`
 	MCPEnableRequest                                                 MCPEnableRequest                                                 `json:"McpEnableRequest"`
 	MCPEnableResult                                                  MCPEnableResult                                                  `json:"McpEnableResult"`
+	MCPOauthLoginRequest                                             MCPOauthLoginRequest                                             `json:"McpOauthLoginRequest"`
+	MCPOauthLoginResult                                              MCPOauthLoginResult                                              `json:"McpOauthLoginResult"`
 	MCPReloadResult                                                  MCPReloadResult                                                  `json:"McpReloadResult"`
 	MCPServer                                                        MCPServer                                                        `json:"McpServer"`
 	MCPServerConfig                                                  MCPServerConfig                                                  `json:"McpServerConfig"`
@@ -88,6 +96,7 @@ type RPCTypes struct {
 	ModelCapabilitiesSupports                                        ModelCapabilitiesSupports                                        `json:"ModelCapabilitiesSupports"`
 	ModelList                                                        ModelList                                                        `json:"ModelList"`
 	ModelPolicy                                                      ModelPolicy                                                      `json:"ModelPolicy"`
+	ModelsListRequest                                                ModelsListRequest                                                `json:"ModelsListRequest"`
 	ModelSwitchToRequest                                             ModelSwitchToRequest                                             `json:"ModelSwitchToRequest"`
 	ModelSwitchToResult                                              ModelSwitchToResult                                              `json:"ModelSwitchToResult"`
 	ModeSetRequest                                                   ModeSetRequest                                                   `json:"ModeSetRequest"`
@@ -97,6 +106,22 @@ type RPCTypes struct {
 	NameSetResult                                                    NameSetResult                                                    `json:"NameSetResult"`
 	PermissionDecision                                               PermissionDecision                                               `json:"PermissionDecision"`
 	PermissionDecisionApproved                                       PermissionDecisionApproved                                       `json:"PermissionDecisionApproved"`
+	PermissionDecisionApprovedForLocation                            PermissionDecisionApprovedForLocation                            `json:"PermissionDecisionApprovedForLocation"`
+	PermissionDecisionApprovedForLocationApproval                    PermissionDecisionApprovedForLocationApproval                    `json:"PermissionDecisionApprovedForLocationApproval"`
+	PermissionDecisionApprovedForLocationApprovalCommands            PermissionDecisionApprovedForLocationApprovalCommands            `json:"PermissionDecisionApprovedForLocationApprovalCommands"`
+	PermissionDecisionApprovedForLocationApprovalCustomTool          PermissionDecisionApprovedForLocationApprovalCustomTool          `json:"PermissionDecisionApprovedForLocationApprovalCustomTool"`
+	PermissionDecisionApprovedForLocationApprovalMCP                 PermissionDecisionApprovedForLocationApprovalMCP                 `json:"PermissionDecisionApprovedForLocationApprovalMcp"`
+	PermissionDecisionApprovedForLocationApprovalMCPSampling         PermissionDecisionApprovedForLocationApprovalMCPSampling         `json:"PermissionDecisionApprovedForLocationApprovalMcpSampling"`
+	PermissionDecisionApprovedForLocationApprovalMemory              PermissionDecisionApprovedForLocationApprovalMemory              `json:"PermissionDecisionApprovedForLocationApprovalMemory"`
+	PermissionDecisionApprovedForLocationApprovalWrite               PermissionDecisionApprovedForLocationApprovalWrite               `json:"PermissionDecisionApprovedForLocationApprovalWrite"`
+	PermissionDecisionApprovedForSession                             PermissionDecisionApprovedForSession                             `json:"PermissionDecisionApprovedForSession"`
+	PermissionDecisionApprovedForSessionApproval                     PermissionDecisionApprovedForSessionApproval                     `json:"PermissionDecisionApprovedForSessionApproval"`
+	PermissionDecisionApprovedForSessionApprovalCommands             PermissionDecisionApprovedForSessionApprovalCommands             `json:"PermissionDecisionApprovedForSessionApprovalCommands"`
+	PermissionDecisionApprovedForSessionApprovalCustomTool           PermissionDecisionApprovedForSessionApprovalCustomTool           `json:"PermissionDecisionApprovedForSessionApprovalCustomTool"`
+	PermissionDecisionApprovedForSessionApprovalMCP                  PermissionDecisionApprovedForSessionApprovalMCP                  `json:"PermissionDecisionApprovedForSessionApprovalMcp"`
+	PermissionDecisionApprovedForSessionApprovalMCPSampling          PermissionDecisionApprovedForSessionApprovalMCPSampling          `json:"PermissionDecisionApprovedForSessionApprovalMcpSampling"`
+	PermissionDecisionApprovedForSessionApprovalMemory               PermissionDecisionApprovedForSessionApprovalMemory               `json:"PermissionDecisionApprovedForSessionApprovalMemory"`
+	PermissionDecisionApprovedForSessionApprovalWrite                PermissionDecisionApprovedForSessionApprovalWrite                `json:"PermissionDecisionApprovedForSessionApprovalWrite"`
 	PermissionDecisionDeniedByContentExclusionPolicy                 PermissionDecisionDeniedByContentExclusionPolicy                 `json:"PermissionDecisionDeniedByContentExclusionPolicy"`
 	PermissionDecisionDeniedByPermissionRequestHook                  PermissionDecisionDeniedByPermissionRequestHook                  `json:"PermissionDecisionDeniedByPermissionRequestHook"`
 	PermissionDecisionDeniedByRules                                  PermissionDecisionDeniedByRules                                  `json:"PermissionDecisionDeniedByRules"`
@@ -104,6 +129,10 @@ type RPCTypes struct {
 	PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser `json:"PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser"`
 	PermissionDecisionRequest                                        PermissionDecisionRequest                                        `json:"PermissionDecisionRequest"`
 	PermissionRequestResult                                          PermissionRequestResult                                          `json:"PermissionRequestResult"`
+	PermissionsResetSessionApprovalsRequest                          PermissionsResetSessionApprovalsRequest                          `json:"PermissionsResetSessionApprovalsRequest"`
+	PermissionsResetSessionApprovalsResult                           PermissionsResetSessionApprovalsResult                           `json:"PermissionsResetSessionApprovalsResult"`
+	PermissionsSetApproveAllRequest                                  PermissionsSetApproveAllRequest                                  `json:"PermissionsSetApproveAllRequest"`
+	PermissionsSetApproveAllResult                                   PermissionsSetApproveAllResult                                   `json:"PermissionsSetApproveAllResult"`
 	PingRequest                                                      PingRequest                                                      `json:"PingRequest"`
 	PingResult                                                       PingResult                                                       `json:"PingResult"`
 	PlanDeleteResult                                                 PlanDeleteResult                                                 `json:"PlanDeleteResult"`
@@ -114,6 +143,7 @@ type RPCTypes struct {
 	PluginList                                                       PluginList                                                       `json:"PluginList"`
 	ServerSkill                                                      ServerSkill                                                      `json:"ServerSkill"`
 	ServerSkillList                                                  ServerSkillList                                                  `json:"ServerSkillList"`
+	SessionAuthStatus                                                SessionAuthStatus                                                `json:"SessionAuthStatus"`
 	SessionFSAppendFileRequest                                       SessionFSAppendFileRequest                                       `json:"SessionFsAppendFileRequest"`
 	SessionFSError                                                   SessionFSError                                                   `json:"SessionFsError"`
 	SessionFSErrorCode                                               SessionFSErrorCode                                               `json:"SessionFsErrorCode"`
@@ -194,6 +224,12 @@ type RPCTypes struct {
 	WorkspacesListFilesResult                                        WorkspacesListFilesResult                                        `json:"WorkspacesListFilesResult"`
 	WorkspacesReadFileRequest                                        WorkspacesReadFileRequest                                        `json:"WorkspacesReadFileRequest"`
 	WorkspacesReadFileResult                                         WorkspacesReadFileResult                                         `json:"WorkspacesReadFileResult"`
+}
+
+type AccountGetQuotaRequest struct {
+	// GitHub token for per-user quota lookup. When provided, resolves this token to determine
+	// the user's quota instead of using the global auth.
+	GitHubToken *string `json:"gitHubToken,omitempty"`
 }
 
 type AccountGetQuotaResult struct {
@@ -463,6 +499,25 @@ type MCPServerConfig struct {
 type MCPConfigAddResult struct {
 }
 
+type MCPConfigDisableRequest struct {
+	// Names of MCP servers to disable. Each server is added to the persisted disabled list so
+	// new sessions skip it. Already-disabled names are ignored. Active sessions keep their
+	// current connections until they end.
+	Names []string `json:"names"`
+}
+
+type MCPConfigDisableResult struct {
+}
+
+type MCPConfigEnableRequest struct {
+	// Names of MCP servers to enable. Each server is removed from the persisted disabled list
+	// so new sessions spawn it. Unknown or already-enabled names are ignored.
+	Names []string `json:"names"`
+}
+
+type MCPConfigEnableResult struct {
+}
+
 type MCPConfigList struct {
 	// All MCP servers from user config, keyed by name
 	Servers map[string]MCPServerConfig `json:"servers"`
@@ -510,6 +565,34 @@ type MCPEnableRequest struct {
 }
 
 type MCPEnableResult struct {
+}
+
+type MCPOauthLoginRequest struct {
+	// Optional override for the body text shown on the OAuth loopback callback success page.
+	// When omitted, the runtime applies a neutral fallback; callers driving interactive auth
+	// should pass surface-specific copy telling the user where to return.
+	CallbackSuccessMessage *string `json:"callbackSuccessMessage,omitempty"`
+	// Optional override for the OAuth client display name shown on the consent screen. Applies
+	// to newly registered dynamic clients only — existing registrations keep the name they were
+	// created with. When omitted, the runtime applies a neutral fallback; callers driving
+	// interactive auth should pass their own surface-specific label so the consent screen
+	// matches the product the user sees.
+	ClientName *string `json:"clientName,omitempty"`
+	// When true, clears any cached OAuth token for the server and runs a full new
+	// authorization. Use when the user explicitly wants to switch accounts or believes their
+	// session is stuck.
+	ForceReauth *bool `json:"forceReauth,omitempty"`
+	// Name of the remote MCP server to authenticate
+	ServerName string `json:"serverName"`
+}
+
+type MCPOauthLoginResult struct {
+	// URL the caller should open in a browser to complete OAuth. Omitted when cached tokens
+	// were still valid and no browser interaction was needed — the server is already
+	// reconnected in that case. When present, the runtime starts the callback listener before
+	// returning and continues the flow in the background; completion is signaled via
+	// session.mcp_server_status_changed.
+	AuthorizationURL *string `json:"authorizationUrl,omitempty"`
 }
 
 type MCPReloadResult struct {
@@ -634,7 +717,7 @@ type ModelPolicy struct {
 	// Current policy state for this model
 	State string `json:"state"`
 	// Usage terms or conditions for this model
-	Terms string `json:"terms"`
+	Terms *string `json:"terms,omitempty"`
 }
 
 // Override individual model capabilities resolved by the runtime
@@ -688,6 +771,12 @@ type ModelSwitchToResult struct {
 	ModelID *string `json:"modelId,omitempty"`
 }
 
+type ModelsListRequest struct {
+	// GitHub token for per-user model listing. When provided, resolves this token to determine
+	// the user's Copilot plan and available models instead of using the global auth.
+	GitHubToken *string `json:"gitHubToken,omitempty"`
+}
+
 type NameGetResult struct {
 	// The session name, falling back to the auto-generated summary, or null if neither exists
 	Name *string `json:"name"`
@@ -704,6 +793,10 @@ type NameSetResult struct {
 type PermissionDecision struct {
 	// The permission request was approved
 	//
+	// Approved and remembered for the rest of the session
+	//
+	// Approved and persisted for this project location
+	//
 	// Denied because approval rules explicitly blocked it
 	//
 	// Denied because no approval rule matched and user confirmation was unavailable
@@ -714,6 +807,12 @@ type PermissionDecision struct {
 	//
 	// Denied by a permission request hook registered by an extension or plugin
 	Kind PermissionDecisionKind `json:"kind"`
+	// The approval to add as a session-scoped rule
+	//
+	// The approval to persist for this location
+	Approval *PermissionDecisionApprovedForLocationApproval `json:"approval,omitempty"`
+	// The location key (git root or cwd) to persist the approval to
+	LocationKey *string `json:"locationKey,omitempty"`
 	// Rules that denied the request
 	Rules []any `json:"rules,omitempty"`
 	// Optional feedback from the user explaining the denial
@@ -731,6 +830,96 @@ type PermissionDecision struct {
 type PermissionDecisionApproved struct {
 	// The permission request was approved
 	Kind PermissionDecisionApprovedKind `json:"kind"`
+}
+
+type PermissionDecisionApprovedForLocation struct {
+	// The approval to persist for this location
+	Approval PermissionDecisionApprovedForLocationApproval `json:"approval"`
+	// Approved and persisted for this project location
+	Kind PermissionDecisionApprovedForLocationKind `json:"kind"`
+	// The location key (git root or cwd) to persist the approval to
+	LocationKey string `json:"locationKey"`
+}
+
+// The approval to persist for this location
+type PermissionDecisionApprovedForLocationApproval struct {
+	CommandIdentifiers []string     `json:"commandIdentifiers,omitempty"`
+	Kind               ApprovalKind `json:"kind"`
+	ServerName         *string      `json:"serverName,omitempty"`
+	ToolName           *string      `json:"toolName"`
+}
+
+type PermissionDecisionApprovedForLocationApprovalCommands struct {
+	CommandIdentifiers []string                                                  `json:"commandIdentifiers"`
+	Kind               PermissionDecisionApprovedForLocationApprovalCommandsKind `json:"kind"`
+}
+
+type PermissionDecisionApprovedForLocationApprovalCustomTool struct {
+	Kind     PermissionDecisionApprovedForLocationApprovalCustomToolKind `json:"kind"`
+	ToolName string                                                      `json:"toolName"`
+}
+
+type PermissionDecisionApprovedForLocationApprovalMCP struct {
+	Kind       PermissionDecisionApprovedForLocationApprovalMCPKind `json:"kind"`
+	ServerName string                                               `json:"serverName"`
+	ToolName   *string                                              `json:"toolName"`
+}
+
+type PermissionDecisionApprovedForLocationApprovalMCPSampling struct {
+	Kind       PermissionDecisionApprovedForLocationApprovalMCPSamplingKind `json:"kind"`
+	ServerName string                                                       `json:"serverName"`
+}
+
+type PermissionDecisionApprovedForLocationApprovalMemory struct {
+	Kind PermissionDecisionApprovedForLocationApprovalMemoryKind `json:"kind"`
+}
+
+type PermissionDecisionApprovedForLocationApprovalWrite struct {
+	Kind PermissionDecisionApprovedForLocationApprovalWriteKind `json:"kind"`
+}
+
+type PermissionDecisionApprovedForSession struct {
+	// The approval to add as a session-scoped rule
+	Approval PermissionDecisionApprovedForSessionApproval `json:"approval"`
+	// Approved and remembered for the rest of the session
+	Kind PermissionDecisionApprovedForSessionKind `json:"kind"`
+}
+
+// The approval to add as a session-scoped rule
+type PermissionDecisionApprovedForSessionApproval struct {
+	CommandIdentifiers []string     `json:"commandIdentifiers,omitempty"`
+	Kind               ApprovalKind `json:"kind"`
+	ServerName         *string      `json:"serverName,omitempty"`
+	ToolName           *string      `json:"toolName"`
+}
+
+type PermissionDecisionApprovedForSessionApprovalCommands struct {
+	CommandIdentifiers []string                                                  `json:"commandIdentifiers"`
+	Kind               PermissionDecisionApprovedForLocationApprovalCommandsKind `json:"kind"`
+}
+
+type PermissionDecisionApprovedForSessionApprovalCustomTool struct {
+	Kind     PermissionDecisionApprovedForLocationApprovalCustomToolKind `json:"kind"`
+	ToolName string                                                      `json:"toolName"`
+}
+
+type PermissionDecisionApprovedForSessionApprovalMCP struct {
+	Kind       PermissionDecisionApprovedForLocationApprovalMCPKind `json:"kind"`
+	ServerName string                                               `json:"serverName"`
+	ToolName   *string                                              `json:"toolName"`
+}
+
+type PermissionDecisionApprovedForSessionApprovalMCPSampling struct {
+	Kind       PermissionDecisionApprovedForLocationApprovalMCPSamplingKind `json:"kind"`
+	ServerName string                                                       `json:"serverName"`
+}
+
+type PermissionDecisionApprovedForSessionApprovalMemory struct {
+	Kind PermissionDecisionApprovedForLocationApprovalMemoryKind `json:"kind"`
+}
+
+type PermissionDecisionApprovedForSessionApprovalWrite struct {
+	Kind PermissionDecisionApprovedForLocationApprovalWriteKind `json:"kind"`
 }
 
 type PermissionDecisionDeniedByContentExclusionPolicy struct {
@@ -778,6 +967,24 @@ type PermissionDecisionRequest struct {
 
 type PermissionRequestResult struct {
 	// Whether the permission request was handled successfully
+	Success bool `json:"success"`
+}
+
+type PermissionsResetSessionApprovalsRequest struct {
+}
+
+type PermissionsResetSessionApprovalsResult struct {
+	// Whether the operation succeeded
+	Success bool `json:"success"`
+}
+
+type PermissionsSetApproveAllRequest struct {
+	// Whether to auto-approve all tool permission requests
+	Enabled bool `json:"enabled"`
+}
+
+type PermissionsSetApproveAllResult struct {
+	// Whether the operation succeeded
 	Success bool `json:"success"`
 }
 
@@ -852,6 +1059,21 @@ type ServerSkill struct {
 type ServerSkillList struct {
 	// All discovered skills across all sources
 	Skills []ServerSkill `json:"skills"`
+}
+
+type SessionAuthStatus struct {
+	// Authentication type
+	AuthType *AuthInfoType `json:"authType,omitempty"`
+	// Copilot plan tier (e.g., individual_pro, business)
+	CopilotPlan *string `json:"copilotPlan,omitempty"`
+	// Authentication host URL
+	Host *string `json:"host,omitempty"`
+	// Whether the session has resolved authentication
+	IsAuthenticated bool `json:"isAuthenticated"`
+	// Authenticated login/username, if available
+	Login *string `json:"login,omitempty"`
+	// Human-readable authentication status description
+	StatusMessage *string `json:"statusMessage,omitempty"`
 }
 
 type SessionFSAppendFileRequest struct {
@@ -1414,6 +1636,19 @@ type WorkspacesReadFileResult struct {
 	Content string `json:"content"`
 }
 
+// Authentication type
+type AuthInfoType string
+
+const (
+	AuthInfoTypeAPIKey          AuthInfoType = "api-key"
+	AuthInfoTypeUser            AuthInfoType = "user"
+	AuthInfoTypeCopilotAPIToken AuthInfoType = "copilot-api-token"
+	AuthInfoTypeEnv             AuthInfoType = "env"
+	AuthInfoTypeGhCli           AuthInfoType = "gh-cli"
+	AuthInfoTypeHmac            AuthInfoType = "hmac"
+	AuthInfoTypeToken           AuthInfoType = "token"
+)
+
 // Configuration source
 //
 // Configuration source: user, workspace, plugin, or builtin
@@ -1431,9 +1666,9 @@ type DiscoveredMCPServerType string
 
 const (
 	DiscoveredMCPServerTypeHTTP   DiscoveredMCPServerType = "http"
+	DiscoveredMCPServerTypeMemory DiscoveredMCPServerType = "memory"
 	DiscoveredMCPServerTypeSSE    DiscoveredMCPServerType = "sse"
 	DiscoveredMCPServerTypeStdio  DiscoveredMCPServerType = "stdio"
-	DiscoveredMCPServerTypeMemory DiscoveredMCPServerType = "memory"
 )
 
 // Discovery source: project (.github/extensions/) or user (~/.copilot/extensions/)
@@ -1539,10 +1774,23 @@ const (
 	SessionModePlan        SessionMode = "plan"
 )
 
+type ApprovalKind string
+
+const (
+	ApprovalKindCommands    ApprovalKind = "commands"
+	ApprovalKindCustomTool  ApprovalKind = "custom-tool"
+	ApprovalKindMcp         ApprovalKind = "mcp"
+	ApprovalKindMcpSampling ApprovalKind = "mcp-sampling"
+	ApprovalKindMemory      ApprovalKind = "memory"
+	ApprovalKindWrite       ApprovalKind = "write"
+)
+
 type PermissionDecisionKind string
 
 const (
 	PermissionDecisionKindApproved                                       PermissionDecisionKind = "approved"
+	PermissionDecisionKindApprovedForLocation                            PermissionDecisionKind = "approved-for-location"
+	PermissionDecisionKindApprovedForSession                             PermissionDecisionKind = "approved-for-session"
 	PermissionDecisionKindDeniedByContentExclusionPolicy                 PermissionDecisionKind = "denied-by-content-exclusion-policy"
 	PermissionDecisionKindDeniedByPermissionRequestHook                  PermissionDecisionKind = "denied-by-permission-request-hook"
 	PermissionDecisionKindDeniedByRules                                  PermissionDecisionKind = "denied-by-rules"
@@ -1554,6 +1802,54 @@ type PermissionDecisionApprovedKind string
 
 const (
 	PermissionDecisionApprovedKindApproved PermissionDecisionApprovedKind = "approved"
+)
+
+type PermissionDecisionApprovedForLocationKind string
+
+const (
+	PermissionDecisionApprovedForLocationKindApprovedForLocation PermissionDecisionApprovedForLocationKind = "approved-for-location"
+)
+
+type PermissionDecisionApprovedForLocationApprovalCommandsKind string
+
+const (
+	PermissionDecisionApprovedForLocationApprovalCommandsKindCommands PermissionDecisionApprovedForLocationApprovalCommandsKind = "commands"
+)
+
+type PermissionDecisionApprovedForLocationApprovalCustomToolKind string
+
+const (
+	PermissionDecisionApprovedForLocationApprovalCustomToolKindCustomTool PermissionDecisionApprovedForLocationApprovalCustomToolKind = "custom-tool"
+)
+
+type PermissionDecisionApprovedForLocationApprovalMCPKind string
+
+const (
+	PermissionDecisionApprovedForLocationApprovalMCPKindMcp PermissionDecisionApprovedForLocationApprovalMCPKind = "mcp"
+)
+
+type PermissionDecisionApprovedForLocationApprovalMCPSamplingKind string
+
+const (
+	PermissionDecisionApprovedForLocationApprovalMCPSamplingKindMcpSampling PermissionDecisionApprovedForLocationApprovalMCPSamplingKind = "mcp-sampling"
+)
+
+type PermissionDecisionApprovedForLocationApprovalMemoryKind string
+
+const (
+	PermissionDecisionApprovedForLocationApprovalMemoryKindMemory PermissionDecisionApprovedForLocationApprovalMemoryKind = "memory"
+)
+
+type PermissionDecisionApprovedForLocationApprovalWriteKind string
+
+const (
+	PermissionDecisionApprovedForLocationApprovalWriteKindWrite PermissionDecisionApprovedForLocationApprovalWriteKind = "write"
+)
+
+type PermissionDecisionApprovedForSessionKind string
+
+const (
+	PermissionDecisionApprovedForSessionKindApprovedForSession PermissionDecisionApprovedForSessionKind = "approved-for-session"
 )
 
 type PermissionDecisionDeniedByContentExclusionPolicyKind string
@@ -1717,8 +2013,8 @@ type serverApi struct {
 
 type ServerModelsApi serverApi
 
-func (a *ServerModelsApi) List(ctx context.Context) (*ModelList, error) {
-	raw, err := a.client.Request("models.list", nil)
+func (a *ServerModelsApi) List(ctx context.Context, params *ModelsListRequest) (*ModelList, error) {
+	raw, err := a.client.Request("models.list", params)
 	if err != nil {
 		return nil, err
 	}
@@ -1745,8 +2041,8 @@ func (a *ServerToolsApi) List(ctx context.Context, params *ToolsListRequest) (*T
 
 type ServerAccountApi serverApi
 
-func (a *ServerAccountApi) GetQuota(ctx context.Context) (*AccountGetQuotaResult, error) {
-	raw, err := a.client.Request("account.getQuota", nil)
+func (a *ServerAccountApi) GetQuota(ctx context.Context, params *AccountGetQuotaRequest) (*AccountGetQuotaResult, error) {
+	raw, err := a.client.Request("account.getQuota", params)
 	if err != nil {
 		return nil, err
 	}
@@ -1815,6 +2111,30 @@ func (a *ServerMcpConfigApi) Remove(ctx context.Context, params *MCPConfigRemove
 		return nil, err
 	}
 	var result MCPConfigRemoveResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (a *ServerMcpConfigApi) Enable(ctx context.Context, params *MCPConfigEnableRequest) (*MCPConfigEnableResult, error) {
+	raw, err := a.client.Request("mcp.config.enable", params)
+	if err != nil {
+		return nil, err
+	}
+	var result MCPConfigEnableResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (a *ServerMcpConfigApi) Disable(ctx context.Context, params *MCPConfigDisableRequest) (*MCPConfigDisableResult, error) {
+	raw, err := a.client.Request("mcp.config.disable", params)
+	if err != nil {
+		return nil, err
+	}
+	var result MCPConfigDisableResult
 	if err := json.Unmarshal(raw, &result); err != nil {
 		return nil, err
 	}
@@ -1927,6 +2247,21 @@ func NewServerRpc(client *jsonrpc2.Client) *ServerRpc {
 type sessionApi struct {
 	client    *jsonrpc2.Client
 	sessionID string
+}
+
+type AuthApi sessionApi
+
+func (a *AuthApi) GetStatus(ctx context.Context) (*SessionAuthStatus, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	raw, err := a.client.Request("session.auth.getStatus", req)
+	if err != nil {
+		return nil, err
+	}
+	var result SessionAuthStatus
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 type ModelApi sessionApi
@@ -2362,6 +2697,39 @@ func (a *McpApi) Reload(ctx context.Context) (*MCPReloadResult, error) {
 	return &result, nil
 }
 
+// Experimental: McpOauthApi contains experimental APIs that may change or be removed.
+type McpOauthApi sessionApi
+
+func (a *McpOauthApi) Login(ctx context.Context, params *MCPOauthLoginRequest) (*MCPOauthLoginResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		req["serverName"] = params.ServerName
+		if params.ForceReauth != nil {
+			req["forceReauth"] = *params.ForceReauth
+		}
+		if params.ClientName != nil {
+			req["clientName"] = *params.ClientName
+		}
+		if params.CallbackSuccessMessage != nil {
+			req["callbackSuccessMessage"] = *params.CallbackSuccessMessage
+		}
+	}
+	raw, err := a.client.Request("session.mcp.oauth.login", req)
+	if err != nil {
+		return nil, err
+	}
+	var result MCPOauthLoginResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// Experimental: Oauth returns experimental APIs that may change or be removed.
+func (s *McpApi) Oauth() *McpOauthApi {
+	return (*McpOauthApi)(s)
+}
+
 // Experimental: PluginsApi contains experimental APIs that may change or be removed.
 type PluginsApi sessionApi
 
@@ -2539,6 +2907,35 @@ func (a *PermissionsApi) HandlePendingPermissionRequest(ctx context.Context, par
 	return &result, nil
 }
 
+func (a *PermissionsApi) SetApproveAll(ctx context.Context, params *PermissionsSetApproveAllRequest) (*PermissionsSetApproveAllResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		req["enabled"] = params.Enabled
+	}
+	raw, err := a.client.Request("session.permissions.setApproveAll", req)
+	if err != nil {
+		return nil, err
+	}
+	var result PermissionsSetApproveAllResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (a *PermissionsApi) ResetSessionApprovals(ctx context.Context) (*PermissionsResetSessionApprovalsResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	raw, err := a.client.Request("session.permissions.resetSessionApprovals", req)
+	if err != nil {
+		return nil, err
+	}
+	var result PermissionsResetSessionApprovalsResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 type ShellApi sessionApi
 
 func (a *ShellApi) Exec(ctx context.Context, params *ShellExecRequest) (*ShellExecResult, error) {
@@ -2634,6 +3031,7 @@ func (a *UsageApi) GetMetrics(ctx context.Context) (*UsageGetMetricsResult, erro
 type SessionRpc struct {
 	common sessionApi // Reuse a single struct instead of allocating one for each service on the heap.
 
+	Auth         *AuthApi
 	Model        *ModelApi
 	Mode         *ModeApi
 	Name         *NameApi
@@ -2683,6 +3081,7 @@ func (a *SessionRpc) Log(ctx context.Context, params *LogRequest) (*LogResult, e
 func NewSessionRpc(client *jsonrpc2.Client, sessionID string) *SessionRpc {
 	r := &SessionRpc{}
 	r.common = sessionApi{client: client, sessionID: sessionID}
+	r.Auth = (*AuthApi)(&r.common)
 	r.Model = (*ModelApi)(&r.common)
 	r.Mode = (*ModeApi)(&r.common)
 	r.Name = (*NameApi)(&r.common)

--- a/go/rpc/generated_rpc.go
+++ b/go/rpc/generated_rpc.go
@@ -13,217 +13,216 @@ import (
 )
 
 type RPCTypes struct {
-	AccountGetQuotaRequest                                           AccountGetQuotaRequest                                           `json:"AccountGetQuotaRequest"`
-	AccountGetQuotaResult                                            AccountGetQuotaResult                                            `json:"AccountGetQuotaResult"`
-	AccountQuotaSnapshot                                             AccountQuotaSnapshot                                             `json:"AccountQuotaSnapshot"`
-	AgentDeselectResult                                              AgentDeselectResult                                              `json:"AgentDeselectResult"`
-	AgentGetCurrentResult                                            AgentGetCurrentResult                                            `json:"AgentGetCurrentResult"`
-	AgentInfo                                                        AgentInfo                                                        `json:"AgentInfo"`
-	AgentList                                                        AgentList                                                        `json:"AgentList"`
-	AgentReloadResult                                                AgentReloadResult                                                `json:"AgentReloadResult"`
-	AgentSelectRequest                                               AgentSelectRequest                                               `json:"AgentSelectRequest"`
-	AgentSelectResult                                                AgentSelectResult                                                `json:"AgentSelectResult"`
-	AuthInfoType                                                     AuthInfoType                                                     `json:"AuthInfoType"`
-	CommandsHandlePendingCommandRequest                              CommandsHandlePendingCommandRequest                              `json:"CommandsHandlePendingCommandRequest"`
-	CommandsHandlePendingCommandResult                               CommandsHandlePendingCommandResult                               `json:"CommandsHandlePendingCommandResult"`
-	CurrentModel                                                     CurrentModel                                                     `json:"CurrentModel"`
-	DiscoveredMCPServer                                              DiscoveredMCPServer                                              `json:"DiscoveredMcpServer"`
-	DiscoveredMCPServerSource                                        MCPServerSource                                                  `json:"DiscoveredMcpServerSource"`
-	DiscoveredMCPServerType                                          DiscoveredMCPServerType                                          `json:"DiscoveredMcpServerType"`
-	Extension                                                        Extension                                                        `json:"Extension"`
-	ExtensionList                                                    ExtensionList                                                    `json:"ExtensionList"`
-	ExtensionsDisableRequest                                         ExtensionsDisableRequest                                         `json:"ExtensionsDisableRequest"`
-	ExtensionsDisableResult                                          ExtensionsDisableResult                                          `json:"ExtensionsDisableResult"`
-	ExtensionsEnableRequest                                          ExtensionsEnableRequest                                          `json:"ExtensionsEnableRequest"`
-	ExtensionsEnableResult                                           ExtensionsEnableResult                                           `json:"ExtensionsEnableResult"`
-	ExtensionSource                                                  ExtensionSource                                                  `json:"ExtensionSource"`
-	ExtensionsReloadResult                                           ExtensionsReloadResult                                           `json:"ExtensionsReloadResult"`
-	ExtensionStatus                                                  ExtensionStatus                                                  `json:"ExtensionStatus"`
-	FilterMapping                                                    *FilterMapping                                                   `json:"FilterMapping"`
-	FilterMappingString                                              FilterMappingString                                              `json:"FilterMappingString"`
-	FilterMappingValue                                               FilterMappingString                                              `json:"FilterMappingValue"`
-	FleetStartRequest                                                FleetStartRequest                                                `json:"FleetStartRequest"`
-	FleetStartResult                                                 FleetStartResult                                                 `json:"FleetStartResult"`
-	HandleToolCallResult                                             HandleToolCallResult                                             `json:"HandleToolCallResult"`
-	HistoryCompactContextWindow                                      HistoryCompactContextWindow                                      `json:"HistoryCompactContextWindow"`
-	HistoryCompactResult                                             HistoryCompactResult                                             `json:"HistoryCompactResult"`
-	HistoryTruncateRequest                                           HistoryTruncateRequest                                           `json:"HistoryTruncateRequest"`
-	HistoryTruncateResult                                            HistoryTruncateResult                                            `json:"HistoryTruncateResult"`
-	InstructionsGetSourcesResult                                     InstructionsGetSourcesResult                                     `json:"InstructionsGetSourcesResult"`
-	InstructionsSources                                              InstructionsSources                                              `json:"InstructionsSources"`
-	InstructionsSourcesLocation                                      InstructionsSourcesLocation                                      `json:"InstructionsSourcesLocation"`
-	InstructionsSourcesType                                          InstructionsSourcesType                                          `json:"InstructionsSourcesType"`
-	LogRequest                                                       LogRequest                                                       `json:"LogRequest"`
-	LogResult                                                        LogResult                                                        `json:"LogResult"`
-	MCPConfigAddRequest                                              MCPConfigAddRequest                                              `json:"McpConfigAddRequest"`
-	MCPConfigAddResult                                               MCPConfigAddResult                                               `json:"McpConfigAddResult"`
-	MCPConfigDisableRequest                                          MCPConfigDisableRequest                                          `json:"McpConfigDisableRequest"`
-	MCPConfigDisableResult                                           MCPConfigDisableResult                                           `json:"McpConfigDisableResult"`
-	MCPConfigEnableRequest                                           MCPConfigEnableRequest                                           `json:"McpConfigEnableRequest"`
-	MCPConfigEnableResult                                            MCPConfigEnableResult                                            `json:"McpConfigEnableResult"`
-	MCPConfigList                                                    MCPConfigList                                                    `json:"McpConfigList"`
-	MCPConfigRemoveRequest                                           MCPConfigRemoveRequest                                           `json:"McpConfigRemoveRequest"`
-	MCPConfigRemoveResult                                            MCPConfigRemoveResult                                            `json:"McpConfigRemoveResult"`
-	MCPConfigUpdateRequest                                           MCPConfigUpdateRequest                                           `json:"McpConfigUpdateRequest"`
-	MCPConfigUpdateResult                                            MCPConfigUpdateResult                                            `json:"McpConfigUpdateResult"`
-	MCPDisableRequest                                                MCPDisableRequest                                                `json:"McpDisableRequest"`
-	MCPDisableResult                                                 MCPDisableResult                                                 `json:"McpDisableResult"`
-	MCPDiscoverRequest                                               MCPDiscoverRequest                                               `json:"McpDiscoverRequest"`
-	MCPDiscoverResult                                                MCPDiscoverResult                                                `json:"McpDiscoverResult"`
-	MCPEnableRequest                                                 MCPEnableRequest                                                 `json:"McpEnableRequest"`
-	MCPEnableResult                                                  MCPEnableResult                                                  `json:"McpEnableResult"`
-	MCPOauthLoginRequest                                             MCPOauthLoginRequest                                             `json:"McpOauthLoginRequest"`
-	MCPOauthLoginResult                                              MCPOauthLoginResult                                              `json:"McpOauthLoginResult"`
-	MCPReloadResult                                                  MCPReloadResult                                                  `json:"McpReloadResult"`
-	MCPServer                                                        MCPServer                                                        `json:"McpServer"`
-	MCPServerConfig                                                  MCPServerConfig                                                  `json:"McpServerConfig"`
-	MCPServerConfigHTTP                                              MCPServerConfigHTTP                                              `json:"McpServerConfigHttp"`
-	MCPServerConfigHTTPType                                          MCPServerConfigHTTPType                                          `json:"McpServerConfigHttpType"`
-	MCPServerConfigLocal                                             MCPServerConfigLocal                                             `json:"McpServerConfigLocal"`
-	MCPServerConfigLocalType                                         MCPServerConfigLocalType                                         `json:"McpServerConfigLocalType"`
-	MCPServerList                                                    MCPServerList                                                    `json:"McpServerList"`
-	MCPServerSource                                                  MCPServerSource                                                  `json:"McpServerSource"`
-	MCPServerStatus                                                  MCPServerStatus                                                  `json:"McpServerStatus"`
-	Model                                                            ModelElement                                                     `json:"Model"`
-	ModelBilling                                                     ModelBilling                                                     `json:"ModelBilling"`
-	ModelCapabilities                                                ModelCapabilities                                                `json:"ModelCapabilities"`
-	ModelCapabilitiesLimits                                          ModelCapabilitiesLimits                                          `json:"ModelCapabilitiesLimits"`
-	ModelCapabilitiesLimitsVision                                    ModelCapabilitiesLimitsVision                                    `json:"ModelCapabilitiesLimitsVision"`
-	ModelCapabilitiesOverride                                        ModelCapabilitiesOverride                                        `json:"ModelCapabilitiesOverride"`
-	ModelCapabilitiesOverrideLimits                                  ModelCapabilitiesOverrideLimits                                  `json:"ModelCapabilitiesOverrideLimits"`
-	ModelCapabilitiesOverrideLimitsVision                            ModelCapabilitiesOverrideLimitsVision                            `json:"ModelCapabilitiesOverrideLimitsVision"`
-	ModelCapabilitiesOverrideSupports                                ModelCapabilitiesOverrideSupports                                `json:"ModelCapabilitiesOverrideSupports"`
-	ModelCapabilitiesSupports                                        ModelCapabilitiesSupports                                        `json:"ModelCapabilitiesSupports"`
-	ModelList                                                        ModelList                                                        `json:"ModelList"`
-	ModelPolicy                                                      ModelPolicy                                                      `json:"ModelPolicy"`
-	ModelsListRequest                                                ModelsListRequest                                                `json:"ModelsListRequest"`
-	ModelSwitchToRequest                                             ModelSwitchToRequest                                             `json:"ModelSwitchToRequest"`
-	ModelSwitchToResult                                              ModelSwitchToResult                                              `json:"ModelSwitchToResult"`
-	ModeSetRequest                                                   ModeSetRequest                                                   `json:"ModeSetRequest"`
-	ModeSetResult                                                    ModeSetResult                                                    `json:"ModeSetResult"`
-	NameGetResult                                                    NameGetResult                                                    `json:"NameGetResult"`
-	NameSetRequest                                                   NameSetRequest                                                   `json:"NameSetRequest"`
-	NameSetResult                                                    NameSetResult                                                    `json:"NameSetResult"`
-	PermissionDecision                                               PermissionDecision                                               `json:"PermissionDecision"`
-	PermissionDecisionApproved                                       PermissionDecisionApproved                                       `json:"PermissionDecisionApproved"`
-	PermissionDecisionApprovedForLocation                            PermissionDecisionApprovedForLocation                            `json:"PermissionDecisionApprovedForLocation"`
-	PermissionDecisionApprovedForLocationApproval                    PermissionDecisionApprovedForLocationApproval                    `json:"PermissionDecisionApprovedForLocationApproval"`
-	PermissionDecisionApprovedForLocationApprovalCommands            PermissionDecisionApprovedForLocationApprovalCommands            `json:"PermissionDecisionApprovedForLocationApprovalCommands"`
-	PermissionDecisionApprovedForLocationApprovalCustomTool          PermissionDecisionApprovedForLocationApprovalCustomTool          `json:"PermissionDecisionApprovedForLocationApprovalCustomTool"`
-	PermissionDecisionApprovedForLocationApprovalMCP                 PermissionDecisionApprovedForLocationApprovalMCP                 `json:"PermissionDecisionApprovedForLocationApprovalMcp"`
-	PermissionDecisionApprovedForLocationApprovalMCPSampling         PermissionDecisionApprovedForLocationApprovalMCPSampling         `json:"PermissionDecisionApprovedForLocationApprovalMcpSampling"`
-	PermissionDecisionApprovedForLocationApprovalMemory              PermissionDecisionApprovedForLocationApprovalMemory              `json:"PermissionDecisionApprovedForLocationApprovalMemory"`
-	PermissionDecisionApprovedForLocationApprovalWrite               PermissionDecisionApprovedForLocationApprovalWrite               `json:"PermissionDecisionApprovedForLocationApprovalWrite"`
-	PermissionDecisionApprovedForSession                             PermissionDecisionApprovedForSession                             `json:"PermissionDecisionApprovedForSession"`
-	PermissionDecisionApprovedForSessionApproval                     PermissionDecisionApprovedForSessionApproval                     `json:"PermissionDecisionApprovedForSessionApproval"`
-	PermissionDecisionApprovedForSessionApprovalCommands             PermissionDecisionApprovedForSessionApprovalCommands             `json:"PermissionDecisionApprovedForSessionApprovalCommands"`
-	PermissionDecisionApprovedForSessionApprovalCustomTool           PermissionDecisionApprovedForSessionApprovalCustomTool           `json:"PermissionDecisionApprovedForSessionApprovalCustomTool"`
-	PermissionDecisionApprovedForSessionApprovalMCP                  PermissionDecisionApprovedForSessionApprovalMCP                  `json:"PermissionDecisionApprovedForSessionApprovalMcp"`
-	PermissionDecisionApprovedForSessionApprovalMCPSampling          PermissionDecisionApprovedForSessionApprovalMCPSampling          `json:"PermissionDecisionApprovedForSessionApprovalMcpSampling"`
-	PermissionDecisionApprovedForSessionApprovalMemory               PermissionDecisionApprovedForSessionApprovalMemory               `json:"PermissionDecisionApprovedForSessionApprovalMemory"`
-	PermissionDecisionApprovedForSessionApprovalWrite                PermissionDecisionApprovedForSessionApprovalWrite                `json:"PermissionDecisionApprovedForSessionApprovalWrite"`
-	PermissionDecisionDeniedByContentExclusionPolicy                 PermissionDecisionDeniedByContentExclusionPolicy                 `json:"PermissionDecisionDeniedByContentExclusionPolicy"`
-	PermissionDecisionDeniedByPermissionRequestHook                  PermissionDecisionDeniedByPermissionRequestHook                  `json:"PermissionDecisionDeniedByPermissionRequestHook"`
-	PermissionDecisionDeniedByRules                                  PermissionDecisionDeniedByRules                                  `json:"PermissionDecisionDeniedByRules"`
-	PermissionDecisionDeniedInteractivelyByUser                      PermissionDecisionDeniedInteractivelyByUser                      `json:"PermissionDecisionDeniedInteractivelyByUser"`
-	PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser `json:"PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser"`
-	PermissionDecisionRequest                                        PermissionDecisionRequest                                        `json:"PermissionDecisionRequest"`
-	PermissionRequestResult                                          PermissionRequestResult                                          `json:"PermissionRequestResult"`
-	PermissionsResetSessionApprovalsRequest                          PermissionsResetSessionApprovalsRequest                          `json:"PermissionsResetSessionApprovalsRequest"`
-	PermissionsResetSessionApprovalsResult                           PermissionsResetSessionApprovalsResult                           `json:"PermissionsResetSessionApprovalsResult"`
-	PermissionsSetApproveAllRequest                                  PermissionsSetApproveAllRequest                                  `json:"PermissionsSetApproveAllRequest"`
-	PermissionsSetApproveAllResult                                   PermissionsSetApproveAllResult                                   `json:"PermissionsSetApproveAllResult"`
-	PingRequest                                                      PingRequest                                                      `json:"PingRequest"`
-	PingResult                                                       PingResult                                                       `json:"PingResult"`
-	PlanDeleteResult                                                 PlanDeleteResult                                                 `json:"PlanDeleteResult"`
-	PlanReadResult                                                   PlanReadResult                                                   `json:"PlanReadResult"`
-	PlanUpdateRequest                                                PlanUpdateRequest                                                `json:"PlanUpdateRequest"`
-	PlanUpdateResult                                                 PlanUpdateResult                                                 `json:"PlanUpdateResult"`
-	Plugin                                                           PluginElement                                                    `json:"Plugin"`
-	PluginList                                                       PluginList                                                       `json:"PluginList"`
-	ServerSkill                                                      ServerSkill                                                      `json:"ServerSkill"`
-	ServerSkillList                                                  ServerSkillList                                                  `json:"ServerSkillList"`
-	SessionAuthStatus                                                SessionAuthStatus                                                `json:"SessionAuthStatus"`
-	SessionFSAppendFileRequest                                       SessionFSAppendFileRequest                                       `json:"SessionFsAppendFileRequest"`
-	SessionFSError                                                   SessionFSError                                                   `json:"SessionFsError"`
-	SessionFSErrorCode                                               SessionFSErrorCode                                               `json:"SessionFsErrorCode"`
-	SessionFSExistsRequest                                           SessionFSExistsRequest                                           `json:"SessionFsExistsRequest"`
-	SessionFSExistsResult                                            SessionFSExistsResult                                            `json:"SessionFsExistsResult"`
-	SessionFSMkdirRequest                                            SessionFSMkdirRequest                                            `json:"SessionFsMkdirRequest"`
-	SessionFSReaddirRequest                                          SessionFSReaddirRequest                                          `json:"SessionFsReaddirRequest"`
-	SessionFSReaddirResult                                           SessionFSReaddirResult                                           `json:"SessionFsReaddirResult"`
-	SessionFSReaddirWithTypesEntry                                   SessionFSReaddirWithTypesEntry                                   `json:"SessionFsReaddirWithTypesEntry"`
-	SessionFSReaddirWithTypesEntryType                               SessionFSReaddirWithTypesEntryType                               `json:"SessionFsReaddirWithTypesEntryType"`
-	SessionFSReaddirWithTypesRequest                                 SessionFSReaddirWithTypesRequest                                 `json:"SessionFsReaddirWithTypesRequest"`
-	SessionFSReaddirWithTypesResult                                  SessionFSReaddirWithTypesResult                                  `json:"SessionFsReaddirWithTypesResult"`
-	SessionFSReadFileRequest                                         SessionFSReadFileRequest                                         `json:"SessionFsReadFileRequest"`
-	SessionFSReadFileResult                                          SessionFSReadFileResult                                          `json:"SessionFsReadFileResult"`
-	SessionFSRenameRequest                                           SessionFSRenameRequest                                           `json:"SessionFsRenameRequest"`
-	SessionFSRmRequest                                               SessionFSRmRequest                                               `json:"SessionFsRmRequest"`
-	SessionFSSetProviderConventions                                  SessionFSSetProviderConventions                                  `json:"SessionFsSetProviderConventions"`
-	SessionFSSetProviderRequest                                      SessionFSSetProviderRequest                                      `json:"SessionFsSetProviderRequest"`
-	SessionFSSetProviderResult                                       SessionFSSetProviderResult                                       `json:"SessionFsSetProviderResult"`
-	SessionFSStatRequest                                             SessionFSStatRequest                                             `json:"SessionFsStatRequest"`
-	SessionFSStatResult                                              SessionFSStatResult                                              `json:"SessionFsStatResult"`
-	SessionFSWriteFileRequest                                        SessionFSWriteFileRequest                                        `json:"SessionFsWriteFileRequest"`
-	SessionLogLevel                                                  SessionLogLevel                                                  `json:"SessionLogLevel"`
-	SessionMode                                                      SessionMode                                                      `json:"SessionMode"`
-	SessionsForkRequest                                              SessionsForkRequest                                              `json:"SessionsForkRequest"`
-	SessionsForkResult                                               SessionsForkResult                                               `json:"SessionsForkResult"`
-	ShellExecRequest                                                 ShellExecRequest                                                 `json:"ShellExecRequest"`
-	ShellExecResult                                                  ShellExecResult                                                  `json:"ShellExecResult"`
-	ShellKillRequest                                                 ShellKillRequest                                                 `json:"ShellKillRequest"`
-	ShellKillResult                                                  ShellKillResult                                                  `json:"ShellKillResult"`
-	ShellKillSignal                                                  ShellKillSignal                                                  `json:"ShellKillSignal"`
-	Skill                                                            Skill                                                            `json:"Skill"`
-	SkillList                                                        SkillList                                                        `json:"SkillList"`
-	SkillsConfigSetDisabledSkillsRequest                             SkillsConfigSetDisabledSkillsRequest                             `json:"SkillsConfigSetDisabledSkillsRequest"`
-	SkillsConfigSetDisabledSkillsResult                              SkillsConfigSetDisabledSkillsResult                              `json:"SkillsConfigSetDisabledSkillsResult"`
-	SkillsDisableRequest                                             SkillsDisableRequest                                             `json:"SkillsDisableRequest"`
-	SkillsDisableResult                                              SkillsDisableResult                                              `json:"SkillsDisableResult"`
-	SkillsDiscoverRequest                                            SkillsDiscoverRequest                                            `json:"SkillsDiscoverRequest"`
-	SkillsEnableRequest                                              SkillsEnableRequest                                              `json:"SkillsEnableRequest"`
-	SkillsEnableResult                                               SkillsEnableResult                                               `json:"SkillsEnableResult"`
-	SkillsReloadResult                                               SkillsReloadResult                                               `json:"SkillsReloadResult"`
-	Tool                                                             Tool                                                             `json:"Tool"`
-	ToolCallResult                                                   ToolCallResult                                                   `json:"ToolCallResult"`
-	ToolList                                                         ToolList                                                         `json:"ToolList"`
-	ToolsHandlePendingToolCall                                       *ToolsHandlePendingToolCall                                      `json:"ToolsHandlePendingToolCall"`
-	ToolsHandlePendingToolCallRequest                                ToolsHandlePendingToolCallRequest                                `json:"ToolsHandlePendingToolCallRequest"`
-	ToolsListRequest                                                 ToolsListRequest                                                 `json:"ToolsListRequest"`
-	UIElicitationArrayAnyOfField                                     UIElicitationArrayAnyOfField                                     `json:"UIElicitationArrayAnyOfField"`
-	UIElicitationArrayAnyOfFieldItems                                UIElicitationArrayAnyOfFieldItems                                `json:"UIElicitationArrayAnyOfFieldItems"`
-	UIElicitationArrayAnyOfFieldItemsAnyOf                           UIElicitationArrayAnyOfFieldItemsAnyOf                           `json:"UIElicitationArrayAnyOfFieldItemsAnyOf"`
-	UIElicitationArrayEnumField                                      UIElicitationArrayEnumField                                      `json:"UIElicitationArrayEnumField"`
-	UIElicitationArrayEnumFieldItems                                 UIElicitationArrayEnumFieldItems                                 `json:"UIElicitationArrayEnumFieldItems"`
-	UIElicitationFieldValue                                          *UIElicitationFieldValue                                         `json:"UIElicitationFieldValue"`
-	UIElicitationRequest                                             UIElicitationRequest                                             `json:"UIElicitationRequest"`
-	UIElicitationResponse                                            UIElicitationResponse                                            `json:"UIElicitationResponse"`
-	UIElicitationResponseAction                                      UIElicitationResponseAction                                      `json:"UIElicitationResponseAction"`
-	UIElicitationResponseContent                                     map[string]*UIElicitationFieldValue                              `json:"UIElicitationResponseContent"`
-	UIElicitationResult                                              UIElicitationResult                                              `json:"UIElicitationResult"`
-	UIElicitationSchema                                              UIElicitationSchema                                              `json:"UIElicitationSchema"`
-	UIElicitationSchemaProperty                                      UIElicitationSchemaProperty                                      `json:"UIElicitationSchemaProperty"`
-	UIElicitationSchemaPropertyBoolean                               UIElicitationSchemaPropertyBoolean                               `json:"UIElicitationSchemaPropertyBoolean"`
-	UIElicitationSchemaPropertyNumber                                UIElicitationSchemaPropertyNumber                                `json:"UIElicitationSchemaPropertyNumber"`
-	UIElicitationSchemaPropertyNumberType                            UIElicitationSchemaPropertyNumberTypeEnum                        `json:"UIElicitationSchemaPropertyNumberType"`
-	UIElicitationSchemaPropertyString                                UIElicitationSchemaPropertyString                                `json:"UIElicitationSchemaPropertyString"`
-	UIElicitationSchemaPropertyStringFormat                          UIElicitationSchemaPropertyStringFormat                          `json:"UIElicitationSchemaPropertyStringFormat"`
-	UIElicitationStringEnumField                                     UIElicitationStringEnumField                                     `json:"UIElicitationStringEnumField"`
-	UIElicitationStringOneOfField                                    UIElicitationStringOneOfField                                    `json:"UIElicitationStringOneOfField"`
-	UIElicitationStringOneOfFieldOneOf                               UIElicitationStringOneOfFieldOneOf                               `json:"UIElicitationStringOneOfFieldOneOf"`
-	UIHandlePendingElicitationRequest                                UIHandlePendingElicitationRequest                                `json:"UIHandlePendingElicitationRequest"`
-	UsageGetMetricsResult                                            UsageGetMetricsResult                                            `json:"UsageGetMetricsResult"`
-	UsageMetricsCodeChanges                                          UsageMetricsCodeChanges                                          `json:"UsageMetricsCodeChanges"`
-	UsageMetricsModelMetric                                          UsageMetricsModelMetric                                          `json:"UsageMetricsModelMetric"`
-	UsageMetricsModelMetricRequests                                  UsageMetricsModelMetricRequests                                  `json:"UsageMetricsModelMetricRequests"`
-	UsageMetricsModelMetricUsage                                     UsageMetricsModelMetricUsage                                     `json:"UsageMetricsModelMetricUsage"`
-	WorkspacesCreateFileRequest                                      WorkspacesCreateFileRequest                                      `json:"WorkspacesCreateFileRequest"`
-	WorkspacesCreateFileResult                                       WorkspacesCreateFileResult                                       `json:"WorkspacesCreateFileResult"`
-	WorkspacesGetWorkspaceResult                                     WorkspacesGetWorkspaceResult                                     `json:"WorkspacesGetWorkspaceResult"`
-	WorkspacesListFilesResult                                        WorkspacesListFilesResult                                        `json:"WorkspacesListFilesResult"`
-	WorkspacesReadFileRequest                                        WorkspacesReadFileRequest                                        `json:"WorkspacesReadFileRequest"`
-	WorkspacesReadFileResult                                         WorkspacesReadFileResult                                         `json:"WorkspacesReadFileResult"`
+	AccountGetQuotaRequest                                  AccountGetQuotaRequest                                  `json:"AccountGetQuotaRequest"`
+	AccountGetQuotaResult                                   AccountGetQuotaResult                                   `json:"AccountGetQuotaResult"`
+	AccountQuotaSnapshot                                    AccountQuotaSnapshot                                    `json:"AccountQuotaSnapshot"`
+	AgentDeselectResult                                     AgentDeselectResult                                     `json:"AgentDeselectResult"`
+	AgentGetCurrentResult                                   AgentGetCurrentResult                                   `json:"AgentGetCurrentResult"`
+	AgentInfo                                               AgentInfo                                               `json:"AgentInfo"`
+	AgentList                                               AgentList                                               `json:"AgentList"`
+	AgentReloadResult                                       AgentReloadResult                                       `json:"AgentReloadResult"`
+	AgentSelectRequest                                      AgentSelectRequest                                      `json:"AgentSelectRequest"`
+	AgentSelectResult                                       AgentSelectResult                                       `json:"AgentSelectResult"`
+	AuthInfoType                                            AuthInfoType                                            `json:"AuthInfoType"`
+	CommandsHandlePendingCommandRequest                     CommandsHandlePendingCommandRequest                     `json:"CommandsHandlePendingCommandRequest"`
+	CommandsHandlePendingCommandResult                      CommandsHandlePendingCommandResult                      `json:"CommandsHandlePendingCommandResult"`
+	CurrentModel                                            CurrentModel                                            `json:"CurrentModel"`
+	DiscoveredMCPServer                                     DiscoveredMCPServer                                     `json:"DiscoveredMcpServer"`
+	DiscoveredMCPServerSource                               MCPServerSource                                         `json:"DiscoveredMcpServerSource"`
+	DiscoveredMCPServerType                                 DiscoveredMCPServerType                                 `json:"DiscoveredMcpServerType"`
+	Extension                                               Extension                                               `json:"Extension"`
+	ExtensionList                                           ExtensionList                                           `json:"ExtensionList"`
+	ExtensionsDisableRequest                                ExtensionsDisableRequest                                `json:"ExtensionsDisableRequest"`
+	ExtensionsDisableResult                                 ExtensionsDisableResult                                 `json:"ExtensionsDisableResult"`
+	ExtensionsEnableRequest                                 ExtensionsEnableRequest                                 `json:"ExtensionsEnableRequest"`
+	ExtensionsEnableResult                                  ExtensionsEnableResult                                  `json:"ExtensionsEnableResult"`
+	ExtensionSource                                         ExtensionSource                                         `json:"ExtensionSource"`
+	ExtensionsReloadResult                                  ExtensionsReloadResult                                  `json:"ExtensionsReloadResult"`
+	ExtensionStatus                                         ExtensionStatus                                         `json:"ExtensionStatus"`
+	FilterMapping                                           *FilterMapping                                          `json:"FilterMapping"`
+	FilterMappingString                                     FilterMappingString                                     `json:"FilterMappingString"`
+	FilterMappingValue                                      FilterMappingString                                     `json:"FilterMappingValue"`
+	FleetStartRequest                                       FleetStartRequest                                       `json:"FleetStartRequest"`
+	FleetStartResult                                        FleetStartResult                                        `json:"FleetStartResult"`
+	HandleToolCallResult                                    HandleToolCallResult                                    `json:"HandleToolCallResult"`
+	HistoryCompactContextWindow                             HistoryCompactContextWindow                             `json:"HistoryCompactContextWindow"`
+	HistoryCompactResult                                    HistoryCompactResult                                    `json:"HistoryCompactResult"`
+	HistoryTruncateRequest                                  HistoryTruncateRequest                                  `json:"HistoryTruncateRequest"`
+	HistoryTruncateResult                                   HistoryTruncateResult                                   `json:"HistoryTruncateResult"`
+	InstructionsGetSourcesResult                            InstructionsGetSourcesResult                            `json:"InstructionsGetSourcesResult"`
+	InstructionsSources                                     InstructionsSources                                     `json:"InstructionsSources"`
+	InstructionsSourcesLocation                             InstructionsSourcesLocation                             `json:"InstructionsSourcesLocation"`
+	InstructionsSourcesType                                 InstructionsSourcesType                                 `json:"InstructionsSourcesType"`
+	LogRequest                                              LogRequest                                              `json:"LogRequest"`
+	LogResult                                               LogResult                                               `json:"LogResult"`
+	MCPConfigAddRequest                                     MCPConfigAddRequest                                     `json:"McpConfigAddRequest"`
+	MCPConfigAddResult                                      MCPConfigAddResult                                      `json:"McpConfigAddResult"`
+	MCPConfigDisableRequest                                 MCPConfigDisableRequest                                 `json:"McpConfigDisableRequest"`
+	MCPConfigDisableResult                                  MCPConfigDisableResult                                  `json:"McpConfigDisableResult"`
+	MCPConfigEnableRequest                                  MCPConfigEnableRequest                                  `json:"McpConfigEnableRequest"`
+	MCPConfigEnableResult                                   MCPConfigEnableResult                                   `json:"McpConfigEnableResult"`
+	MCPConfigList                                           MCPConfigList                                           `json:"McpConfigList"`
+	MCPConfigRemoveRequest                                  MCPConfigRemoveRequest                                  `json:"McpConfigRemoveRequest"`
+	MCPConfigRemoveResult                                   MCPConfigRemoveResult                                   `json:"McpConfigRemoveResult"`
+	MCPConfigUpdateRequest                                  MCPConfigUpdateRequest                                  `json:"McpConfigUpdateRequest"`
+	MCPConfigUpdateResult                                   MCPConfigUpdateResult                                   `json:"McpConfigUpdateResult"`
+	MCPDisableRequest                                       MCPDisableRequest                                       `json:"McpDisableRequest"`
+	MCPDisableResult                                        MCPDisableResult                                        `json:"McpDisableResult"`
+	MCPDiscoverRequest                                      MCPDiscoverRequest                                      `json:"McpDiscoverRequest"`
+	MCPDiscoverResult                                       MCPDiscoverResult                                       `json:"McpDiscoverResult"`
+	MCPEnableRequest                                        MCPEnableRequest                                        `json:"McpEnableRequest"`
+	MCPEnableResult                                         MCPEnableResult                                         `json:"McpEnableResult"`
+	MCPOauthLoginRequest                                    MCPOauthLoginRequest                                    `json:"McpOauthLoginRequest"`
+	MCPOauthLoginResult                                     MCPOauthLoginResult                                     `json:"McpOauthLoginResult"`
+	MCPReloadResult                                         MCPReloadResult                                         `json:"McpReloadResult"`
+	MCPServer                                               MCPServer                                               `json:"McpServer"`
+	MCPServerConfig                                         MCPServerConfig                                         `json:"McpServerConfig"`
+	MCPServerConfigHTTP                                     MCPServerConfigHTTP                                     `json:"McpServerConfigHttp"`
+	MCPServerConfigHTTPType                                 MCPServerConfigHTTPType                                 `json:"McpServerConfigHttpType"`
+	MCPServerConfigLocal                                    MCPServerConfigLocal                                    `json:"McpServerConfigLocal"`
+	MCPServerConfigLocalType                                MCPServerConfigLocalType                                `json:"McpServerConfigLocalType"`
+	MCPServerList                                           MCPServerList                                           `json:"McpServerList"`
+	MCPServerSource                                         MCPServerSource                                         `json:"McpServerSource"`
+	MCPServerStatus                                         MCPServerStatus                                         `json:"McpServerStatus"`
+	Model                                                   ModelElement                                            `json:"Model"`
+	ModelBilling                                            ModelBilling                                            `json:"ModelBilling"`
+	ModelCapabilities                                       ModelCapabilities                                       `json:"ModelCapabilities"`
+	ModelCapabilitiesLimits                                 ModelCapabilitiesLimits                                 `json:"ModelCapabilitiesLimits"`
+	ModelCapabilitiesLimitsVision                           ModelCapabilitiesLimitsVision                           `json:"ModelCapabilitiesLimitsVision"`
+	ModelCapabilitiesOverride                               ModelCapabilitiesOverride                               `json:"ModelCapabilitiesOverride"`
+	ModelCapabilitiesOverrideLimits                         ModelCapabilitiesOverrideLimits                         `json:"ModelCapabilitiesOverrideLimits"`
+	ModelCapabilitiesOverrideLimitsVision                   ModelCapabilitiesOverrideLimitsVision                   `json:"ModelCapabilitiesOverrideLimitsVision"`
+	ModelCapabilitiesOverrideSupports                       ModelCapabilitiesOverrideSupports                       `json:"ModelCapabilitiesOverrideSupports"`
+	ModelCapabilitiesSupports                               ModelCapabilitiesSupports                               `json:"ModelCapabilitiesSupports"`
+	ModelList                                               ModelList                                               `json:"ModelList"`
+	ModelPolicy                                             ModelPolicy                                             `json:"ModelPolicy"`
+	ModelsListRequest                                       ModelsListRequest                                       `json:"ModelsListRequest"`
+	ModelSwitchToRequest                                    ModelSwitchToRequest                                    `json:"ModelSwitchToRequest"`
+	ModelSwitchToResult                                     ModelSwitchToResult                                     `json:"ModelSwitchToResult"`
+	ModeSetRequest                                          ModeSetRequest                                          `json:"ModeSetRequest"`
+	ModeSetResult                                           ModeSetResult                                           `json:"ModeSetResult"`
+	NameGetResult                                           NameGetResult                                           `json:"NameGetResult"`
+	NameSetRequest                                          NameSetRequest                                          `json:"NameSetRequest"`
+	NameSetResult                                           NameSetResult                                           `json:"NameSetResult"`
+	PermissionDecision                                      PermissionDecision                                      `json:"PermissionDecision"`
+	PermissionDecisionApproveForLocation                    PermissionDecisionApproveForLocation                    `json:"PermissionDecisionApproveForLocation"`
+	PermissionDecisionApproveForLocationApproval            PermissionDecisionApproveForLocationApproval            `json:"PermissionDecisionApproveForLocationApproval"`
+	PermissionDecisionApproveForLocationApprovalCommands    PermissionDecisionApproveForLocationApprovalCommands    `json:"PermissionDecisionApproveForLocationApprovalCommands"`
+	PermissionDecisionApproveForLocationApprovalCustomTool  PermissionDecisionApproveForLocationApprovalCustomTool  `json:"PermissionDecisionApproveForLocationApprovalCustomTool"`
+	PermissionDecisionApproveForLocationApprovalMCP         PermissionDecisionApproveForLocationApprovalMCP         `json:"PermissionDecisionApproveForLocationApprovalMcp"`
+	PermissionDecisionApproveForLocationApprovalMCPSampling PermissionDecisionApproveForLocationApprovalMCPSampling `json:"PermissionDecisionApproveForLocationApprovalMcpSampling"`
+	PermissionDecisionApproveForLocationApprovalMemory      PermissionDecisionApproveForLocationApprovalMemory      `json:"PermissionDecisionApproveForLocationApprovalMemory"`
+	PermissionDecisionApproveForLocationApprovalRead        PermissionDecisionApproveForLocationApprovalRead        `json:"PermissionDecisionApproveForLocationApprovalRead"`
+	PermissionDecisionApproveForLocationApprovalWrite       PermissionDecisionApproveForLocationApprovalWrite       `json:"PermissionDecisionApproveForLocationApprovalWrite"`
+	PermissionDecisionApproveForSession                     PermissionDecisionApproveForSession                     `json:"PermissionDecisionApproveForSession"`
+	PermissionDecisionApproveForSessionApproval             PermissionDecisionApproveForSessionApproval             `json:"PermissionDecisionApproveForSessionApproval"`
+	PermissionDecisionApproveForSessionApprovalCommands     PermissionDecisionApproveForSessionApprovalCommands     `json:"PermissionDecisionApproveForSessionApprovalCommands"`
+	PermissionDecisionApproveForSessionApprovalCustomTool   PermissionDecisionApproveForSessionApprovalCustomTool   `json:"PermissionDecisionApproveForSessionApprovalCustomTool"`
+	PermissionDecisionApproveForSessionApprovalMCP          PermissionDecisionApproveForSessionApprovalMCP          `json:"PermissionDecisionApproveForSessionApprovalMcp"`
+	PermissionDecisionApproveForSessionApprovalMCPSampling  PermissionDecisionApproveForSessionApprovalMCPSampling  `json:"PermissionDecisionApproveForSessionApprovalMcpSampling"`
+	PermissionDecisionApproveForSessionApprovalMemory       PermissionDecisionApproveForSessionApprovalMemory       `json:"PermissionDecisionApproveForSessionApprovalMemory"`
+	PermissionDecisionApproveForSessionApprovalRead         PermissionDecisionApproveForSessionApprovalRead         `json:"PermissionDecisionApproveForSessionApprovalRead"`
+	PermissionDecisionApproveForSessionApprovalWrite        PermissionDecisionApproveForSessionApprovalWrite        `json:"PermissionDecisionApproveForSessionApprovalWrite"`
+	PermissionDecisionApproveOnce                           PermissionDecisionApproveOnce                           `json:"PermissionDecisionApproveOnce"`
+	PermissionDecisionReject                                PermissionDecisionReject                                `json:"PermissionDecisionReject"`
+	PermissionDecisionRequest                               PermissionDecisionRequest                               `json:"PermissionDecisionRequest"`
+	PermissionDecisionUserNotAvailable                      PermissionDecisionUserNotAvailable                      `json:"PermissionDecisionUserNotAvailable"`
+	PermissionRequestResult                                 PermissionRequestResult                                 `json:"PermissionRequestResult"`
+	PermissionsResetSessionApprovalsRequest                 PermissionsResetSessionApprovalsRequest                 `json:"PermissionsResetSessionApprovalsRequest"`
+	PermissionsResetSessionApprovalsResult                  PermissionsResetSessionApprovalsResult                  `json:"PermissionsResetSessionApprovalsResult"`
+	PermissionsSetApproveAllRequest                         PermissionsSetApproveAllRequest                         `json:"PermissionsSetApproveAllRequest"`
+	PermissionsSetApproveAllResult                          PermissionsSetApproveAllResult                          `json:"PermissionsSetApproveAllResult"`
+	PingRequest                                             PingRequest                                             `json:"PingRequest"`
+	PingResult                                              PingResult                                              `json:"PingResult"`
+	PlanDeleteResult                                        PlanDeleteResult                                        `json:"PlanDeleteResult"`
+	PlanReadResult                                          PlanReadResult                                          `json:"PlanReadResult"`
+	PlanUpdateRequest                                       PlanUpdateRequest                                       `json:"PlanUpdateRequest"`
+	PlanUpdateResult                                        PlanUpdateResult                                        `json:"PlanUpdateResult"`
+	Plugin                                                  PluginElement                                           `json:"Plugin"`
+	PluginList                                              PluginList                                              `json:"PluginList"`
+	ServerSkill                                             ServerSkill                                             `json:"ServerSkill"`
+	ServerSkillList                                         ServerSkillList                                         `json:"ServerSkillList"`
+	SessionAuthStatus                                       SessionAuthStatus                                       `json:"SessionAuthStatus"`
+	SessionFSAppendFileRequest                              SessionFSAppendFileRequest                              `json:"SessionFsAppendFileRequest"`
+	SessionFSError                                          SessionFSError                                          `json:"SessionFsError"`
+	SessionFSErrorCode                                      SessionFSErrorCode                                      `json:"SessionFsErrorCode"`
+	SessionFSExistsRequest                                  SessionFSExistsRequest                                  `json:"SessionFsExistsRequest"`
+	SessionFSExistsResult                                   SessionFSExistsResult                                   `json:"SessionFsExistsResult"`
+	SessionFSMkdirRequest                                   SessionFSMkdirRequest                                   `json:"SessionFsMkdirRequest"`
+	SessionFSReaddirRequest                                 SessionFSReaddirRequest                                 `json:"SessionFsReaddirRequest"`
+	SessionFSReaddirResult                                  SessionFSReaddirResult                                  `json:"SessionFsReaddirResult"`
+	SessionFSReaddirWithTypesEntry                          SessionFSReaddirWithTypesEntry                          `json:"SessionFsReaddirWithTypesEntry"`
+	SessionFSReaddirWithTypesEntryType                      SessionFSReaddirWithTypesEntryType                      `json:"SessionFsReaddirWithTypesEntryType"`
+	SessionFSReaddirWithTypesRequest                        SessionFSReaddirWithTypesRequest                        `json:"SessionFsReaddirWithTypesRequest"`
+	SessionFSReaddirWithTypesResult                         SessionFSReaddirWithTypesResult                         `json:"SessionFsReaddirWithTypesResult"`
+	SessionFSReadFileRequest                                SessionFSReadFileRequest                                `json:"SessionFsReadFileRequest"`
+	SessionFSReadFileResult                                 SessionFSReadFileResult                                 `json:"SessionFsReadFileResult"`
+	SessionFSRenameRequest                                  SessionFSRenameRequest                                  `json:"SessionFsRenameRequest"`
+	SessionFSRmRequest                                      SessionFSRmRequest                                      `json:"SessionFsRmRequest"`
+	SessionFSSetProviderConventions                         SessionFSSetProviderConventions                         `json:"SessionFsSetProviderConventions"`
+	SessionFSSetProviderRequest                             SessionFSSetProviderRequest                             `json:"SessionFsSetProviderRequest"`
+	SessionFSSetProviderResult                              SessionFSSetProviderResult                              `json:"SessionFsSetProviderResult"`
+	SessionFSStatRequest                                    SessionFSStatRequest                                    `json:"SessionFsStatRequest"`
+	SessionFSStatResult                                     SessionFSStatResult                                     `json:"SessionFsStatResult"`
+	SessionFSWriteFileRequest                               SessionFSWriteFileRequest                               `json:"SessionFsWriteFileRequest"`
+	SessionLogLevel                                         SessionLogLevel                                         `json:"SessionLogLevel"`
+	SessionMode                                             SessionMode                                             `json:"SessionMode"`
+	SessionsForkRequest                                     SessionsForkRequest                                     `json:"SessionsForkRequest"`
+	SessionsForkResult                                      SessionsForkResult                                      `json:"SessionsForkResult"`
+	ShellExecRequest                                        ShellExecRequest                                        `json:"ShellExecRequest"`
+	ShellExecResult                                         ShellExecResult                                         `json:"ShellExecResult"`
+	ShellKillRequest                                        ShellKillRequest                                        `json:"ShellKillRequest"`
+	ShellKillResult                                         ShellKillResult                                         `json:"ShellKillResult"`
+	ShellKillSignal                                         ShellKillSignal                                         `json:"ShellKillSignal"`
+	Skill                                                   Skill                                                   `json:"Skill"`
+	SkillList                                               SkillList                                               `json:"SkillList"`
+	SkillsConfigSetDisabledSkillsRequest                    SkillsConfigSetDisabledSkillsRequest                    `json:"SkillsConfigSetDisabledSkillsRequest"`
+	SkillsConfigSetDisabledSkillsResult                     SkillsConfigSetDisabledSkillsResult                     `json:"SkillsConfigSetDisabledSkillsResult"`
+	SkillsDisableRequest                                    SkillsDisableRequest                                    `json:"SkillsDisableRequest"`
+	SkillsDisableResult                                     SkillsDisableResult                                     `json:"SkillsDisableResult"`
+	SkillsDiscoverRequest                                   SkillsDiscoverRequest                                   `json:"SkillsDiscoverRequest"`
+	SkillsEnableRequest                                     SkillsEnableRequest                                     `json:"SkillsEnableRequest"`
+	SkillsEnableResult                                      SkillsEnableResult                                      `json:"SkillsEnableResult"`
+	SkillsReloadResult                                      SkillsReloadResult                                      `json:"SkillsReloadResult"`
+	Tool                                                    Tool                                                    `json:"Tool"`
+	ToolCallResult                                          ToolCallResult                                          `json:"ToolCallResult"`
+	ToolList                                                ToolList                                                `json:"ToolList"`
+	ToolsHandlePendingToolCall                              *ToolsHandlePendingToolCall                             `json:"ToolsHandlePendingToolCall"`
+	ToolsHandlePendingToolCallRequest                       ToolsHandlePendingToolCallRequest                       `json:"ToolsHandlePendingToolCallRequest"`
+	ToolsListRequest                                        ToolsListRequest                                        `json:"ToolsListRequest"`
+	UIElicitationArrayAnyOfField                            UIElicitationArrayAnyOfField                            `json:"UIElicitationArrayAnyOfField"`
+	UIElicitationArrayAnyOfFieldItems                       UIElicitationArrayAnyOfFieldItems                       `json:"UIElicitationArrayAnyOfFieldItems"`
+	UIElicitationArrayAnyOfFieldItemsAnyOf                  UIElicitationArrayAnyOfFieldItemsAnyOf                  `json:"UIElicitationArrayAnyOfFieldItemsAnyOf"`
+	UIElicitationArrayEnumField                             UIElicitationArrayEnumField                             `json:"UIElicitationArrayEnumField"`
+	UIElicitationArrayEnumFieldItems                        UIElicitationArrayEnumFieldItems                        `json:"UIElicitationArrayEnumFieldItems"`
+	UIElicitationFieldValue                                 *UIElicitationFieldValue                                `json:"UIElicitationFieldValue"`
+	UIElicitationRequest                                    UIElicitationRequest                                    `json:"UIElicitationRequest"`
+	UIElicitationResponse                                   UIElicitationResponse                                   `json:"UIElicitationResponse"`
+	UIElicitationResponseAction                             UIElicitationResponseAction                             `json:"UIElicitationResponseAction"`
+	UIElicitationResponseContent                            map[string]*UIElicitationFieldValue                     `json:"UIElicitationResponseContent"`
+	UIElicitationResult                                     UIElicitationResult                                     `json:"UIElicitationResult"`
+	UIElicitationSchema                                     UIElicitationSchema                                     `json:"UIElicitationSchema"`
+	UIElicitationSchemaProperty                             UIElicitationSchemaProperty                             `json:"UIElicitationSchemaProperty"`
+	UIElicitationSchemaPropertyBoolean                      UIElicitationSchemaPropertyBoolean                      `json:"UIElicitationSchemaPropertyBoolean"`
+	UIElicitationSchemaPropertyNumber                       UIElicitationSchemaPropertyNumber                       `json:"UIElicitationSchemaPropertyNumber"`
+	UIElicitationSchemaPropertyNumberType                   UIElicitationSchemaPropertyNumberTypeEnum               `json:"UIElicitationSchemaPropertyNumberType"`
+	UIElicitationSchemaPropertyString                       UIElicitationSchemaPropertyString                       `json:"UIElicitationSchemaPropertyString"`
+	UIElicitationSchemaPropertyStringFormat                 UIElicitationSchemaPropertyStringFormat                 `json:"UIElicitationSchemaPropertyStringFormat"`
+	UIElicitationStringEnumField                            UIElicitationStringEnumField                            `json:"UIElicitationStringEnumField"`
+	UIElicitationStringOneOfField                           UIElicitationStringOneOfField                           `json:"UIElicitationStringOneOfField"`
+	UIElicitationStringOneOfFieldOneOf                      UIElicitationStringOneOfFieldOneOf                      `json:"UIElicitationStringOneOfFieldOneOf"`
+	UIHandlePendingElicitationRequest                       UIHandlePendingElicitationRequest                       `json:"UIHandlePendingElicitationRequest"`
+	UsageGetMetricsResult                                   UsageGetMetricsResult                                   `json:"UsageGetMetricsResult"`
+	UsageMetricsCodeChanges                                 UsageMetricsCodeChanges                                 `json:"UsageMetricsCodeChanges"`
+	UsageMetricsModelMetric                                 UsageMetricsModelMetric                                 `json:"UsageMetricsModelMetric"`
+	UsageMetricsModelMetricRequests                         UsageMetricsModelMetricRequests                         `json:"UsageMetricsModelMetricRequests"`
+	UsageMetricsModelMetricUsage                            UsageMetricsModelMetricUsage                            `json:"UsageMetricsModelMetricUsage"`
+	WorkspacesCreateFileRequest                             WorkspacesCreateFileRequest                             `json:"WorkspacesCreateFileRequest"`
+	WorkspacesCreateFileResult                              WorkspacesCreateFileResult                              `json:"WorkspacesCreateFileResult"`
+	WorkspacesGetWorkspaceResult                            WorkspacesGetWorkspaceResult                            `json:"WorkspacesGetWorkspaceResult"`
+	WorkspacesListFilesResult                               WorkspacesListFilesResult                               `json:"WorkspacesListFilesResult"`
+	WorkspacesReadFileRequest                               WorkspacesReadFileRequest                               `json:"WorkspacesReadFileRequest"`
+	WorkspacesReadFileResult                                WorkspacesReadFileResult                                `json:"WorkspacesReadFileResult"`
 }
 
 type AccountGetQuotaRequest struct {
@@ -791,178 +790,145 @@ type NameSetResult struct {
 }
 
 type PermissionDecision struct {
-	// The permission request was approved
+	// The permission request was approved for this one instance
 	//
 	// Approved and remembered for the rest of the session
 	//
 	// Approved and persisted for this project location
 	//
-	// Denied because approval rules explicitly blocked it
-	//
-	// Denied because no approval rule matched and user confirmation was unavailable
-	//
 	// Denied by the user during an interactive prompt
 	//
-	// Denied by the organization's content exclusion policy
-	//
-	// Denied by a permission request hook registered by an extension or plugin
+	// Denied because user confirmation was unavailable
 	Kind PermissionDecisionKind `json:"kind"`
 	// The approval to add as a session-scoped rule
 	//
 	// The approval to persist for this location
-	Approval *PermissionDecisionApprovedForLocationApproval `json:"approval,omitempty"`
+	Approval *PermissionDecisionApproveForLocationApproval `json:"approval,omitempty"`
 	// The location key (git root or cwd) to persist the approval to
 	LocationKey *string `json:"locationKey,omitempty"`
-	// Rules that denied the request
-	Rules []any `json:"rules,omitempty"`
 	// Optional feedback from the user explaining the denial
 	Feedback *string `json:"feedback,omitempty"`
-	// Human-readable explanation of why the path was excluded
-	//
-	// Optional message from the hook explaining the denial
-	Message *string `json:"message,omitempty"`
-	// File path that triggered the exclusion
-	Path *string `json:"path,omitempty"`
-	// Whether to interrupt the current agent turn
-	Interrupt *bool `json:"interrupt,omitempty"`
 }
 
-type PermissionDecisionApproved struct {
-	// The permission request was approved
-	Kind PermissionDecisionApprovedKind `json:"kind"`
-}
-
-type PermissionDecisionApprovedForLocation struct {
+type PermissionDecisionApproveForLocation struct {
 	// The approval to persist for this location
-	Approval PermissionDecisionApprovedForLocationApproval `json:"approval"`
+	Approval PermissionDecisionApproveForLocationApproval `json:"approval"`
 	// Approved and persisted for this project location
-	Kind PermissionDecisionApprovedForLocationKind `json:"kind"`
+	Kind PermissionDecisionApproveForLocationKind `json:"kind"`
 	// The location key (git root or cwd) to persist the approval to
 	LocationKey string `json:"locationKey"`
 }
 
 // The approval to persist for this location
-type PermissionDecisionApprovedForLocationApproval struct {
+type PermissionDecisionApproveForLocationApproval struct {
 	CommandIdentifiers []string     `json:"commandIdentifiers,omitempty"`
 	Kind               ApprovalKind `json:"kind"`
 	ServerName         *string      `json:"serverName,omitempty"`
 	ToolName           *string      `json:"toolName"`
 }
 
-type PermissionDecisionApprovedForLocationApprovalCommands struct {
-	CommandIdentifiers []string                                                  `json:"commandIdentifiers"`
-	Kind               PermissionDecisionApprovedForLocationApprovalCommandsKind `json:"kind"`
+type PermissionDecisionApproveForLocationApprovalCommands struct {
+	CommandIdentifiers []string                                                 `json:"commandIdentifiers"`
+	Kind               PermissionDecisionApproveForLocationApprovalCommandsKind `json:"kind"`
 }
 
-type PermissionDecisionApprovedForLocationApprovalCustomTool struct {
-	Kind     PermissionDecisionApprovedForLocationApprovalCustomToolKind `json:"kind"`
-	ToolName string                                                      `json:"toolName"`
+type PermissionDecisionApproveForLocationApprovalCustomTool struct {
+	Kind     PermissionDecisionApproveForLocationApprovalCustomToolKind `json:"kind"`
+	ToolName string                                                     `json:"toolName"`
 }
 
-type PermissionDecisionApprovedForLocationApprovalMCP struct {
-	Kind       PermissionDecisionApprovedForLocationApprovalMCPKind `json:"kind"`
-	ServerName string                                               `json:"serverName"`
-	ToolName   *string                                              `json:"toolName"`
+type PermissionDecisionApproveForLocationApprovalMCP struct {
+	Kind       PermissionDecisionApproveForLocationApprovalMCPKind `json:"kind"`
+	ServerName string                                              `json:"serverName"`
+	ToolName   *string                                             `json:"toolName"`
 }
 
-type PermissionDecisionApprovedForLocationApprovalMCPSampling struct {
-	Kind       PermissionDecisionApprovedForLocationApprovalMCPSamplingKind `json:"kind"`
-	ServerName string                                                       `json:"serverName"`
+type PermissionDecisionApproveForLocationApprovalMCPSampling struct {
+	Kind       PermissionDecisionApproveForLocationApprovalMCPSamplingKind `json:"kind"`
+	ServerName string                                                      `json:"serverName"`
 }
 
-type PermissionDecisionApprovedForLocationApprovalMemory struct {
-	Kind PermissionDecisionApprovedForLocationApprovalMemoryKind `json:"kind"`
+type PermissionDecisionApproveForLocationApprovalMemory struct {
+	Kind PermissionDecisionApproveForLocationApprovalMemoryKind `json:"kind"`
 }
 
-type PermissionDecisionApprovedForLocationApprovalWrite struct {
-	Kind PermissionDecisionApprovedForLocationApprovalWriteKind `json:"kind"`
+type PermissionDecisionApproveForLocationApprovalRead struct {
+	Kind PermissionDecisionApproveForLocationApprovalReadKind `json:"kind"`
 }
 
-type PermissionDecisionApprovedForSession struct {
+type PermissionDecisionApproveForLocationApprovalWrite struct {
+	Kind PermissionDecisionApproveForLocationApprovalWriteKind `json:"kind"`
+}
+
+type PermissionDecisionApproveForSession struct {
 	// The approval to add as a session-scoped rule
-	Approval PermissionDecisionApprovedForSessionApproval `json:"approval"`
+	Approval PermissionDecisionApproveForSessionApproval `json:"approval"`
 	// Approved and remembered for the rest of the session
-	Kind PermissionDecisionApprovedForSessionKind `json:"kind"`
+	Kind PermissionDecisionApproveForSessionKind `json:"kind"`
 }
 
 // The approval to add as a session-scoped rule
-type PermissionDecisionApprovedForSessionApproval struct {
+type PermissionDecisionApproveForSessionApproval struct {
 	CommandIdentifiers []string     `json:"commandIdentifiers,omitempty"`
 	Kind               ApprovalKind `json:"kind"`
 	ServerName         *string      `json:"serverName,omitempty"`
 	ToolName           *string      `json:"toolName"`
 }
 
-type PermissionDecisionApprovedForSessionApprovalCommands struct {
-	CommandIdentifiers []string                                                  `json:"commandIdentifiers"`
-	Kind               PermissionDecisionApprovedForLocationApprovalCommandsKind `json:"kind"`
+type PermissionDecisionApproveForSessionApprovalCommands struct {
+	CommandIdentifiers []string                                                 `json:"commandIdentifiers"`
+	Kind               PermissionDecisionApproveForLocationApprovalCommandsKind `json:"kind"`
 }
 
-type PermissionDecisionApprovedForSessionApprovalCustomTool struct {
-	Kind     PermissionDecisionApprovedForLocationApprovalCustomToolKind `json:"kind"`
-	ToolName string                                                      `json:"toolName"`
+type PermissionDecisionApproveForSessionApprovalCustomTool struct {
+	Kind     PermissionDecisionApproveForLocationApprovalCustomToolKind `json:"kind"`
+	ToolName string                                                     `json:"toolName"`
 }
 
-type PermissionDecisionApprovedForSessionApprovalMCP struct {
-	Kind       PermissionDecisionApprovedForLocationApprovalMCPKind `json:"kind"`
-	ServerName string                                               `json:"serverName"`
-	ToolName   *string                                              `json:"toolName"`
+type PermissionDecisionApproveForSessionApprovalMCP struct {
+	Kind       PermissionDecisionApproveForLocationApprovalMCPKind `json:"kind"`
+	ServerName string                                              `json:"serverName"`
+	ToolName   *string                                             `json:"toolName"`
 }
 
-type PermissionDecisionApprovedForSessionApprovalMCPSampling struct {
-	Kind       PermissionDecisionApprovedForLocationApprovalMCPSamplingKind `json:"kind"`
-	ServerName string                                                       `json:"serverName"`
+type PermissionDecisionApproveForSessionApprovalMCPSampling struct {
+	Kind       PermissionDecisionApproveForLocationApprovalMCPSamplingKind `json:"kind"`
+	ServerName string                                                      `json:"serverName"`
 }
 
-type PermissionDecisionApprovedForSessionApprovalMemory struct {
-	Kind PermissionDecisionApprovedForLocationApprovalMemoryKind `json:"kind"`
+type PermissionDecisionApproveForSessionApprovalMemory struct {
+	Kind PermissionDecisionApproveForLocationApprovalMemoryKind `json:"kind"`
 }
 
-type PermissionDecisionApprovedForSessionApprovalWrite struct {
-	Kind PermissionDecisionApprovedForLocationApprovalWriteKind `json:"kind"`
+type PermissionDecisionApproveForSessionApprovalRead struct {
+	Kind PermissionDecisionApproveForLocationApprovalReadKind `json:"kind"`
 }
 
-type PermissionDecisionDeniedByContentExclusionPolicy struct {
-	// Denied by the organization's content exclusion policy
-	Kind PermissionDecisionDeniedByContentExclusionPolicyKind `json:"kind"`
-	// Human-readable explanation of why the path was excluded
-	Message string `json:"message"`
-	// File path that triggered the exclusion
-	Path string `json:"path"`
+type PermissionDecisionApproveForSessionApprovalWrite struct {
+	Kind PermissionDecisionApproveForLocationApprovalWriteKind `json:"kind"`
 }
 
-type PermissionDecisionDeniedByPermissionRequestHook struct {
-	// Whether to interrupt the current agent turn
-	Interrupt *bool `json:"interrupt,omitempty"`
-	// Denied by a permission request hook registered by an extension or plugin
-	Kind PermissionDecisionDeniedByPermissionRequestHookKind `json:"kind"`
-	// Optional message from the hook explaining the denial
-	Message *string `json:"message,omitempty"`
+type PermissionDecisionApproveOnce struct {
+	// The permission request was approved for this one instance
+	Kind PermissionDecisionApproveOnceKind `json:"kind"`
 }
 
-type PermissionDecisionDeniedByRules struct {
-	// Denied because approval rules explicitly blocked it
-	Kind PermissionDecisionDeniedByRulesKind `json:"kind"`
-	// Rules that denied the request
-	Rules []any `json:"rules"`
-}
-
-type PermissionDecisionDeniedInteractivelyByUser struct {
+type PermissionDecisionReject struct {
 	// Optional feedback from the user explaining the denial
 	Feedback *string `json:"feedback,omitempty"`
 	// Denied by the user during an interactive prompt
-	Kind PermissionDecisionDeniedInteractivelyByUserKind `json:"kind"`
-}
-
-type PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser struct {
-	// Denied because no approval rule matched and user confirmation was unavailable
-	Kind PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUserKind `json:"kind"`
+	Kind PermissionDecisionRejectKind `json:"kind"`
 }
 
 type PermissionDecisionRequest struct {
 	// Request ID of the pending permission request
 	RequestID string             `json:"requestId"`
 	Result    PermissionDecision `json:"result"`
+}
+
+type PermissionDecisionUserNotAvailable struct {
+	// Denied because user confirmation was unavailable
+	Kind PermissionDecisionUserNotAvailableKind `json:"kind"`
 }
 
 type PermissionRequestResult struct {
@@ -1782,104 +1748,90 @@ const (
 	ApprovalKindMcp         ApprovalKind = "mcp"
 	ApprovalKindMcpSampling ApprovalKind = "mcp-sampling"
 	ApprovalKindMemory      ApprovalKind = "memory"
+	ApprovalKindRead        ApprovalKind = "read"
 	ApprovalKindWrite       ApprovalKind = "write"
 )
 
 type PermissionDecisionKind string
 
 const (
-	PermissionDecisionKindApproved                                       PermissionDecisionKind = "approved"
-	PermissionDecisionKindApprovedForLocation                            PermissionDecisionKind = "approved-for-location"
-	PermissionDecisionKindApprovedForSession                             PermissionDecisionKind = "approved-for-session"
-	PermissionDecisionKindDeniedByContentExclusionPolicy                 PermissionDecisionKind = "denied-by-content-exclusion-policy"
-	PermissionDecisionKindDeniedByPermissionRequestHook                  PermissionDecisionKind = "denied-by-permission-request-hook"
-	PermissionDecisionKindDeniedByRules                                  PermissionDecisionKind = "denied-by-rules"
-	PermissionDecisionKindDeniedInteractivelyByUser                      PermissionDecisionKind = "denied-interactively-by-user"
-	PermissionDecisionKindDeniedNoApprovalRuleAndCouldNotRequestFromUser PermissionDecisionKind = "denied-no-approval-rule-and-could-not-request-from-user"
+	PermissionDecisionKindApproveForLocation PermissionDecisionKind = "approve-for-location"
+	PermissionDecisionKindApproveForSession  PermissionDecisionKind = "approve-for-session"
+	PermissionDecisionKindApproveOnce        PermissionDecisionKind = "approve-once"
+	PermissionDecisionKindReject             PermissionDecisionKind = "reject"
+	PermissionDecisionKindUserNotAvailable   PermissionDecisionKind = "user-not-available"
 )
 
-type PermissionDecisionApprovedKind string
+type PermissionDecisionApproveForLocationKind string
 
 const (
-	PermissionDecisionApprovedKindApproved PermissionDecisionApprovedKind = "approved"
+	PermissionDecisionApproveForLocationKindApproveForLocation PermissionDecisionApproveForLocationKind = "approve-for-location"
 )
 
-type PermissionDecisionApprovedForLocationKind string
+type PermissionDecisionApproveForLocationApprovalCommandsKind string
 
 const (
-	PermissionDecisionApprovedForLocationKindApprovedForLocation PermissionDecisionApprovedForLocationKind = "approved-for-location"
+	PermissionDecisionApproveForLocationApprovalCommandsKindCommands PermissionDecisionApproveForLocationApprovalCommandsKind = "commands"
 )
 
-type PermissionDecisionApprovedForLocationApprovalCommandsKind string
+type PermissionDecisionApproveForLocationApprovalCustomToolKind string
 
 const (
-	PermissionDecisionApprovedForLocationApprovalCommandsKindCommands PermissionDecisionApprovedForLocationApprovalCommandsKind = "commands"
+	PermissionDecisionApproveForLocationApprovalCustomToolKindCustomTool PermissionDecisionApproveForLocationApprovalCustomToolKind = "custom-tool"
 )
 
-type PermissionDecisionApprovedForLocationApprovalCustomToolKind string
+type PermissionDecisionApproveForLocationApprovalMCPKind string
 
 const (
-	PermissionDecisionApprovedForLocationApprovalCustomToolKindCustomTool PermissionDecisionApprovedForLocationApprovalCustomToolKind = "custom-tool"
+	PermissionDecisionApproveForLocationApprovalMCPKindMcp PermissionDecisionApproveForLocationApprovalMCPKind = "mcp"
 )
 
-type PermissionDecisionApprovedForLocationApprovalMCPKind string
+type PermissionDecisionApproveForLocationApprovalMCPSamplingKind string
 
 const (
-	PermissionDecisionApprovedForLocationApprovalMCPKindMcp PermissionDecisionApprovedForLocationApprovalMCPKind = "mcp"
+	PermissionDecisionApproveForLocationApprovalMCPSamplingKindMcpSampling PermissionDecisionApproveForLocationApprovalMCPSamplingKind = "mcp-sampling"
 )
 
-type PermissionDecisionApprovedForLocationApprovalMCPSamplingKind string
+type PermissionDecisionApproveForLocationApprovalMemoryKind string
 
 const (
-	PermissionDecisionApprovedForLocationApprovalMCPSamplingKindMcpSampling PermissionDecisionApprovedForLocationApprovalMCPSamplingKind = "mcp-sampling"
+	PermissionDecisionApproveForLocationApprovalMemoryKindMemory PermissionDecisionApproveForLocationApprovalMemoryKind = "memory"
 )
 
-type PermissionDecisionApprovedForLocationApprovalMemoryKind string
+type PermissionDecisionApproveForLocationApprovalReadKind string
 
 const (
-	PermissionDecisionApprovedForLocationApprovalMemoryKindMemory PermissionDecisionApprovedForLocationApprovalMemoryKind = "memory"
+	PermissionDecisionApproveForLocationApprovalReadKindRead PermissionDecisionApproveForLocationApprovalReadKind = "read"
 )
 
-type PermissionDecisionApprovedForLocationApprovalWriteKind string
+type PermissionDecisionApproveForLocationApprovalWriteKind string
 
 const (
-	PermissionDecisionApprovedForLocationApprovalWriteKindWrite PermissionDecisionApprovedForLocationApprovalWriteKind = "write"
+	PermissionDecisionApproveForLocationApprovalWriteKindWrite PermissionDecisionApproveForLocationApprovalWriteKind = "write"
 )
 
-type PermissionDecisionApprovedForSessionKind string
+type PermissionDecisionApproveForSessionKind string
 
 const (
-	PermissionDecisionApprovedForSessionKindApprovedForSession PermissionDecisionApprovedForSessionKind = "approved-for-session"
+	PermissionDecisionApproveForSessionKindApproveForSession PermissionDecisionApproveForSessionKind = "approve-for-session"
 )
 
-type PermissionDecisionDeniedByContentExclusionPolicyKind string
+type PermissionDecisionApproveOnceKind string
 
 const (
-	PermissionDecisionDeniedByContentExclusionPolicyKindDeniedByContentExclusionPolicy PermissionDecisionDeniedByContentExclusionPolicyKind = "denied-by-content-exclusion-policy"
+	PermissionDecisionApproveOnceKindApproveOnce PermissionDecisionApproveOnceKind = "approve-once"
 )
 
-type PermissionDecisionDeniedByPermissionRequestHookKind string
+type PermissionDecisionRejectKind string
 
 const (
-	PermissionDecisionDeniedByPermissionRequestHookKindDeniedByPermissionRequestHook PermissionDecisionDeniedByPermissionRequestHookKind = "denied-by-permission-request-hook"
+	PermissionDecisionRejectKindReject PermissionDecisionRejectKind = "reject"
 )
 
-type PermissionDecisionDeniedByRulesKind string
+type PermissionDecisionUserNotAvailableKind string
 
 const (
-	PermissionDecisionDeniedByRulesKindDeniedByRules PermissionDecisionDeniedByRulesKind = "denied-by-rules"
-)
-
-type PermissionDecisionDeniedInteractivelyByUserKind string
-
-const (
-	PermissionDecisionDeniedInteractivelyByUserKindDeniedInteractivelyByUser PermissionDecisionDeniedInteractivelyByUserKind = "denied-interactively-by-user"
-)
-
-type PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUserKind string
-
-const (
-	PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUserKindDeniedNoApprovalRuleAndCouldNotRequestFromUser PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUserKind = "denied-no-approval-rule-and-could-not-request-from-user"
+	PermissionDecisionUserNotAvailableKindUserNotAvailable PermissionDecisionUserNotAvailableKind = "user-not-available"
 )
 
 // Error classification

--- a/go/session.go
+++ b/go/session.go
@@ -1029,7 +1029,7 @@ func (s *Session) executePermissionAndRespond(requestID string, permissionReques
 			s.RPC.Permissions.HandlePendingPermissionRequest(context.Background(), &rpc.PermissionDecisionRequest{
 				RequestID: requestID,
 				Result: rpc.PermissionDecision{
-					Kind: rpc.PermissionDecisionKindDeniedNoApprovalRuleAndCouldNotRequestFromUser,
+					Kind: rpc.PermissionDecisionKindUserNotAvailable,
 				},
 			})
 		}
@@ -1044,7 +1044,7 @@ func (s *Session) executePermissionAndRespond(requestID string, permissionReques
 		s.RPC.Permissions.HandlePendingPermissionRequest(context.Background(), &rpc.PermissionDecisionRequest{
 			RequestID: requestID,
 			Result: rpc.PermissionDecision{
-				Kind: rpc.PermissionDecisionKindDeniedNoApprovalRuleAndCouldNotRequestFromUser,
+				Kind: rpc.PermissionDecisionKindUserNotAvailable,
 			},
 		})
 		return
@@ -1056,9 +1056,7 @@ func (s *Session) executePermissionAndRespond(requestID string, permissionReques
 	s.RPC.Permissions.HandlePendingPermissionRequest(context.Background(), &rpc.PermissionDecisionRequest{
 		RequestID: requestID,
 		Result: rpc.PermissionDecision{
-			Kind:     rpc.PermissionDecisionKind(result.Kind),
-			Rules:    result.Rules,
-			Feedback: nil,
+			Kind: rpc.PermissionDecisionKind(result.Kind),
 		},
 	})
 }

--- a/go/types.go
+++ b/go/types.go
@@ -207,21 +207,27 @@ type SystemMessageConfig struct {
 type PermissionRequestResultKind string
 
 const (
-	// PermissionRequestResultKindApproved indicates the permission was approved.
-	PermissionRequestResultKindApproved PermissionRequestResultKind = "approved"
+	// PermissionRequestResultKindApproved indicates the permission was approved for this one instance.
+	PermissionRequestResultKindApproved PermissionRequestResultKind = "approve-once"
 
-	// PermissionRequestResultKindDeniedByRules indicates the permission was denied by rules.
-	PermissionRequestResultKindDeniedByRules PermissionRequestResultKind = "denied-by-rules"
+	// PermissionRequestResultKindRejected indicates the permission was denied interactively by the user.
+	PermissionRequestResultKindRejected PermissionRequestResultKind = "reject"
 
-	// PermissionRequestResultKindDeniedCouldNotRequestFromUser indicates the permission was denied because
-	// no approval rule was found and the user could not be prompted.
-	PermissionRequestResultKindDeniedCouldNotRequestFromUser PermissionRequestResultKind = "denied-no-approval-rule-and-could-not-request-from-user"
-
-	// PermissionRequestResultKindDeniedInteractivelyByUser indicates the permission was denied interactively by the user.
-	PermissionRequestResultKindDeniedInteractivelyByUser PermissionRequestResultKind = "denied-interactively-by-user"
+	// PermissionRequestResultKindUserNotAvailable indicates the permission was denied because
+	// user confirmation was unavailable.
+	PermissionRequestResultKindUserNotAvailable PermissionRequestResultKind = "user-not-available"
 
 	// PermissionRequestResultKindNoResult indicates no permission decision was made.
 	PermissionRequestResultKindNoResult PermissionRequestResultKind = "no-result"
+
+	// Deprecated: Use PermissionRequestResultKindRejected instead.
+	PermissionRequestResultKindDeniedInteractivelyByUser = PermissionRequestResultKindRejected
+
+	// Deprecated: Use PermissionRequestResultKindUserNotAvailable instead.
+	PermissionRequestResultKindDeniedCouldNotRequestFromUser = PermissionRequestResultKindUserNotAvailable
+
+	// Deprecated: Use PermissionRequestResultKindUserNotAvailable instead.
+	PermissionRequestResultKindDeniedByRules = PermissionRequestResultKindUserNotAvailable
 )
 
 // PermissionRequestResult represents the result of a permission request

--- a/go/types.go
+++ b/go/types.go
@@ -588,6 +588,10 @@ type SessionConfig struct {
 	// When provided, the server may call back to this client for form-based UI dialogs
 	// (e.g. from MCP tools). Also enables the elicitation capability on the session.
 	OnElicitationRequest ElicitationHandler
+	// GitHubToken is an optional per-session GitHub token used for authentication.
+	// When provided, the session authenticates as the token's owner instead of
+	// using the global client-level auth.
+	GitHubToken string `json:"-"`
 }
 type Tool struct {
 	Name                 string         `json:"name"`
@@ -787,6 +791,10 @@ type ResumeSessionConfig struct {
 	DisabledSkills []string
 	// InfiniteSessions configures infinite sessions for persistent workspaces and automatic compaction.
 	InfiniteSessions *InfiniteSessionConfig
+	// GitHubToken is an optional per-session GitHub token used for authentication.
+	// When provided, the session authenticates as the token's owner instead of
+	// using the global client-level auth.
+	GitHubToken string `json:"-"`
 	// DisableResume, when true, skips emitting the session.resume event.
 	// Useful for reconnecting to a session without triggering resume-related side effects.
 	DisableResume bool
@@ -999,6 +1007,7 @@ type createSessionRequest struct {
 	InfiniteSessions               *InfiniteSessionConfig         `json:"infiniteSessions,omitempty"`
 	Commands                       []wireCommand                  `json:"commands,omitempty"`
 	RequestElicitation             *bool                          `json:"requestElicitation,omitempty"`
+	GitHubToken                    string                         `json:"gitHubToken,omitempty"`
 	Traceparent                    string                         `json:"traceparent,omitempty"`
 	Tracestate                     string                         `json:"tracestate,omitempty"`
 }
@@ -1047,6 +1056,7 @@ type resumeSessionRequest struct {
 	InfiniteSessions               *InfiniteSessionConfig         `json:"infiniteSessions,omitempty"`
 	Commands                       []wireCommand                  `json:"commands,omitempty"`
 	RequestElicitation             *bool                          `json:"requestElicitation,omitempty"`
+	GitHubToken                    string                         `json:"gitHubToken,omitempty"`
 	Traceparent                    string                         `json:"traceparent,omitempty"`
 	Tracestate                     string                         `json:"tracestate,omitempty"`
 }

--- a/go/types_test.go
+++ b/go/types_test.go
@@ -71,14 +71,14 @@ func TestPermissionRequestResult_JSONRoundTrip(t *testing.T) {
 }
 
 func TestPermissionRequestResult_JSONDeserialize(t *testing.T) {
-	jsonStr := `{"kind":"denied-by-rules"}`
+	jsonStr := `{"kind":"reject"}`
 	var result PermissionRequestResult
 	if err := json.Unmarshal([]byte(jsonStr), &result); err != nil {
 		t.Fatalf("failed to unmarshal: %v", err)
 	}
 
-	if result.Kind != PermissionRequestResultKindDeniedByRules {
-		t.Errorf("expected %q, got %q", PermissionRequestResultKindDeniedByRules, result.Kind)
+	if result.Kind != PermissionRequestResultKindRejected {
+		t.Errorf("expected %q, got %q", PermissionRequestResultKindRejected, result.Kind)
 	}
 }
 
@@ -89,7 +89,7 @@ func TestPermissionRequestResult_JSONSerialize(t *testing.T) {
 		t.Fatalf("failed to marshal: %v", err)
 	}
 
-	expected := `{"kind":"approved"}`
+	expected := `{"kind":"approve-once"}`
 	if string(data) != expected {
 		t.Errorf("expected %s, got %s", expected, string(data))
 	}

--- a/go/types_test.go
+++ b/go/types_test.go
@@ -11,11 +11,14 @@ func TestPermissionRequestResultKind_Constants(t *testing.T) {
 		kind     PermissionRequestResultKind
 		expected string
 	}{
-		{"Approved", PermissionRequestResultKindApproved, "approved"},
-		{"DeniedByRules", PermissionRequestResultKindDeniedByRules, "denied-by-rules"},
-		{"DeniedCouldNotRequestFromUser", PermissionRequestResultKindDeniedCouldNotRequestFromUser, "denied-no-approval-rule-and-could-not-request-from-user"},
-		{"DeniedInteractivelyByUser", PermissionRequestResultKindDeniedInteractivelyByUser, "denied-interactively-by-user"},
-		{"NoResult", PermissionRequestResultKind("no-result"), "no-result"},
+		{"Approved", PermissionRequestResultKindApproved, "approve-once"},
+		{"Rejected", PermissionRequestResultKindRejected, "reject"},
+		{"UserNotAvailable", PermissionRequestResultKindUserNotAvailable, "user-not-available"},
+		{"NoResult", PermissionRequestResultKindNoResult, "no-result"},
+		// Deprecated aliases
+		{"DeprecatedDeniedInteractivelyByUser", PermissionRequestResultKindDeniedInteractivelyByUser, "reject"},
+		{"DeprecatedDeniedCouldNotRequestFromUser", PermissionRequestResultKindDeniedCouldNotRequestFromUser, "user-not-available"},
+		{"DeprecatedDeniedByRules", PermissionRequestResultKindDeniedByRules, "user-not-available"},
 	}
 
 	for _, tt := range tests {

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -86,8 +86,8 @@ new CopilotClient(options?: CopilotClientOptions)
 - `useStdio?: boolean` - Use stdio transport instead of TCP (default: true)
 - `logLevel?: string` - Log level (default: "info")
 - `autoStart?: boolean` - Auto-start server (default: true)
-- `githubToken?: string` - GitHub token for authentication. When provided, takes priority over other auth methods.
-- `useLoggedInUser?: boolean` - Whether to use logged-in user for authentication (default: true, but false when `githubToken` is provided). Cannot be used with `cliUrl`.
+- `gitHubToken?: string` - GitHub token for authentication. When provided, takes priority over other auth methods.
+- `useLoggedInUser?: boolean` - Whether to use logged-in user for authentication (default: true, but false when `gitHubToken` is provided). Cannot be used with `cliUrl`.
 - `telemetry?: TelemetryConfig` - OpenTelemetry configuration for the CLI process. Providing this object enables telemetry — no separate flag needed. See [Telemetry](#telemetry) below.
 - `onGetTraceContext?: TraceContextProvider` - Advanced: callback for linking your application's own OpenTelemetry spans into the same distributed trace as the CLI's spans. Not needed for normal telemetry collection. See [Telemetry](#telemetry) below.
 

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.8",
             "license": "MIT",
             "dependencies": {
-                "@github/copilot": "^1.0.35-0",
+                "@github/copilot": "^1.0.35-5",
                 "vscode-jsonrpc": "^8.2.1",
                 "zod": "^4.3.6"
             },
@@ -663,26 +663,26 @@
             }
         },
         "node_modules/@github/copilot": {
-            "version": "1.0.35-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.35-0.tgz",
-            "integrity": "sha512-daPkiDXeXwsoEHy4XvZywVX3Voyaubir27qm/3uyifxeruMGOcUT/XC8tkJhE6VfSy3nvtjV4xXrZ43Wr0x2cg==",
+            "version": "1.0.35-5",
+            "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.35-5.tgz",
+            "integrity": "sha512-/teEQVQOtC+oAsAKHoJBgPSO8HEk93pBxY9jCcJaATJ6ayl1oGeOAqdrmDUK1UUvjOQsLM6Eui8C2D8B7AE8Aw==",
             "license": "SEE LICENSE IN LICENSE.md",
             "bin": {
                 "copilot": "npm-loader.js"
             },
             "optionalDependencies": {
-                "@github/copilot-darwin-arm64": "1.0.35-0",
-                "@github/copilot-darwin-x64": "1.0.35-0",
-                "@github/copilot-linux-arm64": "1.0.35-0",
-                "@github/copilot-linux-x64": "1.0.35-0",
-                "@github/copilot-win32-arm64": "1.0.35-0",
-                "@github/copilot-win32-x64": "1.0.35-0"
+                "@github/copilot-darwin-arm64": "1.0.35-5",
+                "@github/copilot-darwin-x64": "1.0.35-5",
+                "@github/copilot-linux-arm64": "1.0.35-5",
+                "@github/copilot-linux-x64": "1.0.35-5",
+                "@github/copilot-win32-arm64": "1.0.35-5",
+                "@github/copilot-win32-x64": "1.0.35-5"
             }
         },
         "node_modules/@github/copilot-darwin-arm64": {
-            "version": "1.0.35-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.35-0.tgz",
-            "integrity": "sha512-Uc3PIw60y/9fk1F2JlLqBl0VkParTiCIxlLWKFs8N6TJwFafKmLt7B5r4nqoFhsYZOov6ww4nIxxaMiVdFF0YA==",
+            "version": "1.0.35-5",
+            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.35-5.tgz",
+            "integrity": "sha512-98X8ygCOamqMFQ1t4610BJNt/YH5AdQwvUuQbAj6L4svaZgP7UM2/p8ZxZThvoEu/fyxrB6YCz8upwAplClVWQ==",
             "cpu": [
                 "arm64"
             ],
@@ -696,9 +696,9 @@
             }
         },
         "node_modules/@github/copilot-darwin-x64": {
-            "version": "1.0.35-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.35-0.tgz",
-            "integrity": "sha512-5R5hkZ4Z2CnHVdXnKMNjkFi00mdBYF9H9kkzQjmaN8cG4JwZFf209lo1bEzpXWKHl136LXNwLVhHCYfi3FgzXQ==",
+            "version": "1.0.35-5",
+            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.35-5.tgz",
+            "integrity": "sha512-VTKEHjYT4UFt6FBIgBZjI1hZhoVNOayLIkiBi41QltxC6dA2XO0BDanxZZewkWLLY+NZUkY9D9OpLIqMvgBQkA==",
             "cpu": [
                 "x64"
             ],
@@ -712,9 +712,9 @@
             }
         },
         "node_modules/@github/copilot-linux-arm64": {
-            "version": "1.0.35-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.35-0.tgz",
-            "integrity": "sha512-I+kDV2xhvq2t6ux2/ZmWoRkReq8fNlYgW1GfWRmp4c+vQKvH+WsQ5P0WWSt8BmmQGK9hUrTcXg2nvVAPQJ2D8Q==",
+            "version": "1.0.35-5",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.35-5.tgz",
+            "integrity": "sha512-PLYP2LWbL/nxPANQPsiYiX5bRxULlwsPxQ/hZq6U55CBaK9ayMiwUULuZvaklnaEeFlU5z5Ob43DoN9H7bOdbQ==",
             "cpu": [
                 "arm64"
             ],
@@ -728,9 +728,9 @@
             }
         },
         "node_modules/@github/copilot-linux-x64": {
-            "version": "1.0.35-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.35-0.tgz",
-            "integrity": "sha512-mnG6lpzmWvkasdYgmvotb2PQKW/GaCAdZbuv34iOT84Iz3VyEamcUNurw+KCrxitCYRa68cnCQFbGMf8p6Q22A==",
+            "version": "1.0.35-5",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.35-5.tgz",
+            "integrity": "sha512-NI+UaacwA3iqb1ArETHsrSYsFQWCHNo6exwV7Li4vJvfw3xCNRNeV7Wuna/LM0VFXZVZfXjnDdSzKeXiqrlWKA==",
             "cpu": [
                 "x64"
             ],
@@ -744,9 +744,9 @@
             }
         },
         "node_modules/@github/copilot-win32-arm64": {
-            "version": "1.0.35-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.35-0.tgz",
-            "integrity": "sha512-suB5kxHQtD5Hu7NUqH3bUkNBg6e0rPLSf54jCN8UjyxJBfV2mL7BZeqr77Du3UzHHkRKxqITiZ4LBZH8q0bOEg==",
+            "version": "1.0.35-5",
+            "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.35-5.tgz",
+            "integrity": "sha512-T0jj4SjWWeD/hQwDY4cVx0UE0Tn3DkFUoPefErLyvh2qclZF5nuFCSehftwGMeQbxZP8PhmEjiCZu/l2wBlD4A==",
             "cpu": [
                 "arm64"
             ],
@@ -760,9 +760,9 @@
             }
         },
         "node_modules/@github/copilot-win32-x64": {
-            "version": "1.0.35-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.35-0.tgz",
-            "integrity": "sha512-KKuxw+rKpfEn/575l+3aef72/MiGlH8D9CIX6+3+qPQqojt7YBDlEqgL3/aAk9JUrQbiqSUXXKD3mMEHdgNoWQ==",
+            "version": "1.0.35-5",
+            "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.35-5.tgz",
+            "integrity": "sha512-o0Rh2z1xI2zq7VWjR7wgXIEjTuTzUfDHYMf1x5lGXFpRy8SQKvqimuS+nERks1Wamambp7S70OmjkBLk/Iw/IA==",
             "cpu": [
                 "x64"
             ],

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.8",
             "license": "MIT",
             "dependencies": {
-                "@github/copilot": "^1.0.35-5",
+                "@github/copilot": "^1.0.36-0",
                 "vscode-jsonrpc": "^8.2.1",
                 "zod": "^4.3.6"
             },
@@ -663,26 +663,26 @@
             }
         },
         "node_modules/@github/copilot": {
-            "version": "1.0.35-5",
-            "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.35-5.tgz",
-            "integrity": "sha512-/teEQVQOtC+oAsAKHoJBgPSO8HEk93pBxY9jCcJaATJ6ayl1oGeOAqdrmDUK1UUvjOQsLM6Eui8C2D8B7AE8Aw==",
+            "version": "1.0.36-0",
+            "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.36-0.tgz",
+            "integrity": "sha512-M1mxNbdRkiQv4qApKgV33jK6AsA3TqlMAtKyaDv9sJzE/kZa4IRUAUrmO+3d3C+ojZa/Yffjy0/6dC6kllhI4g==",
             "license": "SEE LICENSE IN LICENSE.md",
             "bin": {
                 "copilot": "npm-loader.js"
             },
             "optionalDependencies": {
-                "@github/copilot-darwin-arm64": "1.0.35-5",
-                "@github/copilot-darwin-x64": "1.0.35-5",
-                "@github/copilot-linux-arm64": "1.0.35-5",
-                "@github/copilot-linux-x64": "1.0.35-5",
-                "@github/copilot-win32-arm64": "1.0.35-5",
-                "@github/copilot-win32-x64": "1.0.35-5"
+                "@github/copilot-darwin-arm64": "1.0.36-0",
+                "@github/copilot-darwin-x64": "1.0.36-0",
+                "@github/copilot-linux-arm64": "1.0.36-0",
+                "@github/copilot-linux-x64": "1.0.36-0",
+                "@github/copilot-win32-arm64": "1.0.36-0",
+                "@github/copilot-win32-x64": "1.0.36-0"
             }
         },
         "node_modules/@github/copilot-darwin-arm64": {
-            "version": "1.0.35-5",
-            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.35-5.tgz",
-            "integrity": "sha512-98X8ygCOamqMFQ1t4610BJNt/YH5AdQwvUuQbAj6L4svaZgP7UM2/p8ZxZThvoEu/fyxrB6YCz8upwAplClVWQ==",
+            "version": "1.0.36-0",
+            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.36-0.tgz",
+            "integrity": "sha512-S0/oT9eo2WvjteWjtjougfh6tokq1Upye6tWeTHWq001E2UvrBN69+cQJNcNQUkO2C2AVvoqiI5RJT/E+HDrww==",
             "cpu": [
                 "arm64"
             ],
@@ -696,9 +696,9 @@
             }
         },
         "node_modules/@github/copilot-darwin-x64": {
-            "version": "1.0.35-5",
-            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.35-5.tgz",
-            "integrity": "sha512-VTKEHjYT4UFt6FBIgBZjI1hZhoVNOayLIkiBi41QltxC6dA2XO0BDanxZZewkWLLY+NZUkY9D9OpLIqMvgBQkA==",
+            "version": "1.0.36-0",
+            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.36-0.tgz",
+            "integrity": "sha512-msY1h6J2j005HMHxYqXO6Q5rJdqAjkUnnBwne5p3s71EHGekOl5U8GJs1Q2Y287+e9ZKSY68ANt/JB0Gq2ivmA==",
             "cpu": [
                 "x64"
             ],
@@ -712,9 +712,9 @@
             }
         },
         "node_modules/@github/copilot-linux-arm64": {
-            "version": "1.0.35-5",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.35-5.tgz",
-            "integrity": "sha512-PLYP2LWbL/nxPANQPsiYiX5bRxULlwsPxQ/hZq6U55CBaK9ayMiwUULuZvaklnaEeFlU5z5Ob43DoN9H7bOdbQ==",
+            "version": "1.0.36-0",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.36-0.tgz",
+            "integrity": "sha512-2yIKaU5XdC0xkFXt80pU+Uqr7pU2lHHzcBehzhDHfDeZVNq8jQj61Ka9r9NBjU3W8c3f99ctPMN8gErFnc5L/A==",
             "cpu": [
                 "arm64"
             ],
@@ -728,9 +728,9 @@
             }
         },
         "node_modules/@github/copilot-linux-x64": {
-            "version": "1.0.35-5",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.35-5.tgz",
-            "integrity": "sha512-NI+UaacwA3iqb1ArETHsrSYsFQWCHNo6exwV7Li4vJvfw3xCNRNeV7Wuna/LM0VFXZVZfXjnDdSzKeXiqrlWKA==",
+            "version": "1.0.36-0",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.36-0.tgz",
+            "integrity": "sha512-tiEnl40MmEc4uybJ8at9TagmEcMsNHDiqzER72PYAD4mKwWklZ3RAClaVgzQlTxn1tMdNM7gbajyqSivLmo+rA==",
             "cpu": [
                 "x64"
             ],
@@ -744,9 +744,9 @@
             }
         },
         "node_modules/@github/copilot-win32-arm64": {
-            "version": "1.0.35-5",
-            "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.35-5.tgz",
-            "integrity": "sha512-T0jj4SjWWeD/hQwDY4cVx0UE0Tn3DkFUoPefErLyvh2qclZF5nuFCSehftwGMeQbxZP8PhmEjiCZu/l2wBlD4A==",
+            "version": "1.0.36-0",
+            "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.36-0.tgz",
+            "integrity": "sha512-c6hT1lnl7B44tLJGmyugvqPQ51bIMXtTeCb7Z5riPd4Sv17gsU+gLWewJLddAnu+0XhjzlBsIHv9GUtxGPCgWQ==",
             "cpu": [
                 "arm64"
             ],
@@ -760,9 +760,9 @@
             }
         },
         "node_modules/@github/copilot-win32-x64": {
-            "version": "1.0.35-5",
-            "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.35-5.tgz",
-            "integrity": "sha512-o0Rh2z1xI2zq7VWjR7wgXIEjTuTzUfDHYMf1x5lGXFpRy8SQKvqimuS+nERks1Wamambp7S70OmjkBLk/Iw/IA==",
+            "version": "1.0.36-0",
+            "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.36-0.tgz",
+            "integrity": "sha512-RJy3RtlX+34denR3+ttBZsbyeaGoA2nlYoEtnijsQquK37on4gTwVavRbvjfVa2pL+aMuKhRD+xdvsUd+Fu4Lg==",
             "cpu": [
                 "x64"
             ],

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -56,7 +56,7 @@
     "author": "GitHub",
     "license": "MIT",
     "dependencies": {
-        "@github/copilot": "^1.0.35-5",
+        "@github/copilot": "^1.0.36-0",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
     },

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -56,7 +56,7 @@
     "author": "GitHub",
     "license": "MIT",
     "dependencies": {
-        "@github/copilot": "^1.0.35-0",
+        "@github/copilot": "^1.0.35-5",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
     },

--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -1961,7 +1961,7 @@ export class CopilotClient {
             }
             return {
                 result: {
-                    kind: "denied-no-approval-rule-and-could-not-request-from-user",
+                    kind: "user-not-available",
                 },
             };
         }

--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -215,7 +215,7 @@ export class CopilotClient {
             CopilotClientOptions,
             | "cliPath"
             | "cliUrl"
-            | "githubToken"
+            | "gitHubToken"
             | "useLoggedInUser"
             | "onListModels"
             | "telemetry"
@@ -225,7 +225,7 @@ export class CopilotClient {
     > & {
         cliPath?: string;
         cliUrl?: string;
-        githubToken?: string;
+        gitHubToken?: string;
         useLoggedInUser?: boolean;
         telemetry?: TelemetryConfig;
     };
@@ -294,9 +294,9 @@ export class CopilotClient {
         }
 
         // Validate auth options with external server
-        if (options.cliUrl && (options.githubToken || options.useLoggedInUser !== undefined)) {
+        if (options.cliUrl && (options.gitHubToken || options.useLoggedInUser !== undefined)) {
             throw new Error(
-                "githubToken and useLoggedInUser cannot be used with cliUrl (external server manages its own auth)"
+                "gitHubToken and useLoggedInUser cannot be used with cliUrl (external server manages its own auth)"
             );
         }
 
@@ -336,9 +336,9 @@ export class CopilotClient {
             autoRestart: false,
 
             env: effectiveEnv,
-            githubToken: options.githubToken,
-            // Default useLoggedInUser to false when githubToken is provided, otherwise true
-            useLoggedInUser: options.useLoggedInUser ?? (options.githubToken ? false : true),
+            gitHubToken: options.gitHubToken,
+            // Default useLoggedInUser to false when gitHubToken is provided, otherwise true
+            useLoggedInUser: options.useLoggedInUser ?? (options.gitHubToken ? false : true),
             telemetry: options.telemetry,
             sessionIdleTimeoutSeconds: options.sessionIdleTimeoutSeconds ?? 0,
         };
@@ -763,6 +763,7 @@ export class CopilotClient {
                 skillDirectories: config.skillDirectories,
                 disabledSkills: config.disabledSkills,
                 infiniteSessions: config.infiniteSessions,
+                gitHubToken: config.gitHubToken,
             });
 
             const { workspacePath, capabilities } = response as {
@@ -906,6 +907,7 @@ export class CopilotClient {
                 disabledSkills: config.disabledSkills,
                 infiniteSessions: config.infiniteSessions,
                 disableResume: config.disableResume,
+                gitHubToken: config.gitHubToken,
             });
 
             const { workspacePath, capabilities } = response as {
@@ -1408,7 +1410,7 @@ export class CopilotClient {
             }
 
             // Add auth-related flags
-            if (this.options.githubToken) {
+            if (this.options.gitHubToken) {
                 args.push("--auth-token-env", "COPILOT_SDK_AUTH_TOKEN");
             }
             if (!this.options.useLoggedInUser) {
@@ -1430,8 +1432,8 @@ export class CopilotClient {
             delete envWithoutNodeDebug.NODE_DEBUG;
 
             // Set auth token in environment if provided
-            if (this.options.githubToken) {
-                envWithoutNodeDebug.COPILOT_SDK_AUTH_TOKEN = this.options.githubToken;
+            if (this.options.gitHubToken) {
+                envWithoutNodeDebug.COPILOT_SDK_AUTH_TOKEN = this.options.gitHubToken;
             }
 
             if (!this.options.cliPath) {

--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -110,40 +110,39 @@ export type McpServerSource = "user" | "workspace" | "plugin" | "builtin";
 export type SessionMode = "interactive" | "plan" | "autopilot";
 
 export type PermissionDecision =
-  | PermissionDecisionApproved
-  | PermissionDecisionApprovedForSession
-  | PermissionDecisionApprovedForLocation
-  | PermissionDecisionDeniedByRules
-  | PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser
-  | PermissionDecisionDeniedInteractivelyByUser
-  | PermissionDecisionDeniedByContentExclusionPolicy
-  | PermissionDecisionDeniedByPermissionRequestHook;
+  | PermissionDecisionApproveOnce
+  | PermissionDecisionApproveForSession
+  | PermissionDecisionApproveForLocation
+  | PermissionDecisionReject
+  | PermissionDecisionUserNotAvailable;
 /**
  * The approval to add as a session-scoped rule
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionDecisionApprovedForSessionApproval".
+ * via the `definition` "PermissionDecisionApproveForSessionApproval".
  */
-export type PermissionDecisionApprovedForSessionApproval =
-  | PermissionDecisionApprovedForSessionApprovalCommands
-  | PermissionDecisionApprovedForSessionApprovalWrite
-  | PermissionDecisionApprovedForSessionApprovalMcp
-  | PermissionDecisionApprovedForSessionApprovalMcpSampling
-  | PermissionDecisionApprovedForSessionApprovalMemory
-  | PermissionDecisionApprovedForSessionApprovalCustomTool;
+export type PermissionDecisionApproveForSessionApproval =
+  | PermissionDecisionApproveForSessionApprovalCommands
+  | PermissionDecisionApproveForSessionApprovalRead
+  | PermissionDecisionApproveForSessionApprovalWrite
+  | PermissionDecisionApproveForSessionApprovalMcp
+  | PermissionDecisionApproveForSessionApprovalMcpSampling
+  | PermissionDecisionApproveForSessionApprovalMemory
+  | PermissionDecisionApproveForSessionApprovalCustomTool;
 /**
  * The approval to persist for this location
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionDecisionApprovedForLocationApproval".
+ * via the `definition` "PermissionDecisionApproveForLocationApproval".
  */
-export type PermissionDecisionApprovedForLocationApproval =
-  | PermissionDecisionApprovedForLocationApprovalCommands
-  | PermissionDecisionApprovedForLocationApprovalWrite
-  | PermissionDecisionApprovedForLocationApprovalMcp
-  | PermissionDecisionApprovedForLocationApprovalMcpSampling
-  | PermissionDecisionApprovedForLocationApprovalMemory
-  | PermissionDecisionApprovedForLocationApprovalCustomTool;
+export type PermissionDecisionApproveForLocationApproval =
+  | PermissionDecisionApproveForLocationApprovalCommands
+  | PermissionDecisionApproveForLocationApprovalRead
+  | PermissionDecisionApproveForLocationApprovalWrite
+  | PermissionDecisionApproveForLocationApprovalMcp
+  | PermissionDecisionApproveForLocationApprovalMcpSampling
+  | PermissionDecisionApproveForLocationApprovalMemory
+  | PermissionDecisionApproveForLocationApprovalCustomTool;
 /**
  * Error classification
  *
@@ -914,148 +913,115 @@ export interface NameSetRequest {
   name: string;
 }
 
-export interface PermissionDecisionApproved {
+export interface PermissionDecisionApproveOnce {
   /**
-   * The permission request was approved
+   * The permission request was approved for this one instance
    */
-  kind: "approved";
+  kind: "approve-once";
 }
 
-export interface PermissionDecisionApprovedForSession {
+export interface PermissionDecisionApproveForSession {
   /**
    * Approved and remembered for the rest of the session
    */
-  kind: "approved-for-session";
-  approval: PermissionDecisionApprovedForSessionApproval;
+  kind: "approve-for-session";
+  approval: PermissionDecisionApproveForSessionApproval;
 }
 
-export interface PermissionDecisionApprovedForSessionApprovalCommands {
+export interface PermissionDecisionApproveForSessionApprovalCommands {
   kind: "commands";
   commandIdentifiers: string[];
 }
 
-export interface PermissionDecisionApprovedForSessionApprovalWrite {
+export interface PermissionDecisionApproveForSessionApprovalRead {
+  kind: "read";
+}
+
+export interface PermissionDecisionApproveForSessionApprovalWrite {
   kind: "write";
 }
 
-export interface PermissionDecisionApprovedForSessionApprovalMcp {
+export interface PermissionDecisionApproveForSessionApprovalMcp {
   kind: "mcp";
   serverName: string;
   toolName: string | null;
 }
 
-export interface PermissionDecisionApprovedForSessionApprovalMcpSampling {
+export interface PermissionDecisionApproveForSessionApprovalMcpSampling {
   kind: "mcp-sampling";
   serverName: string;
 }
 
-export interface PermissionDecisionApprovedForSessionApprovalMemory {
+export interface PermissionDecisionApproveForSessionApprovalMemory {
   kind: "memory";
 }
 
-export interface PermissionDecisionApprovedForSessionApprovalCustomTool {
+export interface PermissionDecisionApproveForSessionApprovalCustomTool {
   kind: "custom-tool";
   toolName: string;
 }
 
-export interface PermissionDecisionApprovedForLocation {
+export interface PermissionDecisionApproveForLocation {
   /**
    * Approved and persisted for this project location
    */
-  kind: "approved-for-location";
-  approval: PermissionDecisionApprovedForLocationApproval;
+  kind: "approve-for-location";
+  approval: PermissionDecisionApproveForLocationApproval;
   /**
    * The location key (git root or cwd) to persist the approval to
    */
   locationKey: string;
 }
 
-export interface PermissionDecisionApprovedForLocationApprovalCommands {
+export interface PermissionDecisionApproveForLocationApprovalCommands {
   kind: "commands";
   commandIdentifiers: string[];
 }
 
-export interface PermissionDecisionApprovedForLocationApprovalWrite {
+export interface PermissionDecisionApproveForLocationApprovalRead {
+  kind: "read";
+}
+
+export interface PermissionDecisionApproveForLocationApprovalWrite {
   kind: "write";
 }
 
-export interface PermissionDecisionApprovedForLocationApprovalMcp {
+export interface PermissionDecisionApproveForLocationApprovalMcp {
   kind: "mcp";
   serverName: string;
   toolName: string | null;
 }
 
-export interface PermissionDecisionApprovedForLocationApprovalMcpSampling {
+export interface PermissionDecisionApproveForLocationApprovalMcpSampling {
   kind: "mcp-sampling";
   serverName: string;
 }
 
-export interface PermissionDecisionApprovedForLocationApprovalMemory {
+export interface PermissionDecisionApproveForLocationApprovalMemory {
   kind: "memory";
 }
 
-export interface PermissionDecisionApprovedForLocationApprovalCustomTool {
+export interface PermissionDecisionApproveForLocationApprovalCustomTool {
   kind: "custom-tool";
   toolName: string;
 }
 
-export interface PermissionDecisionDeniedByRules {
-  /**
-   * Denied because approval rules explicitly blocked it
-   */
-  kind: "denied-by-rules";
-  /**
-   * Rules that denied the request
-   */
-  rules: unknown[];
-}
-
-export interface PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser {
-  /**
-   * Denied because no approval rule matched and user confirmation was unavailable
-   */
-  kind: "denied-no-approval-rule-and-could-not-request-from-user";
-}
-
-export interface PermissionDecisionDeniedInteractivelyByUser {
+export interface PermissionDecisionReject {
   /**
    * Denied by the user during an interactive prompt
    */
-  kind: "denied-interactively-by-user";
+  kind: "reject";
   /**
    * Optional feedback from the user explaining the denial
    */
   feedback?: string;
 }
 
-export interface PermissionDecisionDeniedByContentExclusionPolicy {
+export interface PermissionDecisionUserNotAvailable {
   /**
-   * Denied by the organization's content exclusion policy
+   * Denied because user confirmation was unavailable
    */
-  kind: "denied-by-content-exclusion-policy";
-  /**
-   * File path that triggered the exclusion
-   */
-  path: string;
-  /**
-   * Human-readable explanation of why the path was excluded
-   */
-  message: string;
-}
-
-export interface PermissionDecisionDeniedByPermissionRequestHook {
-  /**
-   * Denied by a permission request hook registered by an extension or plugin
-   */
-  kind: "denied-by-permission-request-hook";
-  /**
-   * Optional message from the hook explaining the denial
-   */
-  message?: string;
-  /**
-   * Whether to interrupt the current agent turn
-   */
-  interrupt?: boolean;
+  kind: "user-not-available";
 }
 
 export interface PermissionDecisionRequest {

--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -5,6 +5,16 @@
 
 import type { MessageConnection } from "vscode-jsonrpc/node.js";
 
+export type AccountGetQuotaRequest = {
+      [k: string]: unknown;
+    };
+/**
+ * Authentication type
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "AuthInfoType".
+ */
+export type AuthInfoType = "hmac" | "env" | "user" | "gh-cli" | "api-key" | "token" | "copilot-api-token";
 /**
  * Server transport type: stdio, http, sse, or memory (local configs are normalized to stdio)
  *
@@ -94,6 +104,10 @@ export type McpServerStatus = "connected" | "failed" | "needs-auth" | "pending" 
  * via the `definition` "McpServerSource".
  */
 export type McpServerSource = "user" | "workspace" | "plugin" | "builtin";
+
+export type ModelsListRequest = {
+      [k: string]: unknown;
+    };
 /**
  * The agent mode. Valid values: "interactive", "plan", "autopilot".
  *
@@ -103,12 +117,39 @@ export type McpServerSource = "user" | "workspace" | "plugin" | "builtin";
 export type SessionMode = "interactive" | "plan" | "autopilot";
 
 export type PermissionDecision =
-  | PermissionDecisionApproved
-  | PermissionDecisionDeniedByRules
-  | PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser
-  | PermissionDecisionDeniedInteractivelyByUser
-  | PermissionDecisionDeniedByContentExclusionPolicy
-  | PermissionDecisionDeniedByPermissionRequestHook;
+  | PermissionDecisionApproveOnce
+  | PermissionDecisionApproveForSession
+  | PermissionDecisionApproveForLocation
+  | PermissionDecisionReject
+  | PermissionDecisionUserNotAvailable;
+/**
+ * The approval to add as a session-scoped rule
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionDecisionApproveForSessionApproval".
+ */
+export type PermissionDecisionApproveForSessionApproval =
+  | PermissionDecisionApproveForSessionApprovalCommands
+  | PermissionDecisionApproveForSessionApprovalRead
+  | PermissionDecisionApproveForSessionApprovalWrite
+  | PermissionDecisionApproveForSessionApprovalMcp
+  | PermissionDecisionApproveForSessionApprovalMcpSampling
+  | PermissionDecisionApproveForSessionApprovalMemory
+  | PermissionDecisionApproveForSessionApprovalCustomTool;
+/**
+ * The approval to persist for this location
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionDecisionApproveForLocationApproval".
+ */
+export type PermissionDecisionApproveForLocationApproval =
+  | PermissionDecisionApproveForLocationApprovalCommands
+  | PermissionDecisionApproveForLocationApprovalRead
+  | PermissionDecisionApproveForLocationApprovalWrite
+  | PermissionDecisionApproveForLocationApprovalMcp
+  | PermissionDecisionApproveForLocationApprovalMcpSampling
+  | PermissionDecisionApproveForLocationApprovalMemory
+  | PermissionDecisionApproveForLocationApprovalCustomTool;
 /**
  * Error classification
  *
@@ -537,6 +578,20 @@ export interface McpServerConfigHttp {
   oauthPublicClient?: boolean;
 }
 
+export interface McpConfigDisableRequest {
+  /**
+   * Names of MCP servers to disable. Each server is added to the persisted disabled list so new sessions skip it. Already-disabled names are ignored. Active sessions keep their current connections until they end.
+   */
+  names: string[];
+}
+
+export interface McpConfigEnableRequest {
+  /**
+   * Names of MCP servers to enable. Each server is removed from the persisted disabled list so new sessions spawn it. Unknown or already-enabled names are ignored.
+   */
+  names: string[];
+}
+
 export interface McpConfigList {
   /**
    * All MCP servers from user config, keyed by name
@@ -589,6 +644,34 @@ export interface McpEnableRequest {
    * Name of the MCP server to enable
    */
   serverName: string;
+}
+
+/** @experimental */
+export interface McpOauthLoginRequest {
+  /**
+   * Name of the remote MCP server to authenticate
+   */
+  serverName: string;
+  /**
+   * When true, clears any cached OAuth token for the server and runs a full new authorization. Use when the user explicitly wants to switch accounts or believes their session is stuck.
+   */
+  forceReauth?: boolean;
+  /**
+   * Optional override for the OAuth client display name shown on the consent screen. Applies to newly registered dynamic clients only — existing registrations keep the name they were created with. When omitted, the runtime applies a neutral fallback; callers driving interactive auth should pass their own surface-specific label so the consent screen matches the product the user sees.
+   */
+  clientName?: string;
+  /**
+   * Optional override for the body text shown on the OAuth loopback callback success page. When omitted, the runtime applies a neutral fallback; callers driving interactive auth should pass surface-specific copy telling the user where to return.
+   */
+  callbackSuccessMessage?: string;
+}
+
+/** @experimental */
+export interface McpOauthLoginResult {
+  /**
+   * URL the caller should open in a browser to complete OAuth. Omitted when cached tokens were still valid and no browser interaction was needed — the server is already reconnected in that case. When present, the runtime starts the callback listener before returning and continues the flow in the background; completion is signaled via session.mcp_server_status_changed.
+   */
+  authorizationUrl?: string;
 }
 
 export interface McpServer {
@@ -714,7 +797,7 @@ export interface ModelPolicy {
   /**
    * Usage terms or conditions for this model
    */
-  terms: string;
+  terms?: string;
 }
 /**
  * Billing information
@@ -823,70 +906,115 @@ export interface NameSetRequest {
   name: string;
 }
 
-export interface PermissionDecisionApproved {
+export interface PermissionDecisionApproveOnce {
   /**
-   * The permission request was approved
+   * The permission request was approved for this one instance
    */
-  kind: "approved";
+  kind: "approve-once";
 }
 
-export interface PermissionDecisionDeniedByRules {
+export interface PermissionDecisionApproveForSession {
   /**
-   * Denied because approval rules explicitly blocked it
+   * Approved and remembered for the rest of the session
    */
-  kind: "denied-by-rules";
-  /**
-   * Rules that denied the request
-   */
-  rules: unknown[];
+  kind: "approve-for-session";
+  approval: PermissionDecisionApproveForSessionApproval;
 }
 
-export interface PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser {
-  /**
-   * Denied because no approval rule matched and user confirmation was unavailable
-   */
-  kind: "denied-no-approval-rule-and-could-not-request-from-user";
+export interface PermissionDecisionApproveForSessionApprovalCommands {
+  kind: "commands";
+  commandIdentifiers: string[];
 }
 
-export interface PermissionDecisionDeniedInteractivelyByUser {
+export interface PermissionDecisionApproveForSessionApprovalRead {
+  kind: "read";
+}
+
+export interface PermissionDecisionApproveForSessionApprovalWrite {
+  kind: "write";
+}
+
+export interface PermissionDecisionApproveForSessionApprovalMcp {
+  kind: "mcp";
+  serverName: string;
+  toolName: string | null;
+}
+
+export interface PermissionDecisionApproveForSessionApprovalMcpSampling {
+  kind: "mcp-sampling";
+  serverName: string;
+}
+
+export interface PermissionDecisionApproveForSessionApprovalMemory {
+  kind: "memory";
+}
+
+export interface PermissionDecisionApproveForSessionApprovalCustomTool {
+  kind: "custom-tool";
+  toolName: string;
+}
+
+export interface PermissionDecisionApproveForLocation {
+  /**
+   * Approved and persisted for this project location
+   */
+  kind: "approve-for-location";
+  approval: PermissionDecisionApproveForLocationApproval;
+  /**
+   * The location key (git root or cwd) to persist the approval to
+   */
+  locationKey: string;
+}
+
+export interface PermissionDecisionApproveForLocationApprovalCommands {
+  kind: "commands";
+  commandIdentifiers: string[];
+}
+
+export interface PermissionDecisionApproveForLocationApprovalRead {
+  kind: "read";
+}
+
+export interface PermissionDecisionApproveForLocationApprovalWrite {
+  kind: "write";
+}
+
+export interface PermissionDecisionApproveForLocationApprovalMcp {
+  kind: "mcp";
+  serverName: string;
+  toolName: string | null;
+}
+
+export interface PermissionDecisionApproveForLocationApprovalMcpSampling {
+  kind: "mcp-sampling";
+  serverName: string;
+}
+
+export interface PermissionDecisionApproveForLocationApprovalMemory {
+  kind: "memory";
+}
+
+export interface PermissionDecisionApproveForLocationApprovalCustomTool {
+  kind: "custom-tool";
+  toolName: string;
+}
+
+export interface PermissionDecisionReject {
   /**
    * Denied by the user during an interactive prompt
    */
-  kind: "denied-interactively-by-user";
+  kind: "reject";
   /**
    * Optional feedback from the user explaining the denial
    */
   feedback?: string;
 }
 
-export interface PermissionDecisionDeniedByContentExclusionPolicy {
+export interface PermissionDecisionUserNotAvailable {
   /**
-   * Denied by the organization's content exclusion policy
+   * Denied because user confirmation was unavailable
    */
-  kind: "denied-by-content-exclusion-policy";
-  /**
-   * File path that triggered the exclusion
-   */
-  path: string;
-  /**
-   * Human-readable explanation of why the path was excluded
-   */
-  message: string;
-}
-
-export interface PermissionDecisionDeniedByPermissionRequestHook {
-  /**
-   * Denied by a permission request hook registered by an extension or plugin
-   */
-  kind: "denied-by-permission-request-hook";
-  /**
-   * Optional message from the hook explaining the denial
-   */
-  message?: string;
-  /**
-   * Whether to interrupt the current agent turn
-   */
-  interrupt?: boolean;
+  kind: "user-not-available";
 }
 
 export interface PermissionDecisionRequest {
@@ -900,6 +1028,29 @@ export interface PermissionDecisionRequest {
 export interface PermissionRequestResult {
   /**
    * Whether the permission request was handled successfully
+   */
+  success: boolean;
+}
+
+export interface PermissionsResetSessionApprovalsRequest {}
+
+export interface PermissionsResetSessionApprovalsResult {
+  /**
+   * Whether the operation succeeded
+   */
+  success: boolean;
+}
+
+export interface PermissionsSetApproveAllRequest {
+  /**
+   * Whether to auto-approve all tool permission requests
+   */
+  enabled: boolean;
+}
+
+export interface PermissionsSetApproveAllResult {
+  /**
+   * Whether the operation succeeded
    */
   success: boolean;
 }
@@ -1011,6 +1162,30 @@ export interface ServerSkillList {
    * All discovered skills across all sources
    */
   skills: ServerSkill[];
+}
+
+export interface SessionAuthStatus {
+  /**
+   * Whether the session has resolved authentication
+   */
+  isAuthenticated: boolean;
+  authType?: AuthInfoType;
+  /**
+   * Authentication host URL
+   */
+  host?: string;
+  /**
+   * Authenticated login/username, if available
+   */
+  login?: string;
+  /**
+   * Human-readable authentication status description
+   */
+  statusMessage?: string;
+  /**
+   * Copilot plan tier (e.g., individual_pro, business)
+   */
+  copilotPlan?: string;
 }
 
 export interface SessionFsAppendFileRequest {
@@ -1769,16 +1944,16 @@ export function createServerRpc(connection: MessageConnection) {
         ping: async (params: PingRequest): Promise<PingResult> =>
             connection.sendRequest("ping", params),
         models: {
-            list: async (): Promise<ModelList> =>
-                connection.sendRequest("models.list", {}),
+            list: async (params: ModelsListRequest): Promise<ModelList> =>
+                connection.sendRequest("models.list", params),
         },
         tools: {
             list: async (params: ToolsListRequest): Promise<ToolList> =>
                 connection.sendRequest("tools.list", params),
         },
         account: {
-            getQuota: async (): Promise<AccountGetQuotaResult> =>
-                connection.sendRequest("account.getQuota", {}),
+            getQuota: async (params: AccountGetQuotaRequest): Promise<AccountGetQuotaResult> =>
+                connection.sendRequest("account.getQuota", params),
         },
         mcp: {
             config: {
@@ -1790,6 +1965,10 @@ export function createServerRpc(connection: MessageConnection) {
                     connection.sendRequest("mcp.config.update", params),
                 remove: async (params: McpConfigRemoveRequest): Promise<void> =>
                     connection.sendRequest("mcp.config.remove", params),
+                enable: async (params: McpConfigEnableRequest): Promise<void> =>
+                    connection.sendRequest("mcp.config.enable", params),
+                disable: async (params: McpConfigDisableRequest): Promise<void> =>
+                    connection.sendRequest("mcp.config.disable", params),
             },
             discover: async (params: McpDiscoverRequest): Promise<McpDiscoverResult> =>
                 connection.sendRequest("mcp.discover", params),
@@ -1817,6 +1996,10 @@ export function createServerRpc(connection: MessageConnection) {
 /** Create typed session-scoped RPC methods. */
 export function createSessionRpc(connection: MessageConnection, sessionId: string) {
     return {
+        auth: {
+            getStatus: async (): Promise<SessionAuthStatus> =>
+                connection.sendRequest("session.auth.getStatus", { sessionId }),
+        },
         model: {
             getCurrent: async (): Promise<CurrentModel> =>
                 connection.sendRequest("session.model.getCurrent", { sessionId }),
@@ -1896,6 +2079,11 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                 connection.sendRequest("session.mcp.disable", { sessionId, ...params }),
             reload: async (): Promise<void> =>
                 connection.sendRequest("session.mcp.reload", { sessionId }),
+            /** @experimental */
+            oauth: {
+                login: async (params: Omit<McpOauthLoginRequest, "sessionId">): Promise<McpOauthLoginResult> =>
+                    connection.sendRequest("session.mcp.oauth.login", { sessionId, ...params }),
+            },
         },
         /** @experimental */
         plugins: {
@@ -1930,6 +2118,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
         permissions: {
             handlePendingPermissionRequest: async (params: Omit<PermissionDecisionRequest, "sessionId">): Promise<PermissionRequestResult> =>
                 connection.sendRequest("session.permissions.handlePendingPermissionRequest", { sessionId, ...params }),
+            setApproveAll: async (params: Omit<PermissionsSetApproveAllRequest, "sessionId">): Promise<PermissionsSetApproveAllResult> =>
+                connection.sendRequest("session.permissions.setApproveAll", { sessionId, ...params }),
+            resetSessionApprovals: async (): Promise<PermissionsResetSessionApprovalsResult> =>
+                connection.sendRequest("session.permissions.resetSessionApprovals", { sessionId }),
         },
         log: async (params: Omit<LogRequest, "sessionId">): Promise<LogResult> =>
             connection.sendRequest("session.log", { sessionId, ...params }),

--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -110,39 +110,40 @@ export type McpServerSource = "user" | "workspace" | "plugin" | "builtin";
 export type SessionMode = "interactive" | "plan" | "autopilot";
 
 export type PermissionDecision =
-  | PermissionDecisionApproveOnce
-  | PermissionDecisionApproveForSession
-  | PermissionDecisionApproveForLocation
-  | PermissionDecisionReject
-  | PermissionDecisionUserNotAvailable;
+  | PermissionDecisionApproved
+  | PermissionDecisionApprovedForSession
+  | PermissionDecisionApprovedForLocation
+  | PermissionDecisionDeniedByRules
+  | PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser
+  | PermissionDecisionDeniedInteractivelyByUser
+  | PermissionDecisionDeniedByContentExclusionPolicy
+  | PermissionDecisionDeniedByPermissionRequestHook;
 /**
  * The approval to add as a session-scoped rule
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionDecisionApproveForSessionApproval".
+ * via the `definition` "PermissionDecisionApprovedForSessionApproval".
  */
-export type PermissionDecisionApproveForSessionApproval =
-  | PermissionDecisionApproveForSessionApprovalCommands
-  | PermissionDecisionApproveForSessionApprovalRead
-  | PermissionDecisionApproveForSessionApprovalWrite
-  | PermissionDecisionApproveForSessionApprovalMcp
-  | PermissionDecisionApproveForSessionApprovalMcpSampling
-  | PermissionDecisionApproveForSessionApprovalMemory
-  | PermissionDecisionApproveForSessionApprovalCustomTool;
+export type PermissionDecisionApprovedForSessionApproval =
+  | PermissionDecisionApprovedForSessionApprovalCommands
+  | PermissionDecisionApprovedForSessionApprovalWrite
+  | PermissionDecisionApprovedForSessionApprovalMcp
+  | PermissionDecisionApprovedForSessionApprovalMcpSampling
+  | PermissionDecisionApprovedForSessionApprovalMemory
+  | PermissionDecisionApprovedForSessionApprovalCustomTool;
 /**
  * The approval to persist for this location
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionDecisionApproveForLocationApproval".
+ * via the `definition` "PermissionDecisionApprovedForLocationApproval".
  */
-export type PermissionDecisionApproveForLocationApproval =
-  | PermissionDecisionApproveForLocationApprovalCommands
-  | PermissionDecisionApproveForLocationApprovalRead
-  | PermissionDecisionApproveForLocationApprovalWrite
-  | PermissionDecisionApproveForLocationApprovalMcp
-  | PermissionDecisionApproveForLocationApprovalMcpSampling
-  | PermissionDecisionApproveForLocationApprovalMemory
-  | PermissionDecisionApproveForLocationApprovalCustomTool;
+export type PermissionDecisionApprovedForLocationApproval =
+  | PermissionDecisionApprovedForLocationApprovalCommands
+  | PermissionDecisionApprovedForLocationApprovalWrite
+  | PermissionDecisionApprovedForLocationApprovalMcp
+  | PermissionDecisionApprovedForLocationApprovalMcpSampling
+  | PermissionDecisionApprovedForLocationApprovalMemory
+  | PermissionDecisionApprovedForLocationApprovalCustomTool;
 /**
  * Error classification
  *
@@ -913,115 +914,148 @@ export interface NameSetRequest {
   name: string;
 }
 
-export interface PermissionDecisionApproveOnce {
+export interface PermissionDecisionApproved {
   /**
-   * The permission request was approved for this one instance
+   * The permission request was approved
    */
-  kind: "approve-once";
+  kind: "approved";
 }
 
-export interface PermissionDecisionApproveForSession {
+export interface PermissionDecisionApprovedForSession {
   /**
    * Approved and remembered for the rest of the session
    */
-  kind: "approve-for-session";
-  approval: PermissionDecisionApproveForSessionApproval;
+  kind: "approved-for-session";
+  approval: PermissionDecisionApprovedForSessionApproval;
 }
 
-export interface PermissionDecisionApproveForSessionApprovalCommands {
+export interface PermissionDecisionApprovedForSessionApprovalCommands {
   kind: "commands";
   commandIdentifiers: string[];
 }
 
-export interface PermissionDecisionApproveForSessionApprovalRead {
-  kind: "read";
-}
-
-export interface PermissionDecisionApproveForSessionApprovalWrite {
+export interface PermissionDecisionApprovedForSessionApprovalWrite {
   kind: "write";
 }
 
-export interface PermissionDecisionApproveForSessionApprovalMcp {
+export interface PermissionDecisionApprovedForSessionApprovalMcp {
   kind: "mcp";
   serverName: string;
   toolName: string | null;
 }
 
-export interface PermissionDecisionApproveForSessionApprovalMcpSampling {
+export interface PermissionDecisionApprovedForSessionApprovalMcpSampling {
   kind: "mcp-sampling";
   serverName: string;
 }
 
-export interface PermissionDecisionApproveForSessionApprovalMemory {
+export interface PermissionDecisionApprovedForSessionApprovalMemory {
   kind: "memory";
 }
 
-export interface PermissionDecisionApproveForSessionApprovalCustomTool {
+export interface PermissionDecisionApprovedForSessionApprovalCustomTool {
   kind: "custom-tool";
   toolName: string;
 }
 
-export interface PermissionDecisionApproveForLocation {
+export interface PermissionDecisionApprovedForLocation {
   /**
    * Approved and persisted for this project location
    */
-  kind: "approve-for-location";
-  approval: PermissionDecisionApproveForLocationApproval;
+  kind: "approved-for-location";
+  approval: PermissionDecisionApprovedForLocationApproval;
   /**
    * The location key (git root or cwd) to persist the approval to
    */
   locationKey: string;
 }
 
-export interface PermissionDecisionApproveForLocationApprovalCommands {
+export interface PermissionDecisionApprovedForLocationApprovalCommands {
   kind: "commands";
   commandIdentifiers: string[];
 }
 
-export interface PermissionDecisionApproveForLocationApprovalRead {
-  kind: "read";
-}
-
-export interface PermissionDecisionApproveForLocationApprovalWrite {
+export interface PermissionDecisionApprovedForLocationApprovalWrite {
   kind: "write";
 }
 
-export interface PermissionDecisionApproveForLocationApprovalMcp {
+export interface PermissionDecisionApprovedForLocationApprovalMcp {
   kind: "mcp";
   serverName: string;
   toolName: string | null;
 }
 
-export interface PermissionDecisionApproveForLocationApprovalMcpSampling {
+export interface PermissionDecisionApprovedForLocationApprovalMcpSampling {
   kind: "mcp-sampling";
   serverName: string;
 }
 
-export interface PermissionDecisionApproveForLocationApprovalMemory {
+export interface PermissionDecisionApprovedForLocationApprovalMemory {
   kind: "memory";
 }
 
-export interface PermissionDecisionApproveForLocationApprovalCustomTool {
+export interface PermissionDecisionApprovedForLocationApprovalCustomTool {
   kind: "custom-tool";
   toolName: string;
 }
 
-export interface PermissionDecisionReject {
+export interface PermissionDecisionDeniedByRules {
+  /**
+   * Denied because approval rules explicitly blocked it
+   */
+  kind: "denied-by-rules";
+  /**
+   * Rules that denied the request
+   */
+  rules: unknown[];
+}
+
+export interface PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser {
+  /**
+   * Denied because no approval rule matched and user confirmation was unavailable
+   */
+  kind: "denied-no-approval-rule-and-could-not-request-from-user";
+}
+
+export interface PermissionDecisionDeniedInteractivelyByUser {
   /**
    * Denied by the user during an interactive prompt
    */
-  kind: "reject";
+  kind: "denied-interactively-by-user";
   /**
    * Optional feedback from the user explaining the denial
    */
   feedback?: string;
 }
 
-export interface PermissionDecisionUserNotAvailable {
+export interface PermissionDecisionDeniedByContentExclusionPolicy {
   /**
-   * Denied because user confirmation was unavailable
+   * Denied by the organization's content exclusion policy
    */
-  kind: "user-not-available";
+  kind: "denied-by-content-exclusion-policy";
+  /**
+   * File path that triggered the exclusion
+   */
+  path: string;
+  /**
+   * Human-readable explanation of why the path was excluded
+   */
+  message: string;
+}
+
+export interface PermissionDecisionDeniedByPermissionRequestHook {
+  /**
+   * Denied by a permission request hook registered by an extension or plugin
+   */
+  kind: "denied-by-permission-request-hook";
+  /**
+   * Optional message from the hook explaining the denial
+   */
+  message?: string;
+  /**
+   * Whether to interrupt the current agent turn
+   */
+  interrupt?: boolean;
 }
 
 export interface PermissionDecisionRequest {

--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -5,9 +5,6 @@
 
 import type { MessageConnection } from "vscode-jsonrpc/node.js";
 
-export type AccountGetQuotaRequest = {
-      [k: string]: unknown;
-    };
 /**
  * Authentication type
  *
@@ -104,10 +101,6 @@ export type McpServerStatus = "connected" | "failed" | "needs-auth" | "pending" 
  * via the `definition` "McpServerSource".
  */
 export type McpServerSource = "user" | "workspace" | "plugin" | "builtin";
-
-export type ModelsListRequest = {
-      [k: string]: unknown;
-    };
 /**
  * The agent mode. Valid values: "interactive", "plan", "autopilot".
  *
@@ -207,6 +200,13 @@ export type UIElicitationSchemaPropertyNumberType = "number" | "integer";
  * via the `definition` "UIElicitationResponseAction".
  */
 export type UIElicitationResponseAction = "accept" | "decline" | "cancel";
+
+export interface AccountGetQuotaRequest {
+  /**
+   * GitHub token for per-user quota lookup. When provided, resolves this token to determine the user's quota instead of using the global auth.
+   */
+  gitHubToken?: string;
+}
 
 export interface AccountGetQuotaResult {
   /**
@@ -867,6 +867,13 @@ export interface ModelList {
    * List of available models with full metadata
    */
   models: Model[];
+}
+
+export interface ModelsListRequest {
+  /**
+   * GitHub token for per-user model listing. When provided, resolves this token to determine the user's Copilot plan and available models instead of using the global auth.
+   */
+  gitHubToken?: string;
 }
 
 export interface ModelSwitchToRequest {
@@ -1944,7 +1951,7 @@ export function createServerRpc(connection: MessageConnection) {
         ping: async (params: PingRequest): Promise<PingResult> =>
             connection.sendRequest("ping", params),
         models: {
-            list: async (params: ModelsListRequest): Promise<ModelList> =>
+            list: async (params?: ModelsListRequest): Promise<ModelList> =>
                 connection.sendRequest("models.list", params),
         },
         tools: {
@@ -1952,7 +1959,7 @@ export function createServerRpc(connection: MessageConnection) {
                 connection.sendRequest("tools.list", params),
         },
         account: {
-            getQuota: async (params: AccountGetQuotaRequest): Promise<AccountGetQuotaResult> =>
+            getQuota: async (params?: AccountGetQuotaRequest): Promise<AccountGetQuotaResult> =>
                 connection.sendRequest("account.getQuota", params),
         },
         mcp: {
@@ -2003,25 +2010,25 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
         model: {
             getCurrent: async (): Promise<CurrentModel> =>
                 connection.sendRequest("session.model.getCurrent", { sessionId }),
-            switchTo: async (params: Omit<ModelSwitchToRequest, "sessionId">): Promise<ModelSwitchToResult> =>
+            switchTo: async (params: ModelSwitchToRequest): Promise<ModelSwitchToResult> =>
                 connection.sendRequest("session.model.switchTo", { sessionId, ...params }),
         },
         mode: {
             get: async (): Promise<SessionMode> =>
                 connection.sendRequest("session.mode.get", { sessionId }),
-            set: async (params: Omit<ModeSetRequest, "sessionId">): Promise<void> =>
+            set: async (params: ModeSetRequest): Promise<void> =>
                 connection.sendRequest("session.mode.set", { sessionId, ...params }),
         },
         name: {
             get: async (): Promise<NameGetResult> =>
                 connection.sendRequest("session.name.get", { sessionId }),
-            set: async (params: Omit<NameSetRequest, "sessionId">): Promise<void> =>
+            set: async (params: NameSetRequest): Promise<void> =>
                 connection.sendRequest("session.name.set", { sessionId, ...params }),
         },
         plan: {
             read: async (): Promise<PlanReadResult> =>
                 connection.sendRequest("session.plan.read", { sessionId }),
-            update: async (params: Omit<PlanUpdateRequest, "sessionId">): Promise<void> =>
+            update: async (params: PlanUpdateRequest): Promise<void> =>
                 connection.sendRequest("session.plan.update", { sessionId, ...params }),
             delete: async (): Promise<void> =>
                 connection.sendRequest("session.plan.delete", { sessionId }),
@@ -2031,9 +2038,9 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                 connection.sendRequest("session.workspaces.getWorkspace", { sessionId }),
             listFiles: async (): Promise<WorkspacesListFilesResult> =>
                 connection.sendRequest("session.workspaces.listFiles", { sessionId }),
-            readFile: async (params: Omit<WorkspacesReadFileRequest, "sessionId">): Promise<WorkspacesReadFileResult> =>
+            readFile: async (params: WorkspacesReadFileRequest): Promise<WorkspacesReadFileResult> =>
                 connection.sendRequest("session.workspaces.readFile", { sessionId, ...params }),
-            createFile: async (params: Omit<WorkspacesCreateFileRequest, "sessionId">): Promise<void> =>
+            createFile: async (params: WorkspacesCreateFileRequest): Promise<void> =>
                 connection.sendRequest("session.workspaces.createFile", { sessionId, ...params }),
         },
         instructions: {
@@ -2042,7 +2049,7 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
         },
         /** @experimental */
         fleet: {
-            start: async (params: Omit<FleetStartRequest, "sessionId">): Promise<FleetStartResult> =>
+            start: async (params: FleetStartRequest): Promise<FleetStartResult> =>
                 connection.sendRequest("session.fleet.start", { sessionId, ...params }),
         },
         /** @experimental */
@@ -2051,7 +2058,7 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                 connection.sendRequest("session.agent.list", { sessionId }),
             getCurrent: async (): Promise<AgentGetCurrentResult> =>
                 connection.sendRequest("session.agent.getCurrent", { sessionId }),
-            select: async (params: Omit<AgentSelectRequest, "sessionId">): Promise<AgentSelectResult> =>
+            select: async (params: AgentSelectRequest): Promise<AgentSelectResult> =>
                 connection.sendRequest("session.agent.select", { sessionId, ...params }),
             deselect: async (): Promise<void> =>
                 connection.sendRequest("session.agent.deselect", { sessionId }),
@@ -2062,9 +2069,9 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
         skills: {
             list: async (): Promise<SkillList> =>
                 connection.sendRequest("session.skills.list", { sessionId }),
-            enable: async (params: Omit<SkillsEnableRequest, "sessionId">): Promise<void> =>
+            enable: async (params: SkillsEnableRequest): Promise<void> =>
                 connection.sendRequest("session.skills.enable", { sessionId, ...params }),
-            disable: async (params: Omit<SkillsDisableRequest, "sessionId">): Promise<void> =>
+            disable: async (params: SkillsDisableRequest): Promise<void> =>
                 connection.sendRequest("session.skills.disable", { sessionId, ...params }),
             reload: async (): Promise<void> =>
                 connection.sendRequest("session.skills.reload", { sessionId }),
@@ -2073,15 +2080,15 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
         mcp: {
             list: async (): Promise<McpServerList> =>
                 connection.sendRequest("session.mcp.list", { sessionId }),
-            enable: async (params: Omit<McpEnableRequest, "sessionId">): Promise<void> =>
+            enable: async (params: McpEnableRequest): Promise<void> =>
                 connection.sendRequest("session.mcp.enable", { sessionId, ...params }),
-            disable: async (params: Omit<McpDisableRequest, "sessionId">): Promise<void> =>
+            disable: async (params: McpDisableRequest): Promise<void> =>
                 connection.sendRequest("session.mcp.disable", { sessionId, ...params }),
             reload: async (): Promise<void> =>
                 connection.sendRequest("session.mcp.reload", { sessionId }),
             /** @experimental */
             oauth: {
-                login: async (params: Omit<McpOauthLoginRequest, "sessionId">): Promise<McpOauthLoginResult> =>
+                login: async (params: McpOauthLoginRequest): Promise<McpOauthLoginResult> =>
                     connection.sendRequest("session.mcp.oauth.login", { sessionId, ...params }),
             },
         },
@@ -2094,48 +2101,48 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
         extensions: {
             list: async (): Promise<ExtensionList> =>
                 connection.sendRequest("session.extensions.list", { sessionId }),
-            enable: async (params: Omit<ExtensionsEnableRequest, "sessionId">): Promise<void> =>
+            enable: async (params: ExtensionsEnableRequest): Promise<void> =>
                 connection.sendRequest("session.extensions.enable", { sessionId, ...params }),
-            disable: async (params: Omit<ExtensionsDisableRequest, "sessionId">): Promise<void> =>
+            disable: async (params: ExtensionsDisableRequest): Promise<void> =>
                 connection.sendRequest("session.extensions.disable", { sessionId, ...params }),
             reload: async (): Promise<void> =>
                 connection.sendRequest("session.extensions.reload", { sessionId }),
         },
         tools: {
-            handlePendingToolCall: async (params: Omit<ToolsHandlePendingToolCallRequest, "sessionId">): Promise<HandleToolCallResult> =>
+            handlePendingToolCall: async (params: ToolsHandlePendingToolCallRequest): Promise<HandleToolCallResult> =>
                 connection.sendRequest("session.tools.handlePendingToolCall", { sessionId, ...params }),
         },
         commands: {
-            handlePendingCommand: async (params: Omit<CommandsHandlePendingCommandRequest, "sessionId">): Promise<CommandsHandlePendingCommandResult> =>
+            handlePendingCommand: async (params: CommandsHandlePendingCommandRequest): Promise<CommandsHandlePendingCommandResult> =>
                 connection.sendRequest("session.commands.handlePendingCommand", { sessionId, ...params }),
         },
         ui: {
-            elicitation: async (params: Omit<UIElicitationRequest, "sessionId">): Promise<UIElicitationResponse> =>
+            elicitation: async (params: UIElicitationRequest): Promise<UIElicitationResponse> =>
                 connection.sendRequest("session.ui.elicitation", { sessionId, ...params }),
-            handlePendingElicitation: async (params: Omit<UIHandlePendingElicitationRequest, "sessionId">): Promise<UIElicitationResult> =>
+            handlePendingElicitation: async (params: UIHandlePendingElicitationRequest): Promise<UIElicitationResult> =>
                 connection.sendRequest("session.ui.handlePendingElicitation", { sessionId, ...params }),
         },
         permissions: {
-            handlePendingPermissionRequest: async (params: Omit<PermissionDecisionRequest, "sessionId">): Promise<PermissionRequestResult> =>
+            handlePendingPermissionRequest: async (params: PermissionDecisionRequest): Promise<PermissionRequestResult> =>
                 connection.sendRequest("session.permissions.handlePendingPermissionRequest", { sessionId, ...params }),
-            setApproveAll: async (params: Omit<PermissionsSetApproveAllRequest, "sessionId">): Promise<PermissionsSetApproveAllResult> =>
+            setApproveAll: async (params: PermissionsSetApproveAllRequest): Promise<PermissionsSetApproveAllResult> =>
                 connection.sendRequest("session.permissions.setApproveAll", { sessionId, ...params }),
             resetSessionApprovals: async (): Promise<PermissionsResetSessionApprovalsResult> =>
                 connection.sendRequest("session.permissions.resetSessionApprovals", { sessionId }),
         },
-        log: async (params: Omit<LogRequest, "sessionId">): Promise<LogResult> =>
+        log: async (params: LogRequest): Promise<LogResult> =>
             connection.sendRequest("session.log", { sessionId, ...params }),
         shell: {
-            exec: async (params: Omit<ShellExecRequest, "sessionId">): Promise<ShellExecResult> =>
+            exec: async (params: ShellExecRequest): Promise<ShellExecResult> =>
                 connection.sendRequest("session.shell.exec", { sessionId, ...params }),
-            kill: async (params: Omit<ShellKillRequest, "sessionId">): Promise<ShellKillResult> =>
+            kill: async (params: ShellKillRequest): Promise<ShellKillResult> =>
                 connection.sendRequest("session.shell.kill", { sessionId, ...params }),
         },
         /** @experimental */
         history: {
             compact: async (): Promise<HistoryCompactResult> =>
                 connection.sendRequest("session.history.compact", { sessionId }),
-            truncate: async (params: Omit<HistoryTruncateRequest, "sessionId">): Promise<HistoryTruncateResult> =>
+            truncate: async (params: HistoryTruncateRequest): Promise<HistoryTruncateResult> =>
                 connection.sendRequest("session.history.truncate", { sessionId, ...params }),
         },
         /** @experimental */

--- a/nodejs/src/generated/session-events.ts
+++ b/nodejs/src/generated/session-events.ts
@@ -177,6 +177,31 @@ export type PermissionRequestMemoryAction = "store" | "vote";
  */
 export type PermissionRequestMemoryDirection = "upvote" | "downvote";
 /**
+ * Derived user-facing permission prompt details for UI consumers
+ */
+export type PermissionPromptRequest =
+  | PermissionPromptRequestCommands
+  | PermissionPromptRequestWrite
+  | PermissionPromptRequestRead
+  | PermissionPromptRequestMcp
+  | PermissionPromptRequestUrl
+  | PermissionPromptRequestMemory
+  | PermissionPromptRequestCustomTool
+  | PermissionPromptRequestPath
+  | PermissionPromptRequestHook;
+/**
+ * Whether this is a store or vote memory operation
+ */
+export type PermissionPromptRequestMemoryAction = "store" | "vote";
+/**
+ * Vote direction (vote only)
+ */
+export type PermissionPromptRequestMemoryDirection = "upvote" | "downvote";
+/**
+ * Underlying permission kind that needs path approval
+ */
+export type PermissionPromptRequestPathAccessKind = "read" | "shell" | "write";
+/**
  * The outcome of the permission request
  */
 export type PermissionCompletedKind =
@@ -3133,6 +3158,7 @@ export interface PermissionRequestedEvent {
  */
 export interface PermissionRequestedData {
   permissionRequest: PermissionRequest;
+  promptRequest?: PermissionPromptRequest;
   /**
    * Unique identifier for this permission request; used to respond via session.respondToPermission()
    */
@@ -3398,6 +3424,243 @@ export interface PermissionRequestHook {
    */
   toolName: string;
 }
+/**
+ * Shell command permission prompt
+ */
+export interface PermissionPromptRequestCommands {
+  /**
+   * Whether the UI can offer session-wide approval for this command pattern
+   */
+  canOfferSessionApproval: boolean;
+  /**
+   * Command identifiers covered by this approval prompt
+   */
+  commandIdentifiers: string[];
+  /**
+   * The complete shell command text to be executed
+   */
+  fullCommandText: string;
+  /**
+   * Human-readable description of what the command intends to do
+   */
+  intention: string;
+  /**
+   * Prompt kind discriminator
+   */
+  kind: "commands";
+  /**
+   * Tool call ID that triggered this permission request
+   */
+  toolCallId?: string;
+  /**
+   * Optional warning message about risks of running this command
+   */
+  warning?: string;
+}
+/**
+ * File write permission prompt
+ */
+export interface PermissionPromptRequestWrite {
+  /**
+   * Whether the UI can offer session-wide approval for file write operations
+   */
+  canOfferSessionApproval: boolean;
+  /**
+   * Unified diff showing the proposed changes
+   */
+  diff: string;
+  /**
+   * Path of the file being written to
+   */
+  fileName: string;
+  /**
+   * Human-readable description of the intended file change
+   */
+  intention: string;
+  /**
+   * Prompt kind discriminator
+   */
+  kind: "write";
+  /**
+   * Complete new file contents for newly created files
+   */
+  newFileContents?: string;
+  /**
+   * Tool call ID that triggered this permission request
+   */
+  toolCallId?: string;
+}
+/**
+ * File read permission prompt
+ */
+export interface PermissionPromptRequestRead {
+  /**
+   * Human-readable description of why the file is being read
+   */
+  intention: string;
+  /**
+   * Prompt kind discriminator
+   */
+  kind: "read";
+  /**
+   * Path of the file or directory being read
+   */
+  path: string;
+  /**
+   * Tool call ID that triggered this permission request
+   */
+  toolCallId?: string;
+}
+/**
+ * MCP tool invocation permission prompt
+ */
+export interface PermissionPromptRequestMcp {
+  args?: unknown;
+  /**
+   * Prompt kind discriminator
+   */
+  kind: "mcp";
+  /**
+   * Name of the MCP server providing the tool
+   */
+  serverName: string;
+  /**
+   * Tool call ID that triggered this permission request
+   */
+  toolCallId?: string;
+  /**
+   * Internal name of the MCP tool
+   */
+  toolName: string;
+  /**
+   * Human-readable title of the MCP tool
+   */
+  toolTitle: string;
+}
+/**
+ * URL access permission prompt
+ */
+export interface PermissionPromptRequestUrl {
+  /**
+   * Human-readable description of why the URL is being accessed
+   */
+  intention: string;
+  /**
+   * Prompt kind discriminator
+   */
+  kind: "url";
+  /**
+   * Tool call ID that triggered this permission request
+   */
+  toolCallId?: string;
+  /**
+   * URL to be fetched
+   */
+  url: string;
+}
+/**
+ * Memory operation permission prompt
+ */
+export interface PermissionPromptRequestMemory {
+  action?: PermissionPromptRequestMemoryAction;
+  /**
+   * Source references for the stored fact (store only)
+   */
+  citations?: string;
+  direction?: PermissionPromptRequestMemoryDirection;
+  /**
+   * The fact being stored or voted on
+   */
+  fact: string;
+  /**
+   * Prompt kind discriminator
+   */
+  kind: "memory";
+  /**
+   * Reason for the vote (vote only)
+   */
+  reason?: string;
+  /**
+   * Topic or subject of the memory (store only)
+   */
+  subject?: string;
+  /**
+   * Tool call ID that triggered this permission request
+   */
+  toolCallId?: string;
+}
+/**
+ * Custom tool invocation permission prompt
+ */
+export interface PermissionPromptRequestCustomTool {
+  /**
+   * Arguments to pass to the custom tool
+   */
+  args?: {
+    [k: string]: unknown;
+  };
+  /**
+   * Prompt kind discriminator
+   */
+  kind: "custom-tool";
+  /**
+   * Tool call ID that triggered this permission request
+   */
+  toolCallId?: string;
+  /**
+   * Description of what the custom tool does
+   */
+  toolDescription: string;
+  /**
+   * Name of the custom tool
+   */
+  toolName: string;
+}
+/**
+ * Path access permission prompt
+ */
+export interface PermissionPromptRequestPath {
+  accessKind: PermissionPromptRequestPathAccessKind;
+  /**
+   * Prompt kind discriminator
+   */
+  kind: "path";
+  /**
+   * File paths that require explicit approval
+   */
+  paths: string[];
+  /**
+   * Tool call ID that triggered this permission request
+   */
+  toolCallId?: string;
+}
+/**
+ * Hook confirmation permission prompt
+ */
+export interface PermissionPromptRequestHook {
+  /**
+   * Optional message from the hook explaining why confirmation is needed
+   */
+  hookMessage?: string;
+  /**
+   * Prompt kind discriminator
+   */
+  kind: "hook";
+  /**
+   * Arguments of the tool call being gated
+   */
+  toolArgs?: {
+    [k: string]: unknown;
+  };
+  /**
+   * Tool call ID that triggered this permission request
+   */
+  toolCallId?: string;
+  /**
+   * Name of the tool the hook is gating
+   */
+  toolName: string;
+}
 export interface PermissionCompletedEvent {
   /**
    * Sub-agent instance identifier. Absent for events from the root/main agent and session-level events.
@@ -3428,6 +3691,10 @@ export interface PermissionCompletedData {
    */
   requestId: string;
   result: PermissionCompletedResult;
+  /**
+   * Optional tool call ID associated with this permission prompt; clients may use it to correlate UI created from tool-scoped prompts
+   */
+  toolCallId?: string;
 }
 /**
  * The result of the permission request

--- a/nodejs/src/generated/session-events.ts
+++ b/nodejs/src/generated/session-events.ts
@@ -67,6 +67,8 @@ export type SessionEvent =
   | CommandQueuedEvent
   | CommandExecuteEvent
   | CommandCompletedEvent
+  | AutoModeSwitchRequestedEvent
+  | AutoModeSwitchCompletedEvent
   | CommandsChangedEvent
   | CapabilitiesChangedEvent
   | ExitPlanModeRequestedEvent
@@ -179,6 +181,8 @@ export type PermissionRequestMemoryDirection = "upvote" | "downvote";
  */
 export type PermissionCompletedKind =
   | "approved"
+  | "approved-for-session"
+  | "approved-for-location"
   | "denied-by-rules"
   | "denied-no-approval-rule-and-could-not-request-from-user"
   | "denied-interactively-by-user"
@@ -1251,21 +1255,68 @@ export interface CompactionCompleteData {
   toolDefinitionsTokens?: number;
 }
 /**
- * Token usage breakdown for the compaction LLM call
+ * Token usage breakdown for the compaction LLM call (aligned with assistant.usage format)
  */
 export interface CompactionCompleteCompactionTokensUsed {
   /**
    * Cached input tokens reused in the compaction LLM call
    */
-  cachedInput: number;
+  cacheReadTokens?: number;
+  /**
+   * Tokens written to prompt cache in the compaction LLM call
+   */
+  cacheWriteTokens?: number;
+  copilotUsage?: CompactionCompleteCompactionTokensUsedCopilotUsage;
+  /**
+   * Duration of the compaction LLM call in milliseconds
+   */
+  duration?: number;
   /**
    * Input tokens consumed by the compaction LLM call
    */
-  input: number;
+  inputTokens?: number;
+  /**
+   * Model identifier used for the compaction LLM call
+   */
+  model?: string;
   /**
    * Output tokens produced by the compaction LLM call
    */
-  output: number;
+  outputTokens?: number;
+}
+/**
+ * Per-request cost and usage data from the CAPI copilot_usage response field
+ */
+export interface CompactionCompleteCompactionTokensUsedCopilotUsage {
+  /**
+   * Itemized token usage breakdown
+   */
+  tokenDetails: CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail[];
+  /**
+   * Total cost in nano-AIU (AI Units) for this request
+   */
+  totalNanoAiu: number;
+}
+/**
+ * Token usage detail for a single billing category
+ */
+export interface CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail {
+  /**
+   * Number of tokens in this billing batch
+   */
+  batchSize: number;
+  /**
+   * Cost per batch of tokens
+   */
+  costPerBatch: number;
+  /**
+   * Total token count for this entry
+   */
+  tokenCount: number;
+  /**
+   * Token category (e.g., "input", "output")
+   */
+  tokenType: string;
 }
 export interface TaskCompleteEvent {
   /**
@@ -3915,6 +3966,74 @@ export interface CommandCompletedData {
    * Request ID of the resolved command request; clients should dismiss any UI for this request
    */
   requestId: string;
+}
+export interface AutoModeSwitchRequestedEvent {
+  /**
+   * Sub-agent instance identifier. Absent for events from the root/main agent and session-level events.
+   */
+  agentId?: string;
+  data: AutoModeSwitchRequestedData;
+  ephemeral: true;
+  /**
+   * Unique event identifier (UUID v4), generated when the event is emitted
+   */
+  id: string;
+  /**
+   * ID of the chronologically preceding event in the session, forming a linked chain. Null for the first event.
+   */
+  parentId: string | null;
+  /**
+   * ISO 8601 timestamp when the event was created
+   */
+  timestamp: string;
+  type: "auto_mode_switch.requested";
+}
+/**
+ * Auto mode switch request notification requiring user approval
+ */
+export interface AutoModeSwitchRequestedData {
+  /**
+   * The rate limit error code that triggered this request
+   */
+  errorCode?: string;
+  /**
+   * Unique identifier for this request; used to respond via session.respondToAutoModeSwitch()
+   */
+  requestId: string;
+}
+export interface AutoModeSwitchCompletedEvent {
+  /**
+   * Sub-agent instance identifier. Absent for events from the root/main agent and session-level events.
+   */
+  agentId?: string;
+  data: AutoModeSwitchCompletedData;
+  ephemeral: true;
+  /**
+   * Unique event identifier (UUID v4), generated when the event is emitted
+   */
+  id: string;
+  /**
+   * ID of the chronologically preceding event in the session, forming a linked chain. Null for the first event.
+   */
+  parentId: string | null;
+  /**
+   * ISO 8601 timestamp when the event was created
+   */
+  timestamp: string;
+  type: "auto_mode_switch.completed";
+}
+/**
+ * Auto mode switch completion notification
+ */
+export interface AutoModeSwitchCompletedData {
+  /**
+   * Request ID of the resolved request; clients should dismiss any UI for this request
+   */
+  requestId: string;
+  /**
+   * The user's choice: 'yes', 'yes_always', or 'no'
+   */
+  response: string;
 }
 export interface CommandsChangedEvent {
   /**

--- a/nodejs/src/session.ts
+++ b/nodejs/src/session.ts
@@ -517,7 +517,7 @@ export class CopilotSession {
                 await this.rpc.permissions.handlePendingPermissionRequest({
                     requestId,
                     result: {
-                        kind: "denied-no-approval-rule-and-could-not-request-from-user",
+                        kind: "user-not-available",
                     },
                 });
             } catch (rpcError) {
@@ -831,7 +831,7 @@ export class CopilotSession {
      */
     async _handlePermissionRequestV2(request: unknown): Promise<PermissionRequestResult> {
         if (!this.permissionHandler) {
-            return { kind: "denied-no-approval-rule-and-could-not-request-from-user" };
+            return { kind: "user-not-available" };
         }
 
         try {
@@ -846,7 +846,7 @@ export class CopilotSession {
             if (error instanceof Error && error.message === NO_RESULT_PERMISSION_V2_ERROR) {
                 throw error;
             }
-            return { kind: "denied-no-approval-rule-and-could-not-request-from-user" };
+            return { kind: "user-not-available" };
         }
     }
 

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -126,13 +126,13 @@ export interface CopilotClientOptions {
      * When provided, the token is passed to the CLI server via environment variable.
      * This takes priority over other authentication methods.
      */
-    githubToken?: string;
+    gitHubToken?: string;
 
     /**
      * Whether to use the logged-in user for authentication.
      * When true, the CLI server will attempt to use stored OAuth tokens or gh CLI auth.
-     * When false, only explicit tokens (githubToken or environment variables) are used.
-     * @default true (but defaults to false when githubToken is provided)
+     * When false, only explicit tokens (gitHubToken or environment variables) are used.
+     * @default true (but defaults to false when gitHubToken is provided)
      */
     useLoggedInUser?: boolean;
 
@@ -1351,6 +1351,18 @@ export interface SessionConfig {
     infiniteSessions?: InfiniteSessionConfig;
 
     /**
+     * GitHub token for per-session authentication.
+     * When provided, the runtime resolves this token into a full GitHub identity
+     * (login, Copilot plan, endpoints) and stores it on the session. This enables
+     * multitenancy — different sessions can have different GitHub identities.
+     *
+     * This is independent of the client-level `gitHubToken` in {@link CopilotClientOptions},
+     * which authenticates the CLI process itself. The session-level token determines
+     * the identity used for content exclusion, model routing, and quota checks.
+     */
+    gitHubToken?: string;
+
+    /**
      * Optional event handler that is registered on the session before the
      * session.create RPC is issued. This guarantees that early events emitted
      * by the CLI during session creation (e.g. session.start) are delivered to
@@ -1399,6 +1411,7 @@ export type ResumeSessionConfig = Pick<
     | "skillDirectories"
     | "disabledSkills"
     | "infiniteSessions"
+    | "gitHubToken"
     | "onEvent"
     | "createSessionFsHandler"
 > & {

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -764,7 +764,7 @@ export type PermissionHandler = (
     invocation: { sessionId: string }
 ) => Promise<PermissionRequestResult> | PermissionRequestResult;
 
-export const approveAll: PermissionHandler = () => ({ kind: "approved" });
+export const approveAll: PermissionHandler = () => ({ kind: "approve-once" });
 
 export const defaultJoinSessionPermissionHandler: PermissionHandler =
     (): PermissionRequestResult => ({

--- a/nodejs/test/client.test.ts
+++ b/nodejs/test/client.test.ts
@@ -530,16 +530,16 @@ describe("CopilotClient", () => {
     });
 
     describe("Auth options", () => {
-        it("should accept githubToken option", () => {
+        it("should accept gitHubToken option", () => {
             const client = new CopilotClient({
-                githubToken: "gho_test_token",
+                gitHubToken: "gho_test_token",
                 logLevel: "error",
             });
 
-            expect((client as any).options.githubToken).toBe("gho_test_token");
+            expect((client as any).options.gitHubToken).toBe("gho_test_token");
         });
 
-        it("should default useLoggedInUser to true when no githubToken", () => {
+        it("should default useLoggedInUser to true when no gitHubToken", () => {
             const client = new CopilotClient({
                 logLevel: "error",
             });
@@ -547,18 +547,18 @@ describe("CopilotClient", () => {
             expect((client as any).options.useLoggedInUser).toBe(true);
         });
 
-        it("should default useLoggedInUser to false when githubToken is provided", () => {
+        it("should default useLoggedInUser to false when gitHubToken is provided", () => {
             const client = new CopilotClient({
-                githubToken: "gho_test_token",
+                gitHubToken: "gho_test_token",
                 logLevel: "error",
             });
 
             expect((client as any).options.useLoggedInUser).toBe(false);
         });
 
-        it("should allow explicit useLoggedInUser: true with githubToken", () => {
+        it("should allow explicit useLoggedInUser: true with gitHubToken", () => {
             const client = new CopilotClient({
-                githubToken: "gho_test_token",
+                gitHubToken: "gho_test_token",
                 useLoggedInUser: true,
                 logLevel: "error",
             });
@@ -566,7 +566,7 @@ describe("CopilotClient", () => {
             expect((client as any).options.useLoggedInUser).toBe(true);
         });
 
-        it("should allow explicit useLoggedInUser: false without githubToken", () => {
+        it("should allow explicit useLoggedInUser: false without gitHubToken", () => {
             const client = new CopilotClient({
                 useLoggedInUser: false,
                 logLevel: "error",
@@ -575,14 +575,14 @@ describe("CopilotClient", () => {
             expect((client as any).options.useLoggedInUser).toBe(false);
         });
 
-        it("should throw error when githubToken is used with cliUrl", () => {
+        it("should throw error when gitHubToken is used with cliUrl", () => {
             expect(() => {
                 new CopilotClient({
                     cliUrl: "localhost:8080",
-                    githubToken: "gho_test_token",
+                    gitHubToken: "gho_test_token",
                     logLevel: "error",
                 });
-            }).toThrow(/githubToken and useLoggedInUser cannot be used with cliUrl/);
+            }).toThrow(/gitHubToken and useLoggedInUser cannot be used with cliUrl/);
         });
 
         it("should throw error when useLoggedInUser is used with cliUrl", () => {
@@ -592,7 +592,7 @@ describe("CopilotClient", () => {
                     useLoggedInUser: false,
                     logLevel: "error",
                 });
-            }).toThrow(/githubToken and useLoggedInUser cannot be used with cliUrl/);
+            }).toThrow(/gitHubToken and useLoggedInUser cannot be used with cliUrl/);
         });
     });
 

--- a/nodejs/test/e2e/harness/CapiProxy.ts
+++ b/nodejs/test/e2e/harness/CapiProxy.ts
@@ -1,7 +1,10 @@
 import { spawn } from "child_process";
 import { resolve } from "path";
 import { expect } from "vitest";
-import { ParsedHttpExchange } from "../../../../test/harness/replayingCapiProxy";
+import {
+    CopilotUserResponse,
+    ParsedHttpExchange,
+} from "../../../../test/harness/replayingCapiProxy";
 
 const HARNESS_SERVER_PATH = resolve(__dirname, "../../../../test/harness/server.ts");
 
@@ -49,5 +52,19 @@ export class CapiProxy {
             : `${this.proxyUrl}/stop`;
         const response = await fetch(url, { method: "POST" });
         expect(response.ok).toBe(true);
+    }
+
+    /**
+     * Register a per-token response for the `/copilot_internal/user` endpoint.
+     * When a request with `Authorization: Bearer <token>` arrives at the proxy,
+     * the matching response is returned.
+     */
+    async setCopilotUserByToken(token: string, response: CopilotUserResponse): Promise<void> {
+        const res = await fetch(`${this.proxyUrl}/copilot-user-config`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ token, response }),
+        });
+        expect(res.ok).toBe(true);
     }
 }

--- a/nodejs/test/e2e/harness/sdkTestContext.ts
+++ b/nodejs/test/e2e/harness/sdkTestContext.ts
@@ -51,7 +51,7 @@ export async function createSdkTestContext({
         logLevel: logLevel || "error",
         cliPath: process.env.COPILOT_CLI_PATH,
         // Use fake token in CI to allow cached responses without real auth
-        githubToken: isCI ? "fake-token-for-e2e-tests" : undefined,
+        gitHubToken: isCI ? "fake-token-for-e2e-tests" : undefined,
         useStdio: useStdio,
         ...copilotClientOptions,
     });

--- a/nodejs/test/e2e/multi-client.test.ts
+++ b/nodejs/test/e2e/multi-client.test.ts
@@ -88,7 +88,7 @@ describe("Multi-client broadcast", async () => {
         const session1 = await client1.createSession({
             onPermissionRequest: (request) => {
                 client1PermissionRequests.push(request);
-                return { kind: "approved" as const };
+                return { kind: "approve-once" as const };
             },
         });
 
@@ -142,7 +142,7 @@ describe("Multi-client broadcast", async () => {
     it("one client rejects permission and both see the result", async () => {
         // Client 1 creates a session and denies all permission requests
         const session1 = await client1.createSession({
-            onPermissionRequest: () => ({ kind: "denied-interactively-by-user" as const }),
+            onPermissionRequest: () => ({ kind: "reject" as const }),
         });
 
         // Client 2 resumes — its handler never resolves so only client 1's denial takes effect

--- a/nodejs/test/e2e/per_session_auth.test.ts
+++ b/nodejs/test/e2e/per_session_auth.test.ts
@@ -1,0 +1,100 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from "vitest";
+import { approveAll } from "../../src/index.js";
+import { createSdkTestContext } from "./harness/sdkTestContext.js";
+
+describe("Per-session GitHub auth", async () => {
+    const { copilotClient: client, openAiEndpoint, env } = await createSdkTestContext();
+
+    // Redirect GitHub API calls (e.g., fetchCopilotUser) to the proxy
+    // so per-session auth token resolution can be tested
+    env.COPILOT_DEBUG_GITHUB_API_URL = env.COPILOT_API_URL;
+
+    // Configure per-token responses on the proxy.
+    // endpoints.api points back to the proxy so subsequent CAPI calls are also intercepted.
+    const proxyUrl = env.COPILOT_API_URL;
+    await openAiEndpoint.setCopilotUserByToken("token-alice", {
+        login: "alice",
+        copilot_plan: "individual_pro",
+        endpoints: {
+            api: proxyUrl,
+            telemetry: "https://localhost:1/telemetry",
+        },
+        analytics_tracking_id: "alice-tracking-id",
+    });
+
+    await openAiEndpoint.setCopilotUserByToken("token-bob", {
+        login: "bob",
+        copilot_plan: "business",
+        endpoints: {
+            api: proxyUrl,
+            telemetry: "https://localhost:1/telemetry",
+        },
+        analytics_tracking_id: "bob-tracking-id",
+    });
+
+    it("should create session with gitHubToken and check auth status", async () => {
+        const session = await client.createSession({
+            onPermissionRequest: approveAll,
+            gitHubToken: "token-alice",
+        });
+
+        const authStatus = await session.rpc.auth.getStatus();
+        expect(authStatus.isAuthenticated).toBe(true);
+        expect(authStatus.login).toBe("alice");
+        expect(authStatus.copilotPlan).toBe("individual_pro");
+
+        await session.disconnect();
+    });
+
+    it("should isolate auth between sessions with different tokens", async () => {
+        const sessionA = await client.createSession({
+            onPermissionRequest: approveAll,
+            gitHubToken: "token-alice",
+        });
+        const sessionB = await client.createSession({
+            onPermissionRequest: approveAll,
+            gitHubToken: "token-bob",
+        });
+
+        const statusA = await sessionA.rpc.auth.getStatus();
+        const statusB = await sessionB.rpc.auth.getStatus();
+
+        expect(statusA.isAuthenticated).toBe(true);
+        expect(statusA.login).toBe("alice");
+        expect(statusA.copilotPlan).toBe("individual_pro");
+
+        expect(statusB.isAuthenticated).toBe(true);
+        expect(statusB.login).toBe("bob");
+        expect(statusB.copilotPlan).toBe("business");
+
+        await sessionA.disconnect();
+        await sessionB.disconnect();
+    });
+
+    it("should return unauthenticated when no token is provided", async () => {
+        const session = await client.createSession({
+            onPermissionRequest: approveAll,
+        });
+
+        const authStatus = await session.rpc.auth.getStatus();
+        // Without a per-session GitHub token, there is no per-session identity.
+        // In CI the process-level fake token may still authenticate globally,
+        // so we check login rather than isAuthenticated.
+        expect(authStatus.login).toBeFalsy();
+
+        await session.disconnect();
+    });
+
+    it("should error when creating session with invalid token", async () => {
+        await expect(
+            client.createSession({
+                onPermissionRequest: approveAll,
+                gitHubToken: "invalid-token-12345",
+            })
+        ).rejects.toThrow();
+    });
+});

--- a/nodejs/test/e2e/permissions.test.ts
+++ b/nodejs/test/e2e/permissions.test.ts
@@ -21,7 +21,7 @@ describe("Permission callbacks", async () => {
                 expect(invocation.sessionId).toBe(session.sessionId);
 
                 // Approve the permission
-                const result: PermissionRequestResult = { kind: "approved" };
+                const result: PermissionRequestResult = { kind: "approve-once" };
                 return result;
             },
         });
@@ -45,7 +45,7 @@ describe("Permission callbacks", async () => {
     it("should deny permission when handler returns denied", async () => {
         const session = await client.createSession({
             onPermissionRequest: () => {
-                return { kind: "denied-interactively-by-user" };
+                return { kind: "reject" };
             },
         });
 
@@ -69,7 +69,7 @@ describe("Permission callbacks", async () => {
 
         const session = await client.createSession({
             onPermissionRequest: () => ({
-                kind: "denied-no-approval-rule-and-could-not-request-from-user",
+                kind: "user-not-available",
             }),
         });
         session.on((event) => {
@@ -96,7 +96,7 @@ describe("Permission callbacks", async () => {
 
         const session2 = await client.resumeSession(sessionId, {
             onPermissionRequest: () => ({
-                kind: "denied-no-approval-rule-and-could-not-request-from-user",
+                kind: "user-not-available",
             }),
         });
         let permissionDenied = false;
@@ -138,7 +138,7 @@ describe("Permission callbacks", async () => {
                 // Simulate async permission check (e.g., user prompt)
                 await new Promise((resolve) => setTimeout(resolve, 10));
 
-                return { kind: "approved" };
+                return { kind: "approve-once" };
             },
         });
 
@@ -163,7 +163,7 @@ describe("Permission callbacks", async () => {
         const session2 = await client.resumeSession(sessionId, {
             onPermissionRequest: (request) => {
                 permissionRequests.push(request);
-                return { kind: "approved" };
+                return { kind: "approve-once" };
             },
         });
 
@@ -204,7 +204,7 @@ describe("Permission callbacks", async () => {
                     expect(typeof request.toolCallId).toBe("string");
                     expect(request.toolCallId.length).toBeGreaterThan(0);
                 }
-                return { kind: "approved" };
+                return { kind: "approve-once" };
             },
         });
 

--- a/nodejs/test/e2e/session.test.ts
+++ b/nodejs/test/e2e/session.test.ts
@@ -244,7 +244,7 @@ describe("Sessions", async () => {
         // Resume using a new client
         const newClient = new CopilotClient({
             env,
-            githubToken: isCI ? "fake-token-for-e2e-tests" : undefined,
+            gitHubToken: isCI ? "fake-token-for-e2e-tests" : undefined,
         });
 
         onTestFinished(() => newClient.forceStop());

--- a/nodejs/test/e2e/streaming_fidelity.test.ts
+++ b/nodejs/test/e2e/streaming_fidelity.test.ts
@@ -83,7 +83,7 @@ describe("Streaming Fidelity", async () => {
         // Resume using a new client
         const newClient = new CopilotClient({
             env,
-            githubToken: isCI ? "fake-token-for-e2e-tests" : undefined,
+            gitHubToken: isCI ? "fake-token-for-e2e-tests" : undefined,
         });
         onTestFinished(() => newClient.forceStop());
         const session2 = await newClient.resumeSession(session.sessionId, {

--- a/nodejs/test/e2e/tools.test.ts
+++ b/nodejs/test/e2e/tools.test.ts
@@ -144,7 +144,7 @@ describe("Custom tools", async () => {
             ],
             onPermissionRequest: (request) => {
                 permissionRequests.push(request);
-                return { kind: "approved" };
+                return { kind: "approve-once" };
             },
         });
 
@@ -223,7 +223,7 @@ describe("Custom tools", async () => {
                 }),
             ],
             onPermissionRequest: () => {
-                return { kind: "denied-interactively-by-user" };
+                return { kind: "reject" };
             },
         });
 

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -1220,6 +1220,7 @@ class CopilotClient:
         commands: list[CommandDefinition] | None = None,
         on_elicitation_request: ElicitationHandler | None = None,
         create_session_fs_handler: CreateSessionFsHandler | None = None,
+        github_token: str | None = None,
     ) -> CopilotSession:
         """
         Create a new conversation session with the Copilot CLI.
@@ -1351,6 +1352,10 @@ class CopilotClient:
         # Enable hooks callback if any hook handler provided
         if hooks and any(hooks.values()):
             payload["hooks"] = True
+
+        # Add GitHub token for per-session authentication
+        if github_token is not None:
+            payload["gitHubToken"] = github_token
 
         # Add working directory if provided
         if working_directory:
@@ -1507,6 +1512,7 @@ class CopilotClient:
         commands: list[CommandDefinition] | None = None,
         on_elicitation_request: ElicitationHandler | None = None,
         create_session_fs_handler: CreateSessionFsHandler | None = None,
+        github_token: str | None = None,
     ) -> CopilotSession:
         """
         Resume an existing conversation session by its ID.
@@ -1649,6 +1655,10 @@ class CopilotClient:
 
         if hooks and any(hooks.values()):
             payload["hooks"] = True
+
+        # Add GitHub token for per-session authentication
+        if github_token is not None:
+            payload["gitHubToken"] = github_token
 
         if working_directory:
             payload["workingDirectory"] = working_directory

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -2725,16 +2725,7 @@ class CopilotClient:
             result = await session._handle_permission_request(perm_request)
             if result.kind == "no-result":
                 raise ValueError(NO_RESULT_PERMISSION_V2_ERROR)
-            result_payload: dict = {"kind": result.kind}
-            if result.rules is not None:
-                result_payload["rules"] = result.rules
-            if result.feedback is not None:
-                result_payload["feedback"] = result.feedback
-            if result.message is not None:
-                result_payload["message"] = result.message
-            if result.path is not None:
-                result_payload["path"] = result.path
-            return {"result": result_payload}
+            return {"result": {"kind": result.kind}}
         except ValueError as exc:
             if str(exc) == NO_RESULT_PERMISSION_V2_ERROR:
                 raise

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -2740,12 +2740,12 @@ class CopilotClient:
                 raise
             return {
                 "result": {
-                    "kind": "denied-no-approval-rule-and-could-not-request-from-user",
+                    "kind": "user-not-available",
                 }
             }
         except Exception:  # pylint: disable=broad-except
             return {
                 "result": {
-                    "kind": "denied-no-approval-rule-and-could-not-request-from-user",
+                    "kind": "user-not-available",
                 }
             }

--- a/python/copilot/generated/rpc.py
+++ b/python/copilot/generated/rpc.py
@@ -919,59 +919,51 @@ class ApprovalKind(Enum):
     MCP = "mcp"
     MCP_SAMPLING = "mcp-sampling"
     MEMORY = "memory"
+    READ = "read"
     WRITE = "write"
 
 class PermissionDecisionKind(Enum):
-    APPROVED = "approved"
-    APPROVED_FOR_LOCATION = "approved-for-location"
-    APPROVED_FOR_SESSION = "approved-for-session"
-    DENIED_BY_CONTENT_EXCLUSION_POLICY = "denied-by-content-exclusion-policy"
-    DENIED_BY_PERMISSION_REQUEST_HOOK = "denied-by-permission-request-hook"
-    DENIED_BY_RULES = "denied-by-rules"
-    DENIED_INTERACTIVELY_BY_USER = "denied-interactively-by-user"
-    DENIED_NO_APPROVAL_RULE_AND_COULD_NOT_REQUEST_FROM_USER = "denied-no-approval-rule-and-could-not-request-from-user"
+    APPROVE_FOR_LOCATION = "approve-for-location"
+    APPROVE_FOR_SESSION = "approve-for-session"
+    APPROVE_ONCE = "approve-once"
+    REJECT = "reject"
+    USER_NOT_AVAILABLE = "user-not-available"
 
-class PermissionDecisionApprovedKind(Enum):
-    APPROVED = "approved"
+class PermissionDecisionApproveForLocationKind(Enum):
+    APPROVE_FOR_LOCATION = "approve-for-location"
 
-class PermissionDecisionApprovedForLocationKind(Enum):
-    APPROVED_FOR_LOCATION = "approved-for-location"
-
-class PermissionDecisionApprovedForLocationApprovalCommandsKind(Enum):
+class PermissionDecisionApproveForLocationApprovalCommandsKind(Enum):
     COMMANDS = "commands"
 
-class PermissionDecisionApprovedForLocationApprovalCustomToolKind(Enum):
+class PermissionDecisionApproveForLocationApprovalCustomToolKind(Enum):
     CUSTOM_TOOL = "custom-tool"
 
-class PermissionDecisionApprovedForLocationApprovalMCPKind(Enum):
+class PermissionDecisionApproveForLocationApprovalMCPKind(Enum):
     MCP = "mcp"
 
-class PermissionDecisionApprovedForLocationApprovalMCPSamplingKind(Enum):
+class PermissionDecisionApproveForLocationApprovalMCPSamplingKind(Enum):
     MCP_SAMPLING = "mcp-sampling"
 
-class PermissionDecisionApprovedForLocationApprovalMemoryKind(Enum):
+class PermissionDecisionApproveForLocationApprovalMemoryKind(Enum):
     MEMORY = "memory"
 
-class PermissionDecisionApprovedForLocationApprovalWriteKind(Enum):
+class PermissionDecisionApproveForLocationApprovalReadKind(Enum):
+    READ = "read"
+
+class PermissionDecisionApproveForLocationApprovalWriteKind(Enum):
     WRITE = "write"
 
-class PermissionDecisionApprovedForSessionKind(Enum):
-    APPROVED_FOR_SESSION = "approved-for-session"
+class PermissionDecisionApproveForSessionKind(Enum):
+    APPROVE_FOR_SESSION = "approve-for-session"
 
-class PermissionDecisionDeniedByContentExclusionPolicyKind(Enum):
-    DENIED_BY_CONTENT_EXCLUSION_POLICY = "denied-by-content-exclusion-policy"
+class PermissionDecisionApproveOnceKind(Enum):
+    APPROVE_ONCE = "approve-once"
 
-class PermissionDecisionDeniedByPermissionRequestHookKind(Enum):
-    DENIED_BY_PERMISSION_REQUEST_HOOK = "denied-by-permission-request-hook"
+class PermissionDecisionRejectKind(Enum):
+    REJECT = "reject"
 
-class PermissionDecisionDeniedByRulesKind(Enum):
-    DENIED_BY_RULES = "denied-by-rules"
-
-class PermissionDecisionDeniedInteractivelyByUserKind(Enum):
-    DENIED_INTERACTIVELY_BY_USER = "denied-interactively-by-user"
-
-class PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUserKind(Enum):
-    DENIED_NO_APPROVAL_RULE_AND_COULD_NOT_REQUEST_FROM_USER = "denied-no-approval-rule-and-could-not-request-from-user"
+class PermissionDecisionUserNotAvailableKind(Enum):
+    USER_NOT_AVAILABLE = "user-not-available"
 
 @dataclass
 class PermissionRequestResult:
@@ -2713,7 +2705,7 @@ class ModelCapabilitiesOverrideLimits:
         return result
 
 @dataclass
-class PermissionDecisionApprovedForIonApproval:
+class PermissionDecisionApproveForIonApproval:
     """The approval to add as a session-scoped rule
 
     The approval to persist for this location
@@ -2724,13 +2716,13 @@ class PermissionDecisionApprovedForIonApproval:
     tool_name: str | None = None
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForIonApproval':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveForIonApproval':
         assert isinstance(obj, dict)
         kind = ApprovalKind(obj.get("kind"))
         command_identifiers = from_union([lambda x: from_list(from_str, x), from_none], obj.get("commandIdentifiers"))
         server_name = from_union([from_str, from_none], obj.get("serverName"))
         tool_name = from_union([from_none, from_str], obj.get("toolName"))
-        return PermissionDecisionApprovedForIonApproval(kind, command_identifiers, server_name, tool_name)
+        return PermissionDecisionApproveForIonApproval(kind, command_identifiers, server_name, tool_name)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -2744,7 +2736,7 @@ class PermissionDecisionApprovedForIonApproval:
         return result
 
 @dataclass
-class PermissionDecisionApprovedForLocationApproval:
+class PermissionDecisionApproveForLocationApproval:
     """The approval to persist for this location"""
 
     kind: ApprovalKind
@@ -2753,13 +2745,13 @@ class PermissionDecisionApprovedForLocationApproval:
     tool_name: str | None = None
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForLocationApproval':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveForLocationApproval':
         assert isinstance(obj, dict)
         kind = ApprovalKind(obj.get("kind"))
         command_identifiers = from_union([lambda x: from_list(from_str, x), from_none], obj.get("commandIdentifiers"))
         server_name = from_union([from_str, from_none], obj.get("serverName"))
         tool_name = from_union([from_none, from_str], obj.get("toolName"))
-        return PermissionDecisionApprovedForLocationApproval(kind, command_identifiers, server_name, tool_name)
+        return PermissionDecisionApproveForLocationApproval(kind, command_identifiers, server_name, tool_name)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -2773,7 +2765,7 @@ class PermissionDecisionApprovedForLocationApproval:
         return result
 
 @dataclass
-class PermissionDecisionApprovedForSessionApproval:
+class PermissionDecisionApproveForSessionApproval:
     """The approval to add as a session-scoped rule"""
 
     kind: ApprovalKind
@@ -2782,13 +2774,13 @@ class PermissionDecisionApprovedForSessionApproval:
     tool_name: str | None = None
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForSessionApproval':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveForSessionApproval':
         assert isinstance(obj, dict)
         kind = ApprovalKind(obj.get("kind"))
         command_identifiers = from_union([lambda x: from_list(from_str, x), from_none], obj.get("commandIdentifiers"))
         server_name = from_union([from_str, from_none], obj.get("serverName"))
         tool_name = from_union([from_none, from_str], obj.get("toolName"))
-        return PermissionDecisionApprovedForSessionApproval(kind, command_identifiers, server_name, tool_name)
+        return PermissionDecisionApproveForSessionApproval(kind, command_identifiers, server_name, tool_name)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -2802,342 +2794,297 @@ class PermissionDecisionApprovedForSessionApproval:
         return result
 
 @dataclass
-class PermissionDecisionApproved:
-    kind: PermissionDecisionApprovedKind
-    """The permission request was approved"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApproved':
-        assert isinstance(obj, dict)
-        kind = PermissionDecisionApprovedKind(obj.get("kind"))
-        return PermissionDecisionApproved(kind)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionApprovedKind, self.kind)
-        return result
-
-@dataclass
-class PermissionDecisionApprovedForLocationApprovalCommands:
+class PermissionDecisionApproveForLocationApprovalCommands:
     command_identifiers: list[str]
-    kind: PermissionDecisionApprovedForLocationApprovalCommandsKind
+    kind: PermissionDecisionApproveForLocationApprovalCommandsKind
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForLocationApprovalCommands':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveForLocationApprovalCommands':
         assert isinstance(obj, dict)
         command_identifiers = from_list(from_str, obj.get("commandIdentifiers"))
-        kind = PermissionDecisionApprovedForLocationApprovalCommandsKind(obj.get("kind"))
-        return PermissionDecisionApprovedForLocationApprovalCommands(command_identifiers, kind)
+        kind = PermissionDecisionApproveForLocationApprovalCommandsKind(obj.get("kind"))
+        return PermissionDecisionApproveForLocationApprovalCommands(command_identifiers, kind)
 
     def to_dict(self) -> dict:
         result: dict = {}
         result["commandIdentifiers"] = from_list(from_str, self.command_identifiers)
-        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalCommandsKind, self.kind)
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalCommandsKind, self.kind)
         return result
 
 @dataclass
-class PermissionDecisionApprovedForSessionApprovalCommands:
+class PermissionDecisionApproveForSessionApprovalCommands:
     command_identifiers: list[str]
-    kind: PermissionDecisionApprovedForLocationApprovalCommandsKind
+    kind: PermissionDecisionApproveForLocationApprovalCommandsKind
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForSessionApprovalCommands':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveForSessionApprovalCommands':
         assert isinstance(obj, dict)
         command_identifiers = from_list(from_str, obj.get("commandIdentifiers"))
-        kind = PermissionDecisionApprovedForLocationApprovalCommandsKind(obj.get("kind"))
-        return PermissionDecisionApprovedForSessionApprovalCommands(command_identifiers, kind)
+        kind = PermissionDecisionApproveForLocationApprovalCommandsKind(obj.get("kind"))
+        return PermissionDecisionApproveForSessionApprovalCommands(command_identifiers, kind)
 
     def to_dict(self) -> dict:
         result: dict = {}
         result["commandIdentifiers"] = from_list(from_str, self.command_identifiers)
-        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalCommandsKind, self.kind)
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalCommandsKind, self.kind)
         return result
 
 @dataclass
-class PermissionDecisionApprovedForLocationApprovalCustomTool:
-    kind: PermissionDecisionApprovedForLocationApprovalCustomToolKind
+class PermissionDecisionApproveForLocationApprovalCustomTool:
+    kind: PermissionDecisionApproveForLocationApprovalCustomToolKind
     tool_name: str
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForLocationApprovalCustomTool':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveForLocationApprovalCustomTool':
         assert isinstance(obj, dict)
-        kind = PermissionDecisionApprovedForLocationApprovalCustomToolKind(obj.get("kind"))
+        kind = PermissionDecisionApproveForLocationApprovalCustomToolKind(obj.get("kind"))
         tool_name = from_str(obj.get("toolName"))
-        return PermissionDecisionApprovedForLocationApprovalCustomTool(kind, tool_name)
+        return PermissionDecisionApproveForLocationApprovalCustomTool(kind, tool_name)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalCustomToolKind, self.kind)
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalCustomToolKind, self.kind)
         result["toolName"] = from_str(self.tool_name)
         return result
 
 @dataclass
-class PermissionDecisionApprovedForSessionApprovalCustomTool:
-    kind: PermissionDecisionApprovedForLocationApprovalCustomToolKind
+class PermissionDecisionApproveForSessionApprovalCustomTool:
+    kind: PermissionDecisionApproveForLocationApprovalCustomToolKind
     tool_name: str
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForSessionApprovalCustomTool':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveForSessionApprovalCustomTool':
         assert isinstance(obj, dict)
-        kind = PermissionDecisionApprovedForLocationApprovalCustomToolKind(obj.get("kind"))
+        kind = PermissionDecisionApproveForLocationApprovalCustomToolKind(obj.get("kind"))
         tool_name = from_str(obj.get("toolName"))
-        return PermissionDecisionApprovedForSessionApprovalCustomTool(kind, tool_name)
+        return PermissionDecisionApproveForSessionApprovalCustomTool(kind, tool_name)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalCustomToolKind, self.kind)
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalCustomToolKind, self.kind)
         result["toolName"] = from_str(self.tool_name)
         return result
 
 @dataclass
-class PermissionDecisionApprovedForLocationApprovalMCP:
-    kind: PermissionDecisionApprovedForLocationApprovalMCPKind
+class PermissionDecisionApproveForLocationApprovalMCP:
+    kind: PermissionDecisionApproveForLocationApprovalMCPKind
     server_name: str
     tool_name: str | None = None
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForLocationApprovalMCP':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveForLocationApprovalMCP':
         assert isinstance(obj, dict)
-        kind = PermissionDecisionApprovedForLocationApprovalMCPKind(obj.get("kind"))
+        kind = PermissionDecisionApproveForLocationApprovalMCPKind(obj.get("kind"))
         server_name = from_str(obj.get("serverName"))
         tool_name = from_union([from_none, from_str], obj.get("toolName"))
-        return PermissionDecisionApprovedForLocationApprovalMCP(kind, server_name, tool_name)
+        return PermissionDecisionApproveForLocationApprovalMCP(kind, server_name, tool_name)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalMCPKind, self.kind)
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalMCPKind, self.kind)
         result["serverName"] = from_str(self.server_name)
         result["toolName"] = from_union([from_none, from_str], self.tool_name)
         return result
 
 @dataclass
-class PermissionDecisionApprovedForSessionApprovalMCP:
-    kind: PermissionDecisionApprovedForLocationApprovalMCPKind
+class PermissionDecisionApproveForSessionApprovalMCP:
+    kind: PermissionDecisionApproveForLocationApprovalMCPKind
     server_name: str
     tool_name: str | None = None
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForSessionApprovalMCP':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveForSessionApprovalMCP':
         assert isinstance(obj, dict)
-        kind = PermissionDecisionApprovedForLocationApprovalMCPKind(obj.get("kind"))
+        kind = PermissionDecisionApproveForLocationApprovalMCPKind(obj.get("kind"))
         server_name = from_str(obj.get("serverName"))
         tool_name = from_union([from_none, from_str], obj.get("toolName"))
-        return PermissionDecisionApprovedForSessionApprovalMCP(kind, server_name, tool_name)
+        return PermissionDecisionApproveForSessionApprovalMCP(kind, server_name, tool_name)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalMCPKind, self.kind)
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalMCPKind, self.kind)
         result["serverName"] = from_str(self.server_name)
         result["toolName"] = from_union([from_none, from_str], self.tool_name)
         return result
 
 @dataclass
-class PermissionDecisionApprovedForLocationApprovalMCPSampling:
-    kind: PermissionDecisionApprovedForLocationApprovalMCPSamplingKind
+class PermissionDecisionApproveForLocationApprovalMCPSampling:
+    kind: PermissionDecisionApproveForLocationApprovalMCPSamplingKind
     server_name: str
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForLocationApprovalMCPSampling':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveForLocationApprovalMCPSampling':
         assert isinstance(obj, dict)
-        kind = PermissionDecisionApprovedForLocationApprovalMCPSamplingKind(obj.get("kind"))
+        kind = PermissionDecisionApproveForLocationApprovalMCPSamplingKind(obj.get("kind"))
         server_name = from_str(obj.get("serverName"))
-        return PermissionDecisionApprovedForLocationApprovalMCPSampling(kind, server_name)
+        return PermissionDecisionApproveForLocationApprovalMCPSampling(kind, server_name)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalMCPSamplingKind, self.kind)
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalMCPSamplingKind, self.kind)
         result["serverName"] = from_str(self.server_name)
         return result
 
 @dataclass
-class PermissionDecisionApprovedForSessionApprovalMCPSampling:
-    kind: PermissionDecisionApprovedForLocationApprovalMCPSamplingKind
+class PermissionDecisionApproveForSessionApprovalMCPSampling:
+    kind: PermissionDecisionApproveForLocationApprovalMCPSamplingKind
     server_name: str
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForSessionApprovalMCPSampling':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveForSessionApprovalMCPSampling':
         assert isinstance(obj, dict)
-        kind = PermissionDecisionApprovedForLocationApprovalMCPSamplingKind(obj.get("kind"))
+        kind = PermissionDecisionApproveForLocationApprovalMCPSamplingKind(obj.get("kind"))
         server_name = from_str(obj.get("serverName"))
-        return PermissionDecisionApprovedForSessionApprovalMCPSampling(kind, server_name)
+        return PermissionDecisionApproveForSessionApprovalMCPSampling(kind, server_name)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalMCPSamplingKind, self.kind)
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalMCPSamplingKind, self.kind)
         result["serverName"] = from_str(self.server_name)
         return result
 
 @dataclass
-class PermissionDecisionApprovedForLocationApprovalMemory:
-    kind: PermissionDecisionApprovedForLocationApprovalMemoryKind
+class PermissionDecisionApproveForLocationApprovalMemory:
+    kind: PermissionDecisionApproveForLocationApprovalMemoryKind
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForLocationApprovalMemory':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveForLocationApprovalMemory':
         assert isinstance(obj, dict)
-        kind = PermissionDecisionApprovedForLocationApprovalMemoryKind(obj.get("kind"))
-        return PermissionDecisionApprovedForLocationApprovalMemory(kind)
+        kind = PermissionDecisionApproveForLocationApprovalMemoryKind(obj.get("kind"))
+        return PermissionDecisionApproveForLocationApprovalMemory(kind)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalMemoryKind, self.kind)
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalMemoryKind, self.kind)
         return result
 
 @dataclass
-class PermissionDecisionApprovedForSessionApprovalMemory:
-    kind: PermissionDecisionApprovedForLocationApprovalMemoryKind
+class PermissionDecisionApproveForSessionApprovalMemory:
+    kind: PermissionDecisionApproveForLocationApprovalMemoryKind
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForSessionApprovalMemory':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveForSessionApprovalMemory':
         assert isinstance(obj, dict)
-        kind = PermissionDecisionApprovedForLocationApprovalMemoryKind(obj.get("kind"))
-        return PermissionDecisionApprovedForSessionApprovalMemory(kind)
+        kind = PermissionDecisionApproveForLocationApprovalMemoryKind(obj.get("kind"))
+        return PermissionDecisionApproveForSessionApprovalMemory(kind)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalMemoryKind, self.kind)
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalMemoryKind, self.kind)
         return result
 
 @dataclass
-class PermissionDecisionApprovedForLocationApprovalWrite:
-    kind: PermissionDecisionApprovedForLocationApprovalWriteKind
+class PermissionDecisionApproveForLocationApprovalRead:
+    kind: PermissionDecisionApproveForLocationApprovalReadKind
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForLocationApprovalWrite':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveForLocationApprovalRead':
         assert isinstance(obj, dict)
-        kind = PermissionDecisionApprovedForLocationApprovalWriteKind(obj.get("kind"))
-        return PermissionDecisionApprovedForLocationApprovalWrite(kind)
+        kind = PermissionDecisionApproveForLocationApprovalReadKind(obj.get("kind"))
+        return PermissionDecisionApproveForLocationApprovalRead(kind)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalWriteKind, self.kind)
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalReadKind, self.kind)
         return result
 
 @dataclass
-class PermissionDecisionApprovedForSessionApprovalWrite:
-    kind: PermissionDecisionApprovedForLocationApprovalWriteKind
+class PermissionDecisionApproveForSessionApprovalRead:
+    kind: PermissionDecisionApproveForLocationApprovalReadKind
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForSessionApprovalWrite':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveForSessionApprovalRead':
         assert isinstance(obj, dict)
-        kind = PermissionDecisionApprovedForLocationApprovalWriteKind(obj.get("kind"))
-        return PermissionDecisionApprovedForSessionApprovalWrite(kind)
+        kind = PermissionDecisionApproveForLocationApprovalReadKind(obj.get("kind"))
+        return PermissionDecisionApproveForSessionApprovalRead(kind)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalWriteKind, self.kind)
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalReadKind, self.kind)
         return result
 
 @dataclass
-class PermissionDecisionDeniedByContentExclusionPolicy:
-    kind: PermissionDecisionDeniedByContentExclusionPolicyKind
-    """Denied by the organization's content exclusion policy"""
-
-    message: str
-    """Human-readable explanation of why the path was excluded"""
-
-    path: str
-    """File path that triggered the exclusion"""
+class PermissionDecisionApproveForLocationApprovalWrite:
+    kind: PermissionDecisionApproveForLocationApprovalWriteKind
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionDeniedByContentExclusionPolicy':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveForLocationApprovalWrite':
         assert isinstance(obj, dict)
-        kind = PermissionDecisionDeniedByContentExclusionPolicyKind(obj.get("kind"))
-        message = from_str(obj.get("message"))
-        path = from_str(obj.get("path"))
-        return PermissionDecisionDeniedByContentExclusionPolicy(kind, message, path)
+        kind = PermissionDecisionApproveForLocationApprovalWriteKind(obj.get("kind"))
+        return PermissionDecisionApproveForLocationApprovalWrite(kind)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionDeniedByContentExclusionPolicyKind, self.kind)
-        result["message"] = from_str(self.message)
-        result["path"] = from_str(self.path)
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalWriteKind, self.kind)
         return result
 
 @dataclass
-class PermissionDecisionDeniedByPermissionRequestHook:
-    kind: PermissionDecisionDeniedByPermissionRequestHookKind
-    """Denied by a permission request hook registered by an extension or plugin"""
-
-    interrupt: bool | None = None
-    """Whether to interrupt the current agent turn"""
-
-    message: str | None = None
-    """Optional message from the hook explaining the denial"""
+class PermissionDecisionApproveForSessionApprovalWrite:
+    kind: PermissionDecisionApproveForLocationApprovalWriteKind
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionDeniedByPermissionRequestHook':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveForSessionApprovalWrite':
         assert isinstance(obj, dict)
-        kind = PermissionDecisionDeniedByPermissionRequestHookKind(obj.get("kind"))
-        interrupt = from_union([from_bool, from_none], obj.get("interrupt"))
-        message = from_union([from_str, from_none], obj.get("message"))
-        return PermissionDecisionDeniedByPermissionRequestHook(kind, interrupt, message)
+        kind = PermissionDecisionApproveForLocationApprovalWriteKind(obj.get("kind"))
+        return PermissionDecisionApproveForSessionApprovalWrite(kind)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionDeniedByPermissionRequestHookKind, self.kind)
-        if self.interrupt is not None:
-            result["interrupt"] = from_union([from_bool, from_none], self.interrupt)
-        if self.message is not None:
-            result["message"] = from_union([from_str, from_none], self.message)
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalWriteKind, self.kind)
         return result
 
 @dataclass
-class PermissionDecisionDeniedByRules:
-    kind: PermissionDecisionDeniedByRulesKind
-    """Denied because approval rules explicitly blocked it"""
-
-    rules: list[Any]
-    """Rules that denied the request"""
+class PermissionDecisionApproveOnce:
+    kind: PermissionDecisionApproveOnceKind
+    """The permission request was approved for this one instance"""
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionDeniedByRules':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveOnce':
         assert isinstance(obj, dict)
-        kind = PermissionDecisionDeniedByRulesKind(obj.get("kind"))
-        rules = from_list(lambda x: x, obj.get("rules"))
-        return PermissionDecisionDeniedByRules(kind, rules)
+        kind = PermissionDecisionApproveOnceKind(obj.get("kind"))
+        return PermissionDecisionApproveOnce(kind)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionDeniedByRulesKind, self.kind)
-        result["rules"] = from_list(lambda x: x, self.rules)
+        result["kind"] = to_enum(PermissionDecisionApproveOnceKind, self.kind)
         return result
 
 @dataclass
-class PermissionDecisionDeniedInteractivelyByUser:
-    kind: PermissionDecisionDeniedInteractivelyByUserKind
+class PermissionDecisionReject:
+    kind: PermissionDecisionRejectKind
     """Denied by the user during an interactive prompt"""
 
     feedback: str | None = None
     """Optional feedback from the user explaining the denial"""
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionDeniedInteractivelyByUser':
+    def from_dict(obj: Any) -> 'PermissionDecisionReject':
         assert isinstance(obj, dict)
-        kind = PermissionDecisionDeniedInteractivelyByUserKind(obj.get("kind"))
+        kind = PermissionDecisionRejectKind(obj.get("kind"))
         feedback = from_union([from_str, from_none], obj.get("feedback"))
-        return PermissionDecisionDeniedInteractivelyByUser(kind, feedback)
+        return PermissionDecisionReject(kind, feedback)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionDeniedInteractivelyByUserKind, self.kind)
+        result["kind"] = to_enum(PermissionDecisionRejectKind, self.kind)
         if self.feedback is not None:
             result["feedback"] = from_union([from_str, from_none], self.feedback)
         return result
 
 @dataclass
-class PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser:
-    kind: PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUserKind
-    """Denied because no approval rule matched and user confirmation was unavailable"""
+class PermissionDecisionUserNotAvailable:
+    kind: PermissionDecisionUserNotAvailableKind
+    """Denied because user confirmation was unavailable"""
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser':
+    def from_dict(obj: Any) -> 'PermissionDecisionUserNotAvailable':
         assert isinstance(obj, dict)
-        kind = PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUserKind(obj.get("kind"))
-        return PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser(kind)
+        kind = PermissionDecisionUserNotAvailableKind(obj.get("kind"))
+        return PermissionDecisionUserNotAvailable(kind)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUserKind, self.kind)
+        result["kind"] = to_enum(PermissionDecisionUserNotAvailableKind, self.kind)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -3824,23 +3771,17 @@ class ModelCapabilitiesOverride:
 @dataclass
 class PermissionDecision:
     kind: PermissionDecisionKind
-    """The permission request was approved
+    """The permission request was approved for this one instance
 
     Approved and remembered for the rest of the session
 
     Approved and persisted for this project location
 
-    Denied because approval rules explicitly blocked it
-
-    Denied because no approval rule matched and user confirmation was unavailable
-
     Denied by the user during an interactive prompt
 
-    Denied by the organization's content exclusion policy
-
-    Denied by a permission request hook registered by an extension or plugin
+    Denied because user confirmation was unavailable
     """
-    approval: PermissionDecisionApprovedForIonApproval | None = None
+    approval: PermissionDecisionApproveForIonApproval | None = None
     """The approval to add as a session-scoped rule
 
     The approval to persist for this location
@@ -3848,100 +3789,74 @@ class PermissionDecision:
     location_key: str | None = None
     """The location key (git root or cwd) to persist the approval to"""
 
-    rules: list[Any] | None = None
-    """Rules that denied the request"""
-
     feedback: str | None = None
     """Optional feedback from the user explaining the denial"""
-
-    message: str | None = None
-    """Human-readable explanation of why the path was excluded
-
-    Optional message from the hook explaining the denial
-    """
-    path: str | None = None
-    """File path that triggered the exclusion"""
-
-    interrupt: bool | None = None
-    """Whether to interrupt the current agent turn"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecision':
         assert isinstance(obj, dict)
         kind = PermissionDecisionKind(obj.get("kind"))
-        approval = from_union([PermissionDecisionApprovedForIonApproval.from_dict, from_none], obj.get("approval"))
+        approval = from_union([PermissionDecisionApproveForIonApproval.from_dict, from_none], obj.get("approval"))
         location_key = from_union([from_str, from_none], obj.get("locationKey"))
-        rules = from_union([lambda x: from_list(lambda x: x, x), from_none], obj.get("rules"))
         feedback = from_union([from_str, from_none], obj.get("feedback"))
-        message = from_union([from_str, from_none], obj.get("message"))
-        path = from_union([from_str, from_none], obj.get("path"))
-        interrupt = from_union([from_bool, from_none], obj.get("interrupt"))
-        return PermissionDecision(kind, approval, location_key, rules, feedback, message, path, interrupt)
+        return PermissionDecision(kind, approval, location_key, feedback)
 
     def to_dict(self) -> dict:
         result: dict = {}
         result["kind"] = to_enum(PermissionDecisionKind, self.kind)
         if self.approval is not None:
-            result["approval"] = from_union([lambda x: to_class(PermissionDecisionApprovedForIonApproval, x), from_none], self.approval)
+            result["approval"] = from_union([lambda x: to_class(PermissionDecisionApproveForIonApproval, x), from_none], self.approval)
         if self.location_key is not None:
             result["locationKey"] = from_union([from_str, from_none], self.location_key)
-        if self.rules is not None:
-            result["rules"] = from_union([lambda x: from_list(lambda x: x, x), from_none], self.rules)
         if self.feedback is not None:
             result["feedback"] = from_union([from_str, from_none], self.feedback)
-        if self.message is not None:
-            result["message"] = from_union([from_str, from_none], self.message)
-        if self.path is not None:
-            result["path"] = from_union([from_str, from_none], self.path)
-        if self.interrupt is not None:
-            result["interrupt"] = from_union([from_bool, from_none], self.interrupt)
         return result
 
 @dataclass
-class PermissionDecisionApprovedForLocation:
-    approval: PermissionDecisionApprovedForLocationApproval
+class PermissionDecisionApproveForLocation:
+    approval: PermissionDecisionApproveForLocationApproval
     """The approval to persist for this location"""
 
-    kind: PermissionDecisionApprovedForLocationKind
+    kind: PermissionDecisionApproveForLocationKind
     """Approved and persisted for this project location"""
 
     location_key: str
     """The location key (git root or cwd) to persist the approval to"""
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForLocation':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveForLocation':
         assert isinstance(obj, dict)
-        approval = PermissionDecisionApprovedForLocationApproval.from_dict(obj.get("approval"))
-        kind = PermissionDecisionApprovedForLocationKind(obj.get("kind"))
+        approval = PermissionDecisionApproveForLocationApproval.from_dict(obj.get("approval"))
+        kind = PermissionDecisionApproveForLocationKind(obj.get("kind"))
         location_key = from_str(obj.get("locationKey"))
-        return PermissionDecisionApprovedForLocation(approval, kind, location_key)
+        return PermissionDecisionApproveForLocation(approval, kind, location_key)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["approval"] = to_class(PermissionDecisionApprovedForLocationApproval, self.approval)
-        result["kind"] = to_enum(PermissionDecisionApprovedForLocationKind, self.kind)
+        result["approval"] = to_class(PermissionDecisionApproveForLocationApproval, self.approval)
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationKind, self.kind)
         result["locationKey"] = from_str(self.location_key)
         return result
 
 @dataclass
-class PermissionDecisionApprovedForSession:
-    approval: PermissionDecisionApprovedForSessionApproval
+class PermissionDecisionApproveForSession:
+    approval: PermissionDecisionApproveForSessionApproval
     """The approval to add as a session-scoped rule"""
 
-    kind: PermissionDecisionApprovedForSessionKind
+    kind: PermissionDecisionApproveForSessionKind
     """Approved and remembered for the rest of the session"""
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForSession':
+    def from_dict(obj: Any) -> 'PermissionDecisionApproveForSession':
         assert isinstance(obj, dict)
-        approval = PermissionDecisionApprovedForSessionApproval.from_dict(obj.get("approval"))
-        kind = PermissionDecisionApprovedForSessionKind(obj.get("kind"))
-        return PermissionDecisionApprovedForSession(approval, kind)
+        approval = PermissionDecisionApproveForSessionApproval.from_dict(obj.get("approval"))
+        kind = PermissionDecisionApproveForSessionKind(obj.get("kind"))
+        return PermissionDecisionApproveForSession(approval, kind)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["approval"] = to_class(PermissionDecisionApprovedForSessionApproval, self.approval)
-        result["kind"] = to_enum(PermissionDecisionApprovedForSessionKind, self.kind)
+        result["approval"] = to_class(PermissionDecisionApproveForSessionApproval, self.approval)
+        result["kind"] = to_enum(PermissionDecisionApproveForSessionKind, self.kind)
         return result
 
 @dataclass
@@ -4564,29 +4479,28 @@ class RPC:
     name_get_result: NameGetResult
     name_set_request: NameSetRequest
     permission_decision: PermissionDecision
-    permission_decision_approved: PermissionDecisionApproved
-    permission_decision_approved_for_location: PermissionDecisionApprovedForLocation
-    permission_decision_approved_for_location_approval: PermissionDecisionApprovedForLocationApproval
-    permission_decision_approved_for_location_approval_commands: PermissionDecisionApprovedForLocationApprovalCommands
-    permission_decision_approved_for_location_approval_custom_tool: PermissionDecisionApprovedForLocationApprovalCustomTool
-    permission_decision_approved_for_location_approval_mcp: PermissionDecisionApprovedForLocationApprovalMCP
-    permission_decision_approved_for_location_approval_mcp_sampling: PermissionDecisionApprovedForLocationApprovalMCPSampling
-    permission_decision_approved_for_location_approval_memory: PermissionDecisionApprovedForLocationApprovalMemory
-    permission_decision_approved_for_location_approval_write: PermissionDecisionApprovedForLocationApprovalWrite
-    permission_decision_approved_for_session: PermissionDecisionApprovedForSession
-    permission_decision_approved_for_session_approval: PermissionDecisionApprovedForSessionApproval
-    permission_decision_approved_for_session_approval_commands: PermissionDecisionApprovedForSessionApprovalCommands
-    permission_decision_approved_for_session_approval_custom_tool: PermissionDecisionApprovedForSessionApprovalCustomTool
-    permission_decision_approved_for_session_approval_mcp: PermissionDecisionApprovedForSessionApprovalMCP
-    permission_decision_approved_for_session_approval_mcp_sampling: PermissionDecisionApprovedForSessionApprovalMCPSampling
-    permission_decision_approved_for_session_approval_memory: PermissionDecisionApprovedForSessionApprovalMemory
-    permission_decision_approved_for_session_approval_write: PermissionDecisionApprovedForSessionApprovalWrite
-    permission_decision_denied_by_content_exclusion_policy: PermissionDecisionDeniedByContentExclusionPolicy
-    permission_decision_denied_by_permission_request_hook: PermissionDecisionDeniedByPermissionRequestHook
-    permission_decision_denied_by_rules: PermissionDecisionDeniedByRules
-    permission_decision_denied_interactively_by_user: PermissionDecisionDeniedInteractivelyByUser
-    permission_decision_denied_no_approval_rule_and_could_not_request_from_user: PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser
+    permission_decision_approve_for_location: PermissionDecisionApproveForLocation
+    permission_decision_approve_for_location_approval: PermissionDecisionApproveForLocationApproval
+    permission_decision_approve_for_location_approval_commands: PermissionDecisionApproveForLocationApprovalCommands
+    permission_decision_approve_for_location_approval_custom_tool: PermissionDecisionApproveForLocationApprovalCustomTool
+    permission_decision_approve_for_location_approval_mcp: PermissionDecisionApproveForLocationApprovalMCP
+    permission_decision_approve_for_location_approval_mcp_sampling: PermissionDecisionApproveForLocationApprovalMCPSampling
+    permission_decision_approve_for_location_approval_memory: PermissionDecisionApproveForLocationApprovalMemory
+    permission_decision_approve_for_location_approval_read: PermissionDecisionApproveForLocationApprovalRead
+    permission_decision_approve_for_location_approval_write: PermissionDecisionApproveForLocationApprovalWrite
+    permission_decision_approve_for_session: PermissionDecisionApproveForSession
+    permission_decision_approve_for_session_approval: PermissionDecisionApproveForSessionApproval
+    permission_decision_approve_for_session_approval_commands: PermissionDecisionApproveForSessionApprovalCommands
+    permission_decision_approve_for_session_approval_custom_tool: PermissionDecisionApproveForSessionApprovalCustomTool
+    permission_decision_approve_for_session_approval_mcp: PermissionDecisionApproveForSessionApprovalMCP
+    permission_decision_approve_for_session_approval_mcp_sampling: PermissionDecisionApproveForSessionApprovalMCPSampling
+    permission_decision_approve_for_session_approval_memory: PermissionDecisionApproveForSessionApprovalMemory
+    permission_decision_approve_for_session_approval_read: PermissionDecisionApproveForSessionApprovalRead
+    permission_decision_approve_for_session_approval_write: PermissionDecisionApproveForSessionApprovalWrite
+    permission_decision_approve_once: PermissionDecisionApproveOnce
+    permission_decision_reject: PermissionDecisionReject
     permission_decision_request: PermissionDecisionRequest
+    permission_decision_user_not_available: PermissionDecisionUserNotAvailable
     permission_request_result: PermissionRequestResult
     permissions_reset_session_approvals_request: PermissionsResetSessionApprovalsRequest
     permissions_reset_session_approvals_result: PermissionsResetSessionApprovalsResult
@@ -4758,29 +4672,28 @@ class RPC:
         name_get_result = NameGetResult.from_dict(obj.get("NameGetResult"))
         name_set_request = NameSetRequest.from_dict(obj.get("NameSetRequest"))
         permission_decision = PermissionDecision.from_dict(obj.get("PermissionDecision"))
-        permission_decision_approved = PermissionDecisionApproved.from_dict(obj.get("PermissionDecisionApproved"))
-        permission_decision_approved_for_location = PermissionDecisionApprovedForLocation.from_dict(obj.get("PermissionDecisionApprovedForLocation"))
-        permission_decision_approved_for_location_approval = PermissionDecisionApprovedForLocationApproval.from_dict(obj.get("PermissionDecisionApprovedForLocationApproval"))
-        permission_decision_approved_for_location_approval_commands = PermissionDecisionApprovedForLocationApprovalCommands.from_dict(obj.get("PermissionDecisionApprovedForLocationApprovalCommands"))
-        permission_decision_approved_for_location_approval_custom_tool = PermissionDecisionApprovedForLocationApprovalCustomTool.from_dict(obj.get("PermissionDecisionApprovedForLocationApprovalCustomTool"))
-        permission_decision_approved_for_location_approval_mcp = PermissionDecisionApprovedForLocationApprovalMCP.from_dict(obj.get("PermissionDecisionApprovedForLocationApprovalMcp"))
-        permission_decision_approved_for_location_approval_mcp_sampling = PermissionDecisionApprovedForLocationApprovalMCPSampling.from_dict(obj.get("PermissionDecisionApprovedForLocationApprovalMcpSampling"))
-        permission_decision_approved_for_location_approval_memory = PermissionDecisionApprovedForLocationApprovalMemory.from_dict(obj.get("PermissionDecisionApprovedForLocationApprovalMemory"))
-        permission_decision_approved_for_location_approval_write = PermissionDecisionApprovedForLocationApprovalWrite.from_dict(obj.get("PermissionDecisionApprovedForLocationApprovalWrite"))
-        permission_decision_approved_for_session = PermissionDecisionApprovedForSession.from_dict(obj.get("PermissionDecisionApprovedForSession"))
-        permission_decision_approved_for_session_approval = PermissionDecisionApprovedForSessionApproval.from_dict(obj.get("PermissionDecisionApprovedForSessionApproval"))
-        permission_decision_approved_for_session_approval_commands = PermissionDecisionApprovedForSessionApprovalCommands.from_dict(obj.get("PermissionDecisionApprovedForSessionApprovalCommands"))
-        permission_decision_approved_for_session_approval_custom_tool = PermissionDecisionApprovedForSessionApprovalCustomTool.from_dict(obj.get("PermissionDecisionApprovedForSessionApprovalCustomTool"))
-        permission_decision_approved_for_session_approval_mcp = PermissionDecisionApprovedForSessionApprovalMCP.from_dict(obj.get("PermissionDecisionApprovedForSessionApprovalMcp"))
-        permission_decision_approved_for_session_approval_mcp_sampling = PermissionDecisionApprovedForSessionApprovalMCPSampling.from_dict(obj.get("PermissionDecisionApprovedForSessionApprovalMcpSampling"))
-        permission_decision_approved_for_session_approval_memory = PermissionDecisionApprovedForSessionApprovalMemory.from_dict(obj.get("PermissionDecisionApprovedForSessionApprovalMemory"))
-        permission_decision_approved_for_session_approval_write = PermissionDecisionApprovedForSessionApprovalWrite.from_dict(obj.get("PermissionDecisionApprovedForSessionApprovalWrite"))
-        permission_decision_denied_by_content_exclusion_policy = PermissionDecisionDeniedByContentExclusionPolicy.from_dict(obj.get("PermissionDecisionDeniedByContentExclusionPolicy"))
-        permission_decision_denied_by_permission_request_hook = PermissionDecisionDeniedByPermissionRequestHook.from_dict(obj.get("PermissionDecisionDeniedByPermissionRequestHook"))
-        permission_decision_denied_by_rules = PermissionDecisionDeniedByRules.from_dict(obj.get("PermissionDecisionDeniedByRules"))
-        permission_decision_denied_interactively_by_user = PermissionDecisionDeniedInteractivelyByUser.from_dict(obj.get("PermissionDecisionDeniedInteractivelyByUser"))
-        permission_decision_denied_no_approval_rule_and_could_not_request_from_user = PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser.from_dict(obj.get("PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser"))
+        permission_decision_approve_for_location = PermissionDecisionApproveForLocation.from_dict(obj.get("PermissionDecisionApproveForLocation"))
+        permission_decision_approve_for_location_approval = PermissionDecisionApproveForLocationApproval.from_dict(obj.get("PermissionDecisionApproveForLocationApproval"))
+        permission_decision_approve_for_location_approval_commands = PermissionDecisionApproveForLocationApprovalCommands.from_dict(obj.get("PermissionDecisionApproveForLocationApprovalCommands"))
+        permission_decision_approve_for_location_approval_custom_tool = PermissionDecisionApproveForLocationApprovalCustomTool.from_dict(obj.get("PermissionDecisionApproveForLocationApprovalCustomTool"))
+        permission_decision_approve_for_location_approval_mcp = PermissionDecisionApproveForLocationApprovalMCP.from_dict(obj.get("PermissionDecisionApproveForLocationApprovalMcp"))
+        permission_decision_approve_for_location_approval_mcp_sampling = PermissionDecisionApproveForLocationApprovalMCPSampling.from_dict(obj.get("PermissionDecisionApproveForLocationApprovalMcpSampling"))
+        permission_decision_approve_for_location_approval_memory = PermissionDecisionApproveForLocationApprovalMemory.from_dict(obj.get("PermissionDecisionApproveForLocationApprovalMemory"))
+        permission_decision_approve_for_location_approval_read = PermissionDecisionApproveForLocationApprovalRead.from_dict(obj.get("PermissionDecisionApproveForLocationApprovalRead"))
+        permission_decision_approve_for_location_approval_write = PermissionDecisionApproveForLocationApprovalWrite.from_dict(obj.get("PermissionDecisionApproveForLocationApprovalWrite"))
+        permission_decision_approve_for_session = PermissionDecisionApproveForSession.from_dict(obj.get("PermissionDecisionApproveForSession"))
+        permission_decision_approve_for_session_approval = PermissionDecisionApproveForSessionApproval.from_dict(obj.get("PermissionDecisionApproveForSessionApproval"))
+        permission_decision_approve_for_session_approval_commands = PermissionDecisionApproveForSessionApprovalCommands.from_dict(obj.get("PermissionDecisionApproveForSessionApprovalCommands"))
+        permission_decision_approve_for_session_approval_custom_tool = PermissionDecisionApproveForSessionApprovalCustomTool.from_dict(obj.get("PermissionDecisionApproveForSessionApprovalCustomTool"))
+        permission_decision_approve_for_session_approval_mcp = PermissionDecisionApproveForSessionApprovalMCP.from_dict(obj.get("PermissionDecisionApproveForSessionApprovalMcp"))
+        permission_decision_approve_for_session_approval_mcp_sampling = PermissionDecisionApproveForSessionApprovalMCPSampling.from_dict(obj.get("PermissionDecisionApproveForSessionApprovalMcpSampling"))
+        permission_decision_approve_for_session_approval_memory = PermissionDecisionApproveForSessionApprovalMemory.from_dict(obj.get("PermissionDecisionApproveForSessionApprovalMemory"))
+        permission_decision_approve_for_session_approval_read = PermissionDecisionApproveForSessionApprovalRead.from_dict(obj.get("PermissionDecisionApproveForSessionApprovalRead"))
+        permission_decision_approve_for_session_approval_write = PermissionDecisionApproveForSessionApprovalWrite.from_dict(obj.get("PermissionDecisionApproveForSessionApprovalWrite"))
+        permission_decision_approve_once = PermissionDecisionApproveOnce.from_dict(obj.get("PermissionDecisionApproveOnce"))
+        permission_decision_reject = PermissionDecisionReject.from_dict(obj.get("PermissionDecisionReject"))
         permission_decision_request = PermissionDecisionRequest.from_dict(obj.get("PermissionDecisionRequest"))
+        permission_decision_user_not_available = PermissionDecisionUserNotAvailable.from_dict(obj.get("PermissionDecisionUserNotAvailable"))
         permission_request_result = PermissionRequestResult.from_dict(obj.get("PermissionRequestResult"))
         permissions_reset_session_approvals_request = PermissionsResetSessionApprovalsRequest.from_dict(obj.get("PermissionsResetSessionApprovalsRequest"))
         permissions_reset_session_approvals_result = PermissionsResetSessionApprovalsResult.from_dict(obj.get("PermissionsResetSessionApprovalsResult"))
@@ -4870,7 +4783,7 @@ class RPC:
         workspaces_list_files_result = WorkspacesListFilesResult.from_dict(obj.get("WorkspacesListFilesResult"))
         workspaces_read_file_request = WorkspacesReadFileRequest.from_dict(obj.get("WorkspacesReadFileRequest"))
         workspaces_read_file_result = WorkspacesReadFileResult.from_dict(obj.get("WorkspacesReadFileResult"))
-        return RPC(account_get_quota_request, account_get_quota_result, account_quota_snapshot, agent_get_current_result, agent_info, agent_list, agent_reload_result, agent_select_request, agent_select_result, auth_info_type, commands_handle_pending_command_request, commands_handle_pending_command_result, current_model, discovered_mcp_server, discovered_mcp_server_source, discovered_mcp_server_type, extension, extension_list, extensions_disable_request, extensions_enable_request, extension_source, extension_status, filter_mapping, filter_mapping_string, filter_mapping_value, fleet_start_request, fleet_start_result, handle_tool_call_result, history_compact_context_window, history_compact_result, history_truncate_request, history_truncate_result, instructions_get_sources_result, instructions_sources, instructions_sources_location, instructions_sources_type, log_request, log_result, mcp_config_add_request, mcp_config_disable_request, mcp_config_enable_request, mcp_config_list, mcp_config_remove_request, mcp_config_update_request, mcp_disable_request, mcp_discover_request, mcp_discover_result, mcp_enable_request, mcp_oauth_login_request, mcp_oauth_login_result, mcp_server, mcp_server_config, mcp_server_config_http, mcp_server_config_http_type, mcp_server_config_local, mcp_server_config_local_type, mcp_server_list, mcp_server_source, mcp_server_status, model, model_billing, model_capabilities, model_capabilities_limits, model_capabilities_limits_vision, model_capabilities_override, model_capabilities_override_limits, model_capabilities_override_limits_vision, model_capabilities_override_supports, model_capabilities_supports, model_list, model_policy, models_list_request, model_switch_to_request, model_switch_to_result, mode_set_request, name_get_result, name_set_request, permission_decision, permission_decision_approved, permission_decision_approved_for_location, permission_decision_approved_for_location_approval, permission_decision_approved_for_location_approval_commands, permission_decision_approved_for_location_approval_custom_tool, permission_decision_approved_for_location_approval_mcp, permission_decision_approved_for_location_approval_mcp_sampling, permission_decision_approved_for_location_approval_memory, permission_decision_approved_for_location_approval_write, permission_decision_approved_for_session, permission_decision_approved_for_session_approval, permission_decision_approved_for_session_approval_commands, permission_decision_approved_for_session_approval_custom_tool, permission_decision_approved_for_session_approval_mcp, permission_decision_approved_for_session_approval_mcp_sampling, permission_decision_approved_for_session_approval_memory, permission_decision_approved_for_session_approval_write, permission_decision_denied_by_content_exclusion_policy, permission_decision_denied_by_permission_request_hook, permission_decision_denied_by_rules, permission_decision_denied_interactively_by_user, permission_decision_denied_no_approval_rule_and_could_not_request_from_user, permission_decision_request, permission_request_result, permissions_reset_session_approvals_request, permissions_reset_session_approvals_result, permissions_set_approve_all_request, permissions_set_approve_all_result, ping_request, ping_result, plan_read_result, plan_update_request, plugin, plugin_list, server_skill, server_skill_list, session_auth_status, session_fs_append_file_request, session_fs_error, session_fs_error_code, session_fs_exists_request, session_fs_exists_result, session_fs_mkdir_request, session_fs_readdir_request, session_fs_readdir_result, session_fs_readdir_with_types_entry, session_fs_readdir_with_types_entry_type, session_fs_readdir_with_types_request, session_fs_readdir_with_types_result, session_fs_read_file_request, session_fs_read_file_result, session_fs_rename_request, session_fs_rm_request, session_fs_set_provider_conventions, session_fs_set_provider_request, session_fs_set_provider_result, session_fs_stat_request, session_fs_stat_result, session_fs_write_file_request, session_log_level, session_mode, sessions_fork_request, sessions_fork_result, shell_exec_request, shell_exec_result, shell_kill_request, shell_kill_result, shell_kill_signal, skill, skill_list, skills_config_set_disabled_skills_request, skills_disable_request, skills_discover_request, skills_enable_request, tool, tool_call_result, tool_list, tools_handle_pending_tool_call, tools_handle_pending_tool_call_request, tools_list_request, ui_elicitation_array_any_of_field, ui_elicitation_array_any_of_field_items, ui_elicitation_array_any_of_field_items_any_of, ui_elicitation_array_enum_field, ui_elicitation_array_enum_field_items, ui_elicitation_field_value, ui_elicitation_request, ui_elicitation_response, ui_elicitation_response_action, ui_elicitation_response_content, ui_elicitation_result, ui_elicitation_schema, ui_elicitation_schema_property, ui_elicitation_schema_property_boolean, ui_elicitation_schema_property_number, ui_elicitation_schema_property_number_type, ui_elicitation_schema_property_string, ui_elicitation_schema_property_string_format, ui_elicitation_string_enum_field, ui_elicitation_string_one_of_field, ui_elicitation_string_one_of_field_one_of, ui_handle_pending_elicitation_request, usage_get_metrics_result, usage_metrics_code_changes, usage_metrics_model_metric, usage_metrics_model_metric_requests, usage_metrics_model_metric_usage, workspaces_create_file_request, workspaces_get_workspace_result, workspaces_list_files_result, workspaces_read_file_request, workspaces_read_file_result)
+        return RPC(account_get_quota_request, account_get_quota_result, account_quota_snapshot, agent_get_current_result, agent_info, agent_list, agent_reload_result, agent_select_request, agent_select_result, auth_info_type, commands_handle_pending_command_request, commands_handle_pending_command_result, current_model, discovered_mcp_server, discovered_mcp_server_source, discovered_mcp_server_type, extension, extension_list, extensions_disable_request, extensions_enable_request, extension_source, extension_status, filter_mapping, filter_mapping_string, filter_mapping_value, fleet_start_request, fleet_start_result, handle_tool_call_result, history_compact_context_window, history_compact_result, history_truncate_request, history_truncate_result, instructions_get_sources_result, instructions_sources, instructions_sources_location, instructions_sources_type, log_request, log_result, mcp_config_add_request, mcp_config_disable_request, mcp_config_enable_request, mcp_config_list, mcp_config_remove_request, mcp_config_update_request, mcp_disable_request, mcp_discover_request, mcp_discover_result, mcp_enable_request, mcp_oauth_login_request, mcp_oauth_login_result, mcp_server, mcp_server_config, mcp_server_config_http, mcp_server_config_http_type, mcp_server_config_local, mcp_server_config_local_type, mcp_server_list, mcp_server_source, mcp_server_status, model, model_billing, model_capabilities, model_capabilities_limits, model_capabilities_limits_vision, model_capabilities_override, model_capabilities_override_limits, model_capabilities_override_limits_vision, model_capabilities_override_supports, model_capabilities_supports, model_list, model_policy, models_list_request, model_switch_to_request, model_switch_to_result, mode_set_request, name_get_result, name_set_request, permission_decision, permission_decision_approve_for_location, permission_decision_approve_for_location_approval, permission_decision_approve_for_location_approval_commands, permission_decision_approve_for_location_approval_custom_tool, permission_decision_approve_for_location_approval_mcp, permission_decision_approve_for_location_approval_mcp_sampling, permission_decision_approve_for_location_approval_memory, permission_decision_approve_for_location_approval_read, permission_decision_approve_for_location_approval_write, permission_decision_approve_for_session, permission_decision_approve_for_session_approval, permission_decision_approve_for_session_approval_commands, permission_decision_approve_for_session_approval_custom_tool, permission_decision_approve_for_session_approval_mcp, permission_decision_approve_for_session_approval_mcp_sampling, permission_decision_approve_for_session_approval_memory, permission_decision_approve_for_session_approval_read, permission_decision_approve_for_session_approval_write, permission_decision_approve_once, permission_decision_reject, permission_decision_request, permission_decision_user_not_available, permission_request_result, permissions_reset_session_approvals_request, permissions_reset_session_approvals_result, permissions_set_approve_all_request, permissions_set_approve_all_result, ping_request, ping_result, plan_read_result, plan_update_request, plugin, plugin_list, server_skill, server_skill_list, session_auth_status, session_fs_append_file_request, session_fs_error, session_fs_error_code, session_fs_exists_request, session_fs_exists_result, session_fs_mkdir_request, session_fs_readdir_request, session_fs_readdir_result, session_fs_readdir_with_types_entry, session_fs_readdir_with_types_entry_type, session_fs_readdir_with_types_request, session_fs_readdir_with_types_result, session_fs_read_file_request, session_fs_read_file_result, session_fs_rename_request, session_fs_rm_request, session_fs_set_provider_conventions, session_fs_set_provider_request, session_fs_set_provider_result, session_fs_stat_request, session_fs_stat_result, session_fs_write_file_request, session_log_level, session_mode, sessions_fork_request, sessions_fork_result, shell_exec_request, shell_exec_result, shell_kill_request, shell_kill_result, shell_kill_signal, skill, skill_list, skills_config_set_disabled_skills_request, skills_disable_request, skills_discover_request, skills_enable_request, tool, tool_call_result, tool_list, tools_handle_pending_tool_call, tools_handle_pending_tool_call_request, tools_list_request, ui_elicitation_array_any_of_field, ui_elicitation_array_any_of_field_items, ui_elicitation_array_any_of_field_items_any_of, ui_elicitation_array_enum_field, ui_elicitation_array_enum_field_items, ui_elicitation_field_value, ui_elicitation_request, ui_elicitation_response, ui_elicitation_response_action, ui_elicitation_response_content, ui_elicitation_result, ui_elicitation_schema, ui_elicitation_schema_property, ui_elicitation_schema_property_boolean, ui_elicitation_schema_property_number, ui_elicitation_schema_property_number_type, ui_elicitation_schema_property_string, ui_elicitation_schema_property_string_format, ui_elicitation_string_enum_field, ui_elicitation_string_one_of_field, ui_elicitation_string_one_of_field_one_of, ui_handle_pending_elicitation_request, usage_get_metrics_result, usage_metrics_code_changes, usage_metrics_model_metric, usage_metrics_model_metric_requests, usage_metrics_model_metric_usage, workspaces_create_file_request, workspaces_get_workspace_result, workspaces_list_files_result, workspaces_read_file_request, workspaces_read_file_result)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -4952,29 +4865,28 @@ class RPC:
         result["NameGetResult"] = to_class(NameGetResult, self.name_get_result)
         result["NameSetRequest"] = to_class(NameSetRequest, self.name_set_request)
         result["PermissionDecision"] = to_class(PermissionDecision, self.permission_decision)
-        result["PermissionDecisionApproved"] = to_class(PermissionDecisionApproved, self.permission_decision_approved)
-        result["PermissionDecisionApprovedForLocation"] = to_class(PermissionDecisionApprovedForLocation, self.permission_decision_approved_for_location)
-        result["PermissionDecisionApprovedForLocationApproval"] = to_class(PermissionDecisionApprovedForLocationApproval, self.permission_decision_approved_for_location_approval)
-        result["PermissionDecisionApprovedForLocationApprovalCommands"] = to_class(PermissionDecisionApprovedForLocationApprovalCommands, self.permission_decision_approved_for_location_approval_commands)
-        result["PermissionDecisionApprovedForLocationApprovalCustomTool"] = to_class(PermissionDecisionApprovedForLocationApprovalCustomTool, self.permission_decision_approved_for_location_approval_custom_tool)
-        result["PermissionDecisionApprovedForLocationApprovalMcp"] = to_class(PermissionDecisionApprovedForLocationApprovalMCP, self.permission_decision_approved_for_location_approval_mcp)
-        result["PermissionDecisionApprovedForLocationApprovalMcpSampling"] = to_class(PermissionDecisionApprovedForLocationApprovalMCPSampling, self.permission_decision_approved_for_location_approval_mcp_sampling)
-        result["PermissionDecisionApprovedForLocationApprovalMemory"] = to_class(PermissionDecisionApprovedForLocationApprovalMemory, self.permission_decision_approved_for_location_approval_memory)
-        result["PermissionDecisionApprovedForLocationApprovalWrite"] = to_class(PermissionDecisionApprovedForLocationApprovalWrite, self.permission_decision_approved_for_location_approval_write)
-        result["PermissionDecisionApprovedForSession"] = to_class(PermissionDecisionApprovedForSession, self.permission_decision_approved_for_session)
-        result["PermissionDecisionApprovedForSessionApproval"] = to_class(PermissionDecisionApprovedForSessionApproval, self.permission_decision_approved_for_session_approval)
-        result["PermissionDecisionApprovedForSessionApprovalCommands"] = to_class(PermissionDecisionApprovedForSessionApprovalCommands, self.permission_decision_approved_for_session_approval_commands)
-        result["PermissionDecisionApprovedForSessionApprovalCustomTool"] = to_class(PermissionDecisionApprovedForSessionApprovalCustomTool, self.permission_decision_approved_for_session_approval_custom_tool)
-        result["PermissionDecisionApprovedForSessionApprovalMcp"] = to_class(PermissionDecisionApprovedForSessionApprovalMCP, self.permission_decision_approved_for_session_approval_mcp)
-        result["PermissionDecisionApprovedForSessionApprovalMcpSampling"] = to_class(PermissionDecisionApprovedForSessionApprovalMCPSampling, self.permission_decision_approved_for_session_approval_mcp_sampling)
-        result["PermissionDecisionApprovedForSessionApprovalMemory"] = to_class(PermissionDecisionApprovedForSessionApprovalMemory, self.permission_decision_approved_for_session_approval_memory)
-        result["PermissionDecisionApprovedForSessionApprovalWrite"] = to_class(PermissionDecisionApprovedForSessionApprovalWrite, self.permission_decision_approved_for_session_approval_write)
-        result["PermissionDecisionDeniedByContentExclusionPolicy"] = to_class(PermissionDecisionDeniedByContentExclusionPolicy, self.permission_decision_denied_by_content_exclusion_policy)
-        result["PermissionDecisionDeniedByPermissionRequestHook"] = to_class(PermissionDecisionDeniedByPermissionRequestHook, self.permission_decision_denied_by_permission_request_hook)
-        result["PermissionDecisionDeniedByRules"] = to_class(PermissionDecisionDeniedByRules, self.permission_decision_denied_by_rules)
-        result["PermissionDecisionDeniedInteractivelyByUser"] = to_class(PermissionDecisionDeniedInteractivelyByUser, self.permission_decision_denied_interactively_by_user)
-        result["PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser"] = to_class(PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser, self.permission_decision_denied_no_approval_rule_and_could_not_request_from_user)
+        result["PermissionDecisionApproveForLocation"] = to_class(PermissionDecisionApproveForLocation, self.permission_decision_approve_for_location)
+        result["PermissionDecisionApproveForLocationApproval"] = to_class(PermissionDecisionApproveForLocationApproval, self.permission_decision_approve_for_location_approval)
+        result["PermissionDecisionApproveForLocationApprovalCommands"] = to_class(PermissionDecisionApproveForLocationApprovalCommands, self.permission_decision_approve_for_location_approval_commands)
+        result["PermissionDecisionApproveForLocationApprovalCustomTool"] = to_class(PermissionDecisionApproveForLocationApprovalCustomTool, self.permission_decision_approve_for_location_approval_custom_tool)
+        result["PermissionDecisionApproveForLocationApprovalMcp"] = to_class(PermissionDecisionApproveForLocationApprovalMCP, self.permission_decision_approve_for_location_approval_mcp)
+        result["PermissionDecisionApproveForLocationApprovalMcpSampling"] = to_class(PermissionDecisionApproveForLocationApprovalMCPSampling, self.permission_decision_approve_for_location_approval_mcp_sampling)
+        result["PermissionDecisionApproveForLocationApprovalMemory"] = to_class(PermissionDecisionApproveForLocationApprovalMemory, self.permission_decision_approve_for_location_approval_memory)
+        result["PermissionDecisionApproveForLocationApprovalRead"] = to_class(PermissionDecisionApproveForLocationApprovalRead, self.permission_decision_approve_for_location_approval_read)
+        result["PermissionDecisionApproveForLocationApprovalWrite"] = to_class(PermissionDecisionApproveForLocationApprovalWrite, self.permission_decision_approve_for_location_approval_write)
+        result["PermissionDecisionApproveForSession"] = to_class(PermissionDecisionApproveForSession, self.permission_decision_approve_for_session)
+        result["PermissionDecisionApproveForSessionApproval"] = to_class(PermissionDecisionApproveForSessionApproval, self.permission_decision_approve_for_session_approval)
+        result["PermissionDecisionApproveForSessionApprovalCommands"] = to_class(PermissionDecisionApproveForSessionApprovalCommands, self.permission_decision_approve_for_session_approval_commands)
+        result["PermissionDecisionApproveForSessionApprovalCustomTool"] = to_class(PermissionDecisionApproveForSessionApprovalCustomTool, self.permission_decision_approve_for_session_approval_custom_tool)
+        result["PermissionDecisionApproveForSessionApprovalMcp"] = to_class(PermissionDecisionApproveForSessionApprovalMCP, self.permission_decision_approve_for_session_approval_mcp)
+        result["PermissionDecisionApproveForSessionApprovalMcpSampling"] = to_class(PermissionDecisionApproveForSessionApprovalMCPSampling, self.permission_decision_approve_for_session_approval_mcp_sampling)
+        result["PermissionDecisionApproveForSessionApprovalMemory"] = to_class(PermissionDecisionApproveForSessionApprovalMemory, self.permission_decision_approve_for_session_approval_memory)
+        result["PermissionDecisionApproveForSessionApprovalRead"] = to_class(PermissionDecisionApproveForSessionApprovalRead, self.permission_decision_approve_for_session_approval_read)
+        result["PermissionDecisionApproveForSessionApprovalWrite"] = to_class(PermissionDecisionApproveForSessionApprovalWrite, self.permission_decision_approve_for_session_approval_write)
+        result["PermissionDecisionApproveOnce"] = to_class(PermissionDecisionApproveOnce, self.permission_decision_approve_once)
+        result["PermissionDecisionReject"] = to_class(PermissionDecisionReject, self.permission_decision_reject)
         result["PermissionDecisionRequest"] = to_class(PermissionDecisionRequest, self.permission_decision_request)
+        result["PermissionDecisionUserNotAvailable"] = to_class(PermissionDecisionUserNotAvailable, self.permission_decision_user_not_available)
         result["PermissionRequestResult"] = to_class(PermissionRequestResult, self.permission_request_result)
         result["PermissionsResetSessionApprovalsRequest"] = to_class(PermissionsResetSessionApprovalsRequest, self.permissions_reset_session_approvals_request)
         result["PermissionsResetSessionApprovalsResult"] = to_class(PermissionsResetSessionApprovalsResult, self.permissions_reset_session_approvals_result)

--- a/python/copilot/generated/rpc.py
+++ b/python/copilot/generated/rpc.py
@@ -21,18 +21,6 @@ T = TypeVar("T")
 EnumT = TypeVar("EnumT", bound=Enum)
 
 
-def from_int(x: Any) -> int:
-    assert isinstance(x, int) and not isinstance(x, bool)
-    return x
-
-def from_bool(x: Any) -> bool:
-    assert isinstance(x, bool)
-    return x
-
-def from_float(x: Any) -> float:
-    assert isinstance(x, (float, int)) and not isinstance(x, bool)
-    return float(x)
-
 def from_str(x: Any) -> str:
     assert isinstance(x, str)
     return x
@@ -48,6 +36,18 @@ def from_union(fs, x):
         except Exception:
             pass
     assert False
+
+def from_int(x: Any) -> int:
+    assert isinstance(x, int) and not isinstance(x, bool)
+    return x
+
+def from_bool(x: Any) -> bool:
+    assert isinstance(x, bool)
+    return x
+
+def from_float(x: Any) -> float:
+    assert isinstance(x, (float, int)) and not isinstance(x, bool)
+    return float(x)
 
 def to_float(x: Any) -> float:
     assert isinstance(x, (int, float))
@@ -71,6 +71,25 @@ def to_enum(c: type[EnumT], x: Any) -> EnumT:
 
 def from_datetime(x: Any) -> datetime:
     return dateutil.parser.parse(x)
+
+@dataclass
+class AccountGetQuotaRequest:
+    git_hub_token: str | None = None
+    """GitHub token for per-user quota lookup. When provided, resolves this token to determine
+    the user's quota instead of using the global auth.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'AccountGetQuotaRequest':
+        assert isinstance(obj, dict)
+        git_hub_token = from_union([from_str, from_none], obj.get("gitHubToken"))
+        return AccountGetQuotaRequest(git_hub_token)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.git_hub_token is not None:
+            result["gitHubToken"] = from_union([from_str, from_none], self.git_hub_token)
+        return result
 
 @dataclass
 class AccountQuotaSnapshot:
@@ -168,6 +187,17 @@ class AgentSelectRequest:
         result: dict = {}
         result["name"] = from_str(self.name)
         return result
+
+class AuthInfoType(Enum):
+    """Authentication type"""
+
+    API_KEY = "api-key"
+    COPILOT_API_TOKEN = "copilot-api-token"
+    ENV = "env"
+    GH_CLI = "gh-cli"
+    HMAC = "hmac"
+    TOKEN = "token"
+    USER = "user"
 
 @dataclass
 class CommandsHandlePendingCommandRequest:
@@ -476,6 +506,43 @@ class MCPServerConfigType(Enum):
     STDIO = "stdio"
 
 @dataclass
+class MCPConfigDisableRequest:
+    names: list[str]
+    """Names of MCP servers to disable. Each server is added to the persisted disabled list so
+    new sessions skip it. Already-disabled names are ignored. Active sessions keep their
+    current connections until they end.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MCPConfigDisableRequest':
+        assert isinstance(obj, dict)
+        names = from_list(from_str, obj.get("names"))
+        return MCPConfigDisableRequest(names)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["names"] = from_list(from_str, self.names)
+        return result
+
+@dataclass
+class MCPConfigEnableRequest:
+    names: list[str]
+    """Names of MCP servers to enable. Each server is removed from the persisted disabled list
+    so new sessions spawn it. Unknown or already-enabled names are ignored.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MCPConfigEnableRequest':
+        assert isinstance(obj, dict)
+        names = from_list(from_str, obj.get("names"))
+        return MCPConfigEnableRequest(names)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["names"] = from_list(from_str, self.names)
+        return result
+
+@dataclass
 class MCPConfigRemoveRequest:
     name: str
     """Name of the MCP server to remove"""
@@ -538,6 +605,71 @@ class MCPEnableRequest:
     def to_dict(self) -> dict:
         result: dict = {}
         result["serverName"] = from_str(self.server_name)
+        return result
+
+@dataclass
+class MCPOauthLoginRequest:
+    server_name: str
+    """Name of the remote MCP server to authenticate"""
+
+    callback_success_message: str | None = None
+    """Optional override for the body text shown on the OAuth loopback callback success page.
+    When omitted, the runtime applies a neutral fallback; callers driving interactive auth
+    should pass surface-specific copy telling the user where to return.
+    """
+    client_name: str | None = None
+    """Optional override for the OAuth client display name shown on the consent screen. Applies
+    to newly registered dynamic clients only — existing registrations keep the name they were
+    created with. When omitted, the runtime applies a neutral fallback; callers driving
+    interactive auth should pass their own surface-specific label so the consent screen
+    matches the product the user sees.
+    """
+    force_reauth: bool | None = None
+    """When true, clears any cached OAuth token for the server and runs a full new
+    authorization. Use when the user explicitly wants to switch accounts or believes their
+    session is stuck.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MCPOauthLoginRequest':
+        assert isinstance(obj, dict)
+        server_name = from_str(obj.get("serverName"))
+        callback_success_message = from_union([from_str, from_none], obj.get("callbackSuccessMessage"))
+        client_name = from_union([from_str, from_none], obj.get("clientName"))
+        force_reauth = from_union([from_bool, from_none], obj.get("forceReauth"))
+        return MCPOauthLoginRequest(server_name, callback_success_message, client_name, force_reauth)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["serverName"] = from_str(self.server_name)
+        if self.callback_success_message is not None:
+            result["callbackSuccessMessage"] = from_union([from_str, from_none], self.callback_success_message)
+        if self.client_name is not None:
+            result["clientName"] = from_union([from_str, from_none], self.client_name)
+        if self.force_reauth is not None:
+            result["forceReauth"] = from_union([from_bool, from_none], self.force_reauth)
+        return result
+
+@dataclass
+class MCPOauthLoginResult:
+    authorization_url: str | None = None
+    """URL the caller should open in a browser to complete OAuth. Omitted when cached tokens
+    were still valid and no browser interaction was needed — the server is already
+    reconnected in that case. When present, the runtime starts the callback listener before
+    returning and continues the flow in the background; completion is signaled via
+    session.mcp_server_status_changed.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MCPOauthLoginResult':
+        assert isinstance(obj, dict)
+        authorization_url = from_union([from_str, from_none], obj.get("authorizationUrl"))
+        return MCPOauthLoginResult(authorization_url)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.authorization_url is not None:
+            result["authorizationUrl"] = from_union([from_str, from_none], self.authorization_url)
         return result
 
 class MCPServerStatus(Enum):
@@ -645,20 +777,21 @@ class ModelPolicy:
     state: str
     """Current policy state for this model"""
 
-    terms: str
+    terms: str | None = None
     """Usage terms or conditions for this model"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'ModelPolicy':
         assert isinstance(obj, dict)
         state = from_str(obj.get("state"))
-        terms = from_str(obj.get("terms"))
+        terms = from_union([from_str, from_none], obj.get("terms"))
         return ModelPolicy(state, terms)
 
     def to_dict(self) -> dict:
         result: dict = {}
         result["state"] = from_str(self.state)
-        result["terms"] = from_str(self.terms)
+        if self.terms is not None:
+            result["terms"] = from_union([from_str, from_none], self.terms)
         return result
 
 @dataclass
@@ -730,6 +863,25 @@ class ModelSwitchToResult:
         return result
 
 @dataclass
+class ModelsListRequest:
+    git_hub_token: str | None = None
+    """GitHub token for per-user model listing. When provided, resolves this token to determine
+    the user's Copilot plan and available models instead of using the global auth.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ModelsListRequest':
+        assert isinstance(obj, dict)
+        git_hub_token = from_union([from_str, from_none], obj.get("gitHubToken"))
+        return ModelsListRequest(git_hub_token)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.git_hub_token is not None:
+            result["gitHubToken"] = from_union([from_str, from_none], self.git_hub_token)
+        return result
+
+@dataclass
 class NameGetResult:
     name: str | None = None
     """The session name, falling back to the auto-generated summary, or null if neither exists"""
@@ -761,8 +913,18 @@ class NameSetRequest:
         result["name"] = from_str(self.name)
         return result
 
+class ApprovalKind(Enum):
+    COMMANDS = "commands"
+    CUSTOM_TOOL = "custom-tool"
+    MCP = "mcp"
+    MCP_SAMPLING = "mcp-sampling"
+    MEMORY = "memory"
+    WRITE = "write"
+
 class PermissionDecisionKind(Enum):
     APPROVED = "approved"
+    APPROVED_FOR_LOCATION = "approved-for-location"
+    APPROVED_FOR_SESSION = "approved-for-session"
     DENIED_BY_CONTENT_EXCLUSION_POLICY = "denied-by-content-exclusion-policy"
     DENIED_BY_PERMISSION_REQUEST_HOOK = "denied-by-permission-request-hook"
     DENIED_BY_RULES = "denied-by-rules"
@@ -771,6 +933,30 @@ class PermissionDecisionKind(Enum):
 
 class PermissionDecisionApprovedKind(Enum):
     APPROVED = "approved"
+
+class PermissionDecisionApprovedForLocationKind(Enum):
+    APPROVED_FOR_LOCATION = "approved-for-location"
+
+class PermissionDecisionApprovedForLocationApprovalCommandsKind(Enum):
+    COMMANDS = "commands"
+
+class PermissionDecisionApprovedForLocationApprovalCustomToolKind(Enum):
+    CUSTOM_TOOL = "custom-tool"
+
+class PermissionDecisionApprovedForLocationApprovalMCPKind(Enum):
+    MCP = "mcp"
+
+class PermissionDecisionApprovedForLocationApprovalMCPSamplingKind(Enum):
+    MCP_SAMPLING = "mcp-sampling"
+
+class PermissionDecisionApprovedForLocationApprovalMemoryKind(Enum):
+    MEMORY = "memory"
+
+class PermissionDecisionApprovedForLocationApprovalWriteKind(Enum):
+    WRITE = "write"
+
+class PermissionDecisionApprovedForSessionKind(Enum):
+    APPROVED_FOR_SESSION = "approved-for-session"
 
 class PermissionDecisionDeniedByContentExclusionPolicyKind(Enum):
     DENIED_BY_CONTENT_EXCLUSION_POLICY = "denied-by-content-exclusion-policy"
@@ -797,6 +983,65 @@ class PermissionRequestResult:
         assert isinstance(obj, dict)
         success = from_bool(obj.get("success"))
         return PermissionRequestResult(success)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["success"] = from_bool(self.success)
+        return result
+
+@dataclass
+class PermissionsResetSessionApprovalsRequest:
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsResetSessionApprovalsRequest':
+        assert isinstance(obj, dict)
+        return PermissionsResetSessionApprovalsRequest()
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        return result
+
+@dataclass
+class PermissionsResetSessionApprovalsResult:
+    success: bool
+    """Whether the operation succeeded"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsResetSessionApprovalsResult':
+        assert isinstance(obj, dict)
+        success = from_bool(obj.get("success"))
+        return PermissionsResetSessionApprovalsResult(success)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["success"] = from_bool(self.success)
+        return result
+
+@dataclass
+class PermissionsSetApproveAllRequest:
+    enabled: bool
+    """Whether to auto-approve all tool permission requests"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsSetApproveAllRequest':
+        assert isinstance(obj, dict)
+        enabled = from_bool(obj.get("enabled"))
+        return PermissionsSetApproveAllRequest(enabled)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["enabled"] = from_bool(self.enabled)
+        return result
+
+@dataclass
+class PermissionsSetApproveAllResult:
+    success: bool
+    """Whether the operation succeeded"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsSetApproveAllResult':
+        assert isinstance(obj, dict)
+        success = from_bool(obj.get("success"))
+        return PermissionsSetApproveAllResult(success)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -1940,6 +2185,52 @@ class AgentSelectResult:
         return result
 
 @dataclass
+class SessionAuthStatus:
+    is_authenticated: bool
+    """Whether the session has resolved authentication"""
+
+    auth_type: AuthInfoType | None = None
+    """Authentication type"""
+
+    copilot_plan: str | None = None
+    """Copilot plan tier (e.g., individual_pro, business)"""
+
+    host: str | None = None
+    """Authentication host URL"""
+
+    login: str | None = None
+    """Authenticated login/username, if available"""
+
+    status_message: str | None = None
+    """Human-readable authentication status description"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionAuthStatus':
+        assert isinstance(obj, dict)
+        is_authenticated = from_bool(obj.get("isAuthenticated"))
+        auth_type = from_union([AuthInfoType, from_none], obj.get("authType"))
+        copilot_plan = from_union([from_str, from_none], obj.get("copilotPlan"))
+        host = from_union([from_str, from_none], obj.get("host"))
+        login = from_union([from_str, from_none], obj.get("login"))
+        status_message = from_union([from_str, from_none], obj.get("statusMessage"))
+        return SessionAuthStatus(is_authenticated, auth_type, copilot_plan, host, login, status_message)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["isAuthenticated"] = from_bool(self.is_authenticated)
+        if self.auth_type is not None:
+            result["authType"] = from_union([lambda x: to_enum(AuthInfoType, x), from_none], self.auth_type)
+        if self.copilot_plan is not None:
+            result["copilotPlan"] = from_union([from_str, from_none], self.copilot_plan)
+        if self.host is not None:
+            result["host"] = from_union([from_str, from_none], self.host)
+        if self.login is not None:
+            result["login"] = from_union([from_str, from_none], self.login)
+        if self.status_message is not None:
+            result["statusMessage"] = from_union([from_str, from_none], self.status_message)
+        return result
+
+@dataclass
 class DiscoveredMCPServer:
     enabled: bool
     """Whether the server is enabled (not in the disabled list)"""
@@ -2422,61 +2713,92 @@ class ModelCapabilitiesOverrideLimits:
         return result
 
 @dataclass
-class PermissionDecision:
-    kind: PermissionDecisionKind
-    """The permission request was approved
+class PermissionDecisionApprovedForIonApproval:
+    """The approval to add as a session-scoped rule
 
-    Denied because approval rules explicitly blocked it
-
-    Denied because no approval rule matched and user confirmation was unavailable
-
-    Denied by the user during an interactive prompt
-
-    Denied by the organization's content exclusion policy
-
-    Denied by a permission request hook registered by an extension or plugin
+    The approval to persist for this location
     """
-    rules: list[Any] | None = None
-    """Rules that denied the request"""
-
-    feedback: str | None = None
-    """Optional feedback from the user explaining the denial"""
-
-    message: str | None = None
-    """Human-readable explanation of why the path was excluded
-
-    Optional message from the hook explaining the denial
-    """
-    path: str | None = None
-    """File path that triggered the exclusion"""
-
-    interrupt: bool | None = None
-    """Whether to interrupt the current agent turn"""
+    kind: ApprovalKind
+    command_identifiers: list[str] | None = None
+    server_name: str | None = None
+    tool_name: str | None = None
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecision':
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForIonApproval':
         assert isinstance(obj, dict)
-        kind = PermissionDecisionKind(obj.get("kind"))
-        rules = from_union([lambda x: from_list(lambda x: x, x), from_none], obj.get("rules"))
-        feedback = from_union([from_str, from_none], obj.get("feedback"))
-        message = from_union([from_str, from_none], obj.get("message"))
-        path = from_union([from_str, from_none], obj.get("path"))
-        interrupt = from_union([from_bool, from_none], obj.get("interrupt"))
-        return PermissionDecision(kind, rules, feedback, message, path, interrupt)
+        kind = ApprovalKind(obj.get("kind"))
+        command_identifiers = from_union([lambda x: from_list(from_str, x), from_none], obj.get("commandIdentifiers"))
+        server_name = from_union([from_str, from_none], obj.get("serverName"))
+        tool_name = from_union([from_none, from_str], obj.get("toolName"))
+        return PermissionDecisionApprovedForIonApproval(kind, command_identifiers, server_name, tool_name)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionKind, self.kind)
-        if self.rules is not None:
-            result["rules"] = from_union([lambda x: from_list(lambda x: x, x), from_none], self.rules)
-        if self.feedback is not None:
-            result["feedback"] = from_union([from_str, from_none], self.feedback)
-        if self.message is not None:
-            result["message"] = from_union([from_str, from_none], self.message)
-        if self.path is not None:
-            result["path"] = from_union([from_str, from_none], self.path)
-        if self.interrupt is not None:
-            result["interrupt"] = from_union([from_bool, from_none], self.interrupt)
+        result["kind"] = to_enum(ApprovalKind, self.kind)
+        if self.command_identifiers is not None:
+            result["commandIdentifiers"] = from_union([lambda x: from_list(from_str, x), from_none], self.command_identifiers)
+        if self.server_name is not None:
+            result["serverName"] = from_union([from_str, from_none], self.server_name)
+        if self.tool_name is not None:
+            result["toolName"] = from_union([from_none, from_str], self.tool_name)
+        return result
+
+@dataclass
+class PermissionDecisionApprovedForLocationApproval:
+    """The approval to persist for this location"""
+
+    kind: ApprovalKind
+    command_identifiers: list[str] | None = None
+    server_name: str | None = None
+    tool_name: str | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForLocationApproval':
+        assert isinstance(obj, dict)
+        kind = ApprovalKind(obj.get("kind"))
+        command_identifiers = from_union([lambda x: from_list(from_str, x), from_none], obj.get("commandIdentifiers"))
+        server_name = from_union([from_str, from_none], obj.get("serverName"))
+        tool_name = from_union([from_none, from_str], obj.get("toolName"))
+        return PermissionDecisionApprovedForLocationApproval(kind, command_identifiers, server_name, tool_name)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(ApprovalKind, self.kind)
+        if self.command_identifiers is not None:
+            result["commandIdentifiers"] = from_union([lambda x: from_list(from_str, x), from_none], self.command_identifiers)
+        if self.server_name is not None:
+            result["serverName"] = from_union([from_str, from_none], self.server_name)
+        if self.tool_name is not None:
+            result["toolName"] = from_union([from_none, from_str], self.tool_name)
+        return result
+
+@dataclass
+class PermissionDecisionApprovedForSessionApproval:
+    """The approval to add as a session-scoped rule"""
+
+    kind: ApprovalKind
+    command_identifiers: list[str] | None = None
+    server_name: str | None = None
+    tool_name: str | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForSessionApproval':
+        assert isinstance(obj, dict)
+        kind = ApprovalKind(obj.get("kind"))
+        command_identifiers = from_union([lambda x: from_list(from_str, x), from_none], obj.get("commandIdentifiers"))
+        server_name = from_union([from_str, from_none], obj.get("serverName"))
+        tool_name = from_union([from_none, from_str], obj.get("toolName"))
+        return PermissionDecisionApprovedForSessionApproval(kind, command_identifiers, server_name, tool_name)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(ApprovalKind, self.kind)
+        if self.command_identifiers is not None:
+            result["commandIdentifiers"] = from_union([lambda x: from_list(from_str, x), from_none], self.command_identifiers)
+        if self.server_name is not None:
+            result["serverName"] = from_union([from_str, from_none], self.server_name)
+        if self.tool_name is not None:
+            result["toolName"] = from_union([from_none, from_str], self.tool_name)
         return result
 
 @dataclass
@@ -2493,6 +2815,216 @@ class PermissionDecisionApproved:
     def to_dict(self) -> dict:
         result: dict = {}
         result["kind"] = to_enum(PermissionDecisionApprovedKind, self.kind)
+        return result
+
+@dataclass
+class PermissionDecisionApprovedForLocationApprovalCommands:
+    command_identifiers: list[str]
+    kind: PermissionDecisionApprovedForLocationApprovalCommandsKind
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForLocationApprovalCommands':
+        assert isinstance(obj, dict)
+        command_identifiers = from_list(from_str, obj.get("commandIdentifiers"))
+        kind = PermissionDecisionApprovedForLocationApprovalCommandsKind(obj.get("kind"))
+        return PermissionDecisionApprovedForLocationApprovalCommands(command_identifiers, kind)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["commandIdentifiers"] = from_list(from_str, self.command_identifiers)
+        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalCommandsKind, self.kind)
+        return result
+
+@dataclass
+class PermissionDecisionApprovedForSessionApprovalCommands:
+    command_identifiers: list[str]
+    kind: PermissionDecisionApprovedForLocationApprovalCommandsKind
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForSessionApprovalCommands':
+        assert isinstance(obj, dict)
+        command_identifiers = from_list(from_str, obj.get("commandIdentifiers"))
+        kind = PermissionDecisionApprovedForLocationApprovalCommandsKind(obj.get("kind"))
+        return PermissionDecisionApprovedForSessionApprovalCommands(command_identifiers, kind)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["commandIdentifiers"] = from_list(from_str, self.command_identifiers)
+        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalCommandsKind, self.kind)
+        return result
+
+@dataclass
+class PermissionDecisionApprovedForLocationApprovalCustomTool:
+    kind: PermissionDecisionApprovedForLocationApprovalCustomToolKind
+    tool_name: str
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForLocationApprovalCustomTool':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionApprovedForLocationApprovalCustomToolKind(obj.get("kind"))
+        tool_name = from_str(obj.get("toolName"))
+        return PermissionDecisionApprovedForLocationApprovalCustomTool(kind, tool_name)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalCustomToolKind, self.kind)
+        result["toolName"] = from_str(self.tool_name)
+        return result
+
+@dataclass
+class PermissionDecisionApprovedForSessionApprovalCustomTool:
+    kind: PermissionDecisionApprovedForLocationApprovalCustomToolKind
+    tool_name: str
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForSessionApprovalCustomTool':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionApprovedForLocationApprovalCustomToolKind(obj.get("kind"))
+        tool_name = from_str(obj.get("toolName"))
+        return PermissionDecisionApprovedForSessionApprovalCustomTool(kind, tool_name)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalCustomToolKind, self.kind)
+        result["toolName"] = from_str(self.tool_name)
+        return result
+
+@dataclass
+class PermissionDecisionApprovedForLocationApprovalMCP:
+    kind: PermissionDecisionApprovedForLocationApprovalMCPKind
+    server_name: str
+    tool_name: str | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForLocationApprovalMCP':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionApprovedForLocationApprovalMCPKind(obj.get("kind"))
+        server_name = from_str(obj.get("serverName"))
+        tool_name = from_union([from_none, from_str], obj.get("toolName"))
+        return PermissionDecisionApprovedForLocationApprovalMCP(kind, server_name, tool_name)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalMCPKind, self.kind)
+        result["serverName"] = from_str(self.server_name)
+        result["toolName"] = from_union([from_none, from_str], self.tool_name)
+        return result
+
+@dataclass
+class PermissionDecisionApprovedForSessionApprovalMCP:
+    kind: PermissionDecisionApprovedForLocationApprovalMCPKind
+    server_name: str
+    tool_name: str | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForSessionApprovalMCP':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionApprovedForLocationApprovalMCPKind(obj.get("kind"))
+        server_name = from_str(obj.get("serverName"))
+        tool_name = from_union([from_none, from_str], obj.get("toolName"))
+        return PermissionDecisionApprovedForSessionApprovalMCP(kind, server_name, tool_name)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalMCPKind, self.kind)
+        result["serverName"] = from_str(self.server_name)
+        result["toolName"] = from_union([from_none, from_str], self.tool_name)
+        return result
+
+@dataclass
+class PermissionDecisionApprovedForLocationApprovalMCPSampling:
+    kind: PermissionDecisionApprovedForLocationApprovalMCPSamplingKind
+    server_name: str
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForLocationApprovalMCPSampling':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionApprovedForLocationApprovalMCPSamplingKind(obj.get("kind"))
+        server_name = from_str(obj.get("serverName"))
+        return PermissionDecisionApprovedForLocationApprovalMCPSampling(kind, server_name)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalMCPSamplingKind, self.kind)
+        result["serverName"] = from_str(self.server_name)
+        return result
+
+@dataclass
+class PermissionDecisionApprovedForSessionApprovalMCPSampling:
+    kind: PermissionDecisionApprovedForLocationApprovalMCPSamplingKind
+    server_name: str
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForSessionApprovalMCPSampling':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionApprovedForLocationApprovalMCPSamplingKind(obj.get("kind"))
+        server_name = from_str(obj.get("serverName"))
+        return PermissionDecisionApprovedForSessionApprovalMCPSampling(kind, server_name)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalMCPSamplingKind, self.kind)
+        result["serverName"] = from_str(self.server_name)
+        return result
+
+@dataclass
+class PermissionDecisionApprovedForLocationApprovalMemory:
+    kind: PermissionDecisionApprovedForLocationApprovalMemoryKind
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForLocationApprovalMemory':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionApprovedForLocationApprovalMemoryKind(obj.get("kind"))
+        return PermissionDecisionApprovedForLocationApprovalMemory(kind)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalMemoryKind, self.kind)
+        return result
+
+@dataclass
+class PermissionDecisionApprovedForSessionApprovalMemory:
+    kind: PermissionDecisionApprovedForLocationApprovalMemoryKind
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForSessionApprovalMemory':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionApprovedForLocationApprovalMemoryKind(obj.get("kind"))
+        return PermissionDecisionApprovedForSessionApprovalMemory(kind)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalMemoryKind, self.kind)
+        return result
+
+@dataclass
+class PermissionDecisionApprovedForLocationApprovalWrite:
+    kind: PermissionDecisionApprovedForLocationApprovalWriteKind
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForLocationApprovalWrite':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionApprovedForLocationApprovalWriteKind(obj.get("kind"))
+        return PermissionDecisionApprovedForLocationApprovalWrite(kind)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalWriteKind, self.kind)
+        return result
+
+@dataclass
+class PermissionDecisionApprovedForSessionApprovalWrite:
+    kind: PermissionDecisionApprovedForLocationApprovalWriteKind
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForSessionApprovalWrite':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionApprovedForLocationApprovalWriteKind(obj.get("kind"))
+        return PermissionDecisionApprovedForSessionApprovalWrite(kind)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionApprovedForLocationApprovalWriteKind, self.kind)
         return result
 
 @dataclass
@@ -3290,23 +3822,126 @@ class ModelCapabilitiesOverride:
         return result
 
 @dataclass
-class PermissionDecisionRequest:
-    request_id: str
-    """Request ID of the pending permission request"""
+class PermissionDecision:
+    kind: PermissionDecisionKind
+    """The permission request was approved
 
-    result: PermissionDecision
+    Approved and remembered for the rest of the session
+
+    Approved and persisted for this project location
+
+    Denied because approval rules explicitly blocked it
+
+    Denied because no approval rule matched and user confirmation was unavailable
+
+    Denied by the user during an interactive prompt
+
+    Denied by the organization's content exclusion policy
+
+    Denied by a permission request hook registered by an extension or plugin
+    """
+    approval: PermissionDecisionApprovedForIonApproval | None = None
+    """The approval to add as a session-scoped rule
+
+    The approval to persist for this location
+    """
+    location_key: str | None = None
+    """The location key (git root or cwd) to persist the approval to"""
+
+    rules: list[Any] | None = None
+    """Rules that denied the request"""
+
+    feedback: str | None = None
+    """Optional feedback from the user explaining the denial"""
+
+    message: str | None = None
+    """Human-readable explanation of why the path was excluded
+
+    Optional message from the hook explaining the denial
+    """
+    path: str | None = None
+    """File path that triggered the exclusion"""
+
+    interrupt: bool | None = None
+    """Whether to interrupt the current agent turn"""
 
     @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionRequest':
+    def from_dict(obj: Any) -> 'PermissionDecision':
         assert isinstance(obj, dict)
-        request_id = from_str(obj.get("requestId"))
-        result = PermissionDecision.from_dict(obj.get("result"))
-        return PermissionDecisionRequest(request_id, result)
+        kind = PermissionDecisionKind(obj.get("kind"))
+        approval = from_union([PermissionDecisionApprovedForIonApproval.from_dict, from_none], obj.get("approval"))
+        location_key = from_union([from_str, from_none], obj.get("locationKey"))
+        rules = from_union([lambda x: from_list(lambda x: x, x), from_none], obj.get("rules"))
+        feedback = from_union([from_str, from_none], obj.get("feedback"))
+        message = from_union([from_str, from_none], obj.get("message"))
+        path = from_union([from_str, from_none], obj.get("path"))
+        interrupt = from_union([from_bool, from_none], obj.get("interrupt"))
+        return PermissionDecision(kind, approval, location_key, rules, feedback, message, path, interrupt)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["requestId"] = from_str(self.request_id)
-        result["result"] = to_class(PermissionDecision, self.result)
+        result["kind"] = to_enum(PermissionDecisionKind, self.kind)
+        if self.approval is not None:
+            result["approval"] = from_union([lambda x: to_class(PermissionDecisionApprovedForIonApproval, x), from_none], self.approval)
+        if self.location_key is not None:
+            result["locationKey"] = from_union([from_str, from_none], self.location_key)
+        if self.rules is not None:
+            result["rules"] = from_union([lambda x: from_list(lambda x: x, x), from_none], self.rules)
+        if self.feedback is not None:
+            result["feedback"] = from_union([from_str, from_none], self.feedback)
+        if self.message is not None:
+            result["message"] = from_union([from_str, from_none], self.message)
+        if self.path is not None:
+            result["path"] = from_union([from_str, from_none], self.path)
+        if self.interrupt is not None:
+            result["interrupt"] = from_union([from_bool, from_none], self.interrupt)
+        return result
+
+@dataclass
+class PermissionDecisionApprovedForLocation:
+    approval: PermissionDecisionApprovedForLocationApproval
+    """The approval to persist for this location"""
+
+    kind: PermissionDecisionApprovedForLocationKind
+    """Approved and persisted for this project location"""
+
+    location_key: str
+    """The location key (git root or cwd) to persist the approval to"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForLocation':
+        assert isinstance(obj, dict)
+        approval = PermissionDecisionApprovedForLocationApproval.from_dict(obj.get("approval"))
+        kind = PermissionDecisionApprovedForLocationKind(obj.get("kind"))
+        location_key = from_str(obj.get("locationKey"))
+        return PermissionDecisionApprovedForLocation(approval, kind, location_key)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["approval"] = to_class(PermissionDecisionApprovedForLocationApproval, self.approval)
+        result["kind"] = to_enum(PermissionDecisionApprovedForLocationKind, self.kind)
+        result["locationKey"] = from_str(self.location_key)
+        return result
+
+@dataclass
+class PermissionDecisionApprovedForSession:
+    approval: PermissionDecisionApprovedForSessionApproval
+    """The approval to add as a session-scoped rule"""
+
+    kind: PermissionDecisionApprovedForSessionKind
+    """Approved and remembered for the rest of the session"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForSession':
+        assert isinstance(obj, dict)
+        approval = PermissionDecisionApprovedForSessionApproval.from_dict(obj.get("approval"))
+        kind = PermissionDecisionApprovedForSessionKind(obj.get("kind"))
+        return PermissionDecisionApprovedForSession(approval, kind)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["approval"] = to_class(PermissionDecisionApprovedForSessionApproval, self.approval)
+        result["kind"] = to_enum(PermissionDecisionApprovedForSessionKind, self.kind)
         return result
 
 @dataclass
@@ -3661,6 +4296,26 @@ class WorkspacesGetWorkspaceResult:
         return result
 
 @dataclass
+class PermissionDecisionRequest:
+    request_id: str
+    """Request ID of the pending permission request"""
+
+    result: PermissionDecision
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionRequest':
+        assert isinstance(obj, dict)
+        request_id = from_str(obj.get("requestId"))
+        result = PermissionDecision.from_dict(obj.get("result"))
+        return PermissionDecisionRequest(request_id, result)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["requestId"] = from_str(self.request_id)
+        result["result"] = to_class(PermissionDecision, self.result)
+        return result
+
+@dataclass
 class UIElicitationSchema:
     """JSON Schema describing the form fields to present to the user"""
 
@@ -3831,6 +4486,7 @@ class ModelSwitchToRequest:
 
 @dataclass
 class RPC:
+    account_get_quota_request: AccountGetQuotaRequest
     account_get_quota_result: AccountGetQuotaResult
     account_quota_snapshot: AccountQuotaSnapshot
     agent_get_current_result: AgentGetCurrentResult
@@ -3839,6 +4495,7 @@ class RPC:
     agent_reload_result: AgentReloadResult
     agent_select_request: AgentSelectRequest
     agent_select_result: AgentSelectResult
+    auth_info_type: AuthInfoType
     commands_handle_pending_command_request: CommandsHandlePendingCommandRequest
     commands_handle_pending_command_result: CommandsHandlePendingCommandResult
     current_model: CurrentModel
@@ -3868,6 +4525,8 @@ class RPC:
     log_request: LogRequest
     log_result: LogResult
     mcp_config_add_request: MCPConfigAddRequest
+    mcp_config_disable_request: MCPConfigDisableRequest
+    mcp_config_enable_request: MCPConfigEnableRequest
     mcp_config_list: MCPConfigList
     mcp_config_remove_request: MCPConfigRemoveRequest
     mcp_config_update_request: MCPConfigUpdateRequest
@@ -3875,6 +4534,8 @@ class RPC:
     mcp_discover_request: MCPDiscoverRequest
     mcp_discover_result: MCPDiscoverResult
     mcp_enable_request: MCPEnableRequest
+    mcp_oauth_login_request: MCPOauthLoginRequest
+    mcp_oauth_login_result: MCPOauthLoginResult
     mcp_server: MCPServer
     mcp_server_config: MCPServerConfig
     mcp_server_config_http: MCPServerConfigHTTP
@@ -3896,6 +4557,7 @@ class RPC:
     model_capabilities_supports: ModelCapabilitiesSupports
     model_list: ModelList
     model_policy: ModelPolicy
+    models_list_request: ModelsListRequest
     model_switch_to_request: ModelSwitchToRequest
     model_switch_to_result: ModelSwitchToResult
     mode_set_request: ModeSetRequest
@@ -3903,6 +4565,22 @@ class RPC:
     name_set_request: NameSetRequest
     permission_decision: PermissionDecision
     permission_decision_approved: PermissionDecisionApproved
+    permission_decision_approved_for_location: PermissionDecisionApprovedForLocation
+    permission_decision_approved_for_location_approval: PermissionDecisionApprovedForLocationApproval
+    permission_decision_approved_for_location_approval_commands: PermissionDecisionApprovedForLocationApprovalCommands
+    permission_decision_approved_for_location_approval_custom_tool: PermissionDecisionApprovedForLocationApprovalCustomTool
+    permission_decision_approved_for_location_approval_mcp: PermissionDecisionApprovedForLocationApprovalMCP
+    permission_decision_approved_for_location_approval_mcp_sampling: PermissionDecisionApprovedForLocationApprovalMCPSampling
+    permission_decision_approved_for_location_approval_memory: PermissionDecisionApprovedForLocationApprovalMemory
+    permission_decision_approved_for_location_approval_write: PermissionDecisionApprovedForLocationApprovalWrite
+    permission_decision_approved_for_session: PermissionDecisionApprovedForSession
+    permission_decision_approved_for_session_approval: PermissionDecisionApprovedForSessionApproval
+    permission_decision_approved_for_session_approval_commands: PermissionDecisionApprovedForSessionApprovalCommands
+    permission_decision_approved_for_session_approval_custom_tool: PermissionDecisionApprovedForSessionApprovalCustomTool
+    permission_decision_approved_for_session_approval_mcp: PermissionDecisionApprovedForSessionApprovalMCP
+    permission_decision_approved_for_session_approval_mcp_sampling: PermissionDecisionApprovedForSessionApprovalMCPSampling
+    permission_decision_approved_for_session_approval_memory: PermissionDecisionApprovedForSessionApprovalMemory
+    permission_decision_approved_for_session_approval_write: PermissionDecisionApprovedForSessionApprovalWrite
     permission_decision_denied_by_content_exclusion_policy: PermissionDecisionDeniedByContentExclusionPolicy
     permission_decision_denied_by_permission_request_hook: PermissionDecisionDeniedByPermissionRequestHook
     permission_decision_denied_by_rules: PermissionDecisionDeniedByRules
@@ -3910,6 +4588,10 @@ class RPC:
     permission_decision_denied_no_approval_rule_and_could_not_request_from_user: PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser
     permission_decision_request: PermissionDecisionRequest
     permission_request_result: PermissionRequestResult
+    permissions_reset_session_approvals_request: PermissionsResetSessionApprovalsRequest
+    permissions_reset_session_approvals_result: PermissionsResetSessionApprovalsResult
+    permissions_set_approve_all_request: PermissionsSetApproveAllRequest
+    permissions_set_approve_all_result: PermissionsSetApproveAllResult
     ping_request: PingRequest
     ping_result: PingResult
     plan_read_result: PlanReadResult
@@ -3918,6 +4600,7 @@ class RPC:
     plugin_list: PluginList
     server_skill: ServerSkill
     server_skill_list: ServerSkillList
+    session_auth_status: SessionAuthStatus
     session_fs_append_file_request: SessionFSAppendFileRequest
     session_fs_error: SessionFSError
     session_fs_error_code: SessionFSErrorCode
@@ -3997,6 +4680,7 @@ class RPC:
     @staticmethod
     def from_dict(obj: Any) -> 'RPC':
         assert isinstance(obj, dict)
+        account_get_quota_request = AccountGetQuotaRequest.from_dict(obj.get("AccountGetQuotaRequest"))
         account_get_quota_result = AccountGetQuotaResult.from_dict(obj.get("AccountGetQuotaResult"))
         account_quota_snapshot = AccountQuotaSnapshot.from_dict(obj.get("AccountQuotaSnapshot"))
         agent_get_current_result = AgentGetCurrentResult.from_dict(obj.get("AgentGetCurrentResult"))
@@ -4005,6 +4689,7 @@ class RPC:
         agent_reload_result = AgentReloadResult.from_dict(obj.get("AgentReloadResult"))
         agent_select_request = AgentSelectRequest.from_dict(obj.get("AgentSelectRequest"))
         agent_select_result = AgentSelectResult.from_dict(obj.get("AgentSelectResult"))
+        auth_info_type = AuthInfoType(obj.get("AuthInfoType"))
         commands_handle_pending_command_request = CommandsHandlePendingCommandRequest.from_dict(obj.get("CommandsHandlePendingCommandRequest"))
         commands_handle_pending_command_result = CommandsHandlePendingCommandResult.from_dict(obj.get("CommandsHandlePendingCommandResult"))
         current_model = CurrentModel.from_dict(obj.get("CurrentModel"))
@@ -4034,6 +4719,8 @@ class RPC:
         log_request = LogRequest.from_dict(obj.get("LogRequest"))
         log_result = LogResult.from_dict(obj.get("LogResult"))
         mcp_config_add_request = MCPConfigAddRequest.from_dict(obj.get("McpConfigAddRequest"))
+        mcp_config_disable_request = MCPConfigDisableRequest.from_dict(obj.get("McpConfigDisableRequest"))
+        mcp_config_enable_request = MCPConfigEnableRequest.from_dict(obj.get("McpConfigEnableRequest"))
         mcp_config_list = MCPConfigList.from_dict(obj.get("McpConfigList"))
         mcp_config_remove_request = MCPConfigRemoveRequest.from_dict(obj.get("McpConfigRemoveRequest"))
         mcp_config_update_request = MCPConfigUpdateRequest.from_dict(obj.get("McpConfigUpdateRequest"))
@@ -4041,6 +4728,8 @@ class RPC:
         mcp_discover_request = MCPDiscoverRequest.from_dict(obj.get("McpDiscoverRequest"))
         mcp_discover_result = MCPDiscoverResult.from_dict(obj.get("McpDiscoverResult"))
         mcp_enable_request = MCPEnableRequest.from_dict(obj.get("McpEnableRequest"))
+        mcp_oauth_login_request = MCPOauthLoginRequest.from_dict(obj.get("McpOauthLoginRequest"))
+        mcp_oauth_login_result = MCPOauthLoginResult.from_dict(obj.get("McpOauthLoginResult"))
         mcp_server = MCPServer.from_dict(obj.get("McpServer"))
         mcp_server_config = MCPServerConfig.from_dict(obj.get("McpServerConfig"))
         mcp_server_config_http = MCPServerConfigHTTP.from_dict(obj.get("McpServerConfigHttp"))
@@ -4062,6 +4751,7 @@ class RPC:
         model_capabilities_supports = ModelCapabilitiesSupports.from_dict(obj.get("ModelCapabilitiesSupports"))
         model_list = ModelList.from_dict(obj.get("ModelList"))
         model_policy = ModelPolicy.from_dict(obj.get("ModelPolicy"))
+        models_list_request = ModelsListRequest.from_dict(obj.get("ModelsListRequest"))
         model_switch_to_request = ModelSwitchToRequest.from_dict(obj.get("ModelSwitchToRequest"))
         model_switch_to_result = ModelSwitchToResult.from_dict(obj.get("ModelSwitchToResult"))
         mode_set_request = ModeSetRequest.from_dict(obj.get("ModeSetRequest"))
@@ -4069,6 +4759,22 @@ class RPC:
         name_set_request = NameSetRequest.from_dict(obj.get("NameSetRequest"))
         permission_decision = PermissionDecision.from_dict(obj.get("PermissionDecision"))
         permission_decision_approved = PermissionDecisionApproved.from_dict(obj.get("PermissionDecisionApproved"))
+        permission_decision_approved_for_location = PermissionDecisionApprovedForLocation.from_dict(obj.get("PermissionDecisionApprovedForLocation"))
+        permission_decision_approved_for_location_approval = PermissionDecisionApprovedForLocationApproval.from_dict(obj.get("PermissionDecisionApprovedForLocationApproval"))
+        permission_decision_approved_for_location_approval_commands = PermissionDecisionApprovedForLocationApprovalCommands.from_dict(obj.get("PermissionDecisionApprovedForLocationApprovalCommands"))
+        permission_decision_approved_for_location_approval_custom_tool = PermissionDecisionApprovedForLocationApprovalCustomTool.from_dict(obj.get("PermissionDecisionApprovedForLocationApprovalCustomTool"))
+        permission_decision_approved_for_location_approval_mcp = PermissionDecisionApprovedForLocationApprovalMCP.from_dict(obj.get("PermissionDecisionApprovedForLocationApprovalMcp"))
+        permission_decision_approved_for_location_approval_mcp_sampling = PermissionDecisionApprovedForLocationApprovalMCPSampling.from_dict(obj.get("PermissionDecisionApprovedForLocationApprovalMcpSampling"))
+        permission_decision_approved_for_location_approval_memory = PermissionDecisionApprovedForLocationApprovalMemory.from_dict(obj.get("PermissionDecisionApprovedForLocationApprovalMemory"))
+        permission_decision_approved_for_location_approval_write = PermissionDecisionApprovedForLocationApprovalWrite.from_dict(obj.get("PermissionDecisionApprovedForLocationApprovalWrite"))
+        permission_decision_approved_for_session = PermissionDecisionApprovedForSession.from_dict(obj.get("PermissionDecisionApprovedForSession"))
+        permission_decision_approved_for_session_approval = PermissionDecisionApprovedForSessionApproval.from_dict(obj.get("PermissionDecisionApprovedForSessionApproval"))
+        permission_decision_approved_for_session_approval_commands = PermissionDecisionApprovedForSessionApprovalCommands.from_dict(obj.get("PermissionDecisionApprovedForSessionApprovalCommands"))
+        permission_decision_approved_for_session_approval_custom_tool = PermissionDecisionApprovedForSessionApprovalCustomTool.from_dict(obj.get("PermissionDecisionApprovedForSessionApprovalCustomTool"))
+        permission_decision_approved_for_session_approval_mcp = PermissionDecisionApprovedForSessionApprovalMCP.from_dict(obj.get("PermissionDecisionApprovedForSessionApprovalMcp"))
+        permission_decision_approved_for_session_approval_mcp_sampling = PermissionDecisionApprovedForSessionApprovalMCPSampling.from_dict(obj.get("PermissionDecisionApprovedForSessionApprovalMcpSampling"))
+        permission_decision_approved_for_session_approval_memory = PermissionDecisionApprovedForSessionApprovalMemory.from_dict(obj.get("PermissionDecisionApprovedForSessionApprovalMemory"))
+        permission_decision_approved_for_session_approval_write = PermissionDecisionApprovedForSessionApprovalWrite.from_dict(obj.get("PermissionDecisionApprovedForSessionApprovalWrite"))
         permission_decision_denied_by_content_exclusion_policy = PermissionDecisionDeniedByContentExclusionPolicy.from_dict(obj.get("PermissionDecisionDeniedByContentExclusionPolicy"))
         permission_decision_denied_by_permission_request_hook = PermissionDecisionDeniedByPermissionRequestHook.from_dict(obj.get("PermissionDecisionDeniedByPermissionRequestHook"))
         permission_decision_denied_by_rules = PermissionDecisionDeniedByRules.from_dict(obj.get("PermissionDecisionDeniedByRules"))
@@ -4076,6 +4782,10 @@ class RPC:
         permission_decision_denied_no_approval_rule_and_could_not_request_from_user = PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser.from_dict(obj.get("PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser"))
         permission_decision_request = PermissionDecisionRequest.from_dict(obj.get("PermissionDecisionRequest"))
         permission_request_result = PermissionRequestResult.from_dict(obj.get("PermissionRequestResult"))
+        permissions_reset_session_approvals_request = PermissionsResetSessionApprovalsRequest.from_dict(obj.get("PermissionsResetSessionApprovalsRequest"))
+        permissions_reset_session_approvals_result = PermissionsResetSessionApprovalsResult.from_dict(obj.get("PermissionsResetSessionApprovalsResult"))
+        permissions_set_approve_all_request = PermissionsSetApproveAllRequest.from_dict(obj.get("PermissionsSetApproveAllRequest"))
+        permissions_set_approve_all_result = PermissionsSetApproveAllResult.from_dict(obj.get("PermissionsSetApproveAllResult"))
         ping_request = PingRequest.from_dict(obj.get("PingRequest"))
         ping_result = PingResult.from_dict(obj.get("PingResult"))
         plan_read_result = PlanReadResult.from_dict(obj.get("PlanReadResult"))
@@ -4084,6 +4794,7 @@ class RPC:
         plugin_list = PluginList.from_dict(obj.get("PluginList"))
         server_skill = ServerSkill.from_dict(obj.get("ServerSkill"))
         server_skill_list = ServerSkillList.from_dict(obj.get("ServerSkillList"))
+        session_auth_status = SessionAuthStatus.from_dict(obj.get("SessionAuthStatus"))
         session_fs_append_file_request = SessionFSAppendFileRequest.from_dict(obj.get("SessionFsAppendFileRequest"))
         session_fs_error = SessionFSError.from_dict(obj.get("SessionFsError"))
         session_fs_error_code = SessionFSErrorCode(obj.get("SessionFsErrorCode"))
@@ -4159,10 +4870,11 @@ class RPC:
         workspaces_list_files_result = WorkspacesListFilesResult.from_dict(obj.get("WorkspacesListFilesResult"))
         workspaces_read_file_request = WorkspacesReadFileRequest.from_dict(obj.get("WorkspacesReadFileRequest"))
         workspaces_read_file_result = WorkspacesReadFileResult.from_dict(obj.get("WorkspacesReadFileResult"))
-        return RPC(account_get_quota_result, account_quota_snapshot, agent_get_current_result, agent_info, agent_list, agent_reload_result, agent_select_request, agent_select_result, commands_handle_pending_command_request, commands_handle_pending_command_result, current_model, discovered_mcp_server, discovered_mcp_server_source, discovered_mcp_server_type, extension, extension_list, extensions_disable_request, extensions_enable_request, extension_source, extension_status, filter_mapping, filter_mapping_string, filter_mapping_value, fleet_start_request, fleet_start_result, handle_tool_call_result, history_compact_context_window, history_compact_result, history_truncate_request, history_truncate_result, instructions_get_sources_result, instructions_sources, instructions_sources_location, instructions_sources_type, log_request, log_result, mcp_config_add_request, mcp_config_list, mcp_config_remove_request, mcp_config_update_request, mcp_disable_request, mcp_discover_request, mcp_discover_result, mcp_enable_request, mcp_server, mcp_server_config, mcp_server_config_http, mcp_server_config_http_type, mcp_server_config_local, mcp_server_config_local_type, mcp_server_list, mcp_server_source, mcp_server_status, model, model_billing, model_capabilities, model_capabilities_limits, model_capabilities_limits_vision, model_capabilities_override, model_capabilities_override_limits, model_capabilities_override_limits_vision, model_capabilities_override_supports, model_capabilities_supports, model_list, model_policy, model_switch_to_request, model_switch_to_result, mode_set_request, name_get_result, name_set_request, permission_decision, permission_decision_approved, permission_decision_denied_by_content_exclusion_policy, permission_decision_denied_by_permission_request_hook, permission_decision_denied_by_rules, permission_decision_denied_interactively_by_user, permission_decision_denied_no_approval_rule_and_could_not_request_from_user, permission_decision_request, permission_request_result, ping_request, ping_result, plan_read_result, plan_update_request, plugin, plugin_list, server_skill, server_skill_list, session_fs_append_file_request, session_fs_error, session_fs_error_code, session_fs_exists_request, session_fs_exists_result, session_fs_mkdir_request, session_fs_readdir_request, session_fs_readdir_result, session_fs_readdir_with_types_entry, session_fs_readdir_with_types_entry_type, session_fs_readdir_with_types_request, session_fs_readdir_with_types_result, session_fs_read_file_request, session_fs_read_file_result, session_fs_rename_request, session_fs_rm_request, session_fs_set_provider_conventions, session_fs_set_provider_request, session_fs_set_provider_result, session_fs_stat_request, session_fs_stat_result, session_fs_write_file_request, session_log_level, session_mode, sessions_fork_request, sessions_fork_result, shell_exec_request, shell_exec_result, shell_kill_request, shell_kill_result, shell_kill_signal, skill, skill_list, skills_config_set_disabled_skills_request, skills_disable_request, skills_discover_request, skills_enable_request, tool, tool_call_result, tool_list, tools_handle_pending_tool_call, tools_handle_pending_tool_call_request, tools_list_request, ui_elicitation_array_any_of_field, ui_elicitation_array_any_of_field_items, ui_elicitation_array_any_of_field_items_any_of, ui_elicitation_array_enum_field, ui_elicitation_array_enum_field_items, ui_elicitation_field_value, ui_elicitation_request, ui_elicitation_response, ui_elicitation_response_action, ui_elicitation_response_content, ui_elicitation_result, ui_elicitation_schema, ui_elicitation_schema_property, ui_elicitation_schema_property_boolean, ui_elicitation_schema_property_number, ui_elicitation_schema_property_number_type, ui_elicitation_schema_property_string, ui_elicitation_schema_property_string_format, ui_elicitation_string_enum_field, ui_elicitation_string_one_of_field, ui_elicitation_string_one_of_field_one_of, ui_handle_pending_elicitation_request, usage_get_metrics_result, usage_metrics_code_changes, usage_metrics_model_metric, usage_metrics_model_metric_requests, usage_metrics_model_metric_usage, workspaces_create_file_request, workspaces_get_workspace_result, workspaces_list_files_result, workspaces_read_file_request, workspaces_read_file_result)
+        return RPC(account_get_quota_request, account_get_quota_result, account_quota_snapshot, agent_get_current_result, agent_info, agent_list, agent_reload_result, agent_select_request, agent_select_result, auth_info_type, commands_handle_pending_command_request, commands_handle_pending_command_result, current_model, discovered_mcp_server, discovered_mcp_server_source, discovered_mcp_server_type, extension, extension_list, extensions_disable_request, extensions_enable_request, extension_source, extension_status, filter_mapping, filter_mapping_string, filter_mapping_value, fleet_start_request, fleet_start_result, handle_tool_call_result, history_compact_context_window, history_compact_result, history_truncate_request, history_truncate_result, instructions_get_sources_result, instructions_sources, instructions_sources_location, instructions_sources_type, log_request, log_result, mcp_config_add_request, mcp_config_disable_request, mcp_config_enable_request, mcp_config_list, mcp_config_remove_request, mcp_config_update_request, mcp_disable_request, mcp_discover_request, mcp_discover_result, mcp_enable_request, mcp_oauth_login_request, mcp_oauth_login_result, mcp_server, mcp_server_config, mcp_server_config_http, mcp_server_config_http_type, mcp_server_config_local, mcp_server_config_local_type, mcp_server_list, mcp_server_source, mcp_server_status, model, model_billing, model_capabilities, model_capabilities_limits, model_capabilities_limits_vision, model_capabilities_override, model_capabilities_override_limits, model_capabilities_override_limits_vision, model_capabilities_override_supports, model_capabilities_supports, model_list, model_policy, models_list_request, model_switch_to_request, model_switch_to_result, mode_set_request, name_get_result, name_set_request, permission_decision, permission_decision_approved, permission_decision_approved_for_location, permission_decision_approved_for_location_approval, permission_decision_approved_for_location_approval_commands, permission_decision_approved_for_location_approval_custom_tool, permission_decision_approved_for_location_approval_mcp, permission_decision_approved_for_location_approval_mcp_sampling, permission_decision_approved_for_location_approval_memory, permission_decision_approved_for_location_approval_write, permission_decision_approved_for_session, permission_decision_approved_for_session_approval, permission_decision_approved_for_session_approval_commands, permission_decision_approved_for_session_approval_custom_tool, permission_decision_approved_for_session_approval_mcp, permission_decision_approved_for_session_approval_mcp_sampling, permission_decision_approved_for_session_approval_memory, permission_decision_approved_for_session_approval_write, permission_decision_denied_by_content_exclusion_policy, permission_decision_denied_by_permission_request_hook, permission_decision_denied_by_rules, permission_decision_denied_interactively_by_user, permission_decision_denied_no_approval_rule_and_could_not_request_from_user, permission_decision_request, permission_request_result, permissions_reset_session_approvals_request, permissions_reset_session_approvals_result, permissions_set_approve_all_request, permissions_set_approve_all_result, ping_request, ping_result, plan_read_result, plan_update_request, plugin, plugin_list, server_skill, server_skill_list, session_auth_status, session_fs_append_file_request, session_fs_error, session_fs_error_code, session_fs_exists_request, session_fs_exists_result, session_fs_mkdir_request, session_fs_readdir_request, session_fs_readdir_result, session_fs_readdir_with_types_entry, session_fs_readdir_with_types_entry_type, session_fs_readdir_with_types_request, session_fs_readdir_with_types_result, session_fs_read_file_request, session_fs_read_file_result, session_fs_rename_request, session_fs_rm_request, session_fs_set_provider_conventions, session_fs_set_provider_request, session_fs_set_provider_result, session_fs_stat_request, session_fs_stat_result, session_fs_write_file_request, session_log_level, session_mode, sessions_fork_request, sessions_fork_result, shell_exec_request, shell_exec_result, shell_kill_request, shell_kill_result, shell_kill_signal, skill, skill_list, skills_config_set_disabled_skills_request, skills_disable_request, skills_discover_request, skills_enable_request, tool, tool_call_result, tool_list, tools_handle_pending_tool_call, tools_handle_pending_tool_call_request, tools_list_request, ui_elicitation_array_any_of_field, ui_elicitation_array_any_of_field_items, ui_elicitation_array_any_of_field_items_any_of, ui_elicitation_array_enum_field, ui_elicitation_array_enum_field_items, ui_elicitation_field_value, ui_elicitation_request, ui_elicitation_response, ui_elicitation_response_action, ui_elicitation_response_content, ui_elicitation_result, ui_elicitation_schema, ui_elicitation_schema_property, ui_elicitation_schema_property_boolean, ui_elicitation_schema_property_number, ui_elicitation_schema_property_number_type, ui_elicitation_schema_property_string, ui_elicitation_schema_property_string_format, ui_elicitation_string_enum_field, ui_elicitation_string_one_of_field, ui_elicitation_string_one_of_field_one_of, ui_handle_pending_elicitation_request, usage_get_metrics_result, usage_metrics_code_changes, usage_metrics_model_metric, usage_metrics_model_metric_requests, usage_metrics_model_metric_usage, workspaces_create_file_request, workspaces_get_workspace_result, workspaces_list_files_result, workspaces_read_file_request, workspaces_read_file_result)
 
     def to_dict(self) -> dict:
         result: dict = {}
+        result["AccountGetQuotaRequest"] = to_class(AccountGetQuotaRequest, self.account_get_quota_request)
         result["AccountGetQuotaResult"] = to_class(AccountGetQuotaResult, self.account_get_quota_result)
         result["AccountQuotaSnapshot"] = to_class(AccountQuotaSnapshot, self.account_quota_snapshot)
         result["AgentGetCurrentResult"] = to_class(AgentGetCurrentResult, self.agent_get_current_result)
@@ -4171,6 +4883,7 @@ class RPC:
         result["AgentReloadResult"] = to_class(AgentReloadResult, self.agent_reload_result)
         result["AgentSelectRequest"] = to_class(AgentSelectRequest, self.agent_select_request)
         result["AgentSelectResult"] = to_class(AgentSelectResult, self.agent_select_result)
+        result["AuthInfoType"] = to_enum(AuthInfoType, self.auth_info_type)
         result["CommandsHandlePendingCommandRequest"] = to_class(CommandsHandlePendingCommandRequest, self.commands_handle_pending_command_request)
         result["CommandsHandlePendingCommandResult"] = to_class(CommandsHandlePendingCommandResult, self.commands_handle_pending_command_result)
         result["CurrentModel"] = to_class(CurrentModel, self.current_model)
@@ -4200,6 +4913,8 @@ class RPC:
         result["LogRequest"] = to_class(LogRequest, self.log_request)
         result["LogResult"] = to_class(LogResult, self.log_result)
         result["McpConfigAddRequest"] = to_class(MCPConfigAddRequest, self.mcp_config_add_request)
+        result["McpConfigDisableRequest"] = to_class(MCPConfigDisableRequest, self.mcp_config_disable_request)
+        result["McpConfigEnableRequest"] = to_class(MCPConfigEnableRequest, self.mcp_config_enable_request)
         result["McpConfigList"] = to_class(MCPConfigList, self.mcp_config_list)
         result["McpConfigRemoveRequest"] = to_class(MCPConfigRemoveRequest, self.mcp_config_remove_request)
         result["McpConfigUpdateRequest"] = to_class(MCPConfigUpdateRequest, self.mcp_config_update_request)
@@ -4207,6 +4922,8 @@ class RPC:
         result["McpDiscoverRequest"] = to_class(MCPDiscoverRequest, self.mcp_discover_request)
         result["McpDiscoverResult"] = to_class(MCPDiscoverResult, self.mcp_discover_result)
         result["McpEnableRequest"] = to_class(MCPEnableRequest, self.mcp_enable_request)
+        result["McpOauthLoginRequest"] = to_class(MCPOauthLoginRequest, self.mcp_oauth_login_request)
+        result["McpOauthLoginResult"] = to_class(MCPOauthLoginResult, self.mcp_oauth_login_result)
         result["McpServer"] = to_class(MCPServer, self.mcp_server)
         result["McpServerConfig"] = to_class(MCPServerConfig, self.mcp_server_config)
         result["McpServerConfigHttp"] = to_class(MCPServerConfigHTTP, self.mcp_server_config_http)
@@ -4228,6 +4945,7 @@ class RPC:
         result["ModelCapabilitiesSupports"] = to_class(ModelCapabilitiesSupports, self.model_capabilities_supports)
         result["ModelList"] = to_class(ModelList, self.model_list)
         result["ModelPolicy"] = to_class(ModelPolicy, self.model_policy)
+        result["ModelsListRequest"] = to_class(ModelsListRequest, self.models_list_request)
         result["ModelSwitchToRequest"] = to_class(ModelSwitchToRequest, self.model_switch_to_request)
         result["ModelSwitchToResult"] = to_class(ModelSwitchToResult, self.model_switch_to_result)
         result["ModeSetRequest"] = to_class(ModeSetRequest, self.mode_set_request)
@@ -4235,6 +4953,22 @@ class RPC:
         result["NameSetRequest"] = to_class(NameSetRequest, self.name_set_request)
         result["PermissionDecision"] = to_class(PermissionDecision, self.permission_decision)
         result["PermissionDecisionApproved"] = to_class(PermissionDecisionApproved, self.permission_decision_approved)
+        result["PermissionDecisionApprovedForLocation"] = to_class(PermissionDecisionApprovedForLocation, self.permission_decision_approved_for_location)
+        result["PermissionDecisionApprovedForLocationApproval"] = to_class(PermissionDecisionApprovedForLocationApproval, self.permission_decision_approved_for_location_approval)
+        result["PermissionDecisionApprovedForLocationApprovalCommands"] = to_class(PermissionDecisionApprovedForLocationApprovalCommands, self.permission_decision_approved_for_location_approval_commands)
+        result["PermissionDecisionApprovedForLocationApprovalCustomTool"] = to_class(PermissionDecisionApprovedForLocationApprovalCustomTool, self.permission_decision_approved_for_location_approval_custom_tool)
+        result["PermissionDecisionApprovedForLocationApprovalMcp"] = to_class(PermissionDecisionApprovedForLocationApprovalMCP, self.permission_decision_approved_for_location_approval_mcp)
+        result["PermissionDecisionApprovedForLocationApprovalMcpSampling"] = to_class(PermissionDecisionApprovedForLocationApprovalMCPSampling, self.permission_decision_approved_for_location_approval_mcp_sampling)
+        result["PermissionDecisionApprovedForLocationApprovalMemory"] = to_class(PermissionDecisionApprovedForLocationApprovalMemory, self.permission_decision_approved_for_location_approval_memory)
+        result["PermissionDecisionApprovedForLocationApprovalWrite"] = to_class(PermissionDecisionApprovedForLocationApprovalWrite, self.permission_decision_approved_for_location_approval_write)
+        result["PermissionDecisionApprovedForSession"] = to_class(PermissionDecisionApprovedForSession, self.permission_decision_approved_for_session)
+        result["PermissionDecisionApprovedForSessionApproval"] = to_class(PermissionDecisionApprovedForSessionApproval, self.permission_decision_approved_for_session_approval)
+        result["PermissionDecisionApprovedForSessionApprovalCommands"] = to_class(PermissionDecisionApprovedForSessionApprovalCommands, self.permission_decision_approved_for_session_approval_commands)
+        result["PermissionDecisionApprovedForSessionApprovalCustomTool"] = to_class(PermissionDecisionApprovedForSessionApprovalCustomTool, self.permission_decision_approved_for_session_approval_custom_tool)
+        result["PermissionDecisionApprovedForSessionApprovalMcp"] = to_class(PermissionDecisionApprovedForSessionApprovalMCP, self.permission_decision_approved_for_session_approval_mcp)
+        result["PermissionDecisionApprovedForSessionApprovalMcpSampling"] = to_class(PermissionDecisionApprovedForSessionApprovalMCPSampling, self.permission_decision_approved_for_session_approval_mcp_sampling)
+        result["PermissionDecisionApprovedForSessionApprovalMemory"] = to_class(PermissionDecisionApprovedForSessionApprovalMemory, self.permission_decision_approved_for_session_approval_memory)
+        result["PermissionDecisionApprovedForSessionApprovalWrite"] = to_class(PermissionDecisionApprovedForSessionApprovalWrite, self.permission_decision_approved_for_session_approval_write)
         result["PermissionDecisionDeniedByContentExclusionPolicy"] = to_class(PermissionDecisionDeniedByContentExclusionPolicy, self.permission_decision_denied_by_content_exclusion_policy)
         result["PermissionDecisionDeniedByPermissionRequestHook"] = to_class(PermissionDecisionDeniedByPermissionRequestHook, self.permission_decision_denied_by_permission_request_hook)
         result["PermissionDecisionDeniedByRules"] = to_class(PermissionDecisionDeniedByRules, self.permission_decision_denied_by_rules)
@@ -4242,6 +4976,10 @@ class RPC:
         result["PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser"] = to_class(PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser, self.permission_decision_denied_no_approval_rule_and_could_not_request_from_user)
         result["PermissionDecisionRequest"] = to_class(PermissionDecisionRequest, self.permission_decision_request)
         result["PermissionRequestResult"] = to_class(PermissionRequestResult, self.permission_request_result)
+        result["PermissionsResetSessionApprovalsRequest"] = to_class(PermissionsResetSessionApprovalsRequest, self.permissions_reset_session_approvals_request)
+        result["PermissionsResetSessionApprovalsResult"] = to_class(PermissionsResetSessionApprovalsResult, self.permissions_reset_session_approvals_result)
+        result["PermissionsSetApproveAllRequest"] = to_class(PermissionsSetApproveAllRequest, self.permissions_set_approve_all_request)
+        result["PermissionsSetApproveAllResult"] = to_class(PermissionsSetApproveAllResult, self.permissions_set_approve_all_result)
         result["PingRequest"] = to_class(PingRequest, self.ping_request)
         result["PingResult"] = to_class(PingResult, self.ping_result)
         result["PlanReadResult"] = to_class(PlanReadResult, self.plan_read_result)
@@ -4250,6 +4988,7 @@ class RPC:
         result["PluginList"] = to_class(PluginList, self.plugin_list)
         result["ServerSkill"] = to_class(ServerSkill, self.server_skill)
         result["ServerSkillList"] = to_class(ServerSkillList, self.server_skill_list)
+        result["SessionAuthStatus"] = to_class(SessionAuthStatus, self.session_auth_status)
         result["SessionFsAppendFileRequest"] = to_class(SessionFSAppendFileRequest, self.session_fs_append_file_request)
         result["SessionFsError"] = to_class(SessionFSError, self.session_fs_error)
         result["SessionFsErrorCode"] = to_enum(SessionFSErrorCode, self.session_fs_error_code)
@@ -4366,8 +5105,9 @@ class ServerModelsApi:
     def __init__(self, client: "JsonRpcClient"):
         self._client = client
 
-    async def list(self, *, timeout: float | None = None) -> ModelList:
-        return ModelList.from_dict(_patch_model_capabilities(await self._client.request("models.list", {}, **_timeout_kwargs(timeout))))
+    async def list(self, params: ModelsListRequest | None = None, *, timeout: float | None = None) -> ModelList:
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
+        return ModelList.from_dict(_patch_model_capabilities(await self._client.request("models.list", params_dict, **_timeout_kwargs(timeout))))
 
 
 class ServerToolsApi:
@@ -4383,8 +5123,9 @@ class ServerAccountApi:
     def __init__(self, client: "JsonRpcClient"):
         self._client = client
 
-    async def get_quota(self, *, timeout: float | None = None) -> AccountGetQuotaResult:
-        return AccountGetQuotaResult.from_dict(await self._client.request("account.getQuota", {}, **_timeout_kwargs(timeout)))
+    async def get_quota(self, params: AccountGetQuotaRequest | None = None, *, timeout: float | None = None) -> AccountGetQuotaResult:
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
+        return AccountGetQuotaResult.from_dict(await self._client.request("account.getQuota", params_dict, **_timeout_kwargs(timeout)))
 
 
 class ServerMcpConfigApi:
@@ -4405,6 +5146,14 @@ class ServerMcpConfigApi:
     async def remove(self, params: MCPConfigRemoveRequest, *, timeout: float | None = None) -> None:
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         await self._client.request("mcp.config.remove", params_dict, **_timeout_kwargs(timeout))
+
+    async def enable(self, params: MCPConfigEnableRequest, *, timeout: float | None = None) -> None:
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        await self._client.request("mcp.config.enable", params_dict, **_timeout_kwargs(timeout))
+
+    async def disable(self, params: MCPConfigDisableRequest, *, timeout: float | None = None) -> None:
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        await self._client.request("mcp.config.disable", params_dict, **_timeout_kwargs(timeout))
 
 
 class ServerMcpApi:
@@ -4472,6 +5221,15 @@ class ServerRpc:
         return PingResult.from_dict(await self._client.request("ping", params_dict, **_timeout_kwargs(timeout)))
 
 
+class AuthApi:
+    def __init__(self, client: "JsonRpcClient", session_id: str):
+        self._client = client
+        self._session_id = session_id
+
+    async def get_status(self, *, timeout: float | None = None) -> SessionAuthStatus:
+        return SessionAuthStatus.from_dict(await self._client.request("session.auth.getStatus", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+
 class ModelApi:
     def __init__(self, client: "JsonRpcClient", session_id: str):
         self._client = client
@@ -4481,7 +5239,7 @@ class ModelApi:
         return CurrentModel.from_dict(await self._client.request("session.model.getCurrent", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def switch_to(self, params: ModelSwitchToRequest, *, timeout: float | None = None) -> ModelSwitchToResult:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return ModelSwitchToResult.from_dict(await self._client.request("session.model.switchTo", params_dict, **_timeout_kwargs(timeout)))
 
@@ -4495,7 +5253,7 @@ class ModeApi:
         return SessionMode(await self._client.request("session.mode.get", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def set(self, params: ModeSetRequest, *, timeout: float | None = None) -> None:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.mode.set", params_dict, **_timeout_kwargs(timeout))
 
@@ -4509,7 +5267,7 @@ class NameApi:
         return NameGetResult.from_dict(await self._client.request("session.name.get", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def set(self, params: NameSetRequest, *, timeout: float | None = None) -> None:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.name.set", params_dict, **_timeout_kwargs(timeout))
 
@@ -4523,7 +5281,7 @@ class PlanApi:
         return PlanReadResult.from_dict(await self._client.request("session.plan.read", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def update(self, params: PlanUpdateRequest, *, timeout: float | None = None) -> None:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.plan.update", params_dict, **_timeout_kwargs(timeout))
 
@@ -4543,12 +5301,12 @@ class WorkspacesApi:
         return WorkspacesListFilesResult.from_dict(await self._client.request("session.workspaces.listFiles", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def read_file(self, params: WorkspacesReadFileRequest, *, timeout: float | None = None) -> WorkspacesReadFileResult:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return WorkspacesReadFileResult.from_dict(await self._client.request("session.workspaces.readFile", params_dict, **_timeout_kwargs(timeout)))
 
     async def create_file(self, params: WorkspacesCreateFileRequest, *, timeout: float | None = None) -> None:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.workspaces.createFile", params_dict, **_timeout_kwargs(timeout))
 
@@ -4569,7 +5327,7 @@ class FleetApi:
         self._session_id = session_id
 
     async def start(self, params: FleetStartRequest, *, timeout: float | None = None) -> FleetStartResult:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return FleetStartResult.from_dict(await self._client.request("session.fleet.start", params_dict, **_timeout_kwargs(timeout)))
 
@@ -4587,7 +5345,7 @@ class AgentApi:
         return AgentGetCurrentResult.from_dict(await self._client.request("session.agent.getCurrent", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def select(self, params: AgentSelectRequest, *, timeout: float | None = None) -> AgentSelectResult:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return AgentSelectResult.from_dict(await self._client.request("session.agent.select", params_dict, **_timeout_kwargs(timeout)))
 
@@ -4608,12 +5366,12 @@ class SkillsApi:
         return SkillList.from_dict(await self._client.request("session.skills.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def enable(self, params: SkillsEnableRequest, *, timeout: float | None = None) -> None:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.skills.enable", params_dict, **_timeout_kwargs(timeout))
 
     async def disable(self, params: SkillsDisableRequest, *, timeout: float | None = None) -> None:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.skills.disable", params_dict, **_timeout_kwargs(timeout))
 
@@ -4622,21 +5380,34 @@ class SkillsApi:
 
 
 # Experimental: this API group is experimental and may change or be removed.
+class McpOauthApi:
+    def __init__(self, client: "JsonRpcClient", session_id: str):
+        self._client = client
+        self._session_id = session_id
+
+    async def login(self, params: MCPOauthLoginRequest, *, timeout: float | None = None) -> MCPOauthLoginResult:
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return MCPOauthLoginResult.from_dict(await self._client.request("session.mcp.oauth.login", params_dict, **_timeout_kwargs(timeout)))
+
+
+# Experimental: this API group is experimental and may change or be removed.
 class McpApi:
     def __init__(self, client: "JsonRpcClient", session_id: str):
         self._client = client
         self._session_id = session_id
+        self.oauth = McpOauthApi(client, session_id)
 
     async def list(self, *, timeout: float | None = None) -> MCPServerList:
         return MCPServerList.from_dict(await self._client.request("session.mcp.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def enable(self, params: MCPEnableRequest, *, timeout: float | None = None) -> None:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.mcp.enable", params_dict, **_timeout_kwargs(timeout))
 
     async def disable(self, params: MCPDisableRequest, *, timeout: float | None = None) -> None:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.mcp.disable", params_dict, **_timeout_kwargs(timeout))
 
@@ -4664,12 +5435,12 @@ class ExtensionsApi:
         return ExtensionList.from_dict(await self._client.request("session.extensions.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def enable(self, params: ExtensionsEnableRequest, *, timeout: float | None = None) -> None:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.extensions.enable", params_dict, **_timeout_kwargs(timeout))
 
     async def disable(self, params: ExtensionsDisableRequest, *, timeout: float | None = None) -> None:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.extensions.disable", params_dict, **_timeout_kwargs(timeout))
 
@@ -4683,7 +5454,7 @@ class ToolsApi:
         self._session_id = session_id
 
     async def handle_pending_tool_call(self, params: ToolsHandlePendingToolCallRequest, *, timeout: float | None = None) -> HandleToolCallResult:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return HandleToolCallResult.from_dict(await self._client.request("session.tools.handlePendingToolCall", params_dict, **_timeout_kwargs(timeout)))
 
@@ -4694,7 +5465,7 @@ class CommandsApi:
         self._session_id = session_id
 
     async def handle_pending_command(self, params: CommandsHandlePendingCommandRequest, *, timeout: float | None = None) -> CommandsHandlePendingCommandResult:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return CommandsHandlePendingCommandResult.from_dict(await self._client.request("session.commands.handlePendingCommand", params_dict, **_timeout_kwargs(timeout)))
 
@@ -4705,12 +5476,12 @@ class UiApi:
         self._session_id = session_id
 
     async def elicitation(self, params: UIElicitationRequest, *, timeout: float | None = None) -> UIElicitationResponse:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return UIElicitationResponse.from_dict(await self._client.request("session.ui.elicitation", params_dict, **_timeout_kwargs(timeout)))
 
     async def handle_pending_elicitation(self, params: UIHandlePendingElicitationRequest, *, timeout: float | None = None) -> UIElicitationResult:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return UIElicitationResult.from_dict(await self._client.request("session.ui.handlePendingElicitation", params_dict, **_timeout_kwargs(timeout)))
 
@@ -4721,9 +5492,17 @@ class PermissionsApi:
         self._session_id = session_id
 
     async def handle_pending_permission_request(self, params: PermissionDecisionRequest, *, timeout: float | None = None) -> PermissionRequestResult:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return PermissionRequestResult.from_dict(await self._client.request("session.permissions.handlePendingPermissionRequest", params_dict, **_timeout_kwargs(timeout)))
+
+    async def set_approve_all(self, params: PermissionsSetApproveAllRequest, *, timeout: float | None = None) -> PermissionsSetApproveAllResult:
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return PermissionsSetApproveAllResult.from_dict(await self._client.request("session.permissions.setApproveAll", params_dict, **_timeout_kwargs(timeout)))
+
+    async def reset_session_approvals(self, *, timeout: float | None = None) -> PermissionsResetSessionApprovalsResult:
+        return PermissionsResetSessionApprovalsResult.from_dict(await self._client.request("session.permissions.resetSessionApprovals", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
 class ShellApi:
@@ -4732,12 +5511,12 @@ class ShellApi:
         self._session_id = session_id
 
     async def exec(self, params: ShellExecRequest, *, timeout: float | None = None) -> ShellExecResult:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return ShellExecResult.from_dict(await self._client.request("session.shell.exec", params_dict, **_timeout_kwargs(timeout)))
 
     async def kill(self, params: ShellKillRequest, *, timeout: float | None = None) -> ShellKillResult:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return ShellKillResult.from_dict(await self._client.request("session.shell.kill", params_dict, **_timeout_kwargs(timeout)))
 
@@ -4752,7 +5531,7 @@ class HistoryApi:
         return HistoryCompactResult.from_dict(await self._client.request("session.history.compact", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def truncate(self, params: HistoryTruncateRequest, *, timeout: float | None = None) -> HistoryTruncateResult:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return HistoryTruncateResult.from_dict(await self._client.request("session.history.truncate", params_dict, **_timeout_kwargs(timeout)))
 
@@ -4772,6 +5551,7 @@ class SessionRpc:
     def __init__(self, client: "JsonRpcClient", session_id: str):
         self._client = client
         self._session_id = session_id
+        self.auth = AuthApi(client, session_id)
         self.model = ModelApi(client, session_id)
         self.mode = ModeApi(client, session_id)
         self.name = NameApi(client, session_id)
@@ -4793,7 +5573,7 @@ class SessionRpc:
         self.usage = UsageApi(client, session_id)
 
     async def log(self, params: LogRequest, *, timeout: float | None = None) -> LogResult:
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return LogResult.from_dict(await self._client.request("session.log", params_dict, **_timeout_kwargs(timeout)))
 

--- a/python/copilot/generated/session_events.py
+++ b/python/copilot/generated/session_events.py
@@ -1614,21 +1614,26 @@ class PermissionCompletedData:
     "Permission request completion notification signaling UI dismissal"
     request_id: str
     result: PermissionCompletedResult
+    tool_call_id: str | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "PermissionCompletedData":
         assert isinstance(obj, dict)
         request_id = from_str(obj.get("requestId"))
         result = PermissionCompletedResult.from_dict(obj.get("result"))
+        tool_call_id = from_union([from_none, from_str], obj.get("toolCallId"))
         return PermissionCompletedData(
             request_id=request_id,
             result=result,
+            tool_call_id=tool_call_id,
         )
 
     def to_dict(self) -> dict:
         result: dict = {}
         result["requestId"] = from_str(self.request_id)
         result["result"] = to_class(PermissionCompletedResult, self.result)
+        if self.tool_call_id is not None:
+            result["toolCallId"] = from_union([from_none, from_str], self.tool_call_id)
         return result
 
 
@@ -1648,6 +1653,155 @@ class PermissionCompletedResult:
     def to_dict(self) -> dict:
         result: dict = {}
         result["kind"] = to_enum(PermissionCompletedKind, self.kind)
+        return result
+
+
+@dataclass
+class PermissionPromptRequest:
+    "Derived user-facing permission prompt details for UI consumers"
+    kind: PermissionPromptRequestKind
+    access_kind: PermissionPromptRequestPathAccessKind | None = None
+    action: PermissionPromptRequestMemoryAction | None = None
+    args: Any | None = None
+    can_offer_session_approval: bool | None = None
+    citations: str | None = None
+    command_identifiers: list[str] | None = None
+    diff: str | None = None
+    direction: PermissionPromptRequestMemoryDirection | None = None
+    fact: str | None = None
+    file_name: str | None = None
+    full_command_text: str | None = None
+    hook_message: str | None = None
+    intention: str | None = None
+    new_file_contents: str | None = None
+    path: str | None = None
+    paths: list[str] | None = None
+    reason: str | None = None
+    server_name: str | None = None
+    subject: str | None = None
+    tool_args: Any = None
+    tool_call_id: str | None = None
+    tool_description: str | None = None
+    tool_name: str | None = None
+    tool_title: str | None = None
+    url: str | None = None
+    warning: str | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> "PermissionPromptRequest":
+        assert isinstance(obj, dict)
+        kind = parse_enum(PermissionPromptRequestKind, obj.get("kind"))
+        access_kind = from_union([from_none, lambda x: parse_enum(PermissionPromptRequestPathAccessKind, x)], obj.get("accessKind"))
+        action = from_union([from_none, lambda x: parse_enum(PermissionPromptRequestMemoryAction, x)], obj.get("action", "store"))
+        args = from_union([from_none, lambda x: x], obj.get("args"))
+        can_offer_session_approval = from_union([from_none, from_bool], obj.get("canOfferSessionApproval"))
+        citations = from_union([from_none, from_str], obj.get("citations"))
+        command_identifiers = from_union([from_none, lambda x: from_list(from_str, x)], obj.get("commandIdentifiers"))
+        diff = from_union([from_none, from_str], obj.get("diff"))
+        direction = from_union([from_none, lambda x: parse_enum(PermissionPromptRequestMemoryDirection, x)], obj.get("direction"))
+        fact = from_union([from_none, from_str], obj.get("fact"))
+        file_name = from_union([from_none, from_str], obj.get("fileName"))
+        full_command_text = from_union([from_none, from_str], obj.get("fullCommandText"))
+        hook_message = from_union([from_none, from_str], obj.get("hookMessage"))
+        intention = from_union([from_none, from_str], obj.get("intention"))
+        new_file_contents = from_union([from_none, from_str], obj.get("newFileContents"))
+        path = from_union([from_none, from_str], obj.get("path"))
+        paths = from_union([from_none, lambda x: from_list(from_str, x)], obj.get("paths"))
+        reason = from_union([from_none, from_str], obj.get("reason"))
+        server_name = from_union([from_none, from_str], obj.get("serverName"))
+        subject = from_union([from_none, from_str], obj.get("subject"))
+        tool_args = obj.get("toolArgs")
+        tool_call_id = from_union([from_none, from_str], obj.get("toolCallId"))
+        tool_description = from_union([from_none, from_str], obj.get("toolDescription"))
+        tool_name = from_union([from_none, from_str], obj.get("toolName"))
+        tool_title = from_union([from_none, from_str], obj.get("toolTitle"))
+        url = from_union([from_none, from_str], obj.get("url"))
+        warning = from_union([from_none, from_str], obj.get("warning"))
+        return PermissionPromptRequest(
+            kind=kind,
+            access_kind=access_kind,
+            action=action,
+            args=args,
+            can_offer_session_approval=can_offer_session_approval,
+            citations=citations,
+            command_identifiers=command_identifiers,
+            diff=diff,
+            direction=direction,
+            fact=fact,
+            file_name=file_name,
+            full_command_text=full_command_text,
+            hook_message=hook_message,
+            intention=intention,
+            new_file_contents=new_file_contents,
+            path=path,
+            paths=paths,
+            reason=reason,
+            server_name=server_name,
+            subject=subject,
+            tool_args=tool_args,
+            tool_call_id=tool_call_id,
+            tool_description=tool_description,
+            tool_name=tool_name,
+            tool_title=tool_title,
+            url=url,
+            warning=warning,
+        )
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionPromptRequestKind, self.kind)
+        if self.access_kind is not None:
+            result["accessKind"] = from_union([from_none, lambda x: to_enum(PermissionPromptRequestPathAccessKind, x)], self.access_kind)
+        if self.action is not None:
+            result["action"] = from_union([from_none, lambda x: to_enum(PermissionPromptRequestMemoryAction, x)], self.action)
+        if self.args is not None:
+            result["args"] = from_union([from_none, lambda x: x], self.args)
+        if self.can_offer_session_approval is not None:
+            result["canOfferSessionApproval"] = from_union([from_none, from_bool], self.can_offer_session_approval)
+        if self.citations is not None:
+            result["citations"] = from_union([from_none, from_str], self.citations)
+        if self.command_identifiers is not None:
+            result["commandIdentifiers"] = from_union([from_none, lambda x: from_list(from_str, x)], self.command_identifiers)
+        if self.diff is not None:
+            result["diff"] = from_union([from_none, from_str], self.diff)
+        if self.direction is not None:
+            result["direction"] = from_union([from_none, lambda x: to_enum(PermissionPromptRequestMemoryDirection, x)], self.direction)
+        if self.fact is not None:
+            result["fact"] = from_union([from_none, from_str], self.fact)
+        if self.file_name is not None:
+            result["fileName"] = from_union([from_none, from_str], self.file_name)
+        if self.full_command_text is not None:
+            result["fullCommandText"] = from_union([from_none, from_str], self.full_command_text)
+        if self.hook_message is not None:
+            result["hookMessage"] = from_union([from_none, from_str], self.hook_message)
+        if self.intention is not None:
+            result["intention"] = from_union([from_none, from_str], self.intention)
+        if self.new_file_contents is not None:
+            result["newFileContents"] = from_union([from_none, from_str], self.new_file_contents)
+        if self.path is not None:
+            result["path"] = from_union([from_none, from_str], self.path)
+        if self.paths is not None:
+            result["paths"] = from_union([from_none, lambda x: from_list(from_str, x)], self.paths)
+        if self.reason is not None:
+            result["reason"] = from_union([from_none, from_str], self.reason)
+        if self.server_name is not None:
+            result["serverName"] = from_union([from_none, from_str], self.server_name)
+        if self.subject is not None:
+            result["subject"] = from_union([from_none, from_str], self.subject)
+        if self.tool_args is not None:
+            result["toolArgs"] = self.tool_args
+        if self.tool_call_id is not None:
+            result["toolCallId"] = from_union([from_none, from_str], self.tool_call_id)
+        if self.tool_description is not None:
+            result["toolDescription"] = from_union([from_none, from_str], self.tool_description)
+        if self.tool_name is not None:
+            result["toolName"] = from_union([from_none, from_str], self.tool_name)
+        if self.tool_title is not None:
+            result["toolTitle"] = from_union([from_none, from_str], self.tool_title)
+        if self.url is not None:
+            result["url"] = from_union([from_none, from_str], self.url)
+        if self.warning is not None:
+            result["warning"] = from_union([from_none, from_str], self.warning)
         return result
 
 
@@ -1855,6 +2009,7 @@ class PermissionRequestedData:
     "Permission request notification requiring client approval with request details"
     permission_request: PermissionRequest
     request_id: str
+    prompt_request: PermissionPromptRequest | None = None
     resolved_by_hook: bool | None = None
 
     @staticmethod
@@ -1862,10 +2017,12 @@ class PermissionRequestedData:
         assert isinstance(obj, dict)
         permission_request = PermissionRequest.from_dict(obj.get("permissionRequest"))
         request_id = from_str(obj.get("requestId"))
+        prompt_request = from_union([from_none, PermissionPromptRequest.from_dict], obj.get("promptRequest"))
         resolved_by_hook = from_union([from_none, from_bool], obj.get("resolvedByHook"))
         return PermissionRequestedData(
             permission_request=permission_request,
             request_id=request_id,
+            prompt_request=prompt_request,
             resolved_by_hook=resolved_by_hook,
         )
 
@@ -1873,6 +2030,8 @@ class PermissionRequestedData:
         result: dict = {}
         result["permissionRequest"] = to_class(PermissionRequest, self.permission_request)
         result["requestId"] = from_str(self.request_id)
+        if self.prompt_request is not None:
+            result["promptRequest"] = from_union([from_none, lambda x: to_class(PermissionPromptRequest, x)], self.prompt_request)
         if self.resolved_by_hook is not None:
             result["resolvedByHook"] = from_union([from_none, from_bool], self.resolved_by_hook)
         return result
@@ -4130,6 +4289,38 @@ class PermissionCompletedKind(Enum):
     DENIED_INTERACTIVELY_BY_USER = "denied-interactively-by-user"
     DENIED_BY_CONTENT_EXCLUSION_POLICY = "denied-by-content-exclusion-policy"
     DENIED_BY_PERMISSION_REQUEST_HOOK = "denied-by-permission-request-hook"
+
+
+class PermissionPromptRequestKind(Enum):
+    "Derived user-facing permission prompt details for UI consumers discriminator"
+    COMMANDS = "commands"
+    WRITE = "write"
+    READ = "read"
+    MCP = "mcp"
+    URL = "url"
+    MEMORY = "memory"
+    CUSTOM_TOOL = "custom-tool"
+    PATH = "path"
+    HOOK = "hook"
+
+
+class PermissionPromptRequestMemoryAction(Enum):
+    "Whether this is a store or vote memory operation"
+    STORE = "store"
+    VOTE = "vote"
+
+
+class PermissionPromptRequestMemoryDirection(Enum):
+    "Vote direction (vote only)"
+    UPVOTE = "upvote"
+    DOWNVOTE = "downvote"
+
+
+class PermissionPromptRequestPathAccessKind(Enum):
+    "Underlying permission kind that needs path approval"
+    READ = "read"
+    SHELL = "shell"
+    WRITE = "write"
 
 
 class PermissionRequestKind(Enum):

--- a/python/copilot/generated/session_events.py
+++ b/python/copilot/generated/session_events.py
@@ -167,6 +167,8 @@ class SessionEventType(Enum):
     COMMAND_QUEUED = "command.queued"
     COMMAND_EXECUTE = "command.execute"
     COMMAND_COMPLETED = "command.completed"
+    AUTO_MODE_SWITCH_REQUESTED = "auto_mode_switch.requested"
+    AUTO_MODE_SWITCH_COMPLETED = "auto_mode_switch.completed"
     COMMANDS_CHANGED = "commands.changed"
     CAPABILITIES_CHANGED = "capabilities.changed"
     EXIT_PLAN_MODE_REQUESTED = "exit_plan_mode.requested"
@@ -745,6 +747,53 @@ class AssistantUsageQuotaSnapshot:
 
 
 @dataclass
+class AutoModeSwitchCompletedData:
+    "Auto mode switch completion notification"
+    request_id: str
+    response: str
+
+    @staticmethod
+    def from_dict(obj: Any) -> "AutoModeSwitchCompletedData":
+        assert isinstance(obj, dict)
+        request_id = from_str(obj.get("requestId"))
+        response = from_str(obj.get("response"))
+        return AutoModeSwitchCompletedData(
+            request_id=request_id,
+            response=response,
+        )
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["requestId"] = from_str(self.request_id)
+        result["response"] = from_str(self.response)
+        return result
+
+
+@dataclass
+class AutoModeSwitchRequestedData:
+    "Auto mode switch request notification requiring user approval"
+    request_id: str
+    error_code: str | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> "AutoModeSwitchRequestedData":
+        assert isinstance(obj, dict)
+        request_id = from_str(obj.get("requestId"))
+        error_code = from_union([from_none, from_str], obj.get("errorCode"))
+        return AutoModeSwitchRequestedData(
+            request_id=request_id,
+            error_code=error_code,
+        )
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["requestId"] = from_str(self.request_id)
+        if self.error_code is not None:
+            result["errorCode"] = from_union([from_none, from_str], self.error_code)
+        return result
+
+
+@dataclass
 class CapabilitiesChangedData:
     "Session capability change notification"
     ui: CapabilitiesChangedUI | None = None
@@ -901,28 +950,105 @@ class CommandsChangedData:
 
 @dataclass
 class CompactionCompleteCompactionTokensUsed:
-    "Token usage breakdown for the compaction LLM call"
-    cached_input: float
-    input: float
-    output: float
+    "Token usage breakdown for the compaction LLM call (aligned with assistant.usage format)"
+    cache_read_tokens: float | None = None
+    cache_write_tokens: float | None = None
+    copilot_usage: CompactionCompleteCompactionTokensUsedCopilotUsage | None = None
+    duration: float | None = None
+    input_tokens: float | None = None
+    model: str | None = None
+    output_tokens: float | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "CompactionCompleteCompactionTokensUsed":
         assert isinstance(obj, dict)
-        cached_input = from_float(obj.get("cachedInput"))
-        input = from_float(obj.get("input"))
-        output = from_float(obj.get("output"))
+        cache_read_tokens = from_union([from_none, from_float], obj.get("cacheReadTokens"))
+        cache_write_tokens = from_union([from_none, from_float], obj.get("cacheWriteTokens"))
+        copilot_usage = from_union([from_none, CompactionCompleteCompactionTokensUsedCopilotUsage.from_dict], obj.get("copilotUsage"))
+        duration = from_union([from_none, from_float], obj.get("duration"))
+        input_tokens = from_union([from_none, from_float], obj.get("inputTokens"))
+        model = from_union([from_none, from_str], obj.get("model"))
+        output_tokens = from_union([from_none, from_float], obj.get("outputTokens"))
         return CompactionCompleteCompactionTokensUsed(
-            cached_input=cached_input,
-            input=input,
-            output=output,
+            cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
+            copilot_usage=copilot_usage,
+            duration=duration,
+            input_tokens=input_tokens,
+            model=model,
+            output_tokens=output_tokens,
         )
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["cachedInput"] = to_float(self.cached_input)
-        result["input"] = to_float(self.input)
-        result["output"] = to_float(self.output)
+        if self.cache_read_tokens is not None:
+            result["cacheReadTokens"] = from_union([from_none, to_float], self.cache_read_tokens)
+        if self.cache_write_tokens is not None:
+            result["cacheWriteTokens"] = from_union([from_none, to_float], self.cache_write_tokens)
+        if self.copilot_usage is not None:
+            result["copilotUsage"] = from_union([from_none, lambda x: to_class(CompactionCompleteCompactionTokensUsedCopilotUsage, x)], self.copilot_usage)
+        if self.duration is not None:
+            result["duration"] = from_union([from_none, to_float], self.duration)
+        if self.input_tokens is not None:
+            result["inputTokens"] = from_union([from_none, to_float], self.input_tokens)
+        if self.model is not None:
+            result["model"] = from_union([from_none, from_str], self.model)
+        if self.output_tokens is not None:
+            result["outputTokens"] = from_union([from_none, to_float], self.output_tokens)
+        return result
+
+
+@dataclass
+class CompactionCompleteCompactionTokensUsedCopilotUsage:
+    "Per-request cost and usage data from the CAPI copilot_usage response field"
+    token_details: list[CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail]
+    total_nano_aiu: float
+
+    @staticmethod
+    def from_dict(obj: Any) -> "CompactionCompleteCompactionTokensUsedCopilotUsage":
+        assert isinstance(obj, dict)
+        token_details = from_list(CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail.from_dict, obj.get("tokenDetails"))
+        total_nano_aiu = from_float(obj.get("totalNanoAiu"))
+        return CompactionCompleteCompactionTokensUsedCopilotUsage(
+            token_details=token_details,
+            total_nano_aiu=total_nano_aiu,
+        )
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["tokenDetails"] = from_list(lambda x: to_class(CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail, x), self.token_details)
+        result["totalNanoAiu"] = to_float(self.total_nano_aiu)
+        return result
+
+
+@dataclass
+class CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail:
+    "Token usage detail for a single billing category"
+    batch_size: float
+    cost_per_batch: float
+    token_count: float
+    token_type: str
+
+    @staticmethod
+    def from_dict(obj: Any) -> "CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail":
+        assert isinstance(obj, dict)
+        batch_size = from_float(obj.get("batchSize"))
+        cost_per_batch = from_float(obj.get("costPerBatch"))
+        token_count = from_float(obj.get("tokenCount"))
+        token_type = from_str(obj.get("tokenType"))
+        return CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail(
+            batch_size=batch_size,
+            cost_per_batch=cost_per_batch,
+            token_count=token_count,
+            token_type=token_type,
+        )
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["batchSize"] = to_float(self.batch_size)
+        result["costPerBatch"] = to_float(self.cost_per_batch)
+        result["tokenCount"] = to_float(self.token_count)
+        result["tokenType"] = from_str(self.token_type)
         return result
 
 
@@ -3997,6 +4123,8 @@ class McpServersLoadedServerStatus(Enum):
 class PermissionCompletedKind(Enum):
     "The outcome of the permission request"
     APPROVED = "approved"
+    APPROVED_FOR_SESSION = "approved-for-session"
+    APPROVED_FOR_LOCATION = "approved-for-location"
     DENIED_BY_RULES = "denied-by-rules"
     DENIED_NO_APPROVAL_RULE_AND_COULD_NOT_REQUEST_FROM_USER = "denied-no-approval-rule-and-could-not-request-from-user"
     DENIED_INTERACTIVELY_BY_USER = "denied-interactively-by-user"
@@ -4114,7 +4242,7 @@ class WorkspaceFileChangedOperation(Enum):
     UPDATE = "update"
 
 
-SessionEventData = SessionStartData | SessionResumeData | SessionRemoteSteerableChangedData | SessionErrorData | SessionIdleData | SessionTitleChangedData | SessionInfoData | SessionWarningData | SessionModelChangeData | SessionModeChangedData | SessionPlanChangedData | SessionWorkspaceFileChangedData | SessionHandoffData | SessionTruncationData | SessionSnapshotRewindData | SessionShutdownData | SessionContextChangedData | SessionUsageInfoData | SessionCompactionStartData | SessionCompactionCompleteData | SessionTaskCompleteData | UserMessageData | PendingMessagesModifiedData | AssistantTurnStartData | AssistantIntentData | AssistantReasoningData | AssistantReasoningDeltaData | AssistantStreamingDeltaData | AssistantMessageData | AssistantMessageDeltaData | AssistantTurnEndData | AssistantUsageData | AbortData | ToolUserRequestedData | ToolExecutionStartData | ToolExecutionPartialResultData | ToolExecutionProgressData | ToolExecutionCompleteData | SkillInvokedData | SubagentStartedData | SubagentCompletedData | SubagentFailedData | SubagentSelectedData | SubagentDeselectedData | HookStartData | HookEndData | SystemMessageData | SystemNotificationData | PermissionRequestedData | PermissionCompletedData | UserInputRequestedData | UserInputCompletedData | ElicitationRequestedData | ElicitationCompletedData | SamplingRequestedData | SamplingCompletedData | McpOauthRequiredData | McpOauthCompletedData | ExternalToolRequestedData | ExternalToolCompletedData | CommandQueuedData | CommandExecuteData | CommandCompletedData | CommandsChangedData | CapabilitiesChangedData | ExitPlanModeRequestedData | ExitPlanModeCompletedData | SessionToolsUpdatedData | SessionBackgroundTasksChangedData | SessionSkillsLoadedData | SessionCustomAgentsUpdatedData | SessionMcpServersLoadedData | SessionMcpServerStatusChangedData | SessionExtensionsLoadedData | RawSessionEventData | Data
+SessionEventData = SessionStartData | SessionResumeData | SessionRemoteSteerableChangedData | SessionErrorData | SessionIdleData | SessionTitleChangedData | SessionInfoData | SessionWarningData | SessionModelChangeData | SessionModeChangedData | SessionPlanChangedData | SessionWorkspaceFileChangedData | SessionHandoffData | SessionTruncationData | SessionSnapshotRewindData | SessionShutdownData | SessionContextChangedData | SessionUsageInfoData | SessionCompactionStartData | SessionCompactionCompleteData | SessionTaskCompleteData | UserMessageData | PendingMessagesModifiedData | AssistantTurnStartData | AssistantIntentData | AssistantReasoningData | AssistantReasoningDeltaData | AssistantStreamingDeltaData | AssistantMessageData | AssistantMessageDeltaData | AssistantTurnEndData | AssistantUsageData | AbortData | ToolUserRequestedData | ToolExecutionStartData | ToolExecutionPartialResultData | ToolExecutionProgressData | ToolExecutionCompleteData | SkillInvokedData | SubagentStartedData | SubagentCompletedData | SubagentFailedData | SubagentSelectedData | SubagentDeselectedData | HookStartData | HookEndData | SystemMessageData | SystemNotificationData | PermissionRequestedData | PermissionCompletedData | UserInputRequestedData | UserInputCompletedData | ElicitationRequestedData | ElicitationCompletedData | SamplingRequestedData | SamplingCompletedData | McpOauthRequiredData | McpOauthCompletedData | ExternalToolRequestedData | ExternalToolCompletedData | CommandQueuedData | CommandExecuteData | CommandCompletedData | AutoModeSwitchRequestedData | AutoModeSwitchCompletedData | CommandsChangedData | CapabilitiesChangedData | ExitPlanModeRequestedData | ExitPlanModeCompletedData | SessionToolsUpdatedData | SessionBackgroundTasksChangedData | SessionSkillsLoadedData | SessionCustomAgentsUpdatedData | SessionMcpServersLoadedData | SessionMcpServerStatusChangedData | SessionExtensionsLoadedData | RawSessionEventData | Data
 
 
 @dataclass
@@ -4201,6 +4329,8 @@ class SessionEvent:
             case SessionEventType.COMMAND_QUEUED: data = CommandQueuedData.from_dict(data_obj)
             case SessionEventType.COMMAND_EXECUTE: data = CommandExecuteData.from_dict(data_obj)
             case SessionEventType.COMMAND_COMPLETED: data = CommandCompletedData.from_dict(data_obj)
+            case SessionEventType.AUTO_MODE_SWITCH_REQUESTED: data = AutoModeSwitchRequestedData.from_dict(data_obj)
+            case SessionEventType.AUTO_MODE_SWITCH_COMPLETED: data = AutoModeSwitchCompletedData.from_dict(data_obj)
             case SessionEventType.COMMANDS_CHANGED: data = CommandsChangedData.from_dict(data_obj)
             case SessionEventType.CAPABILITIES_CHANGED: data = CapabilitiesChangedData.from_dict(data_obj)
             case SessionEventType.EXIT_PLAN_MODE_REQUESTED: data = ExitPlanModeRequestedData.from_dict(data_obj)

--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -233,10 +233,6 @@ class PermissionRequestResult:
     """Result of a permission request."""
 
     kind: PermissionRequestResultKind = "user-not-available"
-    rules: list[Any] | None = None
-    feedback: str | None = None
-    message: str | None = None
-    path: str | None = None
 
 
 _PermissionHandlerFn = Callable[
@@ -1453,10 +1449,6 @@ class CopilotSession:
 
             perm_result = PermissionDecision(
                 kind=PermissionDecisionKind(result.kind),
-                rules=result.rules,
-                feedback=result.feedback,
-                message=result.message,
-                path=result.path,
             )
 
             await self.rpc.permissions.handle_pending_permission_request(

--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -221,11 +221,9 @@ SystemMessageConfig = (
 # ============================================================================
 
 PermissionRequestResultKind = Literal[
-    "approved",
-    "denied-by-rules",
-    "denied-by-content-exclusion-policy",
-    "denied-no-approval-rule-and-could-not-request-from-user",
-    "denied-interactively-by-user",
+    "approve-once",
+    "reject",
+    "user-not-available",
     "no-result",
 ]
 
@@ -234,7 +232,7 @@ PermissionRequestResultKind = Literal[
 class PermissionRequestResult:
     """Result of a permission request."""
 
-    kind: PermissionRequestResultKind = "denied-no-approval-rule-and-could-not-request-from-user"
+    kind: PermissionRequestResultKind = "user-not-available"
     rules: list[Any] | None = None
     feedback: str | None = None
     message: str | None = None
@@ -252,7 +250,7 @@ class PermissionHandler:
     def approve_all(
         request: PermissionRequest, invocation: dict[str, str]
     ) -> PermissionRequestResult:
-        return PermissionRequestResult(kind="approved")
+        return PermissionRequestResult(kind="approve-once")
 
 
 # ============================================================================
@@ -1473,7 +1471,7 @@ class CopilotSession:
                     PermissionDecisionRequest(
                         request_id=request_id,
                         result=PermissionDecision(
-                            kind=PermissionDecisionKind.DENIED_NO_APPROVAL_RULE_AND_COULD_NOT_REQUEST_FROM_USER,
+                            kind=PermissionDecisionKind.USER_NOT_AVAILABLE,
                         ),
                     )
                 )

--- a/python/e2e/test_multi_client.py
+++ b/python/e2e/test_multi_client.py
@@ -234,7 +234,7 @@ class TestMultiClientBroadcast:
         # Client 1 creates a session and manually approves permission requests
         session1 = await mctx.client1.create_session(
             on_permission_request=lambda request, invocation: (
-                permission_requests.append(request) or PermissionRequestResult(kind="approved")
+                permission_requests.append(request) or PermissionRequestResult(kind="approve-once")
             ),
         )
 
@@ -280,7 +280,7 @@ class TestMultiClientBroadcast:
         # Client 1 creates a session and denies all permission requests
         session1 = await mctx.client1.create_session(
             on_permission_request=lambda request, invocation: PermissionRequestResult(
-                kind="denied-interactively-by-user"
+                kind="reject"
             ),
         )
 

--- a/python/e2e/test_per_session_auth.py
+++ b/python/e2e/test_per_session_auth.py
@@ -1,0 +1,115 @@
+"""E2E Per-session GitHub auth tests"""
+
+import pytest
+
+from copilot.session import PermissionHandler
+
+from .testharness import E2ETestContext
+
+pytestmark = pytest.mark.asyncio(loop_scope="module")
+
+
+@pytest.fixture(scope="module")
+async def auth_ctx(ctx: E2ETestContext):
+    """Configure per-token user responses on the proxy before tests run."""
+    proxy_url = ctx.proxy_url
+
+    # Redirect GitHub API calls to the proxy so per-session auth token
+    # resolution (fetchCopilotUser) is intercepted. Must be set before the
+    # CLI subprocess is spawned (i.e., before the first create_session call).
+    ctx.client._config.env["COPILOT_DEBUG_GITHUB_API_URL"] = proxy_url
+
+    await ctx.set_copilot_user_by_token(
+        "token-alice",
+        {
+            "login": "alice",
+            "copilot_plan": "individual_pro",
+            "endpoints": {
+                "api": proxy_url,
+                "telemetry": "https://localhost:1/telemetry",
+            },
+            "analytics_tracking_id": "alice-tracking-id",
+        },
+    )
+
+    await ctx.set_copilot_user_by_token(
+        "token-bob",
+        {
+            "login": "bob",
+            "copilot_plan": "business",
+            "endpoints": {
+                "api": proxy_url,
+                "telemetry": "https://localhost:1/telemetry",
+            },
+            "analytics_tracking_id": "bob-tracking-id",
+        },
+    )
+
+    return ctx
+
+
+class TestPerSessionAuth:
+    async def test_should_create_session_with_github_token_and_check_auth_status(
+        self, auth_ctx: E2ETestContext
+    ):
+        session = await auth_ctx.client.create_session(
+            on_permission_request=PermissionHandler.approve_all,
+            github_token="token-alice",
+        )
+
+        auth_status = await session.rpc.auth.get_status()
+        assert auth_status.is_authenticated is True
+        assert auth_status.login == "alice"
+        assert auth_status.copilot_plan == "individual_pro"
+
+        await session.disconnect()
+
+    async def test_should_isolate_auth_between_sessions_with_different_tokens(
+        self, auth_ctx: E2ETestContext
+    ):
+        session_a = await auth_ctx.client.create_session(
+            on_permission_request=PermissionHandler.approve_all,
+            github_token="token-alice",
+        )
+        session_b = await auth_ctx.client.create_session(
+            on_permission_request=PermissionHandler.approve_all,
+            github_token="token-bob",
+        )
+
+        status_a = await session_a.rpc.auth.get_status()
+        status_b = await session_b.rpc.auth.get_status()
+
+        assert status_a.is_authenticated is True
+        assert status_a.login == "alice"
+        assert status_a.copilot_plan == "individual_pro"
+
+        assert status_b.is_authenticated is True
+        assert status_b.login == "bob"
+        assert status_b.copilot_plan == "business"
+
+        await session_a.disconnect()
+        await session_b.disconnect()
+
+    async def test_should_return_unauthenticated_when_no_token_provided(
+        self, auth_ctx: E2ETestContext
+    ):
+        session = await auth_ctx.client.create_session(
+            on_permission_request=PermissionHandler.approve_all,
+        )
+
+        auth_status = await session.rpc.auth.get_status()
+        # Without a per-session token, there is no per-session identity.
+        # In CI the process-level fake token may still authenticate globally,
+        # so we check login rather than is_authenticated.
+        assert auth_status.login is None
+
+        await session.disconnect()
+
+    async def test_should_error_when_creating_session_with_invalid_token(
+        self, auth_ctx: E2ETestContext
+    ):
+        with pytest.raises(Exception):
+            await auth_ctx.client.create_session(
+                on_permission_request=PermissionHandler.approve_all,
+                github_token="invalid-token-12345",
+            )

--- a/python/e2e/test_permissions.py
+++ b/python/e2e/test_permissions.py
@@ -29,7 +29,7 @@ class TestPermissions:
         ) -> PermissionRequestResult:
             permission_requests.append(request)
             assert invocation["session_id"] == session.session_id
-            return PermissionRequestResult(kind="approved")
+            return PermissionRequestResult(kind="approve-once")
 
         session = await ctx.client.create_session(on_permission_request=on_permission_request)
 
@@ -52,7 +52,7 @@ class TestPermissions:
         def on_permission_request(
             request: PermissionRequest, invocation: dict
         ) -> PermissionRequestResult:
-            return PermissionRequestResult(kind="denied-interactively-by-user")
+            return PermissionRequestResult(kind="reject")
 
         session = await ctx.client.create_session(on_permission_request=on_permission_request)
 
@@ -167,7 +167,7 @@ class TestPermissions:
             permission_requests.append(request)
             # Simulate async permission check (e.g., user prompt)
             await asyncio.sleep(0.01)
-            return PermissionRequestResult(kind="approved")
+            return PermissionRequestResult(kind="approve-once")
 
         session = await ctx.client.create_session(on_permission_request=on_permission_request)
 
@@ -193,7 +193,7 @@ class TestPermissions:
             request: PermissionRequest, invocation: dict
         ) -> PermissionRequestResult:
             permission_requests.append(request)
-            return PermissionRequestResult(kind="approved")
+            return PermissionRequestResult(kind="approve-once")
 
         session2 = await ctx.client.resume_session(
             session_id, on_permission_request=on_permission_request
@@ -237,7 +237,7 @@ class TestPermissions:
                 received_tool_call_id = True
                 assert isinstance(request.tool_call_id, str)
                 assert len(request.tool_call_id) > 0
-            return PermissionRequestResult(kind="approved")
+            return PermissionRequestResult(kind="approve-once")
 
         session = await ctx.client.create_session(on_permission_request=on_permission_request)
 

--- a/python/e2e/test_tools.py
+++ b/python/e2e/test_tools.py
@@ -192,6 +192,7 @@ class TestTools:
         def on_permission_request(request, invocation):
             permission_requests.append(request)
             return PermissionRequestResult(kind="approve-once")
+
         session = await ctx.client.create_session(
             on_permission_request=on_permission_request, tools=[encrypt_string]
         )

--- a/python/e2e/test_tools.py
+++ b/python/e2e/test_tools.py
@@ -191,8 +191,7 @@ class TestTools:
 
         def on_permission_request(request, invocation):
             permission_requests.append(request)
-            return PermissionRequestResult(kind="approved")
-
+            return PermissionRequestResult(kind="approve-once")
         session = await ctx.client.create_session(
             on_permission_request=on_permission_request, tools=[encrypt_string]
         )
@@ -219,7 +218,7 @@ class TestTools:
             return params.input.upper()
 
         def on_permission_request(request, invocation):
-            return PermissionRequestResult(kind="denied-interactively-by-user")
+            return PermissionRequestResult(kind="reject")
 
         session = await ctx.client.create_session(
             on_permission_request=on_permission_request, tools=[encrypt_string]

--- a/python/e2e/testharness/context.py
+++ b/python/e2e/testharness/context.py
@@ -9,6 +9,7 @@ import re
 import shutil
 import tempfile
 from pathlib import Path
+from typing import Any
 
 from copilot import CopilotClient
 from copilot.client import SubprocessConfig
@@ -144,6 +145,12 @@ class E2ETestContext:
         if not self._client:
             raise RuntimeError("Context not set up. Call setup() first.")
         return self._client
+
+    async def set_copilot_user_by_token(self, token: str, response: dict[str, Any]) -> None:
+        """Register a per-token response for the /copilot_internal/user endpoint."""
+        if not self._proxy:
+            raise RuntimeError("Proxy not started")
+        await self._proxy.set_copilot_user_by_token(token, response)
 
     async def get_exchanges(self):
         """Retrieve the captured HTTP exchanges from the proxy."""

--- a/python/e2e/testharness/proxy.py
+++ b/python/e2e/testharness/proxy.py
@@ -106,6 +106,18 @@ class CapiProxy:
             resp = await client.get(f"{self._proxy_url}/exchanges")
             return resp.json()
 
+    async def set_copilot_user_by_token(self, token: str, response: dict[str, Any]) -> None:
+        """Register a per-token response for /copilot_internal/user."""
+        if not self._proxy_url:
+            raise RuntimeError("Proxy not started")
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{self._proxy_url}/copilot-user-config",
+                json={"token": token, "response": response},
+            )
+            assert resp.status_code == 200
+
     @property
     def url(self) -> str | None:
         """Return the proxy URL, or None if not started."""

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -405,6 +405,17 @@ function findDiscriminator(variants: JSONSchema7[]): { property: string; mapping
     return null;
 }
 
+/** Callback that resolves the C# type for a property schema within a polymorphic class. */
+type PropertyTypeResolver = (
+    propSchema: JSONSchema7,
+    parentClassName: string,
+    propName: string,
+    isRequired: boolean,
+    knownTypes: Map<string, string>,
+    nestedClasses: Map<string, string>,
+    enumOutput: string[]
+) => string;
+
 /**
  * Generate a polymorphic base class and derived classes for a discriminated union.
  */
@@ -415,8 +426,10 @@ function generatePolymorphicClasses(
     knownTypes: Map<string, string>,
     nestedClasses: Map<string, string>,
     enumOutput: string[],
-    description?: string
+    description?: string,
+    propertyResolver?: PropertyTypeResolver
 ): string {
+    const resolver = propertyResolver ?? resolveSessionPropertyType;
     const lines: string[] = [];
     const discriminatorInfo = findDiscriminator(variants)!;
     const renamedBase = applyTypeRename(baseClassName);
@@ -441,7 +454,7 @@ function generatePolymorphicClasses(
 
     for (const [constValue, variant] of discriminatorInfo.mapping) {
         const derivedClassName = applyTypeRename(`${baseClassName}${toPascalCase(constValue)}`);
-        const derivedCode = generateDerivedClass(derivedClassName, renamedBase, discriminatorProperty, constValue, variant, knownTypes, nestedClasses, enumOutput);
+        const derivedCode = generateDerivedClass(derivedClassName, renamedBase, discriminatorProperty, constValue, variant, knownTypes, nestedClasses, enumOutput, resolver);
         nestedClasses.set(derivedClassName, derivedCode);
     }
 
@@ -459,7 +472,8 @@ function generateDerivedClass(
     schema: JSONSchema7,
     knownTypes: Map<string, string>,
     nestedClasses: Map<string, string>,
-    enumOutput: string[]
+    enumOutput: string[],
+    propertyResolver: PropertyTypeResolver
 ): string {
     const lines: string[] = [];
     const required = new Set(schema.required || []);
@@ -480,7 +494,7 @@ function generateDerivedClass(
 
             const isReq = required.has(propName);
             const csharpName = toPascalCase(propName);
-            const csharpType = resolveSessionPropertyType(propSchema as JSONSchema7, className, csharpName, isReq, knownTypes, nestedClasses, enumOutput);
+            const csharpType = propertyResolver(propSchema as JSONSchema7, className, csharpName, isReq, knownTypes, nestedClasses, enumOutput);
 
             lines.push(...xmlDocPropertyComment((propSchema as JSONSchema7).description, propName, "    "));
             lines.push(...emitDataAnnotations(propSchema as JSONSchema7, "    "));
@@ -901,7 +915,15 @@ function resolveRpcType(schema: JSONSchema7, isRequired: boolean, parentClassNam
                 if (!emittedRpcClassSchemas.has(baseClassName)) {
                     emittedRpcClassSchemas.set(baseClassName, "polymorphic");
                     const nestedMap = new Map<string, string>();
-                    const polymorphicCode = generatePolymorphicClasses(baseClassName, discriminatorInfo.property, variants, rpcKnownTypes, nestedMap, rpcEnumOutput, schema.description);
+                    const rpcPropertyResolver: PropertyTypeResolver = (propSchema, parentClass, pName, isReq, _kt, nestedCls, enumOut) => {
+                        const nestedRpcClasses: string[] = [];
+                        const result = resolveRpcType(propSchema, isReq, parentClass, pName, nestedRpcClasses);
+                        for (const cls of nestedRpcClasses) {
+                            nestedCls.set(cls.match(/class (\w+)/)?.[1] ?? cls.slice(0, 40), cls);
+                        }
+                        return result;
+                    };
+                    const polymorphicCode = generatePolymorphicClasses(baseClassName, discriminatorInfo.property, variants, rpcKnownTypes, nestedMap, rpcEnumOutput, schema.description, rpcPropertyResolver);
                     classes.push(polymorphicCode);
                     for (const nested of nestedMap.values()) classes.push(nested);
                 }

--- a/scripts/codegen/go.ts
+++ b/scripts/codegen/go.ts
@@ -250,6 +250,12 @@ function schemaSourceForNamedDefinition(
     if (schema?.$ref && resolvedSchema) {
         return resolvedSchema;
     }
+    // When the schema is an anyOf/oneOf wrapper (e.g., Zod optional params producing
+    // `anyOf: [{ not: {} }, { $ref }]`), use the resolved object schema to avoid
+    // generating self-referential type aliases that crash quicktype.
+    if ((schema?.anyOf || schema?.oneOf) && resolvedSchema?.properties) {
+        return resolvedSchema;
+    }
     return schema ?? resolvedSchema ?? { type: "object" };
 }
 

--- a/scripts/codegen/python.ts
+++ b/scripts/codegen/python.ts
@@ -408,6 +408,12 @@ function schemaSourceForNamedDefinition(
     if (schema?.$ref && resolvedSchema) {
         return resolvedSchema;
     }
+    // When the schema is an anyOf/oneOf wrapper (e.g., Zod optional params producing
+    // `anyOf: [{ not: {} }, { $ref }]`), use the resolved object schema to avoid
+    // generating self-referential type aliases that crash quicktype.
+    if ((schema?.anyOf || schema?.oneOf) && resolvedSchema?.properties) {
+        return resolvedSchema;
+    }
     return schema ?? resolvedSchema ?? { type: "object" };
 }
 
@@ -436,6 +442,19 @@ function pythonResultTypeName(method: RpcMethod, schemaOverride?: JSONSchema7): 
         if (refName) return toPascalCase(refName);
     }
     return getRpcSchemaTypeName(schema, toPascalCase(method.rpcMethod) + "Result");
+}
+
+/** Detect the Zod optional params pattern: `anyOf: [{ not: {} }, { $ref }]` */
+function isParamsOptional(method: RpcMethod): boolean {
+    const schema = method.params;
+    if (!schema?.anyOf) return false;
+    return schema.anyOf.some(
+        (item) =>
+            typeof item === "object" &&
+            (item as JSONSchema7).not !== undefined &&
+            typeof (item as JSONSchema7).not === "object" &&
+            Object.keys((item as JSONSchema7).not as object).length === 0
+    );
 }
 
 function pythonParamsTypeName(method: RpcMethod): string {
@@ -1813,8 +1832,9 @@ def _patch_model_capabilities(data: dict) -> dict:
         `ModelList.from_dict(_patch_model_capabilities(await self._client.request("models.list"`,
     );
     // Close the extra paren opened by _patch_model_capabilities(
+    // Match everything from _patch_model_capabilities( up to the end of the return statement
     finalCode = finalCode.replace(
-        /(_patch_model_capabilities\(await self\._client\.request\("models\.list",\s*\{[^)]*\)[^)]*\))/,
+        /(_patch_model_capabilities\(await self\._client\.request\("models\.list"[^)]*\)[^)]*\))/,
         "$1)",
     );
     finalCode = unwrapRedundantPythonLambdas(finalCode);
@@ -1943,10 +1963,13 @@ function emitMethod(lines: string[], name: string, method: RpcMethod, isSession:
     const nonSessionParams = Object.keys(paramProps).filter((k) => k !== "sessionId");
     const hasParams = isSession ? nonSessionParams.length > 0 : hasSchemaPayload(effectiveParams);
     const paramsType = resolveType(pythonParamsTypeName(method));
+    const paramsOptional = isParamsOptional(method);
 
     // Build signature with typed params + optional timeout
     const sig = hasParams
-        ? `    async def ${methodName}(self, params: ${paramsType}, *, timeout: float | None = None) -> ${resultType}:`
+        ? paramsOptional
+            ? `    async def ${methodName}(self, params: ${paramsType} | None = None, *, timeout: float | None = None) -> ${resultType}:`
+            : `    async def ${methodName}(self, params: ${paramsType}, *, timeout: float | None = None) -> ${resultType}:`
         : `    async def ${methodName}(self, *, timeout: float | None = None) -> ${resultType}:`;
 
     lines.push(sig);
@@ -1986,7 +2009,11 @@ function emitMethod(lines: string[], name: string, method: RpcMethod, isSession:
 
     if (isSession) {
         if (hasParams) {
-            lines.push(`        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}`);
+            if (paramsOptional) {
+                lines.push(`        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}`);
+            } else {
+                lines.push(`        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}`);
+            }
             lines.push(`        params_dict["sessionId"] = self._session_id`);
             emitRequestCall("params_dict");
         } else {
@@ -1994,7 +2021,11 @@ function emitMethod(lines: string[], name: string, method: RpcMethod, isSession:
         }
     } else {
         if (hasParams) {
-            lines.push(`        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}`);
+            if (paramsOptional) {
+                lines.push(`        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}`);
+            } else {
+                lines.push(`        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}`);
+            }
             emitRequestCall("params_dict");
         } else {
             emitRequestCall("{}");

--- a/scripts/codegen/typescript.ts
+++ b/scripts/codegen/typescript.ts
@@ -235,6 +235,12 @@ function schemaSourceForNamedDefinition(
     if (schema?.$ref && resolvedSchema) {
         return resolvedSchema;
     }
+    // When the schema is an anyOf/oneOf wrapper (e.g., Zod optional params producing
+    // `anyOf: [{ not: {} }, { $ref }]`), use the resolved object schema to avoid
+    // generating self-referential type aliases.
+    if ((schema?.anyOf || schema?.oneOf) && resolvedSchema?.properties) {
+        return resolvedSchema;
+    }
     return schema ?? resolvedSchema ?? { type: "object" };
 }
 
@@ -248,6 +254,19 @@ function getMethodParamsSchema(method: RpcMethod): JSONSchema7 | undefined {
         resolveSchema(method.params, rpcDefinitions) ??
         method.params ??
         undefined
+    );
+}
+
+/** True when the raw params schema uses `anyOf: [{ not: {} }, …]` — Zod's pattern for `.optional()`. */
+function isParamsOptional(method: RpcMethod): boolean {
+    const schema = method.params;
+    if (!schema?.anyOf) return false;
+    return schema.anyOf.some(
+        (item) =>
+            typeof item === "object" &&
+            (item as JSONSchema7).not !== undefined &&
+            typeof (item as JSONSchema7).not === "object" &&
+            Object.keys((item as JSONSchema7).not as object).length === 0
     );
 }
 
@@ -460,14 +479,18 @@ function emitGroup(node: Record<string, unknown>, indent: string, isSession: boo
 
             if (isSession) {
                 if (hasNonSessionParams) {
-                    sigParams.push(`params: Omit<${paramsType}, "sessionId">`);
+                    const optMark = isParamsOptional(value) ? "?" : "";
+                    // sessionId is already stripped from the generated type definition,
+                    // so no need for Omit<..., "sessionId">
+                    sigParams.push(`params${optMark}: ${paramsType}`);
                     bodyArg = "{ sessionId, ...params }";
                 } else {
                     bodyArg = "{ sessionId }";
                 }
             } else {
                 if (hasParams) {
-                    sigParams.push(`params: ${paramsType}`);
+                    const optMark = isParamsOptional(value) ? "?" : "";
+                    sigParams.push(`params${optMark}: ${paramsType}`);
                     bodyArg = "params";
                 } else {
                     bodyArg = "{}";

--- a/scripts/codegen/utils.ts
+++ b/scripts/codegen/utils.ts
@@ -482,7 +482,11 @@ export function resolveObjectSchema(
     }
 
     const singleBranch = (resolved.anyOf ?? resolved.oneOf)
-        ?.filter((item): item is JSONSchema7 => typeof item === "object" && (item as JSONSchema7).type !== "null");
+        ?.filter((item): item is JSONSchema7 =>
+            typeof item === "object" &&
+            (item as JSONSchema7).type !== "null" &&
+            !((item as JSONSchema7).not !== undefined && typeof (item as JSONSchema7).not === "object" && Object.keys((item as JSONSchema7).not as object).length === 0)
+        );
     if (singleBranch && singleBranch.length === 1) {
         return resolveObjectSchema(singleBranch[0], definitions);
     }

--- a/scripts/codegen/utils.ts
+++ b/scripts/codegen/utils.ts
@@ -482,11 +482,14 @@ export function resolveObjectSchema(
     }
 
     const singleBranch = (resolved.anyOf ?? resolved.oneOf)
-        ?.filter((item): item is JSONSchema7 =>
-            typeof item === "object" &&
-            (item as JSONSchema7).type !== "null" &&
-            !((item as JSONSchema7).not !== undefined && typeof (item as JSONSchema7).not === "object" && Object.keys((item as JSONSchema7).not as object).length === 0)
-        );
+        ?.filter((item): item is JSONSchema7 => {
+            if (!item || typeof item !== "object") return false;
+            const s = item as JSONSchema7;
+            // Filter out null types and `{ not: {} }` (Zod's representation of "nothing" in optional anyOf)
+            if (s.type === "null") return false;
+            if (s.not && typeof s.not === "object" && Object.keys(s.not).length === 0) return false;
+            return true;
+        });
     if (singleBranch && singleBranch.length === 1) {
         return resolveObjectSchema(singleBranch[0], definitions);
     }

--- a/test/harness/replayingCapiProxy.ts
+++ b/test/harness/replayingCapiProxy.ts
@@ -57,6 +57,14 @@ export class ReplayingCapiProxy extends CapturingHttpProxy {
   ];
 
   /**
+   * Per-token responses for `/copilot_internal/user` endpoint.
+   * Key is the Bearer token (without "Bearer " prefix), value is the response body.
+   * When a request arrives with `Authorization: Bearer <token>`, the matching response is returned.
+   * If no match is found, a 401 Unauthorized response is returned.
+   */
+  private copilotUserByToken = new Map<string, CopilotUserResponse>();
+
+  /**
    * If true, cached responses are played back slowly (~ 2KiB/sec). Otherwise streaming responses are sent as fast as possible.
    */
   slowStreaming = false;
@@ -139,6 +147,14 @@ export class ReplayingCapiProxy extends CapturingHttpProxy {
     this.state.toolResultNormalizers.push({ toolName, normalizer });
   }
 
+  /**
+   * Register a per-token response for the `/copilot_internal/user` endpoint.
+   * When a request with `Authorization: Bearer <token>` arrives, the matching response is returned.
+   */
+  setCopilotUserByToken(token: string, response: CopilotUserResponse): void {
+    this.copilotUserByToken.set(token, response);
+  }
+
   override performRequest(options: PerformRequestOptions): void {
     void iife(async () => {
       const commonResponseHeaders = {
@@ -146,6 +162,18 @@ export class ReplayingCapiProxy extends CapturingHttpProxy {
       };
 
       try {
+        // Handle /copilot-user-config endpoint for configuring per-token user responses
+        if (
+          options.requestOptions.path === "/copilot-user-config" &&
+          options.requestOptions.method === "POST"
+        ) {
+          const config = JSON.parse(options.body!) as { token: string; response: CopilotUserResponse };
+          this.copilotUserByToken.set(config.token, config.response);
+          options.onResponseStart(200, {});
+          options.onResponseEnd();
+          return;
+        }
+
         // Handle /config endpoint for updating proxy configuration
         if (
           options.requestOptions.path === "/config" &&
@@ -214,6 +242,27 @@ export class ReplayingCapiProxy extends CapturingHttpProxy {
           options.onResponseStart(200, headers);
           options.onData(Buffer.from(body));
           options.onResponseEnd();
+          return;
+        }
+
+        // Handle /copilot_internal/user endpoint for per-session auth
+        if (options.requestOptions.path === "/copilot_internal/user") {
+          const authHeader = options.requestOptions.headers?.["authorization"] as string | undefined;
+          const token = authHeader?.replace("Bearer ", "");
+          const userResponse = token ? this.copilotUserByToken.get(token) : undefined;
+          if (userResponse) {
+            const headers = {
+              "content-type": "application/json",
+              ...commonResponseHeaders,
+            };
+            options.onResponseStart(200, headers);
+            options.onData(Buffer.from(JSON.stringify(userResponse)));
+            options.onResponseEnd();
+          } else {
+            options.onResponseStart(401, commonResponseHeaders);
+            options.onData(Buffer.from(JSON.stringify({ message: "Bad credentials" })));
+            options.onResponseEnd();
+          }
           return;
         }
 
@@ -1111,6 +1160,20 @@ function excludeFailedResponses(exchange: CapturedExchange): boolean {
 export type ToolResultNormalizer = {
   toolName: string;
   normalizer: (result: string) => string;
+};
+
+/**
+ * Response shape for the `/copilot_internal/user` endpoint.
+ * Used by per-session auth tests to mock GitHub identity resolution.
+ */
+export type CopilotUserResponse = {
+  login: string;
+  copilot_plan?: string;
+  endpoints?: {
+    api?: string;
+    telemetry?: string;
+  };
+  analytics_tracking_id?: string;
 };
 
 export type ParsedHttpExchange = {

--- a/test/snapshots/session/should_set_model_with_reasoningeffort.yaml
+++ b/test/snapshots/session/should_set_model_with_reasoningeffort.yaml
@@ -1,0 +1,8 @@
+models:
+  - claude-sonnet-4.5
+conversations:
+  - messages:
+      - role: system
+        content: ${system}
+      - role: user
+        content: Run 'sleep 2 && echo done'


### PR DESCRIPTION
## Summary

Adds per-session GitHub authentication support across all SDK languages (Node, Python, Go, C#). This allows SDK clients to pass a githubToken when creating a session, so each session can authenticate as a distinct GitHub user instead of sharing the process-level auth.

## Changes

### Node SDK
- Added \githubToken\ parameter to \SessionCreateParams\ and \SessionResumeParams\
- E2E tests for per-session auth flow

### Python SDK
- Updated codegen output with \githubToken\ in session create/resume params
- E2E tests for per-session auth flow
- Fixed codegen closing-paren regex for \_patch_model_capabilities\

### Go SDK
- Updated codegen output with \GithubToken\ field in session create/resume params
- E2E tests for per-session auth flow

### C# SDK
- Updated codegen output with \GithubToken\ property in session create/resume params
- E2E tests for per-session auth flow
- Fixed AOT-safe JSON serialization in test harness (typed records instead of anonymous objects)

### Codegen
- Python codegen: fixed regex for \_patch_model_capabilities\ closing paren to handle \params_dict\

## Testing

All languages have E2E tests that verify:
1. Creating a session with a per-session GitHub token
2. The token is resolved to a Copilot user identity
3. The session uses the per-session identity for quota lookups

> **Note:** CI will fail until the corresponding runtime changes are deployed, since the runtime needs to accept the new \githubToken\ parameter.
