### PR TITLE
fix(dotnet): Add AOT-safe SetForegroundSessionRequest for SetForegroundSessionIdAsync()

### DIFF
--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -942,7 +942,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         var connection = await EnsureConnectedAsync(cancellationToken);
 
         var response = await InvokeRpcAsync<SetForegroundSessionResponse>(
-            connection.Rpc, "session.setForeground", [new { sessionId }], cancellationToken);
+            connection.Rpc, "session.setForeground", [new SetForegroundSessionRequest(sessionId)], cancellationToken);
 
         if (!response.Success)
         {
@@ -1753,6 +1753,9 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     internal record GetSessionMetadataResponse(
         SessionMetadata? Session);
 
+    internal record SetForegroundSessionRequest(
+        string SessionId);
+
     internal record UserInputRequestResponse(
         string Answer,
         bool WasFreeform);
@@ -1871,6 +1874,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     [JsonSerializable(typeof(SessionCapabilities))]
     [JsonSerializable(typeof(SessionUiCapabilities))]
     [JsonSerializable(typeof(SessionMetadata))]
+    [JsonSerializable(typeof(SetForegroundSessionRequest))]
     [JsonSerializable(typeof(SystemMessageConfig))]
     [JsonSerializable(typeof(SystemMessageTransformRpcResponse))]
     [JsonSerializable(typeof(CommandWireDefinition))]


### PR DESCRIPTION
## Current State

The current code in `SetForegroundSessionIdAsync()`, used to set the terminal foreground session ID, is not AOT-safe.

The code uses an anonymous type `new { sessionId }` to construct the request:

```csharp
var response = await InvokeRpcAsync<SetForegroundSessionResponse>(
    connection.Rpc, "session.setForeground", [new { sessionId }], cancellationToken);
```

That anonymous type is not registered in `ClientJsonContext`, so this will fail at runtime before the RPC is sent.

## Fix/Changes

This can be updated to use a new source-generated `SetForegroundSessionRequest`:

```csharp
var response = await InvokeRpcAsync<SetForegroundSessionResponse>(
    connection.Rpc, "session.setForeground", [new SetForegroundSessionRequest(sessionId)], cancellationToken);
```

Other functions do this too:

```csharp
var response = await InvokeRpcAsync<GetSessionMetadataResponse>(
    connection.Rpc, "session.getMetadata", [new GetSessionMetadataRequest(sessionId)], cancellationToken);
var response = await InvokeRpcAsync<ListSessionsResponse>(
    connection.Rpc, "session.list", [new ListSessionsRequest(filter)], cancellationToken);
var response = await InvokeRpcAsync<DeleteSessionResponse>(
    connection.Rpc, "session.delete", [new DeleteSessionRequest(sessionId)], cancellationToken);
```

With the necessary JSON attribute and constructor, following the patterns of the surrounding code:

```csharp
[JsonSerializable(typeof(SetForegroundSessionRequest))]

internal record SetForegroundSessionRequest(
    string SessionId);
```

## Testing

Made the change locally and verified that it now works as expected with no error, correctly switching the terminal to the correct session.


## Context

I did see in `CONTRIBUTING.md` that there should be a link to an issue, but I just encountered this bug and the fix is both small, and has surrounding code matching it.

## Error

The error is below, but also find attached a simple `dotnet run` script to reproduce the error:

[PR_SetForegroundSessionRequest.cs](https://github.com/user-attachments/files/27101911/PR_SetForegroundSessionRequest.cs)

```
System.Text.Json.JsonException: An error occured during serialization.
 ---> System.NotSupportedException: JsonTypeInfo metadata for type '<>f__AnonymousType0`1[System.String]' was not provided by TypeInfoResolver of type '[GitHub.Copilot.SDK.CopilotClient+ClientJsonContext, GitHub.Copilot.SDK.TypesJsonContext, GitHub.Copilot.SDK.CopilotSession+SessionJsonContext, GitHub.Copilot.SDK.SessionEventsJsonContext, GitHub.Copilot.SDK.Rpc.RpcJsonContext, GitHub.Copilot.SDK.CopilotClient+RequestIdTypeInfoResolver]'. If using source generation, ensure that all root types passed to the serializer have been annotated with 'JsonSerializableAttribute', along with any types that might be serialized polymorphically.
   at System.Text.Json.ThrowHelper.ThrowNotSupportedException_NoMetadataForType(Type type, IJsonTypeInfoResolver resolver)
   at System.Text.Json.JsonSerializerOptions.GetTypeInfoInternal(Type type, Boolean ensureConfigured, Nullable`1 ensureNotNull, Boolean resolveIfMutable, Boolean fallBackToNearestAncestorType)
   at System.Text.Json.JsonSerializerOptions.GetTypeInfoForRootType(Type type, Boolean fallBackToNearestAncestorType)
   at System.Text.Json.JsonSerializerOptions.TryGetPolymorphicTypeInfoForRootType(Object rootValue, JsonTypeInfo& polymorphicTypeInfo)
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.Serialize(Utf8JsonWriter writer, T& rootValue, Object rootValueBoxed)
   at System.Text.Json.JsonSerializer.Serialize[TValue](Utf8JsonWriter writer, TValue value, JsonSerializerOptions options)
   at StreamJsonRpc.SystemTextJsonFormatter.<Serialize>g__WriteUserData|18_5(Object value, Type declaredType, <>c__DisplayClass18_0&, <>c__DisplayClass18_1&)
   at StreamJsonRpc.SystemTextJsonFormatter.<Serialize>g__WriteArguments|18_2(JsonRpcRequest request, <>c__DisplayClass18_0&, <>c__DisplayClass18_1&)
   at StreamJsonRpc.SystemTextJsonFormatter.Serialize(IBufferWriter`1 bufferWriter, JsonRpcMessage message)
   --- End of inner exception stack trace ---
   at StreamJsonRpc.SystemTextJsonFormatter.Serialize(IBufferWriter`1 bufferWriter, JsonRpcMessage message)
   at StreamJsonRpc.HeaderDelimitedMessageHandler.Write(JsonRpcMessage content, CancellationToken cancellationToken)
   at StreamJsonRpc.PipeMessageHandler.WriteCoreAsync(JsonRpcMessage content, CancellationToken cancellationToken)
   at StreamJsonRpc.MessageHandlerBase.WriteAsync(JsonRpcMessage content, CancellationToken cancellationToken)
   at StreamJsonRpc.JsonRpc.SendAsync(JsonRpcMessage message, CancellationToken cancellationToken)
   at StreamJsonRpc.JsonRpc.InvokeCoreAsync(JsonRpcRequest request, Type expectedResultType, CancellationToken cancellationToken)
   at StreamJsonRpc.JsonRpc.InvokeCoreAsync[TResult](RequestId id, String targetName, IReadOnlyList`1 arguments, IReadOnlyList`1 positionalArgumentDeclaredTypes, IReadOnlyDictionary`2 namedArgumentDeclaredTypes, CancellationToken cancellationToken, Boolean isParameterObject)
   at GitHub.Copilot.SDK.CopilotClient.InvokeRpcAsync[T](JsonRpc rpc, String method, Object[] args, StringBuilder stderrBuffer, CancellationToken cancellationToken)
   at GitHub.Copilot.SDK.CopilotClient.InvokeRpcAsync[T](JsonRpc rpc, String method, Object[] args, CancellationToken cancellationToken)
   at GitHub.Copilot.SDK.CopilotClient.SetForegroundSessionIdAsync(String sessionId, CancellationToken cancellationToken)
   ...
```
