### PR TITLE
docs: add copilot-sdk-supercharged (40 languages) to community SDK listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Please use the [GitHub Issues](https://github.com/github/copilot-sdk/issues) pag
 | **Rust**    | [copilot-community-sdk/copilot-sdk-rust][sdk-rust]       |
 | **Clojure** | [copilot-community-sdk/copilot-sdk-clojure][sdk-clojure] |
 | **C++**     | [0xeb/copilot-sdk-cpp][sdk-cpp]                          |
-| **17+ languages** (Ruby, PHP, Swift, Kotlin, Dart, Scala, R, Perl, Lua, Shell, Elixir, Haskell, C, and more) | [jeremiahjordanisaacson/copilot-sdk-supercharged][sdk-supercharged] |
+| **40 languages** (Java, Ruby, PHP, Swift, Kotlin, C++, C, Dart, Scala, R, Perl, Lua, Shell, Elixir, Haskell, Clojure, F#, Rust, and 22 more) | [jeremiahjordanisaacson/copilot-sdk-supercharged][sdk-supercharged] |
 
 [sdk-rust]: https://github.com/copilot-community-sdk/copilot-sdk-rust
 [sdk-cpp]: https://github.com/0xeb/copilot-sdk-cpp

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Please use the [GitHub Issues](https://github.com/github/copilot-sdk/issues) pag
 | **Rust**    | [copilot-community-sdk/copilot-sdk-rust][sdk-rust]       |
 | **Clojure** | [copilot-community-sdk/copilot-sdk-clojure][sdk-clojure] |
 | **C++**     | [0xeb/copilot-sdk-cpp][sdk-cpp]                          |
-| **40 languages** (Java, Ruby, PHP, Swift, Kotlin, C++, C, Dart, Scala, R, Perl, Lua, Shell, Elixir, Haskell, Clojure, F#, Rust, and 22 more) | [jeremiahjordanisaacson/copilot-sdk-supercharged][sdk-supercharged] |
+| **Multi-language** | [jeremiahjordanisaacson/copilot-sdk-supercharged][sdk-supercharged] |
 
 [sdk-rust]: https://github.com/copilot-community-sdk/copilot-sdk-rust
 [sdk-cpp]: https://github.com/0xeb/copilot-sdk-cpp

--- a/README.md
+++ b/README.md
@@ -138,10 +138,12 @@ Please use the [GitHub Issues](https://github.com/github/copilot-sdk/issues) pag
 | **Rust**    | [copilot-community-sdk/copilot-sdk-rust][sdk-rust]       |
 | **Clojure** | [copilot-community-sdk/copilot-sdk-clojure][sdk-clojure] |
 | **C++**     | [0xeb/copilot-sdk-cpp][sdk-cpp]                          |
+| **17+ languages** (Ruby, PHP, Swift, Kotlin, Dart, Scala, R, Perl, Lua, Shell, Elixir, Haskell, C, and more) | [jeremiahjordanisaacson/copilot-sdk-supercharged][sdk-supercharged] |
 
 [sdk-rust]: https://github.com/copilot-community-sdk/copilot-sdk-rust
 [sdk-cpp]: https://github.com/0xeb/copilot-sdk-cpp
 [sdk-clojure]: https://github.com/copilot-community-sdk/copilot-sdk-clojure
+[sdk-supercharged]: https://github.com/jeremiahjordanisaacson/copilot-sdk-supercharged
 
 ## Contributing
 


### PR DESCRIPTION
Adds [copilot-sdk-supercharged](https://github.com/jeremiahjordanisaacson/copilot-sdk-supercharged) to the Unofficial, Community-maintained SDKs table.

This project extends the Copilot SDK to **40 programming languages** — including Java, Rust, Ruby, PHP, Swift, Kotlin, C++, C, Dart, Scala, R, Perl, Lua, Shell/Bash, Elixir, Haskell, Clojure, F#, and many more. Each SDK follows the same JSON-RPC architecture as the official SDKs and is published to its respective package registry.

- **15,000+ total downloads** across 17 registries (npm, PyPI, NuGet, crates.io, RubyGems, Maven Central, Hex.pm, Clojars, and more)
- Full v2.0 feature parity: SessionFs, idle timeout, skills, session metadata, commands/elicitation, streaming, infinite sessions
- Cookbooks, examples, and per-language README documentation

The table entry uses a stable `Multi-language` label per [reviewer feedback](https://github.com/github/copilot-sdk/pull/1155#discussion_r3157188037) — the linked repo is the source of truth for the full supported-language list.

Per the CONTRIBUTING.md guidance: *'if you want to create a Copilot SDK for another language, we'd love to hear from you and may offer to link to your SDK from our repo.'*

Closes #1154