### PR TITLE
Replace StreamJsonRpc with a custom JSON-RPC implementation in the .NET SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 # Documentation validation output
 docs/.validation/
 .DS_Store
+
+# Visual Studio
+.vs/

--- a/dotnet/.gitignore
+++ b/dotnet/.gitignore
@@ -16,7 +16,6 @@ src/build/GitHub.Copilot.SDK.props
 *.sln.docstates
 
 # IDE
-.vs/
 .vscode/
 *.swp
 *~

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -10,7 +10,6 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.102" />
-    <PackageVersion Include="StreamJsonRpc" Version="2.24.84" />
     <PackageVersion Include="System.Text.Json" Version="10.0.2" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -5,8 +5,6 @@
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using StreamJsonRpc;
-using StreamJsonRpc.Protocol;
 using System.Collections.Concurrent;
 using System.Data;
 using System.Diagnostics;
@@ -80,7 +78,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     private readonly List<Action<SessionLifecycleEvent>> _lifecycleHandlers = [];
     private readonly Dictionary<string, List<Action<SessionLifecycleEvent>>> _typedLifecycleHandlers = [];
     private readonly object _lifecycleHandlersLock = new();
-    private ServerRpc? _rpc;
+    private ServerRpc? _serverRpc;
 
     /// <summary>
     /// Gets the typed RPC client for server-scoped methods (no session required).
@@ -92,7 +90,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     /// <exception cref="InvalidOperationException">Thrown if the client is not started.</exception>
     public ServerRpc Rpc => _disposed
         ? throw new ObjectDisposedException(nameof(CopilotClient))
-        : _rpc ?? throw new InvalidOperationException("Client is not started. Call StartAsync first.");
+        : _serverRpc ?? throw new InvalidOperationException("Client is not started. Call StartAsync first.");
 
     /// <summary>
     /// Gets the actual TCP port the CLI server is listening on, if using TCP transport.
@@ -341,18 +339,12 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         catch (Exception ex) { errors?.Add(ex); }
 
         // Clear RPC and models cache
-        _rpc = null;
+        _serverRpc = null;
         _modelsCache = null;
 
         if (ctx.NetworkStream is not null)
         {
             try { await ctx.NetworkStream.DisposeAsync(); }
-            catch (Exception ex) { errors?.Add(ex); }
-        }
-
-        if (ctx.TcpClient is not null)
-        {
-            try { ctx.TcpClient.Dispose(); }
             catch (Exception ex) { errors?.Add(ex); }
         }
 
@@ -1059,9 +1051,9 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     {
         try
         {
-            return await rpc.InvokeWithCancellationAsync<T>(method, args, cancellationToken);
+            return await rpc.InvokeAsync<T>(method, args, cancellationToken);
         }
-        catch (StreamJsonRpc.ConnectionLostException ex)
+        catch (ConnectionLostException ex)
         {
             string? stderrOutput = null;
             if (stderrBuffer is not null)
@@ -1078,7 +1070,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             }
             throw new IOException($"Communication error with Copilot CLI: {ex.Message}", ex);
         }
-        catch (StreamJsonRpc.RemoteRpcException ex)
+        catch (RemoteRpcException ex)
         {
             throw new IOException($"Communication error with Copilot CLI: {ex.Message}", ex);
         }
@@ -1329,12 +1321,15 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     private async Task<Connection> ConnectToServerAsync(Process? cliProcess, string? tcpHost, int? tcpPort, StringBuilder? stderrBuffer, CancellationToken cancellationToken)
     {
         Stream inputStream, outputStream;
-        TcpClient? tcpClient = null;
         NetworkStream? networkStream = null;
 
         if (_options.UseStdio)
         {
-            if (cliProcess == null) throw new InvalidOperationException("CLI process not started");
+            if (cliProcess == null)
+            {
+                throw new InvalidOperationException("CLI process not started");
+            }
+
             inputStream = cliProcess.StandardOutput.BaseStream;
             outputStream = cliProcess.StandardInput.BaseStream;
         }
@@ -1345,33 +1340,38 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 throw new InvalidOperationException("Cannot connect because TCP host or port are not available");
             }
 
-            tcpClient = new();
-            await tcpClient.ConnectAsync(tcpHost, tcpPort.Value, cancellationToken);
-            networkStream = tcpClient.GetStream();
-            inputStream = networkStream;
-            outputStream = networkStream;
+            var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+            try
+            {
+                await socket.ConnectAsync(tcpHost, tcpPort.Value, cancellationToken);
+            }
+            catch
+            {
+                socket.Dispose();
+                throw;
+            }
+
+            inputStream = outputStream = networkStream = new NetworkStream(socket, ownsSocket: true);
         }
 
-        var rpc = new JsonRpc(new HeaderDelimitedMessageHandler(
+        var rpc = new JsonRpc(
             outputStream,
             inputStream,
-            CreateSystemTextJsonFormatter()))
-        {
-            TraceSource = new LoggerTraceSource(_logger),
-        };
+            SerializerOptionsForMessageFormatter,
+            _logger);
 
         var handler = new RpcHandler(this);
-        rpc.AddLocalRpcMethod("session.event", handler.OnSessionEvent);
-        rpc.AddLocalRpcMethod("session.lifecycle", handler.OnSessionLifecycle);
+        rpc.SetLocalRpcMethod("session.event", handler.OnSessionEvent);
+        rpc.SetLocalRpcMethod("session.lifecycle", handler.OnSessionLifecycle);
         // Protocol v3 servers send tool calls / permission requests as broadcast events.
         // Protocol v2 servers use the older tool.call / permission.request RPC model.
         // We always register v2 adapters because handlers are set up before version
         // negotiation; a v3 server will simply never send these requests.
-        rpc.AddLocalRpcMethod("tool.call", handler.OnToolCallV2);
-        rpc.AddLocalRpcMethod("permission.request", handler.OnPermissionRequestV2);
-        rpc.AddLocalRpcMethod("userInput.request", handler.OnUserInputRequest);
-        rpc.AddLocalRpcMethod("hooks.invoke", handler.OnHooksInvoke);
-        rpc.AddLocalRpcMethod("systemMessage.transform", handler.OnSystemMessageTransform);
+        rpc.SetLocalRpcMethod("tool.call", handler.OnToolCallV2);
+        rpc.SetLocalRpcMethod("permission.request", handler.OnPermissionRequestV2);
+        rpc.SetLocalRpcMethod("userInput.request", handler.OnUserInputRequest);
+        rpc.SetLocalRpcMethod("hooks.invoke", handler.OnHooksInvoke);
+        rpc.SetLocalRpcMethod("systemMessage.transform", handler.OnSystemMessageTransform);
         ClientSessionApiRegistration.RegisterClientSessionApiHandlers(rpc, sessionId =>
         {
             var session = GetSession(sessionId) ?? throw new ArgumentException($"Unknown session {sessionId}");
@@ -1380,18 +1380,11 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         rpc.StartListening();
 
         // Transition state to Disconnected if the JSON-RPC connection drops
-        _ = rpc.Completion.ContinueWith(_ => _disconnected = true, TaskScheduler.Default);
+        _ = rpc.Completion.ContinueWith(_ => _disconnected = true, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
 
-        _rpc = new ServerRpc(rpc);
+        _serverRpc = new ServerRpc(rpc);
 
-        return new Connection(rpc, cliProcess, tcpClient, networkStream, stderrBuffer);
-    }
-
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Using happy path from https://microsoft.github.io/vs-streamjsonrpc/docs/nativeAOT.html")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Using happy path from https://microsoft.github.io/vs-streamjsonrpc/docs/nativeAOT.html")]
-    private static SystemTextJsonFormatter CreateSystemTextJsonFormatter()
-    {
-        return new() { JsonSerializerOptions = SerializerOptionsForMessageFormatter };
+        return new Connection(rpc, cliProcess, networkStream, stderrBuffer);
     }
 
     private static JsonSerializerOptions SerializerOptionsForMessageFormatter { get; } = CreateSerializerOptions();
@@ -1409,12 +1402,6 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         options.TypeInfoResolverChain.Add(CopilotSession.SessionJsonContext.Default);
         options.TypeInfoResolverChain.Add(SessionEventsJsonContext.Default);
         options.TypeInfoResolverChain.Add(SDK.Rpc.RpcJsonContext.Default);
-
-        // StreamJsonRpc's RequestId needs serialization when CancellationToken fires during
-        // JSON-RPC operations. Its built-in converter (RequestIdSTJsonConverter) is internal,
-        // and [JsonSerializable] can't source-gen for it (SYSLIB1220), so we provide our own
-        // AOT-safe resolver + converter.
-        options.TypeInfoResolverChain.Add(new RequestIdTypeInfoResolver());
 
         options.MakeReadOnly();
 
@@ -1484,7 +1471,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             client.DispatchLifecycleEvent(evt);
         }
 
-        public async Task<UserInputRequestResponse> OnUserInputRequest(string sessionId, string question, IList<string>? choices = null, bool? allowFreeform = null)
+        public async ValueTask<UserInputRequestResponse> OnUserInputRequest(string sessionId, string question, IList<string>? choices = null, bool? allowFreeform = null)
         {
             var session = client.GetSession(sessionId) ?? throw new ArgumentException($"Unknown session {sessionId}");
             var request = new UserInputRequest
@@ -1498,14 +1485,14 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             return new UserInputRequestResponse(result.Answer, result.WasFreeform);
         }
 
-        public async Task<HooksInvokeResponse> OnHooksInvoke(string sessionId, string hookType, JsonElement input)
+        public async ValueTask<HooksInvokeResponse> OnHooksInvoke(string sessionId, string hookType, JsonElement input)
         {
             var session = client.GetSession(sessionId) ?? throw new ArgumentException($"Unknown session {sessionId}");
             var output = await session.HandleHooksInvokeAsync(hookType, input);
             return new HooksInvokeResponse(output);
         }
 
-        public async Task<SystemMessageTransformRpcResponse> OnSystemMessageTransform(string sessionId, JsonElement sections)
+        public async ValueTask<SystemMessageTransformRpcResponse> OnSystemMessageTransform(string sessionId, JsonElement sections)
         {
             var session = client.GetSession(sessionId) ?? throw new ArgumentException($"Unknown session {sessionId}");
             return await session.HandleSystemMessageTransformAsync(sections);
@@ -1513,7 +1500,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
         // Protocol v2 backward-compatibility adapters
 
-        public async Task<ToolCallResponseV2> OnToolCallV2(string sessionId,
+        public async ValueTask<ToolCallResponseV2> OnToolCallV2(string sessionId,
             string toolCallId,
             string toolName,
             object? arguments,
@@ -1580,7 +1567,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             }
         }
 
-        public async Task<PermissionRequestResponseV2> OnPermissionRequestV2(string sessionId, JsonElement permissionRequest)
+        public async ValueTask<PermissionRequestResponseV2> OnPermissionRequestV2(string sessionId, JsonElement permissionRequest)
         {
             var session = client.GetSession(sessionId)
                 ?? throw new ArgumentException($"Unknown session {sessionId}");
@@ -1611,12 +1598,10 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     private class Connection(
         JsonRpc rpc,
         Process? cliProcess, // Set if we created the child process
-        TcpClient? tcpClient, // Set if using TCP
         NetworkStream? networkStream, // Set if using TCP
         StringBuilder? stderrBuffer = null) // Captures stderr for error messages
     {
         public Process? CliProcess => cliProcess;
-        public TcpClient? TcpClient => tcpClient;
         public JsonRpc Rpc => rpc;
         public NetworkStream? NetworkStream => networkStream;
         public StringBuilder? StderrBuffer => stderrBuffer;
@@ -1770,90 +1755,11 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     internal record PermissionRequestResponseV2(
         PermissionRequestResult Result);
 
-    /// <summary>Trace source that forwards all logs to the ILogger.</summary>
-    internal sealed class LoggerTraceSource : TraceSource
-    {
-        public LoggerTraceSource(ILogger logger) : base(nameof(LoggerTraceSource), SourceLevels.All)
-        {
-            Listeners.Clear();
-            Listeners.Add(new LoggerTraceListener(logger));
-        }
-
-        private sealed class LoggerTraceListener(ILogger logger) : TraceListener
-        {
-            public override void TraceEvent(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, string? message)
-            {
-                LogLevel level = MapLevel(eventType);
-                if (logger.IsEnabled(level))
-                {
-                    logger.Log(level, "[{Source}] {Message}", source, message);
-                }
-            }
-
-            public override void TraceEvent(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, string? format, params object?[]? args)
-            {
-                LogLevel level = MapLevel(eventType);
-                if (logger.IsEnabled(level))
-                {
-                    logger.Log(level, "[{Source}] {Message}", source, args is null || args.Length == 0 ? format : string.Format(CultureInfo.InvariantCulture, format ?? "", args));
-                }
-            }
-
-            public override void TraceData(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, object? data)
-            {
-                LogLevel level = MapLevel(eventType);
-                if (logger.IsEnabled(level))
-                {
-                    logger.Log(level, "[{Source}] {Data}", source, data);
-                }
-            }
-
-            public override void TraceData(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, params object?[]? data)
-            {
-                LogLevel level = MapLevel(eventType);
-                if (logger.IsEnabled(level))
-                {
-                    logger.Log(level, "[{Source}] {Data}", source, data is null ? null : string.Join(", ", data));
-                }
-            }
-
-            public override void Write(string? message)
-            {
-                if (logger.IsEnabled(LogLevel.Trace))
-                {
-                    logger.LogTrace("{Message}", message);
-                }
-            }
-
-            public override void WriteLine(string? message)
-            {
-                if (logger.IsEnabled(LogLevel.Trace))
-                {
-                    logger.LogTrace("{Message}", message);
-                }
-            }
-
-            private static LogLevel MapLevel(TraceEventType eventType)
-            {
-                return eventType switch
-                {
-                    TraceEventType.Critical => LogLevel.Critical,
-                    TraceEventType.Error => LogLevel.Error,
-                    TraceEventType.Warning => LogLevel.Warning,
-                    TraceEventType.Information => LogLevel.Information,
-                    TraceEventType.Verbose => LogLevel.Debug,
-                    _ => LogLevel.Trace
-                };
-            }
-        }
-    }
-
     [JsonSourceGenerationOptions(
         JsonSerializerDefaults.Web,
         AllowOutOfOrderMetadataProperties = true,
         NumberHandling = JsonNumberHandling.AllowReadingFromString,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonSerializable(typeof(CommonErrorData))]
     [JsonSerializable(typeof(CreateSessionRequest))]
     [JsonSerializable(typeof(CreateSessionResponse))]
     [JsonSerializable(typeof(CustomAgentConfig))]
@@ -1886,50 +1792,6 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     [JsonSerializable(typeof(UserInputRequest))]
     [JsonSerializable(typeof(UserInputResponse))]
     internal partial class ClientJsonContext : JsonSerializerContext;
-
-    /// <summary>
-    /// AOT-safe type info resolver for <see cref="RequestId"/>.
-    /// StreamJsonRpc's own RequestIdSTJsonConverter is internal (SYSLIB1220/CS0122),
-    /// so we provide our own converter and wire it through <see cref="JsonMetadataServices.CreateValueInfo{T}"/>
-    /// to stay fully AOT/trimming-compatible.
-    /// </summary>
-    private sealed class RequestIdTypeInfoResolver : IJsonTypeInfoResolver
-    {
-        public JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options)
-        {
-            if (type == typeof(RequestId))
-                return JsonMetadataServices.CreateValueInfo<RequestId>(options, new RequestIdJsonConverter());
-            return null;
-        }
-    }
-
-    private sealed class RequestIdJsonConverter : JsonConverter<RequestId>
-    {
-        public override RequestId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            return reader.TokenType switch
-            {
-                JsonTokenType.Number => reader.TryGetInt64(out long val)
-                    ? new RequestId(val)
-                    : new RequestId(reader.HasValueSequence
-                        ? Encoding.UTF8.GetString(reader.ValueSequence)
-                        : Encoding.UTF8.GetString(reader.ValueSpan)),
-                JsonTokenType.String => new RequestId(reader.GetString()!),
-                JsonTokenType.Null => RequestId.Null,
-                _ => throw new JsonException($"Unexpected token type for RequestId: {reader.TokenType}"),
-            };
-        }
-
-        public override void Write(Utf8JsonWriter writer, RequestId value, JsonSerializerOptions options)
-        {
-            if (value.Number.HasValue)
-                writer.WriteNumberValue(value.Number.Value);
-            else if (value.String is not null)
-                writer.WriteStringValue(value.String);
-            else
-                writer.WriteNullValue();
-        }
-    }
 
     [GeneratedRegex(@"listening on port ([0-9]+)", RegexOptions.IgnoreCase)]
     private static partial Regex ListeningOnPortRegex();

--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -12,7 +12,6 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using StreamJsonRpc;
 
 namespace GitHub.Copilot.SDK.Rpc;
 
@@ -4096,7 +4095,7 @@ public sealed class ClientSessionApiHandlers
 }
 
 /// <summary>Registers client session API handlers on a JSON-RPC connection.</summary>
-public static class ClientSessionApiRegistration
+internal static class ClientSessionApiRegistration
 {
     /// <summary>
     /// Registers handlers for server-to-client session API calls.
@@ -4105,106 +4104,66 @@ public static class ClientSessionApiRegistration
     /// </summary>
     public static void RegisterClientSessionApiHandlers(JsonRpc rpc, Func<string, ClientSessionApiHandlers> getHandlers)
     {
-        var registerSessionFsReadFileMethod = (Func<SessionFsReadFileRequest, CancellationToken, Task<SessionFsReadFileResult>>)(async (request, cancellationToken) =>
+        rpc.SetLocalRpcMethod("sessionFs.readFile", (Func<SessionFsReadFileRequest, CancellationToken, ValueTask<SessionFsReadFileResult>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.ReadFileAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsReadFileMethod.Method, registerSessionFsReadFileMethod.Target!, new JsonRpcMethodAttribute("sessionFs.readFile")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
-        var registerSessionFsWriteFileMethod = (Func<SessionFsWriteFileRequest, CancellationToken, Task<SessionFsError?>>)(async (request, cancellationToken) =>
+        }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("sessionFs.writeFile", (Func<SessionFsWriteFileRequest, CancellationToken, ValueTask<SessionFsError?>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.WriteFileAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsWriteFileMethod.Method, registerSessionFsWriteFileMethod.Target!, new JsonRpcMethodAttribute("sessionFs.writeFile")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
-        var registerSessionFsAppendFileMethod = (Func<SessionFsAppendFileRequest, CancellationToken, Task<SessionFsError?>>)(async (request, cancellationToken) =>
+        }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("sessionFs.appendFile", (Func<SessionFsAppendFileRequest, CancellationToken, ValueTask<SessionFsError?>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.AppendFileAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsAppendFileMethod.Method, registerSessionFsAppendFileMethod.Target!, new JsonRpcMethodAttribute("sessionFs.appendFile")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
-        var registerSessionFsExistsMethod = (Func<SessionFsExistsRequest, CancellationToken, Task<SessionFsExistsResult>>)(async (request, cancellationToken) =>
+        }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("sessionFs.exists", (Func<SessionFsExistsRequest, CancellationToken, ValueTask<SessionFsExistsResult>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.ExistsAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsExistsMethod.Method, registerSessionFsExistsMethod.Target!, new JsonRpcMethodAttribute("sessionFs.exists")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
-        var registerSessionFsStatMethod = (Func<SessionFsStatRequest, CancellationToken, Task<SessionFsStatResult>>)(async (request, cancellationToken) =>
+        }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("sessionFs.stat", (Func<SessionFsStatRequest, CancellationToken, ValueTask<SessionFsStatResult>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.StatAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsStatMethod.Method, registerSessionFsStatMethod.Target!, new JsonRpcMethodAttribute("sessionFs.stat")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
-        var registerSessionFsMkdirMethod = (Func<SessionFsMkdirRequest, CancellationToken, Task<SessionFsError?>>)(async (request, cancellationToken) =>
+        }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("sessionFs.mkdir", (Func<SessionFsMkdirRequest, CancellationToken, ValueTask<SessionFsError?>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.MkdirAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsMkdirMethod.Method, registerSessionFsMkdirMethod.Target!, new JsonRpcMethodAttribute("sessionFs.mkdir")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
-        var registerSessionFsReaddirMethod = (Func<SessionFsReaddirRequest, CancellationToken, Task<SessionFsReaddirResult>>)(async (request, cancellationToken) =>
+        }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("sessionFs.readdir", (Func<SessionFsReaddirRequest, CancellationToken, ValueTask<SessionFsReaddirResult>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.ReaddirAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsReaddirMethod.Method, registerSessionFsReaddirMethod.Target!, new JsonRpcMethodAttribute("sessionFs.readdir")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
-        var registerSessionFsReaddirWithTypesMethod = (Func<SessionFsReaddirWithTypesRequest, CancellationToken, Task<SessionFsReaddirWithTypesResult>>)(async (request, cancellationToken) =>
+        }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("sessionFs.readdirWithTypes", (Func<SessionFsReaddirWithTypesRequest, CancellationToken, ValueTask<SessionFsReaddirWithTypesResult>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.ReaddirWithTypesAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsReaddirWithTypesMethod.Method, registerSessionFsReaddirWithTypesMethod.Target!, new JsonRpcMethodAttribute("sessionFs.readdirWithTypes")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
-        var registerSessionFsRmMethod = (Func<SessionFsRmRequest, CancellationToken, Task<SessionFsError?>>)(async (request, cancellationToken) =>
+        }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("sessionFs.rm", (Func<SessionFsRmRequest, CancellationToken, ValueTask<SessionFsError?>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.RmAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsRmMethod.Method, registerSessionFsRmMethod.Target!, new JsonRpcMethodAttribute("sessionFs.rm")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
-        var registerSessionFsRenameMethod = (Func<SessionFsRenameRequest, CancellationToken, Task<SessionFsError?>>)(async (request, cancellationToken) =>
+        }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("sessionFs.rename", (Func<SessionFsRenameRequest, CancellationToken, ValueTask<SessionFsError?>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.RenameAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsRenameMethod.Method, registerSessionFsRenameMethod.Target!, new JsonRpcMethodAttribute("sessionFs.rename")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
+        }), singleObjectParam: true);
     }
 }
 

--- a/dotnet/src/GitHub.Copilot.SDK.csproj
+++ b/dotnet/src/GitHub.Copilot.SDK.csproj
@@ -37,7 +37,6 @@
         <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
-        <PackageReference Include="StreamJsonRpc" PrivateAssets="compile" />
         <PackageReference Include="System.Text.Json" />
     </ItemGroup>
 

--- a/dotnet/src/JsonRpc.cs
+++ b/dotnet/src/JsonRpc.cs
@@ -524,11 +524,32 @@ internal sealed partial class JsonRpc : IDisposable
                 }
             }
         }
+        else if (paramsProp.ValueKind == JsonValueKind.Object)
+        {
+            // Named parameters. The CLI sends notifications/requests as a JSON object whose
+            // property names match the handler's parameter names (camelCased per web defaults).
+            // Look up each parameter by name; missing optional parameters fall back to defaults.
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                if (parameters[i].ParameterType == typeof(CancellationToken))
+                {
+                    invokeArgs[i] = cancellationToken;
+                }
+                else if (parameters[i].Name is { } paramName &&
+                         TryGetPropertyCaseInsensitive(paramsProp, paramName, out var valueProp))
+                {
+                    invokeArgs[i] = valueProp.Deserialize(_serializerOptions.GetTypeInfo(parameters[i].ParameterType));
+                }
+                else
+                {
+                    invokeArgs[i] = parameters[i].HasDefaultValue ? parameters[i].DefaultValue : null;
+                }
+            }
+        }
         else
         {
-            // No current handler is parameterless, so missing/null `params` and named-params
-            // (object-without-singleObjectParam) are both protocol violations. Surface them
-            // as invalid-params errors rather than silently filling defaults.
+            // Missing/null `params` for a handler with required positional parameters is a
+            // protocol violation. Surface it as an error rather than silently filling defaults.
             throw new InvalidOperationException(
                 $"Unsupported JSON-RPC params shape '{paramsProp.ValueKind}' for handler with positional parameters.");
         }
@@ -556,11 +577,50 @@ internal sealed partial class JsonRpc : IDisposable
         return result;
     }
 
+    private static bool TryGetPropertyCaseInsensitive(JsonElement obj, string name, out JsonElement value)
+    {
+        // Fast path: exact match. The CLI uses camelCase property names that match the
+        // C# parameter names exactly, so this should hit in the common case.
+        if (obj.TryGetProperty(name, out value))
+        {
+            return true;
+        }
+
+        foreach (var prop in obj.EnumerateObject())
+        {
+            if (string.Equals(prop.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                value = prop.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
     private JsonElement? SerializeArgs(object?[]? args)
     {
         if (args is null || args.Length == 0)
         {
             return null;
+        }
+
+        // The Copilot CLI uses vscode-jsonrpc-style request handlers, which expect
+        // `params` to be the single request object (not wrapped in a positional array).
+        // The other SDKs (Node, Python, Go) all send single-object params, and every
+        // generated call site here passes exactly one request object. For the rare
+        // multi-arg case, fall back to a positional array.
+        if (args.Length == 1)
+        {
+            var arg = args[0];
+            if (arg is null)
+            {
+                return null;
+            }
+
+            var typeInfo = _serializerOptions.GetTypeInfo(arg.GetType());
+            return JsonSerializer.SerializeToElement(arg, typeInfo);
         }
 
         // Source-generated JsonSerializerOptions do not provide metadata for object[],
@@ -594,10 +654,21 @@ internal sealed partial class JsonRpc : IDisposable
     {
         try
         {
+            // Convert the result to a JsonElement using the runtime type, looked up via
+            // the merged resolver. Source-gen serialization of an `object`-typed property
+            // would otherwise have no way to find metadata for the actual response type
+            // (e.g. SystemMessageTransformRpcResponse, SessionFsReadFileResult, ...).
+            JsonElement? resultElement = null;
+            if (result is not null)
+            {
+                var typeInfo = _serializerOptions.GetTypeInfo(result.GetType());
+                resultElement = JsonSerializer.SerializeToElement(result, typeInfo);
+            }
+
             await SendMessageAsync(new JsonRpcResponse
             {
                 Id = id,
-                Result = result,
+                Result = resultElement,
             }, JsonRpcWireContext.Default.JsonRpcResponse, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is IOException or ObjectDisposedException or OperationCanceledException)
@@ -693,7 +764,7 @@ internal sealed partial class JsonRpc : IDisposable
         public JsonElement Id { get; set; }
 
         [JsonPropertyName("result")]
-        public object? Result { get; set; }
+        public JsonElement? Result { get; set; }
     }
 
     private sealed class JsonRpcErrorResponse

--- a/dotnet/src/JsonRpc.cs
+++ b/dotnet/src/JsonRpc.cs
@@ -168,12 +168,17 @@ internal sealed partial class JsonRpc : IDisposable
         bool wrote = Utf8.TryWrite(headerBuf, $"Content-Length: {json.Length}\r\n\r\n", out int headerLen);
         Debug.Assert(wrote && headerLen > 0);
 
+        // Cancellation only applies to *waiting* for the write lock. Once we hold the lock
+        // and start writing a framed message, we must finish it — cancelling between the
+        // header and the body (or mid-body) would leave the peer waiting for N body bytes
+        // that never arrive, desynchronizing the LSP-style stream for every subsequent
+        // message on this connection.
         await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            await _sendStream.WriteAsync(headerBuf.AsMemory(0, headerLen), cancellationToken).ConfigureAwait(false);
-            await _sendStream.WriteAsync(json, cancellationToken).ConfigureAwait(false);
-            await _sendStream.FlushAsync(cancellationToken).ConfigureAwait(false);
+            await _sendStream.WriteAsync(headerBuf.AsMemory(0, headerLen), CancellationToken.None).ConfigureAwait(false);
+            await _sendStream.WriteAsync(json, CancellationToken.None).ConfigureAwait(false);
+            await _sendStream.FlushAsync(CancellationToken.None).ConfigureAwait(false);
         }
         finally
         {

--- a/dotnet/src/JsonRpc.cs
+++ b/dotnet/src/JsonRpc.cs
@@ -769,7 +769,6 @@ internal sealed partial class JsonRpc : IDisposable
         // must emit `result: null` for void-returning handlers — overriding the
         // context-level WhenWritingNull policy.
         [JsonPropertyName("result")]
-        [JsonInclude]
         [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
         public JsonElement? Result { get; set; }
     }

--- a/dotnet/src/JsonRpc.cs
+++ b/dotnet/src/JsonRpc.cs
@@ -335,14 +335,12 @@ internal sealed partial class JsonRpc : IDisposable
             int lineEnd = headerLines.IndexOf("\r\n"u8);
             ReadOnlySpan<byte> line = lineEnd >= 0 ? headerLines.Slice(0, lineEnd) : headerLines;
 
-            if (line.StartsWith(prefix))
+            if (line.StartsWith(prefix) &&
+                (contentLength >= 0 ||
+                 !int.TryParse(line.Slice(prefix.Length), NumberStyles.None, CultureInfo.InvariantCulture, out contentLength) ||
+                 contentLength < 0))
             {
-                if (contentLength >= 0 ||
-                    !int.TryParse(line.Slice(prefix.Length), NumberStyles.None, CultureInfo.InvariantCulture, out contentLength) ||
-                    contentLength < 0)
-                {
-                    throw new InvalidDataException("JSON-RPC frame has a missing, duplicate, or invalid Content-Length header.");
-                }
+                throw new InvalidDataException("JSON-RPC frame has a missing, duplicate, or invalid Content-Length header.");
             }
 
             headerLines = lineEnd >= 0 ? headerLines.Slice(lineEnd + 2) : default;

--- a/dotnet/src/JsonRpc.cs
+++ b/dotnet/src/JsonRpc.cs
@@ -1,0 +1,731 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using System.Text.Unicode;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace GitHub.Copilot.SDK;
+
+/// <summary>
+/// A lightweight JSON-RPC 2.0 implementation covering only the features used
+/// by this SDK to talk to the Copilot CLI. Messages are framed using the
+/// LSP-style header convention (<c>Content-Length: N\r\n\r\n</c> followed by
+/// N bytes of JSON body) — the same wire format used by the Language Server
+/// Protocol and the Copilot CLI's other language SDKs (Go, Node, Python).
+/// This is not a general-purpose JSON-RPC stack: it is narrowly scoped to the
+/// methods, transports, and framing the CLI uses.
+/// </summary>
+internal sealed partial class JsonRpc : IDisposable
+{
+    private const int ErrorCodeMethodNotFound = -32601;
+    private const int ErrorCodeInternalError = -32603;
+
+    private readonly Stream _sendStream;
+    private readonly Stream _receiveStream;
+    private readonly JsonSerializerOptions _serializerOptions;
+    private readonly ILogger _logger;
+    private readonly ConcurrentDictionary<long, PendingRequest> _pendingRequests = new();
+    private readonly ConcurrentDictionary<string, MethodRegistration> _methods = new();
+    private readonly TaskCompletionSource _completionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private readonly CancellationTokenSource _disposeCts = new();
+    private long _nextId;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new <see cref="JsonRpc"/>.
+    /// </summary>
+    /// <param name="sendStream">The stream to write outgoing messages to.</param>
+    /// <param name="receiveStream">The stream to read incoming messages from.</param>
+    /// <param name="serializerOptions">JSON serializer options (should include all needed source-gen contexts).</param>
+    /// <param name="logger">Optional logger for diagnostics.</param>
+    public JsonRpc(Stream sendStream, Stream receiveStream, JsonSerializerOptions serializerOptions, ILogger? logger = null)
+    {
+        _sendStream = sendStream;
+        _receiveStream = receiveStream;
+        _serializerOptions = serializerOptions;
+        _logger = logger ?? NullLogger.Instance;
+    }
+
+    /// <summary>
+    /// A <see cref="Task"/> that completes when the connection is closed or faulted.
+    /// </summary>
+    public Task Completion => _completionSource.Task;
+
+    /// <summary>
+    /// Begins reading messages from the receive stream. Call once after registering all method handlers.
+    /// </summary>
+    public void StartListening()
+    {
+        _ = ReadLoopAsync(_disposeCts.Token);
+    }
+
+    /// <summary>
+    /// Sends a JSON-RPC request and waits for the response.
+    /// </summary>
+    public async Task<T> InvokeAsync<T>(string method, object?[]? args, CancellationToken cancellationToken)
+    {
+        var id = Interlocked.Increment(ref _nextId);
+        var pending = new PendingRequest();
+        _pendingRequests[id] = pending;
+
+        CancellationTokenRegistration cancelRegistration = default;
+        try
+        {
+            if (cancellationToken.CanBeCanceled)
+            {
+                cancelRegistration = cancellationToken.Register(static state =>
+                {
+                    var (self, reqId, ct) = ((JsonRpc, long, CancellationToken))state!;
+                    if (self._pendingRequests.TryRemove(reqId, out var p))
+                    {
+                        p.TrySetCanceled(ct);
+                    }
+
+                    // Best-effort cancel notification
+                    _ = self.SendCancelNotificationAsync(reqId);
+                }, (this, id, cancellationToken));
+            }
+
+            // Send request message
+            await SendMessageAsync(new JsonRpcRequest
+            {
+                Id = id,
+                Method = method,
+                Params = SerializeArgs(args),
+            }, JsonRpcWireContext.Default.JsonRpcRequest, cancellationToken).ConfigureAwait(false);
+
+            var responseElement = await pending.Task.ConfigureAwait(false);
+
+            if (responseElement.ValueKind == JsonValueKind.Null || responseElement.ValueKind == JsonValueKind.Undefined)
+            {
+                return default!;
+            }
+
+            return (T)responseElement.Deserialize(_serializerOptions.GetTypeInfo(typeof(T)))!;
+        }
+        finally
+        {
+            _pendingRequests.TryRemove(id, out _);
+            await cancelRegistration.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Registers a method handler that receives positional parameters.
+    /// If singleObjectParam is false (the default), parameter names and types are inferred from the delegate's signature.
+    /// If singleObjectParam is true, the entire params object is deserialized as the handler's first parameter.
+    /// </summary>
+    public void SetLocalRpcMethod(string methodName, Delegate handler, bool singleObjectParam = false)
+    {
+        _methods[methodName] = new MethodRegistration(handler, singleObjectParam);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _disposeCts.Cancel();
+
+        // Fail all pending requests
+        foreach (var kvp in _pendingRequests)
+        {
+            if (_pendingRequests.TryRemove(kvp.Key, out var pending))
+            {
+                pending.TrySetException(new ObjectDisposedException(nameof(JsonRpc)));
+            }
+        }
+
+        _completionSource.TrySetResult();
+        _writeLock.Dispose();
+    }
+
+    private async Task SendMessageAsync<T>(T message, JsonTypeInfo<T> typeInfo, CancellationToken cancellationToken)
+    {
+        // "Content-Length: " (16) + max int digits (10) + "\r\n\r\n" (4)
+        const int MaxHeaderLength = 30;
+
+        var json = JsonSerializer.SerializeToUtf8Bytes(message, typeInfo);
+
+        var headerBuf = ArrayPool<byte>.Shared.Rent(MaxHeaderLength);
+        bool wrote = Utf8.TryWrite(headerBuf, $"Content-Length: {json.Length}\r\n\r\n", out int headerLen);
+        Debug.Assert(wrote && headerLen > 0);
+
+        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await _sendStream.WriteAsync(headerBuf.AsMemory(0, headerLen), cancellationToken).ConfigureAwait(false);
+            await _sendStream.WriteAsync(json, cancellationToken).ConfigureAwait(false);
+            await _sendStream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+            ArrayPool<byte>.Shared.Return(headerBuf);
+        }
+    }
+
+    private async Task ReadLoopAsync(CancellationToken cancellationToken)
+    {
+        var buffer = new byte[256];
+        int carried = 0; // bytes in buffer carried over from previous read
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                // Read headers and body
+                var (contentLength, buf, newCarried) = await ReadMessageAsync(buffer, carried, cancellationToken).ConfigureAwait(false);
+                if (contentLength < 0)
+                {
+                    break; // Stream ended
+                }
+
+                // Keep the (possibly grown) buffer and carry-over count for next iteration
+                buffer = buf;
+                carried = newCarried;
+
+                // Parse the raw JSON. Body is at buffer[0..contentLength], carried bytes
+                // for the next message are at buffer[contentLength..contentLength+carried].
+                JsonElement? message = null;
+                try
+                {
+                    using var doc = JsonDocument.Parse(buffer.AsMemory(0, contentLength));
+                    message = doc.RootElement.Clone();
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse incoming JSON-RPC message");
+                }
+
+                // Always move carried bytes to the front, even on parse failure — otherwise
+                // the next ReadMessageAsync call would scan stale body bytes as headers.
+                // This must happen AFTER parsing because the carried region overlaps where
+                // the body lived.
+                if (carried > 0)
+                {
+                    Buffer.BlockCopy(buffer, contentLength, buffer, 0, carried);
+                }
+
+                if (message is not { } parsed)
+                {
+                    continue;
+                }
+
+                // Route the message
+                if (parsed.TryGetProperty("id", out var idProp) && !parsed.TryGetProperty("method", out _))
+                {
+                    // It's a response to one of our requests
+                    HandleResponse(parsed, idProp);
+                }
+                else if (parsed.TryGetProperty("method", out var methodProp) && methodProp.GetString() is string methodName)
+                {
+                    _ = HandleIncomingMethodAsync(methodName, parsed, cancellationToken);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Normal shutdown
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "JSON-RPC read loop ended");
+        }
+        finally
+        {
+            // Fail all pending requests
+            foreach (var kvp in _pendingRequests)
+            {
+                if (_pendingRequests.TryRemove(kvp.Key, out var pending))
+                {
+                    pending.TrySetException(new ConnectionLostException());
+                }
+            }
+
+            _completionSource.TrySetResult();
+        }
+    }
+
+    /// <summary>
+    /// Reads headers and body in one pass.
+    /// On return, body is at buffer[0..ContentLength], and any overflow bytes
+    /// from the next message are at buffer[ContentLength..ContentLength+Carried].
+    /// The caller must move the carried bytes to the front before the next call.
+    /// </summary>
+    /// <param name="buffer">Shared buffer (may be grown).</param>
+    /// <param name="carried">Bytes already in buffer[0..carried] from a previous read.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    private async ValueTask<(int ContentLength, byte[] Buffer, int Carried)> ReadMessageAsync(byte[] buffer, int carried, CancellationToken cancellationToken)
+    {
+        // Read until we find the \r\n\r\n header terminator.
+        // carried bytes are already at buffer[0..carried].
+        int filled = carried;
+        int headerEnd = -1; // index of first byte after \r\n\r\n
+
+        // Check carried bytes first for a header terminator
+        {
+            int pos = buffer.AsSpan(0, filled).IndexOf("\r\n\r\n"u8);
+            if (pos >= 0)
+            {
+                headerEnd = pos + 4;
+            }
+        }
+
+        while (headerEnd < 0)
+        {
+            if (filled == buffer.Length)
+            {
+                Array.Resize(ref buffer, buffer.Length * 2);
+            }
+
+            int bytesRead = await _receiveStream.ReadAsync(buffer.AsMemory(filled, buffer.Length - filled), cancellationToken).ConfigureAwait(false);
+            if (bytesRead == 0)
+            {
+                // Clean EOF only if we haven't started a frame; otherwise the peer truncated mid-header.
+                if (filled == 0)
+                {
+                    return (-1, buffer, 0);
+                }
+
+                throw new EndOfStreamException("Stream ended while reading JSON-RPC headers.");
+            }
+
+            filled += bytesRead;
+
+            // Scan for \r\n\r\n starting from where a match could begin
+            int scanStart = Math.Max(filled - bytesRead - 3, 0);
+            int pos = buffer.AsSpan(scanStart, filled - scanStart).IndexOf("\r\n\r\n"u8);
+            if (pos >= 0)
+            {
+                headerEnd = scanStart + pos + 4;
+            }
+        }
+
+        // Parse Content-Length. LSP framing puts each header on its own \r\n-terminated
+        // line; we walk the lines and require an exact "Content-Length: " prefix at the
+        // start of one of them. A substring match anywhere in the header block would
+        // false-positive on values like "X-Trace: Content-Length: 5" and desync the stream.
+        // A missing or unparseable Content-Length means the framing is broken — there's
+        // no safe way to resync, so throw and let the read loop terminate the connection.
+        int contentLength = -1;
+        ReadOnlySpan<byte> prefix = "Content-Length: "u8;
+        // headerEnd points just past the \r\n\r\n terminator. Drop only the trailing
+        // empty line's \r\n; each remaining header line is still \r\n-terminated and
+        // gets split out by the IndexOf below.
+        var headerLines = buffer.AsSpan(0, headerEnd - 2);
+        while (!headerLines.IsEmpty)
+        {
+            int lineEnd = headerLines.IndexOf("\r\n"u8);
+            ReadOnlySpan<byte> line = lineEnd >= 0 ? headerLines.Slice(0, lineEnd) : headerLines;
+
+            if (line.StartsWith(prefix))
+            {
+                if (contentLength >= 0 ||
+                    !int.TryParse(line.Slice(prefix.Length), NumberStyles.None, CultureInfo.InvariantCulture, out contentLength) ||
+                    contentLength < 0)
+                {
+                    throw new InvalidDataException("JSON-RPC frame has a missing, duplicate, or invalid Content-Length header.");
+                }
+            }
+
+            headerLines = lineEnd >= 0 ? headerLines.Slice(lineEnd + 2) : default;
+        }
+
+        if (contentLength < 0)
+        {
+            throw new InvalidDataException("JSON-RPC frame is missing the Content-Length header.");
+        }
+
+        // Bytes after the header that we already have
+        int extraBytes = filled - headerEnd;
+
+        // Ensure buffer is large enough for the body and any overflow already read.
+        int needed = Math.Max(contentLength, extraBytes);
+        if (needed > buffer.Length)
+        {
+            var newBuffer = new byte[needed];
+            Buffer.BlockCopy(buffer, headerEnd, newBuffer, 0, extraBytes);
+            buffer = newBuffer;
+        }
+        else if (extraBytes > 0)
+        {
+            Buffer.BlockCopy(buffer, headerEnd, buffer, 0, extraBytes);
+        }
+
+        // Read remaining body bytes if we don't have enough
+        if (extraBytes < contentLength)
+        {
+            await _receiveStream.ReadExactlyAsync(buffer.AsMemory(extraBytes, contentLength - extraBytes), cancellationToken).ConfigureAwait(false);
+            return (contentLength, buffer, 0);
+        }
+
+        // We read more than the body — overflow belongs to the next message
+        int overflow = extraBytes - contentLength;
+        return (contentLength, buffer, overflow);
+    }
+
+    private void HandleResponse(JsonElement message, JsonElement idProp)
+    {
+        if (!idProp.TryGetInt64(out long id))
+        {
+            return;
+        }
+
+        if (!_pendingRequests.TryRemove(id, out var pending))
+        {
+            return;
+        }
+
+        if (message.TryGetProperty("error", out var errorProp))
+        {
+            var errorMessage = errorProp.TryGetProperty("message", out var msgProp)
+                ? msgProp.GetString() ?? "Unknown error"
+                : "Unknown error";
+            var errorCode = errorProp.TryGetProperty("code", out var codeProp) && codeProp.ValueKind == JsonValueKind.Number
+                ? codeProp.GetInt32()
+                : 0;
+            pending.TrySetException(new RemoteRpcException(errorMessage, errorCode));
+        }
+        else if (message.TryGetProperty("result", out var resultProp))
+        {
+            pending.TrySetResult(resultProp.Clone());
+        }
+        else
+        {
+            // Per JSON-RPC 2.0, a response must have either "result" or "error".
+            // Treat missing result as null result.
+            pending.TrySetResult(default);
+        }
+    }
+
+    private async Task HandleIncomingMethodAsync(string methodName, JsonElement message, CancellationToken cancellationToken)
+    {
+        try
+        {
+            JsonElement? requestId = null;
+            if (message.TryGetProperty("id", out var idProp))
+            {
+                requestId = idProp;
+            }
+
+            if (!_methods.TryGetValue(methodName, out var registration))
+            {
+                if (requestId.HasValue)
+                {
+                    await SendErrorResponseAsync(requestId.Value, ErrorCodeMethodNotFound, $"Method not found: {methodName}", cancellationToken).ConfigureAwait(false);
+                }
+                return;
+            }
+
+            message.TryGetProperty("params", out var paramsProp);
+
+            try
+            {
+                var result = await InvokeHandlerAsync(registration, paramsProp, cancellationToken).ConfigureAwait(false);
+
+                if (requestId.HasValue)
+                {
+                    await SendResultResponseAsync(requestId.Value, result, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("Error handling JSON-RPC method {Method}: {Error}", methodName, ex.Message);
+                }
+                if (requestId.HasValue)
+                {
+                    await SendErrorResponseAsync(requestId.Value, ErrorCodeInternalError, ex.Message, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Normal shutdown — cancellation propagated from the read loop.
+        }
+        catch (Exception ex)
+        {
+            // Belt-and-braces: this method is fire-and-forget from the read loop, so any
+            // exception escaping here would become an unobserved task exception. The most
+            // likely sources are IOException/ObjectDisposedException from sending the error
+            // response after the underlying transport is gone.
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(ex, "Unobserved error in JSON-RPC method dispatch for {Method}", methodName);
+            }
+        }
+    }
+
+    private async ValueTask<object?> InvokeHandlerAsync(MethodRegistration registration, JsonElement paramsProp, CancellationToken cancellationToken)
+    {
+        var parameters = registration.Parameters;
+
+        // Build argument list
+        var invokeArgs = new object?[parameters.Length];
+
+        if (registration.SingleObjectParam)
+        {
+            // Single-object deserialization: entire `params` → first parameter.
+            // Every singleObjectParam handler has shape (TRequest, CancellationToken),
+            // so `params` must be a JSON object.
+            if (paramsProp.ValueKind != JsonValueKind.Object)
+            {
+                throw new InvalidOperationException(
+                    $"Expected JSON object for `params` of single-object-param handler; got '{paramsProp.ValueKind}'.");
+            }
+
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                if (parameters[i].ParameterType == typeof(CancellationToken))
+                {
+                    invokeArgs[i] = cancellationToken;
+                }
+                else if (i == 0)
+                {
+                    invokeArgs[i] = paramsProp.Deserialize(_serializerOptions.GetTypeInfo(parameters[i].ParameterType));
+                }
+            }
+        }
+        else if (paramsProp.ValueKind == JsonValueKind.Array)
+        {
+            // Positional parameters. Optional params (with defaults) are filled when absent.
+            int jsonIndex = 0;
+            int arrayLength = paramsProp.GetArrayLength();
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                if (parameters[i].ParameterType == typeof(CancellationToken))
+                {
+                    invokeArgs[i] = cancellationToken;
+                }
+                else if (jsonIndex < arrayLength)
+                {
+                    invokeArgs[i] = paramsProp[jsonIndex].Deserialize(_serializerOptions.GetTypeInfo(parameters[i].ParameterType));
+                    jsonIndex++;
+                }
+                else
+                {
+                    invokeArgs[i] = parameters[i].HasDefaultValue ? parameters[i].DefaultValue : null;
+                }
+            }
+        }
+        else
+        {
+            // No current handler is parameterless, so missing/null `params` and named-params
+            // (object-without-singleObjectParam) are both protocol violations. Surface them
+            // as invalid-params errors rather than silently filling defaults.
+            throw new InvalidOperationException(
+                $"Unsupported JSON-RPC params shape '{paramsProp.ValueKind}' for handler with positional parameters.");
+        }
+
+        // Invoke
+        var result = registration.Handler.DynamicInvoke(invokeArgs);
+
+        // Handlers return one of: a synchronous value, Task (void async), or ValueTask<T>.
+        if (result is Task task)
+        {
+            // Task<T> handlers are not supported — use ValueTask<T> for results.
+            Debug.Assert(!task.GetType().IsGenericType, "Task<T> handlers are not supported; use ValueTask<T>.");
+            await task.ConfigureAwait(false);
+            return null;
+        }
+
+        if (result is not null && registration.ReturnsValueTaskOfT)
+        {
+            var resultType = result.GetType();
+            var asTask = (Task)resultType.GetMethod("AsTask")!.Invoke(result, null)!;
+            await asTask.ConfigureAwait(false);
+            return asTask.GetType().GetProperty("Result")!.GetValue(asTask);
+        }
+
+        return result;
+    }
+
+    private JsonElement? SerializeArgs(object?[]? args)
+    {
+        if (args is null || args.Length == 0)
+        {
+            return null;
+        }
+
+        return JsonSerializer.SerializeToElement(args, _serializerOptions.GetTypeInfo(typeof(object?[])));
+    }
+
+    private async Task SendResultResponseAsync(JsonElement id, object? result, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await SendMessageAsync(new JsonRpcResponse
+            {
+                Id = id,
+                Result = result,
+            }, JsonRpcWireContext.Default.JsonRpcResponse, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException or OperationCanceledException)
+        {
+            // Connection lost during response — nothing we can do
+        }
+    }
+
+    private async Task SendErrorResponseAsync(JsonElement id, int code, string message, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await SendMessageAsync(new JsonRpcErrorResponse
+            {
+                Id = id,
+                Error = new JsonRpcError { Code = code, Message = message },
+            }, JsonRpcWireContext.Default.JsonRpcErrorResponse, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException or OperationCanceledException)
+        {
+            // Connection lost during error response — nothing we can do
+        }
+    }
+
+    private async Task SendCancelNotificationAsync(long requestId)
+    {
+        try
+        {
+            await SendMessageAsync(new JsonRpcNotification
+            {
+                Method = "$/cancelRequest",
+                Params = JsonSerializer.SerializeToElement(
+                    new CancelRequestParams { Id = requestId },
+                    CancelRequestParamsContext.Default.CancelRequestParams),
+            }, JsonRpcWireContext.Default.JsonRpcNotification, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Best effort — connection may already be gone
+        }
+    }
+
+    private sealed class PendingRequest(): TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private sealed class MethodRegistration
+    {
+        public MethodRegistration(Delegate handler, bool singleObjectParam)
+        {
+            Handler = handler;
+            SingleObjectParam = singleObjectParam;
+            Parameters = handler.Method.GetParameters();
+            ReturnsValueTaskOfT =
+                handler.Method.ReturnType.IsGenericType &&
+                handler.Method.ReturnType.GetGenericTypeDefinition() == typeof(ValueTask<>);
+        }
+
+        public Delegate Handler { get; }
+        public bool SingleObjectParam { get; }
+        public ParameterInfo[] Parameters { get; }
+        public bool ReturnsValueTaskOfT { get; }
+    }
+
+    [JsonSourceGenerationOptions(
+        JsonSerializerDefaults.Web,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonSerializable(typeof(JsonRpcRequest))]
+    [JsonSerializable(typeof(JsonRpcResponse))]
+    [JsonSerializable(typeof(JsonRpcErrorResponse))]
+    [JsonSerializable(typeof(JsonRpcNotification))]
+    private partial class JsonRpcWireContext : JsonSerializerContext;
+
+    private sealed class JsonRpcRequest
+    {
+        [JsonPropertyName("jsonrpc")]
+        public string Jsonrpc { get; } = "2.0";
+
+        [JsonPropertyName("id")]
+        public long Id { get; set; }
+
+        [JsonPropertyName("method")]
+        public string Method { get; set; } = string.Empty;
+
+        [JsonPropertyName("params")]
+        public JsonElement? Params { get; set; }
+    }
+
+    private sealed class JsonRpcResponse
+    {
+        [JsonPropertyName("jsonrpc")]
+        public string Jsonrpc { get; } = "2.0";
+
+        [JsonPropertyName("id")]
+        public JsonElement Id { get; set; }
+
+        [JsonPropertyName("result")]
+        public object? Result { get; set; }
+    }
+
+    private sealed class JsonRpcErrorResponse
+    {
+        [JsonPropertyName("jsonrpc")]
+        public string Jsonrpc { get; } = "2.0";
+
+        [JsonPropertyName("id")]
+        public JsonElement Id { get; set; }
+
+        [JsonPropertyName("error")]
+        public JsonRpcError? Error { get; set; }
+    }
+
+    private sealed class JsonRpcError
+    {
+        [JsonPropertyName("code")]
+        public int Code { get; set; }
+
+        [JsonPropertyName("message")]
+        public string Message { get; set; } = string.Empty;
+    }
+
+    private sealed class JsonRpcNotification
+    {
+        [JsonPropertyName("jsonrpc")]
+        public string Jsonrpc { get; } = "2.0";
+
+        [JsonPropertyName("method")]
+        public string Method { get; set; } = string.Empty;
+
+        [JsonPropertyName("params")]
+        public JsonElement? Params { get; set; }
+    }
+
+    private sealed class CancelRequestParams
+    {
+        [JsonPropertyName("id")]
+        public long Id { get; set; }
+    }
+
+    [JsonSerializable(typeof(CancelRequestParams))]
+    private partial class CancelRequestParamsContext : JsonSerializerContext;
+}
+
+/// <summary>
+/// Thrown when the JSON-RPC connection is lost unexpectedly.
+/// </summary>
+internal sealed class ConnectionLostException() : IOException("The JSON-RPC connection was lost.");
+
+/// <summary>
+/// Thrown when the remote side returns a JSON-RPC error response.
+/// </summary>
+internal sealed class RemoteRpcException(string message, int errorCode, Exception? innerException = null) : Exception(message, innerException)
+{
+    public int ErrorCode { get; } = errorCode;
+}

--- a/dotnet/src/JsonRpc.cs
+++ b/dotnet/src/JsonRpc.cs
@@ -763,7 +763,14 @@ internal sealed partial class JsonRpc : IDisposable
         [JsonPropertyName("id")]
         public JsonElement Id { get; set; }
 
+        // JSON-RPC 2.0 requires every response to carry either `result` or `error`.
+        // vscode-jsonrpc (used by the CLI) rejects responses that have neither with
+        // "The received response has neither a result nor an error property", so we
+        // must emit `result: null` for void-returning handlers — overriding the
+        // context-level WhenWritingNull policy.
         [JsonPropertyName("result")]
+        [JsonInclude]
+        [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
         public JsonElement? Result { get; set; }
     }
 

--- a/dotnet/src/JsonRpc.cs
+++ b/dotnet/src/JsonRpc.cs
@@ -705,7 +705,7 @@ internal sealed partial class JsonRpc : IDisposable
                     CancelRequestParamsContext.Default.CancelRequestParams),
             }, JsonRpcWireContext.Default.JsonRpcNotification, CancellationToken.None).ConfigureAwait(false);
         }
-        catch
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException or OperationCanceledException)
         {
             // Best effort — connection may already be gone
         }

--- a/dotnet/src/JsonRpc.cs
+++ b/dotnet/src/JsonRpc.cs
@@ -565,7 +565,31 @@ internal sealed partial class JsonRpc : IDisposable
             return null;
         }
 
-        return JsonSerializer.SerializeToElement(args, _serializerOptions.GetTypeInfo(typeof(object?[])));
+        // Source-generated JsonSerializerOptions do not provide metadata for object[],
+        // so build the JSON array manually, serializing each element with a TypeInfo
+        // looked up by its runtime type from the merged resolver.
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartArray();
+            foreach (var arg in args)
+            {
+                if (arg is null)
+                {
+                    writer.WriteNullValue();
+                }
+                else
+                {
+                    var typeInfo = _serializerOptions.GetTypeInfo(arg.GetType());
+                    JsonSerializer.Serialize(writer, arg, typeInfo);
+                }
+            }
+
+            writer.WriteEndArray();
+        }
+
+        using var doc = JsonDocument.Parse(buffer.WrittenMemory);
+        return doc.RootElement.Clone();
     }
 
     private async Task SendResultResponseAsync(JsonElement id, object? result, CancellationToken cancellationToken)
@@ -618,7 +642,7 @@ internal sealed partial class JsonRpc : IDisposable
         }
     }
 
-    private sealed class PendingRequest(): TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously);
+    private sealed class PendingRequest() : TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously);
 
     private sealed class MethodRegistration
     {

--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -5,7 +5,6 @@
 using GitHub.Copilot.SDK.Rpc;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
-using StreamJsonRpc;
 using System.Collections.Immutable;
 using System.Text.Json;
 using System.Text.Json.Nodes;

--- a/dotnet/test/GitHub.Copilot.SDK.Test.csproj
+++ b/dotnet/test/GitHub.Copilot.SDK.Test.csproj
@@ -26,7 +26,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="StreamJsonRpc" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/test/Harness/TestHelper.cs
+++ b/dotnet/test/Harness/TestHelper.cs
@@ -14,10 +14,24 @@ public static class TestHelper
         var tcs = new TaskCompletionSource<AssistantMessageEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
         using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(60));
 
-        // Synchronize access to finalAssistantMessage between the subscription callback
-        // (events from the CLI read loop) and CheckExistingMessages (RPC reply thread).
+        // Both `finalAssistantMessage` and `sawIdle` are set from two threads — the
+        // subscription callback (CLI read loop) and CheckExistingMessages (RPC reply).
+        // We complete only once we've observed both, regardless of which path saw which.
         var stateLock = new object();
         AssistantMessageEvent? finalAssistantMessage = null;
+        bool sawIdle = false;
+
+        void TryComplete()
+        {
+            AssistantMessageEvent? snapshot;
+            bool idle;
+            lock (stateLock)
+            {
+                snapshot = finalAssistantMessage;
+                idle = sawIdle;
+            }
+            if (snapshot != null && idle) tcs.TrySetResult(snapshot);
+        }
 
         using var subscription = session.On(evt =>
         {
@@ -25,11 +39,11 @@ public static class TestHelper
             {
                 case AssistantMessageEvent msg:
                     lock (stateLock) { finalAssistantMessage = msg; }
+                    TryComplete();
                     break;
                 case SessionIdleEvent:
-                    AssistantMessageEvent? snapshot;
-                    lock (stateLock) { snapshot = finalAssistantMessage; }
-                    if (snapshot != null) tcs.TrySetResult(snapshot);
+                    lock (stateLock) { sawIdle = true; }
+                    TryComplete();
                     break;
                 case SessionErrorEvent error:
                     tcs.TrySetException(new Exception(error.Data.Message ?? "session error"));
@@ -50,20 +64,16 @@ public static class TestHelper
             try
             {
                 var (existingFinal, existingIdle) = await GetExistingMessagesAsync(session, alreadyIdle);
-                if (existingFinal != null)
+                lock (stateLock)
                 {
-                    lock (stateLock)
+                    // Preserve a newer message captured by the subscription in the meantime.
+                    if (existingFinal != null && finalAssistantMessage == null)
                     {
-                        // Preserve a newer message captured by the subscription in the meantime.
-                        if (finalAssistantMessage == null) finalAssistantMessage = existingFinal;
+                        finalAssistantMessage = existingFinal;
                     }
+                    if (existingIdle) sawIdle = true;
                 }
-
-                // If the turn already finished before we subscribed, complete now.
-                if (existingIdle && existingFinal != null)
-                {
-                    tcs.TrySetResult(existingFinal);
-                }
+                TryComplete();
             }
             catch (Exception ex)
             {

--- a/dotnet/test/Harness/TestHelper.cs
+++ b/dotnet/test/Harness/TestHelper.cs
@@ -12,7 +12,7 @@ public static class TestHelper
         bool alreadyIdle = false)
     {
         var tcs = new TaskCompletionSource<AssistantMessageEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(60));
+        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(120));
 
         // Both `finalAssistantMessage` and `sawIdle` are set from two threads — the
         // subscription callback (CLI read loop) and CheckExistingMessages (RPC reply).
@@ -111,7 +111,7 @@ public static class TestHelper
         TimeSpan? timeout = null) where T : SessionEvent
     {
         var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(60));
+        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(120));
 
         using var subscription = session.On(evt =>
         {

--- a/dotnet/test/Harness/TestHelper.cs
+++ b/dotnet/test/Harness/TestHelper.cs
@@ -12,7 +12,7 @@ public static class TestHelper
         bool alreadyIdle = false)
     {
         var tcs = new TaskCompletionSource<AssistantMessageEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(120));
+        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(60));
 
         // Both `finalAssistantMessage` and `sawIdle` are set from two threads — the
         // subscription callback (CLI read loop) and CheckExistingMessages (RPC reply).
@@ -111,7 +111,7 @@ public static class TestHelper
         TimeSpan? timeout = null) where T : SessionEvent
     {
         var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(120));
+        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(60));
 
         using var subscription = session.On(evt =>
         {

--- a/dotnet/test/Harness/TestHelper.cs
+++ b/dotnet/test/Harness/TestHelper.cs
@@ -14,6 +14,9 @@ public static class TestHelper
         var tcs = new TaskCompletionSource<AssistantMessageEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
         using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(60));
 
+        // Synchronize access to finalAssistantMessage between the subscription callback
+        // (events from the CLI read loop) and CheckExistingMessages (RPC reply thread).
+        var stateLock = new object();
         AssistantMessageEvent? finalAssistantMessage = null;
 
         using var subscription = session.On(evt =>
@@ -21,10 +24,12 @@ public static class TestHelper
             switch (evt)
             {
                 case AssistantMessageEvent msg:
-                    finalAssistantMessage = msg;
+                    lock (stateLock) { finalAssistantMessage = msg; }
                     break;
-                case SessionIdleEvent when finalAssistantMessage != null:
-                    tcs.TrySetResult(finalAssistantMessage);
+                case SessionIdleEvent:
+                    AssistantMessageEvent? snapshot;
+                    lock (stateLock) { snapshot = finalAssistantMessage; }
+                    if (snapshot != null) tcs.TrySetResult(snapshot);
                     break;
                 case SessionErrorEvent error:
                     tcs.TrySetException(new Exception(error.Data.Message ?? "session error"));
@@ -32,7 +37,8 @@ public static class TestHelper
             }
         });
 
-        // Check existing messages
+        // Backfill from already-delivered messages so we don't lose events that arrived
+        // between SendAsync returning and the subscription being installed.
         CheckExistingMessages();
 
         cts.Token.Register(() => tcs.TrySetException(new TimeoutException("Timeout waiting for assistant message")));
@@ -43,8 +49,21 @@ public static class TestHelper
         {
             try
             {
-                var existing = await GetExistingFinalResponseAsync(session, alreadyIdle);
-                if (existing != null) tcs.TrySetResult(existing);
+                var (existingFinal, existingIdle) = await GetExistingMessagesAsync(session, alreadyIdle);
+                if (existingFinal != null)
+                {
+                    lock (stateLock)
+                    {
+                        // Preserve a newer message captured by the subscription in the meantime.
+                        if (finalAssistantMessage == null) finalAssistantMessage = existingFinal;
+                    }
+                }
+
+                // If the turn already finished before we subscribed, complete now.
+                if (existingIdle && existingFinal != null)
+                {
+                    tcs.TrySetResult(existingFinal);
+                }
             }
             catch (Exception ex)
             {
@@ -53,7 +72,7 @@ public static class TestHelper
         }
     }
 
-    private static async Task<AssistantMessageEvent?> GetExistingFinalResponseAsync(CopilotSession session, bool alreadyIdle)
+    private static async Task<(AssistantMessageEvent? Final, bool SawIdle)> GetExistingMessagesAsync(CopilotSession session, bool alreadyIdle)
     {
         var messages = (await session.GetMessagesAsync()).ToList();
 
@@ -64,15 +83,17 @@ public static class TestHelper
         if (error != null) throw new Exception(error.Data.Message ?? "session error");
 
         var idleIdx = alreadyIdle ? currentTurn.Count : currentTurn.FindIndex(m => m is SessionIdleEvent);
-        if (idleIdx == -1) return null;
+        var sawIdle = alreadyIdle || idleIdx >= 0;
 
-        for (var i = idleIdx - 1; i >= 0; i--)
+        // Find the most recent assistant message in the turn (whether idle has arrived or not).
+        var searchEnd = idleIdx >= 0 ? idleIdx : currentTurn.Count;
+        for (var i = searchEnd - 1; i >= 0; i--)
         {
             if (currentTurn[i] is AssistantMessageEvent msg)
-                return msg;
+                return (msg, sawIdle);
         }
 
-        return null;
+        return (null, sawIdle);
     }
 
     public static async Task<T> GetNextEventOfTypeAsync<T>(

--- a/dotnet/test/SerializationTests.cs
+++ b/dotnet/test/SerializationTests.cs
@@ -5,68 +5,14 @@
 using Xunit;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using StreamJsonRpc;
 
 namespace GitHub.Copilot.SDK.Test;
 
 /// <summary>
-/// Tests for JSON serialization compatibility, particularly for StreamJsonRpc types
-/// that are needed when CancellationTokens fire during JSON-RPC operations.
-/// This test suite verifies the fix for https://github.com/PureWeen/PolyPilot/issues/319
+/// Tests for JSON serialization compatibility with the SDK's configured options.
 /// </summary>
 public class SerializationTests
 {
-    /// <summary>
-    /// Verifies that StreamJsonRpc.RequestId can be round-tripped using the SDK's configured
-    /// JsonSerializerOptions. This is critical for preventing NotSupportedException when
-    /// StandardCancellationStrategy fires during JSON-RPC operations.
-    /// </summary>
-    [Fact]
-    public void RequestId_CanBeSerializedAndDeserialized_WithSdkOptions()
-    {
-        var options = GetSerializerOptions();
-
-        // Long id
-        var jsonLong = JsonSerializer.Serialize(new RequestId(42L), options);
-        Assert.Equal("42", jsonLong);
-        Assert.Equal(new RequestId(42L), JsonSerializer.Deserialize<RequestId>(jsonLong, options));
-
-        // String id
-        var jsonStr = JsonSerializer.Serialize(new RequestId("req-1"), options);
-        Assert.Equal("\"req-1\"", jsonStr);
-        Assert.Equal(new RequestId("req-1"), JsonSerializer.Deserialize<RequestId>(jsonStr, options));
-
-        // Null id
-        var jsonNull = JsonSerializer.Serialize(RequestId.Null, options);
-        Assert.Equal("null", jsonNull);
-        Assert.Equal(RequestId.Null, JsonSerializer.Deserialize<RequestId>(jsonNull, options));
-    }
-
-    [Theory]
-    [InlineData(0L)]
-    [InlineData(-1L)]
-    [InlineData(long.MaxValue)]
-    public void RequestId_NumericEdgeCases_RoundTrip(long id)
-    {
-        var options = GetSerializerOptions();
-        var requestId = new RequestId(id);
-        var json = JsonSerializer.Serialize(requestId, options);
-        Assert.Equal(requestId, JsonSerializer.Deserialize<RequestId>(json, options));
-    }
-
-    /// <summary>
-    /// Verifies the SDK's options can resolve type info for RequestId,
-    /// ensuring AOT-safe serialization without falling back to reflection.
-    /// </summary>
-    [Fact]
-    public void SerializerOptions_CanResolveRequestIdTypeInfo()
-    {
-        var options = GetSerializerOptions();
-        var typeInfo = options.GetTypeInfo(typeof(RequestId));
-        Assert.NotNull(typeInfo);
-        Assert.Equal(typeof(RequestId), typeInfo.Type);
-    }
-
     [Fact]
     public void ProviderConfig_CanSerializeHeaders_WithSdkOptions()
     {

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -840,7 +840,13 @@ function resolvedResultTypeName(method: RpcMethod): string {
     return resultTypeName(method);
 }
 
-/** Returns the Task<T> or Task string for a method's result type. */
+/** Returns the ValueTask<T> or ValueTask string for an incoming-handler's result type. */
+function handlerTaskType(method: RpcMethod): string {
+    const schema = getMethodResultSchema(method);
+    return !isVoidSchema(schema) ? `ValueTask<${resolvedResultTypeName(method)}>` : "ValueTask";
+}
+
+/** Returns the Task<T> or Task string for an outgoing-call wrapper's result type. */
 function resultTaskType(method: RpcMethod): string {
     const schema = getMethodResultSchema(method);
     return !isVoidSchema(schema) ? `Task<${resolvedResultTypeName(method)}>` : "Task";
@@ -1465,7 +1471,7 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>,
     lines.push("");
 
     lines.push(`/// <summary>Registers client session API handlers on a JSON-RPC connection.</summary>`);
-    lines.push(`public static class ClientSessionApiRegistration`);
+    lines.push(`internal static class ClientSessionApiRegistration`);
     lines.push(`{`);
     lines.push(`    /// <summary>`);
     lines.push(`    /// Registers handlers for server-to-client session API calls.`);
@@ -1482,11 +1488,10 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>,
             const hasParams = !!effectiveParams?.properties && Object.keys(effectiveParams.properties).length > 0;
             const resultSchema = getMethodResultSchema(method);
             const paramsClass = paramsTypeName(method);
-            const taskType = resultTaskType(method);
-            const registrationVar = `register${typeToClassName(method.rpcMethod)}Method`;
+            const taskType = handlerTaskType(method);
 
             if (hasParams) {
-                lines.push(`        var ${registrationVar} = (Func<${paramsClass}, CancellationToken, ${taskType}>)(async (request, cancellationToken) =>`);
+                lines.push(`        rpc.SetLocalRpcMethod("${method.rpcMethod}", (Func<${paramsClass}, CancellationToken, ${taskType}>)(async (request, cancellationToken) =>`);
                 lines.push(`        {`);
                 lines.push(`            var handler = getHandlers(request.SessionId).${handlerProperty};`);
                 lines.push(`            if (handler is null) throw new InvalidOperationException($"No ${groupName} handler registered for session: {request.SessionId}");`);
@@ -1495,13 +1500,9 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>,
                 } else {
                     lines.push(`            await handler.${handlerMethod}(request, cancellationToken);`);
                 }
-                lines.push(`        });`);
-                lines.push(`        rpc.AddLocalRpcMethod(${registrationVar}.Method, ${registrationVar}.Target!, new JsonRpcMethodAttribute("${method.rpcMethod}")`);
-                lines.push(`        {`);
-                lines.push(`            UseSingleObjectParameterDeserialization = true`);
-                lines.push(`        });`);
+                lines.push(`        }), singleObjectParam: true);`);
             } else {
-                lines.push(`        rpc.AddLocalRpcMethod("${method.rpcMethod}", (Func<CancellationToken, ${taskType}>)(_ =>`);
+                lines.push(`        rpc.SetLocalRpcMethod("${method.rpcMethod}", (Func<CancellationToken, ${taskType}>)(_ =>`);
                 lines.push(`            throw new InvalidOperationException("No params provided for ${method.rpcMethod}")));`);
             }
         }
@@ -1544,7 +1545,6 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using StreamJsonRpc;
 
 namespace GitHub.Copilot.SDK.Rpc;
 


### PR DESCRIPTION
## Why

`StreamJsonRpc` was the only JSON-RPC client the .NET SDK used to talk to the Copilot CLI, but it dragged in 10 transitive runtime dependencies (Newtonsoft.Json, MessagePack, Nerdbank.MessagePack, Nerdbank.Streams, Microsoft.VisualStudio.Threading, etc.) that the SDK never exercised. It also routed every wire interaction through a serialization stack we did not control.

## What

This PR drops `StreamJsonRpc` and replaces it with a focused internal `JsonRpc` class (~720 lines) that implements only what the SDK actually uses against the CLI:

- LSP-style header-delimited framing (`Content-Length: N\r\n\r\n` + body) — the same wire format the Go and Python SDKs already implement against the same CLI.
- JSON-RPC 2.0 requests, responses, notifications, error codes.
- Reflection-based handler dispatch limited to the two shapes we actually register: `singleObjectParam: true` (whole `params` object deserialized as the first arg) and positional (JSON array). Anything else throws `-32603`.
- AOT-friendly serialization via `JsonTypeInfo` everywhere; no `UnconditionalSuppressMessage` shims required.

The codegen script (`scripts/codegen/csharp.ts`) was updated to emit registration calls against the new `JsonRpc` class.

## Notable points

- **Public API surface is unchanged for SDK consumers.** `StreamJsonRpc` was already `PrivateAssets="compile"`, so nothing leaks out either way.
- **Deployment footprint drops by ~3.24 MB / 10 assemblies** in a published `net8.0` app (10.14 MB -> 6.90 MB). Newtonsoft.Json, MessagePack(+Annotations), Nerdbank.MessagePack, Nerdbank.Streams, Microsoft.VisualStudio.Threading, Microsoft.VisualStudio.Validation, PolyType, and Microsoft.NET.StringTools all disappear from the dependency closure.