### PR TITLE
Document --host for non-loopback headless connections

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1599,6 +1599,15 @@ copilot --headless --port 4321
 
 If you don't specify a port, the CLI will choose a random available port.
 
+By default the headless server only accepts connections from loopback (`127.0.0.1`), so the SDK must run on the same machine. To accept connections from other hosts (for example when running the CLI in a container or on a separate server), bind to a non-loopback address with `--host`:
+
+```bash
+# Listen on all interfaces
+copilot --headless --host 0.0.0.0 --port 4321
+```
+
+> **Warning:** Exposing the headless server on a non-loopback address makes it reachable by anyone who can route to that address. Pair it with network controls (firewall, private network, reverse proxy) and authentication appropriate for your environment.
+
 ### Connecting the SDK to the External Server
 
 Once the CLI is running in server mode, configure your SDK client to connect to it using the "cli url" option:

--- a/docs/setup/backend-services.md
+++ b/docs/setup/backend-services.md
@@ -67,15 +67,21 @@ copilot --headless
 # Output: Listening on http://localhost:52431
 ```
 
+By default the headless server only accepts connections from loopback (`127.0.0.1`). To accept connections from other hosts — for example from another machine on your network — bind to a non-loopback address with `--host`:
+
+```bash
+copilot --headless --host 0.0.0.0 --port 4321
+```
+
 For production, run it as a system service or in a container:
 
 ```bash
-# Docker
+# Docker — must bind to 0.0.0.0 so the container's published port is reachable
 docker run -d --name copilot-cli \
     -p 4321:4321 \
     -e COPILOT_GITHUB_TOKEN="$TOKEN" \
     ghcr.io/github/copilot-cli:latest \
-    --headless --port 4321
+    --headless --host 0.0.0.0 --port 4321
 
 # systemd
 [Service]
@@ -415,7 +421,7 @@ version: "3.8"
 services:
   copilot-cli:
     image: ghcr.io/github/copilot-cli:latest
-    command: ["--headless", "--port", "4321"]
+    command: ["--headless", "--host", "0.0.0.0", "--port", "4321"]
     environment:
       - COPILOT_GITHUB_TOKEN=${COPILOT_GITHUB_TOKEN}
     ports:

--- a/docs/setup/scaling.md
+++ b/docs/setup/scaling.md
@@ -520,7 +520,7 @@ spec:
       containers:
         - name: copilot-cli
           image: ghcr.io/github/copilot-cli:latest
-          args: ["--headless", "--port", "4321"]
+          args: ["--headless", "--host", "0.0.0.0", "--port", "4321"]
           env:
             - name: COPILOT_GITHUB_TOKEN
               valueFrom:
@@ -577,7 +577,7 @@ flowchart TB
 containers:
   - name: copilot-cli
     image: ghcr.io/github/copilot-cli:latest
-    command: ["copilot", "--headless", "--port", "4321"]
+    command: ["copilot", "--headless", "--host", "0.0.0.0", "--port", "4321"]
     volumeMounts:
       - name: session-storage
         mountPath: /root/.copilot/session-state

--- a/test/scenarios/bundling/container-proxy/Dockerfile
+++ b/test/scenarios/bundling/container-proxy/Dockerfile
@@ -16,4 +16,4 @@ RUN chmod +x /usr/local/bin/copilot
 
 EXPOSE 3000
 
-ENTRYPOINT ["copilot", "--headless", "--port", "3000", "--bind", "0.0.0.0", "--auth-token-env", "GITHUB_TOKEN"]
+ENTRYPOINT ["copilot", "--headless", "--port", "3000", "--host", "0.0.0.0", "--auth-token-env", "GITHUB_TOKEN"]

--- a/test/scenarios/bundling/container-proxy/README.md
+++ b/test/scenarios/bundling/container-proxy/README.md
@@ -15,7 +15,7 @@ Run the Copilot CLI inside a Docker container with a simple proxy on the host th
 │                    │  Docker Container        │       │
 │                    │  Copilot CLI             │       │
 │                    │  --port 3000 --headless  │       │
-│                    │  --bind 0.0.0.0          │       │
+│                    │  --host 0.0.0.0          │       │
 │                    │  --auth-token-env        │       │
 │                    └────────────┬─────────────┘       │
 │                                │                     │


### PR DESCRIPTION
The headless CLI server binds to 127.0.0.1 by default, so connections from other machines or containers fail unless --host is set. Document this in the getting-started guide and backend-services setup, and update the Docker, Docker Compose, Kubernetes, and Azure Container Instances examples to pass --host 0.0.0.0 (which is required for any container with a published port).

Also fix the container-proxy bundling scenario, which used a non-existent --bind flag instead of --host.

Fixes https://github.com/github/copilot-sdk/issues/1153