### PR TITLE
fix(python): bump __version__ to 0.3.0

### DIFF
--- a/python/copilot/__init__.py
+++ b/python/copilot/__init__.py
@@ -36,7 +36,7 @@ from .session_fs_provider import (
 )
 from .tools import convert_mcp_call_tool_result, define_tool
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"
 
 __all__ = [
     "CommandContext",

--- a/python/copilot/__init__.py
+++ b/python/copilot/__init__.py
@@ -4,6 +4,13 @@ Copilot SDK - Python Client for GitHub Copilot CLI
 JSON-RPC based SDK for programmatic control of GitHub Copilot CLI
 """
 
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("github-copilot-sdk")
+except PackageNotFoundError:
+    __version__ = "0.3.0"
+
 from .client import (
     CopilotClient,
     ExternalServerConfig,
@@ -35,8 +42,6 @@ from .session_fs_provider import (
     create_session_fs_adapter,
 )
 from .tools import convert_mcp_call_tool_result, define_tool
-
-__version__ = "0.3.0"
 
 __all__ = [
     "CommandContext",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "github-copilot-sdk"
-version = "0.1.0"
+version = "0.3.0"
 description = "Python SDK for GitHub Copilot CLI"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

The [v0.3.0 release](https://github.com/github/copilot-sdk/releases/tag/v0.3.0) was published on April 24, 2026, but the Python package version string in `python/copilot/__init__.py` was not updated and still reads `0.1.0`.

## Change

```python
# Before
__version__ = "0.1.0"

# After
__version__ = "0.3.0"
```