### PR TITLE
fix(dotnet): add AgentId to SessionEvent base class

### DIFF
--- a/dotnet/src/Generated/SessionEvents.cs
+++ b/dotnet/src/Generated/SessionEvents.cs
@@ -119,6 +119,11 @@ public partial class SessionEvent
     [JsonPropertyName("ephemeral")]
     public bool? Ephemeral { get; set; }
 
+    /// <summary>Sub-agent instance identifier. Absent for events from the root/main agent and session-level events.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("agentId")]
+    public string? AgentId { get; set; }
+
     /// <summary>
     /// The event type discriminator.
     /// </summary>

--- a/dotnet/test/ForwardCompatibilityTests.cs
+++ b/dotnet/test/ForwardCompatibilityTests.cs
@@ -97,4 +97,41 @@ public class ForwardCompatibilityTests
 
         Assert.Equal("unknown", evt.Type);
     }
+
+        [Fact]
+    public void FromJson_WithAgentId_DeserializesAgentId()
+    {
+        var json = """
+        {
+            "id": "12345678-1234-1234-1234-123456789abc",
+            "timestamp": "2026-06-15T10:30:00Z",
+            "parentId": null,
+            "agentId": "sub-agent-42",
+            "type": "future.feature_from_server",
+            "data": {}
+        }
+        """;
+
+        var result = SessionEvent.FromJson(json);
+
+        Assert.Equal("sub-agent-42", result.AgentId);
+    }
+
+    [Fact]
+    public void FromJson_WithoutAgentId_AgentIdIsNull()
+    {
+        var json = """
+        {
+            "id": "12345678-1234-1234-1234-123456789abc",
+            "timestamp": "2026-06-15T10:30:00Z",
+            "parentId": null,
+            "type": "future.feature_from_server",
+            "data": {}
+        }
+        """;
+
+        var result = SessionEvent.FromJson(json);
+
+        Assert.Null(result.AgentId);
+    }
 }

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -739,6 +739,8 @@ namespace GitHub.Copilot.SDK;
     lines.push(`    [JsonPropertyName("parentId")]`, `    public Guid? ParentId { get; set; }`, "");
     lines.push(...xmlDocComment(baseDesc("ephemeral"), "    "));
     lines.push(`    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`, `    [JsonPropertyName("ephemeral")]`, `    public bool? Ephemeral { get; set; }`, "");
+    lines.push(...xmlDocComment(baseDesc("agentId"), "    "));
+    lines.push(`    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`, `    [JsonPropertyName("agentId")]`, `    public string? AgentId { get; set; }`, "");
     lines.push(`    /// <summary>`, `    /// The event type discriminator.`, `    /// </summary>`);
     lines.push(`    [JsonIgnore]`, `    public virtual string Type => "unknown";`, "");
     lines.push(`    /// <summary>Deserializes a JSON string into a <see cref="SessionEvent"/>.</summary>`);


### PR DESCRIPTION
Add the AgentId property to the SessionEvent base class in the .NET SDK, matching the agentId field present on all event interfaces in the Node.js generated types. This allows consumers to identify which sub-agent emitted a given event, replacing the deprecated ParentToolCallId pattern.

Fixes #1169