### PR TITLE
Ignore C# Dev Kit *.csproj.lscache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ docs/.validation/
 
 # Visual Studio
 .vs/
+
+# C# Dev Kit
+*.csproj.lscache


### PR DESCRIPTION
The VS Code C# Dev Kit extension generates `.csproj.lscache` files alongside `.csproj` files whenever a folder containing them is opened. These show up as untracked noise in `git status` and have to be carefully excluded from commits.

Adds `*.csproj.lscache` to `.gitignore` under a new "C# Dev Kit" section so they're filtered out automatically.