### PR TITLE
Stabilize unknown session delete E2E assertions

### DIFF
--- a/dotnet/test/E2E/ClientSessionManagementE2ETests.cs
+++ b/dotnet/test/E2E/ClientSessionManagementE2ETests.cs
@@ -35,10 +35,11 @@ public class ClientSessionManagementE2ETests(E2ETestFixture fixture, ITestOutput
     public async Task Should_Report_Error_When_Deleting_Unknown_Session_Id()
     {
         await Client.StartAsync();
+        const string UnknownSessionId = "00000000-0000-0000-0000-000000000000";
 
         await AssertFailureAsync(
-            () => Client.DeleteSessionAsync("00000000-0000-0000-0000-000000000000"),
-            "Session file not found");
+            () => Client.DeleteSessionAsync(UnknownSessionId),
+            $"Failed to delete session {UnknownSessionId}");
     }
 
     [Fact]

--- a/go/internal/e2e/client_api_e2e_test.go
+++ b/go/internal/e2e/client_api_e2e_test.go
@@ -50,12 +50,14 @@ func TestClientApiE2E(t *testing.T) {
 	})
 
 	t.Run("should report error when deleting unknown session id", func(t *testing.T) {
-		err := client.DeleteSession(t.Context(), "00000000-0000-0000-0000-000000000000")
+		sessionID := "00000000-0000-0000-0000-000000000000"
+		err := client.DeleteSession(t.Context(), sessionID)
 		if err == nil {
 			t.Fatal("Expected DeleteSession to fail for unknown id")
 		}
-		if !strings.Contains(strings.ToLower(err.Error()), "session file not found") {
-			t.Errorf("Expected error mentioning 'Session file not found', got %v", err)
+		expectedMessage := "failed to delete session " + sessionID
+		if !strings.Contains(strings.ToLower(err.Error()), expectedMessage) {
+			t.Errorf("Expected error mentioning %q, got %v", expectedMessage, err)
 		}
 	})
 

--- a/nodejs/test/e2e/client_api.e2e.test.ts
+++ b/nodejs/test/e2e/client_api.e2e.test.ts
@@ -34,10 +34,11 @@ describe("Client session management", async () => {
 
     it("should report error when deleting unknown session id", async () => {
         await client.start();
+        const unknownSessionId = "00000000-0000-0000-0000-000000000000";
 
         await assertFailure(
-            () => client.deleteSession("00000000-0000-0000-0000-000000000000"),
-            "Session file not found"
+            () => client.deleteSession(unknownSessionId),
+            `Failed to delete session ${unknownSessionId}`
         );
     });
 

--- a/python/e2e/test_client_api_e2e.py
+++ b/python/e2e/test_client_api_e2e.py
@@ -34,10 +34,11 @@ class TestClientApi:
 
     async def test_should_report_error_when_deleting_unknown_session_id(self, ctx: E2ETestContext):
         await ctx.client.start()
+        unknown_session_id = "00000000-0000-0000-0000-000000000000"
 
         with pytest.raises(Exception) as exc_info:
-            await ctx.client.delete_session("00000000-0000-0000-0000-000000000000")
-        assert "session file not found" in str(exc_info.value).lower()
+            await ctx.client.delete_session(unknown_session_id)
+        assert f"failed to delete session {unknown_session_id}" in str(exc_info.value).lower()
 
     async def test_should_get_null_last_session_id_before_any_sessions_exist(
         self, ctx: E2ETestContext


### PR DESCRIPTION
copilot-agent-runtime CI runs these SDK E2Es against the live runtime, whose unknown-session delete detail can differ from the checked-in CLI. The SDKs already add a stable `Failed to delete session <id>` wrapper, so these tests should assert that SDK behavior rather than a runtime-specific detail string.

## Changes

- Update the .NET, Node, Python, and Go client API E2E tests to assert the stable SDK-level delete failure prefix.
- Keep the unknown session ID explicit in each test and remove the brittle dependency on `Session file not found`.

## Testing

- `dotnet test dotnet\test\GitHub.Copilot.SDK.Test.csproj --filter "FullyQualifiedName~ClientSessionManagementE2ETests" --logger "console;verbosity=minimal"`
- `npm test --prefix nodejs -- test/e2e/client_api.e2e.test.ts`
- `go test ./internal/e2e -run TestClientApiE2E -count=1`
- `python -m pytest python\e2e\test_client_api_e2e.py -q`

Generated by Copilot.