### PR TITLE
Harden Extension E2E Tests With --yolo For Permission Gate Compatibility

### DIFF
--- a/dotnet/test/E2E/RpcExtensionsLoadedE2ETests.cs
+++ b/dotnet/test/E2E/RpcExtensionsLoadedE2ETests.cs
@@ -48,6 +48,21 @@ public class RpcExtensionsLoadedE2ETests(E2ETestFixture fixture, ITestOutputHelp
     }
 
     /// <summary>
+    /// Creates a client with the EXTENSIONS feature flag and --yolo CLI arg.
+    /// --yolo auto-approves extension permission gates at the CLI level,
+    /// preventing tests from breaking when new permission gates are added
+    /// (e.g., extension-permission-access from copilot-agent-runtime#6024).
+    /// </summary>
+    private CopilotClient CreateExtensionsClient()
+    {
+        return Ctx.CreateClient(options: new CopilotClientOptions
+        {
+            CliArgs = ["--yolo"],
+            Environment = ExtensionsEnabledEnvironment(),
+        });
+    }
+
+    /// <summary>
     /// Writes a minimal user extension into <c>{HomeDir}/extensions/{name}/extension.mjs</c>.
     /// The body imports <c>@github/copilot-sdk/extension</c>, calls <c>joinSession</c>
     /// to establish the JSON-RPC handshake (so the extension transitions from
@@ -172,10 +187,7 @@ public class RpcExtensionsLoadedE2ETests(E2ETestFixture fixture, ITestOutputHelp
             throw new ArgumentOutOfRangeException(nameof(source), source, null);
         }
 
-        await using var client = Ctx.CreateClient(options: new CopilotClientOptions
-        {
-            Environment = ExtensionsEnabledEnvironment(),
-        });
+        await using var client = CreateExtensionsClient();
 
         await using var session = await client.CreateSessionAsync(new SessionConfig
         {
@@ -200,10 +212,7 @@ public class RpcExtensionsLoadedE2ETests(E2ETestFixture fixture, ITestOutputHelp
         var extName = CreateUserExtension();
         var extId = $"user:{extName}";
 
-        await using var client = Ctx.CreateClient(options: new CopilotClientOptions
-        {
-            Environment = ExtensionsEnabledEnvironment(),
-        });
+        await using var client = CreateExtensionsClient();
 
         await using var session = await client.CreateSessionAsync(new SessionConfig
         {
@@ -229,10 +238,7 @@ public class RpcExtensionsLoadedE2ETests(E2ETestFixture fixture, ITestOutputHelp
     public async Task Reload_Picks_Up_Extension_Added_After_Session_Create()
     {
         // Start the session BEFORE writing the extension so the initial discovery sees nothing.
-        await using var client = Ctx.CreateClient(options: new CopilotClientOptions
-        {
-            Environment = ExtensionsEnabledEnvironment(),
-        });
+        await using var client = CreateExtensionsClient();
 
         await using var session = await client.CreateSessionAsync(new SessionConfig
         {
@@ -277,10 +283,7 @@ public class RpcExtensionsLoadedE2ETests(E2ETestFixture fixture, ITestOutputHelp
 
         var extId = $"user:{extName}";
 
-        await using var client = Ctx.CreateClient(options: new CopilotClientOptions
-        {
-            Environment = ExtensionsEnabledEnvironment(),
-        });
+        await using var client = CreateExtensionsClient();
 
         await using var session = await client.CreateSessionAsync(new SessionConfig
         {
@@ -301,10 +304,7 @@ public class RpcExtensionsLoadedE2ETests(E2ETestFixture fixture, ITestOutputHelp
         var ext1Id = $"user:{ext1Name}";
         var ext2Id = $"user:{ext2Name}";
 
-        await using var client = Ctx.CreateClient(options: new CopilotClientOptions
-        {
-            Environment = ExtensionsEnabledEnvironment(),
-        });
+        await using var client = CreateExtensionsClient();
 
         await using var session = await client.CreateSessionAsync(new SessionConfig
         {
@@ -326,10 +326,7 @@ public class RpcExtensionsLoadedE2ETests(E2ETestFixture fixture, ITestOutputHelp
         var extName = CreateUserExtension(prefix: "persistent-disable");
         var extId = $"user:{extName}";
 
-        await using var client = Ctx.CreateClient(options: new CopilotClientOptions
-        {
-            Environment = ExtensionsEnabledEnvironment(),
-        });
+        await using var client = CreateExtensionsClient();
 
         await using var session = await client.CreateSessionAsync(new SessionConfig
         {

--- a/dotnet/test/E2E/RpcMcpAndSkillsE2ETests.cs
+++ b/dotnet/test/E2E/RpcMcpAndSkillsE2ETests.cs
@@ -98,7 +98,16 @@ public class RpcMcpAndSkillsE2ETests(E2ETestFixture fixture, ITestOutputHelper o
     [Fact]
     public async Task Should_List_Extensions()
     {
-        var session = await CreateSessionAsync();
+        // Use --yolo to auto-approve extension permission gates at the CLI level,
+        // preventing breakage from new gates (e.g., extension-permission-access).
+        await using var yoloClient = Ctx.CreateClient(options: new CopilotClientOptions
+        {
+            CliArgs = ["--yolo"],
+        });
+        await using var session = await yoloClient.CreateSessionAsync(new SessionConfig
+        {
+            OnPermissionRequest = PermissionHandler.ApproveAll,
+        });
 
         var result = await session.Rpc.Extensions.ListAsync();
 
@@ -175,7 +184,16 @@ public class RpcMcpAndSkillsE2ETests(E2ETestFixture fixture, ITestOutputHelper o
     [Fact]
     public async Task Should_Report_Error_When_Extensions_Are_Not_Available()
     {
-        var session = await CreateSessionAsync();
+        // Use --yolo to auto-approve extension permission gates at the CLI level,
+        // preventing breakage from new gates (e.g., extension-permission-access).
+        await using var yoloClient = Ctx.CreateClient(options: new CopilotClientOptions
+        {
+            CliArgs = ["--yolo"],
+        });
+        await using var session = await yoloClient.CreateSessionAsync(new SessionConfig
+        {
+            OnPermissionRequest = PermissionHandler.ApproveAll,
+        });
 
         await AssertFailureAsync(
             () => session.Rpc.Extensions.EnableAsync("missing-extension"),

--- a/go/internal/e2e/rpc_mcp_and_skills_e2e_test.go
+++ b/go/internal/e2e/rpc_mcp_and_skills_e2e_test.go
@@ -16,7 +16,11 @@ import (
 // Tests session-scoped MCP, skills, plugins, and extensions RPCs.
 func TestRpcMcpAndSkillsE2E(t *testing.T) {
 	ctx := testharness.NewTestContext(t)
-	client := ctx.NewClient()
+	// --yolo auto-approves extension permission gates at the CLI level,
+	// preventing breakage from new gates (e.g., extension-permission-access).
+	client := ctx.NewClient(func(o *copilot.ClientOptions) {
+		o.CLIArgs = []string{"--yolo"}
+	})
 	t.Cleanup(func() { client.ForceStop() })
 
 	t.Run("should list and toggle session skills", func(t *testing.T) {

--- a/nodejs/test/e2e/rpc_mcp_and_skills.e2e.test.ts
+++ b/nodejs/test/e2e/rpc_mcp_and_skills.e2e.test.ts
@@ -10,7 +10,11 @@ import type { MCPServerConfig } from "../../src/index.js";
 import { createSdkTestContext } from "./harness/sdkTestContext.js";
 
 describe("Session MCP and skills RPC", async () => {
-    const { copilotClient: client, workDir } = await createSdkTestContext();
+    // --yolo auto-approves extension permission gates at the CLI level,
+    // preventing breakage from new gates (e.g., extension-permission-access).
+    const { copilotClient: client, workDir } = await createSdkTestContext({
+        copilotClientOptions: { cliArgs: ["--yolo"] },
+    });
 
     function createSkill(skillsDir: string, skillName: string, description: string): void {
         const skillSubdir = path.join(skillsDir, skillName);

--- a/python/e2e/test_rpc_mcp_and_skills_e2e.py
+++ b/python/e2e/test_rpc_mcp_and_skills_e2e.py
@@ -12,6 +12,7 @@ import uuid
 from pathlib import Path
 
 import pytest
+import pytest_asyncio
 
 from copilot.generated.rpc import (
     ExtensionsDisableRequest,
@@ -26,6 +27,18 @@ from copilot.session import PermissionHandler
 from .testharness import E2ETestContext
 
 pytestmark = pytest.mark.asyncio(loop_scope="module")
+
+
+# --yolo auto-approves extension permission gates at the CLI level,
+# preventing breakage from new gates (e.g., extension-permission-access).
+@pytest_asyncio.fixture(scope="module", loop_scope="module")
+async def ctx(request):
+    """Module-scoped context with --yolo for extension test hardening."""
+    context = E2ETestContext()
+    await context.setup(cli_args=["--yolo"])
+    yield context
+    any_failed = request.session.stash.get("any_test_failed", False)
+    await context.teardown(test_failed=any_failed)
 
 
 def _create_skill(skills_dir: Path, skill_name: str, description: str) -> None:

--- a/python/e2e/testharness/context.py
+++ b/python/e2e/testharness/context.py
@@ -51,8 +51,12 @@ class E2ETestContext:
         self._proxy: CapiProxy | None = None
         self._client: CopilotClient | None = None
 
-    async def setup(self):
-        """Set up the test context with a shared client."""
+    async def setup(self, cli_args: list[str] | None = None):
+        """Set up the test context with a shared client.
+
+        Args:
+            cli_args: Optional extra CLI arguments passed to the CLI process.
+        """
         self.cli_path = get_cli_path_for_tests()
 
         self.home_dir = os.path.realpath(tempfile.mkdtemp(prefix="copilot-test-config-"))
@@ -69,6 +73,7 @@ class E2ETestContext:
         self._client = CopilotClient(
             SubprocessConfig(
                 cli_path=self.cli_path,
+                cli_args=cli_args or [],
                 cwd=self.work_dir,
                 env=self.get_env(),
                 github_token=github_token,


### PR DESCRIPTION
## What

Adds `--yolo` CLI flag to all extension-related E2E tests across all four SDKs (Node, Python, Go, .NET). This ensures that if extensions ever require user approval before loading then these tests will auto-approve and continue to pass without modification. Tests that specifically validate extension permission behavior are left unchanged.

## Why

The Copilot CLI's extension system is evolving, and new permission gates may be introduced that prompt users before loading extensions. Without this hardening, any extension E2E test that doesn't explicitly handle such a gate would start failing. By passing `--yolo` at the CLI level as defense-in-depth (on top of the existing `approveAll` session handler), these tests are resilient to future permission-related changes in the runtime without masking intentional permission-testing scenarios.
