### PR TITLE
Fix .NET client startup cleanup race

### DIFF
--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -226,26 +226,26 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             _logger.LogDebug("Starting Copilot client");
             _disconnected = false;
 
-            Task<Connection> result;
-
-            if (_optionsHost is not null && _optionsPort is not null)
-            {
-                // External server (TCP)
-                _actualPort = _optionsPort;
-                result = ConnectToServerAsync(null, _optionsHost, _optionsPort, null, ct);
-            }
-            else
-            {
-                // Child process (stdio or TCP)
-                var (cliProcess, portOrNull, stderrBuffer) = await StartCliServerAsync(_options, _effectiveConnectionToken, _logger, ct);
-                _actualPort = portOrNull;
-                result = ConnectToServerAsync(cliProcess, portOrNull is null ? null : "localhost", portOrNull, stderrBuffer, ct);
-            }
-
-            var connection = await result;
+            Connection? connection = null;
+            Process? cliProcess = null;
 
             try
             {
+                if (_optionsHost is not null && _optionsPort is not null)
+                {
+                    // External server (TCP)
+                    _actualPort = _optionsPort;
+                    connection = await ConnectToServerAsync(null, _optionsHost, _optionsPort, null, ct);
+                }
+                else
+                {
+                    // Child process (stdio or TCP)
+                    var (startedProcess, portOrNull, stderrBuffer) = await StartCliServerAsync(_options, _effectiveConnectionToken, _logger, ct);
+                    cliProcess = startedProcess;
+                    _actualPort = portOrNull;
+                    connection = await ConnectToServerAsync(cliProcess, portOrNull is null ? null : "localhost", portOrNull, stderrBuffer, ct);
+                }
+
                 // Verify protocol version compatibility
                 await VerifyProtocolVersionAsync(connection, ct);
                 await ConfigureSessionFsAsync(ct);
@@ -255,7 +255,15 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             }
             catch
             {
-                await CleanupConnectionAsync(connection, errors: null);
+                if (connection is not null)
+                {
+                    await CleanupConnectionAsync(connection, errors: null);
+                }
+                else if (cliProcess is not null)
+                {
+                    await CleanupCliProcessAsync(cliProcess, errors: null, _logger);
+                }
+
                 throw;
             }
         }
@@ -381,7 +389,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     private async Task CleanupConnectionAsync(Connection ctx, List<Exception>? errors)
     {
         try { ctx.Rpc.Dispose(); }
-        catch (Exception ex) { AddCleanupError(errors, ex); }
+        catch (Exception ex) { AddCleanupError(errors, ex, _logger); }
 
         // Clear RPC and models cache
         _serverRpc = null;
@@ -390,10 +398,18 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         if (ctx.NetworkStream is not null)
         {
             try { await ctx.NetworkStream.DisposeAsync(); }
-            catch (Exception ex) { AddCleanupError(errors, ex); }
+            catch (Exception ex) { AddCleanupError(errors, ex, _logger); }
         }
 
         if (ctx.CliProcess is { } childProcess)
+        {
+            await CleanupCliProcessAsync(childProcess, errors, _logger);
+        }
+    }
+
+    private static async Task CleanupCliProcessAsync(Process childProcess, List<Exception>? errors, ILogger? logger)
+    {
+        try
         {
             try
             {
@@ -402,13 +418,19 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                     childProcess.Kill(entireProcessTree: true);
                     await childProcess.WaitForExitAsync();
                 }
+            }
+            finally
+            {
                 childProcess.Dispose();
             }
-            catch (Exception ex) { AddCleanupError(errors, ex); }
+        }
+        catch (Exception ex)
+        {
+            AddCleanupError(errors, ex, logger);
         }
     }
 
-    private void AddCleanupError(List<Exception>? errors, Exception ex)
+    private static void AddCleanupError(List<Exception>? errors, Exception ex, ILogger? logger)
     {
         if (errors is not null)
         {
@@ -416,7 +438,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         }
         else
         {
-            _logger.LogDebug(ex, "Error while cleaning up Copilot CLI connection");
+            logger?.LogDebug(ex, "Error while cleaning up Copilot CLI connection");
         }
     }
 
@@ -1341,58 +1363,71 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             if (telemetry.CaptureContent is { } capture) startInfo.Environment["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = capture ? "true" : "false";
         }
 
-        var cliProcess = new Process { StartInfo = startInfo };
-        cliProcess.Start();
-
-        // Capture stderr for error messages and forward to logger
-        var stderrBuffer = new StringBuilder();
-        var stderrReader = Task.Run(async () =>
+        Process? cliProcess = null;
+        try
         {
-            while (true)
+            cliProcess = new Process { StartInfo = startInfo };
+            cliProcess.Start();
+
+            // Capture stderr for error messages and forward to logger
+            var stderrBuffer = new StringBuilder();
+            var stderrReader = Task.Run(async () =>
             {
-                var line = await cliProcess.StandardError.ReadLineAsync(cancellationToken);
-                if (line is null)
+                while (true)
                 {
-                    break;
-                }
+                    var line = await cliProcess.StandardError.ReadLineAsync(cancellationToken);
+                    if (line is null)
+                    {
+                        break;
+                    }
 
-                lock (stderrBuffer)
-                {
-                    stderrBuffer.AppendLine(line);
-                }
+                    lock (stderrBuffer)
+                    {
+                        stderrBuffer.AppendLine(line);
+                    }
 
-                if (logger.IsEnabled(LogLevel.Debug))
+                    if (logger.IsEnabled(LogLevel.Debug))
+                    {
+                        logger.LogDebug("[CLI] {Line}", line);
+                    }
+                }
+            }, cancellationToken);
+
+            var detectedLocalhostTcpPort = (int?)null;
+            if (options.UseStdio != true)
+            {
+                // Wait for port announcement
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(TimeSpan.FromSeconds(30));
+
+                while (!cts.Token.IsCancellationRequested)
                 {
-                    logger.LogDebug("[CLI] {Line}", line);
+                    var line = await cliProcess.StandardOutput.ReadLineAsync(cts.Token);
+                    if (line is null)
+                    {
+                        await stderrReader;
+                        throw CreateCliExitedException("CLI process exited unexpectedly", stderrBuffer);
+                    }
+
+                    if (ListeningOnPortRegex().Match(line) is { Success: true } match)
+                    {
+                        detectedLocalhostTcpPort = int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
+                        break;
+                    }
                 }
             }
-        }, cancellationToken);
 
-        var detectedLocalhostTcpPort = (int?)null;
-        if (options.UseStdio != true)
-        {
-            // Wait for port announcement
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            cts.CancelAfter(TimeSpan.FromSeconds(30));
-
-            while (!cts.Token.IsCancellationRequested)
-            {
-                var line = await cliProcess.StandardOutput.ReadLineAsync(cts.Token);
-                if (line is null)
-                {
-                    await stderrReader;
-                    throw CreateCliExitedException("CLI process exited unexpectedly", stderrBuffer);
-                }
-
-                if (ListeningOnPortRegex().Match(line) is { Success: true } match)
-                {
-                    detectedLocalhostTcpPort = int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
-                    break;
-                }
-            }
+            return (cliProcess, detectedLocalhostTcpPort, stderrBuffer);
         }
+        catch
+        {
+            if (cliProcess is not null)
+            {
+                await CleanupCliProcessAsync(cliProcess, errors: null, logger);
+            }
 
-        return (cliProcess, detectedLocalhostTcpPort, stderrBuffer);
+            throw;
+        }
     }
 
     private static string? GetBundledCliPath(out string searchedPath)

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -244,12 +244,20 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
             var connection = await result;
 
-            // Verify protocol version compatibility
-            await VerifyProtocolVersionAsync(connection, ct);
-            await ConfigureSessionFsAsync(ct);
+            try
+            {
+                // Verify protocol version compatibility
+                await VerifyProtocolVersionAsync(connection, ct);
+                await ConfigureSessionFsAsync(ct);
 
-            _logger.LogInformation("Copilot client connected");
-            return connection;
+                _logger.LogInformation("Copilot client connected");
+                return connection;
+            }
+            catch
+            {
+                await CleanupConnectionAsync(connection, errors: null);
+                throw;
+            }
         }
     }
 
@@ -353,11 +361,27 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             return;
         }
 
-        var ctx = await _connectionTask;
+        var connectionTask = _connectionTask;
         _connectionTask = null;
 
+        Connection ctx;
+        try
+        {
+            ctx = await connectionTask;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Ignoring failed Copilot client startup during cleanup");
+            return;
+        }
+
+        await CleanupConnectionAsync(ctx, errors);
+    }
+
+    private async Task CleanupConnectionAsync(Connection ctx, List<Exception>? errors)
+    {
         try { ctx.Rpc.Dispose(); }
-        catch (Exception ex) { errors?.Add(ex); }
+        catch (Exception ex) { AddCleanupError(errors, ex); }
 
         // Clear RPC and models cache
         _serverRpc = null;
@@ -366,7 +390,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         if (ctx.NetworkStream is not null)
         {
             try { await ctx.NetworkStream.DisposeAsync(); }
-            catch (Exception ex) { errors?.Add(ex); }
+            catch (Exception ex) { AddCleanupError(errors, ex); }
         }
 
         if (ctx.CliProcess is { } childProcess)
@@ -380,7 +404,19 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 }
                 childProcess.Dispose();
             }
-            catch (Exception ex) { errors?.Add(ex); }
+            catch (Exception ex) { AddCleanupError(errors, ex); }
+        }
+    }
+
+    private void AddCleanupError(List<Exception>? errors, Exception ex)
+    {
+        if (errors is not null)
+        {
+            errors.Add(ex);
+        }
+        else
+        {
+            _logger.LogDebug(ex, "Error while cleaning up Copilot CLI connection");
         }
     }
 

--- a/dotnet/test/E2E/ClientOptionsE2ETests.cs
+++ b/dotnet/test/E2E/ClientOptionsE2ETests.cs
@@ -203,6 +203,28 @@ public class ClientOptionsE2ETests(E2ETestFixture fixture, ITestOutputHelper out
     }
 
     [Fact]
+    public async Task ForceStop_Does_Not_Rethrow_When_Tcp_Cli_Drops_During_Startup()
+    {
+        var cliPath = Path.Join(Ctx.WorkDir, $"fake-tcp-drop-cli-{Guid.NewGuid():N}.js");
+        await File.WriteAllTextAsync(cliPath, FakeTcpDropDuringStartupCliScript);
+
+        await using var client = Ctx.CreateClient(
+            useStdio: false,
+            options: new CopilotClientOptions
+            {
+                AutoStart = false,
+                CliPath = cliPath,
+                UseLoggedInUser = false,
+            });
+
+        var ex = await Assert.ThrowsAsync<IOException>(() => client.StartAsync());
+        Assert.Contains("Communication error", ex.Message, StringComparison.Ordinal);
+
+        await client.ForceStopAsync();
+        Assert.Equal(ConnectionState.Disconnected, client.State);
+    }
+
+    [Fact]
     public async Task Should_Propagate_Activity_TraceContext_To_Session_Resume()
     {
         var (cliPath, capturePath) = await CreateFakeCliCaptureAsync();
@@ -361,6 +383,24 @@ public class ClientOptionsE2ETests(E2ETestFixture fixture, ITestOutputHelper out
             .Single(request => request.GetProperty("method").GetString() == method)
             .GetProperty("params");
     }
+
+    private const string FakeTcpDropDuringStartupCliScript = """
+        const net = require("net");
+
+        const server = net.createServer(socket => {
+          socket.on("data", () => {
+            socket.destroy();
+            server.close(() => process.exit(0));
+          });
+        });
+
+        server.listen(0, "localhost", () => {
+          const address = server.address();
+          console.log(`listening on port ${address.port}`);
+        });
+
+        setTimeout(() => process.exit(2), 30000).unref();
+        """;
 
     private const string FakeStdioCliScript = """
         const fs = require("fs");

--- a/dotnet/test/E2E/ClientOptionsE2ETests.cs
+++ b/dotnet/test/E2E/ClientOptionsE2ETests.cs
@@ -3,6 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System.Diagnostics;
+using System.Globalization;
 using System.Net;
 using System.Net.Sockets;
 using System.Text.Json;
@@ -225,6 +226,33 @@ public class ClientOptionsE2ETests(E2ETestFixture fixture, ITestOutputHelper out
     }
 
     [Fact]
+    public async Task StartAsync_Cleans_Up_Tcp_Cli_Process_When_Connect_Fails()
+    {
+        var cliPath = Path.Join(Ctx.WorkDir, $"fake-tcp-unavailable-port-cli-{Guid.NewGuid():N}.js");
+        var pidPath = Path.Join(Ctx.WorkDir, $"fake-tcp-unavailable-port-cli-{Guid.NewGuid():N}.pid");
+        var unavailablePort = GetAvailableTcpPort();
+        await File.WriteAllTextAsync(cliPath, FakeTcpUnavailablePortCliScript);
+
+        await using var client = Ctx.CreateClient(
+            useStdio: false,
+            options: new CopilotClientOptions
+            {
+                AutoStart = false,
+                CliPath = cliPath,
+                CliArgs = ["--pid-file", pidPath, "--announce-port", unavailablePort.ToString(CultureInfo.InvariantCulture)],
+                UseLoggedInUser = false,
+            });
+
+        await Assert.ThrowsAnyAsync<Exception>(() => client.StartAsync());
+
+        var pid = int.Parse(await File.ReadAllTextAsync(pidPath), CultureInfo.InvariantCulture);
+        await AssertProcessExitedAsync(pid);
+
+        await client.ForceStopAsync();
+        Assert.Equal(ConnectionState.Disconnected, client.State);
+    }
+
+    [Fact]
     public async Task Should_Propagate_Activity_TraceContext_To_Session_Resume()
     {
         var (cliPath, capturePath) = await CreateFakeCliCaptureAsync();
@@ -383,6 +411,46 @@ public class ClientOptionsE2ETests(E2ETestFixture fixture, ITestOutputHelper out
             .Single(request => request.GetProperty("method").GetString() == method)
             .GetProperty("params");
     }
+
+    private static async Task AssertProcessExitedAsync(int pid)
+    {
+        for (var i = 0; i < 50; i++)
+        {
+            if (!IsProcessRunning(pid))
+            {
+                return;
+            }
+
+            await Task.Delay(100);
+        }
+
+        Assert.False(IsProcessRunning(pid), $"Expected process {pid} to have exited.");
+    }
+
+    private static bool IsProcessRunning(int pid)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            return !process.HasExited;
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    private const string FakeTcpUnavailablePortCliScript = """
+        const fs = require("fs");
+
+        const pidFileIndex = process.argv.indexOf("--pid-file");
+        const portIndex = process.argv.indexOf("--announce-port");
+
+        fs.writeFileSync(process.argv[pidFileIndex + 1], String(process.pid));
+        console.log(`listening on port ${process.argv[portIndex + 1]}`);
+
+        setInterval(() => {}, 1000);
+        """;
 
     private const string FakeTcpDropDuringStartupCliScript = """
         const net = require("net");


### PR DESCRIPTION
A four-way parallel run of the .NET SDK E2E suite exposed a load-sensitive cleanup race: if the TCP CLI connection drops after a connection is created but before startup finishes protocol negotiation, later force-stop/dispose cleanup can rethrow the failed startup task instead of just releasing resources.

This change makes startup cleanup tear down partially established connections before rethrowing the startup failure, and makes force-stop cleanup treat an already-failed startup task as cleanup-complete. It also adds a fake TCP CLI regression test that announces a port, accepts the initial JSON-RPC connection, and drops during startup verification to ensure `ForceStopAsync` remains safe afterward.

Validation:
- `dotnet test dotnet\test\GitHub.Copilot.SDK.Test.csproj --filter FullyQualifiedName~ForceStop_Does_Not_Rethrow_When_Tcp_Cli_Drops_During_Startup`
- 4 full C# SDK test suites run in parallel: 4/4 passed