### PR TITLE
Avoid shell kill cwd cleanup flakes

### DIFF
--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -1154,6 +1154,17 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             }
             throw new IOException($"Communication error with Copilot CLI: {ex.Message}", ex);
         }
+        catch (IOException ex) when (stderrBuffer is not null)
+        {
+            var stderrOutput = await GetStderrOutputAsync(stderrBuffer, stderrReader);
+
+            if (!string.IsNullOrEmpty(stderrOutput))
+            {
+                throw new IOException(FormatCliExitedMessage("CLI process exited unexpectedly.", stderrOutput), ex);
+            }
+
+            throw;
+        }
         catch (RemoteRpcException ex)
         {
             throw new IOException($"Communication error with Copilot CLI: {ex.Message}", ex);

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -1154,17 +1154,6 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             }
             throw new IOException($"Communication error with Copilot CLI: {ex.Message}", ex);
         }
-        catch (IOException ex) when (stderrBuffer is not null)
-        {
-            var stderrOutput = await GetStderrOutputAsync(stderrBuffer, stderrReader);
-
-            if (!string.IsNullOrEmpty(stderrOutput))
-            {
-                throw new IOException(FormatCliExitedMessage("CLI process exited unexpectedly.", stderrOutput), ex);
-            }
-
-            throw;
-        }
         catch (RemoteRpcException ex)
         {
             throw new IOException($"Communication error with Copilot CLI: {ex.Message}", ex);

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -235,15 +235,15 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 {
                     // External server (TCP)
                     _actualPort = _optionsPort;
-                    connection = await ConnectToServerAsync(null, _optionsHost, _optionsPort, null, ct);
+                    connection = await ConnectToServerAsync(null, _optionsHost, _optionsPort, null, null, ct);
                 }
                 else
                 {
                     // Child process (stdio or TCP)
-                    var (startedProcess, portOrNull, stderrBuffer) = await StartCliServerAsync(_options, _effectiveConnectionToken, _logger, ct);
+                    var (startedProcess, portOrNull, stderrBuffer, stderrReader) = await StartCliServerAsync(_options, _effectiveConnectionToken, _logger, ct);
                     cliProcess = startedProcess;
                     _actualPort = portOrNull;
-                    connection = await ConnectToServerAsync(cliProcess, portOrNull is null ? null : "localhost", portOrNull, stderrBuffer, ct);
+                    connection = await ConnectToServerAsync(cliProcess, portOrNull is null ? null : "localhost", portOrNull, stderrBuffer, stderrReader, ct);
                 }
 
                 // Verify protocol version compatibility
@@ -1135,20 +1135,18 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
     internal static async Task<T> InvokeRpcAsync<T>(JsonRpc rpc, string method, object?[]? args, StringBuilder? stderrBuffer, CancellationToken cancellationToken)
     {
+        return await InvokeRpcAsync<T>(rpc, method, args, stderrBuffer, stderrReader: null, cancellationToken);
+    }
+
+    internal static async Task<T> InvokeRpcAsync<T>(JsonRpc rpc, string method, object?[]? args, StringBuilder? stderrBuffer, Task? stderrReader, CancellationToken cancellationToken)
+    {
         try
         {
             return await rpc.InvokeAsync<T>(method, args, cancellationToken);
         }
         catch (ConnectionLostException ex)
         {
-            string? stderrOutput = null;
-            if (stderrBuffer is not null)
-            {
-                lock (stderrBuffer)
-                {
-                    stderrOutput = stderrBuffer.ToString().Trim();
-                }
-            }
+            var stderrOutput = await GetStderrOutputAsync(stderrBuffer, stderrReader);
 
             if (!string.IsNullOrEmpty(stderrOutput))
             {
@@ -1169,13 +1167,34 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             : $"{message}\nstderr: {stderrOutput}";
     }
 
-    private static IOException CreateCliExitedException(string message, StringBuilder stderrBuffer)
+    private static async Task<string?> GetStderrOutputAsync(StringBuilder? stderrBuffer, Task? stderrReader)
     {
-        string stderrOutput;
+        if (stderrBuffer is null)
+        {
+            return null;
+        }
+
+        var stderrOutput = ReadStderrBuffer(stderrBuffer);
+        if (string.IsNullOrEmpty(stderrOutput) && stderrReader is not null)
+        {
+            await Task.WhenAny(stderrReader, Task.Delay(TimeSpan.FromMilliseconds(250)));
+            stderrOutput = ReadStderrBuffer(stderrBuffer);
+        }
+
+        return string.IsNullOrEmpty(stderrOutput) ? null : stderrOutput;
+    }
+
+    private static string ReadStderrBuffer(StringBuilder stderrBuffer)
+    {
         lock (stderrBuffer)
         {
-            stderrOutput = stderrBuffer.ToString().Trim();
+            return stderrBuffer.ToString().Trim();
         }
+    }
+
+    private static IOException CreateCliExitedException(string message, StringBuilder stderrBuffer)
+    {
+        var stderrOutput = ReadStderrBuffer(stderrBuffer);
 
         return new IOException(FormatCliExitedMessage(message, stderrOutput));
     }
@@ -1229,7 +1248,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         try
         {
             var connectResponse = await InvokeRpcAsync<ConnectResult>(
-                connection.Rpc, "connect", [new ConnectRequest { Token = _effectiveConnectionToken }], connection.StderrBuffer, cancellationToken);
+                connection.Rpc, "connect", [new ConnectRequest { Token = _effectiveConnectionToken }], connection.StderrBuffer, connection.StderrReader, cancellationToken);
             serverVersion = (int)connectResponse.ProtocolVersion;
         }
         catch (IOException ex) when (ex.InnerException is RemoteRpcException remoteEx && IsUnsupportedConnectMethod(remoteEx))
@@ -1237,7 +1256,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             // Legacy server without `connect`; fall back to `ping`. A token, if any,
             // is silently dropped — the legacy server can't enforce one.
             var pingResponse = await InvokeRpcAsync<PingResponse>(
-                connection.Rpc, "ping", [new PingRequest()], connection.StderrBuffer, cancellationToken);
+                connection.Rpc, "ping", [new PingRequest()], connection.StderrBuffer, connection.StderrReader, cancellationToken);
             serverVersion = pingResponse.ProtocolVersion;
         }
 
@@ -1266,7 +1285,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             || string.Equals(ex.Message, "Unhandled method connect", StringComparison.Ordinal);
     }
 
-    private static async Task<(Process Process, int? DetectedLocalhostTcpPort, StringBuilder StderrBuffer)> StartCliServerAsync(CopilotClientOptions options, string? connectionToken, ILogger logger, CancellationToken cancellationToken)
+    private static async Task<(Process Process, int? DetectedLocalhostTcpPort, StringBuilder StderrBuffer, Task StderrReader)> StartCliServerAsync(CopilotClientOptions options, string? connectionToken, ILogger logger, CancellationToken cancellationToken)
     {
         // Use explicit path, COPILOT_CLI_PATH env var (from options.Environment or process env), or bundled CLI - no PATH fallback
         var envCliPath = options.Environment is not null && options.Environment.TryGetValue("COPILOT_CLI_PATH", out var envValue) ? envValue
@@ -1417,7 +1436,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 }
             }
 
-            return (cliProcess, detectedLocalhostTcpPort, stderrBuffer);
+            return (cliProcess, detectedLocalhostTcpPort, stderrBuffer, stderrReader);
         }
         catch
         {
@@ -1471,7 +1490,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         return (cliPath, args);
     }
 
-    private async Task<Connection> ConnectToServerAsync(Process? cliProcess, string? tcpHost, int? tcpPort, StringBuilder? stderrBuffer, CancellationToken cancellationToken)
+    private async Task<Connection> ConnectToServerAsync(Process? cliProcess, string? tcpHost, int? tcpPort, StringBuilder? stderrBuffer, Task? stderrReader, CancellationToken cancellationToken)
     {
         Stream inputStream, outputStream;
         NetworkStream? networkStream = null;
@@ -1537,7 +1556,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
         _serverRpc = new ServerRpc(rpc);
 
-        return new Connection(rpc, cliProcess, networkStream, stderrBuffer);
+        return new Connection(rpc, cliProcess, networkStream, stderrBuffer, stderrReader);
     }
 
     private static JsonSerializerOptions SerializerOptionsForMessageFormatter { get; } = CreateSerializerOptions();
@@ -1752,12 +1771,14 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         JsonRpc rpc,
         Process? cliProcess, // Set if we created the child process
         NetworkStream? networkStream, // Set if using TCP
-        StringBuilder? stderrBuffer = null) // Captures stderr for error messages
+        StringBuilder? stderrBuffer = null, // Captures stderr for error messages
+        Task? stderrReader = null)
     {
         public Process? CliProcess => cliProcess;
         public JsonRpc Rpc => rpc;
         public NetworkStream? NetworkStream => networkStream;
         public StringBuilder? StderrBuffer => stderrBuffer;
+        public Task? StderrReader => stderrReader;
     }
 
     private static class ProcessArgumentEscaper

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -235,15 +235,15 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 {
                     // External server (TCP)
                     _actualPort = _optionsPort;
-                    connection = await ConnectToServerAsync(null, _optionsHost, _optionsPort, null, null, ct);
+                    connection = await ConnectToServerAsync(null, _optionsHost, _optionsPort, null, ct);
                 }
                 else
                 {
                     // Child process (stdio or TCP)
-                    var (startedProcess, portOrNull, stderrBuffer, stderrReader) = await StartCliServerAsync(_options, _effectiveConnectionToken, _logger, ct);
+                    var (startedProcess, portOrNull, stderrBuffer) = await StartCliServerAsync(_options, _effectiveConnectionToken, _logger, ct);
                     cliProcess = startedProcess;
                     _actualPort = portOrNull;
-                    connection = await ConnectToServerAsync(cliProcess, portOrNull is null ? null : "localhost", portOrNull, stderrBuffer, stderrReader, ct);
+                    connection = await ConnectToServerAsync(cliProcess, portOrNull is null ? null : "localhost", portOrNull, stderrBuffer, ct);
                 }
 
                 // Verify protocol version compatibility
@@ -1135,18 +1135,20 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
     internal static async Task<T> InvokeRpcAsync<T>(JsonRpc rpc, string method, object?[]? args, StringBuilder? stderrBuffer, CancellationToken cancellationToken)
     {
-        return await InvokeRpcAsync<T>(rpc, method, args, stderrBuffer, stderrReader: null, cancellationToken);
-    }
-
-    internal static async Task<T> InvokeRpcAsync<T>(JsonRpc rpc, string method, object?[]? args, StringBuilder? stderrBuffer, Task? stderrReader, CancellationToken cancellationToken)
-    {
         try
         {
             return await rpc.InvokeAsync<T>(method, args, cancellationToken);
         }
         catch (ConnectionLostException ex)
         {
-            var stderrOutput = await GetStderrOutputAsync(stderrBuffer, stderrReader);
+            string? stderrOutput = null;
+            if (stderrBuffer is not null)
+            {
+                lock (stderrBuffer)
+                {
+                    stderrOutput = stderrBuffer.ToString().Trim();
+                }
+            }
 
             if (!string.IsNullOrEmpty(stderrOutput))
             {
@@ -1167,34 +1169,13 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             : $"{message}\nstderr: {stderrOutput}";
     }
 
-    private static async Task<string?> GetStderrOutputAsync(StringBuilder? stderrBuffer, Task? stderrReader)
-    {
-        if (stderrBuffer is null)
-        {
-            return null;
-        }
-
-        var stderrOutput = ReadStderrBuffer(stderrBuffer);
-        if (string.IsNullOrEmpty(stderrOutput) && stderrReader is not null)
-        {
-            await Task.WhenAny(stderrReader, Task.Delay(TimeSpan.FromMilliseconds(250)));
-            stderrOutput = ReadStderrBuffer(stderrBuffer);
-        }
-
-        return string.IsNullOrEmpty(stderrOutput) ? null : stderrOutput;
-    }
-
-    private static string ReadStderrBuffer(StringBuilder stderrBuffer)
-    {
-        lock (stderrBuffer)
-        {
-            return stderrBuffer.ToString().Trim();
-        }
-    }
-
     private static IOException CreateCliExitedException(string message, StringBuilder stderrBuffer)
     {
-        var stderrOutput = ReadStderrBuffer(stderrBuffer);
+        string stderrOutput;
+        lock (stderrBuffer)
+        {
+            stderrOutput = stderrBuffer.ToString().Trim();
+        }
 
         return new IOException(FormatCliExitedMessage(message, stderrOutput));
     }
@@ -1248,7 +1229,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         try
         {
             var connectResponse = await InvokeRpcAsync<ConnectResult>(
-                connection.Rpc, "connect", [new ConnectRequest { Token = _effectiveConnectionToken }], connection.StderrBuffer, connection.StderrReader, cancellationToken);
+                connection.Rpc, "connect", [new ConnectRequest { Token = _effectiveConnectionToken }], connection.StderrBuffer, cancellationToken);
             serverVersion = (int)connectResponse.ProtocolVersion;
         }
         catch (IOException ex) when (ex.InnerException is RemoteRpcException remoteEx && IsUnsupportedConnectMethod(remoteEx))
@@ -1256,7 +1237,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             // Legacy server without `connect`; fall back to `ping`. A token, if any,
             // is silently dropped — the legacy server can't enforce one.
             var pingResponse = await InvokeRpcAsync<PingResponse>(
-                connection.Rpc, "ping", [new PingRequest()], connection.StderrBuffer, connection.StderrReader, cancellationToken);
+                connection.Rpc, "ping", [new PingRequest()], connection.StderrBuffer, cancellationToken);
             serverVersion = pingResponse.ProtocolVersion;
         }
 
@@ -1285,7 +1266,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             || string.Equals(ex.Message, "Unhandled method connect", StringComparison.Ordinal);
     }
 
-    private static async Task<(Process Process, int? DetectedLocalhostTcpPort, StringBuilder StderrBuffer, Task StderrReader)> StartCliServerAsync(CopilotClientOptions options, string? connectionToken, ILogger logger, CancellationToken cancellationToken)
+    private static async Task<(Process Process, int? DetectedLocalhostTcpPort, StringBuilder StderrBuffer)> StartCliServerAsync(CopilotClientOptions options, string? connectionToken, ILogger logger, CancellationToken cancellationToken)
     {
         // Use explicit path, COPILOT_CLI_PATH env var (from options.Environment or process env), or bundled CLI - no PATH fallback
         var envCliPath = options.Environment is not null && options.Environment.TryGetValue("COPILOT_CLI_PATH", out var envValue) ? envValue
@@ -1436,7 +1417,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 }
             }
 
-            return (cliProcess, detectedLocalhostTcpPort, stderrBuffer, stderrReader);
+            return (cliProcess, detectedLocalhostTcpPort, stderrBuffer);
         }
         catch
         {
@@ -1490,7 +1471,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         return (cliPath, args);
     }
 
-    private async Task<Connection> ConnectToServerAsync(Process? cliProcess, string? tcpHost, int? tcpPort, StringBuilder? stderrBuffer, Task? stderrReader, CancellationToken cancellationToken)
+    private async Task<Connection> ConnectToServerAsync(Process? cliProcess, string? tcpHost, int? tcpPort, StringBuilder? stderrBuffer, CancellationToken cancellationToken)
     {
         Stream inputStream, outputStream;
         NetworkStream? networkStream = null;
@@ -1556,7 +1537,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
         _serverRpc = new ServerRpc(rpc);
 
-        return new Connection(rpc, cliProcess, networkStream, stderrBuffer, stderrReader);
+        return new Connection(rpc, cliProcess, networkStream, stderrBuffer);
     }
 
     private static JsonSerializerOptions SerializerOptionsForMessageFormatter { get; } = CreateSerializerOptions();
@@ -1771,14 +1752,12 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         JsonRpc rpc,
         Process? cliProcess, // Set if we created the child process
         NetworkStream? networkStream, // Set if using TCP
-        StringBuilder? stderrBuffer = null, // Captures stderr for error messages
-        Task? stderrReader = null)
+        StringBuilder? stderrBuffer = null) // Captures stderr for error messages
     {
         public Process? CliProcess => cliProcess;
         public JsonRpc Rpc => rpc;
         public NetworkStream? NetworkStream => networkStream;
         public StringBuilder? StderrBuffer => stderrBuffer;
-        public Task? StderrReader => stderrReader;
     }
 
     private static class ProcessArgumentEscaper

--- a/dotnet/test/E2E/RpcShellAndFleetE2ETests.cs
+++ b/dotnet/test/E2E/RpcShellAndFleetE2ETests.cs
@@ -34,7 +34,9 @@ public class RpcShellAndFleetE2ETests(E2ETestFixture fixture, ITestOutputHelper 
             ? "powershell -NoLogo -NoProfile -Command \"Start-Sleep -Seconds 30\""
             : "sleep 30";
 
-        var execResult = await session.Rpc.Shell.ExecAsync(command);
+        // On Windows, terminating the shell wrapper can briefly leave grandchildren alive.
+        // Keep this command outside the fixture workspace so that cleanup is not blocked by cwd handles.
+        var execResult = await session.Rpc.Shell.ExecAsync(command, cwd: Path.GetTempPath());
         Assert.False(string.IsNullOrWhiteSpace(execResult.ProcessId));
 
         var killResult = await session.Rpc.Shell.KillAsync(execResult.ProcessId);

--- a/go/internal/e2e/rpc_shell_and_fleet_e2e_test.go
+++ b/go/internal/e2e/rpc_shell_and_fleet_e2e_test.go
@@ -63,7 +63,10 @@ func TestRpcShellAndFleetE2E(t *testing.T) {
 			command = "sleep 30"
 		}
 
-		exec, err := session.RPC.Shell.Exec(t.Context(), &rpc.ShellExecRequest{Command: command})
+		// On Windows, terminating the shell wrapper can briefly leave grandchildren alive.
+		// Keep this command outside the fixture workspace so cleanup is not blocked by cwd handles.
+		cwd := os.TempDir()
+		exec, err := session.RPC.Shell.Exec(t.Context(), &rpc.ShellExecRequest{Command: command, Cwd: &cwd})
 		if err != nil {
 			t.Fatalf("Failed to call session.shell.exec: %v", err)
 		}

--- a/nodejs/test/e2e/rpc_shell_and_fleet.e2e.test.ts
+++ b/nodejs/test/e2e/rpc_shell_and_fleet.e2e.test.ts
@@ -85,7 +85,9 @@ describe("Shell and fleet RPC", async () => {
                 ? `powershell -NoLogo -NoProfile -Command "Start-Sleep -Seconds 30"`
                 : "sleep 30";
 
-        const execResult = await session.rpc.shell.exec({ command });
+        // On Windows, terminating the shell wrapper can briefly leave grandchildren alive.
+        // Keep this command outside the fixture workspace so cleanup is not blocked by cwd handles.
+        const execResult = await session.rpc.shell.exec({ command, cwd: os.tmpdir() });
         expect(execResult.processId).toBeTruthy();
 
         const killResult = await session.rpc.shell.kill({ processId: execResult.processId });

--- a/python/e2e/test_rpc_shell_and_fleet_e2e.py
+++ b/python/e2e/test_rpc_shell_and_fleet_e2e.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import tempfile
 import uuid
 from pathlib import Path
 
@@ -75,7 +76,11 @@ class TestRpcShellAndFleet:
         else:
             command = "sleep 30"
 
-        exec_result = await session.rpc.shell.exec(ShellExecRequest(command=command))
+        # On Windows, terminating the shell wrapper can briefly leave grandchildren alive.
+        # Keep this command outside the fixture workspace so cleanup is not blocked by cwd handles.
+        exec_result = await session.rpc.shell.exec(
+            ShellExecRequest(command=command, cwd=tempfile.gettempdir())
+        )
         assert (exec_result.process_id or "").strip()
 
         kill_result = await session.rpc.shell.kill(


### PR DESCRIPTION
The Windows .NET E2E failure was caused by a long-running shell-kill test command inheriting the disposable fixture workspace as its current directory. If the shell wrapper was killed but a child process briefly survived, Windows could keep `copilot-test-work-*` locked and fail cleanup.

This updates the shell-kill E2E tests across .NET, Node, Go, and Python to run the long-lived command from the system temp directory instead of the fixture workspace. The tests still exercise `session.shell.kill`, but a surviving child process can no longer block deletion of the per-test workspace.

Validation:
- `dotnet test dotnet\test\GitHub.Copilot.SDK.Test.csproj --filter FullyQualifiedName~RpcShellAndFleetE2ETests.Should_Kill_Shell_Process -v n`
- `cd nodejs && npm test -- --run test/e2e/rpc_shell_and_fleet.e2e.test.ts -t "should kill shell process"`
- `cd go && go test ./internal/e2e -run TestRpcShellAndFleetE2E/should_kill_shell_process -count=1`
- `python -m pytest python\e2e\test_rpc_shell_and_fleet_e2e.py::TestRpcShellAndFleet::test_should_kill_shell_process`
- `cd nodejs && npm exec prettier -- --check test/e2e/rpc_shell_and_fleet.e2e.test.ts`
- `python -m ruff format python\e2e\test_rpc_shell_and_fleet_e2e.py --check`