### PR TITLE
Align Rust SDK public surface

### DIFF
--- a/go/types.go
+++ b/go/types.go
@@ -547,8 +547,7 @@ type SessionConfig struct {
 	// Ignored if AvailableTools is specified.
 	ExcludedTools []string
 	// OnPermissionRequest is a handler for permission requests from the server.
-	// If nil, all permission requests are denied by default.
-	// Provide a handler to approve operations (file writes, shell commands, URL fetches, etc.).
+	// This field is required; use PermissionHandler.ApproveAll to allow all permissions.
 	OnPermissionRequest PermissionHandlerFunc
 	// OnUserInputRequest is a handler for user input requests from the agent (enables ask_user tool)
 	OnUserInputRequest UserInputHandler
@@ -767,8 +766,7 @@ type ResumeSessionConfig struct {
 	// Valid values: "low", "medium", "high", "xhigh"
 	ReasoningEffort string
 	// OnPermissionRequest is a handler for permission requests from the server.
-	// If nil, all permission requests are denied by default.
-	// Provide a handler to approve operations (file writes, shell commands, URL fetches, etc.).
+	// This field is required; use PermissionHandler.ApproveAll to allow all permissions.
 	OnPermissionRequest PermissionHandlerFunc
 	// OnUserInputRequest is a handler for user input requests from the agent (enables ask_user tool)
 	OnUserInputRequest UserInputHandler

--- a/rust/README.md
+++ b/rust/README.md
@@ -105,23 +105,40 @@ let messages = session.get_messages().await?;
 session.abort().await?;
 
 // Model management
-let model = session.get_model().await?;
 session.set_model("claude-sonnet-4.5", None).await?;
 
-// Mode management (interactive, plan, autopilot)
-let mode = session.get_mode().await?;
-session.set_mode("autopilot").await?;
+// Generated typed RPCs cover lower-level session operations.
+let model = session.rpc().model().get_current().await?;
+let mode = session.rpc().mode().get().await?;
 
 // Workspace files
-let files = session.list_workspace_files().await?;
-let content = session.read_workspace_file("plan.md").await?;
+let files = session.rpc().workspaces().list_files().await?;
+let content = session
+    .rpc()
+    .workspaces()
+    .read_file(github_copilot_sdk::generated::api_types::WorkspacesReadFileRequest {
+        path: "plan.md".to_string(),
+    })
+    .await?;
 
 // Plan management
-let (exists, content) = session.read_plan().await?;
-session.update_plan("Updated plan content").await?;
+let plan = session.rpc().plan().read().await?;
+session
+    .rpc()
+    .plan()
+    .update(github_copilot_sdk::generated::api_types::PlanUpdateRequest {
+        content: "Updated plan content".to_string(),
+    })
+    .await?;
 
 // Fleet (sub-agents)
-session.start_fleet(Some("Implement the auth module")).await?;
+session
+    .rpc()
+    .fleet()
+    .start(github_copilot_sdk::generated::api_types::FleetStartRequest {
+        prompt: Some("Implement the auth module".to_string()),
+    })
+    .await?;
 
 // Cleanup (preserves on-disk session state for later resume)
 session.disconnect().await?;
@@ -129,14 +146,14 @@ session.disconnect().await?;
 
 #### Typed RPC namespace
 
-The ergonomic helpers above are convenience wrappers over a fully-typed
+High-level helpers are convenience wrappers over a fully-typed
 JSON-RPC namespace generated from the GitHub Copilot CLI schema. `Client::rpc()`
 and `Session::rpc()` give direct access to every method on the wire,
 including ones with no helper today, with strongly-typed request and
 response structs.
 
 ```rust,ignore
-// Methods with helpers — wire strings live in one generated place.
+// Common generated RPCs.
 let files = session.rpc().workspaces().list_files().await?.files;
 let models = client.rpc().models().list().await?.models;
 
@@ -631,7 +648,7 @@ if err.is_transport_failure() {
 
 ## Differences From Other SDKs
 
-The Rust SDK aligns closely with the Node, Python, and Go SDKs but diverges
+The Rust SDK aligns closely with the Node, Python, Go, and .NET SDKs but diverges
 in a few places where Rust idiom or the type system gives a clearly better
 shape, and exposes a small additional surface where the language affords
 ergonomics the dynamically-typed SDKs don't.
@@ -639,7 +656,7 @@ ergonomics the dynamically-typed SDKs don't.
 ### Shape divergence
 
 - **`SessionFsProvider` registration is direct, not factory-closure.** Where
-  Node/Python/Go accept a closure that the runtime calls on each
+  Node/Python/Go/.NET accept a closure that the runtime calls on each
   session-create to build a fresh provider, the Rust SDK takes
   `Arc<dyn SessionFsProvider>` directly via
   [`SessionConfig::with_session_fs_provider`]. The factory pattern doesn't
@@ -676,7 +693,7 @@ in-memory provider implementation.
 
 A handful of conveniences exist only on the Rust SDK as of 0.1.0. These
 are surface areas where Rust idiom (newtypes, enums, trait objects)
-gives a clearly nicer shape than Node/Python/Go currently expose. Rust
+gives a clearly nicer shape than Node/Python/Go/.NET currently expose. Rust
 gets to be Rust here — cross-SDK parity for these is a post-release
 conversation, not a release blocker. None of these are deprecated and
 none of them are scheduled for removal.
@@ -701,13 +718,6 @@ none of them are scheduled for removal.
   arg vectors for "prepend before subcommand" vs "append after the
   built-in flags", giving precise control over CLI invocation order
   without string-splicing.
-- **`SessionHandler::on_auto_mode_switch`** — typed handler for the CLI's
-  rate-limit-recovery prompt (CLI's `autoModeSwitch.request` callback,
-  added in copilot-agent-runtime PR #7024). Returns
-  `AutoModeSwitchResponse::{Yes, YesAlways, No}`. Default impl declines.
-  Cross-SDK parity is post-release follow-up — Node / Python / Go / .NET
-  consumers currently observe the request as a raw event and must drive
-  the wire response themselves.
 
 ## Layout
 

--- a/rust/src/handler.rs
+++ b/rust/src/handler.rs
@@ -4,11 +4,12 @@
 //! [`on_event`](crate::handler::SessionHandler::on_event) to control how sessions respond to
 //! CLI events, permission requests, tool calls, and user input prompts.
 
+use async_trait::async_trait;
+
 use crate::types::{
     ElicitationRequest, ElicitationResult, PermissionRequestData, RequestId, SessionEvent,
     SessionId, ToolInvocation, ToolResult,
 };
-use async_trait::async_trait;
 
 /// Events dispatched by the SDK session event loop to the handler.
 ///

--- a/rust/src/handler.rs
+++ b/rust/src/handler.rs
@@ -4,13 +4,11 @@
 //! [`on_event`](crate::handler::SessionHandler::on_event) to control how sessions respond to
 //! CLI events, permission requests, tool calls, and user input prompts.
 
-use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
-
 use crate::types::{
-    ElicitationRequest, ElicitationResult, ExitPlanModeData, PermissionRequestData, RequestId,
-    SessionEvent, SessionId, ToolInvocation, ToolResult,
+    ElicitationRequest, ElicitationResult, PermissionRequestData, RequestId, SessionEvent,
+    SessionId, ToolInvocation, ToolResult,
 };
+use async_trait::async_trait;
 
 /// Events dispatched by the SDK session event loop to the handler.
 ///
@@ -69,29 +67,6 @@ pub enum HandlerEvent {
         /// The elicitation request payload.
         request: ElicitationRequest,
     },
-
-    /// The CLI requests exiting plan mode. Return `HandlerResponse::ExitPlanMode(..)`.
-    ExitPlanMode {
-        /// The requesting session.
-        session_id: SessionId,
-        /// Plan mode exit payload.
-        data: ExitPlanModeData,
-    },
-
-    /// The CLI asks whether to switch to auto model when an eligible rate
-    /// limit is hit. Return [`HandlerResponse::AutoModeSwitch`].
-    AutoModeSwitch {
-        /// The requesting session.
-        session_id: SessionId,
-        /// The specific rate-limit error code that triggered the request,
-        /// if known (e.g. `user_weekly_rate_limited`, `user_global_rate_limited`).
-        error_code: Option<String>,
-        /// Seconds until the rate limit resets, when known. Per RFC 9110's
-        /// `Retry-After` `delta-seconds` form, this is an integer count of
-        /// seconds. Handlers can use it to render a humanized reset time
-        /// alongside the prompt.
-        retry_after_seconds: Option<u64>,
-    },
 }
 
 /// Response from the handler back to the SDK, used to construct the
@@ -109,10 +84,6 @@ pub enum HandlerResponse {
     ToolResult(ToolResult),
     /// Elicitation result (accept/decline/cancel with optional form data).
     Elicitation(ElicitationResult),
-    /// Exit plan mode decision.
-    ExitPlanMode(ExitPlanModeResult),
-    /// Auto-mode-switch decision.
-    AutoModeSwitch(AutoModeSwitchResponse),
 }
 
 /// Result of a permission request.
@@ -165,50 +136,11 @@ pub struct UserInputResponse {
     pub was_freeform: bool,
 }
 
-/// Result of an exit-plan-mode request.
-#[derive(Debug, Clone)]
-pub struct ExitPlanModeResult {
-    /// Whether the user approved exiting plan mode.
-    pub approved: bool,
-    /// The action the user selected (if any).
-    pub selected_action: Option<String>,
-    /// Optional feedback text from the user.
-    pub feedback: Option<String>,
-}
-
-impl Default for ExitPlanModeResult {
-    fn default() -> Self {
-        Self {
-            approved: true,
-            selected_action: None,
-            feedback: None,
-        }
-    }
-}
-
-/// Response to a [`HandlerEvent::AutoModeSwitch`] request.
-///
-/// Wire serialization matches the CLI's `autoModeSwitch.request` response
-/// schema: `"yes"`, `"yes_always"`, or `"no"`.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum AutoModeSwitchResponse {
-    /// Approve the auto-mode switch for this rate-limit cycle only.
-    Yes,
-    /// Approve and remember — auto-accept future auto-mode switches in this
-    /// session without prompting.
-    YesAlways,
-    /// Decline the auto-mode switch. The session stays on the current model
-    /// and surfaces the rate-limit error.
-    No,
-}
-
 /// Callback trait for session events.
 ///
 /// Implement this trait to control how a session responds to CLI events,
-/// permission requests, tool calls, user input prompts, elicitations, and
-/// plan-mode exits. There are two styles of implementation — pick whichever
+/// permission requests, tool calls, user input prompts, and elicitations.
+/// There are two styles of implementation — pick whichever
 /// fits your use case:
 ///
 /// 1. **Per-event methods (recommended for most handlers).** Override the
@@ -233,18 +165,15 @@ pub enum AutoModeSwitchResponse {
 /// - User input → `None` (no answer available).
 /// - External tool calls → failure result with "no handler registered".
 /// - Elicitation → `"cancel"`.
-/// - Exit plan mode → [`ExitPlanModeResult::default`].
-/// - Auto-mode-switch → [`AutoModeSwitchResponse::No`] (decline by default; the
-///   session stays on its current model and surfaces the rate-limit error).
 /// - Session events → ignored (fire-and-forget).
 ///
 /// # Concurrency
 ///
 /// **Request-triggered events** (`UserInput`, `ExternalTool` via `tool.call`,
-/// `ExitPlanMode`, `PermissionRequest` via `permission.request`) are awaited
-/// inline in the event loop and therefore processed **serially** per session.
-/// Blocking here pauses that session's event loop — which is correct, since
-/// the CLI is also blocked waiting for the response.
+/// `PermissionRequest` via `permission.request`) are awaited inline in the
+/// event loop and therefore processed **serially** per session. Blocking here
+/// pauses that session's event loop — which is correct, since the CLI is also
+/// blocked waiting for the response.
 ///
 /// **Notification-triggered events** (`PermissionRequest` via
 /// `permission.requested`, `ExternalTool` via `external_tool.requested`) are
@@ -321,17 +250,6 @@ pub trait SessionHandler: Send + Sync + 'static {
             } => HandlerResponse::Elicitation(
                 self.on_elicitation(session_id, request_id, request).await,
             ),
-            HandlerEvent::ExitPlanMode { session_id, data } => {
-                HandlerResponse::ExitPlanMode(self.on_exit_plan_mode(session_id, data).await)
-            }
-            HandlerEvent::AutoModeSwitch {
-                session_id,
-                error_code,
-                retry_after_seconds,
-            } => HandlerResponse::AutoModeSwitch(
-                self.on_auto_mode_switch(session_id, error_code, retry_after_seconds)
-                    .await,
-            ),
         }
     }
 
@@ -385,8 +303,10 @@ pub trait SessionHandler: Send + Sync + 'static {
         ToolResult::Expanded(crate::types::ToolResultExpanded {
             text_result_for_llm: msg.clone(),
             result_type: "failure".to_string(),
+            binary_results_for_llm: None,
             session_log: None,
             error: Some(msg),
+            tool_telemetry: None,
         })
     }
 
@@ -403,35 +323,6 @@ pub trait SessionHandler: Send + Sync + 'static {
             action: "cancel".to_string(),
             content: None,
         }
-    }
-
-    /// The CLI is asking the user whether to exit plan mode.
-    ///
-    /// Default: [`ExitPlanModeResult::default`] (approved with no action).
-    async fn on_exit_plan_mode(
-        &self,
-        _session_id: SessionId,
-        _data: ExitPlanModeData,
-    ) -> ExitPlanModeResult {
-        ExitPlanModeResult::default()
-    }
-
-    /// The CLI is asking whether to switch to auto model after an eligible
-    /// rate limit.
-    ///
-    /// `retry_after_seconds`, when present, is the number of seconds until the
-    /// rate limit resets (RFC 9110 `Retry-After` `delta-seconds`). Handlers
-    /// can use it to render a humanized reset time alongside the prompt.
-    ///
-    /// Default: [`AutoModeSwitchResponse::No`] — decline. Override only if
-    /// your application surfaces a UX for the rate-limit-recovery prompt.
-    async fn on_auto_mode_switch(
-        &self,
-        _session_id: SessionId,
-        _error_code: Option<String>,
-        _retry_after_seconds: Option<u64>,
-    ) -> AutoModeSwitchResponse {
-        AutoModeSwitchResponse::No
     }
 }
 
@@ -456,8 +347,8 @@ impl SessionHandler for ApproveAllHandler {
 
 /// A [`SessionHandler`] that denies all permission requests and otherwise
 /// relies on the trait's default fallback responses for every other event
-/// (e.g. tool invocations return "unhandled", elicitations cancel, plan-mode
-/// prompts decline). This is the safe default used when no handler is set on
+/// (e.g. tool invocations return "unhandled", elicitations cancel). This is the
+/// safe default used when no handler is set on
 /// [`SessionConfig::handler`](crate::types::SessionConfig::handler) — sessions
 /// will not stall on permission prompts (they're denied immediately) but no
 /// privileged actions will be taken without an explicit opt-in.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -927,15 +927,15 @@ impl Client {
                 info!(path = %resolved.display(), "resolved copilot CLI");
                 #[cfg(windows)]
                 {
-                    if let Some(ext) = resolved.extension().and_then(|e| e.to_str()) {
-                        if ext.eq_ignore_ascii_case("cmd") || ext.eq_ignore_ascii_case("bat") {
-                            warn!(
-                                path = %resolved.display(),
-                                ext = %ext,
-                                "resolved copilot CLI is a .cmd/.bat wrapper; \
-                                 this may cause console window flashes on Windows"
-                            );
-                        }
+                    if let Some(ext) = resolved.extension().and_then(|e| e.to_str()).filter(|ext| {
+                        ext.eq_ignore_ascii_case("cmd") || ext.eq_ignore_ascii_case("bat")
+                    }) {
+                        warn!(
+                            path = %resolved.display(),
+                            ext = %ext,
+                            "resolved copilot CLI is a .cmd/.bat wrapper; \
+                             this may cause console window flashes on Windows"
+                        );
                     }
                 }
                 resolved

--- a/rust/src/permission.rs
+++ b/rust/src/permission.rs
@@ -154,13 +154,15 @@ mod tests {
     #[tokio::test]
     async fn non_permission_events_forward_to_inner() {
         let h = deny_all(Arc::new(ApproveAllHandler));
-        let event = HandlerEvent::ExitPlanMode {
+        let event = HandlerEvent::UserInput {
             session_id: SessionId::from("s1"),
-            data: crate::types::ExitPlanModeData::default(),
+            question: "continue?".to_string(),
+            choices: None,
+            allow_freeform: None,
         };
         match h.on_event(event).await {
-            HandlerResponse::ExitPlanMode(_) => {}
-            other => panic!("expected ExitPlanMode forwarded, got {other:?}"),
+            HandlerResponse::UserInput(None) => {}
+            other => panic!("expected UserInput forwarded, got {other:?}"),
         }
     }
 }

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -19,8 +19,7 @@ use crate::generated::session_events::{
     SessionEventType,
 };
 use crate::handler::{
-    AutoModeSwitchResponse, ExitPlanModeResult, HandlerEvent, HandlerResponse, PermissionResult,
-    SessionHandler, UserInputResponse,
+    HandlerEvent, HandlerResponse, PermissionResult, SessionHandler, UserInputResponse,
 };
 use crate::hooks::SessionHooks;
 use crate::session_fs::SessionFsProvider;
@@ -28,10 +27,10 @@ use crate::trace_context::inject_trace_context;
 use crate::transforms::SystemMessageTransform;
 use crate::types::{
     CommandContext, CommandDefinition, CommandHandler, CreateSessionResult, ElicitationRequest,
-    ElicitationResult, ExitPlanModeData, GetMessagesResponse, InputOptions, MessageOptions,
-    PermissionRequestData, RequestId, ResumeSessionConfig, SectionOverride, SessionCapabilities,
-    SessionConfig, SessionEvent, SessionId, SetModelOptions, SystemMessageConfig, ToolInvocation,
-    ToolResult, ToolResultResponse, TraceContext, ensure_attachment_display_names,
+    ElicitationResult, GetMessagesResponse, InputOptions, MessageOptions, PermissionRequestData,
+    RequestId, ResumeSessionConfig, SectionOverride, SessionCapabilities, SessionConfig,
+    SessionEvent, SessionId, SetModelOptions, SystemMessageConfig, ToolInvocation, ToolResult,
+    ToolResultResponse, TraceContext, ensure_attachment_display_names,
 };
 use crate::{Client, Error, JsonRpcResponse, SessionError, SessionEventNotification, error_codes};
 
@@ -1475,82 +1474,6 @@ async fn handle_request(
                 jsonrpc: "2.0".to_string(),
                 id: request.id,
                 result: Some(rpc_result),
-                error: None,
-            };
-            let _ = client.send_response(&rpc_response).await;
-        }
-
-        "exitPlanMode.request" => {
-            let params = request
-                .params
-                .as_ref()
-                .cloned()
-                .unwrap_or(Value::Object(serde_json::Map::new()));
-            let data: ExitPlanModeData = match serde_json::from_value(params) {
-                Ok(d) => d,
-                Err(e) => {
-                    warn!(error = %e, "failed to deserialize exitPlanMode.request params, using defaults");
-                    ExitPlanModeData::default()
-                }
-            };
-
-            let response = handler
-                .on_event(HandlerEvent::ExitPlanMode {
-                    session_id: sid,
-                    data,
-                })
-                .await;
-
-            let rpc_result = match response {
-                HandlerResponse::ExitPlanMode(ExitPlanModeResult {
-                    approved,
-                    selected_action,
-                    feedback,
-                }) => serde_json::json!({
-                    "approved": approved,
-                    "selectedAction": selected_action,
-                    "feedback": feedback,
-                }),
-                _ => serde_json::json!({ "approved": true }),
-            };
-            let rpc_response = JsonRpcResponse {
-                jsonrpc: "2.0".to_string(),
-                id: request.id,
-                result: Some(rpc_result),
-                error: None,
-            };
-            let _ = client.send_response(&rpc_response).await;
-        }
-
-        "autoModeSwitch.request" => {
-            let error_code = request
-                .params
-                .as_ref()
-                .and_then(|p| p.get("errorCode"))
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-            let retry_after_seconds = request
-                .params
-                .as_ref()
-                .and_then(|p| p.get("retryAfterSeconds"))
-                .and_then(|v| v.as_u64());
-
-            let response = handler
-                .on_event(HandlerEvent::AutoModeSwitch {
-                    session_id: sid,
-                    error_code,
-                    retry_after_seconds,
-                })
-                .await;
-
-            let answer = match response {
-                HandlerResponse::AutoModeSwitch(answer) => answer,
-                _ => AutoModeSwitchResponse::No,
-            };
-            let rpc_response = JsonRpcResponse {
-                jsonrpc: "2.0".to_string(),
-                id: request.id,
-                result: Some(serde_json::json!({ "response": answer })),
                 error: None,
             };
             let _ = client.send_response(&rpc_response).await;

--- a/rust/src/tool.rs
+++ b/rust/src/tool.rs
@@ -16,10 +16,10 @@ use async_trait::async_trait;
 pub use schemars::JsonSchema;
 
 use crate::Error;
-use crate::handler::{ExitPlanModeResult, PermissionResult, SessionHandler, UserInputResponse};
+use crate::handler::{PermissionResult, SessionHandler, UserInputResponse};
 use crate::types::{
-    ElicitationRequest, ElicitationResult, ExitPlanModeData, PermissionRequestData, RequestId,
-    SessionEvent, SessionId, Tool, ToolInvocation, ToolResult, ToolResultExpanded,
+    ElicitationRequest, ElicitationResult, PermissionRequestData, RequestId, SessionEvent,
+    SessionId, Tool, ToolBinaryResult, ToolInvocation, ToolResult, ToolResultExpanded,
 };
 
 /// Generate a JSON Schema [`Value`](serde_json::Value) from a Rust type.
@@ -84,6 +84,91 @@ pub fn try_tool_parameters(
     schema: serde_json::Value,
 ) -> Result<HashMap<String, serde_json::Value>, serde_json::Error> {
     serde_json::from_value(schema)
+}
+
+/// Convert an MCP `CallToolResult` JSON value into a Copilot tool result.
+///
+/// Returns `None` when the value is not shaped like a `CallToolResult`.
+pub fn convert_mcp_call_tool_result(value: &serde_json::Value) -> Option<ToolResult> {
+    let content = value.get("content")?.as_array()?;
+    let mut text_parts = Vec::new();
+    let mut binary_results = Vec::new();
+
+    for block in content {
+        match block.get("type").and_then(serde_json::Value::as_str) {
+            Some("text") => {
+                if let Some(text) = block.get("text").and_then(serde_json::Value::as_str) {
+                    text_parts.push(text.to_string());
+                }
+            }
+            Some("image") => {
+                let data = block
+                    .get("data")
+                    .and_then(serde_json::Value::as_str)
+                    .filter(|s| !s.is_empty());
+                let mime_type = block
+                    .get("mimeType")
+                    .and_then(serde_json::Value::as_str)
+                    .filter(|s| !s.is_empty());
+                if let (Some(data), Some(mime_type)) = (data, mime_type) {
+                    binary_results.push(ToolBinaryResult {
+                        data: data.to_string(),
+                        mime_type: mime_type.to_string(),
+                        r#type: "image".to_string(),
+                        description: None,
+                    });
+                }
+            }
+            Some("resource") => {
+                let Some(resource) = block.get("resource").and_then(serde_json::Value::as_object)
+                else {
+                    continue;
+                };
+                if let Some(text) = resource
+                    .get("text")
+                    .and_then(serde_json::Value::as_str)
+                    .filter(|s| !s.is_empty())
+                {
+                    text_parts.push(text.to_string());
+                }
+                if let Some(blob) = resource
+                    .get("blob")
+                    .and_then(serde_json::Value::as_str)
+                    .filter(|s| !s.is_empty())
+                {
+                    let mime_type = resource
+                        .get("mimeType")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("application/octet-stream");
+                    let description = resource
+                        .get("uri")
+                        .and_then(serde_json::Value::as_str)
+                        .filter(|s| !s.is_empty())
+                        .map(ToString::to_string);
+                    binary_results.push(ToolBinaryResult {
+                        data: blob.to_string(),
+                        mime_type: mime_type.to_string(),
+                        r#type: "resource".to_string(),
+                        description,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Some(ToolResult::Expanded(ToolResultExpanded {
+        text_result_for_llm: text_parts.join("\n"),
+        result_type: if value.get("isError").and_then(serde_json::Value::as_bool) == Some(true) {
+            "failure".to_string()
+        } else {
+            "success".to_string()
+        },
+        binary_results_for_llm: (!binary_results.is_empty()).then_some(binary_results),
+        session_log: None,
+        error: None,
+        tool_telemetry: None,
+    }))
 }
 
 /// A client-defined tool with its handler logic.
@@ -317,8 +402,10 @@ impl SessionHandler for ToolHandlerRouter {
                 ToolResult::Expanded(ToolResultExpanded {
                     text_result_for_llm: msg.clone(),
                     result_type: "failure".to_string(),
+                    binary_results_for_llm: None,
                     session_log: None,
                     error: Some(msg),
+                    tool_telemetry: None,
                 })
             }
         }
@@ -360,14 +447,6 @@ impl SessionHandler for ToolHandlerRouter {
         self.inner
             .on_elicitation(session_id, request_id, request)
             .await
-    }
-
-    async fn on_exit_plan_mode(
-        &self,
-        session_id: SessionId,
-        data: ExitPlanModeData,
-    ) -> ExitPlanModeResult {
-        self.inner.on_exit_plan_mode(session_id, data).await
     }
 }
 
@@ -411,6 +490,43 @@ mod tests {
             .expect_err("non-object schemas should be rejected");
 
         assert!(err.is_data());
+    }
+
+    #[test]
+    fn convert_mcp_call_tool_result_collects_text_and_binary_content() {
+        let result = convert_mcp_call_tool_result(&serde_json::json!({
+            "isError": true,
+            "content": [
+                { "type": "text", "text": "hello" },
+                { "type": "image", "data": "aW1n", "mimeType": "image/png" },
+                {
+                    "type": "resource",
+                    "resource": {
+                        "uri": "file:///tmp/data.bin",
+                        "blob": "Ymlu",
+                        "mimeType": "application/octet-stream",
+                        "text": "resource text"
+                    }
+                }
+            ]
+        }))
+        .expect("valid CallToolResult should convert");
+
+        let ToolResult::Expanded(expanded) = result else {
+            panic!("expected expanded tool result");
+        };
+
+        assert_eq!(expanded.text_result_for_llm, "hello\nresource text");
+        assert_eq!(expanded.result_type, "failure");
+        let binary_results = expanded
+            .binary_results_for_llm
+            .expect("binary results should be captured");
+        assert_eq!(binary_results.len(), 2);
+        assert_eq!(binary_results[0].r#type, "image");
+        assert_eq!(
+            binary_results[1].description.as_deref(),
+            Some("file:///tmp/data.bin")
+        );
     }
 
     #[tokio::test]

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -994,23 +994,6 @@ pub struct SessionConfig {
     /// requests so the wire surface is safe out-of-the-box.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_permission: Option<bool>,
-    /// Enable `exitPlanMode.request` JSON-RPC calls for plan approval.
-    /// Defaults to `Some(true)` via [`SessionConfig::default`].
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub request_exit_plan_mode: Option<bool>,
-    /// Enable `autoModeSwitch.request` JSON-RPC calls. When `true`, the CLI
-    /// asks the handler whether to switch to auto model when an eligible
-    /// rate limit is hit. Defaults to `Some(true)` via
-    /// [`SessionConfig::default`]. Without this flag, the CLI surfaces the
-    /// rate-limit error directly without offering the auto-mode switch.
-    ///
-    /// Currently a Rust-only typed handler; cross-SDK parity (Node /
-    /// Python / Go / .NET) is post-release follow-up work — see
-    /// [`SessionHandler::on_auto_mode_switch`].
-    ///
-    /// [`SessionHandler::on_auto_mode_switch`]: crate::handler::SessionHandler::on_auto_mode_switch
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub request_auto_mode_switch: Option<bool>,
     /// Advertise elicitation provider capability. When true, the CLI sends
     /// `elicitation.requested` events that the handler can respond to.
     /// Defaults to `Some(true)` via [`SessionConfig::default`].
@@ -1027,10 +1010,6 @@ pub struct SessionConfig {
     /// even if found in skill directories.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub disabled_skills: Option<Vec<String>>,
-    /// MCP server names to disable. Servers in this set will not be
-    /// started or connected.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub disabled_mcp_servers: Option<Vec<String>>,
     /// Enable session hooks. When `true`, the CLI sends `hooks.invoke`
     /// RPC requests at key lifecycle points (pre/post tool use, prompt
     /// submission, session start/end, errors).
@@ -1128,13 +1107,10 @@ impl std::fmt::Debug for SessionConfig {
             .field("enable_config_discovery", &self.enable_config_discovery)
             .field("request_user_input", &self.request_user_input)
             .field("request_permission", &self.request_permission)
-            .field("request_exit_plan_mode", &self.request_exit_plan_mode)
-            .field("request_auto_mode_switch", &self.request_auto_mode_switch)
             .field("request_elicitation", &self.request_elicitation)
             .field("skill_directories", &self.skill_directories)
             .field("instruction_directories", &self.instruction_directories)
             .field("disabled_skills", &self.disabled_skills)
-            .field("disabled_mcp_servers", &self.disabled_mcp_servers)
             .field("hooks", &self.hooks)
             .field("custom_agents", &self.custom_agents)
             .field("default_agent", &self.default_agent)
@@ -1190,13 +1166,10 @@ impl Default for SessionConfig {
             enable_config_discovery: None,
             request_user_input: Some(true),
             request_permission: Some(true),
-            request_exit_plan_mode: Some(true),
-            request_auto_mode_switch: Some(true),
             request_elicitation: Some(true),
             skill_directories: None,
             instruction_directories: None,
             disabled_skills: None,
-            disabled_mcp_servers: None,
             hooks: None,
             custom_agents: None,
             default_agent: None,
@@ -1401,18 +1374,6 @@ impl SessionConfig {
         self
     }
 
-    /// Enable `exitPlanMode.request` JSON-RPC calls. Defaults to `Some(true)`.
-    pub fn with_request_exit_plan_mode(mut self, enable: bool) -> Self {
-        self.request_exit_plan_mode = Some(enable);
-        self
-    }
-
-    /// Enable `autoModeSwitch.request` JSON-RPC calls. Defaults to `Some(true)`.
-    pub fn with_request_auto_mode_switch(mut self, enable: bool) -> Self {
-        self.request_auto_mode_switch = Some(enable);
-        self
-    }
-
     /// Advertise elicitation provider capability. Defaults to `Some(true)`.
     pub fn with_request_elicitation(mut self, enable: bool) -> Self {
         self.request_elicitation = Some(enable);
@@ -1448,16 +1409,6 @@ impl SessionConfig {
         S: Into<String>,
     {
         self.disabled_skills = Some(names.into_iter().map(Into::into).collect());
-        self
-    }
-
-    /// Set the names of MCP servers to disable.
-    pub fn with_disabled_mcp_servers<I, S>(mut self, names: I) -> Self
-    where
-        I: IntoIterator<Item = S>,
-        S: Into<String>,
-    {
-        self.disabled_mcp_servers = Some(names.into_iter().map(Into::into).collect());
         self
     }
 
@@ -1559,6 +1510,9 @@ pub struct ResumeSessionConfig {
     /// Client-defined tools to re-supply on resume.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<Tool>>,
+    /// Allowlist of tool names the agent may use.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub available_tools: Option<Vec<String>>,
     /// Blocklist of built-in tool names.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub excluded_tools: Option<Vec<String>>,
@@ -1577,14 +1531,6 @@ pub struct ResumeSessionConfig {
     /// Enable permission request RPCs.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_permission: Option<bool>,
-    /// Enable exit-plan-mode request RPCs.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub request_exit_plan_mode: Option<bool>,
-    /// Enable auto-mode-switch request RPCs on resume. Defaults to
-    /// `Some(true)` via [`ResumeSessionConfig::new`]. See
-    /// [`SessionConfig::request_auto_mode_switch`] for details.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub request_auto_mode_switch: Option<bool>,
     /// Advertise elicitation provider capability on resume.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_elicitation: Option<bool>,
@@ -1595,6 +1541,9 @@ pub struct ResumeSessionConfig {
     /// resume. Forwarded to the CLI; not the same as [`skill_directories`](Self::skill_directories).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub instruction_directories: Option<Vec<PathBuf>>,
+    /// Skill names to disable on resume.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disabled_skills: Option<Vec<String>>,
     /// Enable session hooks on resume.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hooks: Option<bool>,
@@ -1672,17 +1621,17 @@ impl std::fmt::Debug for ResumeSessionConfig {
             .field("streaming", &self.streaming)
             .field("system_message", &self.system_message)
             .field("tools", &self.tools)
+            .field("available_tools", &self.available_tools)
             .field("excluded_tools", &self.excluded_tools)
             .field("mcp_servers", &self.mcp_servers)
             .field("env_value_mode", &self.env_value_mode)
             .field("enable_config_discovery", &self.enable_config_discovery)
             .field("request_user_input", &self.request_user_input)
             .field("request_permission", &self.request_permission)
-            .field("request_exit_plan_mode", &self.request_exit_plan_mode)
-            .field("request_auto_mode_switch", &self.request_auto_mode_switch)
             .field("request_elicitation", &self.request_elicitation)
             .field("skill_directories", &self.skill_directories)
             .field("instruction_directories", &self.instruction_directories)
+            .field("disabled_skills", &self.disabled_skills)
             .field("hooks", &self.hooks)
             .field("custom_agents", &self.custom_agents)
             .field("default_agent", &self.default_agent)
@@ -1729,17 +1678,17 @@ impl ResumeSessionConfig {
             streaming: None,
             system_message: None,
             tools: None,
+            available_tools: None,
             excluded_tools: None,
             mcp_servers: None,
             env_value_mode: None,
             enable_config_discovery: None,
             request_user_input: Some(true),
             request_permission: Some(true),
-            request_exit_plan_mode: Some(true),
-            request_auto_mode_switch: Some(true),
             request_elicitation: Some(true),
             skill_directories: None,
             instruction_directories: None,
+            disabled_skills: None,
             hooks: None,
             custom_agents: None,
             default_agent: None,
@@ -1858,6 +1807,16 @@ impl ResumeSessionConfig {
         self
     }
 
+    /// Set the allowlist of tool names the agent may use.
+    pub fn with_available_tools<I, S>(mut self, tools: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.available_tools = Some(tools.into_iter().map(Into::into).collect());
+        self
+    }
+
     /// Set the blocklist of built-in tool names the agent must not use.
     pub fn with_excluded_tools<I, S>(mut self, tools: I) -> Self
     where
@@ -1899,18 +1858,6 @@ impl ResumeSessionConfig {
         self
     }
 
-    /// Enable `exitPlanMode.request` JSON-RPC calls. Defaults to `Some(true)`.
-    pub fn with_request_exit_plan_mode(mut self, enable: bool) -> Self {
-        self.request_exit_plan_mode = Some(enable);
-        self
-    }
-
-    /// Enable `autoModeSwitch.request` JSON-RPC calls. Defaults to `Some(true)`.
-    pub fn with_request_auto_mode_switch(mut self, enable: bool) -> Self {
-        self.request_auto_mode_switch = Some(enable);
-        self
-    }
-
     /// Advertise elicitation provider capability on resume. Defaults to `Some(true)`.
     pub fn with_request_elicitation(mut self, enable: bool) -> Self {
         self.request_elicitation = Some(enable);
@@ -1936,6 +1883,16 @@ impl ResumeSessionConfig {
         P: Into<PathBuf>,
     {
         self.instruction_directories = Some(paths.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Set the names of skills to disable on resume.
+    pub fn with_disabled_skills<I, S>(mut self, names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.disabled_skills = Some(names.into_iter().map(Into::into).collect());
         self
     }
 
@@ -2729,6 +2686,21 @@ impl ToolInvocation {
     }
 }
 
+/// Binary content returned by a tool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolBinaryResult {
+    /// Base64-encoded binary data.
+    pub data: String,
+    /// MIME type for the binary data.
+    pub mime_type: String,
+    /// Type identifier for the binary result.
+    pub r#type: String,
+    /// Optional description shown alongside the binary result.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
 /// Expanded tool result with metadata for the LLM and session log.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -2737,12 +2709,18 @@ pub struct ToolResultExpanded {
     pub text_result_for_llm: String,
     /// `"success"` or `"failure"`.
     pub result_type: String,
+    /// Binary payloads sent back to the LLM.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub binary_results_for_llm: Option<Vec<ToolBinaryResult>>,
     /// Optional log message for the session timeline.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_log: Option<String>,
     /// Error message, if the tool failed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Tool-specific telemetry emitted with the result.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_telemetry: Option<HashMap<String, Value>>,
 }
 
 /// Result of a tool invocation — either a plain text string or an expanded result.
@@ -3025,39 +3003,6 @@ pub struct PermissionRequestData {
     pub extra: Value,
 }
 
-/// Data sent by the CLI with an `exitPlanMode.request` RPC call.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ExitPlanModeData {
-    /// Markdown summary of the plan presented to the user.
-    #[serde(default)]
-    pub summary: String,
-    /// Full plan content (e.g. the plan.md body), if available.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub plan_content: Option<String>,
-    /// Allowed exit actions (e.g. "interactive", "autopilot", "autopilot_fleet").
-    #[serde(default)]
-    pub actions: Vec<String>,
-    /// Which action the CLI recommends, defaults to "autopilot".
-    #[serde(default = "default_recommended_action")]
-    pub recommended_action: String,
-}
-
-fn default_recommended_action() -> String {
-    "autopilot".to_string()
-}
-
-impl Default for ExitPlanModeData {
-    fn default() -> Self {
-        Self {
-            summary: String::new(),
-            plan_content: None,
-            actions: Vec::new(),
-            recommended_action: default_recommended_action(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -3105,8 +3050,6 @@ mod tests {
         let cfg = SessionConfig::default();
         assert_eq!(cfg.request_user_input, Some(true));
         assert_eq!(cfg.request_permission, Some(true));
-        assert_eq!(cfg.request_exit_plan_mode, Some(true));
-        assert_eq!(cfg.request_auto_mode_switch, Some(true));
         assert_eq!(cfg.request_elicitation, Some(true));
     }
 
@@ -3115,8 +3058,6 @@ mod tests {
         let cfg = ResumeSessionConfig::new(SessionId::from("test-id"));
         assert_eq!(cfg.request_user_input, Some(true));
         assert_eq!(cfg.request_permission, Some(true));
-        assert_eq!(cfg.request_exit_plan_mode, Some(true));
-        assert_eq!(cfg.request_auto_mode_switch, Some(true));
         assert_eq!(cfg.request_elicitation, Some(true));
     }
 
@@ -3139,7 +3080,6 @@ mod tests {
             .with_request_user_input(false)
             .with_skill_directories([PathBuf::from("/tmp/skills")])
             .with_disabled_skills(["broken-skill"])
-            .with_disabled_mcp_servers(["broken-server"])
             .with_agent("researcher")
             .with_config_dir(PathBuf::from("/tmp/config"))
             .with_working_directory(PathBuf::from("/tmp/work"))
@@ -3188,12 +3128,14 @@ mod tests {
             .with_client_name("test-app")
             .with_streaming(true)
             .with_tools([Tool::new("greet")])
+            .with_available_tools(["bash", "view"])
             .with_excluded_tools(["dangerous"])
             .with_mcp_servers(HashMap::new())
             .with_env_value_mode("indirect")
             .with_enable_config_discovery(true)
             .with_request_user_input(false)
             .with_skill_directories([PathBuf::from("/tmp/skills")])
+            .with_disabled_skills(["broken-skill"])
             .with_agent("researcher")
             .with_config_dir(PathBuf::from("/tmp/config"))
             .with_working_directory(PathBuf::from("/tmp/work"))
@@ -3207,6 +3149,10 @@ mod tests {
         assert_eq!(cfg.streaming, Some(true));
         assert_eq!(cfg.tools.as_ref().map(|t| t.len()), Some(1));
         assert_eq!(
+            cfg.available_tools.as_deref(),
+            Some(&["bash".to_string(), "view".to_string()][..])
+        );
+        assert_eq!(
             cfg.excluded_tools.as_deref(),
             Some(&["dangerous".to_string()][..])
         );
@@ -3218,6 +3164,10 @@ mod tests {
         assert_eq!(
             cfg.skill_directories.as_deref(),
             Some(&[PathBuf::from("/tmp/skills")][..])
+        );
+        assert_eq!(
+            cfg.disabled_skills.as_deref(),
+            Some(&["broken-skill".to_string()][..])
         );
         assert_eq!(cfg.agent.as_deref(), Some("researcher"));
         assert_eq!(cfg.config_dir, Some(PathBuf::from("/tmp/config")));
@@ -3245,8 +3195,7 @@ mod tests {
     }
 
     /// `instruction_directories` must serialize to wire as
-    /// `instructionDirectories` on `SessionConfig`. Cross-SDK parity field
-    /// (Node/Python pass it through to the CLI verbatim).
+    /// `instructionDirectories` on `SessionConfig`.
     #[test]
     fn session_config_serializes_instruction_directories_to_camel_case() {
         let cfg =

--- a/rust/tests/session_test.rs
+++ b/rust/tests/session_test.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 use github_copilot_sdk::Client;
 use github_copilot_sdk::handler::{
-    ApproveAllHandler, AutoModeSwitchResponse, ExitPlanModeResult, HandlerEvent, HandlerResponse,
-    PermissionResult, SessionHandler, UserInputResponse,
+    ApproveAllHandler, HandlerEvent, HandlerResponse, PermissionResult, SessionHandler,
+    UserInputResponse,
 };
 use github_copilot_sdk::types::{
     CommandContext, CommandDefinition, CommandHandler, DeliveryMode, MessageOptions, SessionConfig,
@@ -1235,115 +1235,7 @@ async fn user_input_requested_notification_does_not_double_dispatch() {
 }
 
 #[tokio::test]
-async fn exit_plan_mode_dispatches_to_handler() {
-    struct PlanHandler;
-    #[async_trait]
-    impl SessionHandler for PlanHandler {
-        async fn on_event(&self, event: HandlerEvent) -> HandlerResponse {
-            match event {
-                HandlerEvent::ExitPlanMode { .. } => {
-                    HandlerResponse::ExitPlanMode(ExitPlanModeResult {
-                        approved: true,
-                        selected_action: Some("autopilot".to_string()),
-                        feedback: None,
-                    })
-                }
-                _ => HandlerResponse::Ok,
-            }
-        }
-    }
-
-    let (_session, mut server) = create_session_pair(Arc::new(PlanHandler)).await;
-    server
-        .send_request(
-            400,
-            "exitPlanMode.request",
-            serde_json::json!({ "sessionId": server.session_id, "plan": "do the thing" }),
-        )
-        .await;
-
-    let response = timeout(TIMEOUT, server.read_response()).await.unwrap();
-    assert_eq!(response["result"]["approved"], true);
-    assert_eq!(response["result"]["selectedAction"], "autopilot");
-}
-
-#[tokio::test]
-async fn auto_mode_switch_dispatches_to_handler_and_serializes_response() {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    struct AutoModeHandler {
-        calls: Arc<AtomicUsize>,
-        last_error_code: Arc<parking_lot::Mutex<Option<String>>>,
-        last_retry_after: Arc<parking_lot::Mutex<Option<u64>>>,
-    }
-    #[async_trait]
-    impl SessionHandler for AutoModeHandler {
-        async fn on_auto_mode_switch(
-            &self,
-            _session_id: github_copilot_sdk::types::SessionId,
-            error_code: Option<String>,
-            retry_after_seconds: Option<u64>,
-        ) -> AutoModeSwitchResponse {
-            self.calls.fetch_add(1, Ordering::SeqCst);
-            *self.last_error_code.lock() = error_code;
-            *self.last_retry_after.lock() = retry_after_seconds;
-            AutoModeSwitchResponse::YesAlways
-        }
-    }
-
-    let calls = Arc::new(AtomicUsize::new(0));
-    let last_error_code = Arc::new(parking_lot::Mutex::new(None));
-    let last_retry_after = Arc::new(parking_lot::Mutex::new(None));
-    let (_session, mut server) = create_session_pair(Arc::new(AutoModeHandler {
-        calls: calls.clone(),
-        last_error_code: last_error_code.clone(),
-        last_retry_after: last_retry_after.clone(),
-    }))
-    .await;
-
-    server
-        .send_request(
-            700,
-            "autoModeSwitch.request",
-            serde_json::json!({
-                "sessionId": server.session_id,
-                "errorCode": "user_weekly_rate_limited",
-                "retryAfterSeconds": 3600,
-            }),
-        )
-        .await;
-
-    let response = timeout(TIMEOUT, server.read_response()).await.unwrap();
-    assert_eq!(response["id"], 700);
-    assert_eq!(response["result"]["response"], "yes_always");
-    assert_eq!(calls.load(Ordering::SeqCst), 1);
-    assert_eq!(
-        last_error_code.lock().as_deref(),
-        Some("user_weekly_rate_limited")
-    );
-    assert_eq!(*last_retry_after.lock(), Some(3600));
-}
-
-#[tokio::test]
-async fn auto_mode_switch_default_handler_replies_no() {
-    let (_session, mut server) = create_session_pair(Arc::new(ApproveAllHandler)).await;
-
-    server
-        .send_request(
-            701,
-            "autoModeSwitch.request",
-            serde_json::json!({
-                "sessionId": server.session_id,
-            }),
-        )
-        .await;
-
-    let response = timeout(TIMEOUT, server.read_response()).await.unwrap();
-    assert_eq!(response["result"]["response"], "no");
-}
-
-#[tokio::test]
-async fn approve_all_handler_approves_permission_and_plan() {
+async fn approve_all_handler_approves_permission() {
     let (_session, mut server) = create_session_pair(Arc::new(ApproveAllHandler)).await;
 
     server
@@ -1359,16 +1251,6 @@ async fn approve_all_handler_approves_permission_and_plan() {
         .await;
     let response = timeout(TIMEOUT, server.read_response()).await.unwrap();
     assert_eq!(response["result"]["kind"], "approve-once");
-
-    server
-        .send_request(
-            501,
-            "exitPlanMode.request",
-            serde_json::json!({ "sessionId": server.session_id, "plan": "go" }),
-        )
-        .await;
-    let response = timeout(TIMEOUT, server.read_response()).await.unwrap();
-    assert_eq!(response["result"]["approved"], true);
 }
 
 #[tokio::test]


### PR DESCRIPTION
This follow-up from the cross-language SDK surface audit keeps Rust aligned with the established C#, Go, Python, and TypeScript public APIs before the new SDK surface settles.

## Summary

- Remove Rust-only high-level `autoModeSwitch`, `exitPlanMode`, and `disabled_mcp_servers` surfaces while leaving generated protocol event types untouched.
- Add Rust `ResumeSessionConfig` parity for `available_tools` and `disabled_skills`.
- Expand Rust tool results with binary payloads, tool telemetry, and an MCP `CallToolResult` conversion helper to match the richer tool-result support in the other SDKs.
- Update Rust README examples to use only valid high-level methods or generated `session.rpc()` calls, and fix Go permission handler comments.