### PR TITLE
Add SDK tracing diagnostics

### DIFF
--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -226,6 +226,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             _logger.LogDebug("Starting Copilot client");
             _disconnected = false;
 
+            var startTimestamp = Stopwatch.GetTimestamp();
             Connection? connection = null;
             Process? cliProcess = null;
 
@@ -246,15 +247,39 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                     connection = await ConnectToServerAsync(cliProcess, portOrNull is null ? null : "localhost", portOrNull, stderrBuffer, ct);
                 }
 
+                LogTiming(_logger, LogLevel.Information, null,
+                    "CopilotClient.StartAsync transport setup complete. Elapsed={Elapsed}",
+                    startTimestamp);
+
                 // Verify protocol version compatibility
                 await VerifyProtocolVersionAsync(connection, ct);
-                await ConfigureSessionFsAsync(ct);
+                LogTiming(_logger, LogLevel.Information, null,
+                    "CopilotClient.StartAsync protocol verification complete. Elapsed={Elapsed}",
+                    startTimestamp);
 
-                _logger.LogInformation("Copilot client connected");
+                var sessionFsTimestamp = Stopwatch.GetTimestamp();
+                await ConfigureSessionFsAsync(ct);
+                if (_options.SessionFs is not null)
+                {
+                    LogTiming(_logger, LogLevel.Information, null,
+                        "CopilotClient.StartAsync session filesystem setup complete. Elapsed={Elapsed}",
+                        sessionFsTimestamp);
+                }
+
+                LogTiming(_logger, LogLevel.Information, null,
+                    "CopilotClient.StartAsync complete. Elapsed={Elapsed}",
+                    startTimestamp);
                 return connection;
             }
-            catch
+            catch (Exception ex)
             {
+                if (ex is not OperationCanceledException)
+                {
+                    LogTiming(_logger, LogLevel.Warning, ex,
+                        "CopilotClient.StartAsync failed. Elapsed={Elapsed}",
+                        startTimestamp);
+                }
+
                 if (connection is not null)
                 {
                     await CleanupConnectionAsync(connection, errors: null);
@@ -515,6 +540,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         }
 
         var connection = await EnsureConnectedAsync(cancellationToken);
+        var totalTimestamp = Stopwatch.GetTimestamp();
 
         var hasHooks = config.Hooks != null && (
             config.Hooks.OnPreToolUse != null ||
@@ -530,6 +556,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
         // Create and register the session before issuing the RPC so that
         // events emitted by the CLI (e.g. session.start) are not dropped.
+        var setupTimestamp = Stopwatch.GetTimestamp();
         var session = new CopilotSession(sessionId, connection.Rpc, _logger);
         session.RegisterTools(config.Tools ?? []);
         session.RegisterPermissionHandler(config.OnPermissionRequest);
@@ -553,6 +580,13 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         }
         ConfigureSessionFsHandlers(session, config.CreateSessionFsHandler);
         _sessions[sessionId] = session;
+        LogTiming(_logger, LogLevel.Debug, null,
+            "CopilotClient.CreateSessionAsync local setup complete. Elapsed={Elapsed}, SessionId={SessionId}, Tools={ToolsCount}, Commands={CommandsCount}, Hooks={HasHooks}",
+            setupTimestamp,
+            sessionId,
+            config.Tools?.Count ?? 0,
+            config.Commands?.Count ?? 0,
+            hasHooks);
 
         try
         {
@@ -592,18 +626,34 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 GitHubToken: config.GitHubToken,
                 InstructionDirectories: config.InstructionDirectories);
 
+            var rpcTimestamp = Stopwatch.GetTimestamp();
             var response = await InvokeRpcAsync<CreateSessionResponse>(
                 connection.Rpc, "session.create", [request], cancellationToken);
+            LogTiming(_logger, LogLevel.Information, null,
+                "CopilotClient.CreateSessionAsync session creation request completed successfully. Elapsed={Elapsed}, SessionId={SessionId}",
+                rpcTimestamp,
+                sessionId);
 
             session.WorkspacePath = response.WorkspacePath;
             session.SetCapabilities(response.Capabilities);
         }
-        catch
+        catch (Exception ex)
         {
             _sessions.TryRemove(sessionId, out _);
+            if (ex is not OperationCanceledException)
+            {
+                LogTiming(_logger, LogLevel.Warning, ex,
+                    "CopilotClient.CreateSessionAsync failed. Elapsed={Elapsed}, SessionId={SessionId}",
+                    totalTimestamp,
+                    sessionId);
+            }
             throw;
         }
 
+        LogTiming(_logger, LogLevel.Information, null,
+            "CopilotClient.CreateSessionAsync complete. Elapsed={Elapsed}, SessionId={SessionId}",
+            totalTimestamp,
+            sessionId);
         return session;
     }
 
@@ -643,6 +693,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         }
 
         var connection = await EnsureConnectedAsync(cancellationToken);
+        var totalTimestamp = Stopwatch.GetTimestamp();
 
         var hasHooks = config.Hooks != null && (
             config.Hooks.OnPreToolUse != null ||
@@ -656,6 +707,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
         // Create and register the session before issuing the RPC so that
         // events emitted by the CLI (e.g. session.start) are not dropped.
+        var setupTimestamp = Stopwatch.GetTimestamp();
         var session = new CopilotSession(sessionId, connection.Rpc, _logger);
         session.RegisterTools(config.Tools ?? []);
         session.RegisterPermissionHandler(config.OnPermissionRequest);
@@ -679,6 +731,13 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         }
         ConfigureSessionFsHandlers(session, config.CreateSessionFsHandler);
         _sessions[sessionId] = session;
+        LogTiming(_logger, LogLevel.Debug, null,
+            "CopilotClient.ResumeSessionAsync local setup complete. Elapsed={Elapsed}, SessionId={SessionId}, Tools={ToolsCount}, Commands={CommandsCount}, Hooks={HasHooks}",
+            setupTimestamp,
+            sessionId,
+            config.Tools?.Count ?? 0,
+            config.Commands?.Count ?? 0,
+            hasHooks);
 
         try
         {
@@ -720,18 +779,34 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 ContinuePendingWork: config.ContinuePendingWork,
                 InstructionDirectories: config.InstructionDirectories);
 
+            var rpcTimestamp = Stopwatch.GetTimestamp();
             var response = await InvokeRpcAsync<ResumeSessionResponse>(
                 connection.Rpc, "session.resume", [request], cancellationToken);
+            LogTiming(_logger, LogLevel.Information, null,
+                "CopilotClient.ResumeSessionAsync session resume request completed successfully. Elapsed={Elapsed}, SessionId={SessionId}",
+                rpcTimestamp,
+                sessionId);
 
             session.WorkspacePath = response.WorkspacePath;
             session.SetCapabilities(response.Capabilities);
         }
-        catch
+        catch (Exception ex)
         {
             _sessions.TryRemove(sessionId, out _);
+            if (ex is not OperationCanceledException)
+            {
+                LogTiming(_logger, LogLevel.Warning, ex,
+                    "CopilotClient.ResumeSessionAsync failed. Elapsed={Elapsed}, SessionId={SessionId}",
+                    totalTimestamp,
+                    sessionId);
+            }
             throw;
         }
 
+        LogTiming(_logger, LogLevel.Information, null,
+            "CopilotClient.ResumeSessionAsync complete. Elapsed={Elapsed}, SessionId={SessionId}",
+            totalTimestamp,
+            sessionId);
         return session;
     }
 
@@ -1162,6 +1237,103 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         }
     }
 
+    private static void LogTiming(
+        ILogger logger,
+        LogLevel level,
+        Exception? exception,
+        string message,
+        long startTimestamp)
+    {
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp));
+    }
+
+    private static void LogTiming<T1>(
+        ILogger logger,
+        LogLevel level,
+        Exception? exception,
+        string message,
+        long startTimestamp,
+        T1 arg1)
+    {
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1);
+    }
+
+    private static void LogTiming<T1, T2>(
+        ILogger logger,
+        LogLevel level,
+        Exception? exception,
+        string message,
+        long startTimestamp,
+        T1 arg1,
+        T2 arg2)
+    {
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1, arg2);
+    }
+
+    private static void LogTiming<T1, T2, T3>(
+        ILogger logger,
+        LogLevel level,
+        Exception? exception,
+        string message,
+        long startTimestamp,
+        T1 arg1,
+        T2 arg2,
+        T3 arg3)
+    {
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1, arg2, arg3);
+    }
+
+    private static void LogTiming<T1, T2, T3, T4>(
+        ILogger logger,
+        LogLevel level,
+        Exception? exception,
+        string message,
+        long startTimestamp,
+        T1 arg1,
+        T2 arg2,
+        T3 arg3,
+        T4 arg4)
+    {
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1, arg2, arg3, arg4);
+    }
+
+    private static void LogTimingCore(
+        ILogger logger,
+        LogLevel level,
+        Exception? exception,
+        string message,
+        params object?[] args)
+    {
+#pragma warning disable CA2254 // Timing call sites pass static templates through this helper.
+        logger.Log(level, exception, message, args);
+#pragma warning restore CA2254
+    }
+
     private static string FormatCliExitedMessage(string message, string stderrOutput)
     {
         return string.IsNullOrEmpty(stderrOutput)
@@ -1224,6 +1396,8 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
     private async Task VerifyProtocolVersionAsync(Connection connection, CancellationToken cancellationToken)
     {
+        var handshakeTimestamp = Stopwatch.GetTimestamp();
+        var usedFallbackPing = false;
         var maxVersion = SdkProtocolVersion.GetVersion();
         int? serverVersion;
         try
@@ -1236,6 +1410,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         {
             // Legacy server without `connect`; fall back to `ping`. A token, if any,
             // is silently dropped — the legacy server can't enforce one.
+            usedFallbackPing = true;
             var pingResponse = await InvokeRpcAsync<PingResponse>(
                 connection.Rpc, "ping", [new PingRequest()], connection.StderrBuffer, cancellationToken);
             serverVersion = pingResponse.ProtocolVersion;
@@ -1258,6 +1433,11 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         }
 
         _negotiatedProtocolVersion = serverVersion.Value;
+        LogTiming(_logger, LogLevel.Information, null,
+            "CopilotClient.VerifyProtocolVersionAsync protocol handshake complete. Elapsed={Elapsed}, ProtocolVersion={ProtocolVersion}, UsedFallbackPing={UsedFallbackPing}",
+            handshakeTimestamp,
+            serverVersion.Value,
+            usedFallbackPing);
     }
 
     private static bool IsUnsupportedConnectMethod(RemoteRpcException ex)
@@ -1275,6 +1455,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             ?? envCliPath
             ?? GetBundledCliPath(out var searchedPath)
             ?? throw new InvalidOperationException($"Copilot CLI not found at '{searchedPath}'. Ensure the SDK NuGet package was restored correctly or provide an explicit CliPath.");
+        var cliPathSource = options.CliPath is not null ? "Options" : envCliPath is not null ? "Environment" : "Bundled";
         var args = new List<string>();
 
         if (options.CliArgs != null)
@@ -1312,6 +1493,14 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         }
 
         var (fileName, processArgs) = ResolveCliCommand(cliPath, args);
+        var configuredPort = options.UseStdio == true ? (int?)null : options.Port;
+        logger.LogInformation(
+            "CopilotClient.StartCliServerAsync starting Copilot CLI. CliPath={CliPath}, Executable={Executable}, CliPathSource={CliPathSource}, UseStdio={UseStdio}, Port={Port}",
+            cliPath,
+            fileName,
+            cliPathSource,
+            options.UseStdio == true,
+            configuredPort);
 
         var startInfo = new ProcessStartInfo
         {
@@ -1367,7 +1556,11 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         try
         {
             cliProcess = new Process { StartInfo = startInfo };
+            var spawnTimestamp = Stopwatch.GetTimestamp();
             cliProcess.Start();
+            LogTiming(logger, LogLevel.Information, null,
+                "CopilotClient.StartCliServerAsync subprocess spawned. Elapsed={Elapsed}",
+                spawnTimestamp);
 
             // Capture stderr for error messages and forward to logger
             var stderrBuffer = new StringBuilder();
@@ -1386,10 +1579,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                         stderrBuffer.AppendLine(line);
                     }
 
-                    if (logger.IsEnabled(LogLevel.Debug))
-                    {
-                        logger.LogDebug("[CLI] {Line}", line);
-                    }
+                    logger.LogWarning("[CLI] {Line}", line);
                 }
             }, cancellationToken);
 
@@ -1397,6 +1587,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             if (options.UseStdio != true)
             {
                 // Wait for port announcement
+                var portWaitTimestamp = Stopwatch.GetTimestamp();
                 using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 cts.CancelAfter(TimeSpan.FromSeconds(30));
 
@@ -1409,9 +1600,18 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                         throw CreateCliExitedException("CLI process exited unexpectedly", stderrBuffer);
                     }
 
+                    if (logger.IsEnabled(LogLevel.Debug))
+                    {
+                        logger.LogDebug("[CLI] {Line}", line);
+                    }
+
                     if (ListeningOnPortRegex().Match(line) is { Success: true } match)
                     {
                         detectedLocalhostTcpPort = int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
+                        LogTiming(logger, LogLevel.Information, null,
+                            "CopilotClient.StartCliServerAsync TCP port wait complete. Elapsed={Elapsed}, Port={Port}",
+                            portWaitTimestamp,
+                            detectedLocalhostTcpPort.Value);
                         break;
                     }
                 }
@@ -1473,6 +1673,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
     private async Task<Connection> ConnectToServerAsync(Process? cliProcess, string? tcpHost, int? tcpPort, StringBuilder? stderrBuffer, CancellationToken cancellationToken)
     {
+        var setupTimestamp = Stopwatch.GetTimestamp();
         Stream inputStream, outputStream;
         NetworkStream? networkStream = null;
 
@@ -1496,7 +1697,14 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
             try
             {
+                var tcpConnectTimestamp = Stopwatch.GetTimestamp();
+                _logger.LogInformation("CopilotClient.ConnectToServerAsync connecting to CLI server. Host={Host}, Port={Port}", tcpHost, tcpPort.Value);
                 await socket.ConnectAsync(tcpHost, tcpPort.Value, cancellationToken);
+                LogTiming(_logger, LogLevel.Information, null,
+                    "CopilotClient.ConnectToServerAsync TCP connect complete. Elapsed={Elapsed}, Host={Host}, Port={Port}",
+                    tcpConnectTimestamp,
+                    tcpHost,
+                    tcpPort.Value);
             }
             catch
             {
@@ -1531,6 +1739,9 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             return session.ClientSessionApis;
         });
         rpc.StartListening();
+        LogTiming(_logger, LogLevel.Information, null,
+            "CopilotClient.ConnectToServerAsync transport setup complete. Elapsed={Elapsed}",
+            setupTimestamp);
 
         // Transition state to Disconnected if the JSON-RPC connection drops
         _ = rpc.Completion.ContinueWith(_ => _disconnected = true, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
@@ -1704,7 +1915,14 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                     }
                 }
 
+                var toolTimestamp = Stopwatch.GetTimestamp();
                 var result = await tool.InvokeAsync(aiFunctionArgs);
+                LogTiming(client._logger, LogLevel.Information, null,
+                    "RpcHandler.OnToolCallV2 tool dispatch. Elapsed={Elapsed}, SessionId={SessionId}, ToolCallId={ToolCallId}, Tool={ToolName}",
+                    toolTimestamp,
+                    sessionId,
+                    toolCallId,
+                    toolName);
 
                 var toolResultObject = ToolResultObject.ConvertFromInvocationResult(result, tool.JsonSerializerOptions);
                 return new ToolCallResponseV2(toolResultObject);

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -247,13 +247,13 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                     connection = await ConnectToServerAsync(cliProcess, portOrNull is null ? null : "localhost", portOrNull, stderrBuffer, ct);
                 }
 
-                LogTiming(_logger, LogLevel.Information, null,
+                LogTiming(_logger, LogLevel.Debug, null,
                     "CopilotClient.StartAsync transport setup complete. Elapsed={Elapsed}",
                     startTimestamp);
 
                 // Verify protocol version compatibility
                 await VerifyProtocolVersionAsync(connection, ct);
-                LogTiming(_logger, LogLevel.Information, null,
+                LogTiming(_logger, LogLevel.Debug, null,
                     "CopilotClient.StartAsync protocol verification complete. Elapsed={Elapsed}",
                     startTimestamp);
 
@@ -261,12 +261,12 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 await ConfigureSessionFsAsync(ct);
                 if (_options.SessionFs is not null)
                 {
-                    LogTiming(_logger, LogLevel.Information, null,
+                    LogTiming(_logger, LogLevel.Debug, null,
                         "CopilotClient.StartAsync session filesystem setup complete. Elapsed={Elapsed}",
                         sessionFsTimestamp);
                 }
 
-                LogTiming(_logger, LogLevel.Information, null,
+                LogTiming(_logger, LogLevel.Debug, null,
                     "CopilotClient.StartAsync complete. Elapsed={Elapsed}",
                     startTimestamp);
                 return connection;
@@ -629,7 +629,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             var rpcTimestamp = Stopwatch.GetTimestamp();
             var response = await InvokeRpcAsync<CreateSessionResponse>(
                 connection.Rpc, "session.create", [request], cancellationToken);
-            LogTiming(_logger, LogLevel.Information, null,
+            LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotClient.CreateSessionAsync session creation request completed successfully. Elapsed={Elapsed}, SessionId={SessionId}",
                 rpcTimestamp,
                 sessionId);
@@ -650,7 +650,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             throw;
         }
 
-        LogTiming(_logger, LogLevel.Information, null,
+        LogTiming(_logger, LogLevel.Debug, null,
             "CopilotClient.CreateSessionAsync complete. Elapsed={Elapsed}, SessionId={SessionId}",
             totalTimestamp,
             sessionId);
@@ -782,7 +782,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             var rpcTimestamp = Stopwatch.GetTimestamp();
             var response = await InvokeRpcAsync<ResumeSessionResponse>(
                 connection.Rpc, "session.resume", [request], cancellationToken);
-            LogTiming(_logger, LogLevel.Information, null,
+            LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotClient.ResumeSessionAsync session resume request completed successfully. Elapsed={Elapsed}, SessionId={SessionId}",
                 rpcTimestamp,
                 sessionId);
@@ -803,7 +803,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             throw;
         }
 
-        LogTiming(_logger, LogLevel.Information, null,
+        LogTiming(_logger, LogLevel.Debug, null,
             "CopilotClient.ResumeSessionAsync complete. Elapsed={Elapsed}, SessionId={SessionId}",
             totalTimestamp,
             sessionId);
@@ -1346,7 +1346,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         }
 
         _negotiatedProtocolVersion = serverVersion.Value;
-        LogTiming(_logger, LogLevel.Information, null,
+        LogTiming(_logger, LogLevel.Debug, null,
             "CopilotClient.VerifyProtocolVersionAsync protocol handshake complete. Elapsed={Elapsed}, ProtocolVersion={ProtocolVersion}, UsedFallbackPing={UsedFallbackPing}",
             handshakeTimestamp,
             serverVersion.Value,
@@ -1465,7 +1465,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             cliProcess = new Process { StartInfo = startInfo };
             var spawnTimestamp = Stopwatch.GetTimestamp();
             cliProcess.Start();
-            LogTiming(logger, LogLevel.Information, null,
+            LogTiming(logger, LogLevel.Debug, null,
                 "CopilotClient.StartCliServerAsync subprocess spawned. Elapsed={Elapsed}",
                 spawnTimestamp);
 
@@ -1515,7 +1515,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                     if (ListeningOnPortRegex().Match(line) is { Success: true } match)
                     {
                         detectedLocalhostTcpPort = int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
-                        LogTiming(logger, LogLevel.Information, null,
+                        LogTiming(logger, LogLevel.Debug, null,
                             "CopilotClient.StartCliServerAsync TCP port wait complete. Elapsed={Elapsed}, Port={Port}",
                             portWaitTimestamp,
                             detectedLocalhostTcpPort.Value);
@@ -1607,7 +1607,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 var tcpConnectTimestamp = Stopwatch.GetTimestamp();
                 LogConnectingToCliServer(_logger, tcpHost, tcpPort.Value);
                 await socket.ConnectAsync(tcpHost, tcpPort.Value, cancellationToken);
-                LogTiming(_logger, LogLevel.Information, null,
+                LogTiming(_logger, LogLevel.Debug, null,
                     "CopilotClient.ConnectToServerAsync TCP connect complete. Elapsed={Elapsed}, Host={Host}, Port={Port}",
                     tcpConnectTimestamp,
                     tcpHost,
@@ -1646,7 +1646,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             return session.ClientSessionApis;
         });
         rpc.StartListening();
-        LogTiming(_logger, LogLevel.Information, null,
+        LogTiming(_logger, LogLevel.Debug, null,
             "CopilotClient.ConnectToServerAsync transport setup complete. Elapsed={Elapsed}",
             setupTimestamp);
 
@@ -1824,7 +1824,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
                 var toolTimestamp = Stopwatch.GetTimestamp();
                 var result = await tool.InvokeAsync(aiFunctionArgs);
-                LogTiming(client._logger, LogLevel.Information, null,
+                LogTiming(client._logger, LogLevel.Debug, null,
                     "RpcHandler.OnToolCallV2 tool dispatch. Elapsed={Elapsed}, SessionId={SessionId}, ToolCallId={ToolCallId}, Tool={ToolName}",
                     toolTimestamp,
                     sessionId,

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -1341,6 +1341,16 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             : $"{message}\nstderr: {stderrOutput}";
     }
 
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "CopilotClient.StartCliServerAsync starting Copilot CLI. CliPath={CliPath}, Executable={Executable}, CliPathSource={CliPathSource}, UseStdio={UseStdio}, Port={Port}")]
+    private static partial void LogStartingCopilotCli(ILogger logger, string cliPath, string executable, string cliPathSource, bool useStdio, int? port);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "CopilotClient.ConnectToServerAsync connecting to CLI server. Host={Host}, Port={Port}")]
+    private static partial void LogConnectingToCliServer(ILogger logger, string host, int port);
+
     private static IOException CreateCliExitedException(string message, StringBuilder stderrBuffer)
     {
         string stderrOutput;
@@ -1494,13 +1504,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
         var (fileName, processArgs) = ResolveCliCommand(cliPath, args);
         var configuredPort = options.UseStdio == true ? (int?)null : options.Port;
-        logger.LogInformation(
-            "CopilotClient.StartCliServerAsync starting Copilot CLI. CliPath={CliPath}, Executable={Executable}, CliPathSource={CliPathSource}, UseStdio={UseStdio}, Port={Port}",
-            cliPath,
-            fileName,
-            cliPathSource,
-            options.UseStdio == true,
-            configuredPort);
+        LogStartingCopilotCli(logger, cliPath, fileName, cliPathSource, options.UseStdio == true, configuredPort);
 
         var startInfo = new ProcessStartInfo
         {
@@ -1698,7 +1702,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             try
             {
                 var tcpConnectTimestamp = Stopwatch.GetTimestamp();
-                _logger.LogInformation("CopilotClient.ConnectToServerAsync connecting to CLI server. Host={Host}, Port={Port}", tcpHost, tcpPort.Value);
+                LogConnectingToCliServer(_logger, tcpHost, tcpPort.Value);
                 await socket.ConnectAsync(tcpHost, tcpPort.Value, cancellationToken);
                 LogTiming(_logger, LogLevel.Information, null,
                     "CopilotClient.ConnectToServerAsync TCP connect complete. Elapsed={Elapsed}, Host={Host}, Port={Port}",

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using System.Collections.Concurrent;
 using System.Data;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
@@ -17,6 +16,7 @@ using System.Text.Json.Serialization.Metadata;
 using System.Text.RegularExpressions;
 using GitHub.Copilot.SDK.Rpc;
 using System.Globalization;
+using static GitHub.Copilot.SDK.LoggingHelpers;
 
 namespace GitHub.Copilot.SDK;
 
@@ -1235,103 +1235,6 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         {
             throw new IOException($"Communication error with Copilot CLI: {ex.Message}", ex);
         }
-    }
-
-    private static void LogTiming(
-        ILogger logger,
-        LogLevel level,
-        Exception? exception,
-        string message,
-        long startTimestamp)
-    {
-        if (!logger.IsEnabled(level))
-        {
-            return;
-        }
-
-        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp));
-    }
-
-    private static void LogTiming<T1>(
-        ILogger logger,
-        LogLevel level,
-        Exception? exception,
-        string message,
-        long startTimestamp,
-        T1 arg1)
-    {
-        if (!logger.IsEnabled(level))
-        {
-            return;
-        }
-
-        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1);
-    }
-
-    private static void LogTiming<T1, T2>(
-        ILogger logger,
-        LogLevel level,
-        Exception? exception,
-        string message,
-        long startTimestamp,
-        T1 arg1,
-        T2 arg2)
-    {
-        if (!logger.IsEnabled(level))
-        {
-            return;
-        }
-
-        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1, arg2);
-    }
-
-    private static void LogTiming<T1, T2, T3>(
-        ILogger logger,
-        LogLevel level,
-        Exception? exception,
-        string message,
-        long startTimestamp,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3)
-    {
-        if (!logger.IsEnabled(level))
-        {
-            return;
-        }
-
-        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1, arg2, arg3);
-    }
-
-    private static void LogTiming<T1, T2, T3, T4>(
-        ILogger logger,
-        LogLevel level,
-        Exception? exception,
-        string message,
-        long startTimestamp,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4)
-    {
-        if (!logger.IsEnabled(level))
-        {
-            return;
-        }
-
-        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1, arg2, arg3, arg4);
-    }
-
-    private static void LogTimingCore(
-        ILogger logger,
-        LogLevel level,
-        Exception? exception,
-        string message,
-        params object?[] args)
-    {
-#pragma warning disable CA2254 // Timing call sites pass static templates through this helper.
-        logger.Log(level, exception, message, args);
-#pragma warning restore CA2254
     }
 
     private static string FormatCliExitedMessage(string message, string stderrOutput)

--- a/dotnet/src/JsonRpc.cs
+++ b/dotnet/src/JsonRpc.cs
@@ -77,6 +77,7 @@ internal sealed partial class JsonRpc : IDisposable
     /// </summary>
     public async Task<T> InvokeAsync<T>(string method, object?[]? args, CancellationToken cancellationToken)
     {
+        var timingTimestamp = Stopwatch.GetTimestamp();
         var id = Interlocked.Increment(ref _nextId);
         var pending = new PendingRequest();
         _pendingRequests[id] = pending;
@@ -111,16 +112,53 @@ internal sealed partial class JsonRpc : IDisposable
 
             if (responseElement.ValueKind == JsonValueKind.Null || responseElement.ValueKind == JsonValueKind.Undefined)
             {
+                LogInvokeTiming(LogLevel.Debug, null, method, id, "Succeeded", timingTimestamp);
                 return default!;
             }
 
-            return (T)responseElement.Deserialize(_serializerOptions.GetTypeInfo(typeof(T)))!;
+            var result = (T)responseElement.Deserialize(_serializerOptions.GetTypeInfo(typeof(T)))!;
+            LogInvokeTiming(LogLevel.Debug, null, method, id, "Succeeded", timingTimestamp);
+            return result;
+        }
+        catch (OperationCanceledException ex)
+        {
+            LogInvokeTiming(LogLevel.Debug, ex, method, id, "Canceled", timingTimestamp);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogInvokeTiming(LogLevel.Warning, ex, method, id, "Failed", timingTimestamp);
+            throw;
         }
         finally
         {
             _pendingRequests.TryRemove(id, out _);
             await cancelRegistration.DisposeAsync().ConfigureAwait(false);
         }
+    }
+
+    private void LogInvokeTiming(
+        LogLevel level,
+        Exception? exception,
+        string method,
+        long requestId,
+        string status,
+        long startTimestamp)
+    {
+        if (!_logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
+        _logger.Log(
+            level,
+            exception,
+            "JsonRpc.InvokeAsync JSON-RPC request finished. Elapsed={Elapsed}, Method={Method}, RequestId={RequestId}, Status={Status}",
+            elapsed,
+            method,
+            requestId,
+            status);
     }
 
     /// <summary>

--- a/dotnet/src/LoggingHelpers.cs
+++ b/dotnet/src/LoggingHelpers.cs
@@ -1,0 +1,108 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
+
+namespace GitHub.Copilot.SDK;
+
+internal static class LoggingHelpers
+{
+    internal static void LogTiming(
+        ILogger logger,
+        LogLevel level,
+        Exception? exception,
+        string message,
+        long startTimestamp)
+    {
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp));
+    }
+
+    internal static void LogTiming<T1>(
+        ILogger logger,
+        LogLevel level,
+        Exception? exception,
+        string message,
+        long startTimestamp,
+        T1 arg1)
+    {
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1);
+    }
+
+    internal static void LogTiming<T1, T2>(
+        ILogger logger,
+        LogLevel level,
+        Exception? exception,
+        string message,
+        long startTimestamp,
+        T1 arg1,
+        T2 arg2)
+    {
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1, arg2);
+    }
+
+    internal static void LogTiming<T1, T2, T3>(
+        ILogger logger,
+        LogLevel level,
+        Exception? exception,
+        string message,
+        long startTimestamp,
+        T1 arg1,
+        T2 arg2,
+        T3 arg3)
+    {
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1, arg2, arg3);
+    }
+
+    internal static void LogTiming<T1, T2, T3, T4>(
+        ILogger logger,
+        LogLevel level,
+        Exception? exception,
+        string message,
+        long startTimestamp,
+        T1 arg1,
+        T2 arg2,
+        T3 arg3,
+        T4 arg4)
+    {
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1, arg2, arg3, arg4);
+    }
+
+    private static void LogTimingCore(
+        ILogger logger,
+        LogLevel level,
+        Exception? exception,
+        string message,
+        params object?[] args)
+    {
+#pragma warning disable CA2254 // Timing call sites pass static templates through this helper.
+        logger.Log(level, exception, message, args);
+#pragma warning restore CA2254
+    }
+}

--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -200,7 +200,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
         var rpcTimestamp = Stopwatch.GetTimestamp();
         var response = await InvokeRpcAsync<SendMessageResponse>(
             "session.send", [request], cancellationToken);
-        LogTiming(_logger, LogLevel.Information, null,
+        LogTiming(_logger, LogLevel.Debug, null,
             "CopilotSession.SendAsync completed successfully. Elapsed={Elapsed}, SessionId={SessionId}, MessageId={MessageId}",
             rpcTimestamp,
             SessionId,
@@ -295,7 +295,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
         try
         {
             var result = await tcs.Task;
-            LogTiming(_logger, LogLevel.Information, null,
+            LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotSession.SendAndWaitAsync complete. Elapsed={Elapsed}, SessionId={SessionId}, CompletedBy={CompletedBy}, AssistantMessageReceived={AssistantMessageReceived}",
                 totalTimestamp,
                 SessionId,
@@ -481,7 +481,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
 
         var permissionTimestamp = Stopwatch.GetTimestamp();
         var result = await handler(request, invocation);
-        LogTiming(_logger, LogLevel.Information, null,
+        LogTiming(_logger, LogLevel.Debug, null,
             "CopilotSession.HandlePermissionRequestAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}",
             permissionTimestamp,
             SessionId);
@@ -639,7 +639,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
 
             var toolTimestamp = Stopwatch.GetTimestamp();
             var result = await tool.InvokeAsync(aiFunctionArgs);
-            LogTiming(_logger, LogLevel.Information, null,
+            LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotSession.ExecuteToolAndRespondAsync tool dispatch. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}, ToolCallId={ToolCallId}, Tool={ToolName}",
                 toolTimestamp,
                 SessionId,
@@ -690,7 +690,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
 
             var permissionTimestamp = Stopwatch.GetTimestamp();
             var result = await handler(permissionRequest, invocation);
-            LogTiming(_logger, LogLevel.Information, null,
+            LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotSession.ExecutePermissionAndRespondAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}",
                 permissionTimestamp,
                 SessionId,
@@ -797,7 +797,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
                 CommandName = commandName,
                 Args = args
             });
-            LogTiming(_logger, LogLevel.Information, null,
+            LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotSession.ExecuteCommandAndRespondAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}, Command={CommandName}",
                 commandTimestamp,
                 SessionId,
@@ -841,7 +841,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
         {
             var elicitationTimestamp = Stopwatch.GetTimestamp();
             var result = await handler(context);
-            LogTiming(_logger, LogLevel.Information, null,
+            LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotSession.HandleElicitationRequestAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}",
                 elicitationTimestamp,
                 SessionId,
@@ -1009,7 +1009,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
 
         var userInputTimestamp = Stopwatch.GetTimestamp();
         var response = await handler(request, invocation);
-        LogTiming(_logger, LogLevel.Information, null,
+        LogTiming(_logger, LogLevel.Debug, null,
             "CopilotSession.HandleUserInputRequestAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}",
             userInputTimestamp,
             SessionId);
@@ -1102,7 +1102,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
         }
         finally
         {
-            LogTiming(_logger, LogLevel.Information, null,
+            LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotSession.HandleHooksInvokeAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}, Hook={HookType}",
                 hookTimestamp,
                 SessionId,

--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -6,6 +6,7 @@ using GitHub.Copilot.SDK.Rpc;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -195,8 +196,14 @@ public sealed partial class CopilotSession : IAsyncDisposable
             RequestHeaders = options.RequestHeaders,
         };
 
+        var rpcTimestamp = Stopwatch.GetTimestamp();
         var response = await InvokeRpcAsync<SendMessageResponse>(
             "session.send", [request], cancellationToken);
+        LogTiming(_logger, LogLevel.Information, null,
+            "CopilotSession.SendAsync completed successfully. Elapsed={Elapsed}, SessionId={SessionId}, MessageId={MessageId}",
+            rpcTimestamp,
+            SessionId,
+            response.MessageId);
 
         return response.MessageId;
     }
@@ -233,9 +240,11 @@ public sealed partial class CopilotSession : IAsyncDisposable
         TimeSpan? timeout = null,
         CancellationToken cancellationToken = default)
     {
+        var totalTimestamp = Stopwatch.GetTimestamp();
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(60);
         var tcs = new TaskCompletionSource<AssistantMessageEvent?>(TaskCreationOptions.RunContinuationsAsynchronously);
         AssistantMessageEvent? lastAssistantMessage = null;
+        var firstAssistantMessageLogged = false;
 
         void Handler(SessionEvent evt)
         {
@@ -243,9 +252,21 @@ public sealed partial class CopilotSession : IAsyncDisposable
             {
                 case AssistantMessageEvent assistantMessage:
                     lastAssistantMessage = assistantMessage;
+                    if (!firstAssistantMessageLogged)
+                    {
+                        firstAssistantMessageLogged = true;
+                        LogTiming(_logger, LogLevel.Debug, null,
+                            "CopilotSession.SendAndWaitAsync first assistant message. Elapsed={Elapsed}, SessionId={SessionId}",
+                            totalTimestamp,
+                            SessionId);
+                    }
                     break;
 
                 case SessionIdleEvent:
+                    LogTiming(_logger, LogLevel.Debug, null,
+                        "CopilotSession.SendAndWaitAsync idle received. Elapsed={Elapsed}, SessionId={SessionId}",
+                        totalTimestamp,
+                        SessionId);
                     tcs.TrySetResult(lastAssistantMessage);
                     break;
 
@@ -270,7 +291,35 @@ public sealed partial class CopilotSession : IAsyncDisposable
             else
                 tcs.TrySetException(new TimeoutException($"SendAndWaitAsync timed out after {effectiveTimeout}"));
         });
-        return await tcs.Task;
+        try
+        {
+            var result = await tcs.Task;
+            LogTiming(_logger, LogLevel.Information, null,
+                "CopilotSession.SendAndWaitAsync complete. Elapsed={Elapsed}, SessionId={SessionId}, CompletedBy={CompletedBy}, AssistantMessageReceived={AssistantMessageReceived}",
+                totalTimestamp,
+                SessionId,
+                "idle",
+                result is not null);
+            return result;
+        }
+        catch (Exception ex) when (ex is TimeoutException)
+        {
+            LogTiming(_logger, LogLevel.Warning, ex,
+                "CopilotSession.SendAndWaitAsync failed. Elapsed={Elapsed}, SessionId={SessionId}, CompletedBy={CompletedBy}",
+                totalTimestamp,
+                SessionId,
+                "timeout");
+            throw;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogTiming(_logger, LogLevel.Warning, ex,
+                "CopilotSession.SendAndWaitAsync failed. Elapsed={Elapsed}, SessionId={SessionId}, CompletedBy={CompletedBy}",
+                totalTimestamp,
+                SessionId,
+                "error");
+            throw;
+        }
     }
 
     /// <summary>
@@ -344,6 +393,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
     {
         await foreach (var sessionEvent in _eventChannel.Reader.ReadAllAsync())
         {
+            var dispatchTimestamp = Stopwatch.GetTimestamp();
             foreach (var handler in _eventHandlers)
             {
                 try
@@ -355,6 +405,11 @@ public sealed partial class CopilotSession : IAsyncDisposable
                     LogEventHandlerError(ex);
                 }
             }
+            LogTiming(_logger, LogLevel.Debug, null,
+                "CopilotSession.ProcessEventsAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}, EventType={EventType}",
+                dispatchTimestamp,
+                SessionId,
+                sessionEvent.Type);
         }
     }
 
@@ -423,7 +478,13 @@ public sealed partial class CopilotSession : IAsyncDisposable
             SessionId = SessionId
         };
 
-        return await handler(request, invocation);
+        var permissionTimestamp = Stopwatch.GetTimestamp();
+        var result = await handler(request, invocation);
+        LogTiming(_logger, LogLevel.Information, null,
+            "CopilotSession.HandlePermissionRequestAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}",
+            permissionTimestamp,
+            SessionId);
+        return result;
     }
 
     /// <summary>
@@ -433,6 +494,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
     /// </summary>
     private async Task HandleBroadcastEventAsync(SessionEvent sessionEvent)
     {
+        var dispatchTimestamp = Stopwatch.GetTimestamp();
         try
         {
             switch (sessionEvent)
@@ -528,6 +590,14 @@ public sealed partial class CopilotSession : IAsyncDisposable
         {
             LogBroadcastHandlerError(ex);
         }
+        finally
+        {
+            LogTiming(_logger, LogLevel.Debug, null,
+                "CopilotSession.HandleBroadcastEventAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}, EventType={EventType}",
+                dispatchTimestamp,
+                SessionId,
+                sessionEvent.Type);
+        }
     }
 
     /// <summary>
@@ -566,11 +636,27 @@ public sealed partial class CopilotSession : IAsyncDisposable
                 }
             }
 
+            var toolTimestamp = Stopwatch.GetTimestamp();
             var result = await tool.InvokeAsync(aiFunctionArgs);
+            LogTiming(_logger, LogLevel.Information, null,
+                "CopilotSession.ExecuteToolAndRespondAsync tool dispatch. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}, ToolCallId={ToolCallId}, Tool={ToolName}",
+                toolTimestamp,
+                SessionId,
+                requestId,
+                toolCallId,
+                toolName);
 
             var toolResultObject = ToolResultObject.ConvertFromInvocationResult(result, tool.JsonSerializerOptions);
 
+            var responseRpcTimestamp = Stopwatch.GetTimestamp();
             await Rpc.Tools.HandlePendingToolCallAsync(requestId, toolResultObject, error: null);
+            LogTiming(_logger, LogLevel.Debug, null,
+                "CopilotSession.ExecuteToolAndRespondAsync response sent successfully. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}, ToolCallId={ToolCallId}, Tool={ToolName}",
+                responseRpcTimestamp,
+                SessionId,
+                requestId,
+                toolCallId,
+                toolName);
         }
         catch (Exception ex)
         {
@@ -601,12 +687,24 @@ public sealed partial class CopilotSession : IAsyncDisposable
                 SessionId = SessionId
             };
 
+            var permissionTimestamp = Stopwatch.GetTimestamp();
             var result = await handler(permissionRequest, invocation);
+            LogTiming(_logger, LogLevel.Information, null,
+                "CopilotSession.ExecutePermissionAndRespondAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}",
+                permissionTimestamp,
+                SessionId,
+                requestId);
             if (result.Kind == new PermissionRequestResultKind("no-result"))
             {
                 return;
             }
+            var responseRpcTimestamp = Stopwatch.GetTimestamp();
             await Rpc.Permissions.HandlePendingPermissionRequestAsync(requestId, new PermissionDecision { Kind = result.Kind.Value });
+            LogTiming(_logger, LogLevel.Debug, null,
+                "CopilotSession.ExecutePermissionAndRespondAsync response sent successfully. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}",
+                responseRpcTimestamp,
+                SessionId,
+                requestId);
         }
         catch (Exception)
         {
@@ -690,6 +788,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
 
         try
         {
+            var commandTimestamp = Stopwatch.GetTimestamp();
             await handler(new CommandContext
             {
                 SessionId = SessionId,
@@ -697,7 +796,20 @@ public sealed partial class CopilotSession : IAsyncDisposable
                 CommandName = commandName,
                 Args = args
             });
+            LogTiming(_logger, LogLevel.Information, null,
+                "CopilotSession.ExecuteCommandAndRespondAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}, Command={CommandName}",
+                commandTimestamp,
+                SessionId,
+                requestId,
+                commandName);
+            var responseRpcTimestamp = Stopwatch.GetTimestamp();
             await Rpc.Commands.HandlePendingCommandAsync(requestId);
+            LogTiming(_logger, LogLevel.Debug, null,
+                "CopilotSession.ExecuteCommandAndRespondAsync response sent successfully. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}, Command={CommandName}",
+                responseRpcTimestamp,
+                SessionId,
+                requestId,
+                commandName);
         }
         catch (Exception error) when (error is not OperationCanceledException)
         {
@@ -726,12 +838,24 @@ public sealed partial class CopilotSession : IAsyncDisposable
 
         try
         {
+            var elicitationTimestamp = Stopwatch.GetTimestamp();
             var result = await handler(context);
+            LogTiming(_logger, LogLevel.Information, null,
+                "CopilotSession.HandleElicitationRequestAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}",
+                elicitationTimestamp,
+                SessionId,
+                requestId);
+            var responseRpcTimestamp = Stopwatch.GetTimestamp();
             await Rpc.Ui.HandlePendingElicitationAsync(requestId, new UIElicitationResponse
             {
                 Action = result.Action,
                 Content = result.Content
             });
+            LogTiming(_logger, LogLevel.Debug, null,
+                "CopilotSession.HandleElicitationRequestAsync response sent successfully. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}",
+                responseRpcTimestamp,
+                SessionId,
+                requestId);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -882,7 +1006,13 @@ public sealed partial class CopilotSession : IAsyncDisposable
             SessionId = SessionId
         };
 
-        return await handler(request, invocation);
+        var userInputTimestamp = Stopwatch.GetTimestamp();
+        var response = await handler(request, invocation);
+        LogTiming(_logger, LogLevel.Information, null,
+            "CopilotSession.HandleUserInputRequestAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}",
+            userInputTimestamp,
+            SessionId);
+        return response;
     }
 
     /// <summary>
@@ -931,40 +1061,52 @@ public sealed partial class CopilotSession : IAsyncDisposable
             SessionId = SessionId
         };
 
-        return hookType switch
+        var hookTimestamp = Stopwatch.GetTimestamp();
+        try
         {
-            "preToolUse" => hooks.OnPreToolUse != null
-                ? await hooks.OnPreToolUse(
-                    JsonSerializer.Deserialize(input.GetRawText(), SessionJsonContext.Default.PreToolUseHookInput)!,
-                    invocation)
-                : null,
-            "postToolUse" => hooks.OnPostToolUse != null
-                ? await hooks.OnPostToolUse(
-                    JsonSerializer.Deserialize(input.GetRawText(), SessionJsonContext.Default.PostToolUseHookInput)!,
-                    invocation)
-                : null,
-            "userPromptSubmitted" => hooks.OnUserPromptSubmitted != null
-                ? await hooks.OnUserPromptSubmitted(
-                    JsonSerializer.Deserialize(input.GetRawText(), SessionJsonContext.Default.UserPromptSubmittedHookInput)!,
-                    invocation)
-                : null,
-            "sessionStart" => hooks.OnSessionStart != null
-                ? await hooks.OnSessionStart(
-                    JsonSerializer.Deserialize(input.GetRawText(), SessionJsonContext.Default.SessionStartHookInput)!,
-                    invocation)
-                : null,
-            "sessionEnd" => hooks.OnSessionEnd != null
-                ? await hooks.OnSessionEnd(
-                    JsonSerializer.Deserialize(input.GetRawText(), SessionJsonContext.Default.SessionEndHookInput)!,
-                    invocation)
-                : null,
-            "errorOccurred" => hooks.OnErrorOccurred != null
-                ? await hooks.OnErrorOccurred(
-                    JsonSerializer.Deserialize(input.GetRawText(), SessionJsonContext.Default.ErrorOccurredHookInput)!,
-                    invocation)
-                : null,
-            _ => null
-        };
+            return hookType switch
+            {
+                "preToolUse" => hooks.OnPreToolUse != null
+                    ? await hooks.OnPreToolUse(
+                        JsonSerializer.Deserialize(input.GetRawText(), SessionJsonContext.Default.PreToolUseHookInput)!,
+                        invocation)
+                    : null,
+                "postToolUse" => hooks.OnPostToolUse != null
+                    ? await hooks.OnPostToolUse(
+                        JsonSerializer.Deserialize(input.GetRawText(), SessionJsonContext.Default.PostToolUseHookInput)!,
+                        invocation)
+                    : null,
+                "userPromptSubmitted" => hooks.OnUserPromptSubmitted != null
+                    ? await hooks.OnUserPromptSubmitted(
+                        JsonSerializer.Deserialize(input.GetRawText(), SessionJsonContext.Default.UserPromptSubmittedHookInput)!,
+                        invocation)
+                    : null,
+                "sessionStart" => hooks.OnSessionStart != null
+                    ? await hooks.OnSessionStart(
+                        JsonSerializer.Deserialize(input.GetRawText(), SessionJsonContext.Default.SessionStartHookInput)!,
+                        invocation)
+                    : null,
+                "sessionEnd" => hooks.OnSessionEnd != null
+                    ? await hooks.OnSessionEnd(
+                        JsonSerializer.Deserialize(input.GetRawText(), SessionJsonContext.Default.SessionEndHookInput)!,
+                        invocation)
+                    : null,
+                "errorOccurred" => hooks.OnErrorOccurred != null
+                    ? await hooks.OnErrorOccurred(
+                        JsonSerializer.Deserialize(input.GetRawText(), SessionJsonContext.Default.ErrorOccurredHookInput)!,
+                        invocation)
+                    : null,
+                _ => null
+            };
+        }
+        finally
+        {
+            LogTiming(_logger, LogLevel.Information, null,
+                "CopilotSession.HandleHooksInvokeAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}, Hook={HookType}",
+                hookTimestamp,
+                SessionId,
+                hookType);
+        }
     }
 
     /// <summary>
@@ -1214,6 +1356,103 @@ public sealed partial class CopilotSession : IAsyncDisposable
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Unhandled exception in session event handler")]
     private partial void LogEventHandlerError(Exception exception);
+
+    private static void LogTiming(
+        ILogger logger,
+        LogLevel level,
+        Exception? exception,
+        string message,
+        long startTimestamp)
+    {
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp));
+    }
+
+    private static void LogTiming<T1>(
+        ILogger logger,
+        LogLevel level,
+        Exception? exception,
+        string message,
+        long startTimestamp,
+        T1 arg1)
+    {
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1);
+    }
+
+    private static void LogTiming<T1, T2>(
+        ILogger logger,
+        LogLevel level,
+        Exception? exception,
+        string message,
+        long startTimestamp,
+        T1 arg1,
+        T2 arg2)
+    {
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1, arg2);
+    }
+
+    private static void LogTiming<T1, T2, T3>(
+        ILogger logger,
+        LogLevel level,
+        Exception? exception,
+        string message,
+        long startTimestamp,
+        T1 arg1,
+        T2 arg2,
+        T3 arg3)
+    {
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1, arg2, arg3);
+    }
+
+    private static void LogTiming<T1, T2, T3, T4>(
+        ILogger logger,
+        LogLevel level,
+        Exception? exception,
+        string message,
+        long startTimestamp,
+        T1 arg1,
+        T2 arg2,
+        T3 arg3,
+        T4 arg4)
+    {
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1, arg2, arg3, arg4);
+    }
+
+    private static void LogTimingCore(
+        ILogger logger,
+        LogLevel level,
+        Exception? exception,
+        string message,
+        params object?[] args)
+    {
+#pragma warning disable CA2254 // Timing call sites pass static templates through this helper.
+        logger.Log(level, exception, message, args);
+#pragma warning restore CA2254
+    }
 
     internal record SendMessageRequest
     {

--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -11,6 +11,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Threading.Channels;
+using static GitHub.Copilot.SDK.LoggingHelpers;
 
 namespace GitHub.Copilot.SDK;
 
@@ -1356,103 +1357,6 @@ public sealed partial class CopilotSession : IAsyncDisposable
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Unhandled exception in session event handler")]
     private partial void LogEventHandlerError(Exception exception);
-
-    private static void LogTiming(
-        ILogger logger,
-        LogLevel level,
-        Exception? exception,
-        string message,
-        long startTimestamp)
-    {
-        if (!logger.IsEnabled(level))
-        {
-            return;
-        }
-
-        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp));
-    }
-
-    private static void LogTiming<T1>(
-        ILogger logger,
-        LogLevel level,
-        Exception? exception,
-        string message,
-        long startTimestamp,
-        T1 arg1)
-    {
-        if (!logger.IsEnabled(level))
-        {
-            return;
-        }
-
-        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1);
-    }
-
-    private static void LogTiming<T1, T2>(
-        ILogger logger,
-        LogLevel level,
-        Exception? exception,
-        string message,
-        long startTimestamp,
-        T1 arg1,
-        T2 arg2)
-    {
-        if (!logger.IsEnabled(level))
-        {
-            return;
-        }
-
-        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1, arg2);
-    }
-
-    private static void LogTiming<T1, T2, T3>(
-        ILogger logger,
-        LogLevel level,
-        Exception? exception,
-        string message,
-        long startTimestamp,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3)
-    {
-        if (!logger.IsEnabled(level))
-        {
-            return;
-        }
-
-        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1, arg2, arg3);
-    }
-
-    private static void LogTiming<T1, T2, T3, T4>(
-        ILogger logger,
-        LogLevel level,
-        Exception? exception,
-        string message,
-        long startTimestamp,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4)
-    {
-        if (!logger.IsEnabled(level))
-        {
-            return;
-        }
-
-        LogTimingCore(logger, level, exception, message, Stopwatch.GetElapsedTime(startTimestamp), arg1, arg2, arg3, arg4);
-    }
-
-    private static void LogTimingCore(
-        ILogger logger,
-        LogLevel level,
-        Exception? exception,
-        string message,
-        params object?[] args)
-    {
-#pragma warning disable CA2254 // Timing call sites pass static templates through this helper.
-        logger.Log(level, exception, message, args);
-#pragma warning restore CA2254
-    }
 
     internal record SendMessageRequest
     {

--- a/python/copilot/_diagnostics.py
+++ b/python/copilot/_diagnostics.py
@@ -1,0 +1,29 @@
+"""Internal diagnostics helpers shared by SDK modules."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+
+def elapsed_ms(start: float) -> float:
+    return (time.perf_counter() - start) * 1000
+
+
+def log_timing(
+    logger: logging.Logger,
+    level: int,
+    message: str,
+    start: float,
+    *,
+    exc_info: bool = False,
+    **fields: Any,
+) -> None:
+    if logger.isEnabledFor(level):
+        logger.log(
+            level,
+            message,
+            extra={"elapsed_ms": elapsed_ms(start), **fields},
+            exc_info=exc_info,
+        )

--- a/python/copilot/_jsonrpc.py
+++ b/python/copilot/_jsonrpc.py
@@ -8,10 +8,14 @@ Much simpler and more reliable than pure asyncio subprocess.
 import asyncio
 import inspect
 import json
+import logging
 import threading
+import time
 import uuid
 from collections.abc import Awaitable, Callable
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 class JsonRpcError(Exception):
@@ -31,6 +35,33 @@ class ProcessExitedError(Exception):
 
 
 RequestHandler = Callable[[dict], dict | Awaitable[dict]]
+
+
+def _elapsed_ms(start: float) -> float:
+    return (time.perf_counter() - start) * 1000
+
+
+def _log_request_timing(
+    level: int,
+    start: float,
+    method: str,
+    request_id: str,
+    status: str,
+    *,
+    exc_info: bool = False,
+) -> None:
+    if logger.isEnabledFor(level):
+        logger.log(
+            level,
+            "JsonRpcClient.request JSON-RPC request finished",
+            extra={
+                "elapsed_ms": _elapsed_ms(start),
+                "method": method,
+                "request_id": request_id,
+                "status": status,
+            },
+            exc_info=exc_info,
+        )
 
 
 class JsonRpcClient:
@@ -84,12 +115,12 @@ class JsonRpcClient:
                 line = self.process.stderr.readline()
                 if not line:
                     break
+                stderr_line = line.decode("utf-8") if isinstance(line, bytes) else line
+                logger.warning("[CLI] %s", stderr_line.rstrip())
                 with self._stderr_lock:
-                    self._stderr_output.append(
-                        line.decode("utf-8") if isinstance(line, bytes) else line
-                    )
+                    self._stderr_output.append(stderr_line)
         except Exception:
-            pass  # Ignore errors reading stderr
+            logger.debug("Error reading Copilot CLI stderr", exc_info=True)
 
     def get_stderr_output(self) -> str:
         """Get captured stderr output"""
@@ -123,6 +154,7 @@ class JsonRpcClient:
             JsonRpcError: If server returns an error
             asyncio.TimeoutError: If request times out (only when timeout is set)
         """
+        request_start = time.perf_counter()
         request_id = str(uuid.uuid4())
 
         # Use the stored loop to ensure consistency with the reader thread
@@ -140,12 +172,28 @@ class JsonRpcClient:
             "params": params or {},
         }
 
-        await self._send_message(message)
-
         try:
+            await self._send_message(message)
             if timeout is not None:
-                return await asyncio.wait_for(future, timeout=timeout)
-            return await future
+                result = await asyncio.wait_for(future, timeout=timeout)
+            else:
+                result = await future
+        except asyncio.CancelledError:
+            _log_request_timing(logging.DEBUG, request_start, method, request_id, "canceled")
+            raise
+        except Exception:
+            _log_request_timing(
+                logging.WARNING,
+                request_start,
+                method,
+                request_id,
+                "failed",
+                exc_info=True,
+            )
+            raise
+        else:
+            _log_request_timing(logging.DEBUG, request_start, method, request_id, "succeeded")
+            return result
         finally:
             with self._pending_lock:
                 self.pending_requests.pop(request_id, None)
@@ -206,11 +254,13 @@ class JsonRpcClient:
             pass
         except Exception as e:
             if self._running:
+                logger.warning("Failed to parse incoming JSON-RPC message", exc_info=True)
                 # Store error for pending requests
                 self._process_exit_error = str(e)
 
         # Process exited or read failed - fail all pending requests
         if self._running:
+            logger.debug("JSON-RPC read loop ended")
             self._fail_pending_requests()
             if self.on_close is not None:
                 self.on_close()
@@ -358,8 +408,17 @@ class JsonRpcClient:
                 )
             await self._send_response(message["id"], outcome)
         except JsonRpcError as exc:
+            logger.debug(
+                "Error handling JSON-RPC method %s: %s", message.get("method", ""), exc.message
+            )
             await self._send_error_response(message["id"], exc.code, exc.message, exc.data)
         except Exception as exc:  # pylint: disable=broad-except
+            logger.debug(
+                "Error handling JSON-RPC method %s: %s",
+                message.get("method", ""),
+                str(exc),
+                exc_info=True,
+            )
             await self._send_error_response(message["id"], -32603, str(exc), None)
 
     async def _send_response(self, request_id: str, result: dict | None):

--- a/python/copilot/_jsonrpc.py
+++ b/python/copilot/_jsonrpc.py
@@ -15,6 +15,8 @@ import uuid
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+from ._diagnostics import elapsed_ms
+
 logger = logging.getLogger(__name__)
 
 
@@ -37,10 +39,6 @@ class ProcessExitedError(Exception):
 RequestHandler = Callable[[dict], dict | Awaitable[dict]]
 
 
-def _elapsed_ms(start: float) -> float:
-    return (time.perf_counter() - start) * 1000
-
-
 def _log_request_timing(
     level: int,
     start: float,
@@ -55,7 +53,7 @@ def _log_request_timing(
             level,
             "JsonRpcClient.request JSON-RPC request finished",
             extra={
-                "elapsed_ms": _elapsed_ms(start),
+                "elapsed_ms": elapsed_ms(start),
                 "method": method,
                 "request_id": request_id,
                 "status": status,

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -16,12 +16,14 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import logging
 import os
 import re
 import shutil
 import subprocess
 import sys
 import threading
+import time
 import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import KW_ONLY, dataclass, field
@@ -64,6 +66,8 @@ from .session import (
 )
 from .session_fs_provider import create_session_fs_adapter
 from .tools import Tool, ToolInvocation, ToolResult
+
+logger = logging.getLogger(__name__)
 
 # ============================================================================
 # Connection Types
@@ -770,6 +774,27 @@ NO_RESULT_PERMISSION_V2_ERROR = (
 MIN_PROTOCOL_VERSION = 2
 
 
+def _elapsed_ms(start: float) -> float:
+    return (time.perf_counter() - start) * 1000
+
+
+def _log_timing(
+    level: int,
+    message: str,
+    start: float,
+    *,
+    exc_info: bool = False,
+    **fields: Any,
+) -> None:
+    if logger.isEnabledFor(level):
+        logger.log(
+            level,
+            message,
+            extra={"elapsed_ms": _elapsed_ms(start), **fields},
+            exc_info=exc_info,
+        )
+
+
 def _get_bundled_cli_path() -> str | None:
     """Get the path to the bundled CLI binary, if available."""
     # The binary is bundled in copilot/bin/ within the package
@@ -923,14 +948,17 @@ class CopilotClient:
 
             # Resolve CLI path: explicit > COPILOT_CLI_PATH env var > bundled binary
             effective_env = config.env if config.env is not None else os.environ
+            self._cli_path_source: str | None = "explicit"
             if config.cli_path is None:
                 env_cli_path = effective_env.get("COPILOT_CLI_PATH")
                 if env_cli_path:
                     config.cli_path = env_cli_path
+                    self._cli_path_source = "environment"
                 else:
                     bundled_path = _get_bundled_cli_path()
                     if bundled_path:
                         config.cli_path = bundled_path
+                        self._cli_path_source = "bundled"
                     else:
                         raise RuntimeError(
                             "Copilot CLI not found. The bundled CLI binary is not available. "
@@ -1074,6 +1102,7 @@ class CopilotClient:
         if self._state == "connected":
             return
 
+        start_time = time.perf_counter()
         self._state = "connecting"
 
         try:
@@ -1083,20 +1112,53 @@ class CopilotClient:
 
             # Connect to the server
             await self._connect_to_server()
+            _log_timing(
+                logging.INFO,
+                "CopilotClient.start transport setup complete",
+                start_time,
+            )
 
             # Verify protocol version compatibility
             await self._verify_protocol_version()
+            _log_timing(
+                logging.INFO,
+                "CopilotClient.start protocol verification complete",
+                start_time,
+            )
 
             if self._session_fs_config:
+                session_fs_start = time.perf_counter()
                 await self._set_session_fs_provider()
+                _log_timing(
+                    logging.INFO,
+                    "CopilotClient.start session filesystem setup complete",
+                    session_fs_start,
+                )
 
             self._state = "connected"
+            _log_timing(
+                logging.INFO,
+                "CopilotClient.start complete",
+                start_time,
+            )
         except ProcessExitedError as e:
             # Process exited with error - reraise as RuntimeError with stderr
             self._state = "error"
+            _log_timing(
+                logging.WARNING,
+                "CopilotClient.start failed",
+                start_time,
+                exc_info=True,
+            )
             raise RuntimeError(str(e)) from None
         except Exception as e:
             self._state = "error"
+            _log_timing(
+                logging.WARNING,
+                "CopilotClient.start failed",
+                start_time,
+                exc_info=True,
+            )
             # Check if process exited and capture any remaining stderr
             if self._process and hasattr(self._process, "poll"):
                 return_code = self._process.poll()
@@ -1143,6 +1205,11 @@ class CopilotClient:
             try:
                 await session.disconnect()
             except Exception as e:
+                logger.debug(
+                    "Error while cleaning up Copilot session %s",
+                    session.session_id,
+                    exc_info=True,
+                )
                 errors.append(
                     StopError(message=f"Failed to disconnect session {session.session_id}: {e}")
                 )
@@ -1204,14 +1271,16 @@ class CopilotClient:
                     self._process.kill()
                     self._process = None
             except Exception:
-                pass
+                logger.debug("Error while force-stopping Copilot CLI process", exc_info=True)
 
         # Then clean up the JSON-RPC client
         if self._client:
             try:
                 await self._client.stop()
             except Exception:
-                pass  # Ignore errors during force stop
+                logger.debug(
+                    "Error while stopping JSON-RPC client during force stop", exc_info=True
+                )
             self._client = None
         self._rpc = None
 
@@ -1482,6 +1551,7 @@ class CopilotClient:
         if not self._client:
             raise RuntimeError("Client not connected")
 
+        total_start = time.perf_counter()
         actual_session_id = session_id or str(uuid.uuid4())
         payload["sessionId"] = actual_session_id
 
@@ -1491,6 +1561,7 @@ class CopilotClient:
 
         # Create and register the session before issuing the RPC so that
         # events emitted by the CLI (e.g. session.start) are not dropped.
+        setup_start = time.perf_counter()
         session = CopilotSession(actual_session_id, self._client, workspace_path=None)
         if self._session_fs_config:
             if create_session_fs_handler is None:
@@ -1516,17 +1587,47 @@ class CopilotClient:
             session.on(on_event)
         with self._sessions_lock:
             self._sessions[actual_session_id] = session
+        _log_timing(
+            logging.DEBUG,
+            "CopilotClient.create_session local setup complete",
+            setup_start,
+            session_id=actual_session_id,
+            tools_count=len(tools or []),
+            commands_count=len(commands or []),
+            has_hooks=hooks is not None,
+        )
 
         try:
+            rpc_start = time.perf_counter()
             response = await self._client.request("session.create", payload)
+            _log_timing(
+                logging.INFO,
+                "CopilotClient.create_session session creation request completed successfully",
+                rpc_start,
+                session_id=actual_session_id,
+            )
             session._workspace_path = response.get("workspacePath")
             capabilities = response.get("capabilities")
             session._set_capabilities(capabilities)
-        except BaseException:
+        except BaseException as exc:
             with self._sessions_lock:
                 self._sessions.pop(actual_session_id, None)
+            if not isinstance(exc, asyncio.CancelledError):
+                _log_timing(
+                    logging.WARNING,
+                    "CopilotClient.create_session failed",
+                    total_start,
+                    exc_info=True,
+                    session_id=actual_session_id,
+                )
             raise
 
+        _log_timing(
+            logging.INFO,
+            "CopilotClient.create_session complete",
+            total_start,
+            session_id=actual_session_id,
+        )
         return session
 
     async def resume_session(
@@ -1774,12 +1875,14 @@ class CopilotClient:
         if not self._client:
             raise RuntimeError("Client not connected")
 
+        total_start = time.perf_counter()
         # Propagate W3C Trace Context to CLI if OpenTelemetry is active
         trace_ctx = get_trace_context()
         payload.update(trace_ctx)
 
         # Create and register the session before issuing the RPC so that
         # events emitted by the CLI (e.g. session.start) are not dropped.
+        setup_start = time.perf_counter()
         session = CopilotSession(session_id, self._client, workspace_path=None)
         if self._session_fs_config:
             if create_session_fs_handler is None:
@@ -1805,17 +1908,47 @@ class CopilotClient:
             session.on(on_event)
         with self._sessions_lock:
             self._sessions[session_id] = session
+        _log_timing(
+            logging.DEBUG,
+            "CopilotClient.resume_session local setup complete",
+            setup_start,
+            session_id=session_id,
+            tools_count=len(tools or []),
+            commands_count=len(commands or []),
+            has_hooks=hooks is not None,
+        )
 
         try:
+            rpc_start = time.perf_counter()
             response = await self._client.request("session.resume", payload)
+            _log_timing(
+                logging.INFO,
+                "CopilotClient.resume_session session resume request completed successfully",
+                rpc_start,
+                session_id=session_id,
+            )
             session._workspace_path = response.get("workspacePath")
             capabilities = response.get("capabilities")
             session._set_capabilities(capabilities)
-        except BaseException:
+        except BaseException as exc:
             with self._sessions_lock:
                 self._sessions.pop(session_id, None)
+            if not isinstance(exc, asyncio.CancelledError):
+                _log_timing(
+                    logging.WARNING,
+                    "CopilotClient.resume_session failed",
+                    total_start,
+                    exc_info=True,
+                    session_id=session_id,
+                )
             raise
 
+        _log_timing(
+            logging.INFO,
+            "CopilotClient.resume_session complete",
+            total_start,
+            session_id=session_id,
+        )
         return session
 
     def get_state(self) -> ConnectionState:
@@ -2217,6 +2350,8 @@ class CopilotClient:
         that don't implement ``connect``."""
         if not self._client:
             raise RuntimeError("Client not connected")
+        handshake_start = time.perf_counter()
+        used_fallback_ping = False
         max_version = get_sdk_protocol_version()
 
         server_version: int | None
@@ -2229,6 +2364,7 @@ class CopilotClient:
             if err.code == -32601 or err.message == "Unhandled method connect":
                 # Legacy server without `connect`; fall back to `ping`. A token, if any,
                 # is silently dropped — the legacy server can't enforce one.
+                used_fallback_ping = True
                 ping_result = await self.ping()
                 server_version = ping_result.protocolVersion
             else:
@@ -2251,6 +2387,13 @@ class CopilotClient:
             )
 
         self._negotiated_protocol_version = server_version
+        _log_timing(
+            logging.INFO,
+            "CopilotClient._verify_protocol_version protocol handshake complete",
+            handshake_start,
+            protocol_version=server_version,
+            used_fallback_ping=used_fallback_ping,
+        )
 
     def _convert_provider_to_wire_format(
         self, provider: ProviderConfig | dict[str, Any]
@@ -2381,6 +2524,16 @@ class CopilotClient:
             args = ["node", cli_path] + args
         else:
             args = [cli_path] + args
+        logger.info(
+            "CopilotClient._start_cli_server starting Copilot CLI",
+            extra={
+                "cli_path": cli_path,
+                "executable": args[0],
+                "cli_path_source": self._cli_path_source,
+                "use_stdio": cfg.use_stdio,
+                "port": None if cfg.use_stdio else cfg.port,
+            },
+        )
 
         # Get environment variables
         if cfg.env is None:
@@ -2420,6 +2573,7 @@ class CopilotClient:
         cwd = cfg.cwd or os.getcwd()
 
         # Choose transport mode
+        spawn_start = time.perf_counter()
         if cfg.use_stdio:
             args.append("--stdio")
             # Use regular Popen with pipes (buffering=0 for unbuffered)
@@ -2445,6 +2599,11 @@ class CopilotClient:
                 env=env,
                 creationflags=creationflags,
             )
+        _log_timing(
+            logging.INFO,
+            "CopilotClient._start_cli_server subprocess spawned",
+            spawn_start,
+        )
 
         # For stdio mode, we're ready immediately
         if cfg.use_stdio:
@@ -2463,13 +2622,21 @@ class CopilotClient:
                     raise RuntimeError("CLI process exited before announcing port")
 
                 line_str = line.decode() if isinstance(line, bytes) else line
+                logger.debug("[CLI] %s", line_str.rstrip())
                 match = re.search(r"listening on port (\d+)", line_str, re.IGNORECASE)
                 if match:
                     self._actual_port = int(match.group(1))
                     return
 
         try:
+            port_wait_start = time.perf_counter()
             await asyncio.wait_for(read_port(), timeout=10.0)
+            _log_timing(
+                logging.INFO,
+                "CopilotClient._start_cli_server TCP port wait complete",
+                port_wait_start,
+                port=self._actual_port,
+            )
         except TimeoutError:
             raise RuntimeError("Timeout waiting for CLI server to start")
 
@@ -2482,11 +2649,17 @@ class CopilotClient:
         Raises:
             RuntimeError: If the connection fails.
         """
+        setup_start = time.perf_counter()
         use_stdio = isinstance(self._config, SubprocessConfig) and self._config.use_stdio
         if use_stdio:
             await self._connect_via_stdio()
         else:
             await self._connect_via_tcp()
+        _log_timing(
+            logging.INFO,
+            "CopilotClient._connect_to_server transport setup complete",
+            setup_start,
+        )
 
     async def _connect_via_stdio(self) -> None:
         """
@@ -2562,8 +2735,20 @@ class CopilotClient:
         sock.settimeout(TCP_CONNECTION_TIMEOUT)
 
         try:
+            tcp_connect_start = time.perf_counter()
+            logger.info(
+                "CopilotClient._connect_via_tcp connecting to CLI server",
+                extra={"host": self._actual_host, "port": self._actual_port},
+            )
             sock.connect((self._actual_host, self._actual_port))
             sock.settimeout(None)  # Remove timeout after connection
+            _log_timing(
+                logging.INFO,
+                "CopilotClient._connect_via_tcp TCP connect complete",
+                tcp_connect_start,
+                host=self._actual_host,
+                port=self._actual_port,
+            )
         except OSError as e:
             raise RuntimeError(
                 f"Failed to connect to CLI server at {self._actual_host}:{self._actual_port}: {e}"
@@ -2779,9 +2964,18 @@ class CopilotClient:
 
         try:
             with trace_context(tp, ts):
+                handler_start = time.perf_counter()
                 result = handler(invocation)
                 if inspect.isawaitable(result):
                     result = await result
+                _log_timing(
+                    logging.INFO,
+                    "CopilotClient._handle_tool_call_request_v2 tool dispatch",
+                    handler_start,
+                    session_id=session_id,
+                    tool_call_id=tool_call_id,
+                    tool_name=tool_name,
+                )
 
             tool_result: ToolResult = result  # type: ignore[assignment]
             return {

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -1094,7 +1094,7 @@ class CopilotClient:
             await self._connect_to_server()
             log_timing(
                 logger,
-                logging.INFO,
+                logging.DEBUG,
                 "CopilotClient.start transport setup complete",
                 start_time,
             )
@@ -1103,7 +1103,7 @@ class CopilotClient:
             await self._verify_protocol_version()
             log_timing(
                 logger,
-                logging.INFO,
+                logging.DEBUG,
                 "CopilotClient.start protocol verification complete",
                 start_time,
             )
@@ -1113,7 +1113,7 @@ class CopilotClient:
                 await self._set_session_fs_provider()
                 log_timing(
                     logger,
-                    logging.INFO,
+                    logging.DEBUG,
                     "CopilotClient.start session filesystem setup complete",
                     session_fs_start,
                 )
@@ -1121,7 +1121,7 @@ class CopilotClient:
             self._state = "connected"
             log_timing(
                 logger,
-                logging.INFO,
+                logging.DEBUG,
                 "CopilotClient.start complete",
                 start_time,
             )
@@ -1589,7 +1589,7 @@ class CopilotClient:
             response = await self._client.request("session.create", payload)
             log_timing(
                 logger,
-                logging.INFO,
+                logging.DEBUG,
                 "CopilotClient.create_session session creation request completed successfully",
                 rpc_start,
                 session_id=actual_session_id,
@@ -1613,7 +1613,7 @@ class CopilotClient:
 
         log_timing(
             logger,
-            logging.INFO,
+            logging.DEBUG,
             "CopilotClient.create_session complete",
             total_start,
             session_id=actual_session_id,
@@ -1914,7 +1914,7 @@ class CopilotClient:
             response = await self._client.request("session.resume", payload)
             log_timing(
                 logger,
-                logging.INFO,
+                logging.DEBUG,
                 "CopilotClient.resume_session session resume request completed successfully",
                 rpc_start,
                 session_id=session_id,
@@ -1938,7 +1938,7 @@ class CopilotClient:
 
         log_timing(
             logger,
-            logging.INFO,
+            logging.DEBUG,
             "CopilotClient.resume_session complete",
             total_start,
             session_id=session_id,
@@ -2383,7 +2383,7 @@ class CopilotClient:
         self._negotiated_protocol_version = server_version
         log_timing(
             logger,
-            logging.INFO,
+            logging.DEBUG,
             "CopilotClient._verify_protocol_version protocol handshake complete",
             handshake_start,
             protocol_version=server_version,
@@ -2596,7 +2596,7 @@ class CopilotClient:
             )
         log_timing(
             logger,
-            logging.INFO,
+            logging.DEBUG,
             "CopilotClient._start_cli_server subprocess spawned",
             spawn_start,
         )
@@ -2629,7 +2629,7 @@ class CopilotClient:
             await asyncio.wait_for(read_port(), timeout=10.0)
             log_timing(
                 logger,
-                logging.INFO,
+                logging.DEBUG,
                 "CopilotClient._start_cli_server TCP port wait complete",
                 port_wait_start,
                 port=self._actual_port,
@@ -2654,7 +2654,7 @@ class CopilotClient:
             await self._connect_via_tcp()
         log_timing(
             logger,
-            logging.INFO,
+            logging.DEBUG,
             "CopilotClient._connect_to_server transport setup complete",
             setup_start,
         )
@@ -2742,7 +2742,7 @@ class CopilotClient:
             sock.settimeout(None)  # Remove timeout after connection
             log_timing(
                 logger,
-                logging.INFO,
+                logging.DEBUG,
                 "CopilotClient._connect_via_tcp TCP connect complete",
                 tcp_connect_start,
                 host=self._actual_host,
@@ -2969,7 +2969,7 @@ class CopilotClient:
                     result = await result
                 log_timing(
                     logger,
-                    logging.INFO,
+                    logging.DEBUG,
                     "CopilotClient._handle_tool_call_request_v2 tool dispatch",
                     handler_start,
                     session_id=session_id,

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from types import TracebackType
 from typing import Any, Literal, TypedDict, cast, overload
 
+from ._diagnostics import log_timing
 from ._jsonrpc import JsonRpcClient, JsonRpcError, ProcessExitedError
 from ._sdk_protocol_version import get_sdk_protocol_version
 from ._telemetry import get_trace_context, trace_context
@@ -774,27 +775,6 @@ NO_RESULT_PERMISSION_V2_ERROR = (
 MIN_PROTOCOL_VERSION = 2
 
 
-def _elapsed_ms(start: float) -> float:
-    return (time.perf_counter() - start) * 1000
-
-
-def _log_timing(
-    level: int,
-    message: str,
-    start: float,
-    *,
-    exc_info: bool = False,
-    **fields: Any,
-) -> None:
-    if logger.isEnabledFor(level):
-        logger.log(
-            level,
-            message,
-            extra={"elapsed_ms": _elapsed_ms(start), **fields},
-            exc_info=exc_info,
-        )
-
-
 def _get_bundled_cli_path() -> str | None:
     """Get the path to the bundled CLI binary, if available."""
     # The binary is bundled in copilot/bin/ within the package
@@ -1112,7 +1092,8 @@ class CopilotClient:
 
             # Connect to the server
             await self._connect_to_server()
-            _log_timing(
+            log_timing(
+                logger,
                 logging.INFO,
                 "CopilotClient.start transport setup complete",
                 start_time,
@@ -1120,7 +1101,8 @@ class CopilotClient:
 
             # Verify protocol version compatibility
             await self._verify_protocol_version()
-            _log_timing(
+            log_timing(
+                logger,
                 logging.INFO,
                 "CopilotClient.start protocol verification complete",
                 start_time,
@@ -1129,14 +1111,16 @@ class CopilotClient:
             if self._session_fs_config:
                 session_fs_start = time.perf_counter()
                 await self._set_session_fs_provider()
-                _log_timing(
+                log_timing(
+                    logger,
                     logging.INFO,
                     "CopilotClient.start session filesystem setup complete",
                     session_fs_start,
                 )
 
             self._state = "connected"
-            _log_timing(
+            log_timing(
+                logger,
                 logging.INFO,
                 "CopilotClient.start complete",
                 start_time,
@@ -1144,7 +1128,8 @@ class CopilotClient:
         except ProcessExitedError as e:
             # Process exited with error - reraise as RuntimeError with stderr
             self._state = "error"
-            _log_timing(
+            log_timing(
+                logger,
                 logging.WARNING,
                 "CopilotClient.start failed",
                 start_time,
@@ -1153,7 +1138,8 @@ class CopilotClient:
             raise RuntimeError(str(e)) from None
         except Exception as e:
             self._state = "error"
-            _log_timing(
+            log_timing(
+                logger,
                 logging.WARNING,
                 "CopilotClient.start failed",
                 start_time,
@@ -1587,7 +1573,8 @@ class CopilotClient:
             session.on(on_event)
         with self._sessions_lock:
             self._sessions[actual_session_id] = session
-        _log_timing(
+        log_timing(
+            logger,
             logging.DEBUG,
             "CopilotClient.create_session local setup complete",
             setup_start,
@@ -1600,7 +1587,8 @@ class CopilotClient:
         try:
             rpc_start = time.perf_counter()
             response = await self._client.request("session.create", payload)
-            _log_timing(
+            log_timing(
+                logger,
                 logging.INFO,
                 "CopilotClient.create_session session creation request completed successfully",
                 rpc_start,
@@ -1613,7 +1601,8 @@ class CopilotClient:
             with self._sessions_lock:
                 self._sessions.pop(actual_session_id, None)
             if not isinstance(exc, asyncio.CancelledError):
-                _log_timing(
+                log_timing(
+                    logger,
                     logging.WARNING,
                     "CopilotClient.create_session failed",
                     total_start,
@@ -1622,7 +1611,8 @@ class CopilotClient:
                 )
             raise
 
-        _log_timing(
+        log_timing(
+            logger,
             logging.INFO,
             "CopilotClient.create_session complete",
             total_start,
@@ -1908,7 +1898,8 @@ class CopilotClient:
             session.on(on_event)
         with self._sessions_lock:
             self._sessions[session_id] = session
-        _log_timing(
+        log_timing(
+            logger,
             logging.DEBUG,
             "CopilotClient.resume_session local setup complete",
             setup_start,
@@ -1921,7 +1912,8 @@ class CopilotClient:
         try:
             rpc_start = time.perf_counter()
             response = await self._client.request("session.resume", payload)
-            _log_timing(
+            log_timing(
+                logger,
                 logging.INFO,
                 "CopilotClient.resume_session session resume request completed successfully",
                 rpc_start,
@@ -1934,7 +1926,8 @@ class CopilotClient:
             with self._sessions_lock:
                 self._sessions.pop(session_id, None)
             if not isinstance(exc, asyncio.CancelledError):
-                _log_timing(
+                log_timing(
+                    logger,
                     logging.WARNING,
                     "CopilotClient.resume_session failed",
                     total_start,
@@ -1943,7 +1936,8 @@ class CopilotClient:
                 )
             raise
 
-        _log_timing(
+        log_timing(
+            logger,
             logging.INFO,
             "CopilotClient.resume_session complete",
             total_start,
@@ -2387,7 +2381,8 @@ class CopilotClient:
             )
 
         self._negotiated_protocol_version = server_version
-        _log_timing(
+        log_timing(
+            logger,
             logging.INFO,
             "CopilotClient._verify_protocol_version protocol handshake complete",
             handshake_start,
@@ -2599,7 +2594,8 @@ class CopilotClient:
                 env=env,
                 creationflags=creationflags,
             )
-        _log_timing(
+        log_timing(
+            logger,
             logging.INFO,
             "CopilotClient._start_cli_server subprocess spawned",
             spawn_start,
@@ -2631,7 +2627,8 @@ class CopilotClient:
         try:
             port_wait_start = time.perf_counter()
             await asyncio.wait_for(read_port(), timeout=10.0)
-            _log_timing(
+            log_timing(
+                logger,
                 logging.INFO,
                 "CopilotClient._start_cli_server TCP port wait complete",
                 port_wait_start,
@@ -2655,7 +2652,8 @@ class CopilotClient:
             await self._connect_via_stdio()
         else:
             await self._connect_via_tcp()
-        _log_timing(
+        log_timing(
+            logger,
             logging.INFO,
             "CopilotClient._connect_to_server transport setup complete",
             setup_start,
@@ -2742,7 +2740,8 @@ class CopilotClient:
             )
             sock.connect((self._actual_host, self._actual_port))
             sock.settimeout(None)  # Remove timeout after connection
-            _log_timing(
+            log_timing(
+                logger,
                 logging.INFO,
                 "CopilotClient._connect_via_tcp TCP connect complete",
                 tcp_connect_start,
@@ -2968,7 +2967,8 @@ class CopilotClient:
                 result = handler(invocation)
                 if inspect.isawaitable(result):
                     result = await result
-                _log_timing(
+                log_timing(
+                    logger,
                     logging.INFO,
                     "CopilotClient._handle_tool_call_request_v2 tool dispatch",
                     handler_start,

--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -1180,7 +1180,7 @@ class CopilotSession:
         message_id = response["messageId"]
         log_timing(
             logger,
-            logging.INFO,
+            logging.DEBUG,
             "CopilotSession.send completed successfully",
             rpc_start,
             session_id=self.session_id,
@@ -1283,7 +1283,7 @@ class CopilotSession:
                 raise error_event
             log_timing(
                 logger,
-                logging.INFO,
+                logging.DEBUG,
                 "CopilotSession.send_and_wait complete",
                 total_start,
                 session_id=self.session_id,
@@ -1501,7 +1501,7 @@ class CopilotSession:
                     result = await result
                 log_timing(
                     logger,
-                    logging.INFO,
+                    logging.DEBUG,
                     "CopilotSession._execute_tool_and_respond tool dispatch",
                     handler_start,
                     session_id=self.session_id,
@@ -1591,7 +1591,7 @@ class CopilotSession:
                 result = await result
             log_timing(
                 logger,
-                logging.INFO,
+                logging.DEBUG,
                 "CopilotSession._execute_permission_and_respond dispatch",
                 handler_start,
                 session_id=self.session_id,
@@ -1670,7 +1670,7 @@ class CopilotSession:
                 await result
             log_timing(
                 logger,
-                logging.INFO,
+                logging.DEBUG,
                 "CopilotSession._execute_command_and_respond dispatch",
                 handler_start,
                 session_id=self.session_id,
@@ -1723,7 +1723,7 @@ class CopilotSession:
                 result = await result
             log_timing(
                 logger,
-                logging.INFO,
+                logging.DEBUG,
                 "CopilotSession._handle_elicitation_request dispatch",
                 handler_start,
                 session_id=self.session_id,
@@ -1891,7 +1891,7 @@ class CopilotSession:
                 result = await result
             log_timing(
                 logger,
-                logging.INFO,
+                logging.DEBUG,
                 "CopilotSession._handle_permission_request dispatch",
                 handler_start,
                 session_id=self.session_id,
@@ -1956,7 +1956,7 @@ class CopilotSession:
                 result = await result
             log_timing(
                 logger,
-                logging.INFO,
+                logging.DEBUG,
                 "CopilotSession._handle_user_input_request dispatch",
                 handler_start,
                 session_id=self.session_id,
@@ -2013,7 +2013,7 @@ class CopilotSession:
                 result[section_id] = {"content": content}
         log_timing(
             logger,
-            logging.INFO,
+            logging.DEBUG,
             "CopilotSession._handle_system_message_transform dispatch",
             transform_start,
             session_id=self.session_id,
@@ -2060,7 +2060,7 @@ class CopilotSession:
                 result = await result
             log_timing(
                 logger,
-                logging.INFO,
+                logging.DEBUG,
                 "CopilotSession._handle_hooks_invoke dispatch",
                 handler_start,
                 session_id=self.session_id,

--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Literal, NotRequired, Required, TypedDict, cast
 
+from ._diagnostics import log_timing
 from ._jsonrpc import JsonRpcError, ProcessExitedError
 from ._telemetry import get_trace_context, trace_context
 from .generated.rpc import (
@@ -61,27 +62,6 @@ from .generated.session_events import (
 from .tools import Tool, ToolHandler, ToolInvocation, ToolResult
 
 logger = logging.getLogger(__name__)
-
-
-def _elapsed_ms(start: float) -> float:
-    return (time.perf_counter() - start) * 1000
-
-
-def _log_timing(
-    level: int,
-    message: str,
-    start: float,
-    *,
-    exc_info: bool = False,
-    **fields: Any,
-) -> None:
-    if logger.isEnabledFor(level):
-        logger.log(
-            level,
-            message,
-            extra={"elapsed_ms": _elapsed_ms(start), **fields},
-            exc_info=exc_info,
-        )
 
 
 if TYPE_CHECKING:
@@ -1198,7 +1178,8 @@ class CopilotSession:
         rpc_start = time.perf_counter()
         response = await self._client.request("session.send", params)
         message_id = response["messageId"]
-        _log_timing(
+        log_timing(
+            logger,
             logging.INFO,
             "CopilotSession.send completed successfully",
             rpc_start,
@@ -1261,14 +1242,16 @@ class CopilotSession:
                     last_assistant_message = event
                     if not first_assistant_message_logged:
                         first_assistant_message_logged = True
-                        _log_timing(
+                        log_timing(
+                            logger,
                             logging.DEBUG,
                             "CopilotSession.send_and_wait first assistant message",
                             total_start,
                             session_id=self.session_id,
                         )
                 case SessionIdleData():
-                    _log_timing(
+                    log_timing(
+                        logger,
                         logging.DEBUG,
                         "CopilotSession.send_and_wait idle received",
                         total_start,
@@ -1289,7 +1272,8 @@ class CopilotSession:
             )
             await asyncio.wait_for(idle_event.wait(), timeout=timeout)
             if error_event:
-                _log_timing(
+                log_timing(
+                    logger,
                     logging.WARNING,
                     "CopilotSession.send_and_wait failed",
                     total_start,
@@ -1297,7 +1281,8 @@ class CopilotSession:
                     completed_by="error",
                 )
                 raise error_event
-            _log_timing(
+            log_timing(
+                logger,
                 logging.INFO,
                 "CopilotSession.send_and_wait complete",
                 total_start,
@@ -1307,7 +1292,8 @@ class CopilotSession:
             )
             return last_assistant_message
         except TimeoutError:
-            _log_timing(
+            log_timing(
+                logger,
                 logging.WARNING,
                 "CopilotSession.send_and_wait failed",
                 total_start,
@@ -1380,7 +1366,8 @@ class CopilotSession:
                 handler(event)
             except Exception:
                 logger.error("Unhandled exception in session event handler", exc_info=True)
-        _log_timing(
+        log_timing(
+            logger,
             logging.DEBUG,
             "CopilotSession._dispatch_event dispatch",
             dispatch_start,
@@ -1512,7 +1499,8 @@ class CopilotSession:
                 result = handler(invocation)
                 if inspect.isawaitable(result):
                     result = await result
-                _log_timing(
+                log_timing(
+                    logger,
                     logging.INFO,
                     "CopilotSession._execute_tool_and_respond tool dispatch",
                     handler_start,
@@ -1545,7 +1533,8 @@ class CopilotSession:
                         error=tool_result.error,
                     )
                 )
-                _log_timing(
+                log_timing(
+                    logger,
                     logging.DEBUG,
                     "CopilotSession._execute_tool_and_respond response sent successfully",
                     rpc_start,
@@ -1567,7 +1556,8 @@ class CopilotSession:
                         ),
                     )
                 )
-                _log_timing(
+                log_timing(
+                    logger,
                     logging.DEBUG,
                     "CopilotSession._execute_tool_and_respond response sent successfully",
                     rpc_start,
@@ -1599,7 +1589,8 @@ class CopilotSession:
             result = handler(permission_request, {"session_id": self.session_id})
             if inspect.isawaitable(result):
                 result = await result
-            _log_timing(
+            log_timing(
+                logger,
                 logging.INFO,
                 "CopilotSession._execute_permission_and_respond dispatch",
                 handler_start,
@@ -1622,7 +1613,8 @@ class CopilotSession:
                     result=perm_result,
                 )
             )
-            _log_timing(
+            log_timing(
+                logger,
                 logging.DEBUG,
                 "CopilotSession._execute_permission_and_respond response sent successfully",
                 rpc_start,
@@ -1676,7 +1668,8 @@ class CopilotSession:
             result = handler(ctx)
             if inspect.isawaitable(result):
                 await result
-            _log_timing(
+            log_timing(
+                logger,
                 logging.INFO,
                 "CopilotSession._execute_command_and_respond dispatch",
                 handler_start,
@@ -1688,7 +1681,8 @@ class CopilotSession:
             await self.rpc.commands.handle_pending_command(
                 CommandsHandlePendingCommandRequest(request_id=request_id)
             )
-            _log_timing(
+            log_timing(
+                logger,
                 logging.DEBUG,
                 "CopilotSession._execute_command_and_respond response sent successfully",
                 rpc_start,
@@ -1727,7 +1721,8 @@ class CopilotSession:
             result = handler(context)
             if inspect.isawaitable(result):
                 result = await result
-            _log_timing(
+            log_timing(
+                logger,
                 logging.INFO,
                 "CopilotSession._handle_elicitation_request dispatch",
                 handler_start,
@@ -1747,7 +1742,8 @@ class CopilotSession:
                     result=rpc_result,
                 )
             )
-            _log_timing(
+            log_timing(
+                logger,
                 logging.DEBUG,
                 "CopilotSession._handle_elicitation_request response sent successfully",
                 rpc_start,
@@ -1893,7 +1889,8 @@ class CopilotSession:
             result = handler(request, {"session_id": self.session_id})
             if inspect.isawaitable(result):
                 result = await result
-            _log_timing(
+            log_timing(
+                logger,
                 logging.INFO,
                 "CopilotSession._handle_permission_request dispatch",
                 handler_start,
@@ -1957,7 +1954,8 @@ class CopilotSession:
             )
             if inspect.isawaitable(result):
                 result = await result
-            _log_timing(
+            log_timing(
+                logger,
                 logging.INFO,
                 "CopilotSession._handle_user_input_request dispatch",
                 handler_start,
@@ -2013,7 +2011,8 @@ class CopilotSession:
                     result[section_id] = {"content": content}
             else:
                 result[section_id] = {"content": content}
-        _log_timing(
+        log_timing(
+            logger,
             logging.INFO,
             "CopilotSession._handle_system_message_transform dispatch",
             transform_start,
@@ -2059,7 +2058,8 @@ class CopilotSession:
             result = handler(input_data, {"session_id": self.session_id})
             if inspect.isawaitable(result):
                 result = await result
-            _log_timing(
+            log_timing(
+                logger,
                 logging.INFO,
                 "CopilotSession._handle_hooks_invoke dispatch",
                 handler_start,

--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -11,9 +11,11 @@ from __future__ import annotations
 import asyncio
 import functools
 import inspect
+import logging
 import os
 import pathlib
 import threading
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from types import TracebackType
@@ -57,6 +59,30 @@ from .generated.session_events import (
     session_event_from_dict,
 )
 from .tools import Tool, ToolHandler, ToolInvocation, ToolResult
+
+logger = logging.getLogger(__name__)
+
+
+def _elapsed_ms(start: float) -> float:
+    return (time.perf_counter() - start) * 1000
+
+
+def _log_timing(
+    level: int,
+    message: str,
+    start: float,
+    *,
+    exc_info: bool = False,
+    **fields: Any,
+) -> None:
+    if logger.isEnabledFor(level):
+        logger.log(
+            level,
+            message,
+            extra={"elapsed_ms": _elapsed_ms(start), **fields},
+            exc_info=exc_info,
+        )
+
 
 if TYPE_CHECKING:
     from .client import ModelCapabilitiesOverride
@@ -1169,8 +1195,17 @@ class CopilotSession:
             params["requestHeaders"] = request_headers
         params.update(get_trace_context())
 
+        rpc_start = time.perf_counter()
         response = await self._client.request("session.send", params)
-        return response["messageId"]
+        message_id = response["messageId"]
+        _log_timing(
+            logging.INFO,
+            "CopilotSession.send completed successfully",
+            rpc_start,
+            session_id=self.session_id,
+            message_id=message_id,
+        )
+        return message_id
 
     async def send_and_wait(
         self,
@@ -1213,16 +1248,32 @@ class CopilotSession:
             ...         case AssistantMessageData() as data:
             ...             print(data.content)
         """
+        total_start = time.perf_counter()
         idle_event = asyncio.Event()
         error_event: Exception | None = None
         last_assistant_message: SessionEvent | None = None
+        first_assistant_message_logged = False
 
         def handler(event: SessionEventTypeAlias) -> None:
-            nonlocal last_assistant_message, error_event
+            nonlocal first_assistant_message_logged, last_assistant_message, error_event
             match event.data:
                 case AssistantMessageData():
                     last_assistant_message = event
+                    if not first_assistant_message_logged:
+                        first_assistant_message_logged = True
+                        _log_timing(
+                            logging.DEBUG,
+                            "CopilotSession.send_and_wait first assistant message",
+                            total_start,
+                            session_id=self.session_id,
+                        )
                 case SessionIdleData():
+                    _log_timing(
+                        logging.DEBUG,
+                        "CopilotSession.send_and_wait idle received",
+                        total_start,
+                        session_id=self.session_id,
+                    )
                     idle_event.set()
                 case SessionErrorData() as data:
                     error_event = Exception(f"Session error: {data.message or str(data)}")
@@ -1238,9 +1289,31 @@ class CopilotSession:
             )
             await asyncio.wait_for(idle_event.wait(), timeout=timeout)
             if error_event:
+                _log_timing(
+                    logging.WARNING,
+                    "CopilotSession.send_and_wait failed",
+                    total_start,
+                    session_id=self.session_id,
+                    completed_by="error",
+                )
                 raise error_event
+            _log_timing(
+                logging.INFO,
+                "CopilotSession.send_and_wait complete",
+                total_start,
+                session_id=self.session_id,
+                completed_by="idle",
+                assistant_message_received=last_assistant_message is not None,
+            )
             return last_assistant_message
         except TimeoutError:
+            _log_timing(
+                logging.WARNING,
+                "CopilotSession.send_and_wait failed",
+                total_start,
+                session_id=self.session_id,
+                completed_by="timeout",
+            )
             raise TimeoutError(f"Timeout after {timeout}s waiting for session.idle")
         finally:
             unsubscribe()
@@ -1294,6 +1367,7 @@ class CopilotSession:
         Args:
             event: The session event to dispatch to all handlers.
         """
+        dispatch_start = time.perf_counter()
         # Handle broadcast request events (protocol v3) before dispatching to user handlers.
         # Fire-and-forget: the response is sent asynchronously via RPC.
         self._handle_broadcast_event(event)
@@ -1304,8 +1378,15 @@ class CopilotSession:
         for handler in handlers:
             try:
                 handler(event)
-            except Exception as e:
-                print(f"Error in session event handler: {e}")
+            except Exception:
+                logger.error("Unhandled exception in session event handler", exc_info=True)
+        _log_timing(
+            logging.DEBUG,
+            "CopilotSession._dispatch_event dispatch",
+            dispatch_start,
+            session_id=self.session_id,
+            event_type=event.type,
+        )
 
     def _handle_broadcast_event(self, event: SessionEvent) -> None:
         """Handle broadcast request events by executing local handlers and responding via RPC.
@@ -1335,6 +1416,14 @@ class CopilotSession:
                 )
 
             case PermissionRequestedData() as data:
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "CopilotSession._dispatch_event permission request received",
+                        extra={
+                            "session_id": self.session_id,
+                            "event_type": event.type.value,
+                        },
+                    )
                 request_id = data.request_id
                 permission_request = data.permission_request
                 if not request_id or not permission_request:
@@ -1419,9 +1508,19 @@ class CopilotSession:
             )
 
             with trace_context(traceparent, tracestate):
+                handler_start = time.perf_counter()
                 result = handler(invocation)
                 if inspect.isawaitable(result):
                     result = await result
+                _log_timing(
+                    logging.INFO,
+                    "CopilotSession._execute_tool_and_respond tool dispatch",
+                    handler_start,
+                    session_id=self.session_id,
+                    request_id=request_id,
+                    tool_call_id=tool_call_id,
+                    tool_name=tool_name,
+                )
 
             tool_result: ToolResult
             if result is None:
@@ -1439,13 +1538,24 @@ class CopilotSession:
             # standard "Failed to execute..." message. Deliberate user-returned
             # failures send the full structured result to preserve metadata.
             if tool_result._from_exception:
+                rpc_start = time.perf_counter()
                 await self.rpc.tools.handle_pending_tool_call(
                     HandlePendingToolCallRequest(
                         request_id=request_id,
                         error=tool_result.error,
                     )
                 )
+                _log_timing(
+                    logging.DEBUG,
+                    "CopilotSession._execute_tool_and_respond response sent successfully",
+                    rpc_start,
+                    session_id=self.session_id,
+                    request_id=request_id,
+                    tool_call_id=tool_call_id,
+                    tool_name=tool_name,
+                )
             else:
+                rpc_start = time.perf_counter()
                 await self.rpc.tools.handle_pending_tool_call(
                     HandlePendingToolCallRequest(
                         request_id=request_id,
@@ -1456,6 +1566,15 @@ class CopilotSession:
                             tool_telemetry=tool_result.tool_telemetry,
                         ),
                     )
+                )
+                _log_timing(
+                    logging.DEBUG,
+                    "CopilotSession._execute_tool_and_respond response sent successfully",
+                    rpc_start,
+                    session_id=self.session_id,
+                    request_id=request_id,
+                    tool_call_id=tool_call_id,
+                    tool_name=tool_name,
                 )
         except Exception as exc:
             try:
@@ -1476,9 +1595,17 @@ class CopilotSession:
     ) -> None:
         """Execute a permission handler and respond via RPC."""
         try:
+            handler_start = time.perf_counter()
             result = handler(permission_request, {"session_id": self.session_id})
             if inspect.isawaitable(result):
                 result = await result
+            _log_timing(
+                logging.INFO,
+                "CopilotSession._execute_permission_and_respond dispatch",
+                handler_start,
+                session_id=self.session_id,
+                request_id=request_id,
+            )
 
             result = cast(PermissionRequestResult, result)
             if result.kind == "no-result":
@@ -1488,11 +1615,19 @@ class CopilotSession:
                 kind=PermissionDecisionKind(result.kind),
             )
 
+            rpc_start = time.perf_counter()
             await self.rpc.permissions.handle_pending_permission_request(
                 PermissionDecisionRequest(
                     request_id=request_id,
                     result=perm_result,
                 )
+            )
+            _log_timing(
+                logging.DEBUG,
+                "CopilotSession._execute_permission_and_respond response sent successfully",
+                rpc_start,
+                session_id=self.session_id,
+                request_id=request_id,
             )
         except Exception:
             try:
@@ -1537,11 +1672,29 @@ class CopilotSession:
                 command_name=command_name,
                 args=args,
             )
+            handler_start = time.perf_counter()
             result = handler(ctx)
             if inspect.isawaitable(result):
                 await result
+            _log_timing(
+                logging.INFO,
+                "CopilotSession._execute_command_and_respond dispatch",
+                handler_start,
+                session_id=self.session_id,
+                request_id=request_id,
+                command_name=command_name,
+            )
+            rpc_start = time.perf_counter()
             await self.rpc.commands.handle_pending_command(
                 CommandsHandlePendingCommandRequest(request_id=request_id)
+            )
+            _log_timing(
+                logging.DEBUG,
+                "CopilotSession._execute_command_and_respond response sent successfully",
+                rpc_start,
+                session_id=self.session_id,
+                request_id=request_id,
+                command_name=command_name,
             )
         except Exception as exc:
             message = str(exc)
@@ -1570,20 +1723,36 @@ class CopilotSession:
         if not handler:
             return
         try:
+            handler_start = time.perf_counter()
             result = handler(context)
             if inspect.isawaitable(result):
                 result = await result
+            _log_timing(
+                logging.INFO,
+                "CopilotSession._handle_elicitation_request dispatch",
+                handler_start,
+                session_id=self.session_id,
+                request_id=request_id,
+            )
             result = cast(ElicitationResult, result)
             action_val = result.get("action", "cancel")
             rpc_result = UIElicitationResponse(
                 action=UIElicitationResponseAction(action_val),
                 content=result.get("content"),
             )
+            rpc_start = time.perf_counter()
             await self.rpc.ui.handle_pending_elicitation(
                 UIHandlePendingElicitationRequest(
                     request_id=request_id,
                     result=rpc_result,
                 )
+            )
+            _log_timing(
+                logging.DEBUG,
+                "CopilotSession._handle_elicitation_request response sent successfully",
+                rpc_start,
+                session_id=self.session_id,
+                request_id=request_id,
             )
         except Exception:
             # Handler failed — attempt to cancel so the request doesn't hang
@@ -1720,12 +1889,24 @@ class CopilotSession:
             return PermissionRequestResult()
 
         try:
+            handler_start = time.perf_counter()
             result = handler(request, {"session_id": self.session_id})
             if inspect.isawaitable(result):
                 result = await result
+            _log_timing(
+                logging.INFO,
+                "CopilotSession._handle_permission_request dispatch",
+                handler_start,
+                session_id=self.session_id,
+            )
             return cast(PermissionRequestResult, result)
         except Exception:  # pylint: disable=broad-except
             # Handler failed, deny permission
+            logger.debug(
+                "Error handling permission request",
+                extra={"session_id": self.session_id},
+                exc_info=True,
+            )
             return PermissionRequestResult()
 
     def _register_user_input_handler(self, handler: UserInputHandler | None) -> None:
@@ -1765,6 +1946,7 @@ class CopilotSession:
             raise RuntimeError("User input requested but no handler registered")
 
         try:
+            handler_start = time.perf_counter()
             result = handler(
                 UserInputRequest(
                     question=request.get("question", ""),
@@ -1775,6 +1957,12 @@ class CopilotSession:
             )
             if inspect.isawaitable(result):
                 result = await result
+            _log_timing(
+                logging.INFO,
+                "CopilotSession._handle_user_input_request dispatch",
+                handler_start,
+                session_id=self.session_id,
+            )
             return cast(UserInputResponse, result)
         except Exception:
             raise
@@ -1807,6 +1995,7 @@ class CopilotSession:
         self, sections: dict[str, dict[str, str]]
     ) -> dict[str, dict[str, dict[str, str]]]:
         """Handle a systemMessage.transform request from the runtime."""
+        transform_start = time.perf_counter()
         with self._transform_callbacks_lock:
             callbacks = self._transform_callbacks
 
@@ -1824,6 +2013,12 @@ class CopilotSession:
                     result[section_id] = {"content": content}
             else:
                 result[section_id] = {"content": content}
+        _log_timing(
+            logging.INFO,
+            "CopilotSession._handle_system_message_transform dispatch",
+            transform_start,
+            session_id=self.session_id,
+        )
         return {"sections": result}
 
     async def _handle_hooks_invoke(self, hook_type: str, input_data: Any) -> Any:
@@ -1860,12 +2055,25 @@ class CopilotSession:
             return None
 
         try:
+            handler_start = time.perf_counter()
             result = handler(input_data, {"session_id": self.session_id})
             if inspect.isawaitable(result):
                 result = await result
+            _log_timing(
+                logging.INFO,
+                "CopilotSession._handle_hooks_invoke dispatch",
+                handler_start,
+                session_id=self.session_id,
+                hook_type=hook_type,
+            )
             return result
         except Exception:  # pylint: disable=broad-except
             # Hook failed, return None
+            logger.warning(
+                "Hook handler failed",
+                extra={"session_id": self.session_id, "hook_type": hook_type},
+                exc_info=True,
+            )
             return None
 
     async def get_messages(self) -> list[SessionEvent]:

--- a/rust/src/hooks.rs
+++ b/rust/src/hooks.rs
@@ -469,7 +469,7 @@ pub(crate) async fn dispatch_hook(
 
     let dispatch_start = Instant::now();
     let output = hooks.on_hook(event).await;
-    tracing::info!(
+    tracing::debug!(
         elapsed_ms = dispatch_start.elapsed().as_millis(),
         session_id = %session_id,
         hook_type = hook_type,

--- a/rust/src/hooks.rs
+++ b/rust/src/hooks.rs
@@ -12,7 +12,6 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::elapsed_ms;
 use crate::types::SessionId;
 
 /// Context provided to every hook invocation.
@@ -471,7 +470,7 @@ pub(crate) async fn dispatch_hook(
     let dispatch_start = Instant::now();
     let output = hooks.on_hook(event).await;
     tracing::info!(
-        elapsed_ms = elapsed_ms(dispatch_start),
+        elapsed_ms = dispatch_start.elapsed().as_millis(),
         session_id = %session_id,
         hook_type = hook_type,
         "SessionHooks::on_hook dispatch"

--- a/rust/src/hooks.rs
+++ b/rust/src/hooks.rs
@@ -6,12 +6,17 @@
 //! [`Client::create_session`](crate::Client::create_session).
 
 use std::path::PathBuf;
+use std::time::Instant;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::types::SessionId;
+
+fn elapsed_ms(start: Instant) -> u128 {
+    start.elapsed().as_millis()
+}
 
 /// Context provided to every hook invocation.
 #[derive(Debug, Clone)]
@@ -466,7 +471,14 @@ pub(crate) async fn dispatch_hook(
         }
     };
 
+    let dispatch_start = Instant::now();
     let output = hooks.on_hook(event).await;
+    tracing::info!(
+        elapsed_ms = elapsed_ms(dispatch_start),
+        session_id = %session_id,
+        hook_type = hook_type,
+        "SessionHooks::on_hook dispatch"
+    );
 
     // Validate that the output variant matches the dispatched hook type.
     // A mismatched return (e.g. HookOutput::SessionEnd for a preToolUse

--- a/rust/src/hooks.rs
+++ b/rust/src/hooks.rs
@@ -12,11 +12,8 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::elapsed_ms;
 use crate::types::SessionId;
-
-fn elapsed_ms(start: Instant) -> u128 {
-    start.elapsed().as_millis()
-}
 
 /// Context provided to every hook invocation.
 #[derive(Debug, Clone)]

--- a/rust/src/jsonrpc.rs
+++ b/rust/src/jsonrpc.rs
@@ -10,7 +10,7 @@ use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWrite
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tracing::{Instrument, debug, error, warn};
 
-use crate::{Error, ProtocolError, elapsed_ms};
+use crate::{Error, ProtocolError};
 
 /// A JSON-RPC 2.0 request message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -391,7 +391,7 @@ impl JsonRpcClient {
         // the read loop owns the cleanup on the happy path.
         if let Err(error) = self.write(&request).await {
             warn!(
-                elapsed_ms = elapsed_ms(request_start),
+                elapsed_ms = request_start.elapsed().as_millis(),
                 method = %method,
                 request_id = id,
                 status = "failed",
@@ -406,7 +406,7 @@ impl JsonRpcClient {
             Err(_) => {
                 let error = Error::Protocol(ProtocolError::RequestCancelled);
                 warn!(
-                    elapsed_ms = elapsed_ms(request_start),
+                    elapsed_ms = request_start.elapsed().as_millis(),
                     method = %method,
                     request_id = id,
                     status = "failed",
@@ -419,7 +419,7 @@ impl JsonRpcClient {
         guard.disarm();
         if let Some(error) = &response.error {
             warn!(
-                elapsed_ms = elapsed_ms(request_start),
+                elapsed_ms = request_start.elapsed().as_millis(),
                 method = %method,
                 request_id = id,
                 status = "failed",
@@ -429,7 +429,7 @@ impl JsonRpcClient {
             );
         } else {
             debug!(
-                elapsed_ms = elapsed_ms(request_start),
+                elapsed_ms = request_start.elapsed().as_millis(),
                 method = %method,
                 request_id = id,
                 status = "succeeded",

--- a/rust/src/jsonrpc.rs
+++ b/rust/src/jsonrpc.rs
@@ -1,13 +1,14 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::sync::{broadcast, mpsc, oneshot};
-use tracing::{Instrument, error, warn};
+use tracing::{Instrument, debug, error, warn};
 
 use crate::{Error, ProtocolError};
 
@@ -147,6 +148,10 @@ impl JsonRpcResponse {
 }
 
 const CONTENT_LENGTH_HEADER: &str = "Content-Length: ";
+
+fn elapsed_ms(start: Instant) -> u128 {
+    start.elapsed().as_millis()
+}
 
 /// One framed JSON-RPC message handed to the writer actor.
 ///
@@ -368,6 +373,7 @@ impl JsonRpcClient {
         method: &str,
         params: Option<serde_json::Value>,
     ) -> Result<JsonRpcResponse, Error> {
+        let request_start = Instant::now();
         let id = self.request_id.fetch_add(1, Ordering::SeqCst);
         let request = JsonRpcRequest::new(id, method, params);
 
@@ -387,12 +393,53 @@ impl JsonRpcClient {
         // The PendingGuard's drop removes the entry on every error path
         // and on cancellation; disarmed below before the success return so
         // the read loop owns the cleanup on the happy path.
-        self.write(&request).await?;
+        if let Err(error) = self.write(&request).await {
+            warn!(
+                elapsed_ms = elapsed_ms(request_start),
+                method = %method,
+                request_id = id,
+                status = "failed",
+                error = %error,
+                "JsonRpcClient::send_request JSON-RPC request finished"
+            );
+            return Err(error);
+        }
 
-        let response = rx
-            .await
-            .map_err(|_| Error::Protocol(ProtocolError::RequestCancelled))?;
+        let response = match rx.await {
+            Ok(response) => response,
+            Err(_) => {
+                let error = Error::Protocol(ProtocolError::RequestCancelled);
+                warn!(
+                    elapsed_ms = elapsed_ms(request_start),
+                    method = %method,
+                    request_id = id,
+                    status = "failed",
+                    error = %error,
+                    "JsonRpcClient::send_request JSON-RPC request finished"
+                );
+                return Err(error);
+            }
+        };
         guard.disarm();
+        if let Some(error) = &response.error {
+            warn!(
+                elapsed_ms = elapsed_ms(request_start),
+                method = %method,
+                request_id = id,
+                status = "failed",
+                code = error.code,
+                error = %error.message,
+                "JsonRpcClient::send_request JSON-RPC request finished"
+            );
+        } else {
+            debug!(
+                elapsed_ms = elapsed_ms(request_start),
+                method = %method,
+                request_id = id,
+                status = "succeeded",
+                "JsonRpcClient::send_request JSON-RPC request finished"
+            );
+        }
         Ok(response)
     }
 

--- a/rust/src/jsonrpc.rs
+++ b/rust/src/jsonrpc.rs
@@ -10,7 +10,7 @@ use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWrite
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tracing::{Instrument, debug, error, warn};
 
-use crate::{Error, ProtocolError};
+use crate::{Error, ProtocolError, elapsed_ms};
 
 /// A JSON-RPC 2.0 request message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -148,10 +148,6 @@ impl JsonRpcResponse {
 }
 
 const CONTENT_LENGTH_HEADER: &str = "Content-Length: ";
-
-fn elapsed_ms(start: Instant) -> u128 {
-    start.elapsed().as_millis()
-}
 
 /// One framed JSON-RPC message handed to the writer actor.
 ///

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -38,6 +38,7 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::{Arc, OnceLock};
+use std::time::Instant;
 
 use async_trait::async_trait;
 // JSON-RPC wire types are internal transport details (like Go SDK's internal/jsonrpc2/).
@@ -68,6 +69,10 @@ pub use subscription::{EventSubscription, Lagged, LifecycleSubscription, RecvErr
 
 /// Minimum protocol version this SDK can communicate with.
 const MIN_PROTOCOL_VERSION: u32 = 2;
+
+fn elapsed_ms(start: Instant) -> u128 {
+    start.elapsed().as_millis()
+}
 
 /// Errors returned by the SDK.
 #[derive(Debug, thiserror::Error)]
@@ -880,6 +885,7 @@ impl Client {
     /// `sessionFs.setProvider` to register the SDK as the filesystem
     /// backend.
     pub async fn start(options: ClientOptions) -> Result<Self, Error> {
+        let start_time = Instant::now();
         if let Some(cfg) = &options.session_fs {
             validate_session_fs_config(cfg)?;
         }
@@ -945,7 +951,14 @@ impl Client {
         let client = match options.transport {
             Transport::External { ref host, port } => {
                 info!(host = %host, port = %port, "connecting to external CLI server");
+                let connect_start = Instant::now();
                 let stream = TcpStream::connect((host.as_str(), port)).await?;
+                info!(
+                    elapsed_ms = elapsed_ms(connect_start),
+                    host = %host,
+                    port,
+                    "Client::start TCP connect complete"
+                );
                 let (reader, writer) = tokio::io::split(stream);
                 Self::from_transport(
                     reader,
@@ -960,7 +973,13 @@ impl Client {
             }
             Transport::Tcp { port } => {
                 let (mut child, actual_port) = Self::spawn_tcp(&program, &options, port).await?;
+                let connect_start = Instant::now();
                 let stream = TcpStream::connect(("127.0.0.1", actual_port)).await?;
+                info!(
+                    elapsed_ms = elapsed_ms(connect_start),
+                    port = actual_port,
+                    "Client::start TCP connect complete"
+                );
                 let (reader, writer) = tokio::io::split(stream);
                 Self::drain_stderr(&mut child);
                 Self::from_transport(
@@ -992,15 +1011,32 @@ impl Client {
             }
         };
 
+        info!(
+            elapsed_ms = elapsed_ms(start_time),
+            "Client::start transport setup complete"
+        );
         client.verify_protocol_version().await?;
+        info!(
+            elapsed_ms = elapsed_ms(start_time),
+            "Client::start protocol verification complete"
+        );
         if let Some(cfg) = session_fs_config {
+            let session_fs_start = Instant::now();
             let request = crate::generated::api_types::SessionFsSetProviderRequest {
                 conventions: cfg.conventions.into_wire(),
                 initial_cwd: cfg.initial_cwd,
                 session_state_path: cfg.session_state_path,
             };
             client.rpc().session_fs().set_provider(request).await?;
+            info!(
+                elapsed_ms = elapsed_ms(session_fs_start),
+                "Client::start session filesystem setup complete"
+            );
         }
+        info!(
+            elapsed_ms = elapsed_ms(start_time),
+            "Client::start complete"
+        );
         Ok(client)
     }
 
@@ -1066,6 +1102,7 @@ impl Client {
         on_get_trace_context: Option<Arc<dyn TraceContextProvider>>,
         effective_connection_token: Option<String>,
     ) -> Result<Self, Error> {
+        let setup_start = Instant::now();
         let (request_tx, request_rx) = mpsc::unbounded_channel::<JsonRpcRequest>();
         let (notification_broadcast_tx, _) = broadcast::channel::<JsonRpcNotification>(1024);
         let rpc = JsonRpcClient::new(
@@ -1096,6 +1133,11 @@ impl Client {
             }),
         };
         client.spawn_lifecycle_dispatcher();
+        info!(
+            elapsed_ms = elapsed_ms(setup_start),
+            pid = ?pid,
+            "Client::from_transport setup complete"
+        );
         Ok(client)
     }
 
@@ -1249,7 +1291,13 @@ impl Client {
             .args(Self::session_idle_timeout_args(options))
             .args(&options.extra_args)
             .stdin(Stdio::piped());
-        Ok(command.spawn()?)
+        let spawn_start = Instant::now();
+        let child = command.spawn()?;
+        info!(
+            elapsed_ms = elapsed_ms(spawn_start),
+            "Client::spawn_stdio subprocess spawned"
+        );
+        Ok(child)
     }
 
     async fn spawn_tcp(
@@ -1273,7 +1321,12 @@ impl Client {
             .args(Self::session_idle_timeout_args(options))
             .args(&options.extra_args)
             .stdin(Stdio::null());
+        let spawn_start = Instant::now();
         let mut child = command.spawn()?;
+        info!(
+            elapsed_ms = elapsed_ms(spawn_start),
+            "Client::spawn_tcp subprocess spawned"
+        );
         let stdout = child.stdout.take().expect("stdout is piped");
 
         let (port_tx, port_rx) = oneshot::channel::<u16>();
@@ -1302,11 +1355,17 @@ impl Client {
             .instrument(span),
         );
 
+        let port_wait_start = Instant::now();
         let actual_port = tokio::time::timeout(std::time::Duration::from_secs(10), port_rx)
             .await
             .map_err(|_| Error::Protocol(ProtocolError::CliStartupTimeout))?
             .map_err(|_| Error::Protocol(ProtocolError::CliStartupFailed))?;
 
+        info!(
+            elapsed_ms = elapsed_ms(port_wait_start),
+            port = actual_port,
+            "Client::spawn_tcp TCP port wait complete"
+        );
         info!(port = %actual_port, "CLI server listening");
         Ok((child, actual_port))
     }
@@ -1467,13 +1526,15 @@ impl Client {
     /// `MIN_PROTOCOL_VERSION`..=[`SDK_PROTOCOL_VERSION`]. If the server
     /// doesn't report a version, logs a warning and succeeds.
     pub async fn verify_protocol_version(&self) -> Result<(), Error> {
+        let handshake_start = Instant::now();
+        let mut used_fallback_ping = false;
         // Try the new `connect` handshake first (sends the connection
         // token, if any). Fall back to `ping` for legacy CLI servers
-        // that don't expose `connect` (-32601 MethodNotFound). Matches
-        // the Node SDK's verify-version sequence.
+        // that don't expose `connect` (-32601 MethodNotFound).
         let server_version = match self.connect_handshake().await {
             Ok(v) => v,
             Err(Error::Rpc { code, .. }) if code == error_codes::METHOD_NOT_FOUND => {
+                used_fallback_ping = true;
                 self.ping(None).await?.protocol_version
             }
             Err(e) => return Err(e),
@@ -1504,6 +1565,12 @@ impl Client {
             }
         }
 
+        info!(
+            elapsed_ms = elapsed_ms(handshake_start),
+            protocol_version = ?server_version,
+            used_fallback_ping,
+            "Client::verify_protocol_version protocol handshake complete"
+        );
         Ok(())
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -70,10 +70,6 @@ pub use subscription::{EventSubscription, Lagged, LifecycleSubscription, RecvErr
 /// Minimum protocol version this SDK can communicate with.
 const MIN_PROTOCOL_VERSION: u32 = 2;
 
-pub(crate) fn elapsed_ms(start: Instant) -> u128 {
-    start.elapsed().as_millis()
-}
-
 /// Errors returned by the SDK.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -953,8 +949,8 @@ impl Client {
                 info!(host = %host, port = %port, "connecting to external CLI server");
                 let connect_start = Instant::now();
                 let stream = TcpStream::connect((host.as_str(), port)).await?;
-                info!(
-                    elapsed_ms = elapsed_ms(connect_start),
+                debug!(
+                    elapsed_ms = connect_start.elapsed().as_millis(),
                     host = %host,
                     port,
                     "Client::start TCP connect complete"
@@ -975,8 +971,8 @@ impl Client {
                 let (mut child, actual_port) = Self::spawn_tcp(&program, &options, port).await?;
                 let connect_start = Instant::now();
                 let stream = TcpStream::connect(("127.0.0.1", actual_port)).await?;
-                info!(
-                    elapsed_ms = elapsed_ms(connect_start),
+                debug!(
+                    elapsed_ms = connect_start.elapsed().as_millis(),
                     port = actual_port,
                     "Client::start TCP connect complete"
                 );
@@ -1011,13 +1007,13 @@ impl Client {
             }
         };
 
-        info!(
-            elapsed_ms = elapsed_ms(start_time),
+        debug!(
+            elapsed_ms = start_time.elapsed().as_millis(),
             "Client::start transport setup complete"
         );
         client.verify_protocol_version().await?;
-        info!(
-            elapsed_ms = elapsed_ms(start_time),
+        debug!(
+            elapsed_ms = start_time.elapsed().as_millis(),
             "Client::start protocol verification complete"
         );
         if let Some(cfg) = session_fs_config {
@@ -1028,13 +1024,13 @@ impl Client {
                 session_state_path: cfg.session_state_path,
             };
             client.rpc().session_fs().set_provider(request).await?;
-            info!(
-                elapsed_ms = elapsed_ms(session_fs_start),
+            debug!(
+                elapsed_ms = session_fs_start.elapsed().as_millis(),
                 "Client::start session filesystem setup complete"
             );
         }
-        info!(
-            elapsed_ms = elapsed_ms(start_time),
+        debug!(
+            elapsed_ms = start_time.elapsed().as_millis(),
             "Client::start complete"
         );
         Ok(client)
@@ -1133,8 +1129,8 @@ impl Client {
             }),
         };
         client.spawn_lifecycle_dispatcher();
-        info!(
-            elapsed_ms = elapsed_ms(setup_start),
+        debug!(
+            elapsed_ms = setup_start.elapsed().as_millis(),
             pid = ?pid,
             "Client::from_transport setup complete"
         );
@@ -1293,8 +1289,8 @@ impl Client {
             .stdin(Stdio::piped());
         let spawn_start = Instant::now();
         let child = command.spawn()?;
-        info!(
-            elapsed_ms = elapsed_ms(spawn_start),
+        debug!(
+            elapsed_ms = spawn_start.elapsed().as_millis(),
             "Client::spawn_stdio subprocess spawned"
         );
         Ok(child)
@@ -1323,8 +1319,8 @@ impl Client {
             .stdin(Stdio::null());
         let spawn_start = Instant::now();
         let mut child = command.spawn()?;
-        info!(
-            elapsed_ms = elapsed_ms(spawn_start),
+        debug!(
+            elapsed_ms = spawn_start.elapsed().as_millis(),
             "Client::spawn_tcp subprocess spawned"
         );
         let stdout = child.stdout.take().expect("stdout is piped");
@@ -1361,8 +1357,8 @@ impl Client {
             .map_err(|_| Error::Protocol(ProtocolError::CliStartupTimeout))?
             .map_err(|_| Error::Protocol(ProtocolError::CliStartupFailed))?;
 
-        info!(
-            elapsed_ms = elapsed_ms(port_wait_start),
+        debug!(
+            elapsed_ms = port_wait_start.elapsed().as_millis(),
             port = actual_port,
             "Client::spawn_tcp TCP port wait complete"
         );
@@ -1565,8 +1561,8 @@ impl Client {
             }
         }
 
-        info!(
-            elapsed_ms = elapsed_ms(handshake_start),
+        debug!(
+            elapsed_ms = handshake_start.elapsed().as_millis(),
             protocol_version = ?server_version,
             used_fallback_ping,
             "Client::verify_protocol_version protocol handshake complete"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -70,7 +70,7 @@ pub use subscription::{EventSubscription, Lagged, LifecycleSubscription, RecvErr
 /// Minimum protocol version this SDK can communicate with.
 const MIN_PROTOCOL_VERSION: u32 = 2;
 
-fn elapsed_ms(start: Instant) -> u128 {
+pub(crate) fn elapsed_ms(start: Instant) -> u128 {
     start.elapsed().as_millis()
 }
 

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -32,9 +32,7 @@ use crate::types::{
     SessionEvent, SessionId, SetModelOptions, SystemMessageConfig, ToolInvocation, ToolResult,
     ToolResultResponse, TraceContext, ensure_attachment_display_names,
 };
-use crate::{
-    Client, Error, JsonRpcResponse, SessionError, SessionEventNotification, elapsed_ms, error_codes,
-};
+use crate::{Client, Error, JsonRpcResponse, SessionError, SessionEventNotification, error_codes};
 
 /// Shared state between a [`Session`] and its event loop, used by [`Session::send_and_wait`].
 struct IdleWaiter {
@@ -320,7 +318,7 @@ impl Session {
             .map(|s| s.to_string())
             .unwrap_or_default();
         tracing::info!(
-            elapsed_ms = elapsed_ms(rpc_start),
+            elapsed_ms = rpc_start.elapsed().as_millis(),
             session_id = %self.id,
             message_id = %message_id,
             "Session::send completed successfully"
@@ -389,7 +387,7 @@ impl Session {
         match result {
             Ok(inner) => {
                 tracing::info!(
-                    elapsed_ms = elapsed_ms(total_start),
+                    elapsed_ms = total_start.elapsed().as_millis(),
                     session_id = %self.id,
                     completed_by = if inner.is_ok() { "idle" } else { "error" },
                     "Session::send_and_wait complete"
@@ -398,7 +396,7 @@ impl Session {
             }
             Err(_) => {
                 tracing::warn!(
-                    elapsed_ms = elapsed_ms(total_start),
+                    elapsed_ms = total_start.elapsed().as_millis(),
                     session_id = %self.id,
                     completed_by = "timeout",
                     "Session::send_and_wait failed"
@@ -743,7 +741,7 @@ impl Client {
         let rpc_start = Instant::now();
         let result = self.call("session.create", Some(params)).await?;
         tracing::info!(
-            elapsed_ms = elapsed_ms(rpc_start),
+            elapsed_ms = rpc_start.elapsed().as_millis(),
             "Client::create_session session creation request completed successfully"
         );
         let create_result: CreateSessionResult = serde_json::from_value(result)?;
@@ -773,7 +771,7 @@ impl Client {
             shutdown.clone(),
         );
         tracing::debug!(
-            elapsed_ms = elapsed_ms(setup_start),
+            elapsed_ms = setup_start.elapsed().as_millis(),
             session_id = %session_id,
             tools_count,
             commands_count,
@@ -782,7 +780,7 @@ impl Client {
         );
 
         tracing::info!(
-            elapsed_ms = elapsed_ms(total_start),
+            elapsed_ms = total_start.elapsed().as_millis(),
             session_id = %session_id,
             "Client::create_session complete"
         );
@@ -840,7 +838,7 @@ impl Client {
         let rpc_start = Instant::now();
         let result = self.call("session.resume", Some(params)).await?;
         tracing::info!(
-            elapsed_ms = elapsed_ms(rpc_start),
+            elapsed_ms = rpc_start.elapsed().as_millis(),
             session_id = %session_id,
             "Client::resume_session session resume request completed successfully"
         );
@@ -875,14 +873,14 @@ impl Client {
             .await
         {
             warn!(
-                elapsed_ms = elapsed_ms(skills_reload_start),
+                elapsed_ms = skills_reload_start.elapsed().as_millis(),
                 session_id = %cli_session_id,
                 error = %e,
                 "Client::resume_session skills reload request failed"
             );
         } else {
             tracing::info!(
-                elapsed_ms = elapsed_ms(skills_reload_start),
+                elapsed_ms = skills_reload_start.elapsed().as_millis(),
                 session_id = %cli_session_id,
                 "Client::resume_session skills reload request completed successfully"
             );
@@ -912,7 +910,7 @@ impl Client {
             shutdown.clone(),
         );
         tracing::debug!(
-            elapsed_ms = elapsed_ms(setup_start),
+            elapsed_ms = setup_start.elapsed().as_millis(),
             session_id = %cli_session_id,
             tools_count,
             commands_count,
@@ -921,7 +919,7 @@ impl Client {
         );
 
         tracing::info!(
-            elapsed_ms = elapsed_ms(total_start),
+            elapsed_ms = total_start.elapsed().as_millis(),
             session_id = %cli_session_id,
             "Client::resume_session complete"
         );
@@ -1122,7 +1120,7 @@ async fn handle_notification(
                         if !waiter.first_assistant_message_seen {
                             waiter.first_assistant_message_seen = true;
                             tracing::debug!(
-                                elapsed_ms = elapsed_ms(waiter.started_at),
+                                elapsed_ms = waiter.started_at.elapsed().as_millis(),
                                 session_id = %session_id,
                                 "Session::send_and_wait first assistant message"
                             );
@@ -1133,7 +1131,7 @@ async fn handle_notification(
                         if let Some(waiter) = guard.take() {
                             if event_type == SessionEventType::SessionIdle {
                                 tracing::debug!(
-                                    elapsed_ms = elapsed_ms(waiter.started_at),
+                                    elapsed_ms = waiter.started_at.elapsed().as_millis(),
                                     session_id = %session_id,
                                     "Session::send_and_wait idle received"
                                 );
@@ -1187,7 +1185,7 @@ async fn handle_notification(
     }
 
     tracing::debug!(
-        elapsed_ms = elapsed_ms(dispatch_start),
+        elapsed_ms = dispatch_start.elapsed().as_millis(),
         session_id = %session_id,
         event_type = %notification.event.event_type,
         "Session::handle_notification dispatch"
@@ -1227,7 +1225,7 @@ async fn handle_notification(
                         })
                         .await;
                     tracing::info!(
-                        elapsed_ms = elapsed_ms(handler_start),
+                        elapsed_ms = handler_start.elapsed().as_millis(),
                         session_id = %sid,
                         request_id = %request_id,
                         "SessionHandler::on_permission_request dispatch"
@@ -1249,7 +1247,7 @@ async fn handle_notification(
                         )
                         .await;
                     tracing::debug!(
-                        elapsed_ms = elapsed_ms(rpc_start),
+                        elapsed_ms = rpc_start.elapsed().as_millis(),
                         session_id = %sid,
                         request_id = %request_id,
                         "Session::handle_notification response sent successfully"
@@ -1288,7 +1286,7 @@ async fn handle_notification(
                                 )
                                 .await;
                                 tracing::debug!(
-                                    elapsed_ms = elapsed_ms(rpc_start),
+                                    elapsed_ms = rpc_start.elapsed().as_millis(),
                                     session_id = %sid,
                                     request_id = %request_id,
                                     "Session::handle_notification response sent successfully"
@@ -1327,7 +1325,7 @@ async fn handle_notification(
                             )
                             .await;
                         tracing::debug!(
-                            elapsed_ms = elapsed_ms(rpc_start),
+                            elapsed_ms = rpc_start.elapsed().as_millis(),
                             session_id = %sid,
                             request_id = %request_id,
                             "Session::handle_notification response sent successfully"
@@ -1351,7 +1349,7 @@ async fn handle_notification(
                         .on_event(HandlerEvent::ExternalTool { invocation })
                         .await;
                     tracing::info!(
-                        elapsed_ms = elapsed_ms(handler_start),
+                        elapsed_ms = handler_start.elapsed().as_millis(),
                         session_id = %sid,
                         request_id = %request_id,
                         tool_call_id = %tool_call_id,
@@ -1375,7 +1373,7 @@ async fn handle_notification(
                         )
                         .await;
                     tracing::debug!(
-                        elapsed_ms = elapsed_ms(rpc_start),
+                        elapsed_ms = rpc_start.elapsed().as_millis(),
                         session_id = %sid,
                         request_id = %request_id,
                         tool_call_id = %tool_call_id,
@@ -1456,7 +1454,7 @@ async fn handle_notification(
                                 })
                                 .await;
                             tracing::info!(
-                                elapsed_ms = elapsed_ms(handler_start),
+                                elapsed_ms = handler_start.elapsed().as_millis(),
                                 session_id = %sid,
                                 request_id = %request_id,
                                 "SessionHandler::on_elicitation dispatch"
@@ -1495,7 +1493,7 @@ async fn handle_notification(
                             .await;
                     } else {
                         tracing::debug!(
-                            elapsed_ms = elapsed_ms(rpc_start),
+                            elapsed_ms = rpc_start.elapsed().as_millis(),
                             session_id = %sid,
                             request_id = %request_id,
                             "Session::handle_notification response sent successfully"
@@ -1534,7 +1532,7 @@ async fn handle_notification(
                             let handler_start = Instant::now();
                             let result = handler.on_command(ctx).await;
                             tracing::info!(
-                                elapsed_ms = elapsed_ms(handler_start),
+                                elapsed_ms = handler_start.elapsed().as_millis(),
                                 session_id = %sid,
                                 request_id = %request_id,
                                 command_name = %command_name,
@@ -1558,7 +1556,7 @@ async fn handle_notification(
                         .call("session.commands.handlePendingCommand", Some(params))
                         .await;
                     tracing::debug!(
-                        elapsed_ms = elapsed_ms(rpc_start),
+                        elapsed_ms = rpc_start.elapsed().as_millis(),
                         session_id = %sid,
                         request_id = %request_id,
                         "Session::handle_notification response sent successfully"
@@ -1646,7 +1644,7 @@ async fn handle_request(
                 .on_event(HandlerEvent::ExternalTool { invocation })
                 .await;
             tracing::info!(
-                elapsed_ms = elapsed_ms(handler_start),
+                elapsed_ms = handler_start.elapsed().as_millis(),
                 session_id = %sid,
                 tool_call_id = %tool_call_id,
                 tool_name = %tool_name,
@@ -1710,7 +1708,7 @@ async fn handle_request(
                 })
                 .await;
             tracing::info!(
-                elapsed_ms = elapsed_ms(handler_start),
+                elapsed_ms = handler_start.elapsed().as_millis(),
                 session_id = %sid,
                 "SessionHandler::on_user_input dispatch"
             );
@@ -1778,7 +1776,7 @@ async fn handle_request(
                 })
                 .await;
             tracing::info!(
-                elapsed_ms = elapsed_ms(handler_start),
+                elapsed_ms = handler_start.elapsed().as_millis(),
                 session_id = %sid,
                 request_id = %request_id,
                 "SessionHandler::on_permission_request dispatch"
@@ -1826,7 +1824,7 @@ async fn handle_request(
                 let response =
                     crate::transforms::dispatch_transform(transforms, &sid, sections).await;
                 tracing::info!(
-                    elapsed_ms = elapsed_ms(transform_start),
+                    elapsed_ms = transform_start.elapsed().as_millis(),
                     session_id = %sid,
                     "SystemMessageTransform::transform_section dispatch"
                 );

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -317,7 +317,7 @@ impl Session {
             .and_then(|v| v.as_str())
             .map(|s| s.to_string())
             .unwrap_or_default();
-        tracing::info!(
+        tracing::debug!(
             elapsed_ms = rpc_start.elapsed().as_millis(),
             session_id = %self.id,
             message_id = %message_id,
@@ -386,7 +386,7 @@ impl Session {
 
         match result {
             Ok(inner) => {
-                tracing::info!(
+                tracing::debug!(
                     elapsed_ms = total_start.elapsed().as_millis(),
                     session_id = %self.id,
                     completed_by = if inner.is_ok() { "idle" } else { "error" },
@@ -740,7 +740,7 @@ impl Client {
         inject_trace_context(&mut params, &trace_ctx);
         let rpc_start = Instant::now();
         let result = self.call("session.create", Some(params)).await?;
-        tracing::info!(
+        tracing::debug!(
             elapsed_ms = rpc_start.elapsed().as_millis(),
             "Client::create_session session creation request completed successfully"
         );
@@ -779,7 +779,7 @@ impl Client {
             "Client::create_session local setup complete"
         );
 
-        tracing::info!(
+        tracing::debug!(
             elapsed_ms = total_start.elapsed().as_millis(),
             session_id = %session_id,
             "Client::create_session complete"
@@ -837,7 +837,7 @@ impl Client {
         inject_trace_context(&mut params, &trace_ctx);
         let rpc_start = Instant::now();
         let result = self.call("session.resume", Some(params)).await?;
-        tracing::info!(
+        tracing::debug!(
             elapsed_ms = rpc_start.elapsed().as_millis(),
             session_id = %session_id,
             "Client::resume_session session resume request completed successfully"
@@ -879,7 +879,7 @@ impl Client {
                 "Client::resume_session skills reload request failed"
             );
         } else {
-            tracing::info!(
+            tracing::debug!(
                 elapsed_ms = skills_reload_start.elapsed().as_millis(),
                 session_id = %cli_session_id,
                 "Client::resume_session skills reload request completed successfully"
@@ -918,7 +918,7 @@ impl Client {
             "Client::resume_session local setup complete"
         );
 
-        tracing::info!(
+        tracing::debug!(
             elapsed_ms = total_start.elapsed().as_millis(),
             session_id = %cli_session_id,
             "Client::resume_session complete"
@@ -1224,7 +1224,7 @@ async fn handle_notification(
                             data,
                         })
                         .await;
-                    tracing::info!(
+                    tracing::debug!(
                         elapsed_ms = handler_start.elapsed().as_millis(),
                         session_id = %sid,
                         request_id = %request_id,
@@ -1348,7 +1348,7 @@ async fn handle_notification(
                     let response = handler
                         .on_event(HandlerEvent::ExternalTool { invocation })
                         .await;
-                    tracing::info!(
+                    tracing::debug!(
                         elapsed_ms = handler_start.elapsed().as_millis(),
                         session_id = %sid,
                         request_id = %request_id,
@@ -1453,7 +1453,7 @@ async fn handle_notification(
                                     request,
                                 })
                                 .await;
-                            tracing::info!(
+                            tracing::debug!(
                                 elapsed_ms = handler_start.elapsed().as_millis(),
                                 session_id = %sid,
                                 request_id = %request_id,
@@ -1531,7 +1531,7 @@ async fn handle_notification(
                             };
                             let handler_start = Instant::now();
                             let result = handler.on_command(ctx).await;
-                            tracing::info!(
+                            tracing::debug!(
                                 elapsed_ms = handler_start.elapsed().as_millis(),
                                 session_id = %sid,
                                 request_id = %request_id,
@@ -1643,7 +1643,7 @@ async fn handle_request(
             let response = handler
                 .on_event(HandlerEvent::ExternalTool { invocation })
                 .await;
-            tracing::info!(
+            tracing::debug!(
                 elapsed_ms = handler_start.elapsed().as_millis(),
                 session_id = %sid,
                 tool_call_id = %tool_call_id,
@@ -1707,7 +1707,7 @@ async fn handle_request(
                     allow_freeform,
                 })
                 .await;
-            tracing::info!(
+            tracing::debug!(
                 elapsed_ms = handler_start.elapsed().as_millis(),
                 session_id = %sid,
                 "SessionHandler::on_user_input dispatch"
@@ -1775,7 +1775,7 @@ async fn handle_request(
                     data,
                 })
                 .await;
-            tracing::info!(
+            tracing::debug!(
                 elapsed_ms = handler_start.elapsed().as_millis(),
                 session_id = %sid,
                 request_id = %request_id,
@@ -1823,7 +1823,7 @@ async fn handle_request(
                 let transform_start = Instant::now();
                 let response =
                     crate::transforms::dispatch_transform(transforms, &sid, sections).await;
-                tracing::info!(
+                tracing::debug!(
                     elapsed_ms = transform_start.elapsed().as_millis(),
                     session_id = %sid,
                     "SystemMessageTransform::transform_section dispatch"

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -32,11 +32,9 @@ use crate::types::{
     SessionEvent, SessionId, SetModelOptions, SystemMessageConfig, ToolInvocation, ToolResult,
     ToolResultResponse, TraceContext, ensure_attachment_display_names,
 };
-use crate::{Client, Error, JsonRpcResponse, SessionError, SessionEventNotification, error_codes};
-
-fn elapsed_ms(start: Instant) -> u128 {
-    start.elapsed().as_millis()
-}
+use crate::{
+    Client, Error, JsonRpcResponse, SessionError, SessionEventNotification, elapsed_ms, error_codes,
+};
 
 /// Shared state between a [`Session`] and its event loop, used by [`Session::send_and_wait`].
 struct IdleWaiter {

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use parking_lot::Mutex as ParkingLotMutex;
 use serde_json::Value;
@@ -34,10 +34,16 @@ use crate::types::{
 };
 use crate::{Client, Error, JsonRpcResponse, SessionError, SessionEventNotification, error_codes};
 
+fn elapsed_ms(start: Instant) -> u128 {
+    start.elapsed().as_millis()
+}
+
 /// Shared state between a [`Session`] and its event loop, used by [`Session::send_and_wait`].
 struct IdleWaiter {
     tx: oneshot::Sender<Result<Option<SessionEvent>, Error>>,
     last_assistant_message: Option<SessionEvent>,
+    started_at: Instant,
+    first_assistant_message_seen: bool,
 }
 
 /// RAII guard that clears the [`Session::idle_waiter`] slot on drop. Used
@@ -308,12 +314,19 @@ impl Session {
             self.client.resolve_trace_context().await
         };
         inject_trace_context(&mut params, &trace_ctx);
+        let rpc_start = Instant::now();
         let result = self.client.call("session.send", Some(params)).await?;
         let message_id = result
             .get("messageId")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string())
             .unwrap_or_default();
+        tracing::info!(
+            elapsed_ms = elapsed_ms(rpc_start),
+            session_id = %self.id,
+            message_id = %message_id,
+            "Session::send completed successfully"
+        );
         Ok(message_id)
     }
 
@@ -340,6 +353,7 @@ impl Session {
         &self,
         opts: impl Into<MessageOptions>,
     ) -> Result<Option<SessionEvent>, Error> {
+        let total_start = Instant::now();
         let opts = opts.into();
         let timeout_duration = opts.wait_timeout.unwrap_or(Duration::from_secs(60));
         let (tx, rx) = oneshot::channel();
@@ -352,6 +366,8 @@ impl Session {
             *guard = Some(IdleWaiter {
                 tx,
                 last_assistant_message: None,
+                started_at: total_start,
+                first_assistant_message_seen: false,
             });
         }
 
@@ -373,8 +389,24 @@ impl Session {
         .await;
 
         match result {
-            Ok(inner) => inner,
-            Err(_) => Err(Error::Session(SessionError::Timeout(timeout_duration))),
+            Ok(inner) => {
+                tracing::info!(
+                    elapsed_ms = elapsed_ms(total_start),
+                    session_id = %self.id,
+                    completed_by = if inner.is_ok() { "idle" } else { "error" },
+                    "Session::send_and_wait complete"
+                );
+                inner
+            }
+            Err(_) => {
+                tracing::warn!(
+                    elapsed_ms = elapsed_ms(total_start),
+                    session_id = %self.id,
+                    completed_by = "timeout",
+                    "Session::send_and_wait failed"
+                );
+                Err(Error::Session(SessionError::Timeout(timeout_duration)))
+            }
         }
     }
 
@@ -685,12 +717,16 @@ impl Client {
     /// [`DenyAllHandler`](crate::handler::DenyAllHandler) — permission
     /// requests are denied; other events are no-ops.
     pub async fn create_session(&self, mut config: SessionConfig) -> Result<Session, Error> {
+        let total_start = Instant::now();
         let handler = config
             .handler
             .take()
             .unwrap_or_else(|| Arc::new(crate::handler::DenyAllHandler));
         let hooks = config.hooks_handler.take();
         let transforms = config.transform.take();
+        let tools_count = config.tools.as_ref().map_or(0, Vec::len);
+        let commands_count = config.commands.as_ref().map_or(0, Vec::len);
+        let has_hooks = hooks.is_some();
         let command_handlers = build_command_handler_map(config.commands.as_deref());
         let session_fs_provider = config.session_fs_provider.take();
         if self.inner.session_fs_configured && session_fs_provider.is_none() {
@@ -706,10 +742,16 @@ impl Client {
         let mut params = serde_json::to_value(&config)?;
         let trace_ctx = self.resolve_trace_context().await;
         inject_trace_context(&mut params, &trace_ctx);
+        let rpc_start = Instant::now();
         let result = self.call("session.create", Some(params)).await?;
+        tracing::info!(
+            elapsed_ms = elapsed_ms(rpc_start),
+            "Client::create_session session creation request completed successfully"
+        );
         let create_result: CreateSessionResult = serde_json::from_value(result)?;
 
         let session_id = create_result.session_id;
+        let setup_start = Instant::now();
         let capabilities = Arc::new(parking_lot::RwLock::new(
             create_result.capabilities.unwrap_or_default(),
         ));
@@ -732,7 +774,20 @@ impl Client {
             event_tx.clone(),
             shutdown.clone(),
         );
+        tracing::debug!(
+            elapsed_ms = elapsed_ms(setup_start),
+            session_id = %session_id,
+            tools_count,
+            commands_count,
+            has_hooks,
+            "Client::create_session local setup complete"
+        );
 
+        tracing::info!(
+            elapsed_ms = elapsed_ms(total_start),
+            session_id = %session_id,
+            "Client::create_session complete"
+        );
         Ok(Session {
             id: session_id,
             cwd: self.cwd().clone(),
@@ -758,12 +813,16 @@ impl Client {
     /// See [`Self::create_session`] for the defaults applied when callback
     /// fields are unset.
     pub async fn resume_session(&self, mut config: ResumeSessionConfig) -> Result<Session, Error> {
+        let total_start = Instant::now();
         let handler = config
             .handler
             .take()
             .unwrap_or_else(|| Arc::new(crate::handler::DenyAllHandler));
         let hooks = config.hooks_handler.take();
         let transforms = config.transform.take();
+        let tools_count = config.tools.as_ref().map_or(0, Vec::len);
+        let commands_count = config.commands.as_ref().map_or(0, Vec::len);
+        let has_hooks = hooks.is_some();
         let command_handlers = build_command_handler_map(config.commands.as_deref());
         let session_fs_provider = config.session_fs_provider.take();
         if self.inner.session_fs_configured && session_fs_provider.is_none() {
@@ -780,7 +839,13 @@ impl Client {
         let mut params = serde_json::to_value(&config)?;
         let trace_ctx = self.resolve_trace_context().await;
         inject_trace_context(&mut params, &trace_ctx);
+        let rpc_start = Instant::now();
         let result = self.call("session.resume", Some(params)).await?;
+        tracing::info!(
+            elapsed_ms = elapsed_ms(rpc_start),
+            session_id = %session_id,
+            "Client::resume_session session resume request completed successfully"
+        );
 
         // The CLI may reassign the session ID on resume.
         let cli_session_id: SessionId = result
@@ -803,6 +868,7 @@ impl Client {
             .map(ToString::to_string);
 
         // Reload skills after resume (best-effort).
+        let skills_reload_start = Instant::now();
         if let Err(e) = self
             .call(
                 "session.skills.reload",
@@ -810,12 +876,24 @@ impl Client {
             )
             .await
         {
-            warn!(error = %e, "failed to reload skills after resume");
+            warn!(
+                elapsed_ms = elapsed_ms(skills_reload_start),
+                session_id = %cli_session_id,
+                error = %e,
+                "Client::resume_session skills reload request failed"
+            );
+        } else {
+            tracing::info!(
+                elapsed_ms = elapsed_ms(skills_reload_start),
+                session_id = %cli_session_id,
+                "Client::resume_session skills reload request completed successfully"
+            );
         }
 
         let capabilities = Arc::new(parking_lot::RwLock::new(
             resume_capabilities.unwrap_or_default(),
         ));
+        let setup_start = Instant::now();
         let channels = self.register_session(&cli_session_id);
 
         let idle_waiter = Arc::new(ParkingLotMutex::new(None));
@@ -835,7 +913,20 @@ impl Client {
             event_tx.clone(),
             shutdown.clone(),
         );
+        tracing::debug!(
+            elapsed_ms = elapsed_ms(setup_start),
+            session_id = %cli_session_id,
+            tools_count,
+            commands_count,
+            has_hooks,
+            "Client::resume_session local setup complete"
+        );
 
+        tracing::info!(
+            elapsed_ms = elapsed_ms(total_start),
+            session_id = %cli_session_id,
+            "Client::resume_session complete"
+        );
         Ok(Session {
             id: cli_session_id,
             cwd: self.cwd().clone(),
@@ -1009,8 +1100,16 @@ async fn handle_notification(
     capabilities: &Arc<parking_lot::RwLock<SessionCapabilities>>,
     event_tx: &tokio::sync::broadcast::Sender<SessionEvent>,
 ) {
+    let dispatch_start = Instant::now();
     let event = notification.event.clone();
     let event_type = event.parsed_type();
+    if event_type == SessionEventType::PermissionRequested {
+        tracing::debug!(
+            session_id = %session_id,
+            event_type = %event.event_type,
+            "Session::handle_notification permission request received"
+        );
+    }
 
     // Signal send_and_wait if active. The lock is only contended when
     // a send_and_wait call is in flight (idle_waiter is Some).
@@ -1022,11 +1121,24 @@ async fn handle_notification(
             if let Some(waiter) = guard.as_mut() {
                 match event_type {
                     SessionEventType::AssistantMessage => {
+                        if !waiter.first_assistant_message_seen {
+                            waiter.first_assistant_message_seen = true;
+                            tracing::debug!(
+                                elapsed_ms = elapsed_ms(waiter.started_at),
+                                session_id = %session_id,
+                                "Session::send_and_wait first assistant message"
+                            );
+                        }
                         waiter.last_assistant_message = Some(event.clone());
                     }
                     SessionEventType::SessionIdle | SessionEventType::SessionError => {
                         if let Some(waiter) = guard.take() {
                             if event_type == SessionEventType::SessionIdle {
+                                tracing::debug!(
+                                    elapsed_ms = elapsed_ms(waiter.started_at),
+                                    session_id = %session_id,
+                                    "Session::send_and_wait idle received"
+                                );
                                 let _ = waiter.tx.send(Ok(waiter.last_assistant_message));
                             } else {
                                 let error_msg = event
@@ -1076,6 +1188,13 @@ async fn handle_notification(
         }
     }
 
+    tracing::debug!(
+        elapsed_ms = elapsed_ms(dispatch_start),
+        session_id = %session_id,
+        event_type = %notification.event.event_type,
+        "Session::handle_notification dispatch"
+    );
+
     // Notification-based permission/tool/elicitation requests require a
     // separate RPC callback. Spawn concurrently since the CLI doesn't block.
     match event_type {
@@ -1094,30 +1213,52 @@ async fn handle_notification(
                         extra: notification.event.data.clone(),
                     }
                 });
-            tokio::spawn(async move {
-                let response = handler
-                    .on_event(HandlerEvent::PermissionRequest {
-                        session_id: sid.clone(),
-                        request_id: request_id.clone(),
-                        data,
-                    })
-                    .await;
-                let Some(result_value) = notification_permission_payload(&response) else {
-                    // Handler returned Deferred — it will call
-                    // handlePendingPermissionRequest itself.
-                    return;
-                };
-                let _ = client
-                    .call(
-                        "session.permissions.handlePendingPermissionRequest",
-                        Some(serde_json::json!({
-                            "sessionId": sid,
-                            "requestId": request_id,
-                            "result": result_value,
-                        })),
-                    )
-                    .await;
-            });
+            let span = tracing::error_span!(
+                "permission_request_handler",
+                session_id = %sid,
+                request_id = %request_id
+            );
+            tokio::spawn(
+                async move {
+                    let handler_start = Instant::now();
+                    let response = handler
+                        .on_event(HandlerEvent::PermissionRequest {
+                            session_id: sid.clone(),
+                            request_id: request_id.clone(),
+                            data,
+                        })
+                        .await;
+                    tracing::info!(
+                        elapsed_ms = elapsed_ms(handler_start),
+                        session_id = %sid,
+                        request_id = %request_id,
+                        "SessionHandler::on_permission_request dispatch"
+                    );
+                    let Some(result_value) = notification_permission_payload(&response) else {
+                        // Handler returned Deferred — it will call
+                        // handlePendingPermissionRequest itself.
+                        return;
+                    };
+                    let rpc_start = Instant::now();
+                    let _ = client
+                        .call(
+                            "session.permissions.handlePendingPermissionRequest",
+                            Some(serde_json::json!({
+                                "sessionId": sid,
+                                "requestId": request_id,
+                                "result": result_value,
+                            })),
+                        )
+                        .await;
+                    tracing::debug!(
+                        elapsed_ms = elapsed_ms(rpc_start),
+                        session_id = %sid,
+                        request_id = %request_id,
+                        "Session::handle_notification response sent successfully"
+                    );
+                }
+                .instrument(span),
+            );
         }
         SessionEventType::ExternalToolRequested => {
             let Some(request_id) = extract_request_id(&notification.event.data) else {
@@ -1130,8 +1271,15 @@ async fn handle_notification(
                         warn!(error = %e, "failed to deserialize external_tool.requested");
                         let client = client.clone();
                         let sid = session_id.clone();
-                        tokio::spawn(async move {
-                            let _ = client
+                        let span = tracing::error_span!(
+                            "external_tool_deserialize_error",
+                            session_id = %sid,
+                            request_id = %request_id
+                        );
+                        tokio::spawn(
+                            async move {
+                                let rpc_start = Instant::now();
+                                let _ = client
                                 .call(
                                     "session.tools.handlePendingToolCall",
                                     Some(serde_json::json!({
@@ -1141,61 +1289,104 @@ async fn handle_notification(
                                     })),
                                 )
                                 .await;
-                        });
+                                tracing::debug!(
+                                    elapsed_ms = elapsed_ms(rpc_start),
+                                    session_id = %sid,
+                                    request_id = %request_id,
+                                    "Session::handle_notification response sent successfully"
+                                );
+                            }
+                            .instrument(span),
+                        );
                         return;
                     }
                 };
             let client = client.clone();
             let handler = handler.clone();
             let sid = session_id.clone();
-            tokio::spawn(async move {
-                if data.tool_call_id.is_empty() || data.tool_name.is_empty() {
-                    let error_msg = if data.tool_call_id.is_empty() {
-                        "Missing toolCallId"
-                    } else {
-                        "Missing toolName"
+            let span = tracing::error_span!(
+                "external_tool_handler",
+                session_id = %sid,
+                request_id = %request_id
+            );
+            tokio::spawn(
+                async move {
+                    if data.tool_call_id.is_empty() || data.tool_name.is_empty() {
+                        let error_msg = if data.tool_call_id.is_empty() {
+                            "Missing toolCallId"
+                        } else {
+                            "Missing toolName"
+                        };
+                        let rpc_start = Instant::now();
+                        let _ = client
+                            .call(
+                                "session.tools.handlePendingToolCall",
+                                Some(serde_json::json!({
+                                    "sessionId": sid,
+                                    "requestId": request_id,
+                                    "error": error_msg,
+                                })),
+                            )
+                            .await;
+                        tracing::debug!(
+                            elapsed_ms = elapsed_ms(rpc_start),
+                            session_id = %sid,
+                            request_id = %request_id,
+                            "Session::handle_notification response sent successfully"
+                        );
+                        return;
+                    }
+                    let tool_call_id = data.tool_call_id.clone();
+                    let tool_name = data.tool_name.clone();
+                    let invocation = ToolInvocation {
+                        session_id: sid.clone(),
+                        tool_call_id: data.tool_call_id,
+                        tool_name: data.tool_name,
+                        arguments: data
+                            .arguments
+                            .unwrap_or(Value::Object(serde_json::Map::new())),
+                        traceparent: data.traceparent,
+                        tracestate: data.tracestate,
                     };
+                    let handler_start = Instant::now();
+                    let response = handler
+                        .on_event(HandlerEvent::ExternalTool { invocation })
+                        .await;
+                    tracing::info!(
+                        elapsed_ms = elapsed_ms(handler_start),
+                        session_id = %sid,
+                        request_id = %request_id,
+                        tool_call_id = %tool_call_id,
+                        tool_name = %tool_name,
+                        "ToolHandler::call dispatch"
+                    );
+                    let tool_result = match response {
+                        HandlerResponse::ToolResult(r) => r,
+                        _ => ToolResult::Text("Unexpected handler response".to_string()),
+                    };
+                    let result_value = serde_json::to_value(&tool_result).unwrap_or(Value::Null);
+                    let rpc_start = Instant::now();
                     let _ = client
                         .call(
                             "session.tools.handlePendingToolCall",
                             Some(serde_json::json!({
                                 "sessionId": sid,
                                 "requestId": request_id,
-                                "error": error_msg,
+                                "result": result_value,
                             })),
                         )
                         .await;
-                    return;
+                    tracing::debug!(
+                        elapsed_ms = elapsed_ms(rpc_start),
+                        session_id = %sid,
+                        request_id = %request_id,
+                        tool_call_id = %tool_call_id,
+                        tool_name = %tool_name,
+                        "Session::handle_notification response sent successfully"
+                    );
                 }
-                let invocation = ToolInvocation {
-                    session_id: sid.clone(),
-                    tool_call_id: data.tool_call_id,
-                    tool_name: data.tool_name,
-                    arguments: data
-                        .arguments
-                        .unwrap_or(Value::Object(serde_json::Map::new())),
-                    traceparent: data.traceparent,
-                    tracestate: data.tracestate,
-                };
-                let response = handler
-                    .on_event(HandlerEvent::ExternalTool { invocation })
-                    .await;
-                let tool_result = match response {
-                    HandlerResponse::ToolResult(r) => r,
-                    _ => ToolResult::Text("Unexpected handler response".to_string()),
-                };
-                let result_value = serde_json::to_value(&tool_result).unwrap_or(Value::Null);
-                let _ = client
-                    .call(
-                        "session.tools.handlePendingToolCall",
-                        Some(serde_json::json!({
-                            "sessionId": sid,
-                            "requestId": request_id,
-                            "result": result_value,
-                        })),
-                    )
-                    .await;
-            });
+                .instrument(span),
+            );
         }
         SessionEventType::UserInputRequested => {
             // Notification-only signal for observers (UI, telemetry).
@@ -1237,55 +1428,84 @@ async fn handle_notification(
             let client = client.clone();
             let handler = handler.clone();
             let sid = session_id.clone();
-            tokio::spawn(async move {
-                let cancel = ElicitationResult {
-                    action: "cancel".to_string(),
-                    content: None,
-                };
-                // Dispatch to handler inside a nested task so panics are
-                // caught as JoinErrors (matches Node SDK's try/catch pattern).
-                let handler_task = tokio::spawn({
-                    let sid = sid.clone();
-                    let request_id = request_id.clone();
-                    async move {
-                        handler
-                            .on_event(HandlerEvent::ElicitationRequest {
-                                session_id: sid,
-                                request_id,
-                                request,
-                            })
-                            .await
-                    }
-                });
-                let result = match handler_task.await {
-                    Ok(HandlerResponse::Elicitation(r)) => r,
-                    _ => cancel.clone(),
-                };
-                if let Err(e) = client
-                    .call(
-                        "session.ui.handlePendingElicitation",
-                        Some(serde_json::json!({
-                            "sessionId": sid,
-                            "requestId": request_id,
-                            "result": result,
-                        })),
-                    )
-                    .await
-                {
-                    // RPC failed — attempt cancel as last resort
-                    warn!(error = %e, "handlePendingElicitation failed, sending cancel");
-                    let _ = client
+            let span = tracing::error_span!(
+                "elicitation_request_handler",
+                session_id = %sid,
+                request_id = %request_id
+            );
+            tokio::spawn(
+                async move {
+                    let cancel = ElicitationResult {
+                        action: "cancel".to_string(),
+                        content: None,
+                    };
+                    // Dispatch to a nested task so panics are caught as JoinErrors.
+                    let handler_task = tokio::spawn({
+                        let sid = sid.clone();
+                        let request_id = request_id.clone();
+                        let span = tracing::error_span!(
+                            "elicitation_callback",
+                            session_id = %sid,
+                            request_id = %request_id
+                        );
+                        async move {
+                            let handler_start = Instant::now();
+                            let response = handler
+                                .on_event(HandlerEvent::ElicitationRequest {
+                                    session_id: sid.clone(),
+                                    request_id: request_id.clone(),
+                                    request,
+                                })
+                                .await;
+                            tracing::info!(
+                                elapsed_ms = elapsed_ms(handler_start),
+                                session_id = %sid,
+                                request_id = %request_id,
+                                "SessionHandler::on_elicitation dispatch"
+                            );
+                            response
+                        }
+                        .instrument(span)
+                    });
+                    let result = match handler_task.await {
+                        Ok(HandlerResponse::Elicitation(r)) => r,
+                        _ => cancel.clone(),
+                    };
+                    let rpc_start = Instant::now();
+                    if let Err(e) = client
                         .call(
                             "session.ui.handlePendingElicitation",
                             Some(serde_json::json!({
                                 "sessionId": sid,
                                 "requestId": request_id,
-                                "result": cancel,
+                                "result": result,
                             })),
                         )
-                        .await;
+                        .await
+                    {
+                        // RPC failed — attempt cancel as last resort
+                        warn!(error = %e, "handlePendingElicitation failed, sending cancel");
+                        let _ = client
+                            .call(
+                                "session.ui.handlePendingElicitation",
+                                Some(serde_json::json!({
+                                    "sessionId": sid,
+                                    "requestId": request_id,
+                                    "result": cancel,
+                                })),
+                            )
+                            .await;
+                    } else {
+                        tracing::debug!(
+                            elapsed_ms = elapsed_ms(rpc_start),
+                            session_id = %sid,
+                            request_id = %request_id,
+                            "Session::handle_notification response sent successfully"
+                        );
+                    }
                 }
-            });
+                .instrument(span),
+            );
         }
         SessionEventType::CommandExecute => {
             let data: CommandExecuteData =
@@ -1299,34 +1519,55 @@ async fn handle_notification(
             let client = client.clone();
             let command_handlers = command_handlers.clone();
             let sid = session_id.clone();
-            tokio::spawn(async move {
-                let request_id = data.request_id;
-                let ack_error = match command_handlers.get(&data.command_name).cloned() {
-                    None => Some(format!("Unknown command: {}", data.command_name)),
-                    Some(handler) => {
-                        let ctx = CommandContext {
-                            session_id: sid.clone(),
-                            command: data.command,
-                            command_name: data.command_name,
-                            args: data.args,
-                        };
-                        match handler.on_command(ctx).await {
-                            Ok(()) => None,
-                            Err(e) => Some(e.to_string()),
+            let span = tracing::error_span!("command_handler", session_id = %sid);
+            tokio::spawn(
+                async move {
+                    let request_id = data.request_id;
+                    let ack_error = match command_handlers.get(&data.command_name).cloned() {
+                        None => Some(format!("Unknown command: {}", data.command_name)),
+                        Some(handler) => {
+                            let command_name = data.command_name.clone();
+                            let ctx = CommandContext {
+                                session_id: sid.clone(),
+                                command: data.command,
+                                command_name: data.command_name,
+                                args: data.args,
+                            };
+                            let handler_start = Instant::now();
+                            let result = handler.on_command(ctx).await;
+                            tracing::info!(
+                                elapsed_ms = elapsed_ms(handler_start),
+                                session_id = %sid,
+                                request_id = %request_id,
+                                command_name = %command_name,
+                                "CommandHandler::call dispatch"
+                            );
+                            match result {
+                                Ok(()) => None,
+                                Err(e) => Some(e.to_string()),
+                            }
                         }
+                    };
+                    let mut params = serde_json::json!({
+                        "sessionId": sid,
+                        "requestId": request_id,
+                    });
+                    if let Some(error_msg) = ack_error {
+                        params["error"] = serde_json::Value::String(error_msg);
                     }
-                };
-                let mut params = serde_json::json!({
-                    "sessionId": sid,
-                    "requestId": request_id,
-                });
-                if let Some(error_msg) = ack_error {
-                    params["error"] = serde_json::Value::String(error_msg);
+                    let rpc_start = Instant::now();
+                    let _ = client
+                        .call("session.commands.handlePendingCommand", Some(params))
+                        .await;
+                    tracing::debug!(
+                        elapsed_ms = elapsed_ms(rpc_start),
+                        session_id = %sid,
+                        request_id = %request_id,
+                        "Session::handle_notification response sent successfully"
+                    );
                 }
-                let _ = client
-                    .call("session.commands.handlePendingCommand", Some(params))
-                    .await;
-            });
+                .instrument(span),
+            );
         }
         _ => {}
     }
@@ -1400,9 +1641,19 @@ async fn handle_request(
                     return;
                 }
             };
+            let tool_call_id = invocation.tool_call_id.clone();
+            let tool_name = invocation.tool_name.clone();
+            let handler_start = Instant::now();
             let response = handler
                 .on_event(HandlerEvent::ExternalTool { invocation })
                 .await;
+            tracing::info!(
+                elapsed_ms = elapsed_ms(handler_start),
+                session_id = %sid,
+                tool_call_id = %tool_call_id,
+                tool_name = %tool_name,
+                "ToolHandler::call dispatch"
+            );
             let tool_result = match response {
                 HandlerResponse::ToolResult(r) => r,
                 _ => ToolResult::Text("Unexpected handler response".to_string()),
@@ -1451,14 +1702,20 @@ async fn handle_request(
                 .and_then(|p| p.get("allowFreeform"))
                 .and_then(|v| v.as_bool());
 
+            let handler_start = Instant::now();
             let response = handler
                 .on_event(HandlerEvent::UserInput {
-                    session_id: sid,
+                    session_id: sid.clone(),
                     question,
                     choices,
                     allow_freeform,
                 })
                 .await;
+            tracing::info!(
+                elapsed_ms = elapsed_ms(handler_start),
+                session_id = %sid,
+                "SessionHandler::on_user_input dispatch"
+            );
 
             let rpc_result = match response {
                 HandlerResponse::UserInput(Some(UserInputResponse {
@@ -1514,13 +1771,20 @@ async fn handle_request(
                     extra: raw_params,
                 });
 
+            let handler_start = Instant::now();
             let response = handler
                 .on_event(HandlerEvent::PermissionRequest {
-                    session_id: sid,
-                    request_id,
+                    session_id: sid.clone(),
+                    request_id: request_id.clone(),
                     data,
                 })
                 .await;
+            tracing::info!(
+                elapsed_ms = elapsed_ms(handler_start),
+                session_id = %sid,
+                request_id = %request_id,
+                "SessionHandler::on_permission_request dispatch"
+            );
             let rpc_response = JsonRpcResponse {
                 jsonrpc: "2.0".to_string(),
                 id: request.id,
@@ -1560,8 +1824,14 @@ async fn handle_request(
                 };
 
             let rpc_result = if let Some(transforms) = transforms {
+                let transform_start = Instant::now();
                 let response =
                     crate::transforms::dispatch_transform(transforms, &sid, sections).await;
+                tracing::info!(
+                    elapsed_ms = elapsed_ms(transform_start),
+                    session_id = %sid,
+                    "SystemMessageTransform::transform_section dispatch"
+                );
                 match serde_json::to_value(response) {
                     Ok(v) => v,
                     Err(e) => {


### PR DESCRIPTION
Adds native logging/tracing diagnostics to make the .NET, Python, and Rust SDKs easier to diagnose when connection setup, JSON-RPC calls, session operations, or host callbacks are slow or failing. The change keeps each SDK idiomatic instead of adding a new telemetry dependency. The TypeScript and Go SDKs were left untouched due to lack of an existing tracing mechanism to utilize.

## Summary

- Add startup breadcrumbs for CLI path selection, process spawn, TCP connect intent/completion, protocol handshake, session filesystem setup, and total client startup.
- Add shared outgoing JSON-RPC request timing plus higher-level session operation timings for create, resume, send, send-and-wait, event dispatch, and callback response paths.
- Improve diagnostic parity across SDKs for CLI output, JSON-RPC read/dispatch failures, session handler failures, hook failures, and cleanup paths.

## Notes

- .NET uses `ILogger` with structured PascalCase fields and `TimeSpan` elapsed values.
- Python uses stdlib `logging` with `extra` fields such as `elapsed_ms`, `session_id`, and request identifiers.
- Rust uses `tracing` structured fields and keeps Rust-specific diagnostics such as lifecycle lag and CLI path resolution warnings.