### PR TITLE
Fix .NET E2E event capture race

### DIFF
--- a/dotnet/test/E2E/RpcShellEdgeCaseE2ETests.cs
+++ b/dotnet/test/E2E/RpcShellEdgeCaseE2ETests.cs
@@ -35,7 +35,9 @@ public class RpcShellEdgeCaseE2ETests(E2ETestFixture fixture, ITestOutputHelper 
             ? $"echo started>\"{startedPath}\" & for /L %i in (1,1,2147483647) do @rem & echo should-not-exist>\"{markerPath}\""
             : $"printf 'started' > '{startedPath}'; sleep 30; printf 'should-not-exist' > '{markerPath}'";
 
-        var result = await session.Rpc.Shell.ExecAsync(command, timeout: TimeSpan.FromMilliseconds(200));
+        // On Windows, terminating the shell wrapper can briefly leave children alive.
+        // Keep this long-running command outside the fixture workspace so cleanup is not blocked by cwd handles.
+        var result = await session.Rpc.Shell.ExecAsync(command, cwd: Path.GetTempPath(), timeout: TimeSpan.FromMilliseconds(200));
         Assert.False(string.IsNullOrWhiteSpace(result.ProcessId));
 
         await TestHelper.WaitForConditionAsync(
@@ -120,7 +122,9 @@ public class RpcShellEdgeCaseE2ETests(E2ETestFixture fixture, ITestOutputHelper 
             ? "powershell -NoLogo -NoProfile -Command \"Start-Sleep -Seconds 60\""
             : "sleep 60";
 
-        var execResult = await session.Rpc.Shell.ExecAsync(command);
+        // On Windows, terminating the shell wrapper can briefly leave grandchildren alive.
+        // Keep this command outside the fixture workspace so cleanup is not blocked by cwd handles.
+        var execResult = await session.Rpc.Shell.ExecAsync(command, cwd: Path.GetTempPath());
         Assert.False(string.IsNullOrWhiteSpace(execResult.ProcessId));
 
         var killResult = await session.Rpc.Shell.KillAsync(execResult.ProcessId, signal);

--- a/dotnet/test/E2E/SessionE2ETests.cs
+++ b/dotnet/test/E2E/SessionE2ETests.cs
@@ -5,6 +5,7 @@
 using GitHub.Copilot.SDK.Test.Harness;
 using GitHub.Copilot.SDK.Rpc;
 using Microsoft.Extensions.AI;
+using System.Collections.Concurrent;
 using System.ComponentModel;
 using Xunit;
 using Xunit.Abstractions;
@@ -401,9 +402,9 @@ public class SessionE2ETests(E2ETestFixture fixture, ITestOutputHelper output) :
         {
             OnPermissionRequest = PermissionHandler.ApproveAll,
         });
-        var events = new List<string>();
+        var events = new ConcurrentQueue<string>();
 
-        session.On(evt => events.Add(evt.Type));
+        session.On(evt => events.Enqueue(evt.Type));
 
         // Use a slow command so we can verify SendAsync() returns before completion
         await session.SendAsync(new MessageOptions { Prompt = "Run 'sleep 2 && echo done'" });
@@ -423,9 +424,9 @@ public class SessionE2ETests(E2ETestFixture fixture, ITestOutputHelper output) :
     public async Task SendAndWait_Blocks_Until_Session_Idle_And_Returns_Final_Assistant_Message()
     {
         var session = await CreateSessionAsync();
-        var events = new List<string>();
+        var events = new ConcurrentQueue<string>();
 
-        session.On(evt => events.Add(evt.Type));
+        session.On(evt => events.Enqueue(evt.Type));
 
         var response = await session.SendAndWaitAsync(new MessageOptions { Prompt = "What is 2+2?" });
 


### PR DESCRIPTION
This fixes two .NET E2E flakes caused by test-side races rather than SDK behavior regressions.

## Changes

- Use `ConcurrentQueue<string>` for event type capture in the affected `SessionE2ETests` cases so assertions can safely enumerate while background event delivery may still append.
- Run long-lived shell edge-case commands from the system temp directory so killed or timed-out child processes cannot keep the fixture workspace directory locked on Windows.
- Preserve the existing assertions and SDK behavior; only test-side synchronization and process cwd selection are changed.

## Validation

- `dotnet build dotnet\test\GitHub.Copilot.SDK.Test.csproj --no-restore`
- `dotnet format dotnet\test\GitHub.Copilot.SDK.Test.csproj --verify-no-changes --include dotnet\test\E2E\SessionE2ETests.cs`
- `dotnet format dotnet\test\GitHub.Copilot.SDK.Test.csproj --verify-no-changes --include dotnet\test\E2E\RpcShellEdgeCaseE2ETests.cs`
- `dotnet test dotnet\test\GitHub.Copilot.SDK.Test.csproj --filter "FullyQualifiedName~RpcShellEdgeCaseE2ETests" --logger "console;verbosity=minimal"`

The targeted `SessionE2ETests.SendAndWait_Blocks_Until_Session_Idle_And_Returns_Final_Assistant_Message` E2E path gets past local dependency startup, but cannot complete in this environment because the CLI auth token lookup fails with `Failed to get token for auth info`.