### PR TITLE
Use string enums for .NET session events

### DIFF
--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -2772,9 +2772,6 @@ public readonly struct DiscoveredMcpServerSource : IEquatable<DiscoveredMcpServe
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="DiscoveredMcpServerSource"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="DiscoveredMcpServerSource"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="DiscoveredMcpServerSource"/>.</param>
     [JsonConstructor]
@@ -2783,6 +2780,9 @@ public readonly struct DiscoveredMcpServerSource : IEquatable<DiscoveredMcpServe
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="DiscoveredMcpServerSource"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>user</c> value.</summary>
     public static DiscoveredMcpServerSource User { get; } = new("user");
@@ -2840,9 +2840,6 @@ public readonly struct DiscoveredMcpServerType : IEquatable<DiscoveredMcpServerT
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="DiscoveredMcpServerType"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="DiscoveredMcpServerType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="DiscoveredMcpServerType"/>.</param>
     [JsonConstructor]
@@ -2851,6 +2848,9 @@ public readonly struct DiscoveredMcpServerType : IEquatable<DiscoveredMcpServerT
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="DiscoveredMcpServerType"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>stdio</c> value.</summary>
     public static DiscoveredMcpServerType Stdio { get; } = new("stdio");
@@ -2908,9 +2908,6 @@ public readonly struct SessionFsSetProviderConventions : IEquatable<SessionFsSet
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="SessionFsSetProviderConventions"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="SessionFsSetProviderConventions"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="SessionFsSetProviderConventions"/>.</param>
     [JsonConstructor]
@@ -2919,6 +2916,9 @@ public readonly struct SessionFsSetProviderConventions : IEquatable<SessionFsSet
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="SessionFsSetProviderConventions"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>windows</c> value.</summary>
     public static SessionFsSetProviderConventions Windows { get; } = new("windows");
@@ -2970,9 +2970,6 @@ public readonly struct SessionLogLevel : IEquatable<SessionLogLevel>
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="SessionLogLevel"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="SessionLogLevel"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="SessionLogLevel"/>.</param>
     [JsonConstructor]
@@ -2981,6 +2978,9 @@ public readonly struct SessionLogLevel : IEquatable<SessionLogLevel>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="SessionLogLevel"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>info</c> value.</summary>
     public static SessionLogLevel Info { get; } = new("info");
@@ -3035,9 +3035,6 @@ public readonly struct AuthInfoType : IEquatable<AuthInfoType>
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="AuthInfoType"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="AuthInfoType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="AuthInfoType"/>.</param>
     [JsonConstructor]
@@ -3046,6 +3043,9 @@ public readonly struct AuthInfoType : IEquatable<AuthInfoType>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="AuthInfoType"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>hmac</c> value.</summary>
     public static AuthInfoType Hmac { get; } = new("hmac");
@@ -3112,9 +3112,6 @@ public readonly struct SessionMode : IEquatable<SessionMode>
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="SessionMode"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="SessionMode"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="SessionMode"/>.</param>
     [JsonConstructor]
@@ -3123,6 +3120,9 @@ public readonly struct SessionMode : IEquatable<SessionMode>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="SessionMode"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>interactive</c> value.</summary>
     public static SessionMode Interactive { get; } = new("interactive");
@@ -3177,9 +3177,6 @@ public readonly struct WorkspacesGetWorkspaceResultWorkspaceHostType : IEquatabl
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="WorkspacesGetWorkspaceResultWorkspaceHostType"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="WorkspacesGetWorkspaceResultWorkspaceHostType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="WorkspacesGetWorkspaceResultWorkspaceHostType"/>.</param>
     [JsonConstructor]
@@ -3188,6 +3185,9 @@ public readonly struct WorkspacesGetWorkspaceResultWorkspaceHostType : IEquatabl
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="WorkspacesGetWorkspaceResultWorkspaceHostType"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>github</c> value.</summary>
     public static WorkspacesGetWorkspaceResultWorkspaceHostType Github { get; } = new("github");
@@ -3239,9 +3239,6 @@ public readonly struct WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel : I
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel"/>.</param>
     [JsonConstructor]
@@ -3250,6 +3247,9 @@ public readonly struct WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel : I
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>local</c> value.</summary>
     public static WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel Local { get; } = new("local");
@@ -3304,9 +3304,6 @@ public readonly struct InstructionsSourcesLocation : IEquatable<InstructionsSour
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="InstructionsSourcesLocation"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="InstructionsSourcesLocation"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="InstructionsSourcesLocation"/>.</param>
     [JsonConstructor]
@@ -3315,6 +3312,9 @@ public readonly struct InstructionsSourcesLocation : IEquatable<InstructionsSour
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="InstructionsSourcesLocation"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>user</c> value.</summary>
     public static InstructionsSourcesLocation User { get; } = new("user");
@@ -3369,9 +3369,6 @@ public readonly struct InstructionsSourcesType : IEquatable<InstructionsSourcesT
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="InstructionsSourcesType"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="InstructionsSourcesType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="InstructionsSourcesType"/>.</param>
     [JsonConstructor]
@@ -3380,6 +3377,9 @@ public readonly struct InstructionsSourcesType : IEquatable<InstructionsSourcesT
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="InstructionsSourcesType"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>home</c> value.</summary>
     public static InstructionsSourcesType Home { get; } = new("home");
@@ -3443,9 +3443,6 @@ public readonly struct TaskAgentInfoExecutionMode : IEquatable<TaskAgentInfoExec
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="TaskAgentInfoExecutionMode"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="TaskAgentInfoExecutionMode"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="TaskAgentInfoExecutionMode"/>.</param>
     [JsonConstructor]
@@ -3454,6 +3451,9 @@ public readonly struct TaskAgentInfoExecutionMode : IEquatable<TaskAgentInfoExec
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="TaskAgentInfoExecutionMode"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>sync</c> value.</summary>
     public static TaskAgentInfoExecutionMode Sync { get; } = new("sync");
@@ -3505,9 +3505,6 @@ public readonly struct TaskAgentInfoStatus : IEquatable<TaskAgentInfoStatus>
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="TaskAgentInfoStatus"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="TaskAgentInfoStatus"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="TaskAgentInfoStatus"/>.</param>
     [JsonConstructor]
@@ -3516,6 +3513,9 @@ public readonly struct TaskAgentInfoStatus : IEquatable<TaskAgentInfoStatus>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="TaskAgentInfoStatus"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>running</c> value.</summary>
     public static TaskAgentInfoStatus Running { get; } = new("running");
@@ -3576,9 +3576,6 @@ public readonly struct TaskShellInfoAttachmentMode : IEquatable<TaskShellInfoAtt
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="TaskShellInfoAttachmentMode"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="TaskShellInfoAttachmentMode"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="TaskShellInfoAttachmentMode"/>.</param>
     [JsonConstructor]
@@ -3587,6 +3584,9 @@ public readonly struct TaskShellInfoAttachmentMode : IEquatable<TaskShellInfoAtt
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="TaskShellInfoAttachmentMode"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>attached</c> value.</summary>
     public static TaskShellInfoAttachmentMode Attached { get; } = new("attached");
@@ -3638,9 +3638,6 @@ public readonly struct TaskShellInfoExecutionMode : IEquatable<TaskShellInfoExec
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="TaskShellInfoExecutionMode"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="TaskShellInfoExecutionMode"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="TaskShellInfoExecutionMode"/>.</param>
     [JsonConstructor]
@@ -3649,6 +3646,9 @@ public readonly struct TaskShellInfoExecutionMode : IEquatable<TaskShellInfoExec
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="TaskShellInfoExecutionMode"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>sync</c> value.</summary>
     public static TaskShellInfoExecutionMode Sync { get; } = new("sync");
@@ -3700,9 +3700,6 @@ public readonly struct TaskShellInfoStatus : IEquatable<TaskShellInfoStatus>
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="TaskShellInfoStatus"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="TaskShellInfoStatus"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="TaskShellInfoStatus"/>.</param>
     [JsonConstructor]
@@ -3711,6 +3708,9 @@ public readonly struct TaskShellInfoStatus : IEquatable<TaskShellInfoStatus>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="TaskShellInfoStatus"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>running</c> value.</summary>
     public static TaskShellInfoStatus Running { get; } = new("running");
@@ -3771,9 +3771,6 @@ public readonly struct McpServerSource : IEquatable<McpServerSource>
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="McpServerSource"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="McpServerSource"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="McpServerSource"/>.</param>
     [JsonConstructor]
@@ -3782,6 +3779,9 @@ public readonly struct McpServerSource : IEquatable<McpServerSource>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="McpServerSource"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>user</c> value.</summary>
     public static McpServerSource User { get; } = new("user");
@@ -3839,9 +3839,6 @@ public readonly struct McpServerStatus : IEquatable<McpServerStatus>
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="McpServerStatus"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="McpServerStatus"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="McpServerStatus"/>.</param>
     [JsonConstructor]
@@ -3850,6 +3847,9 @@ public readonly struct McpServerStatus : IEquatable<McpServerStatus>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="McpServerStatus"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>connected</c> value.</summary>
     public static McpServerStatus Connected { get; } = new("connected");
@@ -3913,9 +3913,6 @@ public readonly struct ExtensionSource : IEquatable<ExtensionSource>
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="ExtensionSource"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="ExtensionSource"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ExtensionSource"/>.</param>
     [JsonConstructor]
@@ -3924,6 +3921,9 @@ public readonly struct ExtensionSource : IEquatable<ExtensionSource>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="ExtensionSource"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>project</c> value.</summary>
     public static ExtensionSource Project { get; } = new("project");
@@ -3975,9 +3975,6 @@ public readonly struct ExtensionStatus : IEquatable<ExtensionStatus>
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="ExtensionStatus"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="ExtensionStatus"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ExtensionStatus"/>.</param>
     [JsonConstructor]
@@ -3986,6 +3983,9 @@ public readonly struct ExtensionStatus : IEquatable<ExtensionStatus>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="ExtensionStatus"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>running</c> value.</summary>
     public static ExtensionStatus Running { get; } = new("running");
@@ -4043,9 +4043,6 @@ public readonly struct UIElicitationResponseAction : IEquatable<UIElicitationRes
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="UIElicitationResponseAction"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="UIElicitationResponseAction"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="UIElicitationResponseAction"/>.</param>
     [JsonConstructor]
@@ -4054,6 +4051,9 @@ public readonly struct UIElicitationResponseAction : IEquatable<UIElicitationRes
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="UIElicitationResponseAction"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>accept</c> value.</summary>
     public static UIElicitationResponseAction Accept { get; } = new("accept");
@@ -4108,9 +4108,6 @@ public readonly struct ShellKillSignal : IEquatable<ShellKillSignal>
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="ShellKillSignal"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="ShellKillSignal"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ShellKillSignal"/>.</param>
     [JsonConstructor]
@@ -4119,6 +4116,9 @@ public readonly struct ShellKillSignal : IEquatable<ShellKillSignal>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="ShellKillSignal"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>SIGTERM</c> value.</summary>
     public static ShellKillSignal SIGTERM { get; } = new("SIGTERM");
@@ -4173,9 +4173,6 @@ public readonly struct SessionFsErrorCode : IEquatable<SessionFsErrorCode>
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="SessionFsErrorCode"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="SessionFsErrorCode"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="SessionFsErrorCode"/>.</param>
     [JsonConstructor]
@@ -4184,6 +4181,9 @@ public readonly struct SessionFsErrorCode : IEquatable<SessionFsErrorCode>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="SessionFsErrorCode"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>ENOENT</c> value.</summary>
     public static SessionFsErrorCode ENOENT { get; } = new("ENOENT");
@@ -4235,9 +4235,6 @@ public readonly struct SessionFsReaddirWithTypesEntryType : IEquatable<SessionFs
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="SessionFsReaddirWithTypesEntryType"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="SessionFsReaddirWithTypesEntryType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="SessionFsReaddirWithTypesEntryType"/>.</param>
     [JsonConstructor]
@@ -4246,6 +4243,9 @@ public readonly struct SessionFsReaddirWithTypesEntryType : IEquatable<SessionFs
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="SessionFsReaddirWithTypesEntryType"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>file</c> value.</summary>
     public static SessionFsReaddirWithTypesEntryType File { get; } = new("file");

--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -2770,18 +2770,6 @@ public sealed class SessionFsRenameRequest
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct DiscoveredMcpServerSource : IEquatable<DiscoveredMcpServerSource>
 {
-    /// <summary>Gets the <c>user</c> value.</summary>
-    public static DiscoveredMcpServerSource User { get; } = new("user");
-
-    /// <summary>Gets the <c>workspace</c> value.</summary>
-    public static DiscoveredMcpServerSource Workspace { get; } = new("workspace");
-
-    /// <summary>Gets the <c>plugin</c> value.</summary>
-    public static DiscoveredMcpServerSource Plugin { get; } = new("plugin");
-
-    /// <summary>Gets the <c>builtin</c> value.</summary>
-    public static DiscoveredMcpServerSource Builtin { get; } = new("builtin");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="DiscoveredMcpServerSource"/>.</summary>
@@ -2795,6 +2783,18 @@ public readonly struct DiscoveredMcpServerSource : IEquatable<DiscoveredMcpServe
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>user</c> value.</summary>
+    public static DiscoveredMcpServerSource User { get; } = new("user");
+
+    /// <summary>Gets the <c>workspace</c> value.</summary>
+    public static DiscoveredMcpServerSource Workspace { get; } = new("workspace");
+
+    /// <summary>Gets the <c>plugin</c> value.</summary>
+    public static DiscoveredMcpServerSource Plugin { get; } = new("plugin");
+
+    /// <summary>Gets the <c>builtin</c> value.</summary>
+    public static DiscoveredMcpServerSource Builtin { get; } = new("builtin");
 
     /// <summary>Returns a value indicating whether two <see cref="DiscoveredMcpServerSource"/> instances are equivalent.</summary>
     public static bool operator ==(DiscoveredMcpServerSource left, DiscoveredMcpServerSource right) => left.Equals(right);
@@ -2838,18 +2838,6 @@ public readonly struct DiscoveredMcpServerSource : IEquatable<DiscoveredMcpServe
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct DiscoveredMcpServerType : IEquatable<DiscoveredMcpServerType>
 {
-    /// <summary>Gets the <c>stdio</c> value.</summary>
-    public static DiscoveredMcpServerType Stdio { get; } = new("stdio");
-
-    /// <summary>Gets the <c>http</c> value.</summary>
-    public static DiscoveredMcpServerType Http { get; } = new("http");
-
-    /// <summary>Gets the <c>sse</c> value.</summary>
-    public static DiscoveredMcpServerType Sse { get; } = new("sse");
-
-    /// <summary>Gets the <c>memory</c> value.</summary>
-    public static DiscoveredMcpServerType Memory { get; } = new("memory");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="DiscoveredMcpServerType"/>.</summary>
@@ -2863,6 +2851,18 @@ public readonly struct DiscoveredMcpServerType : IEquatable<DiscoveredMcpServerT
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>stdio</c> value.</summary>
+    public static DiscoveredMcpServerType Stdio { get; } = new("stdio");
+
+    /// <summary>Gets the <c>http</c> value.</summary>
+    public static DiscoveredMcpServerType Http { get; } = new("http");
+
+    /// <summary>Gets the <c>sse</c> value.</summary>
+    public static DiscoveredMcpServerType Sse { get; } = new("sse");
+
+    /// <summary>Gets the <c>memory</c> value.</summary>
+    public static DiscoveredMcpServerType Memory { get; } = new("memory");
 
     /// <summary>Returns a value indicating whether two <see cref="DiscoveredMcpServerType"/> instances are equivalent.</summary>
     public static bool operator ==(DiscoveredMcpServerType left, DiscoveredMcpServerType right) => left.Equals(right);
@@ -2906,12 +2906,6 @@ public readonly struct DiscoveredMcpServerType : IEquatable<DiscoveredMcpServerT
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct SessionFsSetProviderConventions : IEquatable<SessionFsSetProviderConventions>
 {
-    /// <summary>Gets the <c>windows</c> value.</summary>
-    public static SessionFsSetProviderConventions Windows { get; } = new("windows");
-
-    /// <summary>Gets the <c>posix</c> value.</summary>
-    public static SessionFsSetProviderConventions Posix { get; } = new("posix");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="SessionFsSetProviderConventions"/>.</summary>
@@ -2925,6 +2919,12 @@ public readonly struct SessionFsSetProviderConventions : IEquatable<SessionFsSet
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>windows</c> value.</summary>
+    public static SessionFsSetProviderConventions Windows { get; } = new("windows");
+
+    /// <summary>Gets the <c>posix</c> value.</summary>
+    public static SessionFsSetProviderConventions Posix { get; } = new("posix");
 
     /// <summary>Returns a value indicating whether two <see cref="SessionFsSetProviderConventions"/> instances are equivalent.</summary>
     public static bool operator ==(SessionFsSetProviderConventions left, SessionFsSetProviderConventions right) => left.Equals(right);
@@ -2968,15 +2968,6 @@ public readonly struct SessionFsSetProviderConventions : IEquatable<SessionFsSet
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct SessionLogLevel : IEquatable<SessionLogLevel>
 {
-    /// <summary>Gets the <c>info</c> value.</summary>
-    public static SessionLogLevel Info { get; } = new("info");
-
-    /// <summary>Gets the <c>warning</c> value.</summary>
-    public static SessionLogLevel Warning { get; } = new("warning");
-
-    /// <summary>Gets the <c>error</c> value.</summary>
-    public static SessionLogLevel Error { get; } = new("error");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="SessionLogLevel"/>.</summary>
@@ -2990,6 +2981,15 @@ public readonly struct SessionLogLevel : IEquatable<SessionLogLevel>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>info</c> value.</summary>
+    public static SessionLogLevel Info { get; } = new("info");
+
+    /// <summary>Gets the <c>warning</c> value.</summary>
+    public static SessionLogLevel Warning { get; } = new("warning");
+
+    /// <summary>Gets the <c>error</c> value.</summary>
+    public static SessionLogLevel Error { get; } = new("error");
 
     /// <summary>Returns a value indicating whether two <see cref="SessionLogLevel"/> instances are equivalent.</summary>
     public static bool operator ==(SessionLogLevel left, SessionLogLevel right) => left.Equals(right);
@@ -3033,6 +3033,20 @@ public readonly struct SessionLogLevel : IEquatable<SessionLogLevel>
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct AuthInfoType : IEquatable<AuthInfoType>
 {
+    private readonly string? _value;
+
+    /// <summary>Gets the value associated with this <see cref="AuthInfoType"/>.</summary>
+    public string Value => _value ?? string.Empty;
+
+    /// <summary>Initializes a new instance of the <see cref="AuthInfoType"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="AuthInfoType"/>.</param>
+    [JsonConstructor]
+    public AuthInfoType(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        _value = value;
+    }
+
     /// <summary>Gets the <c>hmac</c> value.</summary>
     public static AuthInfoType Hmac { get; } = new("hmac");
 
@@ -3053,20 +3067,6 @@ public readonly struct AuthInfoType : IEquatable<AuthInfoType>
 
     /// <summary>Gets the <c>copilot-api-token</c> value.</summary>
     public static AuthInfoType CopilotApiToken { get; } = new("copilot-api-token");
-
-    private readonly string? _value;
-
-    /// <summary>Gets the value associated with this <see cref="AuthInfoType"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
-    /// <summary>Initializes a new instance of the <see cref="AuthInfoType"/> struct.</summary>
-    /// <param name="value">The value to associate with this <see cref="AuthInfoType"/>.</param>
-    [JsonConstructor]
-    public AuthInfoType(string value)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        _value = value;
-    }
 
     /// <summary>Returns a value indicating whether two <see cref="AuthInfoType"/> instances are equivalent.</summary>
     public static bool operator ==(AuthInfoType left, AuthInfoType right) => left.Equals(right);
@@ -3110,15 +3110,6 @@ public readonly struct AuthInfoType : IEquatable<AuthInfoType>
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct SessionMode : IEquatable<SessionMode>
 {
-    /// <summary>Gets the <c>interactive</c> value.</summary>
-    public static SessionMode Interactive { get; } = new("interactive");
-
-    /// <summary>Gets the <c>plan</c> value.</summary>
-    public static SessionMode Plan { get; } = new("plan");
-
-    /// <summary>Gets the <c>autopilot</c> value.</summary>
-    public static SessionMode Autopilot { get; } = new("autopilot");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="SessionMode"/>.</summary>
@@ -3132,6 +3123,15 @@ public readonly struct SessionMode : IEquatable<SessionMode>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>interactive</c> value.</summary>
+    public static SessionMode Interactive { get; } = new("interactive");
+
+    /// <summary>Gets the <c>plan</c> value.</summary>
+    public static SessionMode Plan { get; } = new("plan");
+
+    /// <summary>Gets the <c>autopilot</c> value.</summary>
+    public static SessionMode Autopilot { get; } = new("autopilot");
 
     /// <summary>Returns a value indicating whether two <see cref="SessionMode"/> instances are equivalent.</summary>
     public static bool operator ==(SessionMode left, SessionMode right) => left.Equals(right);
@@ -3175,12 +3175,6 @@ public readonly struct SessionMode : IEquatable<SessionMode>
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct WorkspacesGetWorkspaceResultWorkspaceHostType : IEquatable<WorkspacesGetWorkspaceResultWorkspaceHostType>
 {
-    /// <summary>Gets the <c>github</c> value.</summary>
-    public static WorkspacesGetWorkspaceResultWorkspaceHostType Github { get; } = new("github");
-
-    /// <summary>Gets the <c>ado</c> value.</summary>
-    public static WorkspacesGetWorkspaceResultWorkspaceHostType Ado { get; } = new("ado");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="WorkspacesGetWorkspaceResultWorkspaceHostType"/>.</summary>
@@ -3194,6 +3188,12 @@ public readonly struct WorkspacesGetWorkspaceResultWorkspaceHostType : IEquatabl
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>github</c> value.</summary>
+    public static WorkspacesGetWorkspaceResultWorkspaceHostType Github { get; } = new("github");
+
+    /// <summary>Gets the <c>ado</c> value.</summary>
+    public static WorkspacesGetWorkspaceResultWorkspaceHostType Ado { get; } = new("ado");
 
     /// <summary>Returns a value indicating whether two <see cref="WorkspacesGetWorkspaceResultWorkspaceHostType"/> instances are equivalent.</summary>
     public static bool operator ==(WorkspacesGetWorkspaceResultWorkspaceHostType left, WorkspacesGetWorkspaceResultWorkspaceHostType right) => left.Equals(right);
@@ -3237,15 +3237,6 @@ public readonly struct WorkspacesGetWorkspaceResultWorkspaceHostType : IEquatabl
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel : IEquatable<WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel>
 {
-    /// <summary>Gets the <c>local</c> value.</summary>
-    public static WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel Local { get; } = new("local");
-
-    /// <summary>Gets the <c>user</c> value.</summary>
-    public static WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel User { get; } = new("user");
-
-    /// <summary>Gets the <c>repo_and_user</c> value.</summary>
-    public static WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel RepoAndUser { get; } = new("repo_and_user");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel"/>.</summary>
@@ -3259,6 +3250,15 @@ public readonly struct WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel : I
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>local</c> value.</summary>
+    public static WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel Local { get; } = new("local");
+
+    /// <summary>Gets the <c>user</c> value.</summary>
+    public static WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel User { get; } = new("user");
+
+    /// <summary>Gets the <c>repo_and_user</c> value.</summary>
+    public static WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel RepoAndUser { get; } = new("repo_and_user");
 
     /// <summary>Returns a value indicating whether two <see cref="WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel"/> instances are equivalent.</summary>
     public static bool operator ==(WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel left, WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel right) => left.Equals(right);
@@ -3302,15 +3302,6 @@ public readonly struct WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel : I
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct InstructionsSourcesLocation : IEquatable<InstructionsSourcesLocation>
 {
-    /// <summary>Gets the <c>user</c> value.</summary>
-    public static InstructionsSourcesLocation User { get; } = new("user");
-
-    /// <summary>Gets the <c>repository</c> value.</summary>
-    public static InstructionsSourcesLocation Repository { get; } = new("repository");
-
-    /// <summary>Gets the <c>working-directory</c> value.</summary>
-    public static InstructionsSourcesLocation WorkingDirectory { get; } = new("working-directory");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="InstructionsSourcesLocation"/>.</summary>
@@ -3324,6 +3315,15 @@ public readonly struct InstructionsSourcesLocation : IEquatable<InstructionsSour
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>user</c> value.</summary>
+    public static InstructionsSourcesLocation User { get; } = new("user");
+
+    /// <summary>Gets the <c>repository</c> value.</summary>
+    public static InstructionsSourcesLocation Repository { get; } = new("repository");
+
+    /// <summary>Gets the <c>working-directory</c> value.</summary>
+    public static InstructionsSourcesLocation WorkingDirectory { get; } = new("working-directory");
 
     /// <summary>Returns a value indicating whether two <see cref="InstructionsSourcesLocation"/> instances are equivalent.</summary>
     public static bool operator ==(InstructionsSourcesLocation left, InstructionsSourcesLocation right) => left.Equals(right);
@@ -3367,6 +3367,20 @@ public readonly struct InstructionsSourcesLocation : IEquatable<InstructionsSour
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct InstructionsSourcesType : IEquatable<InstructionsSourcesType>
 {
+    private readonly string? _value;
+
+    /// <summary>Gets the value associated with this <see cref="InstructionsSourcesType"/>.</summary>
+    public string Value => _value ?? string.Empty;
+
+    /// <summary>Initializes a new instance of the <see cref="InstructionsSourcesType"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="InstructionsSourcesType"/>.</param>
+    [JsonConstructor]
+    public InstructionsSourcesType(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        _value = value;
+    }
+
     /// <summary>Gets the <c>home</c> value.</summary>
     public static InstructionsSourcesType Home { get; } = new("home");
 
@@ -3384,20 +3398,6 @@ public readonly struct InstructionsSourcesType : IEquatable<InstructionsSourcesT
 
     /// <summary>Gets the <c>child-instructions</c> value.</summary>
     public static InstructionsSourcesType ChildInstructions { get; } = new("child-instructions");
-
-    private readonly string? _value;
-
-    /// <summary>Gets the value associated with this <see cref="InstructionsSourcesType"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
-    /// <summary>Initializes a new instance of the <see cref="InstructionsSourcesType"/> struct.</summary>
-    /// <param name="value">The value to associate with this <see cref="InstructionsSourcesType"/>.</param>
-    [JsonConstructor]
-    public InstructionsSourcesType(string value)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        _value = value;
-    }
 
     /// <summary>Returns a value indicating whether two <see cref="InstructionsSourcesType"/> instances are equivalent.</summary>
     public static bool operator ==(InstructionsSourcesType left, InstructionsSourcesType right) => left.Equals(right);
@@ -3441,12 +3441,6 @@ public readonly struct InstructionsSourcesType : IEquatable<InstructionsSourcesT
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct TaskAgentInfoExecutionMode : IEquatable<TaskAgentInfoExecutionMode>
 {
-    /// <summary>Gets the <c>sync</c> value.</summary>
-    public static TaskAgentInfoExecutionMode Sync { get; } = new("sync");
-
-    /// <summary>Gets the <c>background</c> value.</summary>
-    public static TaskAgentInfoExecutionMode Background { get; } = new("background");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="TaskAgentInfoExecutionMode"/>.</summary>
@@ -3460,6 +3454,12 @@ public readonly struct TaskAgentInfoExecutionMode : IEquatable<TaskAgentInfoExec
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>sync</c> value.</summary>
+    public static TaskAgentInfoExecutionMode Sync { get; } = new("sync");
+
+    /// <summary>Gets the <c>background</c> value.</summary>
+    public static TaskAgentInfoExecutionMode Background { get; } = new("background");
 
     /// <summary>Returns a value indicating whether two <see cref="TaskAgentInfoExecutionMode"/> instances are equivalent.</summary>
     public static bool operator ==(TaskAgentInfoExecutionMode left, TaskAgentInfoExecutionMode right) => left.Equals(right);
@@ -3503,6 +3503,20 @@ public readonly struct TaskAgentInfoExecutionMode : IEquatable<TaskAgentInfoExec
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct TaskAgentInfoStatus : IEquatable<TaskAgentInfoStatus>
 {
+    private readonly string? _value;
+
+    /// <summary>Gets the value associated with this <see cref="TaskAgentInfoStatus"/>.</summary>
+    public string Value => _value ?? string.Empty;
+
+    /// <summary>Initializes a new instance of the <see cref="TaskAgentInfoStatus"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="TaskAgentInfoStatus"/>.</param>
+    [JsonConstructor]
+    public TaskAgentInfoStatus(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        _value = value;
+    }
+
     /// <summary>Gets the <c>running</c> value.</summary>
     public static TaskAgentInfoStatus Running { get; } = new("running");
 
@@ -3517,20 +3531,6 @@ public readonly struct TaskAgentInfoStatus : IEquatable<TaskAgentInfoStatus>
 
     /// <summary>Gets the <c>cancelled</c> value.</summary>
     public static TaskAgentInfoStatus Cancelled { get; } = new("cancelled");
-
-    private readonly string? _value;
-
-    /// <summary>Gets the value associated with this <see cref="TaskAgentInfoStatus"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
-    /// <summary>Initializes a new instance of the <see cref="TaskAgentInfoStatus"/> struct.</summary>
-    /// <param name="value">The value to associate with this <see cref="TaskAgentInfoStatus"/>.</param>
-    [JsonConstructor]
-    public TaskAgentInfoStatus(string value)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        _value = value;
-    }
 
     /// <summary>Returns a value indicating whether two <see cref="TaskAgentInfoStatus"/> instances are equivalent.</summary>
     public static bool operator ==(TaskAgentInfoStatus left, TaskAgentInfoStatus right) => left.Equals(right);
@@ -3574,12 +3574,6 @@ public readonly struct TaskAgentInfoStatus : IEquatable<TaskAgentInfoStatus>
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct TaskShellInfoAttachmentMode : IEquatable<TaskShellInfoAttachmentMode>
 {
-    /// <summary>Gets the <c>attached</c> value.</summary>
-    public static TaskShellInfoAttachmentMode Attached { get; } = new("attached");
-
-    /// <summary>Gets the <c>detached</c> value.</summary>
-    public static TaskShellInfoAttachmentMode Detached { get; } = new("detached");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="TaskShellInfoAttachmentMode"/>.</summary>
@@ -3593,6 +3587,12 @@ public readonly struct TaskShellInfoAttachmentMode : IEquatable<TaskShellInfoAtt
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>attached</c> value.</summary>
+    public static TaskShellInfoAttachmentMode Attached { get; } = new("attached");
+
+    /// <summary>Gets the <c>detached</c> value.</summary>
+    public static TaskShellInfoAttachmentMode Detached { get; } = new("detached");
 
     /// <summary>Returns a value indicating whether two <see cref="TaskShellInfoAttachmentMode"/> instances are equivalent.</summary>
     public static bool operator ==(TaskShellInfoAttachmentMode left, TaskShellInfoAttachmentMode right) => left.Equals(right);
@@ -3636,12 +3636,6 @@ public readonly struct TaskShellInfoAttachmentMode : IEquatable<TaskShellInfoAtt
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct TaskShellInfoExecutionMode : IEquatable<TaskShellInfoExecutionMode>
 {
-    /// <summary>Gets the <c>sync</c> value.</summary>
-    public static TaskShellInfoExecutionMode Sync { get; } = new("sync");
-
-    /// <summary>Gets the <c>background</c> value.</summary>
-    public static TaskShellInfoExecutionMode Background { get; } = new("background");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="TaskShellInfoExecutionMode"/>.</summary>
@@ -3655,6 +3649,12 @@ public readonly struct TaskShellInfoExecutionMode : IEquatable<TaskShellInfoExec
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>sync</c> value.</summary>
+    public static TaskShellInfoExecutionMode Sync { get; } = new("sync");
+
+    /// <summary>Gets the <c>background</c> value.</summary>
+    public static TaskShellInfoExecutionMode Background { get; } = new("background");
 
     /// <summary>Returns a value indicating whether two <see cref="TaskShellInfoExecutionMode"/> instances are equivalent.</summary>
     public static bool operator ==(TaskShellInfoExecutionMode left, TaskShellInfoExecutionMode right) => left.Equals(right);
@@ -3698,6 +3698,20 @@ public readonly struct TaskShellInfoExecutionMode : IEquatable<TaskShellInfoExec
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct TaskShellInfoStatus : IEquatable<TaskShellInfoStatus>
 {
+    private readonly string? _value;
+
+    /// <summary>Gets the value associated with this <see cref="TaskShellInfoStatus"/>.</summary>
+    public string Value => _value ?? string.Empty;
+
+    /// <summary>Initializes a new instance of the <see cref="TaskShellInfoStatus"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="TaskShellInfoStatus"/>.</param>
+    [JsonConstructor]
+    public TaskShellInfoStatus(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        _value = value;
+    }
+
     /// <summary>Gets the <c>running</c> value.</summary>
     public static TaskShellInfoStatus Running { get; } = new("running");
 
@@ -3712,20 +3726,6 @@ public readonly struct TaskShellInfoStatus : IEquatable<TaskShellInfoStatus>
 
     /// <summary>Gets the <c>cancelled</c> value.</summary>
     public static TaskShellInfoStatus Cancelled { get; } = new("cancelled");
-
-    private readonly string? _value;
-
-    /// <summary>Gets the value associated with this <see cref="TaskShellInfoStatus"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
-    /// <summary>Initializes a new instance of the <see cref="TaskShellInfoStatus"/> struct.</summary>
-    /// <param name="value">The value to associate with this <see cref="TaskShellInfoStatus"/>.</param>
-    [JsonConstructor]
-    public TaskShellInfoStatus(string value)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        _value = value;
-    }
 
     /// <summary>Returns a value indicating whether two <see cref="TaskShellInfoStatus"/> instances are equivalent.</summary>
     public static bool operator ==(TaskShellInfoStatus left, TaskShellInfoStatus right) => left.Equals(right);
@@ -3769,18 +3769,6 @@ public readonly struct TaskShellInfoStatus : IEquatable<TaskShellInfoStatus>
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct McpServerSource : IEquatable<McpServerSource>
 {
-    /// <summary>Gets the <c>user</c> value.</summary>
-    public static McpServerSource User { get; } = new("user");
-
-    /// <summary>Gets the <c>workspace</c> value.</summary>
-    public static McpServerSource Workspace { get; } = new("workspace");
-
-    /// <summary>Gets the <c>plugin</c> value.</summary>
-    public static McpServerSource Plugin { get; } = new("plugin");
-
-    /// <summary>Gets the <c>builtin</c> value.</summary>
-    public static McpServerSource Builtin { get; } = new("builtin");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="McpServerSource"/>.</summary>
@@ -3794,6 +3782,18 @@ public readonly struct McpServerSource : IEquatable<McpServerSource>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>user</c> value.</summary>
+    public static McpServerSource User { get; } = new("user");
+
+    /// <summary>Gets the <c>workspace</c> value.</summary>
+    public static McpServerSource Workspace { get; } = new("workspace");
+
+    /// <summary>Gets the <c>plugin</c> value.</summary>
+    public static McpServerSource Plugin { get; } = new("plugin");
+
+    /// <summary>Gets the <c>builtin</c> value.</summary>
+    public static McpServerSource Builtin { get; } = new("builtin");
 
     /// <summary>Returns a value indicating whether two <see cref="McpServerSource"/> instances are equivalent.</summary>
     public static bool operator ==(McpServerSource left, McpServerSource right) => left.Equals(right);
@@ -3837,6 +3837,20 @@ public readonly struct McpServerSource : IEquatable<McpServerSource>
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct McpServerStatus : IEquatable<McpServerStatus>
 {
+    private readonly string? _value;
+
+    /// <summary>Gets the value associated with this <see cref="McpServerStatus"/>.</summary>
+    public string Value => _value ?? string.Empty;
+
+    /// <summary>Initializes a new instance of the <see cref="McpServerStatus"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="McpServerStatus"/>.</param>
+    [JsonConstructor]
+    public McpServerStatus(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        _value = value;
+    }
+
     /// <summary>Gets the <c>connected</c> value.</summary>
     public static McpServerStatus Connected { get; } = new("connected");
 
@@ -3854,20 +3868,6 @@ public readonly struct McpServerStatus : IEquatable<McpServerStatus>
 
     /// <summary>Gets the <c>not_configured</c> value.</summary>
     public static McpServerStatus NotConfigured { get; } = new("not_configured");
-
-    private readonly string? _value;
-
-    /// <summary>Gets the value associated with this <see cref="McpServerStatus"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
-    /// <summary>Initializes a new instance of the <see cref="McpServerStatus"/> struct.</summary>
-    /// <param name="value">The value to associate with this <see cref="McpServerStatus"/>.</param>
-    [JsonConstructor]
-    public McpServerStatus(string value)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        _value = value;
-    }
 
     /// <summary>Returns a value indicating whether two <see cref="McpServerStatus"/> instances are equivalent.</summary>
     public static bool operator ==(McpServerStatus left, McpServerStatus right) => left.Equals(right);
@@ -3911,12 +3911,6 @@ public readonly struct McpServerStatus : IEquatable<McpServerStatus>
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct ExtensionSource : IEquatable<ExtensionSource>
 {
-    /// <summary>Gets the <c>project</c> value.</summary>
-    public static ExtensionSource Project { get; } = new("project");
-
-    /// <summary>Gets the <c>user</c> value.</summary>
-    public static ExtensionSource User { get; } = new("user");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="ExtensionSource"/>.</summary>
@@ -3930,6 +3924,12 @@ public readonly struct ExtensionSource : IEquatable<ExtensionSource>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>project</c> value.</summary>
+    public static ExtensionSource Project { get; } = new("project");
+
+    /// <summary>Gets the <c>user</c> value.</summary>
+    public static ExtensionSource User { get; } = new("user");
 
     /// <summary>Returns a value indicating whether two <see cref="ExtensionSource"/> instances are equivalent.</summary>
     public static bool operator ==(ExtensionSource left, ExtensionSource right) => left.Equals(right);
@@ -3973,18 +3973,6 @@ public readonly struct ExtensionSource : IEquatable<ExtensionSource>
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct ExtensionStatus : IEquatable<ExtensionStatus>
 {
-    /// <summary>Gets the <c>running</c> value.</summary>
-    public static ExtensionStatus Running { get; } = new("running");
-
-    /// <summary>Gets the <c>disabled</c> value.</summary>
-    public static ExtensionStatus Disabled { get; } = new("disabled");
-
-    /// <summary>Gets the <c>failed</c> value.</summary>
-    public static ExtensionStatus Failed { get; } = new("failed");
-
-    /// <summary>Gets the <c>starting</c> value.</summary>
-    public static ExtensionStatus Starting { get; } = new("starting");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="ExtensionStatus"/>.</summary>
@@ -3998,6 +3986,18 @@ public readonly struct ExtensionStatus : IEquatable<ExtensionStatus>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>running</c> value.</summary>
+    public static ExtensionStatus Running { get; } = new("running");
+
+    /// <summary>Gets the <c>disabled</c> value.</summary>
+    public static ExtensionStatus Disabled { get; } = new("disabled");
+
+    /// <summary>Gets the <c>failed</c> value.</summary>
+    public static ExtensionStatus Failed { get; } = new("failed");
+
+    /// <summary>Gets the <c>starting</c> value.</summary>
+    public static ExtensionStatus Starting { get; } = new("starting");
 
     /// <summary>Returns a value indicating whether two <see cref="ExtensionStatus"/> instances are equivalent.</summary>
     public static bool operator ==(ExtensionStatus left, ExtensionStatus right) => left.Equals(right);
@@ -4041,15 +4041,6 @@ public readonly struct ExtensionStatus : IEquatable<ExtensionStatus>
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct UIElicitationResponseAction : IEquatable<UIElicitationResponseAction>
 {
-    /// <summary>Gets the <c>accept</c> value.</summary>
-    public static UIElicitationResponseAction Accept { get; } = new("accept");
-
-    /// <summary>Gets the <c>decline</c> value.</summary>
-    public static UIElicitationResponseAction Decline { get; } = new("decline");
-
-    /// <summary>Gets the <c>cancel</c> value.</summary>
-    public static UIElicitationResponseAction Cancel { get; } = new("cancel");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="UIElicitationResponseAction"/>.</summary>
@@ -4063,6 +4054,15 @@ public readonly struct UIElicitationResponseAction : IEquatable<UIElicitationRes
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>accept</c> value.</summary>
+    public static UIElicitationResponseAction Accept { get; } = new("accept");
+
+    /// <summary>Gets the <c>decline</c> value.</summary>
+    public static UIElicitationResponseAction Decline { get; } = new("decline");
+
+    /// <summary>Gets the <c>cancel</c> value.</summary>
+    public static UIElicitationResponseAction Cancel { get; } = new("cancel");
 
     /// <summary>Returns a value indicating whether two <see cref="UIElicitationResponseAction"/> instances are equivalent.</summary>
     public static bool operator ==(UIElicitationResponseAction left, UIElicitationResponseAction right) => left.Equals(right);
@@ -4106,15 +4106,6 @@ public readonly struct UIElicitationResponseAction : IEquatable<UIElicitationRes
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct ShellKillSignal : IEquatable<ShellKillSignal>
 {
-    /// <summary>Gets the <c>SIGTERM</c> value.</summary>
-    public static ShellKillSignal SIGTERM { get; } = new("SIGTERM");
-
-    /// <summary>Gets the <c>SIGKILL</c> value.</summary>
-    public static ShellKillSignal SIGKILL { get; } = new("SIGKILL");
-
-    /// <summary>Gets the <c>SIGINT</c> value.</summary>
-    public static ShellKillSignal SIGINT { get; } = new("SIGINT");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="ShellKillSignal"/>.</summary>
@@ -4128,6 +4119,15 @@ public readonly struct ShellKillSignal : IEquatable<ShellKillSignal>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>SIGTERM</c> value.</summary>
+    public static ShellKillSignal SIGTERM { get; } = new("SIGTERM");
+
+    /// <summary>Gets the <c>SIGKILL</c> value.</summary>
+    public static ShellKillSignal SIGKILL { get; } = new("SIGKILL");
+
+    /// <summary>Gets the <c>SIGINT</c> value.</summary>
+    public static ShellKillSignal SIGINT { get; } = new("SIGINT");
 
     /// <summary>Returns a value indicating whether two <see cref="ShellKillSignal"/> instances are equivalent.</summary>
     public static bool operator ==(ShellKillSignal left, ShellKillSignal right) => left.Equals(right);
@@ -4171,12 +4171,6 @@ public readonly struct ShellKillSignal : IEquatable<ShellKillSignal>
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct SessionFsErrorCode : IEquatable<SessionFsErrorCode>
 {
-    /// <summary>Gets the <c>ENOENT</c> value.</summary>
-    public static SessionFsErrorCode ENOENT { get; } = new("ENOENT");
-
-    /// <summary>Gets the <c>UNKNOWN</c> value.</summary>
-    public static SessionFsErrorCode UNKNOWN { get; } = new("UNKNOWN");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="SessionFsErrorCode"/>.</summary>
@@ -4190,6 +4184,12 @@ public readonly struct SessionFsErrorCode : IEquatable<SessionFsErrorCode>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>ENOENT</c> value.</summary>
+    public static SessionFsErrorCode ENOENT { get; } = new("ENOENT");
+
+    /// <summary>Gets the <c>UNKNOWN</c> value.</summary>
+    public static SessionFsErrorCode UNKNOWN { get; } = new("UNKNOWN");
 
     /// <summary>Returns a value indicating whether two <see cref="SessionFsErrorCode"/> instances are equivalent.</summary>
     public static bool operator ==(SessionFsErrorCode left, SessionFsErrorCode right) => left.Equals(right);
@@ -4233,12 +4233,6 @@ public readonly struct SessionFsErrorCode : IEquatable<SessionFsErrorCode>
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct SessionFsReaddirWithTypesEntryType : IEquatable<SessionFsReaddirWithTypesEntryType>
 {
-    /// <summary>Gets the <c>file</c> value.</summary>
-    public static SessionFsReaddirWithTypesEntryType File { get; } = new("file");
-
-    /// <summary>Gets the <c>directory</c> value.</summary>
-    public static SessionFsReaddirWithTypesEntryType Directory { get; } = new("directory");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="SessionFsReaddirWithTypesEntryType"/>.</summary>
@@ -4252,6 +4246,12 @@ public readonly struct SessionFsReaddirWithTypesEntryType : IEquatable<SessionFs
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>file</c> value.</summary>
+    public static SessionFsReaddirWithTypesEntryType File { get; } = new("file");
+
+    /// <summary>Gets the <c>directory</c> value.</summary>
+    public static SessionFsReaddirWithTypesEntryType Directory { get; } = new("directory");
 
     /// <summary>Returns a value indicating whether two <see cref="SessionFsReaddirWithTypesEntryType"/> instances are equivalent.</summary>
     public static bool operator ==(SessionFsReaddirWithTypesEntryType left, SessionFsReaddirWithTypesEntryType right) => left.Equals(right);

--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -2782,8 +2782,10 @@ public readonly struct DiscoveredMcpServerSource : IEquatable<DiscoveredMcpServe
     /// <summary>Gets the <c>builtin</c> value.</summary>
     public static DiscoveredMcpServerSource Builtin { get; } = new("builtin");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="DiscoveredMcpServerSource"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="DiscoveredMcpServerSource"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="DiscoveredMcpServerSource"/>.</param>
@@ -2791,7 +2793,7 @@ public readonly struct DiscoveredMcpServerSource : IEquatable<DiscoveredMcpServe
     public DiscoveredMcpServerSource(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="DiscoveredMcpServerSource"/> instances are equivalent.</summary>
@@ -2807,10 +2809,10 @@ public readonly struct DiscoveredMcpServerSource : IEquatable<DiscoveredMcpServe
     public bool Equals(DiscoveredMcpServerSource other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{DiscoveredMcpServerSource}"/> for serializing <see cref="DiscoveredMcpServerSource"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -2851,8 +2853,10 @@ public readonly struct DiscoveredMcpServerType : IEquatable<DiscoveredMcpServerT
     /// <summary>Gets the <c>memory</c> value.</summary>
     public static DiscoveredMcpServerType Memory { get; } = new("memory");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="DiscoveredMcpServerType"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="DiscoveredMcpServerType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="DiscoveredMcpServerType"/>.</param>
@@ -2860,7 +2864,7 @@ public readonly struct DiscoveredMcpServerType : IEquatable<DiscoveredMcpServerT
     public DiscoveredMcpServerType(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="DiscoveredMcpServerType"/> instances are equivalent.</summary>
@@ -2876,10 +2880,10 @@ public readonly struct DiscoveredMcpServerType : IEquatable<DiscoveredMcpServerT
     public bool Equals(DiscoveredMcpServerType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{DiscoveredMcpServerType}"/> for serializing <see cref="DiscoveredMcpServerType"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -2914,8 +2918,10 @@ public readonly struct SessionFsSetProviderConventions : IEquatable<SessionFsSet
     /// <summary>Gets the <c>posix</c> value.</summary>
     public static SessionFsSetProviderConventions Posix { get; } = new("posix");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="SessionFsSetProviderConventions"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="SessionFsSetProviderConventions"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="SessionFsSetProviderConventions"/>.</param>
@@ -2923,7 +2929,7 @@ public readonly struct SessionFsSetProviderConventions : IEquatable<SessionFsSet
     public SessionFsSetProviderConventions(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="SessionFsSetProviderConventions"/> instances are equivalent.</summary>
@@ -2939,10 +2945,10 @@ public readonly struct SessionFsSetProviderConventions : IEquatable<SessionFsSet
     public bool Equals(SessionFsSetProviderConventions other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{SessionFsSetProviderConventions}"/> for serializing <see cref="SessionFsSetProviderConventions"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -2980,8 +2986,10 @@ public readonly struct SessionLogLevel : IEquatable<SessionLogLevel>
     /// <summary>Gets the <c>error</c> value.</summary>
     public static SessionLogLevel Error { get; } = new("error");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="SessionLogLevel"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="SessionLogLevel"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="SessionLogLevel"/>.</param>
@@ -2989,7 +2997,7 @@ public readonly struct SessionLogLevel : IEquatable<SessionLogLevel>
     public SessionLogLevel(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="SessionLogLevel"/> instances are equivalent.</summary>
@@ -3005,10 +3013,10 @@ public readonly struct SessionLogLevel : IEquatable<SessionLogLevel>
     public bool Equals(SessionLogLevel other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{SessionLogLevel}"/> for serializing <see cref="SessionLogLevel"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -3058,8 +3066,10 @@ public readonly struct AuthInfoType : IEquatable<AuthInfoType>
     /// <summary>Gets the <c>copilot-api-token</c> value.</summary>
     public static AuthInfoType CopilotApiToken { get; } = new("copilot-api-token");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="AuthInfoType"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="AuthInfoType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="AuthInfoType"/>.</param>
@@ -3067,7 +3077,7 @@ public readonly struct AuthInfoType : IEquatable<AuthInfoType>
     public AuthInfoType(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="AuthInfoType"/> instances are equivalent.</summary>
@@ -3083,10 +3093,10 @@ public readonly struct AuthInfoType : IEquatable<AuthInfoType>
     public bool Equals(AuthInfoType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{AuthInfoType}"/> for serializing <see cref="AuthInfoType"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -3124,8 +3134,10 @@ public readonly struct SessionMode : IEquatable<SessionMode>
     /// <summary>Gets the <c>autopilot</c> value.</summary>
     public static SessionMode Autopilot { get; } = new("autopilot");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="SessionMode"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="SessionMode"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="SessionMode"/>.</param>
@@ -3133,7 +3145,7 @@ public readonly struct SessionMode : IEquatable<SessionMode>
     public SessionMode(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="SessionMode"/> instances are equivalent.</summary>
@@ -3149,10 +3161,10 @@ public readonly struct SessionMode : IEquatable<SessionMode>
     public bool Equals(SessionMode other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{SessionMode}"/> for serializing <see cref="SessionMode"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -3187,8 +3199,10 @@ public readonly struct WorkspacesGetWorkspaceResultWorkspaceHostType : IEquatabl
     /// <summary>Gets the <c>ado</c> value.</summary>
     public static WorkspacesGetWorkspaceResultWorkspaceHostType Ado { get; } = new("ado");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="WorkspacesGetWorkspaceResultWorkspaceHostType"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="WorkspacesGetWorkspaceResultWorkspaceHostType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="WorkspacesGetWorkspaceResultWorkspaceHostType"/>.</param>
@@ -3196,7 +3210,7 @@ public readonly struct WorkspacesGetWorkspaceResultWorkspaceHostType : IEquatabl
     public WorkspacesGetWorkspaceResultWorkspaceHostType(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="WorkspacesGetWorkspaceResultWorkspaceHostType"/> instances are equivalent.</summary>
@@ -3212,10 +3226,10 @@ public readonly struct WorkspacesGetWorkspaceResultWorkspaceHostType : IEquatabl
     public bool Equals(WorkspacesGetWorkspaceResultWorkspaceHostType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{WorkspacesGetWorkspaceResultWorkspaceHostType}"/> for serializing <see cref="WorkspacesGetWorkspaceResultWorkspaceHostType"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -3253,8 +3267,10 @@ public readonly struct WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel : I
     /// <summary>Gets the <c>repo_and_user</c> value.</summary>
     public static WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel RepoAndUser { get; } = new("repo_and_user");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel"/>.</param>
@@ -3262,7 +3278,7 @@ public readonly struct WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel : I
     public WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel"/> instances are equivalent.</summary>
@@ -3278,10 +3294,10 @@ public readonly struct WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel : I
     public bool Equals(WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel}"/> for serializing <see cref="WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -3319,8 +3335,10 @@ public readonly struct InstructionsSourcesLocation : IEquatable<InstructionsSour
     /// <summary>Gets the <c>working-directory</c> value.</summary>
     public static InstructionsSourcesLocation WorkingDirectory { get; } = new("working-directory");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="InstructionsSourcesLocation"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="InstructionsSourcesLocation"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="InstructionsSourcesLocation"/>.</param>
@@ -3328,7 +3346,7 @@ public readonly struct InstructionsSourcesLocation : IEquatable<InstructionsSour
     public InstructionsSourcesLocation(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="InstructionsSourcesLocation"/> instances are equivalent.</summary>
@@ -3344,10 +3362,10 @@ public readonly struct InstructionsSourcesLocation : IEquatable<InstructionsSour
     public bool Equals(InstructionsSourcesLocation other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{InstructionsSourcesLocation}"/> for serializing <see cref="InstructionsSourcesLocation"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -3394,8 +3412,10 @@ public readonly struct InstructionsSourcesType : IEquatable<InstructionsSourcesT
     /// <summary>Gets the <c>child-instructions</c> value.</summary>
     public static InstructionsSourcesType ChildInstructions { get; } = new("child-instructions");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="InstructionsSourcesType"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="InstructionsSourcesType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="InstructionsSourcesType"/>.</param>
@@ -3403,7 +3423,7 @@ public readonly struct InstructionsSourcesType : IEquatable<InstructionsSourcesT
     public InstructionsSourcesType(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="InstructionsSourcesType"/> instances are equivalent.</summary>
@@ -3419,10 +3439,10 @@ public readonly struct InstructionsSourcesType : IEquatable<InstructionsSourcesT
     public bool Equals(InstructionsSourcesType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{InstructionsSourcesType}"/> for serializing <see cref="InstructionsSourcesType"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -3457,8 +3477,10 @@ public readonly struct TaskAgentInfoExecutionMode : IEquatable<TaskAgentInfoExec
     /// <summary>Gets the <c>background</c> value.</summary>
     public static TaskAgentInfoExecutionMode Background { get; } = new("background");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="TaskAgentInfoExecutionMode"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="TaskAgentInfoExecutionMode"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="TaskAgentInfoExecutionMode"/>.</param>
@@ -3466,7 +3488,7 @@ public readonly struct TaskAgentInfoExecutionMode : IEquatable<TaskAgentInfoExec
     public TaskAgentInfoExecutionMode(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="TaskAgentInfoExecutionMode"/> instances are equivalent.</summary>
@@ -3482,10 +3504,10 @@ public readonly struct TaskAgentInfoExecutionMode : IEquatable<TaskAgentInfoExec
     public bool Equals(TaskAgentInfoExecutionMode other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{TaskAgentInfoExecutionMode}"/> for serializing <see cref="TaskAgentInfoExecutionMode"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -3529,8 +3551,10 @@ public readonly struct TaskAgentInfoStatus : IEquatable<TaskAgentInfoStatus>
     /// <summary>Gets the <c>cancelled</c> value.</summary>
     public static TaskAgentInfoStatus Cancelled { get; } = new("cancelled");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="TaskAgentInfoStatus"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="TaskAgentInfoStatus"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="TaskAgentInfoStatus"/>.</param>
@@ -3538,7 +3562,7 @@ public readonly struct TaskAgentInfoStatus : IEquatable<TaskAgentInfoStatus>
     public TaskAgentInfoStatus(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="TaskAgentInfoStatus"/> instances are equivalent.</summary>
@@ -3554,10 +3578,10 @@ public readonly struct TaskAgentInfoStatus : IEquatable<TaskAgentInfoStatus>
     public bool Equals(TaskAgentInfoStatus other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{TaskAgentInfoStatus}"/> for serializing <see cref="TaskAgentInfoStatus"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -3592,8 +3616,10 @@ public readonly struct TaskShellInfoAttachmentMode : IEquatable<TaskShellInfoAtt
     /// <summary>Gets the <c>detached</c> value.</summary>
     public static TaskShellInfoAttachmentMode Detached { get; } = new("detached");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="TaskShellInfoAttachmentMode"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="TaskShellInfoAttachmentMode"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="TaskShellInfoAttachmentMode"/>.</param>
@@ -3601,7 +3627,7 @@ public readonly struct TaskShellInfoAttachmentMode : IEquatable<TaskShellInfoAtt
     public TaskShellInfoAttachmentMode(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="TaskShellInfoAttachmentMode"/> instances are equivalent.</summary>
@@ -3617,10 +3643,10 @@ public readonly struct TaskShellInfoAttachmentMode : IEquatable<TaskShellInfoAtt
     public bool Equals(TaskShellInfoAttachmentMode other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{TaskShellInfoAttachmentMode}"/> for serializing <see cref="TaskShellInfoAttachmentMode"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -3655,8 +3681,10 @@ public readonly struct TaskShellInfoExecutionMode : IEquatable<TaskShellInfoExec
     /// <summary>Gets the <c>background</c> value.</summary>
     public static TaskShellInfoExecutionMode Background { get; } = new("background");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="TaskShellInfoExecutionMode"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="TaskShellInfoExecutionMode"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="TaskShellInfoExecutionMode"/>.</param>
@@ -3664,7 +3692,7 @@ public readonly struct TaskShellInfoExecutionMode : IEquatable<TaskShellInfoExec
     public TaskShellInfoExecutionMode(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="TaskShellInfoExecutionMode"/> instances are equivalent.</summary>
@@ -3680,10 +3708,10 @@ public readonly struct TaskShellInfoExecutionMode : IEquatable<TaskShellInfoExec
     public bool Equals(TaskShellInfoExecutionMode other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{TaskShellInfoExecutionMode}"/> for serializing <see cref="TaskShellInfoExecutionMode"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -3727,8 +3755,10 @@ public readonly struct TaskShellInfoStatus : IEquatable<TaskShellInfoStatus>
     /// <summary>Gets the <c>cancelled</c> value.</summary>
     public static TaskShellInfoStatus Cancelled { get; } = new("cancelled");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="TaskShellInfoStatus"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="TaskShellInfoStatus"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="TaskShellInfoStatus"/>.</param>
@@ -3736,7 +3766,7 @@ public readonly struct TaskShellInfoStatus : IEquatable<TaskShellInfoStatus>
     public TaskShellInfoStatus(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="TaskShellInfoStatus"/> instances are equivalent.</summary>
@@ -3752,10 +3782,10 @@ public readonly struct TaskShellInfoStatus : IEquatable<TaskShellInfoStatus>
     public bool Equals(TaskShellInfoStatus other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{TaskShellInfoStatus}"/> for serializing <see cref="TaskShellInfoStatus"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -3796,8 +3826,10 @@ public readonly struct McpServerSource : IEquatable<McpServerSource>
     /// <summary>Gets the <c>builtin</c> value.</summary>
     public static McpServerSource Builtin { get; } = new("builtin");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="McpServerSource"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="McpServerSource"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="McpServerSource"/>.</param>
@@ -3805,7 +3837,7 @@ public readonly struct McpServerSource : IEquatable<McpServerSource>
     public McpServerSource(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="McpServerSource"/> instances are equivalent.</summary>
@@ -3821,10 +3853,10 @@ public readonly struct McpServerSource : IEquatable<McpServerSource>
     public bool Equals(McpServerSource other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{McpServerSource}"/> for serializing <see cref="McpServerSource"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -3871,8 +3903,10 @@ public readonly struct McpServerStatus : IEquatable<McpServerStatus>
     /// <summary>Gets the <c>not_configured</c> value.</summary>
     public static McpServerStatus NotConfigured { get; } = new("not_configured");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="McpServerStatus"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="McpServerStatus"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="McpServerStatus"/>.</param>
@@ -3880,7 +3914,7 @@ public readonly struct McpServerStatus : IEquatable<McpServerStatus>
     public McpServerStatus(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="McpServerStatus"/> instances are equivalent.</summary>
@@ -3896,10 +3930,10 @@ public readonly struct McpServerStatus : IEquatable<McpServerStatus>
     public bool Equals(McpServerStatus other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{McpServerStatus}"/> for serializing <see cref="McpServerStatus"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -3934,8 +3968,10 @@ public readonly struct ExtensionSource : IEquatable<ExtensionSource>
     /// <summary>Gets the <c>user</c> value.</summary>
     public static ExtensionSource User { get; } = new("user");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="ExtensionSource"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="ExtensionSource"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ExtensionSource"/>.</param>
@@ -3943,7 +3979,7 @@ public readonly struct ExtensionSource : IEquatable<ExtensionSource>
     public ExtensionSource(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="ExtensionSource"/> instances are equivalent.</summary>
@@ -3959,10 +3995,10 @@ public readonly struct ExtensionSource : IEquatable<ExtensionSource>
     public bool Equals(ExtensionSource other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{ExtensionSource}"/> for serializing <see cref="ExtensionSource"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -4003,8 +4039,10 @@ public readonly struct ExtensionStatus : IEquatable<ExtensionStatus>
     /// <summary>Gets the <c>starting</c> value.</summary>
     public static ExtensionStatus Starting { get; } = new("starting");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="ExtensionStatus"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="ExtensionStatus"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ExtensionStatus"/>.</param>
@@ -4012,7 +4050,7 @@ public readonly struct ExtensionStatus : IEquatable<ExtensionStatus>
     public ExtensionStatus(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="ExtensionStatus"/> instances are equivalent.</summary>
@@ -4028,10 +4066,10 @@ public readonly struct ExtensionStatus : IEquatable<ExtensionStatus>
     public bool Equals(ExtensionStatus other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{ExtensionStatus}"/> for serializing <see cref="ExtensionStatus"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -4069,8 +4107,10 @@ public readonly struct UIElicitationResponseAction : IEquatable<UIElicitationRes
     /// <summary>Gets the <c>cancel</c> value.</summary>
     public static UIElicitationResponseAction Cancel { get; } = new("cancel");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="UIElicitationResponseAction"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="UIElicitationResponseAction"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="UIElicitationResponseAction"/>.</param>
@@ -4078,7 +4118,7 @@ public readonly struct UIElicitationResponseAction : IEquatable<UIElicitationRes
     public UIElicitationResponseAction(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="UIElicitationResponseAction"/> instances are equivalent.</summary>
@@ -4094,10 +4134,10 @@ public readonly struct UIElicitationResponseAction : IEquatable<UIElicitationRes
     public bool Equals(UIElicitationResponseAction other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{UIElicitationResponseAction}"/> for serializing <see cref="UIElicitationResponseAction"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -4135,8 +4175,10 @@ public readonly struct ShellKillSignal : IEquatable<ShellKillSignal>
     /// <summary>Gets the <c>SIGINT</c> value.</summary>
     public static ShellKillSignal SIGINT { get; } = new("SIGINT");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="ShellKillSignal"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="ShellKillSignal"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ShellKillSignal"/>.</param>
@@ -4144,7 +4186,7 @@ public readonly struct ShellKillSignal : IEquatable<ShellKillSignal>
     public ShellKillSignal(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="ShellKillSignal"/> instances are equivalent.</summary>
@@ -4160,10 +4202,10 @@ public readonly struct ShellKillSignal : IEquatable<ShellKillSignal>
     public bool Equals(ShellKillSignal other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{ShellKillSignal}"/> for serializing <see cref="ShellKillSignal"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -4198,8 +4240,10 @@ public readonly struct SessionFsErrorCode : IEquatable<SessionFsErrorCode>
     /// <summary>Gets the <c>UNKNOWN</c> value.</summary>
     public static SessionFsErrorCode UNKNOWN { get; } = new("UNKNOWN");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="SessionFsErrorCode"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="SessionFsErrorCode"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="SessionFsErrorCode"/>.</param>
@@ -4207,7 +4251,7 @@ public readonly struct SessionFsErrorCode : IEquatable<SessionFsErrorCode>
     public SessionFsErrorCode(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="SessionFsErrorCode"/> instances are equivalent.</summary>
@@ -4223,10 +4267,10 @@ public readonly struct SessionFsErrorCode : IEquatable<SessionFsErrorCode>
     public bool Equals(SessionFsErrorCode other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{SessionFsErrorCode}"/> for serializing <see cref="SessionFsErrorCode"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -4261,8 +4305,10 @@ public readonly struct SessionFsReaddirWithTypesEntryType : IEquatable<SessionFs
     /// <summary>Gets the <c>directory</c> value.</summary>
     public static SessionFsReaddirWithTypesEntryType Directory { get; } = new("directory");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="SessionFsReaddirWithTypesEntryType"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="SessionFsReaddirWithTypesEntryType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="SessionFsReaddirWithTypesEntryType"/>.</param>
@@ -4270,7 +4316,7 @@ public readonly struct SessionFsReaddirWithTypesEntryType : IEquatable<SessionFs
     public SessionFsReaddirWithTypesEntryType(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="SessionFsReaddirWithTypesEntryType"/> instances are equivalent.</summary>
@@ -4286,10 +4332,10 @@ public readonly struct SessionFsReaddirWithTypesEntryType : IEquatable<SessionFs
     public bool Equals(SessionFsReaddirWithTypesEntryType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{SessionFsReaddirWithTypesEntryType}"/> for serializing <see cref="SessionFsReaddirWithTypesEntryType"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -8,7 +8,9 @@
 #pragma warning disable CS0612 // Type or member is obsolete
 #pragma warning disable CS0618 // Type or member is obsolete (with message)
 
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -2764,400 +2766,1550 @@ public sealed class SessionFsRenameRequest
 }
 
 /// <summary>Configuration source.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<DiscoveredMcpServerSource>))]
-public enum DiscoveredMcpServerSource
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct DiscoveredMcpServerSource : IEquatable<DiscoveredMcpServerSource>
 {
-    /// <summary>The <c>user</c> variant.</summary>
-    [JsonStringEnumMemberName("user")]
-    User,
-    /// <summary>The <c>workspace</c> variant.</summary>
-    [JsonStringEnumMemberName("workspace")]
-    Workspace,
-    /// <summary>The <c>plugin</c> variant.</summary>
-    [JsonStringEnumMemberName("plugin")]
-    Plugin,
-    /// <summary>The <c>builtin</c> variant.</summary>
-    [JsonStringEnumMemberName("builtin")]
-    Builtin,
+    /// <summary>Gets the <c>user</c> value.</summary>
+    public static DiscoveredMcpServerSource User { get; } = new("user");
+
+    /// <summary>Gets the <c>workspace</c> value.</summary>
+    public static DiscoveredMcpServerSource Workspace { get; } = new("workspace");
+
+    /// <summary>Gets the <c>plugin</c> value.</summary>
+    public static DiscoveredMcpServerSource Plugin { get; } = new("plugin");
+
+    /// <summary>Gets the <c>builtin</c> value.</summary>
+    public static DiscoveredMcpServerSource Builtin { get; } = new("builtin");
+
+    /// <summary>Gets the value associated with this <see cref="DiscoveredMcpServerSource"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="DiscoveredMcpServerSource"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="DiscoveredMcpServerSource"/>.</param>
+    [JsonConstructor]
+    public DiscoveredMcpServerSource(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="DiscoveredMcpServerSource"/> instances are equivalent.</summary>
+    public static bool operator ==(DiscoveredMcpServerSource left, DiscoveredMcpServerSource right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="DiscoveredMcpServerSource"/> instances are not equivalent.</summary>
+    public static bool operator !=(DiscoveredMcpServerSource left, DiscoveredMcpServerSource right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is DiscoveredMcpServerSource other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(DiscoveredMcpServerSource other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{DiscoveredMcpServerSource}"/> for serializing <see cref="DiscoveredMcpServerSource"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<DiscoveredMcpServerSource>
+    {
+        /// <inheritdoc />
+        public override DiscoveredMcpServerSource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, DiscoveredMcpServerSource value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>Server transport type: stdio, http, sse, or memory (local configs are normalized to stdio).</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<DiscoveredMcpServerType>))]
-public enum DiscoveredMcpServerType
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct DiscoveredMcpServerType : IEquatable<DiscoveredMcpServerType>
 {
-    /// <summary>The <c>stdio</c> variant.</summary>
-    [JsonStringEnumMemberName("stdio")]
-    Stdio,
-    /// <summary>The <c>http</c> variant.</summary>
-    [JsonStringEnumMemberName("http")]
-    Http,
-    /// <summary>The <c>sse</c> variant.</summary>
-    [JsonStringEnumMemberName("sse")]
-    Sse,
-    /// <summary>The <c>memory</c> variant.</summary>
-    [JsonStringEnumMemberName("memory")]
-    Memory,
+    /// <summary>Gets the <c>stdio</c> value.</summary>
+    public static DiscoveredMcpServerType Stdio { get; } = new("stdio");
+
+    /// <summary>Gets the <c>http</c> value.</summary>
+    public static DiscoveredMcpServerType Http { get; } = new("http");
+
+    /// <summary>Gets the <c>sse</c> value.</summary>
+    public static DiscoveredMcpServerType Sse { get; } = new("sse");
+
+    /// <summary>Gets the <c>memory</c> value.</summary>
+    public static DiscoveredMcpServerType Memory { get; } = new("memory");
+
+    /// <summary>Gets the value associated with this <see cref="DiscoveredMcpServerType"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="DiscoveredMcpServerType"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="DiscoveredMcpServerType"/>.</param>
+    [JsonConstructor]
+    public DiscoveredMcpServerType(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="DiscoveredMcpServerType"/> instances are equivalent.</summary>
+    public static bool operator ==(DiscoveredMcpServerType left, DiscoveredMcpServerType right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="DiscoveredMcpServerType"/> instances are not equivalent.</summary>
+    public static bool operator !=(DiscoveredMcpServerType left, DiscoveredMcpServerType right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is DiscoveredMcpServerType other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(DiscoveredMcpServerType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{DiscoveredMcpServerType}"/> for serializing <see cref="DiscoveredMcpServerType"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<DiscoveredMcpServerType>
+    {
+        /// <inheritdoc />
+        public override DiscoveredMcpServerType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, DiscoveredMcpServerType value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>Path conventions used by this filesystem.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<SessionFsSetProviderConventions>))]
-public enum SessionFsSetProviderConventions
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct SessionFsSetProviderConventions : IEquatable<SessionFsSetProviderConventions>
 {
-    /// <summary>The <c>windows</c> variant.</summary>
-    [JsonStringEnumMemberName("windows")]
-    Windows,
-    /// <summary>The <c>posix</c> variant.</summary>
-    [JsonStringEnumMemberName("posix")]
-    Posix,
+    /// <summary>Gets the <c>windows</c> value.</summary>
+    public static SessionFsSetProviderConventions Windows { get; } = new("windows");
+
+    /// <summary>Gets the <c>posix</c> value.</summary>
+    public static SessionFsSetProviderConventions Posix { get; } = new("posix");
+
+    /// <summary>Gets the value associated with this <see cref="SessionFsSetProviderConventions"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="SessionFsSetProviderConventions"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="SessionFsSetProviderConventions"/>.</param>
+    [JsonConstructor]
+    public SessionFsSetProviderConventions(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="SessionFsSetProviderConventions"/> instances are equivalent.</summary>
+    public static bool operator ==(SessionFsSetProviderConventions left, SessionFsSetProviderConventions right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="SessionFsSetProviderConventions"/> instances are not equivalent.</summary>
+    public static bool operator !=(SessionFsSetProviderConventions left, SessionFsSetProviderConventions right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is SessionFsSetProviderConventions other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(SessionFsSetProviderConventions other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{SessionFsSetProviderConventions}"/> for serializing <see cref="SessionFsSetProviderConventions"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<SessionFsSetProviderConventions>
+    {
+        /// <inheritdoc />
+        public override SessionFsSetProviderConventions Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, SessionFsSetProviderConventions value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>Log severity level. Determines how the message is displayed in the timeline. Defaults to "info".</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<SessionLogLevel>))]
-public enum SessionLogLevel
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct SessionLogLevel : IEquatable<SessionLogLevel>
 {
-    /// <summary>The <c>info</c> variant.</summary>
-    [JsonStringEnumMemberName("info")]
-    Info,
-    /// <summary>The <c>warning</c> variant.</summary>
-    [JsonStringEnumMemberName("warning")]
-    Warning,
-    /// <summary>The <c>error</c> variant.</summary>
-    [JsonStringEnumMemberName("error")]
-    Error,
+    /// <summary>Gets the <c>info</c> value.</summary>
+    public static SessionLogLevel Info { get; } = new("info");
+
+    /// <summary>Gets the <c>warning</c> value.</summary>
+    public static SessionLogLevel Warning { get; } = new("warning");
+
+    /// <summary>Gets the <c>error</c> value.</summary>
+    public static SessionLogLevel Error { get; } = new("error");
+
+    /// <summary>Gets the value associated with this <see cref="SessionLogLevel"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="SessionLogLevel"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="SessionLogLevel"/>.</param>
+    [JsonConstructor]
+    public SessionLogLevel(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="SessionLogLevel"/> instances are equivalent.</summary>
+    public static bool operator ==(SessionLogLevel left, SessionLogLevel right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="SessionLogLevel"/> instances are not equivalent.</summary>
+    public static bool operator !=(SessionLogLevel left, SessionLogLevel right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is SessionLogLevel other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(SessionLogLevel other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{SessionLogLevel}"/> for serializing <see cref="SessionLogLevel"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<SessionLogLevel>
+    {
+        /// <inheritdoc />
+        public override SessionLogLevel Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, SessionLogLevel value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>Authentication type.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<AuthInfoType>))]
-public enum AuthInfoType
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct AuthInfoType : IEquatable<AuthInfoType>
 {
-    /// <summary>The <c>hmac</c> variant.</summary>
-    [JsonStringEnumMemberName("hmac")]
-    Hmac,
-    /// <summary>The <c>env</c> variant.</summary>
-    [JsonStringEnumMemberName("env")]
-    Env,
-    /// <summary>The <c>user</c> variant.</summary>
-    [JsonStringEnumMemberName("user")]
-    User,
-    /// <summary>The <c>gh-cli</c> variant.</summary>
-    [JsonStringEnumMemberName("gh-cli")]
-    GhCli,
-    /// <summary>The <c>api-key</c> variant.</summary>
-    [JsonStringEnumMemberName("api-key")]
-    ApiKey,
-    /// <summary>The <c>token</c> variant.</summary>
-    [JsonStringEnumMemberName("token")]
-    Token,
-    /// <summary>The <c>copilot-api-token</c> variant.</summary>
-    [JsonStringEnumMemberName("copilot-api-token")]
-    CopilotApiToken,
+    /// <summary>Gets the <c>hmac</c> value.</summary>
+    public static AuthInfoType Hmac { get; } = new("hmac");
+
+    /// <summary>Gets the <c>env</c> value.</summary>
+    public static AuthInfoType Env { get; } = new("env");
+
+    /// <summary>Gets the <c>user</c> value.</summary>
+    public static AuthInfoType User { get; } = new("user");
+
+    /// <summary>Gets the <c>gh-cli</c> value.</summary>
+    public static AuthInfoType GhCli { get; } = new("gh-cli");
+
+    /// <summary>Gets the <c>api-key</c> value.</summary>
+    public static AuthInfoType ApiKey { get; } = new("api-key");
+
+    /// <summary>Gets the <c>token</c> value.</summary>
+    public static AuthInfoType Token { get; } = new("token");
+
+    /// <summary>Gets the <c>copilot-api-token</c> value.</summary>
+    public static AuthInfoType CopilotApiToken { get; } = new("copilot-api-token");
+
+    /// <summary>Gets the value associated with this <see cref="AuthInfoType"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="AuthInfoType"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="AuthInfoType"/>.</param>
+    [JsonConstructor]
+    public AuthInfoType(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="AuthInfoType"/> instances are equivalent.</summary>
+    public static bool operator ==(AuthInfoType left, AuthInfoType right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="AuthInfoType"/> instances are not equivalent.</summary>
+    public static bool operator !=(AuthInfoType left, AuthInfoType right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is AuthInfoType other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(AuthInfoType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{AuthInfoType}"/> for serializing <see cref="AuthInfoType"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<AuthInfoType>
+    {
+        /// <inheritdoc />
+        public override AuthInfoType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, AuthInfoType value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>The agent mode. Valid values: "interactive", "plan", "autopilot".</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<SessionMode>))]
-public enum SessionMode
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct SessionMode : IEquatable<SessionMode>
 {
-    /// <summary>The <c>interactive</c> variant.</summary>
-    [JsonStringEnumMemberName("interactive")]
-    Interactive,
-    /// <summary>The <c>plan</c> variant.</summary>
-    [JsonStringEnumMemberName("plan")]
-    Plan,
-    /// <summary>The <c>autopilot</c> variant.</summary>
-    [JsonStringEnumMemberName("autopilot")]
-    Autopilot,
+    /// <summary>Gets the <c>interactive</c> value.</summary>
+    public static SessionMode Interactive { get; } = new("interactive");
+
+    /// <summary>Gets the <c>plan</c> value.</summary>
+    public static SessionMode Plan { get; } = new("plan");
+
+    /// <summary>Gets the <c>autopilot</c> value.</summary>
+    public static SessionMode Autopilot { get; } = new("autopilot");
+
+    /// <summary>Gets the value associated with this <see cref="SessionMode"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="SessionMode"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="SessionMode"/>.</param>
+    [JsonConstructor]
+    public SessionMode(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="SessionMode"/> instances are equivalent.</summary>
+    public static bool operator ==(SessionMode left, SessionMode right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="SessionMode"/> instances are not equivalent.</summary>
+    public static bool operator !=(SessionMode left, SessionMode right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is SessionMode other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(SessionMode other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{SessionMode}"/> for serializing <see cref="SessionMode"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<SessionMode>
+    {
+        /// <inheritdoc />
+        public override SessionMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, SessionMode value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>Defines the allowed values.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<WorkspacesGetWorkspaceResultWorkspaceHostType>))]
-public enum WorkspacesGetWorkspaceResultWorkspaceHostType
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct WorkspacesGetWorkspaceResultWorkspaceHostType : IEquatable<WorkspacesGetWorkspaceResultWorkspaceHostType>
 {
-    /// <summary>The <c>github</c> variant.</summary>
-    [JsonStringEnumMemberName("github")]
-    Github,
-    /// <summary>The <c>ado</c> variant.</summary>
-    [JsonStringEnumMemberName("ado")]
-    Ado,
+    /// <summary>Gets the <c>github</c> value.</summary>
+    public static WorkspacesGetWorkspaceResultWorkspaceHostType Github { get; } = new("github");
+
+    /// <summary>Gets the <c>ado</c> value.</summary>
+    public static WorkspacesGetWorkspaceResultWorkspaceHostType Ado { get; } = new("ado");
+
+    /// <summary>Gets the value associated with this <see cref="WorkspacesGetWorkspaceResultWorkspaceHostType"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="WorkspacesGetWorkspaceResultWorkspaceHostType"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="WorkspacesGetWorkspaceResultWorkspaceHostType"/>.</param>
+    [JsonConstructor]
+    public WorkspacesGetWorkspaceResultWorkspaceHostType(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="WorkspacesGetWorkspaceResultWorkspaceHostType"/> instances are equivalent.</summary>
+    public static bool operator ==(WorkspacesGetWorkspaceResultWorkspaceHostType left, WorkspacesGetWorkspaceResultWorkspaceHostType right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="WorkspacesGetWorkspaceResultWorkspaceHostType"/> instances are not equivalent.</summary>
+    public static bool operator !=(WorkspacesGetWorkspaceResultWorkspaceHostType left, WorkspacesGetWorkspaceResultWorkspaceHostType right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is WorkspacesGetWorkspaceResultWorkspaceHostType other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(WorkspacesGetWorkspaceResultWorkspaceHostType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{WorkspacesGetWorkspaceResultWorkspaceHostType}"/> for serializing <see cref="WorkspacesGetWorkspaceResultWorkspaceHostType"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<WorkspacesGetWorkspaceResultWorkspaceHostType>
+    {
+        /// <inheritdoc />
+        public override WorkspacesGetWorkspaceResultWorkspaceHostType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, WorkspacesGetWorkspaceResultWorkspaceHostType value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>Defines the allowed values.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel>))]
-public enum WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel : IEquatable<WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel>
 {
-    /// <summary>The <c>local</c> variant.</summary>
-    [JsonStringEnumMemberName("local")]
-    Local,
-    /// <summary>The <c>user</c> variant.</summary>
-    [JsonStringEnumMemberName("user")]
-    User,
-    /// <summary>The <c>repo_and_user</c> variant.</summary>
-    [JsonStringEnumMemberName("repo_and_user")]
-    RepoAndUser,
+    /// <summary>Gets the <c>local</c> value.</summary>
+    public static WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel Local { get; } = new("local");
+
+    /// <summary>Gets the <c>user</c> value.</summary>
+    public static WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel User { get; } = new("user");
+
+    /// <summary>Gets the <c>repo_and_user</c> value.</summary>
+    public static WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel RepoAndUser { get; } = new("repo_and_user");
+
+    /// <summary>Gets the value associated with this <see cref="WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel"/>.</param>
+    [JsonConstructor]
+    public WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel"/> instances are equivalent.</summary>
+    public static bool operator ==(WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel left, WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel"/> instances are not equivalent.</summary>
+    public static bool operator !=(WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel left, WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel}"/> for serializing <see cref="WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel>
+    {
+        /// <inheritdoc />
+        public override WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>Where this source lives — used for UI grouping.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<InstructionsSourcesLocation>))]
-public enum InstructionsSourcesLocation
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct InstructionsSourcesLocation : IEquatable<InstructionsSourcesLocation>
 {
-    /// <summary>The <c>user</c> variant.</summary>
-    [JsonStringEnumMemberName("user")]
-    User,
-    /// <summary>The <c>repository</c> variant.</summary>
-    [JsonStringEnumMemberName("repository")]
-    Repository,
-    /// <summary>The <c>working-directory</c> variant.</summary>
-    [JsonStringEnumMemberName("working-directory")]
-    WorkingDirectory,
+    /// <summary>Gets the <c>user</c> value.</summary>
+    public static InstructionsSourcesLocation User { get; } = new("user");
+
+    /// <summary>Gets the <c>repository</c> value.</summary>
+    public static InstructionsSourcesLocation Repository { get; } = new("repository");
+
+    /// <summary>Gets the <c>working-directory</c> value.</summary>
+    public static InstructionsSourcesLocation WorkingDirectory { get; } = new("working-directory");
+
+    /// <summary>Gets the value associated with this <see cref="InstructionsSourcesLocation"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="InstructionsSourcesLocation"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="InstructionsSourcesLocation"/>.</param>
+    [JsonConstructor]
+    public InstructionsSourcesLocation(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="InstructionsSourcesLocation"/> instances are equivalent.</summary>
+    public static bool operator ==(InstructionsSourcesLocation left, InstructionsSourcesLocation right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="InstructionsSourcesLocation"/> instances are not equivalent.</summary>
+    public static bool operator !=(InstructionsSourcesLocation left, InstructionsSourcesLocation right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is InstructionsSourcesLocation other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(InstructionsSourcesLocation other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{InstructionsSourcesLocation}"/> for serializing <see cref="InstructionsSourcesLocation"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<InstructionsSourcesLocation>
+    {
+        /// <inheritdoc />
+        public override InstructionsSourcesLocation Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, InstructionsSourcesLocation value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>Category of instruction source — used for merge logic.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<InstructionsSourcesType>))]
-public enum InstructionsSourcesType
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct InstructionsSourcesType : IEquatable<InstructionsSourcesType>
 {
-    /// <summary>The <c>home</c> variant.</summary>
-    [JsonStringEnumMemberName("home")]
-    Home,
-    /// <summary>The <c>repo</c> variant.</summary>
-    [JsonStringEnumMemberName("repo")]
-    Repo,
-    /// <summary>The <c>model</c> variant.</summary>
-    [JsonStringEnumMemberName("model")]
-    Model,
-    /// <summary>The <c>vscode</c> variant.</summary>
-    [JsonStringEnumMemberName("vscode")]
-    Vscode,
-    /// <summary>The <c>nested-agents</c> variant.</summary>
-    [JsonStringEnumMemberName("nested-agents")]
-    NestedAgents,
-    /// <summary>The <c>child-instructions</c> variant.</summary>
-    [JsonStringEnumMemberName("child-instructions")]
-    ChildInstructions,
+    /// <summary>Gets the <c>home</c> value.</summary>
+    public static InstructionsSourcesType Home { get; } = new("home");
+
+    /// <summary>Gets the <c>repo</c> value.</summary>
+    public static InstructionsSourcesType Repo { get; } = new("repo");
+
+    /// <summary>Gets the <c>model</c> value.</summary>
+    public static InstructionsSourcesType Model { get; } = new("model");
+
+    /// <summary>Gets the <c>vscode</c> value.</summary>
+    public static InstructionsSourcesType Vscode { get; } = new("vscode");
+
+    /// <summary>Gets the <c>nested-agents</c> value.</summary>
+    public static InstructionsSourcesType NestedAgents { get; } = new("nested-agents");
+
+    /// <summary>Gets the <c>child-instructions</c> value.</summary>
+    public static InstructionsSourcesType ChildInstructions { get; } = new("child-instructions");
+
+    /// <summary>Gets the value associated with this <see cref="InstructionsSourcesType"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="InstructionsSourcesType"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="InstructionsSourcesType"/>.</param>
+    [JsonConstructor]
+    public InstructionsSourcesType(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="InstructionsSourcesType"/> instances are equivalent.</summary>
+    public static bool operator ==(InstructionsSourcesType left, InstructionsSourcesType right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="InstructionsSourcesType"/> instances are not equivalent.</summary>
+    public static bool operator !=(InstructionsSourcesType left, InstructionsSourcesType right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is InstructionsSourcesType other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(InstructionsSourcesType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{InstructionsSourcesType}"/> for serializing <see cref="InstructionsSourcesType"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<InstructionsSourcesType>
+    {
+        /// <inheritdoc />
+        public override InstructionsSourcesType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, InstructionsSourcesType value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>How the agent is currently being managed by the runtime.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<TaskAgentInfoExecutionMode>))]
-public enum TaskAgentInfoExecutionMode
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct TaskAgentInfoExecutionMode : IEquatable<TaskAgentInfoExecutionMode>
 {
-    /// <summary>The <c>sync</c> variant.</summary>
-    [JsonStringEnumMemberName("sync")]
-    Sync,
-    /// <summary>The <c>background</c> variant.</summary>
-    [JsonStringEnumMemberName("background")]
-    Background,
+    /// <summary>Gets the <c>sync</c> value.</summary>
+    public static TaskAgentInfoExecutionMode Sync { get; } = new("sync");
+
+    /// <summary>Gets the <c>background</c> value.</summary>
+    public static TaskAgentInfoExecutionMode Background { get; } = new("background");
+
+    /// <summary>Gets the value associated with this <see cref="TaskAgentInfoExecutionMode"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="TaskAgentInfoExecutionMode"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="TaskAgentInfoExecutionMode"/>.</param>
+    [JsonConstructor]
+    public TaskAgentInfoExecutionMode(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="TaskAgentInfoExecutionMode"/> instances are equivalent.</summary>
+    public static bool operator ==(TaskAgentInfoExecutionMode left, TaskAgentInfoExecutionMode right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="TaskAgentInfoExecutionMode"/> instances are not equivalent.</summary>
+    public static bool operator !=(TaskAgentInfoExecutionMode left, TaskAgentInfoExecutionMode right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is TaskAgentInfoExecutionMode other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(TaskAgentInfoExecutionMode other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{TaskAgentInfoExecutionMode}"/> for serializing <see cref="TaskAgentInfoExecutionMode"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<TaskAgentInfoExecutionMode>
+    {
+        /// <inheritdoc />
+        public override TaskAgentInfoExecutionMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, TaskAgentInfoExecutionMode value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>Current lifecycle status of the task.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<TaskAgentInfoStatus>))]
-public enum TaskAgentInfoStatus
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct TaskAgentInfoStatus : IEquatable<TaskAgentInfoStatus>
 {
-    /// <summary>The <c>running</c> variant.</summary>
-    [JsonStringEnumMemberName("running")]
-    Running,
-    /// <summary>The <c>idle</c> variant.</summary>
-    [JsonStringEnumMemberName("idle")]
-    Idle,
-    /// <summary>The <c>completed</c> variant.</summary>
-    [JsonStringEnumMemberName("completed")]
-    Completed,
-    /// <summary>The <c>failed</c> variant.</summary>
-    [JsonStringEnumMemberName("failed")]
-    Failed,
-    /// <summary>The <c>cancelled</c> variant.</summary>
-    [JsonStringEnumMemberName("cancelled")]
-    Cancelled,
+    /// <summary>Gets the <c>running</c> value.</summary>
+    public static TaskAgentInfoStatus Running { get; } = new("running");
+
+    /// <summary>Gets the <c>idle</c> value.</summary>
+    public static TaskAgentInfoStatus Idle { get; } = new("idle");
+
+    /// <summary>Gets the <c>completed</c> value.</summary>
+    public static TaskAgentInfoStatus Completed { get; } = new("completed");
+
+    /// <summary>Gets the <c>failed</c> value.</summary>
+    public static TaskAgentInfoStatus Failed { get; } = new("failed");
+
+    /// <summary>Gets the <c>cancelled</c> value.</summary>
+    public static TaskAgentInfoStatus Cancelled { get; } = new("cancelled");
+
+    /// <summary>Gets the value associated with this <see cref="TaskAgentInfoStatus"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="TaskAgentInfoStatus"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="TaskAgentInfoStatus"/>.</param>
+    [JsonConstructor]
+    public TaskAgentInfoStatus(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="TaskAgentInfoStatus"/> instances are equivalent.</summary>
+    public static bool operator ==(TaskAgentInfoStatus left, TaskAgentInfoStatus right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="TaskAgentInfoStatus"/> instances are not equivalent.</summary>
+    public static bool operator !=(TaskAgentInfoStatus left, TaskAgentInfoStatus right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is TaskAgentInfoStatus other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(TaskAgentInfoStatus other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{TaskAgentInfoStatus}"/> for serializing <see cref="TaskAgentInfoStatus"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<TaskAgentInfoStatus>
+    {
+        /// <inheritdoc />
+        public override TaskAgentInfoStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, TaskAgentInfoStatus value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>Whether the shell runs inside a managed PTY session or as an independent background process.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<TaskShellInfoAttachmentMode>))]
-public enum TaskShellInfoAttachmentMode
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct TaskShellInfoAttachmentMode : IEquatable<TaskShellInfoAttachmentMode>
 {
-    /// <summary>The <c>attached</c> variant.</summary>
-    [JsonStringEnumMemberName("attached")]
-    Attached,
-    /// <summary>The <c>detached</c> variant.</summary>
-    [JsonStringEnumMemberName("detached")]
-    Detached,
+    /// <summary>Gets the <c>attached</c> value.</summary>
+    public static TaskShellInfoAttachmentMode Attached { get; } = new("attached");
+
+    /// <summary>Gets the <c>detached</c> value.</summary>
+    public static TaskShellInfoAttachmentMode Detached { get; } = new("detached");
+
+    /// <summary>Gets the value associated with this <see cref="TaskShellInfoAttachmentMode"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="TaskShellInfoAttachmentMode"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="TaskShellInfoAttachmentMode"/>.</param>
+    [JsonConstructor]
+    public TaskShellInfoAttachmentMode(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="TaskShellInfoAttachmentMode"/> instances are equivalent.</summary>
+    public static bool operator ==(TaskShellInfoAttachmentMode left, TaskShellInfoAttachmentMode right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="TaskShellInfoAttachmentMode"/> instances are not equivalent.</summary>
+    public static bool operator !=(TaskShellInfoAttachmentMode left, TaskShellInfoAttachmentMode right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is TaskShellInfoAttachmentMode other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(TaskShellInfoAttachmentMode other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{TaskShellInfoAttachmentMode}"/> for serializing <see cref="TaskShellInfoAttachmentMode"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<TaskShellInfoAttachmentMode>
+    {
+        /// <inheritdoc />
+        public override TaskShellInfoAttachmentMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, TaskShellInfoAttachmentMode value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>Whether the shell command is currently sync-waited or background-managed.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<TaskShellInfoExecutionMode>))]
-public enum TaskShellInfoExecutionMode
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct TaskShellInfoExecutionMode : IEquatable<TaskShellInfoExecutionMode>
 {
-    /// <summary>The <c>sync</c> variant.</summary>
-    [JsonStringEnumMemberName("sync")]
-    Sync,
-    /// <summary>The <c>background</c> variant.</summary>
-    [JsonStringEnumMemberName("background")]
-    Background,
+    /// <summary>Gets the <c>sync</c> value.</summary>
+    public static TaskShellInfoExecutionMode Sync { get; } = new("sync");
+
+    /// <summary>Gets the <c>background</c> value.</summary>
+    public static TaskShellInfoExecutionMode Background { get; } = new("background");
+
+    /// <summary>Gets the value associated with this <see cref="TaskShellInfoExecutionMode"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="TaskShellInfoExecutionMode"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="TaskShellInfoExecutionMode"/>.</param>
+    [JsonConstructor]
+    public TaskShellInfoExecutionMode(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="TaskShellInfoExecutionMode"/> instances are equivalent.</summary>
+    public static bool operator ==(TaskShellInfoExecutionMode left, TaskShellInfoExecutionMode right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="TaskShellInfoExecutionMode"/> instances are not equivalent.</summary>
+    public static bool operator !=(TaskShellInfoExecutionMode left, TaskShellInfoExecutionMode right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is TaskShellInfoExecutionMode other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(TaskShellInfoExecutionMode other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{TaskShellInfoExecutionMode}"/> for serializing <see cref="TaskShellInfoExecutionMode"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<TaskShellInfoExecutionMode>
+    {
+        /// <inheritdoc />
+        public override TaskShellInfoExecutionMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, TaskShellInfoExecutionMode value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>Current lifecycle status of the task.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<TaskShellInfoStatus>))]
-public enum TaskShellInfoStatus
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct TaskShellInfoStatus : IEquatable<TaskShellInfoStatus>
 {
-    /// <summary>The <c>running</c> variant.</summary>
-    [JsonStringEnumMemberName("running")]
-    Running,
-    /// <summary>The <c>idle</c> variant.</summary>
-    [JsonStringEnumMemberName("idle")]
-    Idle,
-    /// <summary>The <c>completed</c> variant.</summary>
-    [JsonStringEnumMemberName("completed")]
-    Completed,
-    /// <summary>The <c>failed</c> variant.</summary>
-    [JsonStringEnumMemberName("failed")]
-    Failed,
-    /// <summary>The <c>cancelled</c> variant.</summary>
-    [JsonStringEnumMemberName("cancelled")]
-    Cancelled,
+    /// <summary>Gets the <c>running</c> value.</summary>
+    public static TaskShellInfoStatus Running { get; } = new("running");
+
+    /// <summary>Gets the <c>idle</c> value.</summary>
+    public static TaskShellInfoStatus Idle { get; } = new("idle");
+
+    /// <summary>Gets the <c>completed</c> value.</summary>
+    public static TaskShellInfoStatus Completed { get; } = new("completed");
+
+    /// <summary>Gets the <c>failed</c> value.</summary>
+    public static TaskShellInfoStatus Failed { get; } = new("failed");
+
+    /// <summary>Gets the <c>cancelled</c> value.</summary>
+    public static TaskShellInfoStatus Cancelled { get; } = new("cancelled");
+
+    /// <summary>Gets the value associated with this <see cref="TaskShellInfoStatus"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="TaskShellInfoStatus"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="TaskShellInfoStatus"/>.</param>
+    [JsonConstructor]
+    public TaskShellInfoStatus(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="TaskShellInfoStatus"/> instances are equivalent.</summary>
+    public static bool operator ==(TaskShellInfoStatus left, TaskShellInfoStatus right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="TaskShellInfoStatus"/> instances are not equivalent.</summary>
+    public static bool operator !=(TaskShellInfoStatus left, TaskShellInfoStatus right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is TaskShellInfoStatus other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(TaskShellInfoStatus other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{TaskShellInfoStatus}"/> for serializing <see cref="TaskShellInfoStatus"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<TaskShellInfoStatus>
+    {
+        /// <inheritdoc />
+        public override TaskShellInfoStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, TaskShellInfoStatus value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>Configuration source: user, workspace, plugin, or builtin.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<McpServerSource>))]
-public enum McpServerSource
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct McpServerSource : IEquatable<McpServerSource>
 {
-    /// <summary>The <c>user</c> variant.</summary>
-    [JsonStringEnumMemberName("user")]
-    User,
-    /// <summary>The <c>workspace</c> variant.</summary>
-    [JsonStringEnumMemberName("workspace")]
-    Workspace,
-    /// <summary>The <c>plugin</c> variant.</summary>
-    [JsonStringEnumMemberName("plugin")]
-    Plugin,
-    /// <summary>The <c>builtin</c> variant.</summary>
-    [JsonStringEnumMemberName("builtin")]
-    Builtin,
+    /// <summary>Gets the <c>user</c> value.</summary>
+    public static McpServerSource User { get; } = new("user");
+
+    /// <summary>Gets the <c>workspace</c> value.</summary>
+    public static McpServerSource Workspace { get; } = new("workspace");
+
+    /// <summary>Gets the <c>plugin</c> value.</summary>
+    public static McpServerSource Plugin { get; } = new("plugin");
+
+    /// <summary>Gets the <c>builtin</c> value.</summary>
+    public static McpServerSource Builtin { get; } = new("builtin");
+
+    /// <summary>Gets the value associated with this <see cref="McpServerSource"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="McpServerSource"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="McpServerSource"/>.</param>
+    [JsonConstructor]
+    public McpServerSource(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="McpServerSource"/> instances are equivalent.</summary>
+    public static bool operator ==(McpServerSource left, McpServerSource right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="McpServerSource"/> instances are not equivalent.</summary>
+    public static bool operator !=(McpServerSource left, McpServerSource right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is McpServerSource other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(McpServerSource other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{McpServerSource}"/> for serializing <see cref="McpServerSource"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<McpServerSource>
+    {
+        /// <inheritdoc />
+        public override McpServerSource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, McpServerSource value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>Connection status: connected, failed, needs-auth, pending, disabled, or not_configured.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<McpServerStatus>))]
-public enum McpServerStatus
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct McpServerStatus : IEquatable<McpServerStatus>
 {
-    /// <summary>The <c>connected</c> variant.</summary>
-    [JsonStringEnumMemberName("connected")]
-    Connected,
-    /// <summary>The <c>failed</c> variant.</summary>
-    [JsonStringEnumMemberName("failed")]
-    Failed,
-    /// <summary>The <c>needs-auth</c> variant.</summary>
-    [JsonStringEnumMemberName("needs-auth")]
-    NeedsAuth,
-    /// <summary>The <c>pending</c> variant.</summary>
-    [JsonStringEnumMemberName("pending")]
-    Pending,
-    /// <summary>The <c>disabled</c> variant.</summary>
-    [JsonStringEnumMemberName("disabled")]
-    Disabled,
-    /// <summary>The <c>not_configured</c> variant.</summary>
-    [JsonStringEnumMemberName("not_configured")]
-    NotConfigured,
+    /// <summary>Gets the <c>connected</c> value.</summary>
+    public static McpServerStatus Connected { get; } = new("connected");
+
+    /// <summary>Gets the <c>failed</c> value.</summary>
+    public static McpServerStatus Failed { get; } = new("failed");
+
+    /// <summary>Gets the <c>needs-auth</c> value.</summary>
+    public static McpServerStatus NeedsAuth { get; } = new("needs-auth");
+
+    /// <summary>Gets the <c>pending</c> value.</summary>
+    public static McpServerStatus Pending { get; } = new("pending");
+
+    /// <summary>Gets the <c>disabled</c> value.</summary>
+    public static McpServerStatus Disabled { get; } = new("disabled");
+
+    /// <summary>Gets the <c>not_configured</c> value.</summary>
+    public static McpServerStatus NotConfigured { get; } = new("not_configured");
+
+    /// <summary>Gets the value associated with this <see cref="McpServerStatus"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="McpServerStatus"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="McpServerStatus"/>.</param>
+    [JsonConstructor]
+    public McpServerStatus(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="McpServerStatus"/> instances are equivalent.</summary>
+    public static bool operator ==(McpServerStatus left, McpServerStatus right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="McpServerStatus"/> instances are not equivalent.</summary>
+    public static bool operator !=(McpServerStatus left, McpServerStatus right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is McpServerStatus other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(McpServerStatus other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{McpServerStatus}"/> for serializing <see cref="McpServerStatus"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<McpServerStatus>
+    {
+        /// <inheritdoc />
+        public override McpServerStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, McpServerStatus value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>Discovery source: project (.github/extensions/) or user (~/.copilot/extensions/).</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<ExtensionSource>))]
-public enum ExtensionSource
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct ExtensionSource : IEquatable<ExtensionSource>
 {
-    /// <summary>The <c>project</c> variant.</summary>
-    [JsonStringEnumMemberName("project")]
-    Project,
-    /// <summary>The <c>user</c> variant.</summary>
-    [JsonStringEnumMemberName("user")]
-    User,
+    /// <summary>Gets the <c>project</c> value.</summary>
+    public static ExtensionSource Project { get; } = new("project");
+
+    /// <summary>Gets the <c>user</c> value.</summary>
+    public static ExtensionSource User { get; } = new("user");
+
+    /// <summary>Gets the value associated with this <see cref="ExtensionSource"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="ExtensionSource"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="ExtensionSource"/>.</param>
+    [JsonConstructor]
+    public ExtensionSource(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="ExtensionSource"/> instances are equivalent.</summary>
+    public static bool operator ==(ExtensionSource left, ExtensionSource right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="ExtensionSource"/> instances are not equivalent.</summary>
+    public static bool operator !=(ExtensionSource left, ExtensionSource right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is ExtensionSource other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(ExtensionSource other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{ExtensionSource}"/> for serializing <see cref="ExtensionSource"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<ExtensionSource>
+    {
+        /// <inheritdoc />
+        public override ExtensionSource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, ExtensionSource value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>Current status: running, disabled, failed, or starting.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<ExtensionStatus>))]
-public enum ExtensionStatus
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct ExtensionStatus : IEquatable<ExtensionStatus>
 {
-    /// <summary>The <c>running</c> variant.</summary>
-    [JsonStringEnumMemberName("running")]
-    Running,
-    /// <summary>The <c>disabled</c> variant.</summary>
-    [JsonStringEnumMemberName("disabled")]
-    Disabled,
-    /// <summary>The <c>failed</c> variant.</summary>
-    [JsonStringEnumMemberName("failed")]
-    Failed,
-    /// <summary>The <c>starting</c> variant.</summary>
-    [JsonStringEnumMemberName("starting")]
-    Starting,
+    /// <summary>Gets the <c>running</c> value.</summary>
+    public static ExtensionStatus Running { get; } = new("running");
+
+    /// <summary>Gets the <c>disabled</c> value.</summary>
+    public static ExtensionStatus Disabled { get; } = new("disabled");
+
+    /// <summary>Gets the <c>failed</c> value.</summary>
+    public static ExtensionStatus Failed { get; } = new("failed");
+
+    /// <summary>Gets the <c>starting</c> value.</summary>
+    public static ExtensionStatus Starting { get; } = new("starting");
+
+    /// <summary>Gets the value associated with this <see cref="ExtensionStatus"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="ExtensionStatus"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="ExtensionStatus"/>.</param>
+    [JsonConstructor]
+    public ExtensionStatus(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="ExtensionStatus"/> instances are equivalent.</summary>
+    public static bool operator ==(ExtensionStatus left, ExtensionStatus right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="ExtensionStatus"/> instances are not equivalent.</summary>
+    public static bool operator !=(ExtensionStatus left, ExtensionStatus right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is ExtensionStatus other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(ExtensionStatus other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{ExtensionStatus}"/> for serializing <see cref="ExtensionStatus"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<ExtensionStatus>
+    {
+        /// <inheritdoc />
+        public override ExtensionStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, ExtensionStatus value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>The user's response: accept (submitted), decline (rejected), or cancel (dismissed).</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<UIElicitationResponseAction>))]
-public enum UIElicitationResponseAction
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct UIElicitationResponseAction : IEquatable<UIElicitationResponseAction>
 {
-    /// <summary>The <c>accept</c> variant.</summary>
-    [JsonStringEnumMemberName("accept")]
-    Accept,
-    /// <summary>The <c>decline</c> variant.</summary>
-    [JsonStringEnumMemberName("decline")]
-    Decline,
-    /// <summary>The <c>cancel</c> variant.</summary>
-    [JsonStringEnumMemberName("cancel")]
-    Cancel,
+    /// <summary>Gets the <c>accept</c> value.</summary>
+    public static UIElicitationResponseAction Accept { get; } = new("accept");
+
+    /// <summary>Gets the <c>decline</c> value.</summary>
+    public static UIElicitationResponseAction Decline { get; } = new("decline");
+
+    /// <summary>Gets the <c>cancel</c> value.</summary>
+    public static UIElicitationResponseAction Cancel { get; } = new("cancel");
+
+    /// <summary>Gets the value associated with this <see cref="UIElicitationResponseAction"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="UIElicitationResponseAction"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="UIElicitationResponseAction"/>.</param>
+    [JsonConstructor]
+    public UIElicitationResponseAction(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="UIElicitationResponseAction"/> instances are equivalent.</summary>
+    public static bool operator ==(UIElicitationResponseAction left, UIElicitationResponseAction right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="UIElicitationResponseAction"/> instances are not equivalent.</summary>
+    public static bool operator !=(UIElicitationResponseAction left, UIElicitationResponseAction right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is UIElicitationResponseAction other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(UIElicitationResponseAction other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{UIElicitationResponseAction}"/> for serializing <see cref="UIElicitationResponseAction"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<UIElicitationResponseAction>
+    {
+        /// <inheritdoc />
+        public override UIElicitationResponseAction Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, UIElicitationResponseAction value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>Signal to send (default: SIGTERM).</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<ShellKillSignal>))]
-public enum ShellKillSignal
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct ShellKillSignal : IEquatable<ShellKillSignal>
 {
-    /// <summary>The <c>SIGTERM</c> variant.</summary>
-    [JsonStringEnumMemberName("SIGTERM")]
-    SIGTERM,
-    /// <summary>The <c>SIGKILL</c> variant.</summary>
-    [JsonStringEnumMemberName("SIGKILL")]
-    SIGKILL,
-    /// <summary>The <c>SIGINT</c> variant.</summary>
-    [JsonStringEnumMemberName("SIGINT")]
-    SIGINT,
+    /// <summary>Gets the <c>SIGTERM</c> value.</summary>
+    public static ShellKillSignal SIGTERM { get; } = new("SIGTERM");
+
+    /// <summary>Gets the <c>SIGKILL</c> value.</summary>
+    public static ShellKillSignal SIGKILL { get; } = new("SIGKILL");
+
+    /// <summary>Gets the <c>SIGINT</c> value.</summary>
+    public static ShellKillSignal SIGINT { get; } = new("SIGINT");
+
+    /// <summary>Gets the value associated with this <see cref="ShellKillSignal"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="ShellKillSignal"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="ShellKillSignal"/>.</param>
+    [JsonConstructor]
+    public ShellKillSignal(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="ShellKillSignal"/> instances are equivalent.</summary>
+    public static bool operator ==(ShellKillSignal left, ShellKillSignal right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="ShellKillSignal"/> instances are not equivalent.</summary>
+    public static bool operator !=(ShellKillSignal left, ShellKillSignal right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is ShellKillSignal other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(ShellKillSignal other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{ShellKillSignal}"/> for serializing <see cref="ShellKillSignal"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<ShellKillSignal>
+    {
+        /// <inheritdoc />
+        public override ShellKillSignal Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, ShellKillSignal value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>Error classification.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<SessionFsErrorCode>))]
-public enum SessionFsErrorCode
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct SessionFsErrorCode : IEquatable<SessionFsErrorCode>
 {
-    /// <summary>The <c>ENOENT</c> variant.</summary>
-    [JsonStringEnumMemberName("ENOENT")]
-    ENOENT,
-    /// <summary>The <c>UNKNOWN</c> variant.</summary>
-    [JsonStringEnumMemberName("UNKNOWN")]
-    UNKNOWN,
+    /// <summary>Gets the <c>ENOENT</c> value.</summary>
+    public static SessionFsErrorCode ENOENT { get; } = new("ENOENT");
+
+    /// <summary>Gets the <c>UNKNOWN</c> value.</summary>
+    public static SessionFsErrorCode UNKNOWN { get; } = new("UNKNOWN");
+
+    /// <summary>Gets the value associated with this <see cref="SessionFsErrorCode"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="SessionFsErrorCode"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="SessionFsErrorCode"/>.</param>
+    [JsonConstructor]
+    public SessionFsErrorCode(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="SessionFsErrorCode"/> instances are equivalent.</summary>
+    public static bool operator ==(SessionFsErrorCode left, SessionFsErrorCode right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="SessionFsErrorCode"/> instances are not equivalent.</summary>
+    public static bool operator !=(SessionFsErrorCode left, SessionFsErrorCode right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is SessionFsErrorCode other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(SessionFsErrorCode other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{SessionFsErrorCode}"/> for serializing <see cref="SessionFsErrorCode"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<SessionFsErrorCode>
+    {
+        /// <inheritdoc />
+        public override SessionFsErrorCode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, SessionFsErrorCode value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 
 /// <summary>Entry type.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<SessionFsReaddirWithTypesEntryType>))]
-public enum SessionFsReaddirWithTypesEntryType
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct SessionFsReaddirWithTypesEntryType : IEquatable<SessionFsReaddirWithTypesEntryType>
 {
-    /// <summary>The <c>file</c> variant.</summary>
-    [JsonStringEnumMemberName("file")]
-    File,
-    /// <summary>The <c>directory</c> variant.</summary>
-    [JsonStringEnumMemberName("directory")]
-    Directory,
+    /// <summary>Gets the <c>file</c> value.</summary>
+    public static SessionFsReaddirWithTypesEntryType File { get; } = new("file");
+
+    /// <summary>Gets the <c>directory</c> value.</summary>
+    public static SessionFsReaddirWithTypesEntryType Directory { get; } = new("directory");
+
+    /// <summary>Gets the value associated with this <see cref="SessionFsReaddirWithTypesEntryType"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="SessionFsReaddirWithTypesEntryType"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="SessionFsReaddirWithTypesEntryType"/>.</param>
+    [JsonConstructor]
+    public SessionFsReaddirWithTypesEntryType(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="SessionFsReaddirWithTypesEntryType"/> instances are equivalent.</summary>
+    public static bool operator ==(SessionFsReaddirWithTypesEntryType left, SessionFsReaddirWithTypesEntryType right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="SessionFsReaddirWithTypesEntryType"/> instances are not equivalent.</summary>
+    public static bool operator !=(SessionFsReaddirWithTypesEntryType left, SessionFsReaddirWithTypesEntryType right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is SessionFsReaddirWithTypesEntryType other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(SessionFsReaddirWithTypesEntryType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{SessionFsReaddirWithTypesEntryType}"/> for serializing <see cref="SessionFsReaddirWithTypesEntryType"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<SessionFsReaddirWithTypesEntryType>
+    {
+        /// <inheritdoc />
+        public override SessionFsReaddirWithTypesEntryType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, SessionFsReaddirWithTypesEntryType value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 

--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -2821,17 +2821,13 @@ public readonly struct DiscoveredMcpServerSource : IEquatable<DiscoveredMcpServe
         /// <inheritdoc />
         public override DiscoveredMcpServerSource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading DiscoveredMcpServerSource, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, DiscoveredMcpServerSource value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(DiscoveredMcpServerSource));
         }
     }
 }
@@ -2893,17 +2889,13 @@ public readonly struct DiscoveredMcpServerType : IEquatable<DiscoveredMcpServerT
         /// <inheritdoc />
         public override DiscoveredMcpServerType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading DiscoveredMcpServerType, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, DiscoveredMcpServerType value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(DiscoveredMcpServerType));
         }
     }
 }
@@ -2959,17 +2951,13 @@ public readonly struct SessionFsSetProviderConventions : IEquatable<SessionFsSet
         /// <inheritdoc />
         public override SessionFsSetProviderConventions Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading SessionFsSetProviderConventions, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, SessionFsSetProviderConventions value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(SessionFsSetProviderConventions));
         }
     }
 }
@@ -3028,17 +3016,13 @@ public readonly struct SessionLogLevel : IEquatable<SessionLogLevel>
         /// <inheritdoc />
         public override SessionLogLevel Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading SessionLogLevel, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, SessionLogLevel value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(SessionLogLevel));
         }
     }
 }
@@ -3109,17 +3093,13 @@ public readonly struct AuthInfoType : IEquatable<AuthInfoType>
         /// <inheritdoc />
         public override AuthInfoType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading AuthInfoType, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, AuthInfoType value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(AuthInfoType));
         }
     }
 }
@@ -3178,17 +3158,13 @@ public readonly struct SessionMode : IEquatable<SessionMode>
         /// <inheritdoc />
         public override SessionMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading SessionMode, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, SessionMode value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(SessionMode));
         }
     }
 }
@@ -3244,17 +3220,13 @@ public readonly struct WorkspacesGetWorkspaceResultWorkspaceHostType : IEquatabl
         /// <inheritdoc />
         public override WorkspacesGetWorkspaceResultWorkspaceHostType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading WorkspacesGetWorkspaceResultWorkspaceHostType, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, WorkspacesGetWorkspaceResultWorkspaceHostType value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(WorkspacesGetWorkspaceResultWorkspaceHostType));
         }
     }
 }
@@ -3313,17 +3285,13 @@ public readonly struct WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel : I
         /// <inheritdoc />
         public override WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel));
         }
     }
 }
@@ -3382,17 +3350,13 @@ public readonly struct InstructionsSourcesLocation : IEquatable<InstructionsSour
         /// <inheritdoc />
         public override InstructionsSourcesLocation Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading InstructionsSourcesLocation, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, InstructionsSourcesLocation value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(InstructionsSourcesLocation));
         }
     }
 }
@@ -3460,17 +3424,13 @@ public readonly struct InstructionsSourcesType : IEquatable<InstructionsSourcesT
         /// <inheritdoc />
         public override InstructionsSourcesType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading InstructionsSourcesType, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, InstructionsSourcesType value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(InstructionsSourcesType));
         }
     }
 }
@@ -3526,17 +3486,13 @@ public readonly struct TaskAgentInfoExecutionMode : IEquatable<TaskAgentInfoExec
         /// <inheritdoc />
         public override TaskAgentInfoExecutionMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading TaskAgentInfoExecutionMode, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, TaskAgentInfoExecutionMode value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(TaskAgentInfoExecutionMode));
         }
     }
 }
@@ -3601,17 +3557,13 @@ public readonly struct TaskAgentInfoStatus : IEquatable<TaskAgentInfoStatus>
         /// <inheritdoc />
         public override TaskAgentInfoStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading TaskAgentInfoStatus, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, TaskAgentInfoStatus value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(TaskAgentInfoStatus));
         }
     }
 }
@@ -3667,17 +3619,13 @@ public readonly struct TaskShellInfoAttachmentMode : IEquatable<TaskShellInfoAtt
         /// <inheritdoc />
         public override TaskShellInfoAttachmentMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading TaskShellInfoAttachmentMode, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, TaskShellInfoAttachmentMode value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(TaskShellInfoAttachmentMode));
         }
     }
 }
@@ -3733,17 +3681,13 @@ public readonly struct TaskShellInfoExecutionMode : IEquatable<TaskShellInfoExec
         /// <inheritdoc />
         public override TaskShellInfoExecutionMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading TaskShellInfoExecutionMode, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, TaskShellInfoExecutionMode value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(TaskShellInfoExecutionMode));
         }
     }
 }
@@ -3808,17 +3752,13 @@ public readonly struct TaskShellInfoStatus : IEquatable<TaskShellInfoStatus>
         /// <inheritdoc />
         public override TaskShellInfoStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading TaskShellInfoStatus, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, TaskShellInfoStatus value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(TaskShellInfoStatus));
         }
     }
 }
@@ -3880,17 +3820,13 @@ public readonly struct McpServerSource : IEquatable<McpServerSource>
         /// <inheritdoc />
         public override McpServerSource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading McpServerSource, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, McpServerSource value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(McpServerSource));
         }
     }
 }
@@ -3958,17 +3894,13 @@ public readonly struct McpServerStatus : IEquatable<McpServerStatus>
         /// <inheritdoc />
         public override McpServerStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading McpServerStatus, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, McpServerStatus value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(McpServerStatus));
         }
     }
 }
@@ -4024,17 +3956,13 @@ public readonly struct ExtensionSource : IEquatable<ExtensionSource>
         /// <inheritdoc />
         public override ExtensionSource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ExtensionSource, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, ExtensionSource value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(ExtensionSource));
         }
     }
 }
@@ -4096,17 +4024,13 @@ public readonly struct ExtensionStatus : IEquatable<ExtensionStatus>
         /// <inheritdoc />
         public override ExtensionStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ExtensionStatus, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, ExtensionStatus value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(ExtensionStatus));
         }
     }
 }
@@ -4165,17 +4089,13 @@ public readonly struct UIElicitationResponseAction : IEquatable<UIElicitationRes
         /// <inheritdoc />
         public override UIElicitationResponseAction Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading UIElicitationResponseAction, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, UIElicitationResponseAction value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(UIElicitationResponseAction));
         }
     }
 }
@@ -4234,17 +4154,13 @@ public readonly struct ShellKillSignal : IEquatable<ShellKillSignal>
         /// <inheritdoc />
         public override ShellKillSignal Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ShellKillSignal, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, ShellKillSignal value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(ShellKillSignal));
         }
     }
 }
@@ -4300,17 +4216,13 @@ public readonly struct SessionFsErrorCode : IEquatable<SessionFsErrorCode>
         /// <inheritdoc />
         public override SessionFsErrorCode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading SessionFsErrorCode, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, SessionFsErrorCode value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(SessionFsErrorCode));
         }
     }
 }
@@ -4366,17 +4278,13 @@ public readonly struct SessionFsReaddirWithTypesEntryType : IEquatable<SessionFs
         /// <inheritdoc />
         public override SessionFsReaddirWithTypesEntryType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading SessionFsReaddirWithTypesEntryType, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, SessionFsReaddirWithTypesEntryType value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(SessionFsReaddirWithTypesEntryType));
         }
     }
 }

--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -2821,6 +2821,7 @@ public readonly struct DiscoveredMcpServerSource : IEquatable<DiscoveredMcpServe
         /// <inheritdoc />
         public override DiscoveredMcpServerSource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading DiscoveredMcpServerSource, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -2892,6 +2893,7 @@ public readonly struct DiscoveredMcpServerType : IEquatable<DiscoveredMcpServerT
         /// <inheritdoc />
         public override DiscoveredMcpServerType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading DiscoveredMcpServerType, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -2957,6 +2959,7 @@ public readonly struct SessionFsSetProviderConventions : IEquatable<SessionFsSet
         /// <inheritdoc />
         public override SessionFsSetProviderConventions Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading SessionFsSetProviderConventions, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -3025,6 +3028,7 @@ public readonly struct SessionLogLevel : IEquatable<SessionLogLevel>
         /// <inheritdoc />
         public override SessionLogLevel Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading SessionLogLevel, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -3105,6 +3109,7 @@ public readonly struct AuthInfoType : IEquatable<AuthInfoType>
         /// <inheritdoc />
         public override AuthInfoType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading AuthInfoType, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -3173,6 +3178,7 @@ public readonly struct SessionMode : IEquatable<SessionMode>
         /// <inheritdoc />
         public override SessionMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading SessionMode, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -3238,6 +3244,7 @@ public readonly struct WorkspacesGetWorkspaceResultWorkspaceHostType : IEquatabl
         /// <inheritdoc />
         public override WorkspacesGetWorkspaceResultWorkspaceHostType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading WorkspacesGetWorkspaceResultWorkspaceHostType, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -3306,6 +3313,7 @@ public readonly struct WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel : I
         /// <inheritdoc />
         public override WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading WorkspacesGetWorkspaceResultWorkspaceSessionSyncLevel, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -3374,6 +3382,7 @@ public readonly struct InstructionsSourcesLocation : IEquatable<InstructionsSour
         /// <inheritdoc />
         public override InstructionsSourcesLocation Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading InstructionsSourcesLocation, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -3451,6 +3460,7 @@ public readonly struct InstructionsSourcesType : IEquatable<InstructionsSourcesT
         /// <inheritdoc />
         public override InstructionsSourcesType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading InstructionsSourcesType, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -3516,6 +3526,7 @@ public readonly struct TaskAgentInfoExecutionMode : IEquatable<TaskAgentInfoExec
         /// <inheritdoc />
         public override TaskAgentInfoExecutionMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading TaskAgentInfoExecutionMode, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -3590,6 +3601,7 @@ public readonly struct TaskAgentInfoStatus : IEquatable<TaskAgentInfoStatus>
         /// <inheritdoc />
         public override TaskAgentInfoStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading TaskAgentInfoStatus, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -3655,6 +3667,7 @@ public readonly struct TaskShellInfoAttachmentMode : IEquatable<TaskShellInfoAtt
         /// <inheritdoc />
         public override TaskShellInfoAttachmentMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading TaskShellInfoAttachmentMode, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -3720,6 +3733,7 @@ public readonly struct TaskShellInfoExecutionMode : IEquatable<TaskShellInfoExec
         /// <inheritdoc />
         public override TaskShellInfoExecutionMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading TaskShellInfoExecutionMode, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -3794,6 +3808,7 @@ public readonly struct TaskShellInfoStatus : IEquatable<TaskShellInfoStatus>
         /// <inheritdoc />
         public override TaskShellInfoStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading TaskShellInfoStatus, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -3865,6 +3880,7 @@ public readonly struct McpServerSource : IEquatable<McpServerSource>
         /// <inheritdoc />
         public override McpServerSource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading McpServerSource, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -3942,6 +3958,7 @@ public readonly struct McpServerStatus : IEquatable<McpServerStatus>
         /// <inheritdoc />
         public override McpServerStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading McpServerStatus, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -4007,6 +4024,7 @@ public readonly struct ExtensionSource : IEquatable<ExtensionSource>
         /// <inheritdoc />
         public override ExtensionSource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ExtensionSource, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -4078,6 +4096,7 @@ public readonly struct ExtensionStatus : IEquatable<ExtensionStatus>
         /// <inheritdoc />
         public override ExtensionStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ExtensionStatus, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -4146,6 +4165,7 @@ public readonly struct UIElicitationResponseAction : IEquatable<UIElicitationRes
         /// <inheritdoc />
         public override UIElicitationResponseAction Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading UIElicitationResponseAction, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -4214,6 +4234,7 @@ public readonly struct ShellKillSignal : IEquatable<ShellKillSignal>
         /// <inheritdoc />
         public override ShellKillSignal Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ShellKillSignal, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -4279,6 +4300,7 @@ public readonly struct SessionFsErrorCode : IEquatable<SessionFsErrorCode>
         /// <inheritdoc />
         public override SessionFsErrorCode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading SessionFsErrorCode, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -4344,6 +4366,7 @@ public readonly struct SessionFsReaddirWithTypesEntryType : IEquatable<SessionFs
         /// <inheritdoc />
         public override SessionFsReaddirWithTypesEntryType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading SessionFsReaddirWithTypesEntryType, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);

--- a/dotnet/src/Generated/SessionEvents.cs
+++ b/dotnet/src/Generated/SessionEvents.cs
@@ -4887,9 +4887,6 @@ public readonly struct WorkingDirectoryContextHostType : IEquatable<WorkingDirec
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="WorkingDirectoryContextHostType"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="WorkingDirectoryContextHostType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="WorkingDirectoryContextHostType"/>.</param>
     [JsonConstructor]
@@ -4898,6 +4895,9 @@ public readonly struct WorkingDirectoryContextHostType : IEquatable<WorkingDirec
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="WorkingDirectoryContextHostType"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>github</c> value.</summary>
     public static WorkingDirectoryContextHostType Github { get; } = new("github");
@@ -4948,9 +4948,6 @@ public readonly struct PlanChangedOperation : IEquatable<PlanChangedOperation>
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="PlanChangedOperation"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="PlanChangedOperation"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="PlanChangedOperation"/>.</param>
     [JsonConstructor]
@@ -4959,6 +4956,9 @@ public readonly struct PlanChangedOperation : IEquatable<PlanChangedOperation>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="PlanChangedOperation"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>create</c> value.</summary>
     public static PlanChangedOperation Create { get; } = new("create");
@@ -5012,9 +5012,6 @@ public readonly struct WorkspaceFileChangedOperation : IEquatable<WorkspaceFileC
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="WorkspaceFileChangedOperation"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="WorkspaceFileChangedOperation"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="WorkspaceFileChangedOperation"/>.</param>
     [JsonConstructor]
@@ -5023,6 +5020,9 @@ public readonly struct WorkspaceFileChangedOperation : IEquatable<WorkspaceFileC
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="WorkspaceFileChangedOperation"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>create</c> value.</summary>
     public static WorkspaceFileChangedOperation Create { get; } = new("create");
@@ -5073,9 +5073,6 @@ public readonly struct HandoffSourceType : IEquatable<HandoffSourceType>
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="HandoffSourceType"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="HandoffSourceType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="HandoffSourceType"/>.</param>
     [JsonConstructor]
@@ -5084,6 +5081,9 @@ public readonly struct HandoffSourceType : IEquatable<HandoffSourceType>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="HandoffSourceType"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>remote</c> value.</summary>
     public static HandoffSourceType Remote { get; } = new("remote");
@@ -5134,9 +5134,6 @@ public readonly struct ShutdownType : IEquatable<ShutdownType>
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="ShutdownType"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="ShutdownType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ShutdownType"/>.</param>
     [JsonConstructor]
@@ -5145,6 +5142,9 @@ public readonly struct ShutdownType : IEquatable<ShutdownType>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="ShutdownType"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>routine</c> value.</summary>
     public static ShutdownType Routine { get; } = new("routine");
@@ -5195,9 +5195,6 @@ public readonly struct UserMessageAgentMode : IEquatable<UserMessageAgentMode>
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="UserMessageAgentMode"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="UserMessageAgentMode"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="UserMessageAgentMode"/>.</param>
     [JsonConstructor]
@@ -5206,6 +5203,9 @@ public readonly struct UserMessageAgentMode : IEquatable<UserMessageAgentMode>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="UserMessageAgentMode"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>interactive</c> value.</summary>
     public static UserMessageAgentMode Interactive { get; } = new("interactive");
@@ -5262,9 +5262,6 @@ public readonly struct UserMessageAttachmentGithubReferenceType : IEquatable<Use
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="UserMessageAttachmentGithubReferenceType"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="UserMessageAttachmentGithubReferenceType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="UserMessageAttachmentGithubReferenceType"/>.</param>
     [JsonConstructor]
@@ -5273,6 +5270,9 @@ public readonly struct UserMessageAttachmentGithubReferenceType : IEquatable<Use
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="UserMessageAttachmentGithubReferenceType"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>issue</c> value.</summary>
     public static UserMessageAttachmentGithubReferenceType Issue { get; } = new("issue");
@@ -5326,9 +5326,6 @@ public readonly struct AssistantMessageToolRequestType : IEquatable<AssistantMes
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="AssistantMessageToolRequestType"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="AssistantMessageToolRequestType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="AssistantMessageToolRequestType"/>.</param>
     [JsonConstructor]
@@ -5337,6 +5334,9 @@ public readonly struct AssistantMessageToolRequestType : IEquatable<AssistantMes
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="AssistantMessageToolRequestType"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>function</c> value.</summary>
     public static AssistantMessageToolRequestType Function { get; } = new("function");
@@ -5387,9 +5387,6 @@ public readonly struct ModelCallFailureSource : IEquatable<ModelCallFailureSourc
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="ModelCallFailureSource"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="ModelCallFailureSource"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ModelCallFailureSource"/>.</param>
     [JsonConstructor]
@@ -5398,6 +5395,9 @@ public readonly struct ModelCallFailureSource : IEquatable<ModelCallFailureSourc
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="ModelCallFailureSource"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>top_level</c> value.</summary>
     public static ModelCallFailureSource TopLevel { get; } = new("top_level");
@@ -5451,9 +5451,6 @@ public readonly struct AbortReason : IEquatable<AbortReason>
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="AbortReason"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="AbortReason"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="AbortReason"/>.</param>
     [JsonConstructor]
@@ -5462,6 +5459,9 @@ public readonly struct AbortReason : IEquatable<AbortReason>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="AbortReason"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>user_initiated</c> value.</summary>
     public static AbortReason UserInitiated { get; } = new("user_initiated");
@@ -5515,9 +5515,6 @@ public readonly struct ToolExecutionCompleteContentResourceLinkIconTheme : IEqua
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="ToolExecutionCompleteContentResourceLinkIconTheme"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="ToolExecutionCompleteContentResourceLinkIconTheme"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ToolExecutionCompleteContentResourceLinkIconTheme"/>.</param>
     [JsonConstructor]
@@ -5526,6 +5523,9 @@ public readonly struct ToolExecutionCompleteContentResourceLinkIconTheme : IEqua
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="ToolExecutionCompleteContentResourceLinkIconTheme"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>light</c> value.</summary>
     public static ToolExecutionCompleteContentResourceLinkIconTheme Light { get; } = new("light");
@@ -5576,9 +5576,6 @@ public readonly struct SystemMessageRole : IEquatable<SystemMessageRole>
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="SystemMessageRole"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="SystemMessageRole"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="SystemMessageRole"/>.</param>
     [JsonConstructor]
@@ -5587,6 +5584,9 @@ public readonly struct SystemMessageRole : IEquatable<SystemMessageRole>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="SystemMessageRole"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>system</c> value.</summary>
     public static SystemMessageRole System { get; } = new("system");
@@ -5637,9 +5637,6 @@ public readonly struct SystemNotificationAgentCompletedStatus : IEquatable<Syste
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="SystemNotificationAgentCompletedStatus"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="SystemNotificationAgentCompletedStatus"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="SystemNotificationAgentCompletedStatus"/>.</param>
     [JsonConstructor]
@@ -5648,6 +5645,9 @@ public readonly struct SystemNotificationAgentCompletedStatus : IEquatable<Syste
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="SystemNotificationAgentCompletedStatus"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>completed</c> value.</summary>
     public static SystemNotificationAgentCompletedStatus Completed { get; } = new("completed");
@@ -5698,9 +5698,6 @@ public readonly struct PermissionRequestMemoryAction : IEquatable<PermissionRequ
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="PermissionRequestMemoryAction"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="PermissionRequestMemoryAction"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="PermissionRequestMemoryAction"/>.</param>
     [JsonConstructor]
@@ -5709,6 +5706,9 @@ public readonly struct PermissionRequestMemoryAction : IEquatable<PermissionRequ
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="PermissionRequestMemoryAction"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>store</c> value.</summary>
     public static PermissionRequestMemoryAction Store { get; } = new("store");
@@ -5759,9 +5759,6 @@ public readonly struct PermissionRequestMemoryDirection : IEquatable<PermissionR
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="PermissionRequestMemoryDirection"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="PermissionRequestMemoryDirection"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="PermissionRequestMemoryDirection"/>.</param>
     [JsonConstructor]
@@ -5770,6 +5767,9 @@ public readonly struct PermissionRequestMemoryDirection : IEquatable<PermissionR
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="PermissionRequestMemoryDirection"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>upvote</c> value.</summary>
     public static PermissionRequestMemoryDirection Upvote { get; } = new("upvote");
@@ -5820,9 +5820,6 @@ public readonly struct PermissionPromptRequestMemoryAction : IEquatable<Permissi
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="PermissionPromptRequestMemoryAction"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="PermissionPromptRequestMemoryAction"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="PermissionPromptRequestMemoryAction"/>.</param>
     [JsonConstructor]
@@ -5831,6 +5828,9 @@ public readonly struct PermissionPromptRequestMemoryAction : IEquatable<Permissi
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="PermissionPromptRequestMemoryAction"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>store</c> value.</summary>
     public static PermissionPromptRequestMemoryAction Store { get; } = new("store");
@@ -5881,9 +5881,6 @@ public readonly struct PermissionPromptRequestMemoryDirection : IEquatable<Permi
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="PermissionPromptRequestMemoryDirection"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="PermissionPromptRequestMemoryDirection"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="PermissionPromptRequestMemoryDirection"/>.</param>
     [JsonConstructor]
@@ -5892,6 +5889,9 @@ public readonly struct PermissionPromptRequestMemoryDirection : IEquatable<Permi
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="PermissionPromptRequestMemoryDirection"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>upvote</c> value.</summary>
     public static PermissionPromptRequestMemoryDirection Upvote { get; } = new("upvote");
@@ -5942,9 +5942,6 @@ public readonly struct PermissionPromptRequestPathAccessKind : IEquatable<Permis
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="PermissionPromptRequestPathAccessKind"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="PermissionPromptRequestPathAccessKind"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="PermissionPromptRequestPathAccessKind"/>.</param>
     [JsonConstructor]
@@ -5953,6 +5950,9 @@ public readonly struct PermissionPromptRequestPathAccessKind : IEquatable<Permis
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="PermissionPromptRequestPathAccessKind"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>read</c> value.</summary>
     public static PermissionPromptRequestPathAccessKind Read { get; } = new("read");
@@ -6006,9 +6006,6 @@ public readonly struct ElicitationRequestedMode : IEquatable<ElicitationRequeste
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="ElicitationRequestedMode"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="ElicitationRequestedMode"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ElicitationRequestedMode"/>.</param>
     [JsonConstructor]
@@ -6017,6 +6014,9 @@ public readonly struct ElicitationRequestedMode : IEquatable<ElicitationRequeste
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="ElicitationRequestedMode"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>form</c> value.</summary>
     public static ElicitationRequestedMode Form { get; } = new("form");
@@ -6067,9 +6067,6 @@ public readonly struct ElicitationCompletedAction : IEquatable<ElicitationComple
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="ElicitationCompletedAction"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="ElicitationCompletedAction"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ElicitationCompletedAction"/>.</param>
     [JsonConstructor]
@@ -6078,6 +6075,9 @@ public readonly struct ElicitationCompletedAction : IEquatable<ElicitationComple
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="ElicitationCompletedAction"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>accept</c> value.</summary>
     public static ElicitationCompletedAction Accept { get; } = new("accept");
@@ -6131,9 +6131,6 @@ public readonly struct McpServersLoadedServerStatus : IEquatable<McpServersLoade
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="McpServersLoadedServerStatus"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="McpServersLoadedServerStatus"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="McpServersLoadedServerStatus"/>.</param>
     [JsonConstructor]
@@ -6142,6 +6139,9 @@ public readonly struct McpServersLoadedServerStatus : IEquatable<McpServersLoade
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="McpServersLoadedServerStatus"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>connected</c> value.</summary>
     public static McpServersLoadedServerStatus Connected { get; } = new("connected");
@@ -6204,9 +6204,6 @@ public readonly struct McpServerStatusChangedStatus : IEquatable<McpServerStatus
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="McpServerStatusChangedStatus"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="McpServerStatusChangedStatus"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="McpServerStatusChangedStatus"/>.</param>
     [JsonConstructor]
@@ -6215,6 +6212,9 @@ public readonly struct McpServerStatusChangedStatus : IEquatable<McpServerStatus
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="McpServerStatusChangedStatus"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>connected</c> value.</summary>
     public static McpServerStatusChangedStatus Connected { get; } = new("connected");
@@ -6277,9 +6277,6 @@ public readonly struct ExtensionsLoadedExtensionSource : IEquatable<ExtensionsLo
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="ExtensionsLoadedExtensionSource"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="ExtensionsLoadedExtensionSource"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ExtensionsLoadedExtensionSource"/>.</param>
     [JsonConstructor]
@@ -6288,6 +6285,9 @@ public readonly struct ExtensionsLoadedExtensionSource : IEquatable<ExtensionsLo
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="ExtensionsLoadedExtensionSource"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>project</c> value.</summary>
     public static ExtensionsLoadedExtensionSource Project { get; } = new("project");
@@ -6338,9 +6338,6 @@ public readonly struct ExtensionsLoadedExtensionStatus : IEquatable<ExtensionsLo
 {
     private readonly string? _value;
 
-    /// <summary>Gets the value associated with this <see cref="ExtensionsLoadedExtensionStatus"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
     /// <summary>Initializes a new instance of the <see cref="ExtensionsLoadedExtensionStatus"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ExtensionsLoadedExtensionStatus"/>.</param>
     [JsonConstructor]
@@ -6349,6 +6346,9 @@ public readonly struct ExtensionsLoadedExtensionStatus : IEquatable<ExtensionsLo
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the value associated with this <see cref="ExtensionsLoadedExtensionStatus"/>.</summary>
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Gets the <c>running</c> value.</summary>
     public static ExtensionsLoadedExtensionStatus Running { get; } = new("running");

--- a/dotnet/src/Generated/SessionEvents.cs
+++ b/dotnet/src/Generated/SessionEvents.cs
@@ -4930,17 +4930,13 @@ public readonly struct WorkingDirectoryContextHostType : IEquatable<WorkingDirec
         /// <inheritdoc />
         public override WorkingDirectoryContextHostType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading WorkingDirectoryContextHostType, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, WorkingDirectoryContextHostType value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(WorkingDirectoryContextHostType));
         }
     }
 }
@@ -4998,17 +4994,13 @@ public readonly struct PlanChangedOperation : IEquatable<PlanChangedOperation>
         /// <inheritdoc />
         public override PlanChangedOperation Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading PlanChangedOperation, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, PlanChangedOperation value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(PlanChangedOperation));
         }
     }
 }
@@ -5063,17 +5055,13 @@ public readonly struct WorkspaceFileChangedOperation : IEquatable<WorkspaceFileC
         /// <inheritdoc />
         public override WorkspaceFileChangedOperation Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading WorkspaceFileChangedOperation, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, WorkspaceFileChangedOperation value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(WorkspaceFileChangedOperation));
         }
     }
 }
@@ -5128,17 +5116,13 @@ public readonly struct HandoffSourceType : IEquatable<HandoffSourceType>
         /// <inheritdoc />
         public override HandoffSourceType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading HandoffSourceType, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, HandoffSourceType value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(HandoffSourceType));
         }
     }
 }
@@ -5193,17 +5177,13 @@ public readonly struct ShutdownType : IEquatable<ShutdownType>
         /// <inheritdoc />
         public override ShutdownType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ShutdownType, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, ShutdownType value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(ShutdownType));
         }
     }
 }
@@ -5264,17 +5244,13 @@ public readonly struct UserMessageAgentMode : IEquatable<UserMessageAgentMode>
         /// <inheritdoc />
         public override UserMessageAgentMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading UserMessageAgentMode, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, UserMessageAgentMode value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(UserMessageAgentMode));
         }
     }
 }
@@ -5332,17 +5308,13 @@ public readonly struct UserMessageAttachmentGithubReferenceType : IEquatable<Use
         /// <inheritdoc />
         public override UserMessageAttachmentGithubReferenceType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading UserMessageAttachmentGithubReferenceType, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, UserMessageAttachmentGithubReferenceType value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(UserMessageAttachmentGithubReferenceType));
         }
     }
 }
@@ -5397,17 +5369,13 @@ public readonly struct AssistantMessageToolRequestType : IEquatable<AssistantMes
         /// <inheritdoc />
         public override AssistantMessageToolRequestType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading AssistantMessageToolRequestType, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, AssistantMessageToolRequestType value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(AssistantMessageToolRequestType));
         }
     }
 }
@@ -5465,17 +5433,13 @@ public readonly struct ModelCallFailureSource : IEquatable<ModelCallFailureSourc
         /// <inheritdoc />
         public override ModelCallFailureSource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ModelCallFailureSource, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, ModelCallFailureSource value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(ModelCallFailureSource));
         }
     }
 }
@@ -5533,17 +5497,13 @@ public readonly struct AbortReason : IEquatable<AbortReason>
         /// <inheritdoc />
         public override AbortReason Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading AbortReason, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, AbortReason value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(AbortReason));
         }
     }
 }
@@ -5598,17 +5558,13 @@ public readonly struct ToolExecutionCompleteContentResourceLinkIconTheme : IEqua
         /// <inheritdoc />
         public override ToolExecutionCompleteContentResourceLinkIconTheme Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ToolExecutionCompleteContentResourceLinkIconTheme, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, ToolExecutionCompleteContentResourceLinkIconTheme value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(ToolExecutionCompleteContentResourceLinkIconTheme));
         }
     }
 }
@@ -5663,17 +5619,13 @@ public readonly struct SystemMessageRole : IEquatable<SystemMessageRole>
         /// <inheritdoc />
         public override SystemMessageRole Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading SystemMessageRole, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, SystemMessageRole value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(SystemMessageRole));
         }
     }
 }
@@ -5728,17 +5680,13 @@ public readonly struct SystemNotificationAgentCompletedStatus : IEquatable<Syste
         /// <inheritdoc />
         public override SystemNotificationAgentCompletedStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading SystemNotificationAgentCompletedStatus, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, SystemNotificationAgentCompletedStatus value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(SystemNotificationAgentCompletedStatus));
         }
     }
 }
@@ -5793,17 +5741,13 @@ public readonly struct PermissionRequestMemoryAction : IEquatable<PermissionRequ
         /// <inheritdoc />
         public override PermissionRequestMemoryAction Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading PermissionRequestMemoryAction, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, PermissionRequestMemoryAction value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(PermissionRequestMemoryAction));
         }
     }
 }
@@ -5858,17 +5802,13 @@ public readonly struct PermissionRequestMemoryDirection : IEquatable<PermissionR
         /// <inheritdoc />
         public override PermissionRequestMemoryDirection Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading PermissionRequestMemoryDirection, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, PermissionRequestMemoryDirection value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(PermissionRequestMemoryDirection));
         }
     }
 }
@@ -5923,17 +5863,13 @@ public readonly struct PermissionPromptRequestMemoryAction : IEquatable<Permissi
         /// <inheritdoc />
         public override PermissionPromptRequestMemoryAction Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading PermissionPromptRequestMemoryAction, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, PermissionPromptRequestMemoryAction value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(PermissionPromptRequestMemoryAction));
         }
     }
 }
@@ -5988,17 +5924,13 @@ public readonly struct PermissionPromptRequestMemoryDirection : IEquatable<Permi
         /// <inheritdoc />
         public override PermissionPromptRequestMemoryDirection Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading PermissionPromptRequestMemoryDirection, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, PermissionPromptRequestMemoryDirection value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(PermissionPromptRequestMemoryDirection));
         }
     }
 }
@@ -6056,17 +5988,13 @@ public readonly struct PermissionPromptRequestPathAccessKind : IEquatable<Permis
         /// <inheritdoc />
         public override PermissionPromptRequestPathAccessKind Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading PermissionPromptRequestPathAccessKind, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, PermissionPromptRequestPathAccessKind value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(PermissionPromptRequestPathAccessKind));
         }
     }
 }
@@ -6121,17 +6049,13 @@ public readonly struct ElicitationRequestedMode : IEquatable<ElicitationRequeste
         /// <inheritdoc />
         public override ElicitationRequestedMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ElicitationRequestedMode, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, ElicitationRequestedMode value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(ElicitationRequestedMode));
         }
     }
 }
@@ -6189,17 +6113,13 @@ public readonly struct ElicitationCompletedAction : IEquatable<ElicitationComple
         /// <inheritdoc />
         public override ElicitationCompletedAction Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ElicitationCompletedAction, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, ElicitationCompletedAction value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(ElicitationCompletedAction));
         }
     }
 }
@@ -6266,17 +6186,13 @@ public readonly struct McpServersLoadedServerStatus : IEquatable<McpServersLoade
         /// <inheritdoc />
         public override McpServersLoadedServerStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading McpServersLoadedServerStatus, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, McpServersLoadedServerStatus value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(McpServersLoadedServerStatus));
         }
     }
 }
@@ -6343,17 +6259,13 @@ public readonly struct McpServerStatusChangedStatus : IEquatable<McpServerStatus
         /// <inheritdoc />
         public override McpServerStatusChangedStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading McpServerStatusChangedStatus, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, McpServerStatusChangedStatus value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(McpServerStatusChangedStatus));
         }
     }
 }
@@ -6408,17 +6320,13 @@ public readonly struct ExtensionsLoadedExtensionSource : IEquatable<ExtensionsLo
         /// <inheritdoc />
         public override ExtensionsLoadedExtensionSource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ExtensionsLoadedExtensionSource, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, ExtensionsLoadedExtensionSource value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(ExtensionsLoadedExtensionSource));
         }
     }
 }
@@ -6479,17 +6387,13 @@ public readonly struct ExtensionsLoadedExtensionStatus : IEquatable<ExtensionsLo
         /// <inheritdoc />
         public override ExtensionsLoadedExtensionStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ExtensionsLoadedExtensionStatus, but found {reader.TokenType}.");
-            var value = reader.GetString();
-            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
-            return new(value);
+            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, ExtensionsLoadedExtensionStatus value, JsonSerializerOptions options)
         {
-            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
-            writer.WriteStringValue(value.Value);
+            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(ExtensionsLoadedExtensionStatus));
         }
     }
 }

--- a/dotnet/src/Generated/SessionEvents.cs
+++ b/dotnet/src/Generated/SessionEvents.cs
@@ -4930,6 +4930,7 @@ public readonly struct WorkingDirectoryContextHostType : IEquatable<WorkingDirec
         /// <inheritdoc />
         public override WorkingDirectoryContextHostType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading WorkingDirectoryContextHostType, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -4997,6 +4998,7 @@ public readonly struct PlanChangedOperation : IEquatable<PlanChangedOperation>
         /// <inheritdoc />
         public override PlanChangedOperation Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading PlanChangedOperation, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -5061,6 +5063,7 @@ public readonly struct WorkspaceFileChangedOperation : IEquatable<WorkspaceFileC
         /// <inheritdoc />
         public override WorkspaceFileChangedOperation Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading WorkspaceFileChangedOperation, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -5125,6 +5128,7 @@ public readonly struct HandoffSourceType : IEquatable<HandoffSourceType>
         /// <inheritdoc />
         public override HandoffSourceType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading HandoffSourceType, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -5189,6 +5193,7 @@ public readonly struct ShutdownType : IEquatable<ShutdownType>
         /// <inheritdoc />
         public override ShutdownType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ShutdownType, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -5259,6 +5264,7 @@ public readonly struct UserMessageAgentMode : IEquatable<UserMessageAgentMode>
         /// <inheritdoc />
         public override UserMessageAgentMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading UserMessageAgentMode, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -5326,6 +5332,7 @@ public readonly struct UserMessageAttachmentGithubReferenceType : IEquatable<Use
         /// <inheritdoc />
         public override UserMessageAttachmentGithubReferenceType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading UserMessageAttachmentGithubReferenceType, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -5390,6 +5397,7 @@ public readonly struct AssistantMessageToolRequestType : IEquatable<AssistantMes
         /// <inheritdoc />
         public override AssistantMessageToolRequestType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading AssistantMessageToolRequestType, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -5457,6 +5465,7 @@ public readonly struct ModelCallFailureSource : IEquatable<ModelCallFailureSourc
         /// <inheritdoc />
         public override ModelCallFailureSource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ModelCallFailureSource, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -5524,6 +5533,7 @@ public readonly struct AbortReason : IEquatable<AbortReason>
         /// <inheritdoc />
         public override AbortReason Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading AbortReason, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -5588,6 +5598,7 @@ public readonly struct ToolExecutionCompleteContentResourceLinkIconTheme : IEqua
         /// <inheritdoc />
         public override ToolExecutionCompleteContentResourceLinkIconTheme Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ToolExecutionCompleteContentResourceLinkIconTheme, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -5652,6 +5663,7 @@ public readonly struct SystemMessageRole : IEquatable<SystemMessageRole>
         /// <inheritdoc />
         public override SystemMessageRole Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading SystemMessageRole, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -5716,6 +5728,7 @@ public readonly struct SystemNotificationAgentCompletedStatus : IEquatable<Syste
         /// <inheritdoc />
         public override SystemNotificationAgentCompletedStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading SystemNotificationAgentCompletedStatus, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -5780,6 +5793,7 @@ public readonly struct PermissionRequestMemoryAction : IEquatable<PermissionRequ
         /// <inheritdoc />
         public override PermissionRequestMemoryAction Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading PermissionRequestMemoryAction, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -5844,6 +5858,7 @@ public readonly struct PermissionRequestMemoryDirection : IEquatable<PermissionR
         /// <inheritdoc />
         public override PermissionRequestMemoryDirection Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading PermissionRequestMemoryDirection, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -5908,6 +5923,7 @@ public readonly struct PermissionPromptRequestMemoryAction : IEquatable<Permissi
         /// <inheritdoc />
         public override PermissionPromptRequestMemoryAction Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading PermissionPromptRequestMemoryAction, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -5972,6 +5988,7 @@ public readonly struct PermissionPromptRequestMemoryDirection : IEquatable<Permi
         /// <inheritdoc />
         public override PermissionPromptRequestMemoryDirection Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading PermissionPromptRequestMemoryDirection, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -6039,6 +6056,7 @@ public readonly struct PermissionPromptRequestPathAccessKind : IEquatable<Permis
         /// <inheritdoc />
         public override PermissionPromptRequestPathAccessKind Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading PermissionPromptRequestPathAccessKind, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -6103,6 +6121,7 @@ public readonly struct ElicitationRequestedMode : IEquatable<ElicitationRequeste
         /// <inheritdoc />
         public override ElicitationRequestedMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ElicitationRequestedMode, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -6170,6 +6189,7 @@ public readonly struct ElicitationCompletedAction : IEquatable<ElicitationComple
         /// <inheritdoc />
         public override ElicitationCompletedAction Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ElicitationCompletedAction, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -6246,6 +6266,7 @@ public readonly struct McpServersLoadedServerStatus : IEquatable<McpServersLoade
         /// <inheritdoc />
         public override McpServersLoadedServerStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading McpServersLoadedServerStatus, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -6322,6 +6343,7 @@ public readonly struct McpServerStatusChangedStatus : IEquatable<McpServerStatus
         /// <inheritdoc />
         public override McpServerStatusChangedStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading McpServerStatusChangedStatus, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -6386,6 +6408,7 @@ public readonly struct ExtensionsLoadedExtensionSource : IEquatable<ExtensionsLo
         /// <inheritdoc />
         public override ExtensionsLoadedExtensionSource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ExtensionsLoadedExtensionSource, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);
@@ -6456,6 +6479,7 @@ public readonly struct ExtensionsLoadedExtensionStatus : IEquatable<ExtensionsLo
         /// <inheritdoc />
         public override ExtensionsLoadedExtensionStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ExtensionsLoadedExtensionStatus, but found {reader.TokenType}.");
             var value = reader.GetString();
             if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
             return new(value);

--- a/dotnet/src/Generated/SessionEvents.cs
+++ b/dotnet/src/Generated/SessionEvents.cs
@@ -4891,8 +4891,10 @@ public readonly struct WorkingDirectoryContextHostType : IEquatable<WorkingDirec
     /// <summary>Gets the <c>ado</c> value.</summary>
     public static WorkingDirectoryContextHostType Ado { get; } = new("ado");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="WorkingDirectoryContextHostType"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="WorkingDirectoryContextHostType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="WorkingDirectoryContextHostType"/>.</param>
@@ -4900,7 +4902,7 @@ public readonly struct WorkingDirectoryContextHostType : IEquatable<WorkingDirec
     public WorkingDirectoryContextHostType(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="WorkingDirectoryContextHostType"/> instances are equivalent.</summary>
@@ -4916,10 +4918,10 @@ public readonly struct WorkingDirectoryContextHostType : IEquatable<WorkingDirec
     public bool Equals(WorkingDirectoryContextHostType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{WorkingDirectoryContextHostType}"/> for serializing <see cref="WorkingDirectoryContextHostType"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -4956,8 +4958,10 @@ public readonly struct PlanChangedOperation : IEquatable<PlanChangedOperation>
     /// <summary>Gets the <c>delete</c> value.</summary>
     public static PlanChangedOperation Delete { get; } = new("delete");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="PlanChangedOperation"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="PlanChangedOperation"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="PlanChangedOperation"/>.</param>
@@ -4965,7 +4969,7 @@ public readonly struct PlanChangedOperation : IEquatable<PlanChangedOperation>
     public PlanChangedOperation(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="PlanChangedOperation"/> instances are equivalent.</summary>
@@ -4981,10 +4985,10 @@ public readonly struct PlanChangedOperation : IEquatable<PlanChangedOperation>
     public bool Equals(PlanChangedOperation other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{PlanChangedOperation}"/> for serializing <see cref="PlanChangedOperation"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -5018,8 +5022,10 @@ public readonly struct WorkspaceFileChangedOperation : IEquatable<WorkspaceFileC
     /// <summary>Gets the <c>update</c> value.</summary>
     public static WorkspaceFileChangedOperation Update { get; } = new("update");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="WorkspaceFileChangedOperation"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="WorkspaceFileChangedOperation"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="WorkspaceFileChangedOperation"/>.</param>
@@ -5027,7 +5033,7 @@ public readonly struct WorkspaceFileChangedOperation : IEquatable<WorkspaceFileC
     public WorkspaceFileChangedOperation(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="WorkspaceFileChangedOperation"/> instances are equivalent.</summary>
@@ -5043,10 +5049,10 @@ public readonly struct WorkspaceFileChangedOperation : IEquatable<WorkspaceFileC
     public bool Equals(WorkspaceFileChangedOperation other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{WorkspaceFileChangedOperation}"/> for serializing <see cref="WorkspaceFileChangedOperation"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -5080,8 +5086,10 @@ public readonly struct HandoffSourceType : IEquatable<HandoffSourceType>
     /// <summary>Gets the <c>local</c> value.</summary>
     public static HandoffSourceType Local { get; } = new("local");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="HandoffSourceType"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="HandoffSourceType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="HandoffSourceType"/>.</param>
@@ -5089,7 +5097,7 @@ public readonly struct HandoffSourceType : IEquatable<HandoffSourceType>
     public HandoffSourceType(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="HandoffSourceType"/> instances are equivalent.</summary>
@@ -5105,10 +5113,10 @@ public readonly struct HandoffSourceType : IEquatable<HandoffSourceType>
     public bool Equals(HandoffSourceType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{HandoffSourceType}"/> for serializing <see cref="HandoffSourceType"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -5142,8 +5150,10 @@ public readonly struct ShutdownType : IEquatable<ShutdownType>
     /// <summary>Gets the <c>error</c> value.</summary>
     public static ShutdownType Error { get; } = new("error");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="ShutdownType"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="ShutdownType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ShutdownType"/>.</param>
@@ -5151,7 +5161,7 @@ public readonly struct ShutdownType : IEquatable<ShutdownType>
     public ShutdownType(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="ShutdownType"/> instances are equivalent.</summary>
@@ -5167,10 +5177,10 @@ public readonly struct ShutdownType : IEquatable<ShutdownType>
     public bool Equals(ShutdownType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{ShutdownType}"/> for serializing <see cref="ShutdownType"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -5210,8 +5220,10 @@ public readonly struct UserMessageAgentMode : IEquatable<UserMessageAgentMode>
     /// <summary>Gets the <c>shell</c> value.</summary>
     public static UserMessageAgentMode Shell { get; } = new("shell");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="UserMessageAgentMode"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="UserMessageAgentMode"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="UserMessageAgentMode"/>.</param>
@@ -5219,7 +5231,7 @@ public readonly struct UserMessageAgentMode : IEquatable<UserMessageAgentMode>
     public UserMessageAgentMode(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="UserMessageAgentMode"/> instances are equivalent.</summary>
@@ -5235,10 +5247,10 @@ public readonly struct UserMessageAgentMode : IEquatable<UserMessageAgentMode>
     public bool Equals(UserMessageAgentMode other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{UserMessageAgentMode}"/> for serializing <see cref="UserMessageAgentMode"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -5275,8 +5287,10 @@ public readonly struct UserMessageAttachmentGithubReferenceType : IEquatable<Use
     /// <summary>Gets the <c>discussion</c> value.</summary>
     public static UserMessageAttachmentGithubReferenceType Discussion { get; } = new("discussion");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="UserMessageAttachmentGithubReferenceType"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="UserMessageAttachmentGithubReferenceType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="UserMessageAttachmentGithubReferenceType"/>.</param>
@@ -5284,7 +5298,7 @@ public readonly struct UserMessageAttachmentGithubReferenceType : IEquatable<Use
     public UserMessageAttachmentGithubReferenceType(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="UserMessageAttachmentGithubReferenceType"/> instances are equivalent.</summary>
@@ -5300,10 +5314,10 @@ public readonly struct UserMessageAttachmentGithubReferenceType : IEquatable<Use
     public bool Equals(UserMessageAttachmentGithubReferenceType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{UserMessageAttachmentGithubReferenceType}"/> for serializing <see cref="UserMessageAttachmentGithubReferenceType"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -5337,8 +5351,10 @@ public readonly struct AssistantMessageToolRequestType : IEquatable<AssistantMes
     /// <summary>Gets the <c>custom</c> value.</summary>
     public static AssistantMessageToolRequestType Custom { get; } = new("custom");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="AssistantMessageToolRequestType"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="AssistantMessageToolRequestType"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="AssistantMessageToolRequestType"/>.</param>
@@ -5346,7 +5362,7 @@ public readonly struct AssistantMessageToolRequestType : IEquatable<AssistantMes
     public AssistantMessageToolRequestType(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="AssistantMessageToolRequestType"/> instances are equivalent.</summary>
@@ -5362,10 +5378,10 @@ public readonly struct AssistantMessageToolRequestType : IEquatable<AssistantMes
     public bool Equals(AssistantMessageToolRequestType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{AssistantMessageToolRequestType}"/> for serializing <see cref="AssistantMessageToolRequestType"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -5402,8 +5418,10 @@ public readonly struct ModelCallFailureSource : IEquatable<ModelCallFailureSourc
     /// <summary>Gets the <c>mcp_sampling</c> value.</summary>
     public static ModelCallFailureSource McpSampling { get; } = new("mcp_sampling");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="ModelCallFailureSource"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="ModelCallFailureSource"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ModelCallFailureSource"/>.</param>
@@ -5411,7 +5429,7 @@ public readonly struct ModelCallFailureSource : IEquatable<ModelCallFailureSourc
     public ModelCallFailureSource(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="ModelCallFailureSource"/> instances are equivalent.</summary>
@@ -5427,10 +5445,10 @@ public readonly struct ModelCallFailureSource : IEquatable<ModelCallFailureSourc
     public bool Equals(ModelCallFailureSource other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{ModelCallFailureSource}"/> for serializing <see cref="ModelCallFailureSource"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -5467,8 +5485,10 @@ public readonly struct AbortReason : IEquatable<AbortReason>
     /// <summary>Gets the <c>user_abort</c> value.</summary>
     public static AbortReason UserAbort { get; } = new("user_abort");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="AbortReason"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="AbortReason"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="AbortReason"/>.</param>
@@ -5476,7 +5496,7 @@ public readonly struct AbortReason : IEquatable<AbortReason>
     public AbortReason(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="AbortReason"/> instances are equivalent.</summary>
@@ -5492,10 +5512,10 @@ public readonly struct AbortReason : IEquatable<AbortReason>
     public bool Equals(AbortReason other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{AbortReason}"/> for serializing <see cref="AbortReason"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -5529,8 +5549,10 @@ public readonly struct ToolExecutionCompleteContentResourceLinkIconTheme : IEqua
     /// <summary>Gets the <c>dark</c> value.</summary>
     public static ToolExecutionCompleteContentResourceLinkIconTheme Dark { get; } = new("dark");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="ToolExecutionCompleteContentResourceLinkIconTheme"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="ToolExecutionCompleteContentResourceLinkIconTheme"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ToolExecutionCompleteContentResourceLinkIconTheme"/>.</param>
@@ -5538,7 +5560,7 @@ public readonly struct ToolExecutionCompleteContentResourceLinkIconTheme : IEqua
     public ToolExecutionCompleteContentResourceLinkIconTheme(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="ToolExecutionCompleteContentResourceLinkIconTheme"/> instances are equivalent.</summary>
@@ -5554,10 +5576,10 @@ public readonly struct ToolExecutionCompleteContentResourceLinkIconTheme : IEqua
     public bool Equals(ToolExecutionCompleteContentResourceLinkIconTheme other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{ToolExecutionCompleteContentResourceLinkIconTheme}"/> for serializing <see cref="ToolExecutionCompleteContentResourceLinkIconTheme"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -5591,8 +5613,10 @@ public readonly struct SystemMessageRole : IEquatable<SystemMessageRole>
     /// <summary>Gets the <c>developer</c> value.</summary>
     public static SystemMessageRole Developer { get; } = new("developer");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="SystemMessageRole"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="SystemMessageRole"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="SystemMessageRole"/>.</param>
@@ -5600,7 +5624,7 @@ public readonly struct SystemMessageRole : IEquatable<SystemMessageRole>
     public SystemMessageRole(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="SystemMessageRole"/> instances are equivalent.</summary>
@@ -5616,10 +5640,10 @@ public readonly struct SystemMessageRole : IEquatable<SystemMessageRole>
     public bool Equals(SystemMessageRole other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{SystemMessageRole}"/> for serializing <see cref="SystemMessageRole"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -5653,8 +5677,10 @@ public readonly struct SystemNotificationAgentCompletedStatus : IEquatable<Syste
     /// <summary>Gets the <c>failed</c> value.</summary>
     public static SystemNotificationAgentCompletedStatus Failed { get; } = new("failed");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="SystemNotificationAgentCompletedStatus"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="SystemNotificationAgentCompletedStatus"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="SystemNotificationAgentCompletedStatus"/>.</param>
@@ -5662,7 +5688,7 @@ public readonly struct SystemNotificationAgentCompletedStatus : IEquatable<Syste
     public SystemNotificationAgentCompletedStatus(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="SystemNotificationAgentCompletedStatus"/> instances are equivalent.</summary>
@@ -5678,10 +5704,10 @@ public readonly struct SystemNotificationAgentCompletedStatus : IEquatable<Syste
     public bool Equals(SystemNotificationAgentCompletedStatus other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{SystemNotificationAgentCompletedStatus}"/> for serializing <see cref="SystemNotificationAgentCompletedStatus"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -5715,8 +5741,10 @@ public readonly struct PermissionRequestMemoryAction : IEquatable<PermissionRequ
     /// <summary>Gets the <c>vote</c> value.</summary>
     public static PermissionRequestMemoryAction Vote { get; } = new("vote");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="PermissionRequestMemoryAction"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="PermissionRequestMemoryAction"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="PermissionRequestMemoryAction"/>.</param>
@@ -5724,7 +5752,7 @@ public readonly struct PermissionRequestMemoryAction : IEquatable<PermissionRequ
     public PermissionRequestMemoryAction(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="PermissionRequestMemoryAction"/> instances are equivalent.</summary>
@@ -5740,10 +5768,10 @@ public readonly struct PermissionRequestMemoryAction : IEquatable<PermissionRequ
     public bool Equals(PermissionRequestMemoryAction other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{PermissionRequestMemoryAction}"/> for serializing <see cref="PermissionRequestMemoryAction"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -5777,8 +5805,10 @@ public readonly struct PermissionRequestMemoryDirection : IEquatable<PermissionR
     /// <summary>Gets the <c>downvote</c> value.</summary>
     public static PermissionRequestMemoryDirection Downvote { get; } = new("downvote");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="PermissionRequestMemoryDirection"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="PermissionRequestMemoryDirection"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="PermissionRequestMemoryDirection"/>.</param>
@@ -5786,7 +5816,7 @@ public readonly struct PermissionRequestMemoryDirection : IEquatable<PermissionR
     public PermissionRequestMemoryDirection(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="PermissionRequestMemoryDirection"/> instances are equivalent.</summary>
@@ -5802,10 +5832,10 @@ public readonly struct PermissionRequestMemoryDirection : IEquatable<PermissionR
     public bool Equals(PermissionRequestMemoryDirection other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{PermissionRequestMemoryDirection}"/> for serializing <see cref="PermissionRequestMemoryDirection"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -5839,8 +5869,10 @@ public readonly struct PermissionPromptRequestMemoryAction : IEquatable<Permissi
     /// <summary>Gets the <c>vote</c> value.</summary>
     public static PermissionPromptRequestMemoryAction Vote { get; } = new("vote");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="PermissionPromptRequestMemoryAction"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="PermissionPromptRequestMemoryAction"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="PermissionPromptRequestMemoryAction"/>.</param>
@@ -5848,7 +5880,7 @@ public readonly struct PermissionPromptRequestMemoryAction : IEquatable<Permissi
     public PermissionPromptRequestMemoryAction(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="PermissionPromptRequestMemoryAction"/> instances are equivalent.</summary>
@@ -5864,10 +5896,10 @@ public readonly struct PermissionPromptRequestMemoryAction : IEquatable<Permissi
     public bool Equals(PermissionPromptRequestMemoryAction other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{PermissionPromptRequestMemoryAction}"/> for serializing <see cref="PermissionPromptRequestMemoryAction"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -5901,8 +5933,10 @@ public readonly struct PermissionPromptRequestMemoryDirection : IEquatable<Permi
     /// <summary>Gets the <c>downvote</c> value.</summary>
     public static PermissionPromptRequestMemoryDirection Downvote { get; } = new("downvote");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="PermissionPromptRequestMemoryDirection"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="PermissionPromptRequestMemoryDirection"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="PermissionPromptRequestMemoryDirection"/>.</param>
@@ -5910,7 +5944,7 @@ public readonly struct PermissionPromptRequestMemoryDirection : IEquatable<Permi
     public PermissionPromptRequestMemoryDirection(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="PermissionPromptRequestMemoryDirection"/> instances are equivalent.</summary>
@@ -5926,10 +5960,10 @@ public readonly struct PermissionPromptRequestMemoryDirection : IEquatable<Permi
     public bool Equals(PermissionPromptRequestMemoryDirection other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{PermissionPromptRequestMemoryDirection}"/> for serializing <see cref="PermissionPromptRequestMemoryDirection"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -5966,8 +6000,10 @@ public readonly struct PermissionPromptRequestPathAccessKind : IEquatable<Permis
     /// <summary>Gets the <c>write</c> value.</summary>
     public static PermissionPromptRequestPathAccessKind Write { get; } = new("write");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="PermissionPromptRequestPathAccessKind"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="PermissionPromptRequestPathAccessKind"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="PermissionPromptRequestPathAccessKind"/>.</param>
@@ -5975,7 +6011,7 @@ public readonly struct PermissionPromptRequestPathAccessKind : IEquatable<Permis
     public PermissionPromptRequestPathAccessKind(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="PermissionPromptRequestPathAccessKind"/> instances are equivalent.</summary>
@@ -5991,10 +6027,10 @@ public readonly struct PermissionPromptRequestPathAccessKind : IEquatable<Permis
     public bool Equals(PermissionPromptRequestPathAccessKind other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{PermissionPromptRequestPathAccessKind}"/> for serializing <see cref="PermissionPromptRequestPathAccessKind"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -6028,8 +6064,10 @@ public readonly struct ElicitationRequestedMode : IEquatable<ElicitationRequeste
     /// <summary>Gets the <c>url</c> value.</summary>
     public static ElicitationRequestedMode Url { get; } = new("url");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="ElicitationRequestedMode"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="ElicitationRequestedMode"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ElicitationRequestedMode"/>.</param>
@@ -6037,7 +6075,7 @@ public readonly struct ElicitationRequestedMode : IEquatable<ElicitationRequeste
     public ElicitationRequestedMode(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="ElicitationRequestedMode"/> instances are equivalent.</summary>
@@ -6053,10 +6091,10 @@ public readonly struct ElicitationRequestedMode : IEquatable<ElicitationRequeste
     public bool Equals(ElicitationRequestedMode other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{ElicitationRequestedMode}"/> for serializing <see cref="ElicitationRequestedMode"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -6093,8 +6131,10 @@ public readonly struct ElicitationCompletedAction : IEquatable<ElicitationComple
     /// <summary>Gets the <c>cancel</c> value.</summary>
     public static ElicitationCompletedAction Cancel { get; } = new("cancel");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="ElicitationCompletedAction"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="ElicitationCompletedAction"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ElicitationCompletedAction"/>.</param>
@@ -6102,7 +6142,7 @@ public readonly struct ElicitationCompletedAction : IEquatable<ElicitationComple
     public ElicitationCompletedAction(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="ElicitationCompletedAction"/> instances are equivalent.</summary>
@@ -6118,10 +6158,10 @@ public readonly struct ElicitationCompletedAction : IEquatable<ElicitationComple
     public bool Equals(ElicitationCompletedAction other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{ElicitationCompletedAction}"/> for serializing <see cref="ElicitationCompletedAction"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -6167,8 +6207,10 @@ public readonly struct McpServersLoadedServerStatus : IEquatable<McpServersLoade
     /// <summary>Gets the <c>not_configured</c> value.</summary>
     public static McpServersLoadedServerStatus NotConfigured { get; } = new("not_configured");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="McpServersLoadedServerStatus"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="McpServersLoadedServerStatus"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="McpServersLoadedServerStatus"/>.</param>
@@ -6176,7 +6218,7 @@ public readonly struct McpServersLoadedServerStatus : IEquatable<McpServersLoade
     public McpServersLoadedServerStatus(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="McpServersLoadedServerStatus"/> instances are equivalent.</summary>
@@ -6192,10 +6234,10 @@ public readonly struct McpServersLoadedServerStatus : IEquatable<McpServersLoade
     public bool Equals(McpServersLoadedServerStatus other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{McpServersLoadedServerStatus}"/> for serializing <see cref="McpServersLoadedServerStatus"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -6241,8 +6283,10 @@ public readonly struct McpServerStatusChangedStatus : IEquatable<McpServerStatus
     /// <summary>Gets the <c>not_configured</c> value.</summary>
     public static McpServerStatusChangedStatus NotConfigured { get; } = new("not_configured");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="McpServerStatusChangedStatus"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="McpServerStatusChangedStatus"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="McpServerStatusChangedStatus"/>.</param>
@@ -6250,7 +6294,7 @@ public readonly struct McpServerStatusChangedStatus : IEquatable<McpServerStatus
     public McpServerStatusChangedStatus(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="McpServerStatusChangedStatus"/> instances are equivalent.</summary>
@@ -6266,10 +6310,10 @@ public readonly struct McpServerStatusChangedStatus : IEquatable<McpServerStatus
     public bool Equals(McpServerStatusChangedStatus other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{McpServerStatusChangedStatus}"/> for serializing <see cref="McpServerStatusChangedStatus"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -6303,8 +6347,10 @@ public readonly struct ExtensionsLoadedExtensionSource : IEquatable<ExtensionsLo
     /// <summary>Gets the <c>user</c> value.</summary>
     public static ExtensionsLoadedExtensionSource User { get; } = new("user");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="ExtensionsLoadedExtensionSource"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="ExtensionsLoadedExtensionSource"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ExtensionsLoadedExtensionSource"/>.</param>
@@ -6312,7 +6358,7 @@ public readonly struct ExtensionsLoadedExtensionSource : IEquatable<ExtensionsLo
     public ExtensionsLoadedExtensionSource(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="ExtensionsLoadedExtensionSource"/> instances are equivalent.</summary>
@@ -6328,10 +6374,10 @@ public readonly struct ExtensionsLoadedExtensionSource : IEquatable<ExtensionsLo
     public bool Equals(ExtensionsLoadedExtensionSource other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{ExtensionsLoadedExtensionSource}"/> for serializing <see cref="ExtensionsLoadedExtensionSource"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -6371,8 +6417,10 @@ public readonly struct ExtensionsLoadedExtensionStatus : IEquatable<ExtensionsLo
     /// <summary>Gets the <c>starting</c> value.</summary>
     public static ExtensionsLoadedExtensionStatus Starting { get; } = new("starting");
 
+    private readonly string? _value;
+
     /// <summary>Gets the value associated with this <see cref="ExtensionsLoadedExtensionStatus"/>.</summary>
-    public string Value { get; }
+    public string Value => _value ?? string.Empty;
 
     /// <summary>Initializes a new instance of the <see cref="ExtensionsLoadedExtensionStatus"/> struct.</summary>
     /// <param name="value">The value to associate with this <see cref="ExtensionsLoadedExtensionStatus"/>.</param>
@@ -6380,7 +6428,7 @@ public readonly struct ExtensionsLoadedExtensionStatus : IEquatable<ExtensionsLo
     public ExtensionsLoadedExtensionStatus(string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        Value = value;
+        _value = value;
     }
 
     /// <summary>Returns a value indicating whether two <see cref="ExtensionsLoadedExtensionStatus"/> instances are equivalent.</summary>
@@ -6396,10 +6444,10 @@ public readonly struct ExtensionsLoadedExtensionStatus : IEquatable<ExtensionsLo
     public bool Equals(ExtensionsLoadedExtensionStatus other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc />
-    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
 
     /// <inheritdoc />
-    public override string ToString() => Value ?? string.Empty;
+    public override string ToString() => Value;
 
     /// <summary>Provides a <see cref="JsonConverter{ExtensionsLoadedExtensionStatus}"/> for serializing <see cref="ExtensionsLoadedExtensionStatus"/> instances.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/dotnet/src/Generated/SessionEvents.cs
+++ b/dotnet/src/Generated/SessionEvents.cs
@@ -8,6 +8,7 @@
 #pragma warning disable CS0612 // Type or member is obsolete
 #pragma warning disable CS0618 // Type or member is obsolete (with message)
 
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -4880,345 +4881,1545 @@ public partial class ExtensionsLoadedExtension
 }
 
 /// <summary>Hosting platform type of the repository (github or ado).</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<WorkingDirectoryContextHostType>))]
-public enum WorkingDirectoryContextHostType
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct WorkingDirectoryContextHostType : IEquatable<WorkingDirectoryContextHostType>
 {
-    /// <summary>The <c>github</c> variant.</summary>
-    [JsonStringEnumMemberName("github")]
-    Github,
-    /// <summary>The <c>ado</c> variant.</summary>
-    [JsonStringEnumMemberName("ado")]
-    Ado,
+    /// <summary>Gets the <c>github</c> value.</summary>
+    public static WorkingDirectoryContextHostType Github { get; } = new("github");
+
+    /// <summary>Gets the <c>ado</c> value.</summary>
+    public static WorkingDirectoryContextHostType Ado { get; } = new("ado");
+
+    /// <summary>Gets the value associated with this <see cref="WorkingDirectoryContextHostType"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="WorkingDirectoryContextHostType"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="WorkingDirectoryContextHostType"/>.</param>
+    [JsonConstructor]
+    public WorkingDirectoryContextHostType(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="WorkingDirectoryContextHostType"/> instances are equivalent.</summary>
+    public static bool operator ==(WorkingDirectoryContextHostType left, WorkingDirectoryContextHostType right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="WorkingDirectoryContextHostType"/> instances are not equivalent.</summary>
+    public static bool operator !=(WorkingDirectoryContextHostType left, WorkingDirectoryContextHostType right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is WorkingDirectoryContextHostType other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(WorkingDirectoryContextHostType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{WorkingDirectoryContextHostType}"/> for serializing <see cref="WorkingDirectoryContextHostType"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<WorkingDirectoryContextHostType>
+    {
+        /// <inheritdoc />
+        public override WorkingDirectoryContextHostType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, WorkingDirectoryContextHostType value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>The type of operation performed on the plan file.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<PlanChangedOperation>))]
-public enum PlanChangedOperation
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct PlanChangedOperation : IEquatable<PlanChangedOperation>
 {
-    /// <summary>The <c>create</c> variant.</summary>
-    [JsonStringEnumMemberName("create")]
-    Create,
-    /// <summary>The <c>update</c> variant.</summary>
-    [JsonStringEnumMemberName("update")]
-    Update,
-    /// <summary>The <c>delete</c> variant.</summary>
-    [JsonStringEnumMemberName("delete")]
-    Delete,
+    /// <summary>Gets the <c>create</c> value.</summary>
+    public static PlanChangedOperation Create { get; } = new("create");
+
+    /// <summary>Gets the <c>update</c> value.</summary>
+    public static PlanChangedOperation Update { get; } = new("update");
+
+    /// <summary>Gets the <c>delete</c> value.</summary>
+    public static PlanChangedOperation Delete { get; } = new("delete");
+
+    /// <summary>Gets the value associated with this <see cref="PlanChangedOperation"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="PlanChangedOperation"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="PlanChangedOperation"/>.</param>
+    [JsonConstructor]
+    public PlanChangedOperation(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="PlanChangedOperation"/> instances are equivalent.</summary>
+    public static bool operator ==(PlanChangedOperation left, PlanChangedOperation right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="PlanChangedOperation"/> instances are not equivalent.</summary>
+    public static bool operator !=(PlanChangedOperation left, PlanChangedOperation right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is PlanChangedOperation other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(PlanChangedOperation other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{PlanChangedOperation}"/> for serializing <see cref="PlanChangedOperation"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<PlanChangedOperation>
+    {
+        /// <inheritdoc />
+        public override PlanChangedOperation Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, PlanChangedOperation value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>Whether the file was newly created or updated.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<WorkspaceFileChangedOperation>))]
-public enum WorkspaceFileChangedOperation
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct WorkspaceFileChangedOperation : IEquatable<WorkspaceFileChangedOperation>
 {
-    /// <summary>The <c>create</c> variant.</summary>
-    [JsonStringEnumMemberName("create")]
-    Create,
-    /// <summary>The <c>update</c> variant.</summary>
-    [JsonStringEnumMemberName("update")]
-    Update,
+    /// <summary>Gets the <c>create</c> value.</summary>
+    public static WorkspaceFileChangedOperation Create { get; } = new("create");
+
+    /// <summary>Gets the <c>update</c> value.</summary>
+    public static WorkspaceFileChangedOperation Update { get; } = new("update");
+
+    /// <summary>Gets the value associated with this <see cref="WorkspaceFileChangedOperation"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="WorkspaceFileChangedOperation"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="WorkspaceFileChangedOperation"/>.</param>
+    [JsonConstructor]
+    public WorkspaceFileChangedOperation(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="WorkspaceFileChangedOperation"/> instances are equivalent.</summary>
+    public static bool operator ==(WorkspaceFileChangedOperation left, WorkspaceFileChangedOperation right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="WorkspaceFileChangedOperation"/> instances are not equivalent.</summary>
+    public static bool operator !=(WorkspaceFileChangedOperation left, WorkspaceFileChangedOperation right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is WorkspaceFileChangedOperation other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(WorkspaceFileChangedOperation other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{WorkspaceFileChangedOperation}"/> for serializing <see cref="WorkspaceFileChangedOperation"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<WorkspaceFileChangedOperation>
+    {
+        /// <inheritdoc />
+        public override WorkspaceFileChangedOperation Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, WorkspaceFileChangedOperation value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>Origin type of the session being handed off.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<HandoffSourceType>))]
-public enum HandoffSourceType
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct HandoffSourceType : IEquatable<HandoffSourceType>
 {
-    /// <summary>The <c>remote</c> variant.</summary>
-    [JsonStringEnumMemberName("remote")]
-    Remote,
-    /// <summary>The <c>local</c> variant.</summary>
-    [JsonStringEnumMemberName("local")]
-    Local,
+    /// <summary>Gets the <c>remote</c> value.</summary>
+    public static HandoffSourceType Remote { get; } = new("remote");
+
+    /// <summary>Gets the <c>local</c> value.</summary>
+    public static HandoffSourceType Local { get; } = new("local");
+
+    /// <summary>Gets the value associated with this <see cref="HandoffSourceType"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="HandoffSourceType"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="HandoffSourceType"/>.</param>
+    [JsonConstructor]
+    public HandoffSourceType(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="HandoffSourceType"/> instances are equivalent.</summary>
+    public static bool operator ==(HandoffSourceType left, HandoffSourceType right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="HandoffSourceType"/> instances are not equivalent.</summary>
+    public static bool operator !=(HandoffSourceType left, HandoffSourceType right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is HandoffSourceType other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(HandoffSourceType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{HandoffSourceType}"/> for serializing <see cref="HandoffSourceType"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<HandoffSourceType>
+    {
+        /// <inheritdoc />
+        public override HandoffSourceType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, HandoffSourceType value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>Whether the session ended normally ("routine") or due to a crash/fatal error ("error").</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<ShutdownType>))]
-public enum ShutdownType
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct ShutdownType : IEquatable<ShutdownType>
 {
-    /// <summary>The <c>routine</c> variant.</summary>
-    [JsonStringEnumMemberName("routine")]
-    Routine,
-    /// <summary>The <c>error</c> variant.</summary>
-    [JsonStringEnumMemberName("error")]
-    Error,
+    /// <summary>Gets the <c>routine</c> value.</summary>
+    public static ShutdownType Routine { get; } = new("routine");
+
+    /// <summary>Gets the <c>error</c> value.</summary>
+    public static ShutdownType Error { get; } = new("error");
+
+    /// <summary>Gets the value associated with this <see cref="ShutdownType"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="ShutdownType"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="ShutdownType"/>.</param>
+    [JsonConstructor]
+    public ShutdownType(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="ShutdownType"/> instances are equivalent.</summary>
+    public static bool operator ==(ShutdownType left, ShutdownType right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="ShutdownType"/> instances are not equivalent.</summary>
+    public static bool operator !=(ShutdownType left, ShutdownType right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is ShutdownType other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(ShutdownType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{ShutdownType}"/> for serializing <see cref="ShutdownType"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<ShutdownType>
+    {
+        /// <inheritdoc />
+        public override ShutdownType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, ShutdownType value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>The agent mode that was active when this message was sent.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<UserMessageAgentMode>))]
-public enum UserMessageAgentMode
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct UserMessageAgentMode : IEquatable<UserMessageAgentMode>
 {
-    /// <summary>The <c>interactive</c> variant.</summary>
-    [JsonStringEnumMemberName("interactive")]
-    Interactive,
-    /// <summary>The <c>plan</c> variant.</summary>
-    [JsonStringEnumMemberName("plan")]
-    Plan,
-    /// <summary>The <c>autopilot</c> variant.</summary>
-    [JsonStringEnumMemberName("autopilot")]
-    Autopilot,
-    /// <summary>The <c>shell</c> variant.</summary>
-    [JsonStringEnumMemberName("shell")]
-    Shell,
+    /// <summary>Gets the <c>interactive</c> value.</summary>
+    public static UserMessageAgentMode Interactive { get; } = new("interactive");
+
+    /// <summary>Gets the <c>plan</c> value.</summary>
+    public static UserMessageAgentMode Plan { get; } = new("plan");
+
+    /// <summary>Gets the <c>autopilot</c> value.</summary>
+    public static UserMessageAgentMode Autopilot { get; } = new("autopilot");
+
+    /// <summary>Gets the <c>shell</c> value.</summary>
+    public static UserMessageAgentMode Shell { get; } = new("shell");
+
+    /// <summary>Gets the value associated with this <see cref="UserMessageAgentMode"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="UserMessageAgentMode"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="UserMessageAgentMode"/>.</param>
+    [JsonConstructor]
+    public UserMessageAgentMode(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="UserMessageAgentMode"/> instances are equivalent.</summary>
+    public static bool operator ==(UserMessageAgentMode left, UserMessageAgentMode right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="UserMessageAgentMode"/> instances are not equivalent.</summary>
+    public static bool operator !=(UserMessageAgentMode left, UserMessageAgentMode right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is UserMessageAgentMode other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(UserMessageAgentMode other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{UserMessageAgentMode}"/> for serializing <see cref="UserMessageAgentMode"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<UserMessageAgentMode>
+    {
+        /// <inheritdoc />
+        public override UserMessageAgentMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, UserMessageAgentMode value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>Type of GitHub reference.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<UserMessageAttachmentGithubReferenceType>))]
-public enum UserMessageAttachmentGithubReferenceType
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct UserMessageAttachmentGithubReferenceType : IEquatable<UserMessageAttachmentGithubReferenceType>
 {
-    /// <summary>The <c>issue</c> variant.</summary>
-    [JsonStringEnumMemberName("issue")]
-    Issue,
-    /// <summary>The <c>pr</c> variant.</summary>
-    [JsonStringEnumMemberName("pr")]
-    Pr,
-    /// <summary>The <c>discussion</c> variant.</summary>
-    [JsonStringEnumMemberName("discussion")]
-    Discussion,
+    /// <summary>Gets the <c>issue</c> value.</summary>
+    public static UserMessageAttachmentGithubReferenceType Issue { get; } = new("issue");
+
+    /// <summary>Gets the <c>pr</c> value.</summary>
+    public static UserMessageAttachmentGithubReferenceType Pr { get; } = new("pr");
+
+    /// <summary>Gets the <c>discussion</c> value.</summary>
+    public static UserMessageAttachmentGithubReferenceType Discussion { get; } = new("discussion");
+
+    /// <summary>Gets the value associated with this <see cref="UserMessageAttachmentGithubReferenceType"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="UserMessageAttachmentGithubReferenceType"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="UserMessageAttachmentGithubReferenceType"/>.</param>
+    [JsonConstructor]
+    public UserMessageAttachmentGithubReferenceType(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="UserMessageAttachmentGithubReferenceType"/> instances are equivalent.</summary>
+    public static bool operator ==(UserMessageAttachmentGithubReferenceType left, UserMessageAttachmentGithubReferenceType right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="UserMessageAttachmentGithubReferenceType"/> instances are not equivalent.</summary>
+    public static bool operator !=(UserMessageAttachmentGithubReferenceType left, UserMessageAttachmentGithubReferenceType right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is UserMessageAttachmentGithubReferenceType other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(UserMessageAttachmentGithubReferenceType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{UserMessageAttachmentGithubReferenceType}"/> for serializing <see cref="UserMessageAttachmentGithubReferenceType"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<UserMessageAttachmentGithubReferenceType>
+    {
+        /// <inheritdoc />
+        public override UserMessageAttachmentGithubReferenceType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, UserMessageAttachmentGithubReferenceType value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>Tool call type: "function" for standard tool calls, "custom" for grammar-based tool calls. Defaults to "function" when absent.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<AssistantMessageToolRequestType>))]
-public enum AssistantMessageToolRequestType
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct AssistantMessageToolRequestType : IEquatable<AssistantMessageToolRequestType>
 {
-    /// <summary>The <c>function</c> variant.</summary>
-    [JsonStringEnumMemberName("function")]
-    Function,
-    /// <summary>The <c>custom</c> variant.</summary>
-    [JsonStringEnumMemberName("custom")]
-    Custom,
+    /// <summary>Gets the <c>function</c> value.</summary>
+    public static AssistantMessageToolRequestType Function { get; } = new("function");
+
+    /// <summary>Gets the <c>custom</c> value.</summary>
+    public static AssistantMessageToolRequestType Custom { get; } = new("custom");
+
+    /// <summary>Gets the value associated with this <see cref="AssistantMessageToolRequestType"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="AssistantMessageToolRequestType"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="AssistantMessageToolRequestType"/>.</param>
+    [JsonConstructor]
+    public AssistantMessageToolRequestType(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="AssistantMessageToolRequestType"/> instances are equivalent.</summary>
+    public static bool operator ==(AssistantMessageToolRequestType left, AssistantMessageToolRequestType right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="AssistantMessageToolRequestType"/> instances are not equivalent.</summary>
+    public static bool operator !=(AssistantMessageToolRequestType left, AssistantMessageToolRequestType right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is AssistantMessageToolRequestType other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(AssistantMessageToolRequestType other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{AssistantMessageToolRequestType}"/> for serializing <see cref="AssistantMessageToolRequestType"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<AssistantMessageToolRequestType>
+    {
+        /// <inheritdoc />
+        public override AssistantMessageToolRequestType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, AssistantMessageToolRequestType value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>Where the failed model call originated.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<ModelCallFailureSource>))]
-public enum ModelCallFailureSource
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct ModelCallFailureSource : IEquatable<ModelCallFailureSource>
 {
-    /// <summary>The <c>top_level</c> variant.</summary>
-    [JsonStringEnumMemberName("top_level")]
-    TopLevel,
-    /// <summary>The <c>subagent</c> variant.</summary>
-    [JsonStringEnumMemberName("subagent")]
-    Subagent,
-    /// <summary>The <c>mcp_sampling</c> variant.</summary>
-    [JsonStringEnumMemberName("mcp_sampling")]
-    McpSampling,
+    /// <summary>Gets the <c>top_level</c> value.</summary>
+    public static ModelCallFailureSource TopLevel { get; } = new("top_level");
+
+    /// <summary>Gets the <c>subagent</c> value.</summary>
+    public static ModelCallFailureSource Subagent { get; } = new("subagent");
+
+    /// <summary>Gets the <c>mcp_sampling</c> value.</summary>
+    public static ModelCallFailureSource McpSampling { get; } = new("mcp_sampling");
+
+    /// <summary>Gets the value associated with this <see cref="ModelCallFailureSource"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="ModelCallFailureSource"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="ModelCallFailureSource"/>.</param>
+    [JsonConstructor]
+    public ModelCallFailureSource(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="ModelCallFailureSource"/> instances are equivalent.</summary>
+    public static bool operator ==(ModelCallFailureSource left, ModelCallFailureSource right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="ModelCallFailureSource"/> instances are not equivalent.</summary>
+    public static bool operator !=(ModelCallFailureSource left, ModelCallFailureSource right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is ModelCallFailureSource other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(ModelCallFailureSource other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{ModelCallFailureSource}"/> for serializing <see cref="ModelCallFailureSource"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<ModelCallFailureSource>
+    {
+        /// <inheritdoc />
+        public override ModelCallFailureSource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, ModelCallFailureSource value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>Finite reason code describing why the current turn was aborted.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<AbortReason>))]
-public enum AbortReason
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct AbortReason : IEquatable<AbortReason>
 {
-    /// <summary>The <c>user_initiated</c> variant.</summary>
-    [JsonStringEnumMemberName("user_initiated")]
-    UserInitiated,
-    /// <summary>The <c>remote_command</c> variant.</summary>
-    [JsonStringEnumMemberName("remote_command")]
-    RemoteCommand,
-    /// <summary>The <c>user_abort</c> variant.</summary>
-    [JsonStringEnumMemberName("user_abort")]
-    UserAbort,
+    /// <summary>Gets the <c>user_initiated</c> value.</summary>
+    public static AbortReason UserInitiated { get; } = new("user_initiated");
+
+    /// <summary>Gets the <c>remote_command</c> value.</summary>
+    public static AbortReason RemoteCommand { get; } = new("remote_command");
+
+    /// <summary>Gets the <c>user_abort</c> value.</summary>
+    public static AbortReason UserAbort { get; } = new("user_abort");
+
+    /// <summary>Gets the value associated with this <see cref="AbortReason"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="AbortReason"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="AbortReason"/>.</param>
+    [JsonConstructor]
+    public AbortReason(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="AbortReason"/> instances are equivalent.</summary>
+    public static bool operator ==(AbortReason left, AbortReason right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="AbortReason"/> instances are not equivalent.</summary>
+    public static bool operator !=(AbortReason left, AbortReason right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is AbortReason other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(AbortReason other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{AbortReason}"/> for serializing <see cref="AbortReason"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<AbortReason>
+    {
+        /// <inheritdoc />
+        public override AbortReason Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, AbortReason value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>Theme variant this icon is intended for.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<ToolExecutionCompleteContentResourceLinkIconTheme>))]
-public enum ToolExecutionCompleteContentResourceLinkIconTheme
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct ToolExecutionCompleteContentResourceLinkIconTheme : IEquatable<ToolExecutionCompleteContentResourceLinkIconTheme>
 {
-    /// <summary>The <c>light</c> variant.</summary>
-    [JsonStringEnumMemberName("light")]
-    Light,
-    /// <summary>The <c>dark</c> variant.</summary>
-    [JsonStringEnumMemberName("dark")]
-    Dark,
+    /// <summary>Gets the <c>light</c> value.</summary>
+    public static ToolExecutionCompleteContentResourceLinkIconTheme Light { get; } = new("light");
+
+    /// <summary>Gets the <c>dark</c> value.</summary>
+    public static ToolExecutionCompleteContentResourceLinkIconTheme Dark { get; } = new("dark");
+
+    /// <summary>Gets the value associated with this <see cref="ToolExecutionCompleteContentResourceLinkIconTheme"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="ToolExecutionCompleteContentResourceLinkIconTheme"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="ToolExecutionCompleteContentResourceLinkIconTheme"/>.</param>
+    [JsonConstructor]
+    public ToolExecutionCompleteContentResourceLinkIconTheme(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="ToolExecutionCompleteContentResourceLinkIconTheme"/> instances are equivalent.</summary>
+    public static bool operator ==(ToolExecutionCompleteContentResourceLinkIconTheme left, ToolExecutionCompleteContentResourceLinkIconTheme right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="ToolExecutionCompleteContentResourceLinkIconTheme"/> instances are not equivalent.</summary>
+    public static bool operator !=(ToolExecutionCompleteContentResourceLinkIconTheme left, ToolExecutionCompleteContentResourceLinkIconTheme right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is ToolExecutionCompleteContentResourceLinkIconTheme other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(ToolExecutionCompleteContentResourceLinkIconTheme other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{ToolExecutionCompleteContentResourceLinkIconTheme}"/> for serializing <see cref="ToolExecutionCompleteContentResourceLinkIconTheme"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<ToolExecutionCompleteContentResourceLinkIconTheme>
+    {
+        /// <inheritdoc />
+        public override ToolExecutionCompleteContentResourceLinkIconTheme Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, ToolExecutionCompleteContentResourceLinkIconTheme value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>Message role: "system" for system prompts, "developer" for developer-injected instructions.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<SystemMessageRole>))]
-public enum SystemMessageRole
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct SystemMessageRole : IEquatable<SystemMessageRole>
 {
-    /// <summary>The <c>system</c> variant.</summary>
-    [JsonStringEnumMemberName("system")]
-    System,
-    /// <summary>The <c>developer</c> variant.</summary>
-    [JsonStringEnumMemberName("developer")]
-    Developer,
+    /// <summary>Gets the <c>system</c> value.</summary>
+    public static SystemMessageRole System { get; } = new("system");
+
+    /// <summary>Gets the <c>developer</c> value.</summary>
+    public static SystemMessageRole Developer { get; } = new("developer");
+
+    /// <summary>Gets the value associated with this <see cref="SystemMessageRole"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="SystemMessageRole"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="SystemMessageRole"/>.</param>
+    [JsonConstructor]
+    public SystemMessageRole(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="SystemMessageRole"/> instances are equivalent.</summary>
+    public static bool operator ==(SystemMessageRole left, SystemMessageRole right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="SystemMessageRole"/> instances are not equivalent.</summary>
+    public static bool operator !=(SystemMessageRole left, SystemMessageRole right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is SystemMessageRole other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(SystemMessageRole other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{SystemMessageRole}"/> for serializing <see cref="SystemMessageRole"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<SystemMessageRole>
+    {
+        /// <inheritdoc />
+        public override SystemMessageRole Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, SystemMessageRole value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>Whether the agent completed successfully or failed.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<SystemNotificationAgentCompletedStatus>))]
-public enum SystemNotificationAgentCompletedStatus
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct SystemNotificationAgentCompletedStatus : IEquatable<SystemNotificationAgentCompletedStatus>
 {
-    /// <summary>The <c>completed</c> variant.</summary>
-    [JsonStringEnumMemberName("completed")]
-    Completed,
-    /// <summary>The <c>failed</c> variant.</summary>
-    [JsonStringEnumMemberName("failed")]
-    Failed,
+    /// <summary>Gets the <c>completed</c> value.</summary>
+    public static SystemNotificationAgentCompletedStatus Completed { get; } = new("completed");
+
+    /// <summary>Gets the <c>failed</c> value.</summary>
+    public static SystemNotificationAgentCompletedStatus Failed { get; } = new("failed");
+
+    /// <summary>Gets the value associated with this <see cref="SystemNotificationAgentCompletedStatus"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="SystemNotificationAgentCompletedStatus"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="SystemNotificationAgentCompletedStatus"/>.</param>
+    [JsonConstructor]
+    public SystemNotificationAgentCompletedStatus(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="SystemNotificationAgentCompletedStatus"/> instances are equivalent.</summary>
+    public static bool operator ==(SystemNotificationAgentCompletedStatus left, SystemNotificationAgentCompletedStatus right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="SystemNotificationAgentCompletedStatus"/> instances are not equivalent.</summary>
+    public static bool operator !=(SystemNotificationAgentCompletedStatus left, SystemNotificationAgentCompletedStatus right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is SystemNotificationAgentCompletedStatus other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(SystemNotificationAgentCompletedStatus other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{SystemNotificationAgentCompletedStatus}"/> for serializing <see cref="SystemNotificationAgentCompletedStatus"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<SystemNotificationAgentCompletedStatus>
+    {
+        /// <inheritdoc />
+        public override SystemNotificationAgentCompletedStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, SystemNotificationAgentCompletedStatus value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>Whether this is a store or vote memory operation.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<PermissionRequestMemoryAction>))]
-public enum PermissionRequestMemoryAction
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct PermissionRequestMemoryAction : IEquatable<PermissionRequestMemoryAction>
 {
-    /// <summary>The <c>store</c> variant.</summary>
-    [JsonStringEnumMemberName("store")]
-    Store,
-    /// <summary>The <c>vote</c> variant.</summary>
-    [JsonStringEnumMemberName("vote")]
-    Vote,
+    /// <summary>Gets the <c>store</c> value.</summary>
+    public static PermissionRequestMemoryAction Store { get; } = new("store");
+
+    /// <summary>Gets the <c>vote</c> value.</summary>
+    public static PermissionRequestMemoryAction Vote { get; } = new("vote");
+
+    /// <summary>Gets the value associated with this <see cref="PermissionRequestMemoryAction"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="PermissionRequestMemoryAction"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="PermissionRequestMemoryAction"/>.</param>
+    [JsonConstructor]
+    public PermissionRequestMemoryAction(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="PermissionRequestMemoryAction"/> instances are equivalent.</summary>
+    public static bool operator ==(PermissionRequestMemoryAction left, PermissionRequestMemoryAction right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="PermissionRequestMemoryAction"/> instances are not equivalent.</summary>
+    public static bool operator !=(PermissionRequestMemoryAction left, PermissionRequestMemoryAction right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is PermissionRequestMemoryAction other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(PermissionRequestMemoryAction other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{PermissionRequestMemoryAction}"/> for serializing <see cref="PermissionRequestMemoryAction"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<PermissionRequestMemoryAction>
+    {
+        /// <inheritdoc />
+        public override PermissionRequestMemoryAction Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, PermissionRequestMemoryAction value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>Vote direction (vote only).</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<PermissionRequestMemoryDirection>))]
-public enum PermissionRequestMemoryDirection
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct PermissionRequestMemoryDirection : IEquatable<PermissionRequestMemoryDirection>
 {
-    /// <summary>The <c>upvote</c> variant.</summary>
-    [JsonStringEnumMemberName("upvote")]
-    Upvote,
-    /// <summary>The <c>downvote</c> variant.</summary>
-    [JsonStringEnumMemberName("downvote")]
-    Downvote,
+    /// <summary>Gets the <c>upvote</c> value.</summary>
+    public static PermissionRequestMemoryDirection Upvote { get; } = new("upvote");
+
+    /// <summary>Gets the <c>downvote</c> value.</summary>
+    public static PermissionRequestMemoryDirection Downvote { get; } = new("downvote");
+
+    /// <summary>Gets the value associated with this <see cref="PermissionRequestMemoryDirection"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="PermissionRequestMemoryDirection"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="PermissionRequestMemoryDirection"/>.</param>
+    [JsonConstructor]
+    public PermissionRequestMemoryDirection(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="PermissionRequestMemoryDirection"/> instances are equivalent.</summary>
+    public static bool operator ==(PermissionRequestMemoryDirection left, PermissionRequestMemoryDirection right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="PermissionRequestMemoryDirection"/> instances are not equivalent.</summary>
+    public static bool operator !=(PermissionRequestMemoryDirection left, PermissionRequestMemoryDirection right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is PermissionRequestMemoryDirection other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(PermissionRequestMemoryDirection other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{PermissionRequestMemoryDirection}"/> for serializing <see cref="PermissionRequestMemoryDirection"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<PermissionRequestMemoryDirection>
+    {
+        /// <inheritdoc />
+        public override PermissionRequestMemoryDirection Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, PermissionRequestMemoryDirection value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>Whether this is a store or vote memory operation.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<PermissionPromptRequestMemoryAction>))]
-public enum PermissionPromptRequestMemoryAction
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct PermissionPromptRequestMemoryAction : IEquatable<PermissionPromptRequestMemoryAction>
 {
-    /// <summary>The <c>store</c> variant.</summary>
-    [JsonStringEnumMemberName("store")]
-    Store,
-    /// <summary>The <c>vote</c> variant.</summary>
-    [JsonStringEnumMemberName("vote")]
-    Vote,
+    /// <summary>Gets the <c>store</c> value.</summary>
+    public static PermissionPromptRequestMemoryAction Store { get; } = new("store");
+
+    /// <summary>Gets the <c>vote</c> value.</summary>
+    public static PermissionPromptRequestMemoryAction Vote { get; } = new("vote");
+
+    /// <summary>Gets the value associated with this <see cref="PermissionPromptRequestMemoryAction"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="PermissionPromptRequestMemoryAction"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="PermissionPromptRequestMemoryAction"/>.</param>
+    [JsonConstructor]
+    public PermissionPromptRequestMemoryAction(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="PermissionPromptRequestMemoryAction"/> instances are equivalent.</summary>
+    public static bool operator ==(PermissionPromptRequestMemoryAction left, PermissionPromptRequestMemoryAction right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="PermissionPromptRequestMemoryAction"/> instances are not equivalent.</summary>
+    public static bool operator !=(PermissionPromptRequestMemoryAction left, PermissionPromptRequestMemoryAction right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is PermissionPromptRequestMemoryAction other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(PermissionPromptRequestMemoryAction other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{PermissionPromptRequestMemoryAction}"/> for serializing <see cref="PermissionPromptRequestMemoryAction"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<PermissionPromptRequestMemoryAction>
+    {
+        /// <inheritdoc />
+        public override PermissionPromptRequestMemoryAction Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, PermissionPromptRequestMemoryAction value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>Vote direction (vote only).</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<PermissionPromptRequestMemoryDirection>))]
-public enum PermissionPromptRequestMemoryDirection
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct PermissionPromptRequestMemoryDirection : IEquatable<PermissionPromptRequestMemoryDirection>
 {
-    /// <summary>The <c>upvote</c> variant.</summary>
-    [JsonStringEnumMemberName("upvote")]
-    Upvote,
-    /// <summary>The <c>downvote</c> variant.</summary>
-    [JsonStringEnumMemberName("downvote")]
-    Downvote,
+    /// <summary>Gets the <c>upvote</c> value.</summary>
+    public static PermissionPromptRequestMemoryDirection Upvote { get; } = new("upvote");
+
+    /// <summary>Gets the <c>downvote</c> value.</summary>
+    public static PermissionPromptRequestMemoryDirection Downvote { get; } = new("downvote");
+
+    /// <summary>Gets the value associated with this <see cref="PermissionPromptRequestMemoryDirection"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="PermissionPromptRequestMemoryDirection"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="PermissionPromptRequestMemoryDirection"/>.</param>
+    [JsonConstructor]
+    public PermissionPromptRequestMemoryDirection(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="PermissionPromptRequestMemoryDirection"/> instances are equivalent.</summary>
+    public static bool operator ==(PermissionPromptRequestMemoryDirection left, PermissionPromptRequestMemoryDirection right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="PermissionPromptRequestMemoryDirection"/> instances are not equivalent.</summary>
+    public static bool operator !=(PermissionPromptRequestMemoryDirection left, PermissionPromptRequestMemoryDirection right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is PermissionPromptRequestMemoryDirection other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(PermissionPromptRequestMemoryDirection other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{PermissionPromptRequestMemoryDirection}"/> for serializing <see cref="PermissionPromptRequestMemoryDirection"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<PermissionPromptRequestMemoryDirection>
+    {
+        /// <inheritdoc />
+        public override PermissionPromptRequestMemoryDirection Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, PermissionPromptRequestMemoryDirection value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>Underlying permission kind that needs path approval.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<PermissionPromptRequestPathAccessKind>))]
-public enum PermissionPromptRequestPathAccessKind
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct PermissionPromptRequestPathAccessKind : IEquatable<PermissionPromptRequestPathAccessKind>
 {
-    /// <summary>The <c>read</c> variant.</summary>
-    [JsonStringEnumMemberName("read")]
-    Read,
-    /// <summary>The <c>shell</c> variant.</summary>
-    [JsonStringEnumMemberName("shell")]
-    Shell,
-    /// <summary>The <c>write</c> variant.</summary>
-    [JsonStringEnumMemberName("write")]
-    Write,
+    /// <summary>Gets the <c>read</c> value.</summary>
+    public static PermissionPromptRequestPathAccessKind Read { get; } = new("read");
+
+    /// <summary>Gets the <c>shell</c> value.</summary>
+    public static PermissionPromptRequestPathAccessKind Shell { get; } = new("shell");
+
+    /// <summary>Gets the <c>write</c> value.</summary>
+    public static PermissionPromptRequestPathAccessKind Write { get; } = new("write");
+
+    /// <summary>Gets the value associated with this <see cref="PermissionPromptRequestPathAccessKind"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="PermissionPromptRequestPathAccessKind"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="PermissionPromptRequestPathAccessKind"/>.</param>
+    [JsonConstructor]
+    public PermissionPromptRequestPathAccessKind(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="PermissionPromptRequestPathAccessKind"/> instances are equivalent.</summary>
+    public static bool operator ==(PermissionPromptRequestPathAccessKind left, PermissionPromptRequestPathAccessKind right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="PermissionPromptRequestPathAccessKind"/> instances are not equivalent.</summary>
+    public static bool operator !=(PermissionPromptRequestPathAccessKind left, PermissionPromptRequestPathAccessKind right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is PermissionPromptRequestPathAccessKind other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(PermissionPromptRequestPathAccessKind other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{PermissionPromptRequestPathAccessKind}"/> for serializing <see cref="PermissionPromptRequestPathAccessKind"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<PermissionPromptRequestPathAccessKind>
+    {
+        /// <inheritdoc />
+        public override PermissionPromptRequestPathAccessKind Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, PermissionPromptRequestPathAccessKind value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>Elicitation mode; "form" for structured input, "url" for browser-based. Defaults to "form" when absent.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<ElicitationRequestedMode>))]
-public enum ElicitationRequestedMode
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct ElicitationRequestedMode : IEquatable<ElicitationRequestedMode>
 {
-    /// <summary>The <c>form</c> variant.</summary>
-    [JsonStringEnumMemberName("form")]
-    Form,
-    /// <summary>The <c>url</c> variant.</summary>
-    [JsonStringEnumMemberName("url")]
-    Url,
+    /// <summary>Gets the <c>form</c> value.</summary>
+    public static ElicitationRequestedMode Form { get; } = new("form");
+
+    /// <summary>Gets the <c>url</c> value.</summary>
+    public static ElicitationRequestedMode Url { get; } = new("url");
+
+    /// <summary>Gets the value associated with this <see cref="ElicitationRequestedMode"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="ElicitationRequestedMode"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="ElicitationRequestedMode"/>.</param>
+    [JsonConstructor]
+    public ElicitationRequestedMode(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="ElicitationRequestedMode"/> instances are equivalent.</summary>
+    public static bool operator ==(ElicitationRequestedMode left, ElicitationRequestedMode right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="ElicitationRequestedMode"/> instances are not equivalent.</summary>
+    public static bool operator !=(ElicitationRequestedMode left, ElicitationRequestedMode right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is ElicitationRequestedMode other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(ElicitationRequestedMode other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{ElicitationRequestedMode}"/> for serializing <see cref="ElicitationRequestedMode"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<ElicitationRequestedMode>
+    {
+        /// <inheritdoc />
+        public override ElicitationRequestedMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, ElicitationRequestedMode value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>The user action: "accept" (submitted form), "decline" (explicitly refused), or "cancel" (dismissed).</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<ElicitationCompletedAction>))]
-public enum ElicitationCompletedAction
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct ElicitationCompletedAction : IEquatable<ElicitationCompletedAction>
 {
-    /// <summary>The <c>accept</c> variant.</summary>
-    [JsonStringEnumMemberName("accept")]
-    Accept,
-    /// <summary>The <c>decline</c> variant.</summary>
-    [JsonStringEnumMemberName("decline")]
-    Decline,
-    /// <summary>The <c>cancel</c> variant.</summary>
-    [JsonStringEnumMemberName("cancel")]
-    Cancel,
+    /// <summary>Gets the <c>accept</c> value.</summary>
+    public static ElicitationCompletedAction Accept { get; } = new("accept");
+
+    /// <summary>Gets the <c>decline</c> value.</summary>
+    public static ElicitationCompletedAction Decline { get; } = new("decline");
+
+    /// <summary>Gets the <c>cancel</c> value.</summary>
+    public static ElicitationCompletedAction Cancel { get; } = new("cancel");
+
+    /// <summary>Gets the value associated with this <see cref="ElicitationCompletedAction"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="ElicitationCompletedAction"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="ElicitationCompletedAction"/>.</param>
+    [JsonConstructor]
+    public ElicitationCompletedAction(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="ElicitationCompletedAction"/> instances are equivalent.</summary>
+    public static bool operator ==(ElicitationCompletedAction left, ElicitationCompletedAction right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="ElicitationCompletedAction"/> instances are not equivalent.</summary>
+    public static bool operator !=(ElicitationCompletedAction left, ElicitationCompletedAction right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is ElicitationCompletedAction other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(ElicitationCompletedAction other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{ElicitationCompletedAction}"/> for serializing <see cref="ElicitationCompletedAction"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<ElicitationCompletedAction>
+    {
+        /// <inheritdoc />
+        public override ElicitationCompletedAction Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, ElicitationCompletedAction value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>Connection status: connected, failed, needs-auth, pending, disabled, or not_configured.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<McpServersLoadedServerStatus>))]
-public enum McpServersLoadedServerStatus
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct McpServersLoadedServerStatus : IEquatable<McpServersLoadedServerStatus>
 {
-    /// <summary>The <c>connected</c> variant.</summary>
-    [JsonStringEnumMemberName("connected")]
-    Connected,
-    /// <summary>The <c>failed</c> variant.</summary>
-    [JsonStringEnumMemberName("failed")]
-    Failed,
-    /// <summary>The <c>needs-auth</c> variant.</summary>
-    [JsonStringEnumMemberName("needs-auth")]
-    NeedsAuth,
-    /// <summary>The <c>pending</c> variant.</summary>
-    [JsonStringEnumMemberName("pending")]
-    Pending,
-    /// <summary>The <c>disabled</c> variant.</summary>
-    [JsonStringEnumMemberName("disabled")]
-    Disabled,
-    /// <summary>The <c>not_configured</c> variant.</summary>
-    [JsonStringEnumMemberName("not_configured")]
-    NotConfigured,
+    /// <summary>Gets the <c>connected</c> value.</summary>
+    public static McpServersLoadedServerStatus Connected { get; } = new("connected");
+
+    /// <summary>Gets the <c>failed</c> value.</summary>
+    public static McpServersLoadedServerStatus Failed { get; } = new("failed");
+
+    /// <summary>Gets the <c>needs-auth</c> value.</summary>
+    public static McpServersLoadedServerStatus NeedsAuth { get; } = new("needs-auth");
+
+    /// <summary>Gets the <c>pending</c> value.</summary>
+    public static McpServersLoadedServerStatus Pending { get; } = new("pending");
+
+    /// <summary>Gets the <c>disabled</c> value.</summary>
+    public static McpServersLoadedServerStatus Disabled { get; } = new("disabled");
+
+    /// <summary>Gets the <c>not_configured</c> value.</summary>
+    public static McpServersLoadedServerStatus NotConfigured { get; } = new("not_configured");
+
+    /// <summary>Gets the value associated with this <see cref="McpServersLoadedServerStatus"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="McpServersLoadedServerStatus"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="McpServersLoadedServerStatus"/>.</param>
+    [JsonConstructor]
+    public McpServersLoadedServerStatus(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="McpServersLoadedServerStatus"/> instances are equivalent.</summary>
+    public static bool operator ==(McpServersLoadedServerStatus left, McpServersLoadedServerStatus right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="McpServersLoadedServerStatus"/> instances are not equivalent.</summary>
+    public static bool operator !=(McpServersLoadedServerStatus left, McpServersLoadedServerStatus right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is McpServersLoadedServerStatus other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(McpServersLoadedServerStatus other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{McpServersLoadedServerStatus}"/> for serializing <see cref="McpServersLoadedServerStatus"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<McpServersLoadedServerStatus>
+    {
+        /// <inheritdoc />
+        public override McpServersLoadedServerStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, McpServersLoadedServerStatus value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>New connection status: connected, failed, needs-auth, pending, disabled, or not_configured.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<McpServerStatusChangedStatus>))]
-public enum McpServerStatusChangedStatus
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct McpServerStatusChangedStatus : IEquatable<McpServerStatusChangedStatus>
 {
-    /// <summary>The <c>connected</c> variant.</summary>
-    [JsonStringEnumMemberName("connected")]
-    Connected,
-    /// <summary>The <c>failed</c> variant.</summary>
-    [JsonStringEnumMemberName("failed")]
-    Failed,
-    /// <summary>The <c>needs-auth</c> variant.</summary>
-    [JsonStringEnumMemberName("needs-auth")]
-    NeedsAuth,
-    /// <summary>The <c>pending</c> variant.</summary>
-    [JsonStringEnumMemberName("pending")]
-    Pending,
-    /// <summary>The <c>disabled</c> variant.</summary>
-    [JsonStringEnumMemberName("disabled")]
-    Disabled,
-    /// <summary>The <c>not_configured</c> variant.</summary>
-    [JsonStringEnumMemberName("not_configured")]
-    NotConfigured,
+    /// <summary>Gets the <c>connected</c> value.</summary>
+    public static McpServerStatusChangedStatus Connected { get; } = new("connected");
+
+    /// <summary>Gets the <c>failed</c> value.</summary>
+    public static McpServerStatusChangedStatus Failed { get; } = new("failed");
+
+    /// <summary>Gets the <c>needs-auth</c> value.</summary>
+    public static McpServerStatusChangedStatus NeedsAuth { get; } = new("needs-auth");
+
+    /// <summary>Gets the <c>pending</c> value.</summary>
+    public static McpServerStatusChangedStatus Pending { get; } = new("pending");
+
+    /// <summary>Gets the <c>disabled</c> value.</summary>
+    public static McpServerStatusChangedStatus Disabled { get; } = new("disabled");
+
+    /// <summary>Gets the <c>not_configured</c> value.</summary>
+    public static McpServerStatusChangedStatus NotConfigured { get; } = new("not_configured");
+
+    /// <summary>Gets the value associated with this <see cref="McpServerStatusChangedStatus"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="McpServerStatusChangedStatus"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="McpServerStatusChangedStatus"/>.</param>
+    [JsonConstructor]
+    public McpServerStatusChangedStatus(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="McpServerStatusChangedStatus"/> instances are equivalent.</summary>
+    public static bool operator ==(McpServerStatusChangedStatus left, McpServerStatusChangedStatus right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="McpServerStatusChangedStatus"/> instances are not equivalent.</summary>
+    public static bool operator !=(McpServerStatusChangedStatus left, McpServerStatusChangedStatus right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is McpServerStatusChangedStatus other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(McpServerStatusChangedStatus other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{McpServerStatusChangedStatus}"/> for serializing <see cref="McpServerStatusChangedStatus"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<McpServerStatusChangedStatus>
+    {
+        /// <inheritdoc />
+        public override McpServerStatusChangedStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, McpServerStatusChangedStatus value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>Discovery source.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<ExtensionsLoadedExtensionSource>))]
-public enum ExtensionsLoadedExtensionSource
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct ExtensionsLoadedExtensionSource : IEquatable<ExtensionsLoadedExtensionSource>
 {
-    /// <summary>The <c>project</c> variant.</summary>
-    [JsonStringEnumMemberName("project")]
-    Project,
-    /// <summary>The <c>user</c> variant.</summary>
-    [JsonStringEnumMemberName("user")]
-    User,
+    /// <summary>Gets the <c>project</c> value.</summary>
+    public static ExtensionsLoadedExtensionSource Project { get; } = new("project");
+
+    /// <summary>Gets the <c>user</c> value.</summary>
+    public static ExtensionsLoadedExtensionSource User { get; } = new("user");
+
+    /// <summary>Gets the value associated with this <see cref="ExtensionsLoadedExtensionSource"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="ExtensionsLoadedExtensionSource"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="ExtensionsLoadedExtensionSource"/>.</param>
+    [JsonConstructor]
+    public ExtensionsLoadedExtensionSource(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="ExtensionsLoadedExtensionSource"/> instances are equivalent.</summary>
+    public static bool operator ==(ExtensionsLoadedExtensionSource left, ExtensionsLoadedExtensionSource right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="ExtensionsLoadedExtensionSource"/> instances are not equivalent.</summary>
+    public static bool operator !=(ExtensionsLoadedExtensionSource left, ExtensionsLoadedExtensionSource right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is ExtensionsLoadedExtensionSource other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(ExtensionsLoadedExtensionSource other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{ExtensionsLoadedExtensionSource}"/> for serializing <see cref="ExtensionsLoadedExtensionSource"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<ExtensionsLoadedExtensionSource>
+    {
+        /// <inheritdoc />
+        public override ExtensionsLoadedExtensionSource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, ExtensionsLoadedExtensionSource value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 /// <summary>Current status: running, disabled, failed, or starting.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<ExtensionsLoadedExtensionStatus>))]
-public enum ExtensionsLoadedExtensionStatus
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct ExtensionsLoadedExtensionStatus : IEquatable<ExtensionsLoadedExtensionStatus>
 {
-    /// <summary>The <c>running</c> variant.</summary>
-    [JsonStringEnumMemberName("running")]
-    Running,
-    /// <summary>The <c>disabled</c> variant.</summary>
-    [JsonStringEnumMemberName("disabled")]
-    Disabled,
-    /// <summary>The <c>failed</c> variant.</summary>
-    [JsonStringEnumMemberName("failed")]
-    Failed,
-    /// <summary>The <c>starting</c> variant.</summary>
-    [JsonStringEnumMemberName("starting")]
-    Starting,
+    /// <summary>Gets the <c>running</c> value.</summary>
+    public static ExtensionsLoadedExtensionStatus Running { get; } = new("running");
+
+    /// <summary>Gets the <c>disabled</c> value.</summary>
+    public static ExtensionsLoadedExtensionStatus Disabled { get; } = new("disabled");
+
+    /// <summary>Gets the <c>failed</c> value.</summary>
+    public static ExtensionsLoadedExtensionStatus Failed { get; } = new("failed");
+
+    /// <summary>Gets the <c>starting</c> value.</summary>
+    public static ExtensionsLoadedExtensionStatus Starting { get; } = new("starting");
+
+    /// <summary>Gets the value associated with this <see cref="ExtensionsLoadedExtensionStatus"/>.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="ExtensionsLoadedExtensionStatus"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="ExtensionsLoadedExtensionStatus"/>.</param>
+    [JsonConstructor]
+    public ExtensionsLoadedExtensionStatus(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>Returns a value indicating whether two <see cref="ExtensionsLoadedExtensionStatus"/> instances are equivalent.</summary>
+    public static bool operator ==(ExtensionsLoadedExtensionStatus left, ExtensionsLoadedExtensionStatus right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="ExtensionsLoadedExtensionStatus"/> instances are not equivalent.</summary>
+    public static bool operator !=(ExtensionsLoadedExtensionStatus left, ExtensionsLoadedExtensionStatus right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is ExtensionsLoadedExtensionStatus other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(ExtensionsLoadedExtensionStatus other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+
+    /// <inheritdoc />
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <summary>Provides a <see cref="JsonConverter{ExtensionsLoadedExtensionStatus}"/> for serializing <see cref="ExtensionsLoadedExtensionStatus"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<ExtensionsLoadedExtensionStatus>
+    {
+        /// <inheritdoc />
+        public override ExtensionsLoadedExtensionStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();
+            return new(value);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, ExtensionsLoadedExtensionStatus value, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();
+            writer.WriteStringValue(value.Value);
+        }
+    }
 }
 
 [JsonSourceGenerationOptions(

--- a/dotnet/src/Generated/SessionEvents.cs
+++ b/dotnet/src/Generated/SessionEvents.cs
@@ -4885,12 +4885,6 @@ public partial class ExtensionsLoadedExtension
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct WorkingDirectoryContextHostType : IEquatable<WorkingDirectoryContextHostType>
 {
-    /// <summary>Gets the <c>github</c> value.</summary>
-    public static WorkingDirectoryContextHostType Github { get; } = new("github");
-
-    /// <summary>Gets the <c>ado</c> value.</summary>
-    public static WorkingDirectoryContextHostType Ado { get; } = new("ado");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="WorkingDirectoryContextHostType"/>.</summary>
@@ -4904,6 +4898,12 @@ public readonly struct WorkingDirectoryContextHostType : IEquatable<WorkingDirec
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>github</c> value.</summary>
+    public static WorkingDirectoryContextHostType Github { get; } = new("github");
+
+    /// <summary>Gets the <c>ado</c> value.</summary>
+    public static WorkingDirectoryContextHostType Ado { get; } = new("ado");
 
     /// <summary>Returns a value indicating whether two <see cref="WorkingDirectoryContextHostType"/> instances are equivalent.</summary>
     public static bool operator ==(WorkingDirectoryContextHostType left, WorkingDirectoryContextHostType right) => left.Equals(right);
@@ -4946,15 +4946,6 @@ public readonly struct WorkingDirectoryContextHostType : IEquatable<WorkingDirec
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct PlanChangedOperation : IEquatable<PlanChangedOperation>
 {
-    /// <summary>Gets the <c>create</c> value.</summary>
-    public static PlanChangedOperation Create { get; } = new("create");
-
-    /// <summary>Gets the <c>update</c> value.</summary>
-    public static PlanChangedOperation Update { get; } = new("update");
-
-    /// <summary>Gets the <c>delete</c> value.</summary>
-    public static PlanChangedOperation Delete { get; } = new("delete");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="PlanChangedOperation"/>.</summary>
@@ -4968,6 +4959,15 @@ public readonly struct PlanChangedOperation : IEquatable<PlanChangedOperation>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>create</c> value.</summary>
+    public static PlanChangedOperation Create { get; } = new("create");
+
+    /// <summary>Gets the <c>update</c> value.</summary>
+    public static PlanChangedOperation Update { get; } = new("update");
+
+    /// <summary>Gets the <c>delete</c> value.</summary>
+    public static PlanChangedOperation Delete { get; } = new("delete");
 
     /// <summary>Returns a value indicating whether two <see cref="PlanChangedOperation"/> instances are equivalent.</summary>
     public static bool operator ==(PlanChangedOperation left, PlanChangedOperation right) => left.Equals(right);
@@ -5010,12 +5010,6 @@ public readonly struct PlanChangedOperation : IEquatable<PlanChangedOperation>
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct WorkspaceFileChangedOperation : IEquatable<WorkspaceFileChangedOperation>
 {
-    /// <summary>Gets the <c>create</c> value.</summary>
-    public static WorkspaceFileChangedOperation Create { get; } = new("create");
-
-    /// <summary>Gets the <c>update</c> value.</summary>
-    public static WorkspaceFileChangedOperation Update { get; } = new("update");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="WorkspaceFileChangedOperation"/>.</summary>
@@ -5029,6 +5023,12 @@ public readonly struct WorkspaceFileChangedOperation : IEquatable<WorkspaceFileC
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>create</c> value.</summary>
+    public static WorkspaceFileChangedOperation Create { get; } = new("create");
+
+    /// <summary>Gets the <c>update</c> value.</summary>
+    public static WorkspaceFileChangedOperation Update { get; } = new("update");
 
     /// <summary>Returns a value indicating whether two <see cref="WorkspaceFileChangedOperation"/> instances are equivalent.</summary>
     public static bool operator ==(WorkspaceFileChangedOperation left, WorkspaceFileChangedOperation right) => left.Equals(right);
@@ -5071,12 +5071,6 @@ public readonly struct WorkspaceFileChangedOperation : IEquatable<WorkspaceFileC
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct HandoffSourceType : IEquatable<HandoffSourceType>
 {
-    /// <summary>Gets the <c>remote</c> value.</summary>
-    public static HandoffSourceType Remote { get; } = new("remote");
-
-    /// <summary>Gets the <c>local</c> value.</summary>
-    public static HandoffSourceType Local { get; } = new("local");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="HandoffSourceType"/>.</summary>
@@ -5090,6 +5084,12 @@ public readonly struct HandoffSourceType : IEquatable<HandoffSourceType>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>remote</c> value.</summary>
+    public static HandoffSourceType Remote { get; } = new("remote");
+
+    /// <summary>Gets the <c>local</c> value.</summary>
+    public static HandoffSourceType Local { get; } = new("local");
 
     /// <summary>Returns a value indicating whether two <see cref="HandoffSourceType"/> instances are equivalent.</summary>
     public static bool operator ==(HandoffSourceType left, HandoffSourceType right) => left.Equals(right);
@@ -5132,12 +5132,6 @@ public readonly struct HandoffSourceType : IEquatable<HandoffSourceType>
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct ShutdownType : IEquatable<ShutdownType>
 {
-    /// <summary>Gets the <c>routine</c> value.</summary>
-    public static ShutdownType Routine { get; } = new("routine");
-
-    /// <summary>Gets the <c>error</c> value.</summary>
-    public static ShutdownType Error { get; } = new("error");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="ShutdownType"/>.</summary>
@@ -5151,6 +5145,12 @@ public readonly struct ShutdownType : IEquatable<ShutdownType>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>routine</c> value.</summary>
+    public static ShutdownType Routine { get; } = new("routine");
+
+    /// <summary>Gets the <c>error</c> value.</summary>
+    public static ShutdownType Error { get; } = new("error");
 
     /// <summary>Returns a value indicating whether two <see cref="ShutdownType"/> instances are equivalent.</summary>
     public static bool operator ==(ShutdownType left, ShutdownType right) => left.Equals(right);
@@ -5193,18 +5193,6 @@ public readonly struct ShutdownType : IEquatable<ShutdownType>
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct UserMessageAgentMode : IEquatable<UserMessageAgentMode>
 {
-    /// <summary>Gets the <c>interactive</c> value.</summary>
-    public static UserMessageAgentMode Interactive { get; } = new("interactive");
-
-    /// <summary>Gets the <c>plan</c> value.</summary>
-    public static UserMessageAgentMode Plan { get; } = new("plan");
-
-    /// <summary>Gets the <c>autopilot</c> value.</summary>
-    public static UserMessageAgentMode Autopilot { get; } = new("autopilot");
-
-    /// <summary>Gets the <c>shell</c> value.</summary>
-    public static UserMessageAgentMode Shell { get; } = new("shell");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="UserMessageAgentMode"/>.</summary>
@@ -5218,6 +5206,18 @@ public readonly struct UserMessageAgentMode : IEquatable<UserMessageAgentMode>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>interactive</c> value.</summary>
+    public static UserMessageAgentMode Interactive { get; } = new("interactive");
+
+    /// <summary>Gets the <c>plan</c> value.</summary>
+    public static UserMessageAgentMode Plan { get; } = new("plan");
+
+    /// <summary>Gets the <c>autopilot</c> value.</summary>
+    public static UserMessageAgentMode Autopilot { get; } = new("autopilot");
+
+    /// <summary>Gets the <c>shell</c> value.</summary>
+    public static UserMessageAgentMode Shell { get; } = new("shell");
 
     /// <summary>Returns a value indicating whether two <see cref="UserMessageAgentMode"/> instances are equivalent.</summary>
     public static bool operator ==(UserMessageAgentMode left, UserMessageAgentMode right) => left.Equals(right);
@@ -5260,15 +5260,6 @@ public readonly struct UserMessageAgentMode : IEquatable<UserMessageAgentMode>
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct UserMessageAttachmentGithubReferenceType : IEquatable<UserMessageAttachmentGithubReferenceType>
 {
-    /// <summary>Gets the <c>issue</c> value.</summary>
-    public static UserMessageAttachmentGithubReferenceType Issue { get; } = new("issue");
-
-    /// <summary>Gets the <c>pr</c> value.</summary>
-    public static UserMessageAttachmentGithubReferenceType Pr { get; } = new("pr");
-
-    /// <summary>Gets the <c>discussion</c> value.</summary>
-    public static UserMessageAttachmentGithubReferenceType Discussion { get; } = new("discussion");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="UserMessageAttachmentGithubReferenceType"/>.</summary>
@@ -5282,6 +5273,15 @@ public readonly struct UserMessageAttachmentGithubReferenceType : IEquatable<Use
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>issue</c> value.</summary>
+    public static UserMessageAttachmentGithubReferenceType Issue { get; } = new("issue");
+
+    /// <summary>Gets the <c>pr</c> value.</summary>
+    public static UserMessageAttachmentGithubReferenceType Pr { get; } = new("pr");
+
+    /// <summary>Gets the <c>discussion</c> value.</summary>
+    public static UserMessageAttachmentGithubReferenceType Discussion { get; } = new("discussion");
 
     /// <summary>Returns a value indicating whether two <see cref="UserMessageAttachmentGithubReferenceType"/> instances are equivalent.</summary>
     public static bool operator ==(UserMessageAttachmentGithubReferenceType left, UserMessageAttachmentGithubReferenceType right) => left.Equals(right);
@@ -5324,12 +5324,6 @@ public readonly struct UserMessageAttachmentGithubReferenceType : IEquatable<Use
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct AssistantMessageToolRequestType : IEquatable<AssistantMessageToolRequestType>
 {
-    /// <summary>Gets the <c>function</c> value.</summary>
-    public static AssistantMessageToolRequestType Function { get; } = new("function");
-
-    /// <summary>Gets the <c>custom</c> value.</summary>
-    public static AssistantMessageToolRequestType Custom { get; } = new("custom");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="AssistantMessageToolRequestType"/>.</summary>
@@ -5343,6 +5337,12 @@ public readonly struct AssistantMessageToolRequestType : IEquatable<AssistantMes
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>function</c> value.</summary>
+    public static AssistantMessageToolRequestType Function { get; } = new("function");
+
+    /// <summary>Gets the <c>custom</c> value.</summary>
+    public static AssistantMessageToolRequestType Custom { get; } = new("custom");
 
     /// <summary>Returns a value indicating whether two <see cref="AssistantMessageToolRequestType"/> instances are equivalent.</summary>
     public static bool operator ==(AssistantMessageToolRequestType left, AssistantMessageToolRequestType right) => left.Equals(right);
@@ -5385,15 +5385,6 @@ public readonly struct AssistantMessageToolRequestType : IEquatable<AssistantMes
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct ModelCallFailureSource : IEquatable<ModelCallFailureSource>
 {
-    /// <summary>Gets the <c>top_level</c> value.</summary>
-    public static ModelCallFailureSource TopLevel { get; } = new("top_level");
-
-    /// <summary>Gets the <c>subagent</c> value.</summary>
-    public static ModelCallFailureSource Subagent { get; } = new("subagent");
-
-    /// <summary>Gets the <c>mcp_sampling</c> value.</summary>
-    public static ModelCallFailureSource McpSampling { get; } = new("mcp_sampling");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="ModelCallFailureSource"/>.</summary>
@@ -5407,6 +5398,15 @@ public readonly struct ModelCallFailureSource : IEquatable<ModelCallFailureSourc
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>top_level</c> value.</summary>
+    public static ModelCallFailureSource TopLevel { get; } = new("top_level");
+
+    /// <summary>Gets the <c>subagent</c> value.</summary>
+    public static ModelCallFailureSource Subagent { get; } = new("subagent");
+
+    /// <summary>Gets the <c>mcp_sampling</c> value.</summary>
+    public static ModelCallFailureSource McpSampling { get; } = new("mcp_sampling");
 
     /// <summary>Returns a value indicating whether two <see cref="ModelCallFailureSource"/> instances are equivalent.</summary>
     public static bool operator ==(ModelCallFailureSource left, ModelCallFailureSource right) => left.Equals(right);
@@ -5449,15 +5449,6 @@ public readonly struct ModelCallFailureSource : IEquatable<ModelCallFailureSourc
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct AbortReason : IEquatable<AbortReason>
 {
-    /// <summary>Gets the <c>user_initiated</c> value.</summary>
-    public static AbortReason UserInitiated { get; } = new("user_initiated");
-
-    /// <summary>Gets the <c>remote_command</c> value.</summary>
-    public static AbortReason RemoteCommand { get; } = new("remote_command");
-
-    /// <summary>Gets the <c>user_abort</c> value.</summary>
-    public static AbortReason UserAbort { get; } = new("user_abort");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="AbortReason"/>.</summary>
@@ -5471,6 +5462,15 @@ public readonly struct AbortReason : IEquatable<AbortReason>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>user_initiated</c> value.</summary>
+    public static AbortReason UserInitiated { get; } = new("user_initiated");
+
+    /// <summary>Gets the <c>remote_command</c> value.</summary>
+    public static AbortReason RemoteCommand { get; } = new("remote_command");
+
+    /// <summary>Gets the <c>user_abort</c> value.</summary>
+    public static AbortReason UserAbort { get; } = new("user_abort");
 
     /// <summary>Returns a value indicating whether two <see cref="AbortReason"/> instances are equivalent.</summary>
     public static bool operator ==(AbortReason left, AbortReason right) => left.Equals(right);
@@ -5513,12 +5513,6 @@ public readonly struct AbortReason : IEquatable<AbortReason>
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct ToolExecutionCompleteContentResourceLinkIconTheme : IEquatable<ToolExecutionCompleteContentResourceLinkIconTheme>
 {
-    /// <summary>Gets the <c>light</c> value.</summary>
-    public static ToolExecutionCompleteContentResourceLinkIconTheme Light { get; } = new("light");
-
-    /// <summary>Gets the <c>dark</c> value.</summary>
-    public static ToolExecutionCompleteContentResourceLinkIconTheme Dark { get; } = new("dark");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="ToolExecutionCompleteContentResourceLinkIconTheme"/>.</summary>
@@ -5532,6 +5526,12 @@ public readonly struct ToolExecutionCompleteContentResourceLinkIconTheme : IEqua
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>light</c> value.</summary>
+    public static ToolExecutionCompleteContentResourceLinkIconTheme Light { get; } = new("light");
+
+    /// <summary>Gets the <c>dark</c> value.</summary>
+    public static ToolExecutionCompleteContentResourceLinkIconTheme Dark { get; } = new("dark");
 
     /// <summary>Returns a value indicating whether two <see cref="ToolExecutionCompleteContentResourceLinkIconTheme"/> instances are equivalent.</summary>
     public static bool operator ==(ToolExecutionCompleteContentResourceLinkIconTheme left, ToolExecutionCompleteContentResourceLinkIconTheme right) => left.Equals(right);
@@ -5574,12 +5574,6 @@ public readonly struct ToolExecutionCompleteContentResourceLinkIconTheme : IEqua
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct SystemMessageRole : IEquatable<SystemMessageRole>
 {
-    /// <summary>Gets the <c>system</c> value.</summary>
-    public static SystemMessageRole System { get; } = new("system");
-
-    /// <summary>Gets the <c>developer</c> value.</summary>
-    public static SystemMessageRole Developer { get; } = new("developer");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="SystemMessageRole"/>.</summary>
@@ -5593,6 +5587,12 @@ public readonly struct SystemMessageRole : IEquatable<SystemMessageRole>
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>system</c> value.</summary>
+    public static SystemMessageRole System { get; } = new("system");
+
+    /// <summary>Gets the <c>developer</c> value.</summary>
+    public static SystemMessageRole Developer { get; } = new("developer");
 
     /// <summary>Returns a value indicating whether two <see cref="SystemMessageRole"/> instances are equivalent.</summary>
     public static bool operator ==(SystemMessageRole left, SystemMessageRole right) => left.Equals(right);
@@ -5635,12 +5635,6 @@ public readonly struct SystemMessageRole : IEquatable<SystemMessageRole>
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct SystemNotificationAgentCompletedStatus : IEquatable<SystemNotificationAgentCompletedStatus>
 {
-    /// <summary>Gets the <c>completed</c> value.</summary>
-    public static SystemNotificationAgentCompletedStatus Completed { get; } = new("completed");
-
-    /// <summary>Gets the <c>failed</c> value.</summary>
-    public static SystemNotificationAgentCompletedStatus Failed { get; } = new("failed");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="SystemNotificationAgentCompletedStatus"/>.</summary>
@@ -5654,6 +5648,12 @@ public readonly struct SystemNotificationAgentCompletedStatus : IEquatable<Syste
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>completed</c> value.</summary>
+    public static SystemNotificationAgentCompletedStatus Completed { get; } = new("completed");
+
+    /// <summary>Gets the <c>failed</c> value.</summary>
+    public static SystemNotificationAgentCompletedStatus Failed { get; } = new("failed");
 
     /// <summary>Returns a value indicating whether two <see cref="SystemNotificationAgentCompletedStatus"/> instances are equivalent.</summary>
     public static bool operator ==(SystemNotificationAgentCompletedStatus left, SystemNotificationAgentCompletedStatus right) => left.Equals(right);
@@ -5696,12 +5696,6 @@ public readonly struct SystemNotificationAgentCompletedStatus : IEquatable<Syste
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct PermissionRequestMemoryAction : IEquatable<PermissionRequestMemoryAction>
 {
-    /// <summary>Gets the <c>store</c> value.</summary>
-    public static PermissionRequestMemoryAction Store { get; } = new("store");
-
-    /// <summary>Gets the <c>vote</c> value.</summary>
-    public static PermissionRequestMemoryAction Vote { get; } = new("vote");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="PermissionRequestMemoryAction"/>.</summary>
@@ -5715,6 +5709,12 @@ public readonly struct PermissionRequestMemoryAction : IEquatable<PermissionRequ
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>store</c> value.</summary>
+    public static PermissionRequestMemoryAction Store { get; } = new("store");
+
+    /// <summary>Gets the <c>vote</c> value.</summary>
+    public static PermissionRequestMemoryAction Vote { get; } = new("vote");
 
     /// <summary>Returns a value indicating whether two <see cref="PermissionRequestMemoryAction"/> instances are equivalent.</summary>
     public static bool operator ==(PermissionRequestMemoryAction left, PermissionRequestMemoryAction right) => left.Equals(right);
@@ -5757,12 +5757,6 @@ public readonly struct PermissionRequestMemoryAction : IEquatable<PermissionRequ
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct PermissionRequestMemoryDirection : IEquatable<PermissionRequestMemoryDirection>
 {
-    /// <summary>Gets the <c>upvote</c> value.</summary>
-    public static PermissionRequestMemoryDirection Upvote { get; } = new("upvote");
-
-    /// <summary>Gets the <c>downvote</c> value.</summary>
-    public static PermissionRequestMemoryDirection Downvote { get; } = new("downvote");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="PermissionRequestMemoryDirection"/>.</summary>
@@ -5776,6 +5770,12 @@ public readonly struct PermissionRequestMemoryDirection : IEquatable<PermissionR
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>upvote</c> value.</summary>
+    public static PermissionRequestMemoryDirection Upvote { get; } = new("upvote");
+
+    /// <summary>Gets the <c>downvote</c> value.</summary>
+    public static PermissionRequestMemoryDirection Downvote { get; } = new("downvote");
 
     /// <summary>Returns a value indicating whether two <see cref="PermissionRequestMemoryDirection"/> instances are equivalent.</summary>
     public static bool operator ==(PermissionRequestMemoryDirection left, PermissionRequestMemoryDirection right) => left.Equals(right);
@@ -5818,12 +5818,6 @@ public readonly struct PermissionRequestMemoryDirection : IEquatable<PermissionR
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct PermissionPromptRequestMemoryAction : IEquatable<PermissionPromptRequestMemoryAction>
 {
-    /// <summary>Gets the <c>store</c> value.</summary>
-    public static PermissionPromptRequestMemoryAction Store { get; } = new("store");
-
-    /// <summary>Gets the <c>vote</c> value.</summary>
-    public static PermissionPromptRequestMemoryAction Vote { get; } = new("vote");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="PermissionPromptRequestMemoryAction"/>.</summary>
@@ -5837,6 +5831,12 @@ public readonly struct PermissionPromptRequestMemoryAction : IEquatable<Permissi
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>store</c> value.</summary>
+    public static PermissionPromptRequestMemoryAction Store { get; } = new("store");
+
+    /// <summary>Gets the <c>vote</c> value.</summary>
+    public static PermissionPromptRequestMemoryAction Vote { get; } = new("vote");
 
     /// <summary>Returns a value indicating whether two <see cref="PermissionPromptRequestMemoryAction"/> instances are equivalent.</summary>
     public static bool operator ==(PermissionPromptRequestMemoryAction left, PermissionPromptRequestMemoryAction right) => left.Equals(right);
@@ -5879,12 +5879,6 @@ public readonly struct PermissionPromptRequestMemoryAction : IEquatable<Permissi
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct PermissionPromptRequestMemoryDirection : IEquatable<PermissionPromptRequestMemoryDirection>
 {
-    /// <summary>Gets the <c>upvote</c> value.</summary>
-    public static PermissionPromptRequestMemoryDirection Upvote { get; } = new("upvote");
-
-    /// <summary>Gets the <c>downvote</c> value.</summary>
-    public static PermissionPromptRequestMemoryDirection Downvote { get; } = new("downvote");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="PermissionPromptRequestMemoryDirection"/>.</summary>
@@ -5898,6 +5892,12 @@ public readonly struct PermissionPromptRequestMemoryDirection : IEquatable<Permi
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>upvote</c> value.</summary>
+    public static PermissionPromptRequestMemoryDirection Upvote { get; } = new("upvote");
+
+    /// <summary>Gets the <c>downvote</c> value.</summary>
+    public static PermissionPromptRequestMemoryDirection Downvote { get; } = new("downvote");
 
     /// <summary>Returns a value indicating whether two <see cref="PermissionPromptRequestMemoryDirection"/> instances are equivalent.</summary>
     public static bool operator ==(PermissionPromptRequestMemoryDirection left, PermissionPromptRequestMemoryDirection right) => left.Equals(right);
@@ -5940,15 +5940,6 @@ public readonly struct PermissionPromptRequestMemoryDirection : IEquatable<Permi
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct PermissionPromptRequestPathAccessKind : IEquatable<PermissionPromptRequestPathAccessKind>
 {
-    /// <summary>Gets the <c>read</c> value.</summary>
-    public static PermissionPromptRequestPathAccessKind Read { get; } = new("read");
-
-    /// <summary>Gets the <c>shell</c> value.</summary>
-    public static PermissionPromptRequestPathAccessKind Shell { get; } = new("shell");
-
-    /// <summary>Gets the <c>write</c> value.</summary>
-    public static PermissionPromptRequestPathAccessKind Write { get; } = new("write");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="PermissionPromptRequestPathAccessKind"/>.</summary>
@@ -5962,6 +5953,15 @@ public readonly struct PermissionPromptRequestPathAccessKind : IEquatable<Permis
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>read</c> value.</summary>
+    public static PermissionPromptRequestPathAccessKind Read { get; } = new("read");
+
+    /// <summary>Gets the <c>shell</c> value.</summary>
+    public static PermissionPromptRequestPathAccessKind Shell { get; } = new("shell");
+
+    /// <summary>Gets the <c>write</c> value.</summary>
+    public static PermissionPromptRequestPathAccessKind Write { get; } = new("write");
 
     /// <summary>Returns a value indicating whether two <see cref="PermissionPromptRequestPathAccessKind"/> instances are equivalent.</summary>
     public static bool operator ==(PermissionPromptRequestPathAccessKind left, PermissionPromptRequestPathAccessKind right) => left.Equals(right);
@@ -6004,12 +6004,6 @@ public readonly struct PermissionPromptRequestPathAccessKind : IEquatable<Permis
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct ElicitationRequestedMode : IEquatable<ElicitationRequestedMode>
 {
-    /// <summary>Gets the <c>form</c> value.</summary>
-    public static ElicitationRequestedMode Form { get; } = new("form");
-
-    /// <summary>Gets the <c>url</c> value.</summary>
-    public static ElicitationRequestedMode Url { get; } = new("url");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="ElicitationRequestedMode"/>.</summary>
@@ -6023,6 +6017,12 @@ public readonly struct ElicitationRequestedMode : IEquatable<ElicitationRequeste
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>form</c> value.</summary>
+    public static ElicitationRequestedMode Form { get; } = new("form");
+
+    /// <summary>Gets the <c>url</c> value.</summary>
+    public static ElicitationRequestedMode Url { get; } = new("url");
 
     /// <summary>Returns a value indicating whether two <see cref="ElicitationRequestedMode"/> instances are equivalent.</summary>
     public static bool operator ==(ElicitationRequestedMode left, ElicitationRequestedMode right) => left.Equals(right);
@@ -6065,15 +6065,6 @@ public readonly struct ElicitationRequestedMode : IEquatable<ElicitationRequeste
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct ElicitationCompletedAction : IEquatable<ElicitationCompletedAction>
 {
-    /// <summary>Gets the <c>accept</c> value.</summary>
-    public static ElicitationCompletedAction Accept { get; } = new("accept");
-
-    /// <summary>Gets the <c>decline</c> value.</summary>
-    public static ElicitationCompletedAction Decline { get; } = new("decline");
-
-    /// <summary>Gets the <c>cancel</c> value.</summary>
-    public static ElicitationCompletedAction Cancel { get; } = new("cancel");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="ElicitationCompletedAction"/>.</summary>
@@ -6087,6 +6078,15 @@ public readonly struct ElicitationCompletedAction : IEquatable<ElicitationComple
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>accept</c> value.</summary>
+    public static ElicitationCompletedAction Accept { get; } = new("accept");
+
+    /// <summary>Gets the <c>decline</c> value.</summary>
+    public static ElicitationCompletedAction Decline { get; } = new("decline");
+
+    /// <summary>Gets the <c>cancel</c> value.</summary>
+    public static ElicitationCompletedAction Cancel { get; } = new("cancel");
 
     /// <summary>Returns a value indicating whether two <see cref="ElicitationCompletedAction"/> instances are equivalent.</summary>
     public static bool operator ==(ElicitationCompletedAction left, ElicitationCompletedAction right) => left.Equals(right);
@@ -6129,6 +6129,20 @@ public readonly struct ElicitationCompletedAction : IEquatable<ElicitationComple
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct McpServersLoadedServerStatus : IEquatable<McpServersLoadedServerStatus>
 {
+    private readonly string? _value;
+
+    /// <summary>Gets the value associated with this <see cref="McpServersLoadedServerStatus"/>.</summary>
+    public string Value => _value ?? string.Empty;
+
+    /// <summary>Initializes a new instance of the <see cref="McpServersLoadedServerStatus"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="McpServersLoadedServerStatus"/>.</param>
+    [JsonConstructor]
+    public McpServersLoadedServerStatus(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        _value = value;
+    }
+
     /// <summary>Gets the <c>connected</c> value.</summary>
     public static McpServersLoadedServerStatus Connected { get; } = new("connected");
 
@@ -6146,20 +6160,6 @@ public readonly struct McpServersLoadedServerStatus : IEquatable<McpServersLoade
 
     /// <summary>Gets the <c>not_configured</c> value.</summary>
     public static McpServersLoadedServerStatus NotConfigured { get; } = new("not_configured");
-
-    private readonly string? _value;
-
-    /// <summary>Gets the value associated with this <see cref="McpServersLoadedServerStatus"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
-    /// <summary>Initializes a new instance of the <see cref="McpServersLoadedServerStatus"/> struct.</summary>
-    /// <param name="value">The value to associate with this <see cref="McpServersLoadedServerStatus"/>.</param>
-    [JsonConstructor]
-    public McpServersLoadedServerStatus(string value)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        _value = value;
-    }
 
     /// <summary>Returns a value indicating whether two <see cref="McpServersLoadedServerStatus"/> instances are equivalent.</summary>
     public static bool operator ==(McpServersLoadedServerStatus left, McpServersLoadedServerStatus right) => left.Equals(right);
@@ -6202,6 +6202,20 @@ public readonly struct McpServersLoadedServerStatus : IEquatable<McpServersLoade
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct McpServerStatusChangedStatus : IEquatable<McpServerStatusChangedStatus>
 {
+    private readonly string? _value;
+
+    /// <summary>Gets the value associated with this <see cref="McpServerStatusChangedStatus"/>.</summary>
+    public string Value => _value ?? string.Empty;
+
+    /// <summary>Initializes a new instance of the <see cref="McpServerStatusChangedStatus"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="McpServerStatusChangedStatus"/>.</param>
+    [JsonConstructor]
+    public McpServerStatusChangedStatus(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        _value = value;
+    }
+
     /// <summary>Gets the <c>connected</c> value.</summary>
     public static McpServerStatusChangedStatus Connected { get; } = new("connected");
 
@@ -6219,20 +6233,6 @@ public readonly struct McpServerStatusChangedStatus : IEquatable<McpServerStatus
 
     /// <summary>Gets the <c>not_configured</c> value.</summary>
     public static McpServerStatusChangedStatus NotConfigured { get; } = new("not_configured");
-
-    private readonly string? _value;
-
-    /// <summary>Gets the value associated with this <see cref="McpServerStatusChangedStatus"/>.</summary>
-    public string Value => _value ?? string.Empty;
-
-    /// <summary>Initializes a new instance of the <see cref="McpServerStatusChangedStatus"/> struct.</summary>
-    /// <param name="value">The value to associate with this <see cref="McpServerStatusChangedStatus"/>.</param>
-    [JsonConstructor]
-    public McpServerStatusChangedStatus(string value)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        _value = value;
-    }
 
     /// <summary>Returns a value indicating whether two <see cref="McpServerStatusChangedStatus"/> instances are equivalent.</summary>
     public static bool operator ==(McpServerStatusChangedStatus left, McpServerStatusChangedStatus right) => left.Equals(right);
@@ -6275,12 +6275,6 @@ public readonly struct McpServerStatusChangedStatus : IEquatable<McpServerStatus
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct ExtensionsLoadedExtensionSource : IEquatable<ExtensionsLoadedExtensionSource>
 {
-    /// <summary>Gets the <c>project</c> value.</summary>
-    public static ExtensionsLoadedExtensionSource Project { get; } = new("project");
-
-    /// <summary>Gets the <c>user</c> value.</summary>
-    public static ExtensionsLoadedExtensionSource User { get; } = new("user");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="ExtensionsLoadedExtensionSource"/>.</summary>
@@ -6294,6 +6288,12 @@ public readonly struct ExtensionsLoadedExtensionSource : IEquatable<ExtensionsLo
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>project</c> value.</summary>
+    public static ExtensionsLoadedExtensionSource Project { get; } = new("project");
+
+    /// <summary>Gets the <c>user</c> value.</summary>
+    public static ExtensionsLoadedExtensionSource User { get; } = new("user");
 
     /// <summary>Returns a value indicating whether two <see cref="ExtensionsLoadedExtensionSource"/> instances are equivalent.</summary>
     public static bool operator ==(ExtensionsLoadedExtensionSource left, ExtensionsLoadedExtensionSource right) => left.Equals(right);
@@ -6336,18 +6336,6 @@ public readonly struct ExtensionsLoadedExtensionSource : IEquatable<ExtensionsLo
 [DebuggerDisplay("{Value,nq}")]
 public readonly struct ExtensionsLoadedExtensionStatus : IEquatable<ExtensionsLoadedExtensionStatus>
 {
-    /// <summary>Gets the <c>running</c> value.</summary>
-    public static ExtensionsLoadedExtensionStatus Running { get; } = new("running");
-
-    /// <summary>Gets the <c>disabled</c> value.</summary>
-    public static ExtensionsLoadedExtensionStatus Disabled { get; } = new("disabled");
-
-    /// <summary>Gets the <c>failed</c> value.</summary>
-    public static ExtensionsLoadedExtensionStatus Failed { get; } = new("failed");
-
-    /// <summary>Gets the <c>starting</c> value.</summary>
-    public static ExtensionsLoadedExtensionStatus Starting { get; } = new("starting");
-
     private readonly string? _value;
 
     /// <summary>Gets the value associated with this <see cref="ExtensionsLoadedExtensionStatus"/>.</summary>
@@ -6361,6 +6349,18 @@ public readonly struct ExtensionsLoadedExtensionStatus : IEquatable<ExtensionsLo
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         _value = value;
     }
+
+    /// <summary>Gets the <c>running</c> value.</summary>
+    public static ExtensionsLoadedExtensionStatus Running { get; } = new("running");
+
+    /// <summary>Gets the <c>disabled</c> value.</summary>
+    public static ExtensionsLoadedExtensionStatus Disabled { get; } = new("disabled");
+
+    /// <summary>Gets the <c>failed</c> value.</summary>
+    public static ExtensionsLoadedExtensionStatus Failed { get; } = new("failed");
+
+    /// <summary>Gets the <c>starting</c> value.</summary>
+    public static ExtensionsLoadedExtensionStatus Starting { get; } = new("starting");
 
     /// <summary>Returns a value indicating whether two <see cref="ExtensionsLoadedExtensionStatus"/> instances are equivalent.</summary>
     public static bool operator ==(ExtensionsLoadedExtensionStatus left, ExtensionsLoadedExtensionStatus right) => left.Equals(right);

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -13,6 +13,35 @@ using Microsoft.Extensions.Logging;
 
 namespace GitHub.Copilot.SDK;
 
+internal static class GeneratedStringEnumJson
+{
+    internal static string ReadValue(ref Utf8JsonReader reader, Type typeToConvert)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+        {
+            throw new JsonException($"Expected a string token when reading {typeToConvert.Name}, but found {reader.TokenType}.");
+        }
+
+        var value = reader.GetString();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new JsonException($"Expected a non-empty string token when reading {typeToConvert.Name}.");
+        }
+
+        return value;
+    }
+
+    internal static void WriteValue(Utf8JsonWriter writer, string value, Type typeToConvert)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new JsonException($"Expected a non-empty string value when writing {typeToConvert.Name}.");
+        }
+
+        writer.WriteStringValue(value);
+    }
+}
+
 /// <summary>
 /// Represents the connection state of the Copilot client.
 /// </summary>

--- a/dotnet/test/E2E/RpcExtensionsLoadedE2ETests.cs
+++ b/dotnet/test/E2E/RpcExtensionsLoadedE2ETests.cs
@@ -165,10 +165,11 @@ public class RpcExtensionsLoadedE2ETests(E2ETestFixture fixture, ITestOutputHelp
     }
 
     [Theory]
-    [InlineData(ExtensionSource.User)]
-    [InlineData(ExtensionSource.Project)]
-    public async Task Discovers_Loads_And_Reports_Running_Extension(ExtensionSource source)
+    [InlineData("user")]
+    [InlineData("project")]
+    public async Task Discovers_Loads_And_Reports_Running_Extension(string sourceValue)
     {
+        var source = new ExtensionSource(sourceValue);
         string extName;
         string extId;
         string? workingDirectory;
@@ -184,7 +185,7 @@ public class RpcExtensionsLoadedE2ETests(E2ETestFixture fixture, ITestOutputHelp
         }
         else
         {
-            throw new ArgumentOutOfRangeException(nameof(source), source, null);
+            throw new ArgumentOutOfRangeException(nameof(sourceValue), sourceValue, null);
         }
 
         await using var client = CreateExtensionsClient();

--- a/dotnet/test/E2E/RpcMcpAndSkillsE2ETests.cs
+++ b/dotnet/test/E2E/RpcMcpAndSkillsE2ETests.cs
@@ -81,7 +81,7 @@ public class RpcMcpAndSkillsE2ETests(E2ETestFixture fixture, ITestOutputHelper o
         var result = await session.Rpc.Mcp.ListAsync();
 
         var server = Assert.Single(result.Servers, server => string.Equals(server.Name, serverName, StringComparison.Ordinal));
-        Assert.True(Enum.IsDefined(server.Status));
+        Assert.False(string.IsNullOrWhiteSpace(server.Status.Value));
     }
 
     [Fact]

--- a/dotnet/test/E2E/RpcSessionStateE2ETests.cs
+++ b/dotnet/test/E2E/RpcSessionStateE2ETests.cs
@@ -63,12 +63,13 @@ public class RpcSessionStateE2ETests(E2ETestFixture fixture, ITestOutputHelper o
     }
 
     [Theory]
-    [InlineData(SessionMode.Interactive)]
-    [InlineData(SessionMode.Plan)]
-    [InlineData(SessionMode.Autopilot)]
-    public async Task Should_Set_And_Get_Each_Session_Mode_Value(SessionMode mode)
+    [InlineData("interactive")]
+    [InlineData("plan")]
+    [InlineData("autopilot")]
+    public async Task Should_Set_And_Get_Each_Session_Mode_Value(string modeValue)
     {
         await using var session = await CreateSessionAsync();
+        var mode = new SessionMode(modeValue);
 
         await session.Rpc.Mode.SetAsync(mode);
         Assert.Equal(mode, await session.Rpc.Mode.GetAsync());

--- a/dotnet/test/E2E/RpcShellEdgeCaseE2ETests.cs
+++ b/dotnet/test/E2E/RpcShellEdgeCaseE2ETests.cs
@@ -113,11 +113,12 @@ public class RpcShellEdgeCaseE2ETests(E2ETestFixture fixture, ITestOutputHelper 
     }
 
     [Theory]
-    [InlineData(ShellKillSignal.SIGTERM)]
-    [InlineData(ShellKillSignal.SIGKILL)]
-    public async Task Shell_Kill_Cleans_Up_After_Terminating_Signal(ShellKillSignal signal)
+    [InlineData("SIGTERM")]
+    [InlineData("SIGKILL")]
+    public async Task Shell_Kill_Cleans_Up_After_Terminating_Signal(string signalValue)
     {
         var session = await CreateSessionAsync();
+        var signal = new ShellKillSignal(signalValue);
         var command = OperatingSystem.IsWindows()
             ? "powershell -NoLogo -NoProfile -Command \"Start-Sleep -Seconds 60\""
             : "sleep 60";

--- a/dotnet/test/E2E/RpcTasksAndHandlersE2ETests.cs
+++ b/dotnet/test/E2E/RpcTasksAndHandlersE2ETests.cs
@@ -114,7 +114,8 @@ public class RpcTasksAndHandlersE2ETests(E2ETestFixture fixture, ITestOutputHelp
                 task = await FindAgentTaskAsync(session, started.AgentId);
                 return task?.LatestResponse?.Contains("TASK_AGENT_DONE", StringComparison.Ordinal) == true
                     || task?.Result?.Contains("TASK_AGENT_DONE", StringComparison.Ordinal) == true
-                    || task?.Status is TaskAgentInfoStatus.Completed or TaskAgentInfoStatus.Failed;
+                    || task?.Status == TaskAgentInfoStatus.Completed
+                    || task?.Status == TaskAgentInfoStatus.Failed;
             },
             timeout: TimeSpan.FromSeconds(60),
             timeoutMessage: $"Background agent task '{started.AgentId}' did not produce a final observable state.");

--- a/dotnet/test/Unit/ForwardCompatibilityTests.cs
+++ b/dotnet/test/Unit/ForwardCompatibilityTests.cs
@@ -167,6 +167,27 @@ public class ForwardCompatibilityTests
     }
 
     [Fact]
+    public void FromJson_KnownEventType_WithUnknownEnumInData_PreservesValue()
+    {
+        var json = """
+        {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "parentId": null,
+            "type": "abort",
+            "data": {
+                "reason": "future_abort_reason"
+            }
+        }
+        """;
+
+        var result = SessionEvent.FromJson(json);
+
+        var abort = Assert.IsType<AbortEvent>(result);
+        Assert.Equal("future_abort_reason", abort.Data.Reason.Value);
+    }
+
+    [Fact]
     public void FromJson_KnownEventType_WithNullOptionalFields_DoesNotThrow()
     {
         // The CLI may emit null for optional fields. Verify parsing doesn't throw.

--- a/dotnet/test/Unit/ForwardCompatibilityTests.cs
+++ b/dotnet/test/Unit/ForwardCompatibilityTests.cs
@@ -190,6 +190,25 @@ public class ForwardCompatibilityTests
     }
 
     [Fact]
+    public void FromJson_KnownEventType_WithNonStringEnumInData_ThrowsJsonException()
+    {
+        var json = """
+        {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "parentId": null,
+            "type": "abort",
+            "data": {
+                "reason": false
+            }
+        }
+        """;
+
+        var exception = Assert.Throws<JsonException>(() => SessionEvent.FromJson(json));
+        Assert.Contains("AbortReason", exception.Message);
+    }
+
+    [Fact]
     public void RpcEnum_WithUnknownValue_PreservesValue()
     {
         var mode = JsonSerializer.Deserialize(
@@ -204,6 +223,18 @@ public class ForwardCompatibilityTests
             "future_mode"
             """,
             JsonSerializer.Serialize(mode, ForwardCompatibilityJsonContext.Default.SessionMode));
+    }
+
+    [Fact]
+    public void RpcEnum_WithNonStringValue_ThrowsJsonException()
+    {
+        var exception = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(
+            """
+            42
+            """,
+            ForwardCompatibilityJsonContext.Default.SessionMode));
+
+        Assert.Contains("SessionMode", exception.Message);
     }
 
     [Fact]

--- a/dotnet/test/Unit/ForwardCompatibilityTests.cs
+++ b/dotnet/test/Unit/ForwardCompatibilityTests.cs
@@ -247,6 +247,18 @@ public class ForwardCompatibilityTests
     }
 
     [Fact]
+    public void RpcEnum_DefaultValueSerialization_ThrowsJsonException()
+    {
+        GitHub.Copilot.SDK.Rpc.SessionMode mode = default;
+
+        var exception = Assert.Throws<JsonException>(() => JsonSerializer.Serialize(
+            mode,
+            ForwardCompatibilityJsonContext.Default.SessionMode));
+
+        Assert.Contains("SessionMode", exception.Message);
+    }
+
+    [Fact]
     public void FromJson_KnownEventType_WithNullOptionalFields_DoesNotThrow()
     {
         // The CLI may emit null for optional fields. Verify parsing doesn't throw.

--- a/dotnet/test/Unit/ForwardCompatibilityTests.cs
+++ b/dotnet/test/Unit/ForwardCompatibilityTests.cs
@@ -207,6 +207,15 @@ public class ForwardCompatibilityTests
     }
 
     [Fact]
+    public void RpcEnum_DefaultValue_HasEmptyStringValue()
+    {
+        GitHub.Copilot.SDK.Rpc.SessionMode mode = default;
+
+        Assert.Equal(string.Empty, mode.Value);
+        Assert.Equal(string.Empty, mode.ToString());
+    }
+
+    [Fact]
     public void FromJson_KnownEventType_WithNullOptionalFields_DoesNotThrow()
     {
         // The CLI may emit null for optional fields. Verify parsing doesn't throw.

--- a/dotnet/test/Unit/ForwardCompatibilityTests.cs
+++ b/dotnet/test/Unit/ForwardCompatibilityTests.cs
@@ -2,6 +2,8 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Xunit;
 
 namespace GitHub.Copilot.SDK.Test.Unit;
@@ -188,6 +190,23 @@ public class ForwardCompatibilityTests
     }
 
     [Fact]
+    public void RpcEnum_WithUnknownValue_PreservesValue()
+    {
+        var mode = JsonSerializer.Deserialize(
+            """
+            "future_mode"
+            """,
+            ForwardCompatibilityJsonContext.Default.SessionMode);
+
+        Assert.Equal("future_mode", mode.Value);
+        Assert.Equal(
+            """
+            "future_mode"
+            """,
+            JsonSerializer.Serialize(mode, ForwardCompatibilityJsonContext.Default.SessionMode));
+    }
+
+    [Fact]
     public void FromJson_KnownEventType_WithNullOptionalFields_DoesNotThrow()
     {
         // The CLI may emit null for optional fields. Verify parsing doesn't throw.
@@ -232,3 +251,6 @@ public class ForwardCompatibilityTests
         Assert.Null(result.AgentId);
     }
 }
+
+[JsonSerializable(typeof(GitHub.Copilot.SDK.Rpc.SessionMode))]
+internal partial class ForwardCompatibilityJsonContext : JsonSerializerContext;

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -348,8 +348,6 @@ function getOrCreateEnum(
     lines.push(`public readonly struct ${enumName} : IEquatable<${enumName}>`);
     lines.push(`{`);
     lines.push(`    private readonly string? _value;`, "");
-    lines.push(`    /// <summary>Gets the value associated with this <see cref="${enumName}"/>.</summary>`);
-    lines.push(`    public string Value => _value ?? string.Empty;`, "");
     lines.push(`    /// <summary>Initializes a new instance of the <see cref="${enumName}"/> struct.</summary>`);
     lines.push(`    /// <param name="value">The value to associate with this <see cref="${enumName}"/>.</param>`);
     lines.push(`    [JsonConstructor]`);
@@ -358,6 +356,8 @@ function getOrCreateEnum(
     lines.push(`        ArgumentException.ThrowIfNullOrWhiteSpace(value);`);
     lines.push(`        _value = value;`);
     lines.push(`    }`, "");
+    lines.push(`    /// <summary>Gets the value associated with this <see cref="${enumName}"/>.</summary>`);
+    lines.push(`    public string Value => _value ?? string.Empty;`, "");
     for (const value of values) {
         lines.push(`    /// <summary>Gets the <c>${escapeXml(value)}</c> value.</summary>`);
         lines.push(`    public static ${enumName} ${toPascalCaseEnumMember(value)} { get; } = new("${value}");`, "");

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -381,16 +381,12 @@ function getOrCreateEnum(
     lines.push(`        /// <inheritdoc />`);
     lines.push(`        public override ${enumName} Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)`);
     lines.push(`        {`);
-    lines.push(`            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ${enumName}, but found {reader.TokenType}.");`);
-    lines.push(`            var value = reader.GetString();`);
-    lines.push(`            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();`);
-    lines.push(`            return new(value);`);
+    lines.push(`            return new(GitHub.Copilot.SDK.GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));`);
     lines.push(`        }`, "");
     lines.push(`        /// <inheritdoc />`);
     lines.push(`        public override void Write(Utf8JsonWriter writer, ${enumName} value, JsonSerializerOptions options)`);
     lines.push(`        {`);
-    lines.push(`            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();`);
-    lines.push(`            writer.WriteStringValue(value.Value);`);
+    lines.push(`            GitHub.Copilot.SDK.GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(${enumName}));`);
     lines.push(`        }`);
     lines.push(`    }`);
     lines.push(`}`, "");

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -320,17 +320,12 @@ interface EventVariant {
     dataDescription?: string;
 }
 
-let generatedEnums = new Map<string, { enumName: string; values: string[]; useStringEnum: boolean }>();
+let generatedEnums = new Map<string, { enumName: string; values: string[] }>();
 
 /** Schema definitions available during session event generation (for $ref resolution). */
 let sessionDefinitions: DefinitionCollections = { definitions: {}, $defs: {} };
 
-/**
- * Emits a schema enum type. RPC schemas use the default regular .NET enum output
- * because RPC method contracts are closed to the schema version. Session event
- * schemas pass useStringEnum=true because persisted runtime events need to
- * deserialize and preserve enum strings added by newer runtimes.
- */
+/** Emits a schema enum as a string-backed value type that preserves unknown runtime values. */
 function getOrCreateEnum(
     parentClassName: string,
     propName: string,
@@ -338,77 +333,64 @@ function getOrCreateEnum(
     enumOutput: string[],
     description?: string,
     explicitName?: string,
-    deprecated?: boolean,
-    useStringEnum = false
+    deprecated?: boolean
 ): string {
     const enumName = explicitName ?? `${parentClassName}${propName}`;
     const existing = generatedEnums.get(enumName);
     if (existing) return existing.enumName;
-    generatedEnums.set(enumName, { enumName, values, useStringEnum });
+    generatedEnums.set(enumName, { enumName, values });
 
     const lines: string[] = [];
     lines.push(...xmlDocEnumComment(description, ""));
     if (deprecated) lines.push(`[Obsolete("This member is deprecated and will be removed in a future version.")]`);
-
-    if (useStringEnum) {
-        lines.push(`[JsonConverter(typeof(Converter))]`);
-        lines.push(`[DebuggerDisplay("{Value,nq}")]`);
-        lines.push(`public readonly struct ${enumName} : IEquatable<${enumName}>`);
-        lines.push(`{`);
-        for (const value of values) {
-            lines.push(`    /// <summary>Gets the <c>${escapeXml(value)}</c> value.</summary>`);
-            lines.push(`    public static ${enumName} ${toPascalCaseEnumMember(value)} { get; } = new("${value}");`, "");
-        }
-        lines.push(`    /// <summary>Gets the value associated with this <see cref="${enumName}"/>.</summary>`);
-        lines.push(`    public string Value { get; }`, "");
-        lines.push(`    /// <summary>Initializes a new instance of the <see cref="${enumName}"/> struct.</summary>`);
-        lines.push(`    /// <param name="value">The value to associate with this <see cref="${enumName}"/>.</param>`);
-        lines.push(`    [JsonConstructor]`);
-        lines.push(`    public ${enumName}(string value)`);
-        lines.push(`    {`);
-        lines.push(`        ArgumentException.ThrowIfNullOrWhiteSpace(value);`);
-        lines.push(`        Value = value;`);
-        lines.push(`    }`, "");
-        lines.push(`    /// <summary>Returns a value indicating whether two <see cref="${enumName}"/> instances are equivalent.</summary>`);
-        lines.push(`    public static bool operator ==(${enumName} left, ${enumName} right) => left.Equals(right);`, "");
-        lines.push(`    /// <summary>Returns a value indicating whether two <see cref="${enumName}"/> instances are not equivalent.</summary>`);
-        lines.push(`    public static bool operator !=(${enumName} left, ${enumName} right) => !(left == right);`, "");
-        lines.push(`    /// <inheritdoc />`);
-        lines.push(`    public override bool Equals(object? obj) => obj is ${enumName} other && Equals(other);`, "");
-        lines.push(`    /// <inheritdoc />`);
-        lines.push(`    public bool Equals(${enumName} other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);`, "");
-        lines.push(`    /// <inheritdoc />`);
-        lines.push(`    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);`, "");
-        lines.push(`    /// <inheritdoc />`);
-        lines.push(`    public override string ToString() => Value ?? string.Empty;`, "");
-        lines.push(`    /// <summary>Provides a <see cref="JsonConverter{${enumName}}"/> for serializing <see cref="${enumName}"/> instances.</summary>`);
-        lines.push(`    [EditorBrowsable(EditorBrowsableState.Never)]`);
-        lines.push(`    public sealed class Converter : JsonConverter<${enumName}>`);
-        lines.push(`    {`);
-        lines.push(`        /// <inheritdoc />`);
-        lines.push(`        public override ${enumName} Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)`);
-        lines.push(`        {`);
-        lines.push(`            var value = reader.GetString();`);
-        lines.push(`            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();`);
-        lines.push(`            return new(value);`);
-        lines.push(`        }`, "");
-        lines.push(`        /// <inheritdoc />`);
-        lines.push(`        public override void Write(Utf8JsonWriter writer, ${enumName} value, JsonSerializerOptions options)`);
-        lines.push(`        {`);
-        lines.push(`            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();`);
-        lines.push(`            writer.WriteStringValue(value.Value);`);
-        lines.push(`        }`);
-        lines.push(`    }`);
-        lines.push(`}`, "");
-        enumOutput.push(lines.join("\n"));
-        return enumName;
-    }
-
-    lines.push(`[JsonConverter(typeof(JsonStringEnumConverter<${enumName}>))]`, `public enum ${enumName}`, `{`);
+    lines.push(`[JsonConverter(typeof(Converter))]`);
+    lines.push(`[DebuggerDisplay("{Value,nq}")]`);
+    lines.push(`public readonly struct ${enumName} : IEquatable<${enumName}>`);
+    lines.push(`{`);
     for (const value of values) {
-        lines.push(`    /// <summary>The <c>${escapeXml(value)}</c> variant.</summary>`);
-        lines.push(`    [JsonStringEnumMemberName("${value}")]`, `    ${toPascalCaseEnumMember(value)},`);
+        lines.push(`    /// <summary>Gets the <c>${escapeXml(value)}</c> value.</summary>`);
+        lines.push(`    public static ${enumName} ${toPascalCaseEnumMember(value)} { get; } = new("${value}");`, "");
     }
+    lines.push(`    /// <summary>Gets the value associated with this <see cref="${enumName}"/>.</summary>`);
+    lines.push(`    public string Value { get; }`, "");
+    lines.push(`    /// <summary>Initializes a new instance of the <see cref="${enumName}"/> struct.</summary>`);
+    lines.push(`    /// <param name="value">The value to associate with this <see cref="${enumName}"/>.</param>`);
+    lines.push(`    [JsonConstructor]`);
+    lines.push(`    public ${enumName}(string value)`);
+    lines.push(`    {`);
+    lines.push(`        ArgumentException.ThrowIfNullOrWhiteSpace(value);`);
+    lines.push(`        Value = value;`);
+    lines.push(`    }`, "");
+    lines.push(`    /// <summary>Returns a value indicating whether two <see cref="${enumName}"/> instances are equivalent.</summary>`);
+    lines.push(`    public static bool operator ==(${enumName} left, ${enumName} right) => left.Equals(right);`, "");
+    lines.push(`    /// <summary>Returns a value indicating whether two <see cref="${enumName}"/> instances are not equivalent.</summary>`);
+    lines.push(`    public static bool operator !=(${enumName} left, ${enumName} right) => !(left == right);`, "");
+    lines.push(`    /// <inheritdoc />`);
+    lines.push(`    public override bool Equals(object? obj) => obj is ${enumName} other && Equals(other);`, "");
+    lines.push(`    /// <inheritdoc />`);
+    lines.push(`    public bool Equals(${enumName} other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);`, "");
+    lines.push(`    /// <inheritdoc />`);
+    lines.push(`    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);`, "");
+    lines.push(`    /// <inheritdoc />`);
+    lines.push(`    public override string ToString() => Value ?? string.Empty;`, "");
+    lines.push(`    /// <summary>Provides a <see cref="JsonConverter{${enumName}}"/> for serializing <see cref="${enumName}"/> instances.</summary>`);
+    lines.push(`    [EditorBrowsable(EditorBrowsableState.Never)]`);
+    lines.push(`    public sealed class Converter : JsonConverter<${enumName}>`);
+    lines.push(`    {`);
+    lines.push(`        /// <inheritdoc />`);
+    lines.push(`        public override ${enumName} Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)`);
+    lines.push(`        {`);
+    lines.push(`            var value = reader.GetString();`);
+    lines.push(`            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();`);
+    lines.push(`            return new(value);`);
+    lines.push(`        }`, "");
+    lines.push(`        /// <inheritdoc />`);
+    lines.push(`        public override void Write(Utf8JsonWriter writer, ${enumName} value, JsonSerializerOptions options)`);
+    lines.push(`        {`);
+    lines.push(`            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();`);
+    lines.push(`            writer.WriteStringValue(value.Value);`);
+    lines.push(`        }`);
+    lines.push(`    }`);
     lines.push(`}`, "");
     enumOutput.push(lines.join("\n"));
     return enumName;
@@ -627,7 +609,7 @@ function resolveSessionPropertyType(
         }
 
         if (refSchema.enum && Array.isArray(refSchema.enum)) {
-            const enumName = getOrCreateEnum(className, "", refSchema.enum as string[], enumOutput, refSchema.description, undefined, isSchemaDeprecated(refSchema), true);
+            const enumName = getOrCreateEnum(className, "", refSchema.enum as string[], enumOutput, refSchema.description, undefined, isSchemaDeprecated(refSchema));
             return isRequired ? enumName : `${enumName}?`;
         }
 
@@ -669,7 +651,7 @@ function resolveSessionPropertyType(
         return !isRequired ? "object?" : "object";
     }
     if (propSchema.enum && Array.isArray(propSchema.enum)) {
-        const enumName = getOrCreateEnum(parentClassName, propName, propSchema.enum as string[], enumOutput, propSchema.description, propSchema.title as string | undefined, isSchemaDeprecated(propSchema), true);
+        const enumName = getOrCreateEnum(parentClassName, propName, propSchema.enum as string[], enumOutput, propSchema.description, propSchema.title as string | undefined, isSchemaDeprecated(propSchema));
         return isRequired ? enumName : `${enumName}?`;
     }
     if (propSchema.type === "object" && propSchema.properties) {
@@ -1627,7 +1609,9 @@ function generateRpcCode(schema: ApiSchema): string {
 #pragma warning disable CS0612 // Type or member is obsolete
 #pragma warning disable CS0618 // Type or member is obsolete (with message)
 
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -347,10 +347,6 @@ function getOrCreateEnum(
     lines.push(`[DebuggerDisplay("{Value,nq}")]`);
     lines.push(`public readonly struct ${enumName} : IEquatable<${enumName}>`);
     lines.push(`{`);
-    for (const value of values) {
-        lines.push(`    /// <summary>Gets the <c>${escapeXml(value)}</c> value.</summary>`);
-        lines.push(`    public static ${enumName} ${toPascalCaseEnumMember(value)} { get; } = new("${value}");`, "");
-    }
     lines.push(`    private readonly string? _value;`, "");
     lines.push(`    /// <summary>Gets the value associated with this <see cref="${enumName}"/>.</summary>`);
     lines.push(`    public string Value => _value ?? string.Empty;`, "");
@@ -362,6 +358,10 @@ function getOrCreateEnum(
     lines.push(`        ArgumentException.ThrowIfNullOrWhiteSpace(value);`);
     lines.push(`        _value = value;`);
     lines.push(`    }`, "");
+    for (const value of values) {
+        lines.push(`    /// <summary>Gets the <c>${escapeXml(value)}</c> value.</summary>`);
+        lines.push(`    public static ${enumName} ${toPascalCaseEnumMember(value)} { get; } = new("${value}");`, "");
+    }
     lines.push(`    /// <summary>Returns a value indicating whether two <see cref="${enumName}"/> instances are equivalent.</summary>`);
     lines.push(`    public static bool operator ==(${enumName} left, ${enumName} right) => left.Equals(right);`, "");
     lines.push(`    /// <summary>Returns a value indicating whether two <see cref="${enumName}"/> instances are not equivalent.</summary>`);

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -351,15 +351,16 @@ function getOrCreateEnum(
         lines.push(`    /// <summary>Gets the <c>${escapeXml(value)}</c> value.</summary>`);
         lines.push(`    public static ${enumName} ${toPascalCaseEnumMember(value)} { get; } = new("${value}");`, "");
     }
+    lines.push(`    private readonly string? _value;`, "");
     lines.push(`    /// <summary>Gets the value associated with this <see cref="${enumName}"/>.</summary>`);
-    lines.push(`    public string Value { get; }`, "");
+    lines.push(`    public string Value => _value ?? string.Empty;`, "");
     lines.push(`    /// <summary>Initializes a new instance of the <see cref="${enumName}"/> struct.</summary>`);
     lines.push(`    /// <param name="value">The value to associate with this <see cref="${enumName}"/>.</param>`);
     lines.push(`    [JsonConstructor]`);
     lines.push(`    public ${enumName}(string value)`);
     lines.push(`    {`);
     lines.push(`        ArgumentException.ThrowIfNullOrWhiteSpace(value);`);
-    lines.push(`        Value = value;`);
+    lines.push(`        _value = value;`);
     lines.push(`    }`, "");
     lines.push(`    /// <summary>Returns a value indicating whether two <see cref="${enumName}"/> instances are equivalent.</summary>`);
     lines.push(`    public static bool operator ==(${enumName} left, ${enumName} right) => left.Equals(right);`, "");
@@ -370,9 +371,9 @@ function getOrCreateEnum(
     lines.push(`    /// <inheritdoc />`);
     lines.push(`    public bool Equals(${enumName} other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);`, "");
     lines.push(`    /// <inheritdoc />`);
-    lines.push(`    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);`, "");
+    lines.push(`    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);`, "");
     lines.push(`    /// <inheritdoc />`);
-    lines.push(`    public override string ToString() => Value ?? string.Empty;`, "");
+    lines.push(`    public override string ToString() => Value;`, "");
     lines.push(`    /// <summary>Provides a <see cref="JsonConverter{${enumName}}"/> for serializing <see cref="${enumName}"/> instances.</summary>`);
     lines.push(`    [EditorBrowsable(EditorBrowsableState.Never)]`);
     lines.push(`    public sealed class Converter : JsonConverter<${enumName}>`);

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -381,6 +381,7 @@ function getOrCreateEnum(
     lines.push(`        /// <inheritdoc />`);
     lines.push(`        public override ${enumName} Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)`);
     lines.push(`        {`);
+    lines.push(`            if (reader.TokenType != JsonTokenType.String) throw new JsonException($"Expected a string token when reading ${enumName}, but found {reader.TokenType}.");`);
     lines.push(`            var value = reader.GetString();`);
     lines.push(`            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();`);
     lines.push(`            return new(value);`);

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -320,20 +320,90 @@ interface EventVariant {
     dataDescription?: string;
 }
 
-let generatedEnums = new Map<string, { enumName: string; values: string[] }>();
+let generatedEnums = new Map<string, { enumName: string; values: string[]; useStringEnum: boolean }>();
 
 /** Schema definitions available during session event generation (for $ref resolution). */
 let sessionDefinitions: DefinitionCollections = { definitions: {}, $defs: {} };
 
-function getOrCreateEnum(parentClassName: string, propName: string, values: string[], enumOutput: string[], description?: string, explicitName?: string, deprecated?: boolean): string {
+/**
+ * Emits a schema enum type. RPC schemas use the default regular .NET enum output
+ * because RPC method contracts are closed to the schema version. Session event
+ * schemas pass useStringEnum=true because persisted runtime events need to
+ * deserialize and preserve enum strings added by newer runtimes.
+ */
+function getOrCreateEnum(
+    parentClassName: string,
+    propName: string,
+    values: string[],
+    enumOutput: string[],
+    description?: string,
+    explicitName?: string,
+    deprecated?: boolean,
+    useStringEnum = false
+): string {
     const enumName = explicitName ?? `${parentClassName}${propName}`;
     const existing = generatedEnums.get(enumName);
     if (existing) return existing.enumName;
-    generatedEnums.set(enumName, { enumName, values });
+    generatedEnums.set(enumName, { enumName, values, useStringEnum });
 
     const lines: string[] = [];
     lines.push(...xmlDocEnumComment(description, ""));
     if (deprecated) lines.push(`[Obsolete("This member is deprecated and will be removed in a future version.")]`);
+
+    if (useStringEnum) {
+        lines.push(`[JsonConverter(typeof(Converter))]`);
+        lines.push(`[DebuggerDisplay("{Value,nq}")]`);
+        lines.push(`public readonly struct ${enumName} : IEquatable<${enumName}>`);
+        lines.push(`{`);
+        for (const value of values) {
+            lines.push(`    /// <summary>Gets the <c>${escapeXml(value)}</c> value.</summary>`);
+            lines.push(`    public static ${enumName} ${toPascalCaseEnumMember(value)} { get; } = new("${value}");`, "");
+        }
+        lines.push(`    /// <summary>Gets the value associated with this <see cref="${enumName}"/>.</summary>`);
+        lines.push(`    public string Value { get; }`, "");
+        lines.push(`    /// <summary>Initializes a new instance of the <see cref="${enumName}"/> struct.</summary>`);
+        lines.push(`    /// <param name="value">The value to associate with this <see cref="${enumName}"/>.</param>`);
+        lines.push(`    [JsonConstructor]`);
+        lines.push(`    public ${enumName}(string value)`);
+        lines.push(`    {`);
+        lines.push(`        ArgumentException.ThrowIfNullOrWhiteSpace(value);`);
+        lines.push(`        Value = value;`);
+        lines.push(`    }`, "");
+        lines.push(`    /// <summary>Returns a value indicating whether two <see cref="${enumName}"/> instances are equivalent.</summary>`);
+        lines.push(`    public static bool operator ==(${enumName} left, ${enumName} right) => left.Equals(right);`, "");
+        lines.push(`    /// <summary>Returns a value indicating whether two <see cref="${enumName}"/> instances are not equivalent.</summary>`);
+        lines.push(`    public static bool operator !=(${enumName} left, ${enumName} right) => !(left == right);`, "");
+        lines.push(`    /// <inheritdoc />`);
+        lines.push(`    public override bool Equals(object? obj) => obj is ${enumName} other && Equals(other);`, "");
+        lines.push(`    /// <inheritdoc />`);
+        lines.push(`    public bool Equals(${enumName} other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);`, "");
+        lines.push(`    /// <inheritdoc />`);
+        lines.push(`    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);`, "");
+        lines.push(`    /// <inheritdoc />`);
+        lines.push(`    public override string ToString() => Value ?? string.Empty;`, "");
+        lines.push(`    /// <summary>Provides a <see cref="JsonConverter{${enumName}}"/> for serializing <see cref="${enumName}"/> instances.</summary>`);
+        lines.push(`    [EditorBrowsable(EditorBrowsableState.Never)]`);
+        lines.push(`    public sealed class Converter : JsonConverter<${enumName}>`);
+        lines.push(`    {`);
+        lines.push(`        /// <inheritdoc />`);
+        lines.push(`        public override ${enumName} Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)`);
+        lines.push(`        {`);
+        lines.push(`            var value = reader.GetString();`);
+        lines.push(`            if (string.IsNullOrWhiteSpace(value)) throw new JsonException();`);
+        lines.push(`            return new(value);`);
+        lines.push(`        }`, "");
+        lines.push(`        /// <inheritdoc />`);
+        lines.push(`        public override void Write(Utf8JsonWriter writer, ${enumName} value, JsonSerializerOptions options)`);
+        lines.push(`        {`);
+        lines.push(`            if (string.IsNullOrWhiteSpace(value.Value)) throw new JsonException();`);
+        lines.push(`            writer.WriteStringValue(value.Value);`);
+        lines.push(`        }`);
+        lines.push(`    }`);
+        lines.push(`}`, "");
+        enumOutput.push(lines.join("\n"));
+        return enumName;
+    }
+
     lines.push(`[JsonConverter(typeof(JsonStringEnumConverter<${enumName}>))]`, `public enum ${enumName}`, `{`);
     for (const value of values) {
         lines.push(`    /// <summary>The <c>${escapeXml(value)}</c> variant.</summary>`);
@@ -557,7 +627,7 @@ function resolveSessionPropertyType(
         }
 
         if (refSchema.enum && Array.isArray(refSchema.enum)) {
-            const enumName = getOrCreateEnum(className, "", refSchema.enum as string[], enumOutput, refSchema.description, undefined, isSchemaDeprecated(refSchema));
+            const enumName = getOrCreateEnum(className, "", refSchema.enum as string[], enumOutput, refSchema.description, undefined, isSchemaDeprecated(refSchema), true);
             return isRequired ? enumName : `${enumName}?`;
         }
 
@@ -599,7 +669,7 @@ function resolveSessionPropertyType(
         return !isRequired ? "object?" : "object";
     }
     if (propSchema.enum && Array.isArray(propSchema.enum)) {
-        const enumName = getOrCreateEnum(parentClassName, propName, propSchema.enum as string[], enumOutput, propSchema.description, propSchema.title as string | undefined, isSchemaDeprecated(propSchema));
+        const enumName = getOrCreateEnum(parentClassName, propName, propSchema.enum as string[], enumOutput, propSchema.description, propSchema.title as string | undefined, isSchemaDeprecated(propSchema), true);
         return isRequired ? enumName : `${enumName}?`;
     }
     if (propSchema.type === "object" && propSchema.properties) {
@@ -718,6 +788,7 @@ function generateSessionEventsCode(schema: JSONSchema7): string {
 #pragma warning disable CS0612 // Type or member is obsolete
 #pragma warning disable CS0618 // Type or member is obsolete (with message)
 
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;


### PR DESCRIPTION
Newer Copilot runtime versions can add string enum values to persisted session events before the .NET SDK schema has been regenerated. Regular .NET enums throw during deserialization in that case, which can break `GetMessagesAsync` when replaying session history.

## Summary

- Update C# session-event codegen to emit string-backed readonly structs for schema enum values, preserving unknown runtime strings instead of throwing.
- Keep RPC schema enums as regular .NET enums, since RPC method contracts are closed to the schema version.
- Regenerate `dotnet/src/Generated/SessionEvents.cs` and hide generated JSON converter types from IntelliSense with `EditorBrowsable(Never)`.
- Add forward-compatibility coverage for unknown abort reason values.

## Testing

- `dotnet test dotnet\test\GitHub.Copilot.SDK.Test.csproj --filter "FullyQualifiedName~GitHub.Copilot.SDK.Test.Unit.ForwardCompatibilityTests|FullyQualifiedName~GitHub.Copilot.SDK.Test.Unit.SessionEventSerializationTests" --logger "console;verbosity=minimal"`