### PR TITLE
Disable CI workflows on forked repositories

### DIFF
--- a/.github/workflows/codegen-check.yml
+++ b/.github/workflows/codegen-check.yml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   check:
     name: "Verify generated files are up-to-date"
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   # The job MUST be called 'copilot-setup-steps' to be recognized by GitHub Copilot Agent
   copilot-setup-steps:
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
 
     # Set minimal permissions for setup steps

--- a/.github/workflows/corrections-tests.yml
+++ b/.github/workflows/corrections-tests.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   validate-typescript:
     name: "Validate TypeScript"
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -44,6 +45,7 @@ jobs:
 
   validate-python:
     name: "Validate Python"
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -76,6 +78,7 @@ jobs:
 
   validate-go:
     name: "Validate Go"
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -99,6 +102,7 @@ jobs:
 
   validate-csharp:
     name: "Validate C#"
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/dotnet-sdk-tests.yml
+++ b/.github/workflows/dotnet-sdk-tests.yml
@@ -29,6 +29,7 @@ permissions:
 jobs:
   test:
     name: ".NET SDK Tests"
+    if: github.event.repository.fork == false
     env:
       POWERSHELL_UPDATECHECK: Off
     strategy:

--- a/.github/workflows/go-sdk-tests.yml
+++ b/.github/workflows/go-sdk-tests.yml
@@ -30,6 +30,7 @@ permissions:
 jobs:
   test:
     name: "Go SDK Tests"
+    if: github.event.repository.fork == false
     env:
       POWERSHELL_UPDATECHECK: Off
     strategy:

--- a/.github/workflows/nodejs-sdk-tests.yml
+++ b/.github/workflows/nodejs-sdk-tests.yml
@@ -32,6 +32,7 @@ permissions:
 jobs:
   test:
     name: "Node.js SDK Tests"
+    if: github.event.repository.fork == false
     env:
       POWERSHELL_UPDATECHECK: Off
     strategy:

--- a/.github/workflows/python-sdk-tests.yml
+++ b/.github/workflows/python-sdk-tests.yml
@@ -32,6 +32,7 @@ permissions:
 jobs:
   test:
     name: "Python SDK Tests"
+    if: github.event.repository.fork == false
     env:
       POWERSHELL_UPDATECHECK: Off
     strategy:

--- a/.github/workflows/rust-publish-release.yml
+++ b/.github/workflows/rust-publish-release.yml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   publish:
     name: Publish to crates.io
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/rust-sdk-tests.yml
+++ b/.github/workflows/rust-sdk-tests.yml
@@ -30,6 +30,7 @@ permissions:
 jobs:
   test:
     name: "Rust SDK Tests"
+    if: github.event.repository.fork == false
     env:
       POWERSHELL_UPDATECHECK: Off
       CARGO_TERM_COLOR: always

--- a/.github/workflows/rust-sdk-tests.yml
+++ b/.github/workflows/rust-sdk-tests.yml
@@ -120,6 +120,7 @@ jobs:
   # bundled-CLI release pipeline) hit them downstream.
   bundle:
     name: "Rust SDK Bundled CLI Build"
+    if: github.event.repository.fork == false
     env:
       CARGO_TERM_COLOR: always
       RUST_BACKTRACE: 1

--- a/.github/workflows/scenario-builds.yml
+++ b/.github/workflows/scenario-builds.yml
@@ -28,6 +28,7 @@ jobs:
   # ── TypeScript ──────────────────────────────────────────────────────
   build-typescript:
     name: "TypeScript scenarios"
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -74,6 +75,7 @@ jobs:
   # ── Python ──────────────────────────────────────────────────────────
   build-python:
     name: "Python scenarios"
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -112,6 +114,7 @@ jobs:
   # ── Go ──────────────────────────────────────────────────────────────
   build-go:
     name: "Go scenarios"
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -149,6 +152,7 @@ jobs:
   # ── C# ─────────────────────────────────────────────────────────────
   build-csharp:
     name: "C# scenarios"
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -191,6 +195,7 @@ jobs:
   # ── Rust ────────────────────────────────────────────────────────────
   build-rust:
     name: "Rust scenarios"
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/verify-compiled.yml
+++ b/.github/workflows/verify-compiled.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   verify:
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
When i forked and made some changes to the repo the other week, it automatically trigged github actions.
I don't think it's desirable/necessary to run the CI workflows on fork repositories as it's a lot of wasted action minutes.