### PR TITLE
Fix SDK documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Advanced: You can override the bundled CLI using `cliPath` or `cliUrl` if you wa
 
 ### What tools are enabled by default?
 
-By default, the SDK will operate the Copilot CLI in the equivalent of `--allow-all` being passed to the CLI, enabling all first-party tools, which means that the agents can perform a wide range of actions, including file system operations, Git operations, and web requests. You can customize tool availability by configuring the SDK client options to enable and disable specific tools. Refer to the individual SDK documentation for details on tool configuration and Copilot CLI for the list of tools available.
+By default, the SDK operates the Copilot CLI as if `--allow-all` were passed, enabling all first-party tools. This means that agents can perform a wide range of actions, including file system operations, Git operations, and web requests. You can customize tool availability by configuring the SDK client options to enable and disable specific tools. Refer to the individual SDK documentation for details on tool configuration and to the Copilot CLI documentation for the list of available tools.
 
 ### Can I use custom agents, skills or tools?
 

--- a/docs/setup/github-oauth.md
+++ b/docs/setup/github-oauth.md
@@ -113,7 +113,7 @@ async function handleOAuthCallback(code: string): Promise<string> {
 
 ## Step 3: pass the token to the SDK
 
-Create a SDK client for each authenticated user, passing their token:
+Create an SDK client for each authenticated user, passing their token:
 
 <details open>
 <summary><strong>Node.js / TypeScript</strong></summary>

--- a/docs/troubleshooting/mcp-debugging.md
+++ b/docs/troubleshooting/mcp-debugging.md
@@ -335,7 +335,7 @@ Windows Defender or other AV may block:
 #### Gatekeeper blocking
 
 ```bash
-# If server is blocked
+# If the server is blocked
 xattr -d com.apple.quarantine /path/to/mcp-server
 ```
 

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -35,7 +35,7 @@ await using var session = await client.CreateSessionAsync(new SessionConfig
     OnPermissionRequest = PermissionHandler.ApproveAll,
 });
 
-// Wait for response using session.idle event
+// Wait for the response using the session.idle event
 var done = new TaskCompletionSource();
 
 session.On(evt =>

--- a/dotnet/src/JsonRpc.cs
+++ b/dotnet/src/JsonRpc.cs
@@ -365,7 +365,7 @@ internal sealed partial class JsonRpc : IDisposable
         // line; we walk the lines and require an exact "Content-Length: " prefix at the
         // start of one of them. A substring match anywhere in the header block would
         // false-positive on values like "X-Trace: Content-Length: 5" and desync the stream.
-        // A missing or unparseable Content-Length means the framing is broken — there's
+        // A missing or unparsable Content-Length means the framing is broken — there's
         // no safe way to resync, so throw and let the read loop terminate the connection.
         int contentLength = -1;
         ReadOnlySpan<byte> prefix = "Content-Length: "u8;

--- a/go/internal/embeddedcli/embeddedcli.go
+++ b/go/internal/embeddedcli/embeddedcli.go
@@ -79,7 +79,7 @@ func install() (path string) {
 		start := time.Now()
 		defer func() {
 			duration := time.Since(start)
-			fmt.Printf("installing embedded CLI at %s; installation took %s\n", path, duration)
+			fmt.Printf("installing embedded CLI at %s installation took %s\n", path, duration)
 		}()
 	}
 	installDir := config.Dir

--- a/go/internal/embeddedcli/embeddedcli.go
+++ b/go/internal/embeddedcli/embeddedcli.go
@@ -79,7 +79,7 @@ func install() (path string) {
 		start := time.Now()
 		defer func() {
 			duration := time.Since(start)
-			fmt.Printf("installing embedded CLI at %s installation took %s\n", path, duration)
+			fmt.Printf("installing embedded CLI at %s; installation took %s\n", path, duration)
 		}()
 	}
 	installDir := config.Dir

--- a/go/internal/jsonrpc2/frame.go
+++ b/go/internal/jsonrpc2/frame.go
@@ -82,7 +82,7 @@ func newHeaderWriter(w io.Writer) *headerWriter {
 	return &headerWriter{out: w}
 }
 
-// Write sends a single frame with Content-Length header.
+// Write sends a single frame with a Content-Length header.
 func (w *headerWriter) Write(data []byte) error {
 	if _, err := fmt.Fprintf(w.out, "Content-Length: %d\r\n\r\n", len(data)); err != nil {
 		return err

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -38,7 +38,7 @@ const session = await client.createSession({
     onPermissionRequest: approveAll,
 });
 
-// Wait for response using typed event handlers
+// Wait for the response using typed event handlers
 const done = new Promise<void>((resolve) => {
     session.on("assistant.message", (event) => {
         console.log(event.data.content);

--- a/nodejs/src/sessionFsProvider.ts
+++ b/nodejs/src/sessionFsProvider.ts
@@ -17,7 +17,7 @@ import type {
 export type SessionFsFileInfo = Omit<SessionFsStatResult, "error">;
 
 /**
- * Interface for session filesystem providers. Implementors use idiomatic
+ * Interface for session filesystem providers. Implementers use idiomatic
  * TypeScript patterns: throw on error, return values directly. Use
  * {@link createSessionFsAdapter} to convert a provider into the
  * {@link SessionFsHandler} expected by the SDK.

--- a/python/copilot/_jsonrpc.py
+++ b/python/copilot/_jsonrpc.py
@@ -137,7 +137,7 @@ class JsonRpcClient:
         self, method: str, params: dict | None = None, timeout: float | None = None
     ) -> Any:
         """
-        Send a JSON-RPC request and wait for response
+        Send a JSON-RPC request and wait for the response.
 
         Args:
             method: Method name
@@ -149,8 +149,8 @@ class JsonRpcClient:
             The result from the response
 
         Raises:
-            JsonRpcError: If server returns an error
-            asyncio.TimeoutError: If request times out (only when timeout is set)
+            JsonRpcError: If the server returns an error
+            asyncio.TimeoutError: If the request times out (only when timeout is set)
         """
         request_start = time.perf_counter()
         request_id = str(uuid.uuid4())
@@ -198,7 +198,7 @@ class JsonRpcClient:
 
     async def notify(self, method: str, params: dict | None = None):
         """
-        Send a JSON-RPC notification (no response expected)
+        Send a JSON-RPC notification (no response expected).
 
         Args:
             method: Method name
@@ -212,7 +212,7 @@ class JsonRpcClient:
         await self._send_message(message)
 
     def set_notification_handler(self, handler: Callable[[str, dict], None]):
-        """Set handler for incoming notifications from server"""
+        """Set the handler for incoming notifications from the server."""
         self.notification_handler = handler
 
     def set_request_handler(self, method: str, handler: RequestHandler):
@@ -222,7 +222,7 @@ class JsonRpcClient:
             self.request_handlers[method] = handler
 
     async def _send_message(self, message: dict):
-        """Send a JSON-RPC message with Content-Length header"""
+        """Send a JSON-RPC message with a Content-Length header."""
         loop = self._loop or asyncio.get_event_loop()
 
         def write():
@@ -311,10 +311,10 @@ class JsonRpcClient:
 
     def _read_message(self) -> dict | None:
         """
-        Read a single JSON-RPC message with Content-Length header (blocking)
+        Read a single JSON-RPC message with a Content-Length header (blocking).
 
         Returns:
-            Parsed JSON message or None if connection closed
+            Parsed JSON message, or None if the connection is closed.
         """
         # Read header line
         header_line = self.process.stdout.readline()
@@ -362,7 +362,7 @@ class JsonRpcClient:
                     loop.call_soon_threadsafe(future.set_exception, exc)
                 return
 
-        # Check if it's a notification from server
+        # Check if it's a notification from the server
         if "method" in message and "id" not in message:
             if self.notification_handler and self._loop:
                 method = message["method"]

--- a/python/test_jsonrpc.py
+++ b/python/test_jsonrpc.py
@@ -166,7 +166,7 @@ class TestReadMessageWithLargePayloads:
     """Tests for _read_message() with large JSON-RPC messages"""
 
     def create_jsonrpc_message(self, content_dict: dict) -> bytes:
-        """Create a complete JSON-RPC message with Content-Length header"""
+        """Create a complete JSON-RPC message with a Content-Length header."""
         content = json.dumps(content_dict, separators=(",", ":"))
         content_bytes = content.encode("utf-8")
         header = f"Content-Length: {len(content_bytes)}\r\n\r\n"


### PR DESCRIPTION
This cleanup fixes small grammar and wording issues across the SDK documentation and public comments so examples and API docs read consistently for users.

The changes tighten wording in README guidance, OAuth and MCP docs, Node and .NET README snippets, C# and Go comments, and Python JSON-RPC docstrings without changing runtime behavior.

Validation:
- `go test ./internal/jsonrpc2 ./internal/embeddedcli`
- `python -m pytest test_jsonrpc.py`
- `dotnet format src\GitHub.Copilot.SDK.csproj --verify-no-changes --include src\JsonRpc.cs`
- `npm exec --yes --package prettier@3.8.1 -- prettier --check src\sessionFsProvider.ts`