### PR TITLE
Fix C# listFiles E2E ordering assumption

### DIFF
--- a/dotnet/test/E2E/RpcAdditionalEdgeCasesE2ETests.cs
+++ b/dotnet/test/E2E/RpcAdditionalEdgeCasesE2ETests.cs
@@ -188,7 +188,7 @@ public class RpcAdditionalEdgeCasesE2ETests(E2ETestFixture fixture, ITestOutputH
     }
 
     [Fact]
-    public async Task Workspaces_CreateFile_Then_ListFiles_Returns_Sorted_Or_Stable_Order()
+    public async Task Workspaces_CreateFile_Then_ListFiles_Returns_All_Files()
     {
         var session = await CreateSessionAsync();
         var prefix = $"order-{Guid.NewGuid():N}-";
@@ -204,15 +204,16 @@ public class RpcAdditionalEdgeCasesE2ETests(E2ETestFixture fixture, ITestOutputH
             .Where(path => path.StartsWith(prefix, StringComparison.Ordinal))
             .ToList();
 
-        // The files this test created should be returned in sorted order.
-        Assert.Equal(paths, matchingFiles);
+        // The files this test created should all be returned; the runtime does not guarantee
+        // that workspace file enumeration is sorted.
+        Assert.Equal(paths, matchingFiles.OrderBy(path => path, StringComparer.Ordinal));
 
-        // Calling list again immediately must preserve the same order.
+        // A repeated list should still include the files regardless of returned order.
         var listed2 = await session.Rpc.Workspaces.ListFilesAsync();
         var matchingFiles2 = listed2.Files
             .Where(path => path.StartsWith(prefix, StringComparison.Ordinal))
             .ToList();
-        Assert.Equal(matchingFiles, matchingFiles2);
+        Assert.Equal(paths, matchingFiles2.OrderBy(path => path, StringComparer.Ordinal));
     }
 
     [Fact]

--- a/rust/tests/e2e/rpc_additional_edge_cases.rs
+++ b/rust/tests/e2e/rpc_additional_edge_cases.rs
@@ -428,10 +428,10 @@ async fn permissions_set_approve_all_toggle_round_trips() {
 }
 
 #[tokio::test]
-async fn workspaces_createfile_then_listfiles_returns_sorted_or_stable_order() {
+async fn workspaces_createfile_then_listfiles_returns_all_files() {
     with_e2e_context(
         "rpc_additional_edge_cases",
-        "workspaces_createfile_then_listfiles_returns_sorted_or_stable_order",
+        "workspaces_createfile_then_listfiles_returns_all_files",
         |ctx| {
             Box::pin(async move {
                 ctx.set_default_copilot_user();
@@ -465,9 +465,10 @@ async fn workspaces_createfile_then_listfiles_returns_sorted_or_stable_order() {
                     .list_files()
                     .await
                     .expect("list files again");
-                assert_eq!(first.files, second.files);
-                for expected in ["a-rust.txt", "b-rust.txt", "c-rust.txt"] {
-                    assert!(first.files.iter().any(|file| file == expected));
+                for files in [&first.files, &second.files] {
+                    for expected in ["a-rust.txt", "b-rust.txt", "c-rust.txt"] {
+                        assert!(files.iter().any(|file| file == expected));
+                    }
                 }
 
                 session.disconnect().await.expect("disconnect session");


### PR DESCRIPTION
The C# and Rust E2E tests assumed `workspaces.listFiles` returns files in sorted or stable order, but the runtime does not guarantee workspace file enumeration order. That made the tests flaky when created files came back in a different filesystem/RPC order.

This updates both tests to assert the supported behavior instead: each `listFiles` call includes all files created by the test without asserting the returned order. The assertions compare the filtered results after ordinal sorting in C# and use presence checks for each Rust call.

Validation:
- `dotnet test dotnet\test\GitHub.Copilot.SDK.Test.csproj --filter "FullyQualifiedName~Workspaces_CreateFile_Then_ListFiles_Returns_All_Files" --logger "console;verbosity=minimal"`
- `cargo +nightly-2026-04-14 fmt --check && cargo test --features test-support --test e2e workspaces_createfile_then_listfiles_returns_all_files -- --nocapture`