### PR TITLE
Normalize skill context replay snapshots

### DIFF
--- a/test/harness/replayingCapiProxy.test.ts
+++ b/test/harness/replayingCapiProxy.test.ts
@@ -370,6 +370,45 @@ describe("ReplayingCapiProxy", () => {
     expect(result.conversations[0].messages[0].content).toBe("Say hello.");
   });
 
+  test("strips skill metadata frontmatter from skill-context user messages", async () => {
+    const skillDir = path.join(workDir, ".test_skills", "test-skill");
+    const requestBody = JSON.stringify({
+      messages: [
+        {
+          role: "user",
+          content: `<skill-context name="test-skill">
+Base directory for this skill: ${skillDir}
+
+---
+name: test-skill
+description: A test skill that adds a marker to responses
+---
+
+# Test Skill Instructions
+
+Always include PINEAPPLE_COCONUT_42.
+</skill-context>`,
+        },
+      ],
+    });
+    const responseBody = JSON.stringify({
+      choices: [{ message: { role: "assistant", content: "OK!" } }],
+    });
+
+    const outputPath = await createProxy([
+      { url: "/chat/completions", requestBody, responseBody },
+    ]);
+
+    const result = await readYamlOutput(outputPath);
+    expect(result.conversations[0].messages[0].content).toBe(`<skill-context name="test-skill">
+Base directory for this skill: ${workingDirPlaceholder}/.test_skills/test-skill
+
+# Test Skill Instructions
+
+Always include PINEAPPLE_COCONUT_42.
+</skill-context>`);
+  });
+
   test("applies tool result normalizers to tool response content", async () => {
     const requestBody = JSON.stringify({
       messages: [

--- a/test/harness/replayingCapiProxy.ts
+++ b/test/harness/replayingCapiProxy.ts
@@ -1032,7 +1032,7 @@ function transformOpenAIRequestMessage(
 }
 
 function normalizeUserMessage(content: string): string {
-  return content
+  return normalizeSkillContextFrontmatter(content)
     .replace(/<current_datetime>.*?<\/current_datetime>/g, "")
     .replace(/<reminder>[\s\S]*?<\/reminder>/g, "")
     .replace(/<system_reminder>[\s\S]*?<\/system_reminder>/g, "")
@@ -1042,6 +1042,14 @@ function normalizeUserMessage(content: string): string {
       "${compaction_prompt}",
     )
     .trim();
+}
+
+function normalizeSkillContextFrontmatter(content: string): string {
+  // Runtime versions may include or omit SKILL.md metadata in the prompt context.
+  return content.replace(
+    /(<skill-context\b[^>]*>\s*Base directory for this skill:[^\r\n]*(?:\r?\n)+)---\r?\n(?:(?!<\/skill-context>)[\s\S])*?\r?\n---(?:\r?\n)+/g,
+    "$1",
+  );
 }
 
 function normalizeLargeOutputFilepaths(result: string): string {

--- a/test/snapshots/skills/should_load_and_apply_skill_from_skilldirectories.yaml
+++ b/test/snapshots/skills/should_load_and_apply_skill_from_skilldirectories.yaml
@@ -23,15 +23,6 @@ conversations:
           Base directory for this skill: ${workdir}/.test_skills/test-skill
 
 
-          ---
-
-          name: test-skill
-
-          description: A test skill that adds a marker to responses
-
-          ---
-
-
           # Test Skill Instructions
 
 


### PR DESCRIPTION
The live runtime changed the skill prompt context so `SKILL.md` YAML frontmatter may be omitted before the model call. That made the shared replay snapshot for the skills E2E brittle during the transition, causing cache mismatches even though the behavior under test is unchanged.

This updates the replay proxy to canonicalize skill-context user messages by stripping skill metadata frontmatter before matching or writing snapshots. The shared skills snapshot now stores the normalized no-frontmatter form, and a harness unit test covers the normalization so Node, Python, Go, .NET, and Rust E2Es all use the same compatible replay behavior.

Validation:
- `npm test -- replayingCapiProxy.test.ts` from `test/harness`
- `dotnet test dotnet\test\GitHub.Copilot.SDK.Test.csproj --filter "FullyQualifiedName~SkillsE2ETests.Should_Load_And_Apply_Skill_From_SkillDirectories" --no-restore --no-build` with `GITHUB_ACTIONS=true`