### PR TITLE
Temporarily use beta versions for "latest" dist-tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,13 +59,10 @@ jobs:
           if [ -n "${{ github.event.inputs.version }}" ]; then
             VERSION="${{ github.event.inputs.version }}"
             # Validate version format matches dist-tag
-            if [ "${{ github.event.inputs.dist-tag }}" = "latest" ]; then
-              if [[ "$VERSION" == *-* ]]; then
-                echo "❌ Error: Version '$VERSION' has a prerelease suffix but dist-tag is 'latest'" >> $GITHUB_STEP_SUMMARY
-                echo "Use a version without suffix (e.g., '1.0.0') for latest releases"
-                exit 1
-              fi
-            else
+            # TEMPORARY: skips validation for "latest" so prerelease versions
+            # can be published under that tag. To ship stable 1.0.0, revert the
+            # commit that introduced this temporary change.
+            if [ "${{ github.event.inputs.dist-tag }}" != "latest" ]; then
               if [[ "$VERSION" != *-* ]]; then
                 echo "❌ Error: Version '$VERSION' has no prerelease suffix but dist-tag is '${{ github.event.inputs.dist-tag }}'" >> $GITHUB_STEP_SUMMARY
                 echo "Use a version with suffix (e.g., '1.0.0-preview.0') for prerelease/unstable"
@@ -222,21 +219,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+      # TEMPORARY: both "latest" and "prerelease" create GitHub pre-releases
+      # since "latest" publishes beta versions. To ship stable 1.0.0, revert
+      # the commit that introduced this temporary change.
       - name: Create GitHub Release
-        if: github.event.inputs.dist-tag == 'latest'
-        run: |
-          NOTES_FLAG=""
-          if git rev-parse "v${{ needs.version.outputs.current }}" >/dev/null 2>&1; then
-            NOTES_FLAG="--notes-start-tag v${{ needs.version.outputs.current }}"
-          fi
-          gh release create "v${{ needs.version.outputs.version }}" \
-            --title "v${{ needs.version.outputs.version }}" \
-            --generate-notes $NOTES_FLAG \
-            --target ${{ github.sha }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create GitHub Pre-Release
-        if: github.event.inputs.dist-tag == 'prerelease'
+        if: github.event.inputs.dist-tag == 'latest' || github.event.inputs.dist-tag == 'prerelease'
         run: |
           NOTES_FLAG=""
           if git rev-parse "v${{ needs.version.outputs.current-prerelease }}" >/dev/null 2>&1; then

--- a/nodejs/scripts/calculate-version.js
+++ b/nodejs/scripts/calculate-version.js
@@ -43,10 +43,13 @@ export function calculateVersion(command, { latest, prerelease, unstable }) {
         }
     }
 
-    const increment = command === "latest" ? "patch" : "prerelease";
+    // TEMPORARY: "latest" uses prerelease increments so we publish beta versions
+    // under the "latest" dist-tag. To ship stable 1.0.0, revert the commit that
+    // introduced this temporary change.
+    const increment = "prerelease";
     const isIncrementingExistingPrerelease = semver.prerelease(higherVersion) !== null;
     const prereleaseIdentifier =
-        command === "prerelease"
+        command === "prerelease" || command === "latest"
             ? isIncrementingExistingPrerelease
                 ? undefined
                 : "preview"

--- a/nodejs/test/get-version.test.ts
+++ b/nodejs/test/get-version.test.ts
@@ -2,13 +2,15 @@ import { describe, expect, it } from "vitest";
 import { calculateVersion } from "../scripts/calculate-version.js";
 
 describe("get-version", () => {
-    it("increments stable latest versions by patch", () => {
-        expect(calculateVersion("latest", { latest: "1.0.1" })).toBe("1.0.2");
+    // TEMPORARY: these two tests reflect beta-as-latest behavior. To ship
+    // stable 1.0.0, revert the commit that introduced this temporary change.
+    it("increments latest versions as prerelease (temporary beta behavior)", () => {
+        expect(calculateVersion("latest", { latest: "1.0.1" })).toBe("1.0.2-preview.0");
     });
 
-    it("promotes a higher prerelease to stable for latest releases", () => {
+    it("continues beta prerelease for latest releases (temporary beta behavior)", () => {
         expect(calculateVersion("latest", { latest: "0.3.0", prerelease: "1.0.0-beta.1" })).toBe(
-            "1.0.0"
+            "1.0.0-beta.2"
         );
     });
 


### PR DESCRIPTION
We've been using the `latest` dist-tag for prior versions like 0.3.0. But since we started shipping beta versions, all the releases have been marked as prerelease, so 0.3.0 was still the current `latest`.

This risks people staying on 0.3.0 and not updating to the betas.

So, until 1.0.0 ships, this PR changes the version number calculation logic so that even `latest` releases get beta version numbers. We should use `latest` for any publish that we really want people to use, which is likely all of them.

Once 1.0.0 ships, we'll go back to the logic that puts suffixes like `-preview.1` onto prereleases and no suffixes for latest/stable releases.