### PR TITLE
Use schema descriptions in generated SDK docs

### DIFF
--- a/.github/actions/setup-copilot/action.yml
+++ b/.github/actions/setup-copilot/action.yml
@@ -8,9 +8,14 @@ runs:
   using: "composite"
   steps:
     - uses: actions/setup-node@v6
+      if: runner.os != 'Windows'
       with:
         cache: "npm"
         cache-dependency-path: "./nodejs/package-lock.json"
+        node-version: 22
+    - uses: actions/setup-node@v6
+      if: runner.os == 'Windows'
+      with:
         node-version: 22
     - name: Install dependencies
       run: npm --prefix "$(pwd)/nodejs" ci --ignore-scripts

--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -4996,6 +4996,8 @@ public sealed class ServerRpc
     }
 
     /// <summary>Calls "ping".</summary>
+    /// <param name="message">Optional message to echo back.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<PingResult> PingAsync(string? message = null, CancellationToken cancellationToken = default)
     {
         var request = new PingRequest { Message = message };
@@ -5003,6 +5005,8 @@ public sealed class ServerRpc
     }
 
     /// <summary>Calls "connect".</summary>
+    /// <param name="token">Connection token; required when the server was started with COPILOT_CONNECTION_TOKEN.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     internal async Task<ConnectResult> ConnectAsync(string? token = null, CancellationToken cancellationToken = default)
     {
         var request = new ConnectRequest { Token = token };
@@ -5042,6 +5046,8 @@ public sealed class ServerModelsApi
     }
 
     /// <summary>Calls "models.list".</summary>
+    /// <param name="gitHubToken">GitHub token for per-user model listing. When provided, resolves this token to determine the user's Copilot plan and available models instead of using the global auth.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<ModelList> ListAsync(string? gitHubToken = null, CancellationToken cancellationToken = default)
     {
         var request = new ModelsListRequest { GitHubToken = gitHubToken };
@@ -5060,6 +5066,8 @@ public sealed class ServerToolsApi
     }
 
     /// <summary>Calls "tools.list".</summary>
+    /// <param name="model">Optional model ID — when provided, the returned tool list reflects model-specific overrides.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<ToolList> ListAsync(string? model = null, CancellationToken cancellationToken = default)
     {
         var request = new ToolsListRequest { Model = model };
@@ -5078,6 +5086,8 @@ public sealed class ServerAccountApi
     }
 
     /// <summary>Calls "account.getQuota".</summary>
+    /// <param name="gitHubToken">GitHub token for per-user quota lookup. When provided, resolves this token to determine the user's quota instead of using the global auth.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<AccountGetQuotaResult> GetQuotaAsync(string? gitHubToken = null, CancellationToken cancellationToken = default)
     {
         var request = new AccountGetQuotaRequest { GitHubToken = gitHubToken };
@@ -5097,6 +5107,8 @@ public sealed class ServerMcpApi
     }
 
     /// <summary>Calls "mcp.discover".</summary>
+    /// <param name="workingDirectory">Working directory used as context for discovery (e.g., plugin resolution).</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<McpDiscoverResult> DiscoverAsync(string? workingDirectory = null, CancellationToken cancellationToken = default)
     {
         var request = new McpDiscoverRequest { WorkingDirectory = workingDirectory };
@@ -5118,12 +5130,16 @@ public sealed class ServerMcpConfigApi
     }
 
     /// <summary>Calls "mcp.config.list".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<McpConfigList> ListAsync(CancellationToken cancellationToken = default)
     {
         return await CopilotClient.InvokeRpcAsync<McpConfigList>(_rpc, "mcp.config.list", [], cancellationToken);
     }
 
     /// <summary>Calls "mcp.config.add".</summary>
+    /// <param name="name">Unique name for the MCP server.</param>
+    /// <param name="config">MCP server configuration (local/stdio or remote/http).</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task AddAsync(string name, object config, CancellationToken cancellationToken = default)
     {
         var request = new McpConfigAddRequest { Name = name, Config = config };
@@ -5131,6 +5147,9 @@ public sealed class ServerMcpConfigApi
     }
 
     /// <summary>Calls "mcp.config.update".</summary>
+    /// <param name="name">Name of the MCP server to update.</param>
+    /// <param name="config">MCP server configuration (local/stdio or remote/http).</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task UpdateAsync(string name, object config, CancellationToken cancellationToken = default)
     {
         var request = new McpConfigUpdateRequest { Name = name, Config = config };
@@ -5138,6 +5157,8 @@ public sealed class ServerMcpConfigApi
     }
 
     /// <summary>Calls "mcp.config.remove".</summary>
+    /// <param name="name">Name of the MCP server to remove.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task RemoveAsync(string name, CancellationToken cancellationToken = default)
     {
         var request = new McpConfigRemoveRequest { Name = name };
@@ -5145,6 +5166,8 @@ public sealed class ServerMcpConfigApi
     }
 
     /// <summary>Calls "mcp.config.enable".</summary>
+    /// <param name="names">Names of MCP servers to enable. Each server is removed from the persisted disabled list so new sessions spawn it. Unknown or already-enabled names are ignored.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task EnableAsync(IList<string> names, CancellationToken cancellationToken = default)
     {
         var request = new McpConfigEnableRequest { Names = names };
@@ -5152,6 +5175,8 @@ public sealed class ServerMcpConfigApi
     }
 
     /// <summary>Calls "mcp.config.disable".</summary>
+    /// <param name="names">Names of MCP servers to disable. Each server is added to the persisted disabled list so new sessions skip it. Already-disabled names are ignored. Active sessions keep their current connections until they end.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task DisableAsync(IList<string> names, CancellationToken cancellationToken = default)
     {
         var request = new McpConfigDisableRequest { Names = names };
@@ -5171,6 +5196,9 @@ public sealed class ServerSkillsApi
     }
 
     /// <summary>Calls "skills.discover".</summary>
+    /// <param name="projectPaths">Optional list of project directory paths to scan for project-scoped skills.</param>
+    /// <param name="skillDirectories">Optional list of additional skill directory paths to include.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<ServerSkillList> DiscoverAsync(IList<string>? projectPaths = null, IList<string>? skillDirectories = null, CancellationToken cancellationToken = default)
     {
         var request = new SkillsDiscoverRequest { ProjectPaths = projectPaths, SkillDirectories = skillDirectories };
@@ -5192,6 +5220,8 @@ public sealed class ServerSkillsConfigApi
     }
 
     /// <summary>Calls "skills.config.setDisabledSkills".</summary>
+    /// <param name="disabledSkills">List of skill names to disable.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task SetDisabledSkillsAsync(IList<string> disabledSkills, CancellationToken cancellationToken = default)
     {
         var request = new SkillsConfigSetDisabledSkillsRequest { DisabledSkills = disabledSkills };
@@ -5210,6 +5240,10 @@ public sealed class ServerSessionFsApi
     }
 
     /// <summary>Calls "sessionFs.setProvider".</summary>
+    /// <param name="initialCwd">Initial working directory for sessions.</param>
+    /// <param name="sessionStatePath">Path within each session's SessionFs where the runtime stores files for that session.</param>
+    /// <param name="conventions">Path conventions used by this filesystem.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<SessionFsSetProviderResult> SetProviderAsync(string initialCwd, string sessionStatePath, SessionFsSetProviderConventions conventions, CancellationToken cancellationToken = default)
     {
         var request = new SessionFsSetProviderRequest { InitialCwd = initialCwd, SessionStatePath = sessionStatePath, Conventions = conventions };
@@ -5229,6 +5263,10 @@ public sealed class ServerSessionsApi
     }
 
     /// <summary>Calls "sessions.fork".</summary>
+    /// <param name="sessionId">Source session ID to fork from.</param>
+    /// <param name="toEventId">Optional event ID boundary. When provided, the fork includes only events before this ID (exclusive). When omitted, all events are included.</param>
+    /// <param name="name">Optional friendly name to assign to the forked session.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<SessionsForkResult> ForkAsync(string sessionId, string? toEventId = null, string? name = null, CancellationToken cancellationToken = default)
     {
         var request = new SessionsForkRequest { SessionId = sessionId, ToEventId = toEventId, Name = name };
@@ -5337,6 +5375,7 @@ public sealed class SessionRpc
     public RemoteApi Remote { get; }
 
     /// <summary>Calls "session.suspend".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task SuspendAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionSuspendRequest { SessionId = _sessionId };
@@ -5344,6 +5383,11 @@ public sealed class SessionRpc
     }
 
     /// <summary>Calls "session.log".</summary>
+    /// <param name="message">Human-readable message.</param>
+    /// <param name="level">Log severity level. Determines how the message is displayed in the timeline. Defaults to "info".</param>
+    /// <param name="ephemeral">When true, the message is transient and not persisted to the session event log on disk.</param>
+    /// <param name="url">Optional URL the user can open in their browser for more details.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<LogResult> LogAsync(string message, SessionLogLevel? level = null, bool? ephemeral = null, string? url = null, CancellationToken cancellationToken = default)
     {
         var request = new LogRequest { SessionId = _sessionId, Message = message, Level = level, Ephemeral = ephemeral, Url = url };
@@ -5364,6 +5408,7 @@ public sealed class AuthApi
     }
 
     /// <summary>Calls "session.auth.getStatus".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<SessionAuthStatus> GetStatusAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionAuthGetStatusRequest { SessionId = _sessionId };
@@ -5384,6 +5429,7 @@ public sealed class ModelApi
     }
 
     /// <summary>Calls "session.model.getCurrent".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<CurrentModel> GetCurrentAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionModelGetCurrentRequest { SessionId = _sessionId };
@@ -5391,6 +5437,10 @@ public sealed class ModelApi
     }
 
     /// <summary>Calls "session.model.switchTo".</summary>
+    /// <param name="modelId">Model identifier to switch to.</param>
+    /// <param name="reasoningEffort">Reasoning effort level to use for the model.</param>
+    /// <param name="modelCapabilities">Override individual model capabilities resolved by the runtime.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<ModelSwitchToResult> SwitchToAsync(string modelId, string? reasoningEffort = null, ModelCapabilitiesOverride? modelCapabilities = null, CancellationToken cancellationToken = default)
     {
         var request = new ModelSwitchToRequest { SessionId = _sessionId, ModelId = modelId, ReasoningEffort = reasoningEffort, ModelCapabilities = modelCapabilities };
@@ -5411,6 +5461,8 @@ public sealed class ModeApi
     }
 
     /// <summary>Calls "session.mode.get".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The agent mode. Valid values: "interactive", "plan", "autopilot".</returns>
     public async Task<SessionMode> GetAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionModeGetRequest { SessionId = _sessionId };
@@ -5418,6 +5470,8 @@ public sealed class ModeApi
     }
 
     /// <summary>Calls "session.mode.set".</summary>
+    /// <param name="mode">The agent mode. Valid values: "interactive", "plan", "autopilot".</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task SetAsync(SessionMode mode, CancellationToken cancellationToken = default)
     {
         var request = new ModeSetRequest { SessionId = _sessionId, Mode = mode };
@@ -5438,6 +5492,7 @@ public sealed class NameApi
     }
 
     /// <summary>Calls "session.name.get".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<NameGetResult> GetAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionNameGetRequest { SessionId = _sessionId };
@@ -5445,6 +5500,8 @@ public sealed class NameApi
     }
 
     /// <summary>Calls "session.name.set".</summary>
+    /// <param name="name">New session name (1–100 characters, trimmed of leading/trailing whitespace).</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task SetAsync(string name, CancellationToken cancellationToken = default)
     {
         var request = new NameSetRequest { SessionId = _sessionId, Name = name };
@@ -5465,6 +5522,7 @@ public sealed class PlanApi
     }
 
     /// <summary>Calls "session.plan.read".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<PlanReadResult> ReadAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionPlanReadRequest { SessionId = _sessionId };
@@ -5472,6 +5530,8 @@ public sealed class PlanApi
     }
 
     /// <summary>Calls "session.plan.update".</summary>
+    /// <param name="content">The new content for the plan file.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task UpdateAsync(string content, CancellationToken cancellationToken = default)
     {
         var request = new PlanUpdateRequest { SessionId = _sessionId, Content = content };
@@ -5479,6 +5539,7 @@ public sealed class PlanApi
     }
 
     /// <summary>Calls "session.plan.delete".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task DeleteAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionPlanDeleteRequest { SessionId = _sessionId };
@@ -5499,6 +5560,7 @@ public sealed class WorkspacesApi
     }
 
     /// <summary>Calls "session.workspaces.getWorkspace".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<WorkspacesGetWorkspaceResult> GetWorkspaceAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionWorkspacesGetWorkspaceRequest { SessionId = _sessionId };
@@ -5506,6 +5568,7 @@ public sealed class WorkspacesApi
     }
 
     /// <summary>Calls "session.workspaces.listFiles".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<WorkspacesListFilesResult> ListFilesAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionWorkspacesListFilesRequest { SessionId = _sessionId };
@@ -5513,6 +5576,8 @@ public sealed class WorkspacesApi
     }
 
     /// <summary>Calls "session.workspaces.readFile".</summary>
+    /// <param name="path">Relative path within the workspace files directory.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<WorkspacesReadFileResult> ReadFileAsync(string path, CancellationToken cancellationToken = default)
     {
         var request = new WorkspacesReadFileRequest { SessionId = _sessionId, Path = path };
@@ -5520,6 +5585,9 @@ public sealed class WorkspacesApi
     }
 
     /// <summary>Calls "session.workspaces.createFile".</summary>
+    /// <param name="path">Relative path within the workspace files directory.</param>
+    /// <param name="content">File content to write as a UTF-8 string.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task CreateFileAsync(string path, string content, CancellationToken cancellationToken = default)
     {
         var request = new WorkspacesCreateFileRequest { SessionId = _sessionId, Path = path, Content = content };
@@ -5540,6 +5608,7 @@ public sealed class InstructionsApi
     }
 
     /// <summary>Calls "session.instructions.getSources".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<InstructionsGetSourcesResult> GetSourcesAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionInstructionsGetSourcesRequest { SessionId = _sessionId };
@@ -5561,6 +5630,8 @@ public sealed class FleetApi
     }
 
     /// <summary>Calls "session.fleet.start".</summary>
+    /// <param name="prompt">Optional user prompt to combine with fleet instructions.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<FleetStartResult> StartAsync(string? prompt = null, CancellationToken cancellationToken = default)
     {
         var request = new FleetStartRequest { SessionId = _sessionId, Prompt = prompt };
@@ -5582,6 +5653,7 @@ public sealed class AgentApi
     }
 
     /// <summary>Calls "session.agent.list".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<AgentList> ListAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionAgentListRequest { SessionId = _sessionId };
@@ -5589,6 +5661,7 @@ public sealed class AgentApi
     }
 
     /// <summary>Calls "session.agent.getCurrent".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<AgentGetCurrentResult> GetCurrentAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionAgentGetCurrentRequest { SessionId = _sessionId };
@@ -5596,6 +5669,8 @@ public sealed class AgentApi
     }
 
     /// <summary>Calls "session.agent.select".</summary>
+    /// <param name="name">Name of the custom agent to select.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<AgentSelectResult> SelectAsync(string name, CancellationToken cancellationToken = default)
     {
         var request = new AgentSelectRequest { SessionId = _sessionId, Name = name };
@@ -5603,6 +5678,7 @@ public sealed class AgentApi
     }
 
     /// <summary>Calls "session.agent.deselect".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task DeselectAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionAgentDeselectRequest { SessionId = _sessionId };
@@ -5610,6 +5686,7 @@ public sealed class AgentApi
     }
 
     /// <summary>Calls "session.agent.reload".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<AgentReloadResult> ReloadAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionAgentReloadRequest { SessionId = _sessionId };
@@ -5631,6 +5708,12 @@ public sealed class TasksApi
     }
 
     /// <summary>Calls "session.tasks.startAgent".</summary>
+    /// <param name="agentType">Type of agent to start (e.g., 'explore', 'task', 'general-purpose').</param>
+    /// <param name="prompt">Task prompt for the agent.</param>
+    /// <param name="name">Short name for the agent, used to generate a human-readable ID.</param>
+    /// <param name="description">Short description of the task.</param>
+    /// <param name="model">Optional model override.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<TasksStartAgentResult> StartAgentAsync(string agentType, string prompt, string name, string? description = null, string? model = null, CancellationToken cancellationToken = default)
     {
         var request = new TasksStartAgentRequest { SessionId = _sessionId, AgentType = agentType, Prompt = prompt, Name = name, Description = description, Model = model };
@@ -5638,6 +5721,7 @@ public sealed class TasksApi
     }
 
     /// <summary>Calls "session.tasks.list".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<TaskList> ListAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionTasksListRequest { SessionId = _sessionId };
@@ -5645,6 +5729,8 @@ public sealed class TasksApi
     }
 
     /// <summary>Calls "session.tasks.promoteToBackground".</summary>
+    /// <param name="id">Task identifier.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<TasksPromoteToBackgroundResult> PromoteToBackgroundAsync(string id, CancellationToken cancellationToken = default)
     {
         var request = new TasksPromoteToBackgroundRequest { SessionId = _sessionId, Id = id };
@@ -5652,6 +5738,8 @@ public sealed class TasksApi
     }
 
     /// <summary>Calls "session.tasks.cancel".</summary>
+    /// <param name="id">Task identifier.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<TasksCancelResult> CancelAsync(string id, CancellationToken cancellationToken = default)
     {
         var request = new TasksCancelRequest { SessionId = _sessionId, Id = id };
@@ -5659,6 +5747,8 @@ public sealed class TasksApi
     }
 
     /// <summary>Calls "session.tasks.remove".</summary>
+    /// <param name="id">Task identifier.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<TasksRemoveResult> RemoveAsync(string id, CancellationToken cancellationToken = default)
     {
         var request = new TasksRemoveRequest { SessionId = _sessionId, Id = id };
@@ -5666,6 +5756,10 @@ public sealed class TasksApi
     }
 
     /// <summary>Calls "session.tasks.sendMessage".</summary>
+    /// <param name="id">Agent task identifier.</param>
+    /// <param name="message">Message content to send to the agent.</param>
+    /// <param name="fromAgentId">Agent ID of the sender, if sent on behalf of another agent.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<TasksSendMessageResult> SendMessageAsync(string id, string message, string? fromAgentId = null, CancellationToken cancellationToken = default)
     {
         var request = new TasksSendMessageRequest { SessionId = _sessionId, Id = id, Message = message, FromAgentId = fromAgentId };
@@ -5687,6 +5781,7 @@ public sealed class SkillsApi
     }
 
     /// <summary>Calls "session.skills.list".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<SkillList> ListAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionSkillsListRequest { SessionId = _sessionId };
@@ -5694,6 +5789,8 @@ public sealed class SkillsApi
     }
 
     /// <summary>Calls "session.skills.enable".</summary>
+    /// <param name="name">Name of the skill to enable.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task EnableAsync(string name, CancellationToken cancellationToken = default)
     {
         var request = new SkillsEnableRequest { SessionId = _sessionId, Name = name };
@@ -5701,6 +5798,8 @@ public sealed class SkillsApi
     }
 
     /// <summary>Calls "session.skills.disable".</summary>
+    /// <param name="name">Name of the skill to disable.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task DisableAsync(string name, CancellationToken cancellationToken = default)
     {
         var request = new SkillsDisableRequest { SessionId = _sessionId, Name = name };
@@ -5708,6 +5807,7 @@ public sealed class SkillsApi
     }
 
     /// <summary>Calls "session.skills.reload".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<SkillsLoadDiagnostics> ReloadAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionSkillsReloadRequest { SessionId = _sessionId };
@@ -5730,6 +5830,7 @@ public sealed class McpApi
     }
 
     /// <summary>Calls "session.mcp.list".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<McpServerList> ListAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionMcpListRequest { SessionId = _sessionId };
@@ -5737,6 +5838,8 @@ public sealed class McpApi
     }
 
     /// <summary>Calls "session.mcp.enable".</summary>
+    /// <param name="serverName">Name of the MCP server to enable.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task EnableAsync(string serverName, CancellationToken cancellationToken = default)
     {
         var request = new McpEnableRequest { SessionId = _sessionId, ServerName = serverName };
@@ -5744,6 +5847,8 @@ public sealed class McpApi
     }
 
     /// <summary>Calls "session.mcp.disable".</summary>
+    /// <param name="serverName">Name of the MCP server to disable.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task DisableAsync(string serverName, CancellationToken cancellationToken = default)
     {
         var request = new McpDisableRequest { SessionId = _sessionId, ServerName = serverName };
@@ -5751,6 +5856,7 @@ public sealed class McpApi
     }
 
     /// <summary>Calls "session.mcp.reload".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task ReloadAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionMcpReloadRequest { SessionId = _sessionId };
@@ -5775,6 +5881,11 @@ public sealed class McpOauthApi
     }
 
     /// <summary>Calls "session.mcp.oauth.login".</summary>
+    /// <param name="serverName">Name of the remote MCP server to authenticate.</param>
+    /// <param name="forceReauth">When true, clears any cached OAuth token for the server and runs a full new authorization. Use when the user explicitly wants to switch accounts or believes their session is stuck.</param>
+    /// <param name="clientName">Optional override for the OAuth client display name shown on the consent screen. Applies to newly registered dynamic clients only — existing registrations keep the name they were created with. When omitted, the runtime applies a neutral fallback; callers driving interactive auth should pass their own surface-specific label so the consent screen matches the product the user sees.</param>
+    /// <param name="callbackSuccessMessage">Optional override for the body text shown on the OAuth loopback callback success page. When omitted, the runtime applies a neutral fallback; callers driving interactive auth should pass surface-specific copy telling the user where to return.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<McpOauthLoginResult> LoginAsync(string serverName, bool? forceReauth = null, string? clientName = null, string? callbackSuccessMessage = null, CancellationToken cancellationToken = default)
     {
         var request = new McpOauthLoginRequest { SessionId = _sessionId, ServerName = serverName, ForceReauth = forceReauth, ClientName = clientName, CallbackSuccessMessage = callbackSuccessMessage };
@@ -5796,6 +5907,7 @@ public sealed class PluginsApi
     }
 
     /// <summary>Calls "session.plugins.list".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<PluginList> ListAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionPluginsListRequest { SessionId = _sessionId };
@@ -5817,6 +5929,7 @@ public sealed class ExtensionsApi
     }
 
     /// <summary>Calls "session.extensions.list".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<ExtensionList> ListAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionExtensionsListRequest { SessionId = _sessionId };
@@ -5824,6 +5937,8 @@ public sealed class ExtensionsApi
     }
 
     /// <summary>Calls "session.extensions.enable".</summary>
+    /// <param name="id">Source-qualified extension ID to enable.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task EnableAsync(string id, CancellationToken cancellationToken = default)
     {
         var request = new ExtensionsEnableRequest { SessionId = _sessionId, Id = id };
@@ -5831,6 +5946,8 @@ public sealed class ExtensionsApi
     }
 
     /// <summary>Calls "session.extensions.disable".</summary>
+    /// <param name="id">Source-qualified extension ID to disable.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task DisableAsync(string id, CancellationToken cancellationToken = default)
     {
         var request = new ExtensionsDisableRequest { SessionId = _sessionId, Id = id };
@@ -5838,6 +5955,7 @@ public sealed class ExtensionsApi
     }
 
     /// <summary>Calls "session.extensions.reload".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task ReloadAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionExtensionsReloadRequest { SessionId = _sessionId };
@@ -5858,6 +5976,10 @@ public sealed class ToolsApi
     }
 
     /// <summary>Calls "session.tools.handlePendingToolCall".</summary>
+    /// <param name="requestId">Request ID of the pending tool call.</param>
+    /// <param name="result">Tool call result (string or expanded result object).</param>
+    /// <param name="error">Error message if the tool call failed.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<HandlePendingToolCallResult> HandlePendingToolCallAsync(string requestId, object? result = null, string? error = null, CancellationToken cancellationToken = default)
     {
         var request = new HandlePendingToolCallRequest { SessionId = _sessionId, RequestId = requestId, Result = result, Error = error };
@@ -5878,6 +6000,8 @@ public sealed class CommandsApi
     }
 
     /// <summary>Calls "session.commands.list".</summary>
+    /// <param name="request">The request parameters.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<CommandList> ListAsync(CommandsListRequest? request = null, CancellationToken cancellationToken = default)
     {
         var rpcRequest = new CommandsListRequestWithSession { SessionId = _sessionId, IncludeBuiltins = request?.IncludeBuiltins, IncludeSkills = request?.IncludeSkills, IncludeClientCommands = request?.IncludeClientCommands };
@@ -5885,6 +6009,9 @@ public sealed class CommandsApi
     }
 
     /// <summary>Calls "session.commands.invoke".</summary>
+    /// <param name="name">Command name. Leading slashes are stripped and the name is matched case-insensitively.</param>
+    /// <param name="input">Raw input after the command name.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<SlashCommandInvocationResult> InvokeAsync(string name, string? input = null, CancellationToken cancellationToken = default)
     {
         var request = new CommandsInvokeRequest { SessionId = _sessionId, Name = name, Input = input };
@@ -5892,6 +6019,9 @@ public sealed class CommandsApi
     }
 
     /// <summary>Calls "session.commands.handlePendingCommand".</summary>
+    /// <param name="requestId">Request ID from the command invocation event.</param>
+    /// <param name="error">Error message if the command handler failed.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<CommandsHandlePendingCommandResult> HandlePendingCommandAsync(string requestId, string? error = null, CancellationToken cancellationToken = default)
     {
         var request = new CommandsHandlePendingCommandRequest { SessionId = _sessionId, RequestId = requestId, Error = error };
@@ -5899,6 +6029,9 @@ public sealed class CommandsApi
     }
 
     /// <summary>Calls "session.commands.respondToQueuedCommand".</summary>
+    /// <param name="requestId">Request ID from the queued command event.</param>
+    /// <param name="result">Result of the queued command execution.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<CommandsRespondToQueuedCommandResult> RespondToQueuedCommandAsync(string requestId, QueuedCommandResult result, CancellationToken cancellationToken = default)
     {
         var request = new CommandsRespondToQueuedCommandRequest { SessionId = _sessionId, RequestId = requestId, Result = result };
@@ -5919,6 +6052,10 @@ public sealed class UiApi
     }
 
     /// <summary>Calls "session.ui.elicitation".</summary>
+    /// <param name="message">Message describing what information is needed from the user.</param>
+    /// <param name="requestedSchema">JSON Schema describing the form fields to present to the user.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The elicitation response (accept with form values, decline, or cancel).</returns>
     public async Task<UIElicitationResponse> ElicitationAsync(string message, UIElicitationSchema requestedSchema, CancellationToken cancellationToken = default)
     {
         var request = new UIElicitationRequest { SessionId = _sessionId, Message = message, RequestedSchema = requestedSchema };
@@ -5926,6 +6063,9 @@ public sealed class UiApi
     }
 
     /// <summary>Calls "session.ui.handlePendingElicitation".</summary>
+    /// <param name="requestId">The unique request ID from the elicitation.requested event.</param>
+    /// <param name="result">The elicitation response (accept with form values, decline, or cancel).</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<UIElicitationResult> HandlePendingElicitationAsync(string requestId, UIElicitationResponse result, CancellationToken cancellationToken = default)
     {
         var request = new UIHandlePendingElicitationRequest { SessionId = _sessionId, RequestId = requestId, Result = result };
@@ -5946,6 +6086,9 @@ public sealed class PermissionsApi
     }
 
     /// <summary>Calls "session.permissions.handlePendingPermissionRequest".</summary>
+    /// <param name="requestId">Request ID of the pending permission request.</param>
+    /// <param name="result">The result parameter.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<PermissionRequestResult> HandlePendingPermissionRequestAsync(string requestId, PermissionDecision result, CancellationToken cancellationToken = default)
     {
         var request = new PermissionDecisionRequest { SessionId = _sessionId, RequestId = requestId, Result = result };
@@ -5953,6 +6096,8 @@ public sealed class PermissionsApi
     }
 
     /// <summary>Calls "session.permissions.setApproveAll".</summary>
+    /// <param name="enabled">Whether to auto-approve all tool permission requests.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<PermissionsSetApproveAllResult> SetApproveAllAsync(bool enabled, CancellationToken cancellationToken = default)
     {
         var request = new PermissionsSetApproveAllRequest { SessionId = _sessionId, Enabled = enabled };
@@ -5960,6 +6105,7 @@ public sealed class PermissionsApi
     }
 
     /// <summary>Calls "session.permissions.resetSessionApprovals".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<PermissionsResetSessionApprovalsResult> ResetSessionApprovalsAsync(CancellationToken cancellationToken = default)
     {
         var request = new PermissionsResetSessionApprovalsRequest { SessionId = _sessionId };
@@ -5980,6 +6126,10 @@ public sealed class ShellApi
     }
 
     /// <summary>Calls "session.shell.exec".</summary>
+    /// <param name="command">Shell command to execute.</param>
+    /// <param name="cwd">Working directory (defaults to session working directory).</param>
+    /// <param name="timeout">Timeout in milliseconds (default: 30000).</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<ShellExecResult> ExecAsync(string command, string? cwd = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
         var request = new ShellExecRequest { SessionId = _sessionId, Command = command, Cwd = cwd, Timeout = timeout };
@@ -5987,6 +6137,9 @@ public sealed class ShellApi
     }
 
     /// <summary>Calls "session.shell.kill".</summary>
+    /// <param name="processId">Process identifier returned by shell.exec.</param>
+    /// <param name="signal">Signal to send (default: SIGTERM).</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<ShellKillResult> KillAsync(string processId, ShellKillSignal? signal = null, CancellationToken cancellationToken = default)
     {
         var request = new ShellKillRequest { SessionId = _sessionId, ProcessId = processId, Signal = signal };
@@ -6008,6 +6161,7 @@ public sealed class HistoryApi
     }
 
     /// <summary>Calls "session.history.compact".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<HistoryCompactResult> CompactAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionHistoryCompactRequest { SessionId = _sessionId };
@@ -6015,6 +6169,8 @@ public sealed class HistoryApi
     }
 
     /// <summary>Calls "session.history.truncate".</summary>
+    /// <param name="eventId">Event ID to truncate to. This event and all events after it are removed from the session.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<HistoryTruncateResult> TruncateAsync(string eventId, CancellationToken cancellationToken = default)
     {
         var request = new HistoryTruncateRequest { SessionId = _sessionId, EventId = eventId };
@@ -6036,6 +6192,7 @@ public sealed class UsageApi
     }
 
     /// <summary>Calls "session.usage.getMetrics".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<UsageGetMetricsResult> GetMetricsAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionUsageGetMetricsRequest { SessionId = _sessionId };
@@ -6057,6 +6214,8 @@ public sealed class RemoteApi
     }
 
     /// <summary>Calls "session.remote.enable".</summary>
+    /// <param name="mode">Per-session remote mode. "off" disables remote, "export" exports session events to Mission Control without enabling remote steering, "on" enables both export and remote steering.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task<RemoteEnableResult> EnableAsync(RemoteSessionMode? mode = null, CancellationToken cancellationToken = default)
     {
         var request = new RemoteEnableRequest { SessionId = _sessionId, Mode = mode };
@@ -6064,6 +6223,7 @@ public sealed class RemoteApi
     }
 
     /// <summary>Calls "session.remote.disable".</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task DisableAsync(CancellationToken cancellationToken = default)
     {
         var request = new SessionRemoteDisableRequest { SessionId = _sessionId };
@@ -6074,25 +6234,50 @@ public sealed class RemoteApi
 /// <summary>Handles `sessionFs` client session API methods.</summary>
 public interface ISessionFsHandler
 {
-    /// <summary>Handles "sessionFs.readFile".</summary>
+    /// <summary>Calls "sessionFs.readFile".</summary>
+    /// <param name="request">The request parameters.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     Task<SessionFsReadFileResult> ReadFileAsync(SessionFsReadFileRequest request, CancellationToken cancellationToken = default);
-    /// <summary>Handles "sessionFs.writeFile".</summary>
+    /// <summary>Calls "sessionFs.writeFile".</summary>
+    /// <param name="request">The request parameters.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Describes a filesystem error.</returns>
     Task<SessionFsError?> WriteFileAsync(SessionFsWriteFileRequest request, CancellationToken cancellationToken = default);
-    /// <summary>Handles "sessionFs.appendFile".</summary>
+    /// <summary>Calls "sessionFs.appendFile".</summary>
+    /// <param name="request">The request parameters.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Describes a filesystem error.</returns>
     Task<SessionFsError?> AppendFileAsync(SessionFsAppendFileRequest request, CancellationToken cancellationToken = default);
-    /// <summary>Handles "sessionFs.exists".</summary>
+    /// <summary>Calls "sessionFs.exists".</summary>
+    /// <param name="request">The request parameters.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     Task<SessionFsExistsResult> ExistsAsync(SessionFsExistsRequest request, CancellationToken cancellationToken = default);
-    /// <summary>Handles "sessionFs.stat".</summary>
+    /// <summary>Calls "sessionFs.stat".</summary>
+    /// <param name="request">The request parameters.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     Task<SessionFsStatResult> StatAsync(SessionFsStatRequest request, CancellationToken cancellationToken = default);
-    /// <summary>Handles "sessionFs.mkdir".</summary>
+    /// <summary>Calls "sessionFs.mkdir".</summary>
+    /// <param name="request">The request parameters.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Describes a filesystem error.</returns>
     Task<SessionFsError?> MkdirAsync(SessionFsMkdirRequest request, CancellationToken cancellationToken = default);
-    /// <summary>Handles "sessionFs.readdir".</summary>
+    /// <summary>Calls "sessionFs.readdir".</summary>
+    /// <param name="request">The request parameters.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     Task<SessionFsReaddirResult> ReaddirAsync(SessionFsReaddirRequest request, CancellationToken cancellationToken = default);
-    /// <summary>Handles "sessionFs.readdirWithTypes".</summary>
+    /// <summary>Calls "sessionFs.readdirWithTypes".</summary>
+    /// <param name="request">The request parameters.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     Task<SessionFsReaddirWithTypesResult> ReaddirWithTypesAsync(SessionFsReaddirWithTypesRequest request, CancellationToken cancellationToken = default);
-    /// <summary>Handles "sessionFs.rm".</summary>
+    /// <summary>Calls "sessionFs.rm".</summary>
+    /// <param name="request">The request parameters.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Describes a filesystem error.</returns>
     Task<SessionFsError?> RmAsync(SessionFsRmRequest request, CancellationToken cancellationToken = default);
-    /// <summary>Handles "sessionFs.rename".</summary>
+    /// <summary>Calls "sessionFs.rename".</summary>
+    /// <param name="request">The request parameters.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Describes a filesystem error.</returns>
     Task<SessionFsError?> RenameAsync(SessionFsRenameRequest request, CancellationToken cancellationToken = default);
 }
 

--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -6234,47 +6234,47 @@ public sealed class RemoteApi
 /// <summary>Handles `sessionFs` client session API methods.</summary>
 public interface ISessionFsHandler
 {
-    /// <summary>Calls "sessionFs.readFile".</summary>
+    /// <summary>Handles "sessionFs.readFile".</summary>
     /// <param name="request">The request parameters.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     Task<SessionFsReadFileResult> ReadFileAsync(SessionFsReadFileRequest request, CancellationToken cancellationToken = default);
-    /// <summary>Calls "sessionFs.writeFile".</summary>
+    /// <summary>Handles "sessionFs.writeFile".</summary>
     /// <param name="request">The request parameters.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Describes a filesystem error.</returns>
     Task<SessionFsError?> WriteFileAsync(SessionFsWriteFileRequest request, CancellationToken cancellationToken = default);
-    /// <summary>Calls "sessionFs.appendFile".</summary>
+    /// <summary>Handles "sessionFs.appendFile".</summary>
     /// <param name="request">The request parameters.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Describes a filesystem error.</returns>
     Task<SessionFsError?> AppendFileAsync(SessionFsAppendFileRequest request, CancellationToken cancellationToken = default);
-    /// <summary>Calls "sessionFs.exists".</summary>
+    /// <summary>Handles "sessionFs.exists".</summary>
     /// <param name="request">The request parameters.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     Task<SessionFsExistsResult> ExistsAsync(SessionFsExistsRequest request, CancellationToken cancellationToken = default);
-    /// <summary>Calls "sessionFs.stat".</summary>
+    /// <summary>Handles "sessionFs.stat".</summary>
     /// <param name="request">The request parameters.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     Task<SessionFsStatResult> StatAsync(SessionFsStatRequest request, CancellationToken cancellationToken = default);
-    /// <summary>Calls "sessionFs.mkdir".</summary>
+    /// <summary>Handles "sessionFs.mkdir".</summary>
     /// <param name="request">The request parameters.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Describes a filesystem error.</returns>
     Task<SessionFsError?> MkdirAsync(SessionFsMkdirRequest request, CancellationToken cancellationToken = default);
-    /// <summary>Calls "sessionFs.readdir".</summary>
+    /// <summary>Handles "sessionFs.readdir".</summary>
     /// <param name="request">The request parameters.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     Task<SessionFsReaddirResult> ReaddirAsync(SessionFsReaddirRequest request, CancellationToken cancellationToken = default);
-    /// <summary>Calls "sessionFs.readdirWithTypes".</summary>
+    /// <summary>Handles "sessionFs.readdirWithTypes".</summary>
     /// <param name="request">The request parameters.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     Task<SessionFsReaddirWithTypesResult> ReaddirWithTypesAsync(SessionFsReaddirWithTypesRequest request, CancellationToken cancellationToken = default);
-    /// <summary>Calls "sessionFs.rm".</summary>
+    /// <summary>Handles "sessionFs.rm".</summary>
     /// <param name="request">The request parameters.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Describes a filesystem error.</returns>
     Task<SessionFsError?> RmAsync(SessionFsRmRequest request, CancellationToken cancellationToken = default);
-    /// <summary>Calls "sessionFs.rename".</summary>
+    /// <summary>Handles "sessionFs.rename".</summary>
     /// <param name="request">The request parameters.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Describes a filesystem error.</returns>

--- a/go/rpc/zrpc.go
+++ b/go/rpc/zrpc.go
@@ -2642,6 +2642,9 @@ type serverApi struct {
 
 type ServerAccountApi serverApi
 
+// GetQuota calls account.getQuota.
+//
+// RPC method: account.getQuota.
 func (a *ServerAccountApi) GetQuota(ctx context.Context, params ...*AccountGetQuotaRequest) (*AccountGetQuotaResult, error) {
 	var requestParams *AccountGetQuotaRequest
 	if len(params) > 0 {
@@ -2660,6 +2663,9 @@ func (a *ServerAccountApi) GetQuota(ctx context.Context, params ...*AccountGetQu
 
 type ServerMcpApi serverApi
 
+// Discover calls mcp.discover.
+//
+// RPC method: mcp.discover.
 func (a *ServerMcpApi) Discover(ctx context.Context, params *McpDiscoverRequest) (*McpDiscoverResult, error) {
 	raw, err := a.client.Request("mcp.discover", params)
 	if err != nil {
@@ -2674,6 +2680,9 @@ func (a *ServerMcpApi) Discover(ctx context.Context, params *McpDiscoverRequest)
 
 type ServerMcpConfigApi serverApi
 
+// Add calls mcp.config.add.
+//
+// RPC method: mcp.config.add.
 func (a *ServerMcpConfigApi) Add(ctx context.Context, params *McpConfigAddRequest) (*McpConfigAddResult, error) {
 	raw, err := a.client.Request("mcp.config.add", params)
 	if err != nil {
@@ -2686,6 +2695,9 @@ func (a *ServerMcpConfigApi) Add(ctx context.Context, params *McpConfigAddReques
 	return &result, nil
 }
 
+// Disable calls mcp.config.disable.
+//
+// RPC method: mcp.config.disable.
 func (a *ServerMcpConfigApi) Disable(ctx context.Context, params *McpConfigDisableRequest) (*McpConfigDisableResult, error) {
 	raw, err := a.client.Request("mcp.config.disable", params)
 	if err != nil {
@@ -2698,6 +2710,9 @@ func (a *ServerMcpConfigApi) Disable(ctx context.Context, params *McpConfigDisab
 	return &result, nil
 }
 
+// Enable calls mcp.config.enable.
+//
+// RPC method: mcp.config.enable.
 func (a *ServerMcpConfigApi) Enable(ctx context.Context, params *McpConfigEnableRequest) (*McpConfigEnableResult, error) {
 	raw, err := a.client.Request("mcp.config.enable", params)
 	if err != nil {
@@ -2710,6 +2725,9 @@ func (a *ServerMcpConfigApi) Enable(ctx context.Context, params *McpConfigEnable
 	return &result, nil
 }
 
+// List calls mcp.config.list.
+//
+// RPC method: mcp.config.list.
 func (a *ServerMcpConfigApi) List(ctx context.Context) (*McpConfigList, error) {
 	raw, err := a.client.Request("mcp.config.list", nil)
 	if err != nil {
@@ -2722,6 +2740,9 @@ func (a *ServerMcpConfigApi) List(ctx context.Context) (*McpConfigList, error) {
 	return &result, nil
 }
 
+// Remove calls mcp.config.remove.
+//
+// RPC method: mcp.config.remove.
 func (a *ServerMcpConfigApi) Remove(ctx context.Context, params *McpConfigRemoveRequest) (*McpConfigRemoveResult, error) {
 	raw, err := a.client.Request("mcp.config.remove", params)
 	if err != nil {
@@ -2734,6 +2755,9 @@ func (a *ServerMcpConfigApi) Remove(ctx context.Context, params *McpConfigRemove
 	return &result, nil
 }
 
+// Update calls mcp.config.update.
+//
+// RPC method: mcp.config.update.
 func (a *ServerMcpConfigApi) Update(ctx context.Context, params *McpConfigUpdateRequest) (*McpConfigUpdateResult, error) {
 	raw, err := a.client.Request("mcp.config.update", params)
 	if err != nil {
@@ -2752,6 +2776,9 @@ func (s *ServerMcpApi) Config() *ServerMcpConfigApi {
 
 type ServerModelsApi serverApi
 
+// List calls models.list.
+//
+// RPC method: models.list.
 func (a *ServerModelsApi) List(ctx context.Context, params ...*ModelsListRequest) (*ModelList, error) {
 	var requestParams *ModelsListRequest
 	if len(params) > 0 {
@@ -2770,6 +2797,9 @@ func (a *ServerModelsApi) List(ctx context.Context, params ...*ModelsListRequest
 
 type ServerSessionFsApi serverApi
 
+// SetProvider calls sessionFs.setProvider.
+//
+// RPC method: sessionFs.setProvider.
 func (a *ServerSessionFsApi) SetProvider(ctx context.Context, params *SessionFsSetProviderRequest) (*SessionFsSetProviderResult, error) {
 	raw, err := a.client.Request("sessionFs.setProvider", params)
 	if err != nil {
@@ -2785,6 +2815,9 @@ func (a *ServerSessionFsApi) SetProvider(ctx context.Context, params *SessionFsS
 // Experimental: ServerSessionsApi contains experimental APIs that may change or be removed.
 type ServerSessionsApi serverApi
 
+// Fork calls sessions.fork.
+//
+// RPC method: sessions.fork.
 func (a *ServerSessionsApi) Fork(ctx context.Context, params *SessionsForkRequest) (*SessionsForkResult, error) {
 	raw, err := a.client.Request("sessions.fork", params)
 	if err != nil {
@@ -2799,6 +2832,9 @@ func (a *ServerSessionsApi) Fork(ctx context.Context, params *SessionsForkReques
 
 type ServerSkillsApi serverApi
 
+// Discover calls skills.discover.
+//
+// RPC method: skills.discover.
 func (a *ServerSkillsApi) Discover(ctx context.Context, params *SkillsDiscoverRequest) (*ServerSkillList, error) {
 	raw, err := a.client.Request("skills.discover", params)
 	if err != nil {
@@ -2813,6 +2849,9 @@ func (a *ServerSkillsApi) Discover(ctx context.Context, params *SkillsDiscoverRe
 
 type ServerSkillsConfigApi serverApi
 
+// SetDisabledSkills calls skills.config.setDisabledSkills.
+//
+// RPC method: skills.config.setDisabledSkills.
 func (a *ServerSkillsConfigApi) SetDisabledSkills(ctx context.Context, params *SkillsConfigSetDisabledSkillsRequest) (*SkillsConfigSetDisabledSkillsResult, error) {
 	raw, err := a.client.Request("skills.config.setDisabledSkills", params)
 	if err != nil {
@@ -2831,6 +2870,9 @@ func (s *ServerSkillsApi) Config() *ServerSkillsConfigApi {
 
 type ServerToolsApi serverApi
 
+// List calls tools.list.
+//
+// RPC method: tools.list.
 func (a *ServerToolsApi) List(ctx context.Context, params *ToolsListRequest) (*ToolList, error) {
 	raw, err := a.client.Request("tools.list", params)
 	if err != nil {
@@ -2857,6 +2899,9 @@ type ServerRpc struct {
 	Tools     *ServerToolsApi
 }
 
+// Ping calls ping.
+//
+// RPC method: ping.
 func (a *ServerRpc) Ping(ctx context.Context, params *PingRequest) (*PingResult, error) {
 	raw, err := a.common.client.Request("ping", params)
 	if err != nil {
@@ -2893,6 +2938,9 @@ type InternalServerRpc struct {
 	common internalServerApi
 }
 
+// Connect calls connect.
+//
+// RPC method: connect.
 // Internal: Connect is part of the SDK's internal handshake/plumbing; external callers
 // should not use it.
 func (a *InternalServerRpc) Connect(ctx context.Context, params *ConnectRequest) (*ConnectResult, error) {
@@ -2921,6 +2969,9 @@ type sessionApi struct {
 // Experimental: AgentApi contains experimental APIs that may change or be removed.
 type AgentApi sessionApi
 
+// Deselect calls session.agent.deselect.
+//
+// RPC method: session.agent.deselect.
 func (a *AgentApi) Deselect(ctx context.Context) (*AgentDeselectResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.agent.deselect", req)
@@ -2934,6 +2985,9 @@ func (a *AgentApi) Deselect(ctx context.Context) (*AgentDeselectResult, error) {
 	return &result, nil
 }
 
+// GetCurrent calls session.agent.getCurrent.
+//
+// RPC method: session.agent.getCurrent.
 func (a *AgentApi) GetCurrent(ctx context.Context) (*AgentGetCurrentResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.agent.getCurrent", req)
@@ -2947,6 +3001,9 @@ func (a *AgentApi) GetCurrent(ctx context.Context) (*AgentGetCurrentResult, erro
 	return &result, nil
 }
 
+// List calls session.agent.list.
+//
+// RPC method: session.agent.list.
 func (a *AgentApi) List(ctx context.Context) (*AgentList, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.agent.list", req)
@@ -2960,6 +3017,9 @@ func (a *AgentApi) List(ctx context.Context) (*AgentList, error) {
 	return &result, nil
 }
 
+// Reload calls session.agent.reload.
+//
+// RPC method: session.agent.reload.
 func (a *AgentApi) Reload(ctx context.Context) (*AgentReloadResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.agent.reload", req)
@@ -2973,6 +3033,9 @@ func (a *AgentApi) Reload(ctx context.Context) (*AgentReloadResult, error) {
 	return &result, nil
 }
 
+// Select calls session.agent.select.
+//
+// RPC method: session.agent.select.
 func (a *AgentApi) Select(ctx context.Context, params *AgentSelectRequest) (*AgentSelectResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -2991,6 +3054,9 @@ func (a *AgentApi) Select(ctx context.Context, params *AgentSelectRequest) (*Age
 
 type AuthApi sessionApi
 
+// GetStatus calls session.auth.getStatus.
+//
+// RPC method: session.auth.getStatus.
 func (a *AuthApi) GetStatus(ctx context.Context) (*SessionAuthStatus, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.auth.getStatus", req)
@@ -3006,6 +3072,9 @@ func (a *AuthApi) GetStatus(ctx context.Context) (*SessionAuthStatus, error) {
 
 type CommandsApi sessionApi
 
+// HandlePendingCommand calls session.commands.handlePendingCommand.
+//
+// RPC method: session.commands.handlePendingCommand.
 func (a *CommandsApi) HandlePendingCommand(ctx context.Context, params *CommandsHandlePendingCommandRequest) (*CommandsHandlePendingCommandResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3025,6 +3094,9 @@ func (a *CommandsApi) HandlePendingCommand(ctx context.Context, params *Commands
 	return &result, nil
 }
 
+// Invoke calls session.commands.invoke.
+//
+// RPC method: session.commands.invoke.
 func (a *CommandsApi) Invoke(ctx context.Context, params *CommandsInvokeRequest) (SlashCommandInvocationResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3044,6 +3116,9 @@ func (a *CommandsApi) Invoke(ctx context.Context, params *CommandsInvokeRequest)
 	return result, nil
 }
 
+// List calls session.commands.list.
+//
+// RPC method: session.commands.list.
 func (a *CommandsApi) List(ctx context.Context, params ...*CommandsListRequest) (*CommandList, error) {
 	var requestParams *CommandsListRequest
 	if len(params) > 0 {
@@ -3072,6 +3147,9 @@ func (a *CommandsApi) List(ctx context.Context, params ...*CommandsListRequest) 
 	return &result, nil
 }
 
+// RespondToQueuedCommand calls session.commands.respondToQueuedCommand.
+//
+// RPC method: session.commands.respondToQueuedCommand.
 func (a *CommandsApi) RespondToQueuedCommand(ctx context.Context, params *CommandsRespondToQueuedCommandRequest) (*CommandsRespondToQueuedCommandResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3092,6 +3170,9 @@ func (a *CommandsApi) RespondToQueuedCommand(ctx context.Context, params *Comman
 // Experimental: ExtensionsApi contains experimental APIs that may change or be removed.
 type ExtensionsApi sessionApi
 
+// Disable calls session.extensions.disable.
+//
+// RPC method: session.extensions.disable.
 func (a *ExtensionsApi) Disable(ctx context.Context, params *ExtensionsDisableRequest) (*ExtensionsDisableResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3108,6 +3189,9 @@ func (a *ExtensionsApi) Disable(ctx context.Context, params *ExtensionsDisableRe
 	return &result, nil
 }
 
+// Enable calls session.extensions.enable.
+//
+// RPC method: session.extensions.enable.
 func (a *ExtensionsApi) Enable(ctx context.Context, params *ExtensionsEnableRequest) (*ExtensionsEnableResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3124,6 +3208,9 @@ func (a *ExtensionsApi) Enable(ctx context.Context, params *ExtensionsEnableRequ
 	return &result, nil
 }
 
+// List calls session.extensions.list.
+//
+// RPC method: session.extensions.list.
 func (a *ExtensionsApi) List(ctx context.Context) (*ExtensionList, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.extensions.list", req)
@@ -3137,6 +3224,9 @@ func (a *ExtensionsApi) List(ctx context.Context) (*ExtensionList, error) {
 	return &result, nil
 }
 
+// Reload calls session.extensions.reload.
+//
+// RPC method: session.extensions.reload.
 func (a *ExtensionsApi) Reload(ctx context.Context) (*ExtensionsReloadResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.extensions.reload", req)
@@ -3153,6 +3243,9 @@ func (a *ExtensionsApi) Reload(ctx context.Context) (*ExtensionsReloadResult, er
 // Experimental: FleetApi contains experimental APIs that may change or be removed.
 type FleetApi sessionApi
 
+// Start calls session.fleet.start.
+//
+// RPC method: session.fleet.start.
 func (a *FleetApi) Start(ctx context.Context, params *FleetStartRequest) (*FleetStartResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3174,6 +3267,9 @@ func (a *FleetApi) Start(ctx context.Context, params *FleetStartRequest) (*Fleet
 // Experimental: HistoryApi contains experimental APIs that may change or be removed.
 type HistoryApi sessionApi
 
+// Compact calls session.history.compact.
+//
+// RPC method: session.history.compact.
 func (a *HistoryApi) Compact(ctx context.Context) (*HistoryCompactResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.history.compact", req)
@@ -3187,6 +3283,9 @@ func (a *HistoryApi) Compact(ctx context.Context) (*HistoryCompactResult, error)
 	return &result, nil
 }
 
+// Truncate calls session.history.truncate.
+//
+// RPC method: session.history.truncate.
 func (a *HistoryApi) Truncate(ctx context.Context, params *HistoryTruncateRequest) (*HistoryTruncateResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3205,6 +3304,9 @@ func (a *HistoryApi) Truncate(ctx context.Context, params *HistoryTruncateReques
 
 type InstructionsApi sessionApi
 
+// GetSources calls session.instructions.getSources.
+//
+// RPC method: session.instructions.getSources.
 func (a *InstructionsApi) GetSources(ctx context.Context) (*InstructionsGetSourcesResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.instructions.getSources", req)
@@ -3221,6 +3323,9 @@ func (a *InstructionsApi) GetSources(ctx context.Context) (*InstructionsGetSourc
 // Experimental: McpApi contains experimental APIs that may change or be removed.
 type McpApi sessionApi
 
+// Disable calls session.mcp.disable.
+//
+// RPC method: session.mcp.disable.
 func (a *McpApi) Disable(ctx context.Context, params *McpDisableRequest) (*McpDisableResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3237,6 +3342,9 @@ func (a *McpApi) Disable(ctx context.Context, params *McpDisableRequest) (*McpDi
 	return &result, nil
 }
 
+// Enable calls session.mcp.enable.
+//
+// RPC method: session.mcp.enable.
 func (a *McpApi) Enable(ctx context.Context, params *McpEnableRequest) (*McpEnableResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3253,6 +3361,9 @@ func (a *McpApi) Enable(ctx context.Context, params *McpEnableRequest) (*McpEnab
 	return &result, nil
 }
 
+// List calls session.mcp.list.
+//
+// RPC method: session.mcp.list.
 func (a *McpApi) List(ctx context.Context) (*McpServerList, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.mcp.list", req)
@@ -3266,6 +3377,9 @@ func (a *McpApi) List(ctx context.Context) (*McpServerList, error) {
 	return &result, nil
 }
 
+// Reload calls session.mcp.reload.
+//
+// RPC method: session.mcp.reload.
 func (a *McpApi) Reload(ctx context.Context) (*McpReloadResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.mcp.reload", req)
@@ -3282,6 +3396,9 @@ func (a *McpApi) Reload(ctx context.Context) (*McpReloadResult, error) {
 // Experimental: McpOauthApi contains experimental APIs that may change or be removed.
 type McpOauthApi sessionApi
 
+// Login calls session.mcp.oauth.login.
+//
+// RPC method: session.mcp.oauth.login.
 func (a *McpOauthApi) Login(ctx context.Context, params *McpOauthLoginRequest) (*McpOauthLoginResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3314,6 +3431,11 @@ func (s *McpApi) Oauth() *McpOauthApi {
 
 type ModeApi sessionApi
 
+// Get calls session.mode.get.
+//
+// RPC method: session.mode.get.
+//
+// Returns: The agent mode. Valid values: "interactive", "plan", "autopilot".
 func (a *ModeApi) Get(ctx context.Context) (*SessionMode, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.mode.get", req)
@@ -3327,6 +3449,9 @@ func (a *ModeApi) Get(ctx context.Context) (*SessionMode, error) {
 	return &result, nil
 }
 
+// Set calls session.mode.set.
+//
+// RPC method: session.mode.set.
 func (a *ModeApi) Set(ctx context.Context, params *ModeSetRequest) (*ModeSetResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3345,6 +3470,9 @@ func (a *ModeApi) Set(ctx context.Context, params *ModeSetRequest) (*ModeSetResu
 
 type ModelApi sessionApi
 
+// GetCurrent calls session.model.getCurrent.
+//
+// RPC method: session.model.getCurrent.
 func (a *ModelApi) GetCurrent(ctx context.Context) (*CurrentModel, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.model.getCurrent", req)
@@ -3358,6 +3486,9 @@ func (a *ModelApi) GetCurrent(ctx context.Context) (*CurrentModel, error) {
 	return &result, nil
 }
 
+// SwitchTo calls session.model.switchTo.
+//
+// RPC method: session.model.switchTo.
 func (a *ModelApi) SwitchTo(ctx context.Context, params *ModelSwitchToRequest) (*ModelSwitchToResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3382,6 +3513,9 @@ func (a *ModelApi) SwitchTo(ctx context.Context, params *ModelSwitchToRequest) (
 
 type NameApi sessionApi
 
+// Get calls session.name.get.
+//
+// RPC method: session.name.get.
 func (a *NameApi) Get(ctx context.Context) (*NameGetResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.name.get", req)
@@ -3395,6 +3529,9 @@ func (a *NameApi) Get(ctx context.Context) (*NameGetResult, error) {
 	return &result, nil
 }
 
+// Set calls session.name.set.
+//
+// RPC method: session.name.set.
 func (a *NameApi) Set(ctx context.Context, params *NameSetRequest) (*NameSetResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3413,6 +3550,9 @@ func (a *NameApi) Set(ctx context.Context, params *NameSetRequest) (*NameSetResu
 
 type PermissionsApi sessionApi
 
+// HandlePendingPermissionRequest calls session.permissions.handlePendingPermissionRequest.
+//
+// RPC method: session.permissions.handlePendingPermissionRequest.
 func (a *PermissionsApi) HandlePendingPermissionRequest(ctx context.Context, params *PermissionDecisionRequest) (*PermissionRequestResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3430,6 +3570,9 @@ func (a *PermissionsApi) HandlePendingPermissionRequest(ctx context.Context, par
 	return &result, nil
 }
 
+// ResetSessionApprovals calls session.permissions.resetSessionApprovals.
+//
+// RPC method: session.permissions.resetSessionApprovals.
 func (a *PermissionsApi) ResetSessionApprovals(ctx context.Context) (*PermissionsResetSessionApprovalsResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.permissions.resetSessionApprovals", req)
@@ -3443,6 +3586,9 @@ func (a *PermissionsApi) ResetSessionApprovals(ctx context.Context) (*Permission
 	return &result, nil
 }
 
+// SetApproveAll calls session.permissions.setApproveAll.
+//
+// RPC method: session.permissions.setApproveAll.
 func (a *PermissionsApi) SetApproveAll(ctx context.Context, params *PermissionsSetApproveAllRequest) (*PermissionsSetApproveAllResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3461,6 +3607,9 @@ func (a *PermissionsApi) SetApproveAll(ctx context.Context, params *PermissionsS
 
 type PlanApi sessionApi
 
+// Delete calls session.plan.delete.
+//
+// RPC method: session.plan.delete.
 func (a *PlanApi) Delete(ctx context.Context) (*PlanDeleteResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.plan.delete", req)
@@ -3474,6 +3623,9 @@ func (a *PlanApi) Delete(ctx context.Context) (*PlanDeleteResult, error) {
 	return &result, nil
 }
 
+// Read calls session.plan.read.
+//
+// RPC method: session.plan.read.
 func (a *PlanApi) Read(ctx context.Context) (*PlanReadResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.plan.read", req)
@@ -3487,6 +3639,9 @@ func (a *PlanApi) Read(ctx context.Context) (*PlanReadResult, error) {
 	return &result, nil
 }
 
+// Update calls session.plan.update.
+//
+// RPC method: session.plan.update.
 func (a *PlanApi) Update(ctx context.Context, params *PlanUpdateRequest) (*PlanUpdateResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3506,6 +3661,9 @@ func (a *PlanApi) Update(ctx context.Context, params *PlanUpdateRequest) (*PlanU
 // Experimental: PluginsApi contains experimental APIs that may change or be removed.
 type PluginsApi sessionApi
 
+// List calls session.plugins.list.
+//
+// RPC method: session.plugins.list.
 func (a *PluginsApi) List(ctx context.Context) (*PluginList, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.plugins.list", req)
@@ -3522,6 +3680,9 @@ func (a *PluginsApi) List(ctx context.Context) (*PluginList, error) {
 // Experimental: RemoteApi contains experimental APIs that may change or be removed.
 type RemoteApi sessionApi
 
+// Disable calls session.remote.disable.
+//
+// RPC method: session.remote.disable.
 func (a *RemoteApi) Disable(ctx context.Context) (*RemoteDisableResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.remote.disable", req)
@@ -3535,6 +3696,9 @@ func (a *RemoteApi) Disable(ctx context.Context) (*RemoteDisableResult, error) {
 	return &result, nil
 }
 
+// Enable calls session.remote.enable.
+//
+// RPC method: session.remote.enable.
 func (a *RemoteApi) Enable(ctx context.Context, params *RemoteEnableRequest) (*RemoteEnableResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3555,6 +3719,9 @@ func (a *RemoteApi) Enable(ctx context.Context, params *RemoteEnableRequest) (*R
 
 type ShellApi sessionApi
 
+// Exec calls session.shell.exec.
+//
+// RPC method: session.shell.exec.
 func (a *ShellApi) Exec(ctx context.Context, params *ShellExecRequest) (*ShellExecResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3577,6 +3744,9 @@ func (a *ShellApi) Exec(ctx context.Context, params *ShellExecRequest) (*ShellEx
 	return &result, nil
 }
 
+// Kill calls session.shell.kill.
+//
+// RPC method: session.shell.kill.
 func (a *ShellApi) Kill(ctx context.Context, params *ShellKillRequest) (*ShellKillResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3599,6 +3769,9 @@ func (a *ShellApi) Kill(ctx context.Context, params *ShellKillRequest) (*ShellKi
 // Experimental: SkillsApi contains experimental APIs that may change or be removed.
 type SkillsApi sessionApi
 
+// Disable calls session.skills.disable.
+//
+// RPC method: session.skills.disable.
 func (a *SkillsApi) Disable(ctx context.Context, params *SkillsDisableRequest) (*SkillsDisableResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3615,6 +3788,9 @@ func (a *SkillsApi) Disable(ctx context.Context, params *SkillsDisableRequest) (
 	return &result, nil
 }
 
+// Enable calls session.skills.enable.
+//
+// RPC method: session.skills.enable.
 func (a *SkillsApi) Enable(ctx context.Context, params *SkillsEnableRequest) (*SkillsEnableResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3631,6 +3807,9 @@ func (a *SkillsApi) Enable(ctx context.Context, params *SkillsEnableRequest) (*S
 	return &result, nil
 }
 
+// List calls session.skills.list.
+//
+// RPC method: session.skills.list.
 func (a *SkillsApi) List(ctx context.Context) (*SkillList, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.skills.list", req)
@@ -3644,6 +3823,9 @@ func (a *SkillsApi) List(ctx context.Context) (*SkillList, error) {
 	return &result, nil
 }
 
+// Reload calls session.skills.reload.
+//
+// RPC method: session.skills.reload.
 func (a *SkillsApi) Reload(ctx context.Context) (*SkillsLoadDiagnostics, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.skills.reload", req)
@@ -3660,6 +3842,9 @@ func (a *SkillsApi) Reload(ctx context.Context) (*SkillsLoadDiagnostics, error) 
 // Experimental: TasksApi contains experimental APIs that may change or be removed.
 type TasksApi sessionApi
 
+// Cancel calls session.tasks.cancel.
+//
+// RPC method: session.tasks.cancel.
 func (a *TasksApi) Cancel(ctx context.Context, params *TasksCancelRequest) (*TasksCancelResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3676,6 +3861,9 @@ func (a *TasksApi) Cancel(ctx context.Context, params *TasksCancelRequest) (*Tas
 	return &result, nil
 }
 
+// List calls session.tasks.list.
+//
+// RPC method: session.tasks.list.
 func (a *TasksApi) List(ctx context.Context) (*TaskList, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.tasks.list", req)
@@ -3689,6 +3877,9 @@ func (a *TasksApi) List(ctx context.Context) (*TaskList, error) {
 	return &result, nil
 }
 
+// PromoteToBackground calls session.tasks.promoteToBackground.
+//
+// RPC method: session.tasks.promoteToBackground.
 func (a *TasksApi) PromoteToBackground(ctx context.Context, params *TasksPromoteToBackgroundRequest) (*TasksPromoteToBackgroundResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3705,6 +3896,9 @@ func (a *TasksApi) PromoteToBackground(ctx context.Context, params *TasksPromote
 	return &result, nil
 }
 
+// Remove calls session.tasks.remove.
+//
+// RPC method: session.tasks.remove.
 func (a *TasksApi) Remove(ctx context.Context, params *TasksRemoveRequest) (*TasksRemoveResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3721,6 +3915,9 @@ func (a *TasksApi) Remove(ctx context.Context, params *TasksRemoveRequest) (*Tas
 	return &result, nil
 }
 
+// SendMessage calls session.tasks.sendMessage.
+//
+// RPC method: session.tasks.sendMessage.
 func (a *TasksApi) SendMessage(ctx context.Context, params *TasksSendMessageRequest) (*TasksSendMessageResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3741,6 +3938,9 @@ func (a *TasksApi) SendMessage(ctx context.Context, params *TasksSendMessageRequ
 	return &result, nil
 }
 
+// StartAgent calls session.tasks.startAgent.
+//
+// RPC method: session.tasks.startAgent.
 func (a *TasksApi) StartAgent(ctx context.Context, params *TasksStartAgentRequest) (*TasksStartAgentResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3767,6 +3967,9 @@ func (a *TasksApi) StartAgent(ctx context.Context, params *TasksStartAgentReques
 
 type ToolsApi sessionApi
 
+// HandlePendingToolCall calls session.tools.handlePendingToolCall.
+//
+// RPC method: session.tools.handlePendingToolCall.
 func (a *ToolsApi) HandlePendingToolCall(ctx context.Context, params *HandlePendingToolCallRequest) (*HandlePendingToolCallResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3791,6 +3994,11 @@ func (a *ToolsApi) HandlePendingToolCall(ctx context.Context, params *HandlePend
 
 type UIApi sessionApi
 
+// Elicitation calls session.ui.elicitation.
+//
+// RPC method: session.ui.elicitation.
+//
+// Returns: The elicitation response (accept with form values, decline, or cancel)
 func (a *UIApi) Elicitation(ctx context.Context, params *UIElicitationRequest) (*UIElicitationResponse, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3808,6 +4016,9 @@ func (a *UIApi) Elicitation(ctx context.Context, params *UIElicitationRequest) (
 	return &result, nil
 }
 
+// HandlePendingElicitation calls session.ui.handlePendingElicitation.
+//
+// RPC method: session.ui.handlePendingElicitation.
 func (a *UIApi) HandlePendingElicitation(ctx context.Context, params *UIHandlePendingElicitationRequest) (*UIElicitationResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3828,6 +4039,9 @@ func (a *UIApi) HandlePendingElicitation(ctx context.Context, params *UIHandlePe
 // Experimental: UsageApi contains experimental APIs that may change or be removed.
 type UsageApi sessionApi
 
+// GetMetrics calls session.usage.getMetrics.
+//
+// RPC method: session.usage.getMetrics.
 func (a *UsageApi) GetMetrics(ctx context.Context) (*UsageGetMetricsResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.usage.getMetrics", req)
@@ -3843,6 +4057,9 @@ func (a *UsageApi) GetMetrics(ctx context.Context) (*UsageGetMetricsResult, erro
 
 type WorkspacesApi sessionApi
 
+// CreateFile calls session.workspaces.createFile.
+//
+// RPC method: session.workspaces.createFile.
 func (a *WorkspacesApi) CreateFile(ctx context.Context, params *WorkspacesCreateFileRequest) (*WorkspacesCreateFileResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3860,6 +4077,9 @@ func (a *WorkspacesApi) CreateFile(ctx context.Context, params *WorkspacesCreate
 	return &result, nil
 }
 
+// GetWorkspace calls session.workspaces.getWorkspace.
+//
+// RPC method: session.workspaces.getWorkspace.
 func (a *WorkspacesApi) GetWorkspace(ctx context.Context) (*WorkspacesGetWorkspaceResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.workspaces.getWorkspace", req)
@@ -3873,6 +4093,9 @@ func (a *WorkspacesApi) GetWorkspace(ctx context.Context) (*WorkspacesGetWorkspa
 	return &result, nil
 }
 
+// ListFiles calls session.workspaces.listFiles.
+//
+// RPC method: session.workspaces.listFiles.
 func (a *WorkspacesApi) ListFiles(ctx context.Context) (*WorkspacesListFilesResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.workspaces.listFiles", req)
@@ -3886,6 +4109,9 @@ func (a *WorkspacesApi) ListFiles(ctx context.Context) (*WorkspacesListFilesResu
 	return &result, nil
 }
 
+// ReadFile calls session.workspaces.readFile.
+//
+// RPC method: session.workspaces.readFile.
 func (a *WorkspacesApi) ReadFile(ctx context.Context, params *WorkspacesReadFileRequest) (*WorkspacesReadFileResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
@@ -3931,6 +4157,9 @@ type SessionRpc struct {
 	Workspaces   *WorkspacesApi
 }
 
+// Log calls session.log.
+//
+// RPC method: session.log.
 func (a *SessionRpc) Log(ctx context.Context, params *LogRequest) (*LogResult, error) {
 	req := map[string]any{"sessionId": a.common.sessionID}
 	if params != nil {
@@ -3956,6 +4185,9 @@ func (a *SessionRpc) Log(ctx context.Context, params *LogRequest) (*LogResult, e
 	return &result, nil
 }
 
+// Suspend calls session.suspend.
+//
+// RPC method: session.suspend.
 func (a *SessionRpc) Suspend(ctx context.Context) (*SuspendResult, error) {
 	req := map[string]any{"sessionId": a.common.sessionID}
 	raw, err := a.common.client.Request("session.suspend", req)
@@ -3998,15 +4230,55 @@ func NewSessionRpc(client *jsonrpc2.Client, sessionID string) *SessionRpc {
 }
 
 type SessionFsHandler interface {
+	// AppendFile calls sessionFs.appendFile.
+	//
+	// RPC method: sessionFs.appendFile.
+	//
+	// Returns: Describes a filesystem error.
 	AppendFile(request *SessionFsAppendFileRequest) (*SessionFsError, error)
+	// Exists calls sessionFs.exists.
+	//
+	// RPC method: sessionFs.exists.
 	Exists(request *SessionFsExistsRequest) (*SessionFsExistsResult, error)
+	// Mkdir calls sessionFs.mkdir.
+	//
+	// RPC method: sessionFs.mkdir.
+	//
+	// Returns: Describes a filesystem error.
 	Mkdir(request *SessionFsMkdirRequest) (*SessionFsError, error)
+	// Readdir calls sessionFs.readdir.
+	//
+	// RPC method: sessionFs.readdir.
 	Readdir(request *SessionFsReaddirRequest) (*SessionFsReaddirResult, error)
+	// ReaddirWithTypes calls sessionFs.readdirWithTypes.
+	//
+	// RPC method: sessionFs.readdirWithTypes.
 	ReaddirWithTypes(request *SessionFsReaddirWithTypesRequest) (*SessionFsReaddirWithTypesResult, error)
+	// ReadFile calls sessionFs.readFile.
+	//
+	// RPC method: sessionFs.readFile.
 	ReadFile(request *SessionFsReadFileRequest) (*SessionFsReadFileResult, error)
+	// Rename calls sessionFs.rename.
+	//
+	// RPC method: sessionFs.rename.
+	//
+	// Returns: Describes a filesystem error.
 	Rename(request *SessionFsRenameRequest) (*SessionFsError, error)
+	// Rm calls sessionFs.rm.
+	//
+	// RPC method: sessionFs.rm.
+	//
+	// Returns: Describes a filesystem error.
 	Rm(request *SessionFsRmRequest) (*SessionFsError, error)
+	// Stat calls sessionFs.stat.
+	//
+	// RPC method: sessionFs.stat.
 	Stat(request *SessionFsStatRequest) (*SessionFsStatResult, error)
+	// WriteFile calls sessionFs.writeFile.
+	//
+	// RPC method: sessionFs.writeFile.
+	//
+	// Returns: Describes a filesystem error.
 	WriteFile(request *SessionFsWriteFileRequest) (*SessionFsError, error)
 }
 

--- a/go/rpc/zrpc.go
+++ b/go/rpc/zrpc.go
@@ -4230,51 +4230,51 @@ func NewSessionRpc(client *jsonrpc2.Client, sessionID string) *SessionRpc {
 }
 
 type SessionFsHandler interface {
-	// AppendFile calls sessionFs.appendFile.
+	// AppendFile handles sessionFs.appendFile.
 	//
 	// RPC method: sessionFs.appendFile.
 	//
 	// Returns: Describes a filesystem error.
 	AppendFile(request *SessionFsAppendFileRequest) (*SessionFsError, error)
-	// Exists calls sessionFs.exists.
+	// Exists handles sessionFs.exists.
 	//
 	// RPC method: sessionFs.exists.
 	Exists(request *SessionFsExistsRequest) (*SessionFsExistsResult, error)
-	// Mkdir calls sessionFs.mkdir.
+	// Mkdir handles sessionFs.mkdir.
 	//
 	// RPC method: sessionFs.mkdir.
 	//
 	// Returns: Describes a filesystem error.
 	Mkdir(request *SessionFsMkdirRequest) (*SessionFsError, error)
-	// Readdir calls sessionFs.readdir.
+	// Readdir handles sessionFs.readdir.
 	//
 	// RPC method: sessionFs.readdir.
 	Readdir(request *SessionFsReaddirRequest) (*SessionFsReaddirResult, error)
-	// ReaddirWithTypes calls sessionFs.readdirWithTypes.
+	// ReaddirWithTypes handles sessionFs.readdirWithTypes.
 	//
 	// RPC method: sessionFs.readdirWithTypes.
 	ReaddirWithTypes(request *SessionFsReaddirWithTypesRequest) (*SessionFsReaddirWithTypesResult, error)
-	// ReadFile calls sessionFs.readFile.
+	// ReadFile handles sessionFs.readFile.
 	//
 	// RPC method: sessionFs.readFile.
 	ReadFile(request *SessionFsReadFileRequest) (*SessionFsReadFileResult, error)
-	// Rename calls sessionFs.rename.
+	// Rename handles sessionFs.rename.
 	//
 	// RPC method: sessionFs.rename.
 	//
 	// Returns: Describes a filesystem error.
 	Rename(request *SessionFsRenameRequest) (*SessionFsError, error)
-	// Rm calls sessionFs.rm.
+	// Rm handles sessionFs.rm.
 	//
 	// RPC method: sessionFs.rm.
 	//
 	// Returns: Describes a filesystem error.
 	Rm(request *SessionFsRmRequest) (*SessionFsError, error)
-	// Stat calls sessionFs.stat.
+	// Stat handles sessionFs.stat.
 	//
 	// RPC method: sessionFs.stat.
 	Stat(request *SessionFsStatRequest) (*SessionFsStatResult, error)
-	// WriteFile calls sessionFs.writeFile.
+	// WriteFile handles sessionFs.writeFile.
 	//
 	// RPC method: sessionFs.writeFile.
 	//

--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -2803,52 +2803,97 @@ export interface WorkspacesReadFileResult {
 /** Create typed server-scoped RPC methods (no session required). */
 export function createServerRpc(connection: MessageConnection) {
     return {
+        /**
+         * Calls `ping`.
+         */
         ping: async (params: PingRequest): Promise<PingResult> =>
             connection.sendRequest("ping", params),
         models: {
+            /**
+             * Calls `models.list`.
+             */
             list: async (params?: ModelsListRequest): Promise<ModelList> =>
                 connection.sendRequest("models.list", params),
         },
         tools: {
+            /**
+             * Calls `tools.list`.
+             */
             list: async (params: ToolsListRequest): Promise<ToolList> =>
                 connection.sendRequest("tools.list", params),
         },
         account: {
+            /**
+             * Calls `account.getQuota`.
+             */
             getQuota: async (params?: AccountGetQuotaRequest): Promise<AccountGetQuotaResult> =>
                 connection.sendRequest("account.getQuota", params),
         },
         mcp: {
             config: {
+                /**
+                 * Calls `mcp.config.list`.
+                 */
                 list: async (): Promise<McpConfigList> =>
                     connection.sendRequest("mcp.config.list", {}),
+                /**
+                 * Calls `mcp.config.add`.
+                 */
                 add: async (params: McpConfigAddRequest): Promise<void> =>
                     connection.sendRequest("mcp.config.add", params),
+                /**
+                 * Calls `mcp.config.update`.
+                 */
                 update: async (params: McpConfigUpdateRequest): Promise<void> =>
                     connection.sendRequest("mcp.config.update", params),
+                /**
+                 * Calls `mcp.config.remove`.
+                 */
                 remove: async (params: McpConfigRemoveRequest): Promise<void> =>
                     connection.sendRequest("mcp.config.remove", params),
+                /**
+                 * Calls `mcp.config.enable`.
+                 */
                 enable: async (params: McpConfigEnableRequest): Promise<void> =>
                     connection.sendRequest("mcp.config.enable", params),
+                /**
+                 * Calls `mcp.config.disable`.
+                 */
                 disable: async (params: McpConfigDisableRequest): Promise<void> =>
                     connection.sendRequest("mcp.config.disable", params),
             },
+            /**
+             * Calls `mcp.discover`.
+             */
             discover: async (params: McpDiscoverRequest): Promise<McpDiscoverResult> =>
                 connection.sendRequest("mcp.discover", params),
         },
         skills: {
             config: {
+                /**
+                 * Calls `skills.config.setDisabledSkills`.
+                 */
                 setDisabledSkills: async (params: SkillsConfigSetDisabledSkillsRequest): Promise<void> =>
                     connection.sendRequest("skills.config.setDisabledSkills", params),
             },
+            /**
+             * Calls `skills.discover`.
+             */
             discover: async (params: SkillsDiscoverRequest): Promise<ServerSkillList> =>
                 connection.sendRequest("skills.discover", params),
         },
         sessionFs: {
+            /**
+             * Calls `sessionFs.setProvider`.
+             */
             setProvider: async (params: SessionFsSetProviderRequest): Promise<SessionFsSetProviderResult> =>
                 connection.sendRequest("sessionFs.setProvider", params),
         },
         /** @experimental */
         sessions: {
+            /**
+             * Calls `sessions.fork`.
+             */
             fork: async (params: SessionsForkRequest): Promise<SessionsForkResult> =>
                 connection.sendRequest("sessions.fork", params),
         },
@@ -2862,6 +2907,9 @@ export function createServerRpc(connection: MessageConnection) {
  */
 export function createInternalServerRpc(connection: MessageConnection) {
     return {
+        /**
+         * Calls `connect`.
+         */
         connect: async (params: ConnectRequest): Promise<ConnectResult> =>
             connection.sendRequest("connect", params),
     };
@@ -2870,180 +2918,364 @@ export function createInternalServerRpc(connection: MessageConnection) {
 /** Create typed session-scoped RPC methods. */
 export function createSessionRpc(connection: MessageConnection, sessionId: string) {
     return {
+        /**
+         * Calls `session.suspend`.
+         */
         suspend: async (): Promise<void> =>
             connection.sendRequest("session.suspend", { sessionId }),
         auth: {
+            /**
+             * Calls `session.auth.getStatus`.
+             */
             getStatus: async (): Promise<SessionAuthStatus> =>
                 connection.sendRequest("session.auth.getStatus", { sessionId }),
         },
         model: {
+            /**
+             * Calls `session.model.getCurrent`.
+             */
             getCurrent: async (): Promise<CurrentModel> =>
                 connection.sendRequest("session.model.getCurrent", { sessionId }),
+            /**
+             * Calls `session.model.switchTo`.
+             */
             switchTo: async (params: ModelSwitchToRequest): Promise<ModelSwitchToResult> =>
                 connection.sendRequest("session.model.switchTo", { sessionId, ...params }),
         },
         mode: {
+            /**
+             * Calls `session.mode.get`.
+             *
+             * @returns The agent mode. Valid values: "interactive", "plan", "autopilot".
+             */
             get: async (): Promise<SessionMode> =>
                 connection.sendRequest("session.mode.get", { sessionId }),
+            /**
+             * Calls `session.mode.set`.
+             */
             set: async (params: ModeSetRequest): Promise<void> =>
                 connection.sendRequest("session.mode.set", { sessionId, ...params }),
         },
         name: {
+            /**
+             * Calls `session.name.get`.
+             */
             get: async (): Promise<NameGetResult> =>
                 connection.sendRequest("session.name.get", { sessionId }),
+            /**
+             * Calls `session.name.set`.
+             */
             set: async (params: NameSetRequest): Promise<void> =>
                 connection.sendRequest("session.name.set", { sessionId, ...params }),
         },
         plan: {
+            /**
+             * Calls `session.plan.read`.
+             */
             read: async (): Promise<PlanReadResult> =>
                 connection.sendRequest("session.plan.read", { sessionId }),
+            /**
+             * Calls `session.plan.update`.
+             */
             update: async (params: PlanUpdateRequest): Promise<void> =>
                 connection.sendRequest("session.plan.update", { sessionId, ...params }),
+            /**
+             * Calls `session.plan.delete`.
+             */
             delete: async (): Promise<void> =>
                 connection.sendRequest("session.plan.delete", { sessionId }),
         },
         workspaces: {
+            /**
+             * Calls `session.workspaces.getWorkspace`.
+             */
             getWorkspace: async (): Promise<WorkspacesGetWorkspaceResult> =>
                 connection.sendRequest("session.workspaces.getWorkspace", { sessionId }),
+            /**
+             * Calls `session.workspaces.listFiles`.
+             */
             listFiles: async (): Promise<WorkspacesListFilesResult> =>
                 connection.sendRequest("session.workspaces.listFiles", { sessionId }),
+            /**
+             * Calls `session.workspaces.readFile`.
+             */
             readFile: async (params: WorkspacesReadFileRequest): Promise<WorkspacesReadFileResult> =>
                 connection.sendRequest("session.workspaces.readFile", { sessionId, ...params }),
+            /**
+             * Calls `session.workspaces.createFile`.
+             */
             createFile: async (params: WorkspacesCreateFileRequest): Promise<void> =>
                 connection.sendRequest("session.workspaces.createFile", { sessionId, ...params }),
         },
         instructions: {
+            /**
+             * Calls `session.instructions.getSources`.
+             */
             getSources: async (): Promise<InstructionsGetSourcesResult> =>
                 connection.sendRequest("session.instructions.getSources", { sessionId }),
         },
         /** @experimental */
         fleet: {
+            /**
+             * Calls `session.fleet.start`.
+             */
             start: async (params: FleetStartRequest): Promise<FleetStartResult> =>
                 connection.sendRequest("session.fleet.start", { sessionId, ...params }),
         },
         /** @experimental */
         agent: {
+            /**
+             * Calls `session.agent.list`.
+             */
             list: async (): Promise<AgentList> =>
                 connection.sendRequest("session.agent.list", { sessionId }),
+            /**
+             * Calls `session.agent.getCurrent`.
+             */
             getCurrent: async (): Promise<AgentGetCurrentResult> =>
                 connection.sendRequest("session.agent.getCurrent", { sessionId }),
+            /**
+             * Calls `session.agent.select`.
+             */
             select: async (params: AgentSelectRequest): Promise<AgentSelectResult> =>
                 connection.sendRequest("session.agent.select", { sessionId, ...params }),
+            /**
+             * Calls `session.agent.deselect`.
+             */
             deselect: async (): Promise<void> =>
                 connection.sendRequest("session.agent.deselect", { sessionId }),
+            /**
+             * Calls `session.agent.reload`.
+             */
             reload: async (): Promise<AgentReloadResult> =>
                 connection.sendRequest("session.agent.reload", { sessionId }),
         },
         /** @experimental */
         tasks: {
+            /**
+             * Calls `session.tasks.startAgent`.
+             */
             startAgent: async (params: TasksStartAgentRequest): Promise<TasksStartAgentResult> =>
                 connection.sendRequest("session.tasks.startAgent", { sessionId, ...params }),
+            /**
+             * Calls `session.tasks.list`.
+             */
             list: async (): Promise<TaskList> =>
                 connection.sendRequest("session.tasks.list", { sessionId }),
+            /**
+             * Calls `session.tasks.promoteToBackground`.
+             */
             promoteToBackground: async (params: TasksPromoteToBackgroundRequest): Promise<TasksPromoteToBackgroundResult> =>
                 connection.sendRequest("session.tasks.promoteToBackground", { sessionId, ...params }),
+            /**
+             * Calls `session.tasks.cancel`.
+             */
             cancel: async (params: TasksCancelRequest): Promise<TasksCancelResult> =>
                 connection.sendRequest("session.tasks.cancel", { sessionId, ...params }),
+            /**
+             * Calls `session.tasks.remove`.
+             */
             remove: async (params: TasksRemoveRequest): Promise<TasksRemoveResult> =>
                 connection.sendRequest("session.tasks.remove", { sessionId, ...params }),
+            /**
+             * Calls `session.tasks.sendMessage`.
+             */
             sendMessage: async (params: TasksSendMessageRequest): Promise<TasksSendMessageResult> =>
                 connection.sendRequest("session.tasks.sendMessage", { sessionId, ...params }),
         },
         /** @experimental */
         skills: {
+            /**
+             * Calls `session.skills.list`.
+             */
             list: async (): Promise<SkillList> =>
                 connection.sendRequest("session.skills.list", { sessionId }),
+            /**
+             * Calls `session.skills.enable`.
+             */
             enable: async (params: SkillsEnableRequest): Promise<void> =>
                 connection.sendRequest("session.skills.enable", { sessionId, ...params }),
+            /**
+             * Calls `session.skills.disable`.
+             */
             disable: async (params: SkillsDisableRequest): Promise<void> =>
                 connection.sendRequest("session.skills.disable", { sessionId, ...params }),
+            /**
+             * Calls `session.skills.reload`.
+             */
             reload: async (): Promise<SkillsLoadDiagnostics> =>
                 connection.sendRequest("session.skills.reload", { sessionId }),
         },
         /** @experimental */
         mcp: {
+            /**
+             * Calls `session.mcp.list`.
+             */
             list: async (): Promise<McpServerList> =>
                 connection.sendRequest("session.mcp.list", { sessionId }),
+            /**
+             * Calls `session.mcp.enable`.
+             */
             enable: async (params: McpEnableRequest): Promise<void> =>
                 connection.sendRequest("session.mcp.enable", { sessionId, ...params }),
+            /**
+             * Calls `session.mcp.disable`.
+             */
             disable: async (params: McpDisableRequest): Promise<void> =>
                 connection.sendRequest("session.mcp.disable", { sessionId, ...params }),
+            /**
+             * Calls `session.mcp.reload`.
+             */
             reload: async (): Promise<void> =>
                 connection.sendRequest("session.mcp.reload", { sessionId }),
             /** @experimental */
             oauth: {
+                /**
+                 * Calls `session.mcp.oauth.login`.
+                 */
                 login: async (params: McpOauthLoginRequest): Promise<McpOauthLoginResult> =>
                     connection.sendRequest("session.mcp.oauth.login", { sessionId, ...params }),
             },
         },
         /** @experimental */
         plugins: {
+            /**
+             * Calls `session.plugins.list`.
+             */
             list: async (): Promise<PluginList> =>
                 connection.sendRequest("session.plugins.list", { sessionId }),
         },
         /** @experimental */
         extensions: {
+            /**
+             * Calls `session.extensions.list`.
+             */
             list: async (): Promise<ExtensionList> =>
                 connection.sendRequest("session.extensions.list", { sessionId }),
+            /**
+             * Calls `session.extensions.enable`.
+             */
             enable: async (params: ExtensionsEnableRequest): Promise<void> =>
                 connection.sendRequest("session.extensions.enable", { sessionId, ...params }),
+            /**
+             * Calls `session.extensions.disable`.
+             */
             disable: async (params: ExtensionsDisableRequest): Promise<void> =>
                 connection.sendRequest("session.extensions.disable", { sessionId, ...params }),
+            /**
+             * Calls `session.extensions.reload`.
+             */
             reload: async (): Promise<void> =>
                 connection.sendRequest("session.extensions.reload", { sessionId }),
         },
         tools: {
+            /**
+             * Calls `session.tools.handlePendingToolCall`.
+             */
             handlePendingToolCall: async (params: HandlePendingToolCallRequest): Promise<HandlePendingToolCallResult> =>
                 connection.sendRequest("session.tools.handlePendingToolCall", { sessionId, ...params }),
         },
         commands: {
+            /**
+             * Calls `session.commands.list`.
+             */
             list: async (params?: CommandsListRequest): Promise<CommandList> =>
                 connection.sendRequest("session.commands.list", { sessionId, ...params }),
+            /**
+             * Calls `session.commands.invoke`.
+             */
             invoke: async (params: CommandsInvokeRequest): Promise<SlashCommandInvocationResult> =>
                 connection.sendRequest("session.commands.invoke", { sessionId, ...params }),
+            /**
+             * Calls `session.commands.handlePendingCommand`.
+             */
             handlePendingCommand: async (params: CommandsHandlePendingCommandRequest): Promise<CommandsHandlePendingCommandResult> =>
                 connection.sendRequest("session.commands.handlePendingCommand", { sessionId, ...params }),
+            /**
+             * Calls `session.commands.respondToQueuedCommand`.
+             */
             respondToQueuedCommand: async (params: CommandsRespondToQueuedCommandRequest): Promise<CommandsRespondToQueuedCommandResult> =>
                 connection.sendRequest("session.commands.respondToQueuedCommand", { sessionId, ...params }),
         },
         ui: {
+            /**
+             * Calls `session.ui.elicitation`.
+             *
+             * @returns The elicitation response (accept with form values, decline, or cancel)
+             */
             elicitation: async (params: UIElicitationRequest): Promise<UIElicitationResponse> =>
                 connection.sendRequest("session.ui.elicitation", { sessionId, ...params }),
+            /**
+             * Calls `session.ui.handlePendingElicitation`.
+             */
             handlePendingElicitation: async (params: UIHandlePendingElicitationRequest): Promise<UIElicitationResult> =>
                 connection.sendRequest("session.ui.handlePendingElicitation", { sessionId, ...params }),
         },
         permissions: {
+            /**
+             * Calls `session.permissions.handlePendingPermissionRequest`.
+             */
             handlePendingPermissionRequest: async (params: PermissionDecisionRequest): Promise<PermissionRequestResult> =>
                 connection.sendRequest("session.permissions.handlePendingPermissionRequest", { sessionId, ...params }),
+            /**
+             * Calls `session.permissions.setApproveAll`.
+             */
             setApproveAll: async (params: PermissionsSetApproveAllRequest): Promise<PermissionsSetApproveAllResult> =>
                 connection.sendRequest("session.permissions.setApproveAll", { sessionId, ...params }),
+            /**
+             * Calls `session.permissions.resetSessionApprovals`.
+             */
             resetSessionApprovals: async (): Promise<PermissionsResetSessionApprovalsResult> =>
                 connection.sendRequest("session.permissions.resetSessionApprovals", { sessionId }),
         },
+        /**
+         * Calls `session.log`.
+         */
         log: async (params: LogRequest): Promise<LogResult> =>
             connection.sendRequest("session.log", { sessionId, ...params }),
         shell: {
+            /**
+             * Calls `session.shell.exec`.
+             */
             exec: async (params: ShellExecRequest): Promise<ShellExecResult> =>
                 connection.sendRequest("session.shell.exec", { sessionId, ...params }),
+            /**
+             * Calls `session.shell.kill`.
+             */
             kill: async (params: ShellKillRequest): Promise<ShellKillResult> =>
                 connection.sendRequest("session.shell.kill", { sessionId, ...params }),
         },
         /** @experimental */
         history: {
+            /**
+             * Calls `session.history.compact`.
+             */
             compact: async (): Promise<HistoryCompactResult> =>
                 connection.sendRequest("session.history.compact", { sessionId }),
+            /**
+             * Calls `session.history.truncate`.
+             */
             truncate: async (params: HistoryTruncateRequest): Promise<HistoryTruncateResult> =>
                 connection.sendRequest("session.history.truncate", { sessionId, ...params }),
         },
         /** @experimental */
         usage: {
+            /**
+             * Calls `session.usage.getMetrics`.
+             */
             getMetrics: async (): Promise<UsageGetMetricsResult> =>
                 connection.sendRequest("session.usage.getMetrics", { sessionId }),
         },
         /** @experimental */
         remote: {
+            /**
+             * Calls `session.remote.enable`.
+             */
             enable: async (params: RemoteEnableRequest): Promise<RemoteEnableResult> =>
                 connection.sendRequest("session.remote.enable", { sessionId, ...params }),
+            /**
+             * Calls `session.remote.disable`.
+             */
             disable: async (): Promise<void> =>
                 connection.sendRequest("session.remote.disable", { sessionId }),
         },
@@ -3052,15 +3284,55 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
 
 /** Handler for `sessionFs` client session API methods. */
 export interface SessionFsHandler {
+    /**
+     * Calls `sessionFs.readFile`.
+     */
     readFile(params: SessionFsReadFileRequest): Promise<SessionFsReadFileResult>;
+    /**
+     * Calls `sessionFs.writeFile`.
+     *
+     * @returns Describes a filesystem error.
+     */
     writeFile(params: SessionFsWriteFileRequest): Promise<SessionFsError | undefined>;
+    /**
+     * Calls `sessionFs.appendFile`.
+     *
+     * @returns Describes a filesystem error.
+     */
     appendFile(params: SessionFsAppendFileRequest): Promise<SessionFsError | undefined>;
+    /**
+     * Calls `sessionFs.exists`.
+     */
     exists(params: SessionFsExistsRequest): Promise<SessionFsExistsResult>;
+    /**
+     * Calls `sessionFs.stat`.
+     */
     stat(params: SessionFsStatRequest): Promise<SessionFsStatResult>;
+    /**
+     * Calls `sessionFs.mkdir`.
+     *
+     * @returns Describes a filesystem error.
+     */
     mkdir(params: SessionFsMkdirRequest): Promise<SessionFsError | undefined>;
+    /**
+     * Calls `sessionFs.readdir`.
+     */
     readdir(params: SessionFsReaddirRequest): Promise<SessionFsReaddirResult>;
+    /**
+     * Calls `sessionFs.readdirWithTypes`.
+     */
     readdirWithTypes(params: SessionFsReaddirWithTypesRequest): Promise<SessionFsReaddirWithTypesResult>;
+    /**
+     * Calls `sessionFs.rm`.
+     *
+     * @returns Describes a filesystem error.
+     */
     rm(params: SessionFsRmRequest): Promise<SessionFsError | undefined>;
+    /**
+     * Calls `sessionFs.rename`.
+     *
+     * @returns Describes a filesystem error.
+     */
     rename(params: SessionFsRenameRequest): Promise<SessionFsError | undefined>;
 }
 

--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -3285,51 +3285,51 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
 /** Handler for `sessionFs` client session API methods. */
 export interface SessionFsHandler {
     /**
-     * Calls `sessionFs.readFile`.
+     * Handles `sessionFs.readFile`.
      */
     readFile(params: SessionFsReadFileRequest): Promise<SessionFsReadFileResult>;
     /**
-     * Calls `sessionFs.writeFile`.
+     * Handles `sessionFs.writeFile`.
      *
      * @returns Describes a filesystem error.
      */
     writeFile(params: SessionFsWriteFileRequest): Promise<SessionFsError | undefined>;
     /**
-     * Calls `sessionFs.appendFile`.
+     * Handles `sessionFs.appendFile`.
      *
      * @returns Describes a filesystem error.
      */
     appendFile(params: SessionFsAppendFileRequest): Promise<SessionFsError | undefined>;
     /**
-     * Calls `sessionFs.exists`.
+     * Handles `sessionFs.exists`.
      */
     exists(params: SessionFsExistsRequest): Promise<SessionFsExistsResult>;
     /**
-     * Calls `sessionFs.stat`.
+     * Handles `sessionFs.stat`.
      */
     stat(params: SessionFsStatRequest): Promise<SessionFsStatResult>;
     /**
-     * Calls `sessionFs.mkdir`.
+     * Handles `sessionFs.mkdir`.
      *
      * @returns Describes a filesystem error.
      */
     mkdir(params: SessionFsMkdirRequest): Promise<SessionFsError | undefined>;
     /**
-     * Calls `sessionFs.readdir`.
+     * Handles `sessionFs.readdir`.
      */
     readdir(params: SessionFsReaddirRequest): Promise<SessionFsReaddirResult>;
     /**
-     * Calls `sessionFs.readdirWithTypes`.
+     * Handles `sessionFs.readdirWithTypes`.
      */
     readdirWithTypes(params: SessionFsReaddirWithTypesRequest): Promise<SessionFsReaddirWithTypesResult>;
     /**
-     * Calls `sessionFs.rm`.
+     * Handles `sessionFs.rm`.
      *
      * @returns Describes a filesystem error.
      */
     rm(params: SessionFsRmRequest): Promise<SessionFsError | undefined>;
     /**
-     * Calls `sessionFs.rename`.
+     * Handles `sessionFs.rename`.
      *
      * @returns Describes a filesystem error.
      */

--- a/python/copilot/generated/rpc.py
+++ b/python/copilot/generated/rpc.py
@@ -7095,6 +7095,7 @@ class ServerModelsApi:
         self._client = client
 
     async def list(self, params: ModelsListRequest | None = None, *, timeout: float | None = None) -> ModelList:
+        "Calls models.list."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return ModelList.from_dict(_patch_model_capabilities(await self._client.request("models.list", params_dict, **_timeout_kwargs(timeout))))
 
@@ -7104,6 +7105,7 @@ class ServerToolsApi:
         self._client = client
 
     async def list(self, params: ToolsListRequest, *, timeout: float | None = None) -> ToolList:
+        "Calls tools.list."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return ToolList.from_dict(await self._client.request("tools.list", params_dict, **_timeout_kwargs(timeout)))
 
@@ -7113,6 +7115,7 @@ class ServerAccountApi:
         self._client = client
 
     async def get_quota(self, params: AccountGetQuotaRequest | None = None, *, timeout: float | None = None) -> AccountGetQuotaResult:
+        "Calls account.getQuota."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return AccountGetQuotaResult.from_dict(await self._client.request("account.getQuota", params_dict, **_timeout_kwargs(timeout)))
 
@@ -7122,25 +7125,31 @@ class ServerMcpConfigApi:
         self._client = client
 
     async def list(self, *, timeout: float | None = None) -> MCPConfigList:
+        "Calls mcp.config.list."
         return MCPConfigList.from_dict(await self._client.request("mcp.config.list", {}, **_timeout_kwargs(timeout)))
 
     async def add(self, params: MCPConfigAddRequest, *, timeout: float | None = None) -> None:
+        "Calls mcp.config.add."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         await self._client.request("mcp.config.add", params_dict, **_timeout_kwargs(timeout))
 
     async def update(self, params: MCPConfigUpdateRequest, *, timeout: float | None = None) -> None:
+        "Calls mcp.config.update."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         await self._client.request("mcp.config.update", params_dict, **_timeout_kwargs(timeout))
 
     async def remove(self, params: MCPConfigRemoveRequest, *, timeout: float | None = None) -> None:
+        "Calls mcp.config.remove."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         await self._client.request("mcp.config.remove", params_dict, **_timeout_kwargs(timeout))
 
     async def enable(self, params: MCPConfigEnableRequest, *, timeout: float | None = None) -> None:
+        "Calls mcp.config.enable."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         await self._client.request("mcp.config.enable", params_dict, **_timeout_kwargs(timeout))
 
     async def disable(self, params: MCPConfigDisableRequest, *, timeout: float | None = None) -> None:
+        "Calls mcp.config.disable."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         await self._client.request("mcp.config.disable", params_dict, **_timeout_kwargs(timeout))
 
@@ -7151,6 +7160,7 @@ class ServerMcpApi:
         self.config = ServerMcpConfigApi(client)
 
     async def discover(self, params: MCPDiscoverRequest, *, timeout: float | None = None) -> MCPDiscoverResult:
+        "Calls mcp.discover."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return MCPDiscoverResult.from_dict(await self._client.request("mcp.discover", params_dict, **_timeout_kwargs(timeout)))
 
@@ -7160,6 +7170,7 @@ class ServerSkillsConfigApi:
         self._client = client
 
     async def set_disabled_skills(self, params: SkillsConfigSetDisabledSkillsRequest, *, timeout: float | None = None) -> None:
+        "Calls skills.config.setDisabledSkills."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         await self._client.request("skills.config.setDisabledSkills", params_dict, **_timeout_kwargs(timeout))
 
@@ -7170,6 +7181,7 @@ class ServerSkillsApi:
         self.config = ServerSkillsConfigApi(client)
 
     async def discover(self, params: SkillsDiscoverRequest, *, timeout: float | None = None) -> ServerSkillList:
+        "Calls skills.discover."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return ServerSkillList.from_dict(await self._client.request("skills.discover", params_dict, **_timeout_kwargs(timeout)))
 
@@ -7179,6 +7191,7 @@ class ServerSessionFsApi:
         self._client = client
 
     async def set_provider(self, params: SessionFSSetProviderRequest, *, timeout: float | None = None) -> SessionFSSetProviderResult:
+        "Calls sessionFs.setProvider."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return SessionFSSetProviderResult.from_dict(await self._client.request("sessionFs.setProvider", params_dict, **_timeout_kwargs(timeout)))
 
@@ -7189,6 +7202,7 @@ class ServerSessionsApi:
         self._client = client
 
     async def fork(self, params: SessionsForkRequest, *, timeout: float | None = None) -> SessionsForkResult:
+        "Calls sessions.fork."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return SessionsForkResult.from_dict(await self._client.request("sessions.fork", params_dict, **_timeout_kwargs(timeout)))
 
@@ -7206,6 +7220,7 @@ class ServerRpc:
         self.sessions = ServerSessionsApi(client)
 
     async def ping(self, params: PingRequest, *, timeout: float | None = None) -> PingResult:
+        "Calls ping."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return PingResult.from_dict(await self._client.request("ping", params_dict, **_timeout_kwargs(timeout)))
 
@@ -7216,7 +7231,7 @@ class _InternalServerRpc:
         self._client = client
 
     async def connect(self, params: ConnectRequest, *, timeout: float | None = None) -> ConnectResult:
-        """:meta private: Internal SDK API; not part of the public surface."""
+        "Calls connect.\n\nInternal SDK API; not part of the public surface."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return ConnectResult.from_dict(await self._client.request("connect", params_dict, **_timeout_kwargs(timeout)))
 
@@ -7227,6 +7242,7 @@ class AuthApi:
         self._session_id = session_id
 
     async def get_status(self, *, timeout: float | None = None) -> SessionAuthStatus:
+        "Calls session.auth.getStatus."
         return SessionAuthStatus.from_dict(await self._client.request("session.auth.getStatus", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
@@ -7236,9 +7252,11 @@ class ModelApi:
         self._session_id = session_id
 
     async def get_current(self, *, timeout: float | None = None) -> CurrentModel:
+        "Calls session.model.getCurrent."
         return CurrentModel.from_dict(await self._client.request("session.model.getCurrent", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def switch_to(self, params: ModelSwitchToRequest, *, timeout: float | None = None) -> ModelSwitchToResult:
+        "Calls session.model.switchTo."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return ModelSwitchToResult.from_dict(await self._client.request("session.model.switchTo", params_dict, **_timeout_kwargs(timeout)))
@@ -7250,9 +7268,11 @@ class ModeApi:
         self._session_id = session_id
 
     async def get(self, *, timeout: float | None = None) -> Mode:
+        "Calls session.mode.get.\n\nReturns:\n    The agent mode. Valid values: \"interactive\", \"plan\", \"autopilot\"."
         return Mode(await self._client.request("session.mode.get", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def set(self, params: ModeSetRequest, *, timeout: float | None = None) -> None:
+        "Calls session.mode.set."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.mode.set", params_dict, **_timeout_kwargs(timeout))
@@ -7264,9 +7284,11 @@ class NameApi:
         self._session_id = session_id
 
     async def get(self, *, timeout: float | None = None) -> NameGetResult:
+        "Calls session.name.get."
         return NameGetResult.from_dict(await self._client.request("session.name.get", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def set(self, params: NameSetRequest, *, timeout: float | None = None) -> None:
+        "Calls session.name.set."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.name.set", params_dict, **_timeout_kwargs(timeout))
@@ -7278,14 +7300,17 @@ class PlanApi:
         self._session_id = session_id
 
     async def read(self, *, timeout: float | None = None) -> PlanReadResult:
+        "Calls session.plan.read."
         return PlanReadResult.from_dict(await self._client.request("session.plan.read", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def update(self, params: PlanUpdateRequest, *, timeout: float | None = None) -> None:
+        "Calls session.plan.update."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.plan.update", params_dict, **_timeout_kwargs(timeout))
 
     async def delete(self, *, timeout: float | None = None) -> None:
+        "Calls session.plan.delete."
         await self._client.request("session.plan.delete", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
 
@@ -7295,17 +7320,21 @@ class WorkspacesApi:
         self._session_id = session_id
 
     async def get_workspace(self, *, timeout: float | None = None) -> WorkspacesGetWorkspaceResult:
+        "Calls session.workspaces.getWorkspace."
         return WorkspacesGetWorkspaceResult.from_dict(await self._client.request("session.workspaces.getWorkspace", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def list_files(self, *, timeout: float | None = None) -> WorkspacesListFilesResult:
+        "Calls session.workspaces.listFiles."
         return WorkspacesListFilesResult.from_dict(await self._client.request("session.workspaces.listFiles", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def read_file(self, params: WorkspacesReadFileRequest, *, timeout: float | None = None) -> WorkspacesReadFileResult:
+        "Calls session.workspaces.readFile."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return WorkspacesReadFileResult.from_dict(await self._client.request("session.workspaces.readFile", params_dict, **_timeout_kwargs(timeout)))
 
     async def create_file(self, params: WorkspacesCreateFileRequest, *, timeout: float | None = None) -> None:
+        "Calls session.workspaces.createFile."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.workspaces.createFile", params_dict, **_timeout_kwargs(timeout))
@@ -7317,6 +7346,7 @@ class InstructionsApi:
         self._session_id = session_id
 
     async def get_sources(self, *, timeout: float | None = None) -> InstructionsGetSourcesResult:
+        "Calls session.instructions.getSources."
         return InstructionsGetSourcesResult.from_dict(await self._client.request("session.instructions.getSources", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
@@ -7327,6 +7357,7 @@ class FleetApi:
         self._session_id = session_id
 
     async def start(self, params: FleetStartRequest, *, timeout: float | None = None) -> FleetStartResult:
+        "Calls session.fleet.start."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return FleetStartResult.from_dict(await self._client.request("session.fleet.start", params_dict, **_timeout_kwargs(timeout)))
@@ -7339,20 +7370,25 @@ class AgentApi:
         self._session_id = session_id
 
     async def list(self, *, timeout: float | None = None) -> AgentList:
+        "Calls session.agent.list."
         return AgentList.from_dict(await self._client.request("session.agent.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def get_current(self, *, timeout: float | None = None) -> AgentGetCurrentResult:
+        "Calls session.agent.getCurrent."
         return AgentGetCurrentResult.from_dict(await self._client.request("session.agent.getCurrent", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def select(self, params: AgentSelectRequest, *, timeout: float | None = None) -> AgentSelectResult:
+        "Calls session.agent.select."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return AgentSelectResult.from_dict(await self._client.request("session.agent.select", params_dict, **_timeout_kwargs(timeout)))
 
     async def deselect(self, *, timeout: float | None = None) -> None:
+        "Calls session.agent.deselect."
         await self._client.request("session.agent.deselect", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
     async def reload(self, *, timeout: float | None = None) -> AgentReloadResult:
+        "Calls session.agent.reload."
         return AgentReloadResult.from_dict(await self._client.request("session.agent.reload", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
@@ -7363,29 +7399,35 @@ class TasksApi:
         self._session_id = session_id
 
     async def start_agent(self, params: TasksStartAgentRequest, *, timeout: float | None = None) -> TasksStartAgentResult:
+        "Calls session.tasks.startAgent."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return TasksStartAgentResult.from_dict(await self._client.request("session.tasks.startAgent", params_dict, **_timeout_kwargs(timeout)))
 
     async def list(self, *, timeout: float | None = None) -> TaskList:
+        "Calls session.tasks.list."
         return TaskList.from_dict(await self._client.request("session.tasks.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def promote_to_background(self, params: TasksPromoteToBackgroundRequest, *, timeout: float | None = None) -> TasksPromoteToBackgroundResult:
+        "Calls session.tasks.promoteToBackground."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return TasksPromoteToBackgroundResult.from_dict(await self._client.request("session.tasks.promoteToBackground", params_dict, **_timeout_kwargs(timeout)))
 
     async def cancel(self, params: TasksCancelRequest, *, timeout: float | None = None) -> TasksCancelResult:
+        "Calls session.tasks.cancel."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return TasksCancelResult.from_dict(await self._client.request("session.tasks.cancel", params_dict, **_timeout_kwargs(timeout)))
 
     async def remove(self, params: TasksRemoveRequest, *, timeout: float | None = None) -> TasksRemoveResult:
+        "Calls session.tasks.remove."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return TasksRemoveResult.from_dict(await self._client.request("session.tasks.remove", params_dict, **_timeout_kwargs(timeout)))
 
     async def send_message(self, params: TasksSendMessageRequest, *, timeout: float | None = None) -> TasksSendMessageResult:
+        "Calls session.tasks.sendMessage."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return TasksSendMessageResult.from_dict(await self._client.request("session.tasks.sendMessage", params_dict, **_timeout_kwargs(timeout)))
@@ -7398,19 +7440,23 @@ class SkillsApi:
         self._session_id = session_id
 
     async def list(self, *, timeout: float | None = None) -> SkillList:
+        "Calls session.skills.list."
         return SkillList.from_dict(await self._client.request("session.skills.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def enable(self, params: SkillsEnableRequest, *, timeout: float | None = None) -> None:
+        "Calls session.skills.enable."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.skills.enable", params_dict, **_timeout_kwargs(timeout))
 
     async def disable(self, params: SkillsDisableRequest, *, timeout: float | None = None) -> None:
+        "Calls session.skills.disable."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.skills.disable", params_dict, **_timeout_kwargs(timeout))
 
     async def reload(self, *, timeout: float | None = None) -> SkillsLoadDiagnostics:
+        "Calls session.skills.reload."
         return SkillsLoadDiagnostics.from_dict(await self._client.request("session.skills.reload", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
@@ -7421,6 +7467,7 @@ class McpOauthApi:
         self._session_id = session_id
 
     async def login(self, params: MCPOauthLoginRequest, *, timeout: float | None = None) -> MCPOauthLoginResult:
+        "Calls session.mcp.oauth.login."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return MCPOauthLoginResult.from_dict(await self._client.request("session.mcp.oauth.login", params_dict, **_timeout_kwargs(timeout)))
@@ -7434,19 +7481,23 @@ class McpApi:
         self.oauth = McpOauthApi(client, session_id)
 
     async def list(self, *, timeout: float | None = None) -> MCPServerList:
+        "Calls session.mcp.list."
         return MCPServerList.from_dict(await self._client.request("session.mcp.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def enable(self, params: MCPEnableRequest, *, timeout: float | None = None) -> None:
+        "Calls session.mcp.enable."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.mcp.enable", params_dict, **_timeout_kwargs(timeout))
 
     async def disable(self, params: MCPDisableRequest, *, timeout: float | None = None) -> None:
+        "Calls session.mcp.disable."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.mcp.disable", params_dict, **_timeout_kwargs(timeout))
 
     async def reload(self, *, timeout: float | None = None) -> None:
+        "Calls session.mcp.reload."
         await self._client.request("session.mcp.reload", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
 
@@ -7457,6 +7508,7 @@ class PluginsApi:
         self._session_id = session_id
 
     async def list(self, *, timeout: float | None = None) -> PluginList:
+        "Calls session.plugins.list."
         return PluginList.from_dict(await self._client.request("session.plugins.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
@@ -7467,19 +7519,23 @@ class ExtensionsApi:
         self._session_id = session_id
 
     async def list(self, *, timeout: float | None = None) -> ExtensionList:
+        "Calls session.extensions.list."
         return ExtensionList.from_dict(await self._client.request("session.extensions.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def enable(self, params: ExtensionsEnableRequest, *, timeout: float | None = None) -> None:
+        "Calls session.extensions.enable."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.extensions.enable", params_dict, **_timeout_kwargs(timeout))
 
     async def disable(self, params: ExtensionsDisableRequest, *, timeout: float | None = None) -> None:
+        "Calls session.extensions.disable."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.extensions.disable", params_dict, **_timeout_kwargs(timeout))
 
     async def reload(self, *, timeout: float | None = None) -> None:
+        "Calls session.extensions.reload."
         await self._client.request("session.extensions.reload", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
 
@@ -7489,6 +7545,7 @@ class ToolsApi:
         self._session_id = session_id
 
     async def handle_pending_tool_call(self, params: HandlePendingToolCallRequest, *, timeout: float | None = None) -> HandlePendingToolCallResult:
+        "Calls session.tools.handlePendingToolCall."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return HandlePendingToolCallResult.from_dict(await self._client.request("session.tools.handlePendingToolCall", params_dict, **_timeout_kwargs(timeout)))
@@ -7500,21 +7557,25 @@ class CommandsApi:
         self._session_id = session_id
 
     async def list(self, params: CommandsListRequest | None = None, *, timeout: float | None = None) -> CommandList:
+        "Calls session.commands.list."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         params_dict["sessionId"] = self._session_id
         return CommandList.from_dict(await self._client.request("session.commands.list", params_dict, **_timeout_kwargs(timeout)))
 
     async def invoke(self, params: CommandsInvokeRequest, *, timeout: float | None = None) -> SlashCommandInvocationResult:
+        "Calls session.commands.invoke."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return SlashCommandInvocationResult.from_dict(await self._client.request("session.commands.invoke", params_dict, **_timeout_kwargs(timeout)))
 
     async def handle_pending_command(self, params: CommandsHandlePendingCommandRequest, *, timeout: float | None = None) -> CommandsHandlePendingCommandResult:
+        "Calls session.commands.handlePendingCommand."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return CommandsHandlePendingCommandResult.from_dict(await self._client.request("session.commands.handlePendingCommand", params_dict, **_timeout_kwargs(timeout)))
 
     async def respond_to_queued_command(self, params: CommandsRespondToQueuedCommandRequest, *, timeout: float | None = None) -> CommandsRespondToQueuedCommandResult:
+        "Calls session.commands.respondToQueuedCommand."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return CommandsRespondToQueuedCommandResult.from_dict(await self._client.request("session.commands.respondToQueuedCommand", params_dict, **_timeout_kwargs(timeout)))
@@ -7526,11 +7587,13 @@ class UiApi:
         self._session_id = session_id
 
     async def elicitation(self, params: UIElicitationRequest, *, timeout: float | None = None) -> UIElicitationResponse:
+        "Calls session.ui.elicitation.\n\nReturns:\n    The elicitation response (accept with form values, decline, or cancel)"
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return UIElicitationResponse.from_dict(await self._client.request("session.ui.elicitation", params_dict, **_timeout_kwargs(timeout)))
 
     async def handle_pending_elicitation(self, params: UIHandlePendingElicitationRequest, *, timeout: float | None = None) -> UIElicitationResult:
+        "Calls session.ui.handlePendingElicitation."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return UIElicitationResult.from_dict(await self._client.request("session.ui.handlePendingElicitation", params_dict, **_timeout_kwargs(timeout)))
@@ -7542,16 +7605,19 @@ class PermissionsApi:
         self._session_id = session_id
 
     async def handle_pending_permission_request(self, params: PermissionDecisionRequest, *, timeout: float | None = None) -> PermissionRequestResult:
+        "Calls session.permissions.handlePendingPermissionRequest."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return PermissionRequestResult.from_dict(await self._client.request("session.permissions.handlePendingPermissionRequest", params_dict, **_timeout_kwargs(timeout)))
 
     async def set_approve_all(self, params: PermissionsSetApproveAllRequest, *, timeout: float | None = None) -> PermissionsSetApproveAllResult:
+        "Calls session.permissions.setApproveAll."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return PermissionsSetApproveAllResult.from_dict(await self._client.request("session.permissions.setApproveAll", params_dict, **_timeout_kwargs(timeout)))
 
     async def reset_session_approvals(self, *, timeout: float | None = None) -> PermissionsResetSessionApprovalsResult:
+        "Calls session.permissions.resetSessionApprovals."
         return PermissionsResetSessionApprovalsResult.from_dict(await self._client.request("session.permissions.resetSessionApprovals", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
@@ -7561,11 +7627,13 @@ class ShellApi:
         self._session_id = session_id
 
     async def exec(self, params: ShellExecRequest, *, timeout: float | None = None) -> ShellExecResult:
+        "Calls session.shell.exec."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return ShellExecResult.from_dict(await self._client.request("session.shell.exec", params_dict, **_timeout_kwargs(timeout)))
 
     async def kill(self, params: ShellKillRequest, *, timeout: float | None = None) -> ShellKillResult:
+        "Calls session.shell.kill."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return ShellKillResult.from_dict(await self._client.request("session.shell.kill", params_dict, **_timeout_kwargs(timeout)))
@@ -7578,9 +7646,11 @@ class HistoryApi:
         self._session_id = session_id
 
     async def compact(self, *, timeout: float | None = None) -> HistoryCompactResult:
+        "Calls session.history.compact."
         return HistoryCompactResult.from_dict(await self._client.request("session.history.compact", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def truncate(self, params: HistoryTruncateRequest, *, timeout: float | None = None) -> HistoryTruncateResult:
+        "Calls session.history.truncate."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return HistoryTruncateResult.from_dict(await self._client.request("session.history.truncate", params_dict, **_timeout_kwargs(timeout)))
@@ -7593,6 +7663,7 @@ class UsageApi:
         self._session_id = session_id
 
     async def get_metrics(self, *, timeout: float | None = None) -> UsageGetMetricsResult:
+        "Calls session.usage.getMetrics."
         return UsageGetMetricsResult.from_dict(await self._client.request("session.usage.getMetrics", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
@@ -7603,11 +7674,13 @@ class RemoteApi:
         self._session_id = session_id
 
     async def enable(self, params: RemoteEnableRequest, *, timeout: float | None = None) -> RemoteEnableResult:
+        "Calls session.remote.enable."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return RemoteEnableResult.from_dict(await self._client.request("session.remote.enable", params_dict, **_timeout_kwargs(timeout)))
 
     async def disable(self, *, timeout: float | None = None) -> None:
+        "Calls session.remote.disable."
         await self._client.request("session.remote.disable", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
 
@@ -7640,9 +7713,11 @@ class SessionRpc:
         self.remote = RemoteApi(client, session_id)
 
     async def suspend(self, *, timeout: float | None = None) -> None:
+        "Calls session.suspend."
         await self._client.request("session.suspend", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
     async def log(self, params: LogRequest, *, timeout: float | None = None) -> LogResult:
+        "Calls session.log."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return LogResult.from_dict(await self._client.request("session.log", params_dict, **_timeout_kwargs(timeout)))
@@ -7650,24 +7725,34 @@ class SessionRpc:
 
 class SessionFsHandler(Protocol):
     async def read_file(self, params: SessionFSReadFileRequest) -> SessionFSReadFileResult:
+        "Calls sessionFs.readFile."
         pass
     async def write_file(self, params: SessionFSWriteFileRequest) -> SessionFSError | None:
+        "Calls sessionFs.writeFile.\n\nReturns:\n    Describes a filesystem error."
         pass
     async def append_file(self, params: SessionFSAppendFileRequest) -> SessionFSError | None:
+        "Calls sessionFs.appendFile.\n\nReturns:\n    Describes a filesystem error."
         pass
     async def exists(self, params: SessionFSExistsRequest) -> SessionFSExistsResult:
+        "Calls sessionFs.exists."
         pass
     async def stat(self, params: SessionFSStatRequest) -> SessionFSStatResult:
+        "Calls sessionFs.stat."
         pass
     async def mkdir(self, params: SessionFSMkdirRequest) -> SessionFSError | None:
+        "Calls sessionFs.mkdir.\n\nReturns:\n    Describes a filesystem error."
         pass
     async def readdir(self, params: SessionFSReaddirRequest) -> SessionFSReaddirResult:
+        "Calls sessionFs.readdir."
         pass
     async def readdir_with_types(self, params: SessionFSReaddirWithTypesRequest) -> SessionFSReaddirWithTypesResult:
+        "Calls sessionFs.readdirWithTypes."
         pass
     async def rm(self, params: SessionFSRmRequest) -> SessionFSError | None:
+        "Calls sessionFs.rm.\n\nReturns:\n    Describes a filesystem error."
         pass
     async def rename(self, params: SessionFSRenameRequest) -> SessionFSError | None:
+        "Calls sessionFs.rename.\n\nReturns:\n    Describes a filesystem error."
         pass
 
 @dataclass

--- a/python/copilot/generated/rpc.py
+++ b/python/copilot/generated/rpc.py
@@ -7231,7 +7231,7 @@ class _InternalServerRpc:
         self._client = client
 
     async def connect(self, params: ConnectRequest, *, timeout: float | None = None) -> ConnectResult:
-        "Calls connect.\n\nInternal SDK API; not part of the public surface."
+        "Calls connect.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return ConnectResult.from_dict(await self._client.request("connect", params_dict, **_timeout_kwargs(timeout)))
 

--- a/rust/src/generated/rpc.rs
+++ b/rust/src/generated/rpc.rs
@@ -68,6 +68,8 @@ impl<'a> ClientRpc<'a> {
         }
     }
 
+    /// Calls `ping`.
+    ///
     /// Wire method: `ping`.
     pub async fn ping(&self, params: PingRequest) -> Result<PingResult, Error> {
         let wire_params = serde_json::to_value(params)?;
@@ -78,6 +80,8 @@ impl<'a> ClientRpc<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `connect`.
+    ///
     /// Wire method: `connect`.
     pub async fn connect(&self, params: ConnectRequest) -> Result<ConnectResult, Error> {
         let wire_params = serde_json::to_value(params)?;
@@ -96,6 +100,8 @@ pub struct ClientRpcAccount<'a> {
 }
 
 impl<'a> ClientRpcAccount<'a> {
+    /// Calls `account.getQuota`.
+    ///
     /// Wire method: `account.getQuota`.
     pub async fn get_quota(&self) -> Result<AccountGetQuotaResult, Error> {
         let wire_params = serde_json::json!({});
@@ -106,6 +112,8 @@ impl<'a> ClientRpcAccount<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `account.getQuota`.
+    ///
     /// Wire method: `account.getQuota`.
     pub async fn get_quota_with_params(
         &self,
@@ -134,6 +142,8 @@ impl<'a> ClientRpcMcp<'a> {
         }
     }
 
+    /// Calls `mcp.discover`.
+    ///
     /// Wire method: `mcp.discover`.
     pub async fn discover(&self, params: McpDiscoverRequest) -> Result<McpDiscoverResult, Error> {
         let wire_params = serde_json::to_value(params)?;
@@ -152,6 +162,8 @@ pub struct ClientRpcMcpConfig<'a> {
 }
 
 impl<'a> ClientRpcMcpConfig<'a> {
+    /// Calls `mcp.config.list`.
+    ///
     /// Wire method: `mcp.config.list`.
     pub async fn list(&self) -> Result<McpConfigList, Error> {
         let wire_params = serde_json::json!({});
@@ -162,6 +174,8 @@ impl<'a> ClientRpcMcpConfig<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `mcp.config.add`.
+    ///
     /// Wire method: `mcp.config.add`.
     pub async fn add(&self, params: McpConfigAddRequest) -> Result<(), Error> {
         let wire_params = serde_json::to_value(params)?;
@@ -172,6 +186,8 @@ impl<'a> ClientRpcMcpConfig<'a> {
         Ok(())
     }
 
+    /// Calls `mcp.config.update`.
+    ///
     /// Wire method: `mcp.config.update`.
     pub async fn update(&self, params: McpConfigUpdateRequest) -> Result<(), Error> {
         let wire_params = serde_json::to_value(params)?;
@@ -182,6 +198,8 @@ impl<'a> ClientRpcMcpConfig<'a> {
         Ok(())
     }
 
+    /// Calls `mcp.config.remove`.
+    ///
     /// Wire method: `mcp.config.remove`.
     pub async fn remove(&self, params: McpConfigRemoveRequest) -> Result<(), Error> {
         let wire_params = serde_json::to_value(params)?;
@@ -192,6 +210,8 @@ impl<'a> ClientRpcMcpConfig<'a> {
         Ok(())
     }
 
+    /// Calls `mcp.config.enable`.
+    ///
     /// Wire method: `mcp.config.enable`.
     pub async fn enable(&self, params: McpConfigEnableRequest) -> Result<(), Error> {
         let wire_params = serde_json::to_value(params)?;
@@ -202,6 +222,8 @@ impl<'a> ClientRpcMcpConfig<'a> {
         Ok(())
     }
 
+    /// Calls `mcp.config.disable`.
+    ///
     /// Wire method: `mcp.config.disable`.
     pub async fn disable(&self, params: McpConfigDisableRequest) -> Result<(), Error> {
         let wire_params = serde_json::to_value(params)?;
@@ -220,6 +242,8 @@ pub struct ClientRpcModels<'a> {
 }
 
 impl<'a> ClientRpcModels<'a> {
+    /// Calls `models.list`.
+    ///
     /// Wire method: `models.list`.
     pub async fn list(&self) -> Result<ModelList, Error> {
         let wire_params = serde_json::json!({});
@@ -230,6 +254,8 @@ impl<'a> ClientRpcModels<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `models.list`.
+    ///
     /// Wire method: `models.list`.
     pub async fn list_with_params(&self, params: ModelsListRequest) -> Result<ModelList, Error> {
         let wire_params = serde_json::to_value(params)?;
@@ -248,6 +274,8 @@ pub struct ClientRpcSessionFs<'a> {
 }
 
 impl<'a> ClientRpcSessionFs<'a> {
+    /// Calls `sessionFs.setProvider`.
+    ///
     /// Wire method: `sessionFs.setProvider`.
     pub async fn set_provider(
         &self,
@@ -269,6 +297,8 @@ pub struct ClientRpcSessions<'a> {
 }
 
 impl<'a> ClientRpcSessions<'a> {
+    /// Calls `sessions.fork`.
+    ///
     /// Wire method: `sessions.fork`.
     ///
     /// <div class="warning">
@@ -302,6 +332,8 @@ impl<'a> ClientRpcSkills<'a> {
         }
     }
 
+    /// Calls `skills.discover`.
+    ///
     /// Wire method: `skills.discover`.
     pub async fn discover(&self, params: SkillsDiscoverRequest) -> Result<ServerSkillList, Error> {
         let wire_params = serde_json::to_value(params)?;
@@ -320,6 +352,8 @@ pub struct ClientRpcSkillsConfig<'a> {
 }
 
 impl<'a> ClientRpcSkillsConfig<'a> {
+    /// Calls `skills.config.setDisabledSkills`.
+    ///
     /// Wire method: `skills.config.setDisabledSkills`.
     pub async fn set_disabled_skills(
         &self,
@@ -344,6 +378,8 @@ pub struct ClientRpcTools<'a> {
 }
 
 impl<'a> ClientRpcTools<'a> {
+    /// Calls `tools.list`.
+    ///
     /// Wire method: `tools.list`.
     pub async fn list(&self, params: ToolsListRequest) -> Result<ToolList, Error> {
         let wire_params = serde_json::to_value(params)?;
@@ -516,6 +552,8 @@ impl<'a> SessionRpc<'a> {
         }
     }
 
+    /// Calls `session.suspend`.
+    ///
     /// Wire method: `session.suspend`.
     pub async fn suspend(&self) -> Result<(), Error> {
         let wire_params = serde_json::json!({ "sessionId": self.session.id() });
@@ -527,6 +565,8 @@ impl<'a> SessionRpc<'a> {
         Ok(())
     }
 
+    /// Calls `session.log`.
+    ///
     /// Wire method: `session.log`.
     pub async fn log(&self, params: LogRequest) -> Result<LogResult, Error> {
         let mut wire_params = serde_json::to_value(params)?;
@@ -547,6 +587,8 @@ pub struct SessionRpcAgent<'a> {
 }
 
 impl<'a> SessionRpcAgent<'a> {
+    /// Calls `session.agent.list`.
+    ///
     /// Wire method: `session.agent.list`.
     ///
     /// <div class="warning">
@@ -566,6 +608,8 @@ impl<'a> SessionRpcAgent<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.agent.getCurrent`.
+    ///
     /// Wire method: `session.agent.getCurrent`.
     ///
     /// <div class="warning">
@@ -585,6 +629,8 @@ impl<'a> SessionRpcAgent<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.agent.select`.
+    ///
     /// Wire method: `session.agent.select`.
     ///
     /// <div class="warning">
@@ -605,6 +651,8 @@ impl<'a> SessionRpcAgent<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.agent.deselect`.
+    ///
     /// Wire method: `session.agent.deselect`.
     ///
     /// <div class="warning">
@@ -624,6 +672,8 @@ impl<'a> SessionRpcAgent<'a> {
         Ok(())
     }
 
+    /// Calls `session.agent.reload`.
+    ///
     /// Wire method: `session.agent.reload`.
     ///
     /// <div class="warning">
@@ -651,6 +701,8 @@ pub struct SessionRpcAuth<'a> {
 }
 
 impl<'a> SessionRpcAuth<'a> {
+    /// Calls `session.auth.getStatus`.
+    ///
     /// Wire method: `session.auth.getStatus`.
     pub async fn get_status(&self) -> Result<SessionAuthStatus, Error> {
         let wire_params = serde_json::json!({ "sessionId": self.session.id() });
@@ -670,6 +722,8 @@ pub struct SessionRpcCommands<'a> {
 }
 
 impl<'a> SessionRpcCommands<'a> {
+    /// Calls `session.commands.list`.
+    ///
     /// Wire method: `session.commands.list`.
     pub async fn list(&self) -> Result<CommandList, Error> {
         let wire_params = serde_json::json!({ "sessionId": self.session.id() });
@@ -681,6 +735,8 @@ impl<'a> SessionRpcCommands<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.commands.list`.
+    ///
     /// Wire method: `session.commands.list`.
     pub async fn list_with_params(
         &self,
@@ -696,6 +752,8 @@ impl<'a> SessionRpcCommands<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.commands.invoke`.
+    ///
     /// Wire method: `session.commands.invoke`.
     pub async fn invoke(
         &self,
@@ -711,6 +769,8 @@ impl<'a> SessionRpcCommands<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.commands.handlePendingCommand`.
+    ///
     /// Wire method: `session.commands.handlePendingCommand`.
     pub async fn handle_pending_command(
         &self,
@@ -729,6 +789,8 @@ impl<'a> SessionRpcCommands<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.commands.respondToQueuedCommand`.
+    ///
     /// Wire method: `session.commands.respondToQueuedCommand`.
     pub async fn respond_to_queued_command(
         &self,
@@ -755,6 +817,8 @@ pub struct SessionRpcExtensions<'a> {
 }
 
 impl<'a> SessionRpcExtensions<'a> {
+    /// Calls `session.extensions.list`.
+    ///
     /// Wire method: `session.extensions.list`.
     ///
     /// <div class="warning">
@@ -774,6 +838,8 @@ impl<'a> SessionRpcExtensions<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.extensions.enable`.
+    ///
     /// Wire method: `session.extensions.enable`.
     ///
     /// <div class="warning">
@@ -794,6 +860,8 @@ impl<'a> SessionRpcExtensions<'a> {
         Ok(())
     }
 
+    /// Calls `session.extensions.disable`.
+    ///
     /// Wire method: `session.extensions.disable`.
     ///
     /// <div class="warning">
@@ -814,6 +882,8 @@ impl<'a> SessionRpcExtensions<'a> {
         Ok(())
     }
 
+    /// Calls `session.extensions.reload`.
+    ///
     /// Wire method: `session.extensions.reload`.
     ///
     /// <div class="warning">
@@ -841,6 +911,8 @@ pub struct SessionRpcFleet<'a> {
 }
 
 impl<'a> SessionRpcFleet<'a> {
+    /// Calls `session.fleet.start`.
+    ///
     /// Wire method: `session.fleet.start`.
     ///
     /// <div class="warning">
@@ -869,6 +941,8 @@ pub struct SessionRpcHistory<'a> {
 }
 
 impl<'a> SessionRpcHistory<'a> {
+    /// Calls `session.history.compact`.
+    ///
     /// Wire method: `session.history.compact`.
     ///
     /// <div class="warning">
@@ -888,6 +962,8 @@ impl<'a> SessionRpcHistory<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.history.truncate`.
+    ///
     /// Wire method: `session.history.truncate`.
     ///
     /// <div class="warning">
@@ -919,6 +995,8 @@ pub struct SessionRpcInstructions<'a> {
 }
 
 impl<'a> SessionRpcInstructions<'a> {
+    /// Calls `session.instructions.getSources`.
+    ///
     /// Wire method: `session.instructions.getSources`.
     pub async fn get_sources(&self) -> Result<InstructionsGetSourcesResult, Error> {
         let wire_params = serde_json::json!({ "sessionId": self.session.id() });
@@ -948,6 +1026,8 @@ impl<'a> SessionRpcMcp<'a> {
         }
     }
 
+    /// Calls `session.mcp.list`.
+    ///
     /// Wire method: `session.mcp.list`.
     ///
     /// <div class="warning">
@@ -967,6 +1047,8 @@ impl<'a> SessionRpcMcp<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.mcp.enable`.
+    ///
     /// Wire method: `session.mcp.enable`.
     ///
     /// <div class="warning">
@@ -987,6 +1069,8 @@ impl<'a> SessionRpcMcp<'a> {
         Ok(())
     }
 
+    /// Calls `session.mcp.disable`.
+    ///
     /// Wire method: `session.mcp.disable`.
     ///
     /// <div class="warning">
@@ -1007,6 +1091,8 @@ impl<'a> SessionRpcMcp<'a> {
         Ok(())
     }
 
+    /// Calls `session.mcp.reload`.
+    ///
     /// Wire method: `session.mcp.reload`.
     ///
     /// <div class="warning">
@@ -1034,6 +1120,8 @@ pub struct SessionRpcMcpOauth<'a> {
 }
 
 impl<'a> SessionRpcMcpOauth<'a> {
+    /// Calls `session.mcp.oauth.login`.
+    ///
     /// Wire method: `session.mcp.oauth.login`.
     ///
     /// <div class="warning">
@@ -1062,7 +1150,13 @@ pub struct SessionRpcMode<'a> {
 }
 
 impl<'a> SessionRpcMode<'a> {
+    /// Calls `session.mode.get`.
+    ///
     /// Wire method: `session.mode.get`.
+    ///
+    /// # Returns
+    ///
+    /// The agent mode. Valid values: "interactive", "plan", "autopilot".
     pub async fn get(&self) -> Result<SessionMode, Error> {
         let wire_params = serde_json::json!({ "sessionId": self.session.id() });
         let _value = self
@@ -1073,6 +1167,8 @@ impl<'a> SessionRpcMode<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.mode.set`.
+    ///
     /// Wire method: `session.mode.set`.
     pub async fn set(&self, params: ModeSetRequest) -> Result<(), Error> {
         let mut wire_params = serde_json::to_value(params)?;
@@ -1093,6 +1189,8 @@ pub struct SessionRpcModel<'a> {
 }
 
 impl<'a> SessionRpcModel<'a> {
+    /// Calls `session.model.getCurrent`.
+    ///
     /// Wire method: `session.model.getCurrent`.
     pub async fn get_current(&self) -> Result<CurrentModel, Error> {
         let wire_params = serde_json::json!({ "sessionId": self.session.id() });
@@ -1104,6 +1202,8 @@ impl<'a> SessionRpcModel<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.model.switchTo`.
+    ///
     /// Wire method: `session.model.switchTo`.
     pub async fn switch_to(
         &self,
@@ -1127,6 +1227,8 @@ pub struct SessionRpcName<'a> {
 }
 
 impl<'a> SessionRpcName<'a> {
+    /// Calls `session.name.get`.
+    ///
     /// Wire method: `session.name.get`.
     pub async fn get(&self) -> Result<NameGetResult, Error> {
         let wire_params = serde_json::json!({ "sessionId": self.session.id() });
@@ -1138,6 +1240,8 @@ impl<'a> SessionRpcName<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.name.set`.
+    ///
     /// Wire method: `session.name.set`.
     pub async fn set(&self, params: NameSetRequest) -> Result<(), Error> {
         let mut wire_params = serde_json::to_value(params)?;
@@ -1158,6 +1262,8 @@ pub struct SessionRpcPermissions<'a> {
 }
 
 impl<'a> SessionRpcPermissions<'a> {
+    /// Calls `session.permissions.handlePendingPermissionRequest`.
+    ///
     /// Wire method: `session.permissions.handlePendingPermissionRequest`.
     pub async fn handle_pending_permission_request(
         &self,
@@ -1176,6 +1282,8 @@ impl<'a> SessionRpcPermissions<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.permissions.setApproveAll`.
+    ///
     /// Wire method: `session.permissions.setApproveAll`.
     pub async fn set_approve_all(
         &self,
@@ -1194,6 +1302,8 @@ impl<'a> SessionRpcPermissions<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.permissions.resetSessionApprovals`.
+    ///
     /// Wire method: `session.permissions.resetSessionApprovals`.
     pub async fn reset_session_approvals(
         &self,
@@ -1218,6 +1328,8 @@ pub struct SessionRpcPlan<'a> {
 }
 
 impl<'a> SessionRpcPlan<'a> {
+    /// Calls `session.plan.read`.
+    ///
     /// Wire method: `session.plan.read`.
     pub async fn read(&self) -> Result<PlanReadResult, Error> {
         let wire_params = serde_json::json!({ "sessionId": self.session.id() });
@@ -1229,6 +1341,8 @@ impl<'a> SessionRpcPlan<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.plan.update`.
+    ///
     /// Wire method: `session.plan.update`.
     pub async fn update(&self, params: PlanUpdateRequest) -> Result<(), Error> {
         let mut wire_params = serde_json::to_value(params)?;
@@ -1241,6 +1355,8 @@ impl<'a> SessionRpcPlan<'a> {
         Ok(())
     }
 
+    /// Calls `session.plan.delete`.
+    ///
     /// Wire method: `session.plan.delete`.
     pub async fn delete(&self) -> Result<(), Error> {
         let wire_params = serde_json::json!({ "sessionId": self.session.id() });
@@ -1260,6 +1376,8 @@ pub struct SessionRpcPlugins<'a> {
 }
 
 impl<'a> SessionRpcPlugins<'a> {
+    /// Calls `session.plugins.list`.
+    ///
     /// Wire method: `session.plugins.list`.
     ///
     /// <div class="warning">
@@ -1287,6 +1405,8 @@ pub struct SessionRpcRemote<'a> {
 }
 
 impl<'a> SessionRpcRemote<'a> {
+    /// Calls `session.remote.enable`.
+    ///
     /// Wire method: `session.remote.enable`.
     ///
     /// <div class="warning">
@@ -1307,6 +1427,8 @@ impl<'a> SessionRpcRemote<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.remote.disable`.
+    ///
     /// Wire method: `session.remote.disable`.
     ///
     /// <div class="warning">
@@ -1334,6 +1456,8 @@ pub struct SessionRpcShell<'a> {
 }
 
 impl<'a> SessionRpcShell<'a> {
+    /// Calls `session.shell.exec`.
+    ///
     /// Wire method: `session.shell.exec`.
     pub async fn exec(&self, params: ShellExecRequest) -> Result<ShellExecResult, Error> {
         let mut wire_params = serde_json::to_value(params)?;
@@ -1346,6 +1470,8 @@ impl<'a> SessionRpcShell<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.shell.kill`.
+    ///
     /// Wire method: `session.shell.kill`.
     pub async fn kill(&self, params: ShellKillRequest) -> Result<ShellKillResult, Error> {
         let mut wire_params = serde_json::to_value(params)?;
@@ -1366,6 +1492,8 @@ pub struct SessionRpcSkills<'a> {
 }
 
 impl<'a> SessionRpcSkills<'a> {
+    /// Calls `session.skills.list`.
+    ///
     /// Wire method: `session.skills.list`.
     ///
     /// <div class="warning">
@@ -1385,6 +1513,8 @@ impl<'a> SessionRpcSkills<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.skills.enable`.
+    ///
     /// Wire method: `session.skills.enable`.
     ///
     /// <div class="warning">
@@ -1405,6 +1535,8 @@ impl<'a> SessionRpcSkills<'a> {
         Ok(())
     }
 
+    /// Calls `session.skills.disable`.
+    ///
     /// Wire method: `session.skills.disable`.
     ///
     /// <div class="warning">
@@ -1425,6 +1557,8 @@ impl<'a> SessionRpcSkills<'a> {
         Ok(())
     }
 
+    /// Calls `session.skills.reload`.
+    ///
     /// Wire method: `session.skills.reload`.
     ///
     /// <div class="warning">
@@ -1452,6 +1586,8 @@ pub struct SessionRpcTasks<'a> {
 }
 
 impl<'a> SessionRpcTasks<'a> {
+    /// Calls `session.tasks.startAgent`.
+    ///
     /// Wire method: `session.tasks.startAgent`.
     ///
     /// <div class="warning">
@@ -1475,6 +1611,8 @@ impl<'a> SessionRpcTasks<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.tasks.list`.
+    ///
     /// Wire method: `session.tasks.list`.
     ///
     /// <div class="warning">
@@ -1494,6 +1632,8 @@ impl<'a> SessionRpcTasks<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.tasks.promoteToBackground`.
+    ///
     /// Wire method: `session.tasks.promoteToBackground`.
     ///
     /// <div class="warning">
@@ -1520,6 +1660,8 @@ impl<'a> SessionRpcTasks<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.tasks.cancel`.
+    ///
     /// Wire method: `session.tasks.cancel`.
     ///
     /// <div class="warning">
@@ -1540,6 +1682,8 @@ impl<'a> SessionRpcTasks<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.tasks.remove`.
+    ///
     /// Wire method: `session.tasks.remove`.
     ///
     /// <div class="warning">
@@ -1560,6 +1704,8 @@ impl<'a> SessionRpcTasks<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.tasks.sendMessage`.
+    ///
     /// Wire method: `session.tasks.sendMessage`.
     ///
     /// <div class="warning">
@@ -1591,6 +1737,8 @@ pub struct SessionRpcTools<'a> {
 }
 
 impl<'a> SessionRpcTools<'a> {
+    /// Calls `session.tools.handlePendingToolCall`.
+    ///
     /// Wire method: `session.tools.handlePendingToolCall`.
     pub async fn handle_pending_tool_call(
         &self,
@@ -1617,7 +1765,13 @@ pub struct SessionRpcUi<'a> {
 }
 
 impl<'a> SessionRpcUi<'a> {
+    /// Calls `session.ui.elicitation`.
+    ///
     /// Wire method: `session.ui.elicitation`.
+    ///
+    /// # Returns
+    ///
+    /// The elicitation response (accept with form values, decline, or cancel)
     pub async fn elicitation(
         &self,
         params: UIElicitationRequest,
@@ -1632,6 +1786,8 @@ impl<'a> SessionRpcUi<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.ui.handlePendingElicitation`.
+    ///
     /// Wire method: `session.ui.handlePendingElicitation`.
     pub async fn handle_pending_elicitation(
         &self,
@@ -1658,6 +1814,8 @@ pub struct SessionRpcUsage<'a> {
 }
 
 impl<'a> SessionRpcUsage<'a> {
+    /// Calls `session.usage.getMetrics`.
+    ///
     /// Wire method: `session.usage.getMetrics`.
     ///
     /// <div class="warning">
@@ -1685,6 +1843,8 @@ pub struct SessionRpcWorkspaces<'a> {
 }
 
 impl<'a> SessionRpcWorkspaces<'a> {
+    /// Calls `session.workspaces.getWorkspace`.
+    ///
     /// Wire method: `session.workspaces.getWorkspace`.
     pub async fn get_workspace(&self) -> Result<WorkspacesGetWorkspaceResult, Error> {
         let wire_params = serde_json::json!({ "sessionId": self.session.id() });
@@ -1699,6 +1859,8 @@ impl<'a> SessionRpcWorkspaces<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.workspaces.listFiles`.
+    ///
     /// Wire method: `session.workspaces.listFiles`.
     pub async fn list_files(&self) -> Result<WorkspacesListFilesResult, Error> {
         let wire_params = serde_json::json!({ "sessionId": self.session.id() });
@@ -1710,6 +1872,8 @@ impl<'a> SessionRpcWorkspaces<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.workspaces.readFile`.
+    ///
     /// Wire method: `session.workspaces.readFile`.
     pub async fn read_file(
         &self,
@@ -1725,6 +1889,8 @@ impl<'a> SessionRpcWorkspaces<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Calls `session.workspaces.createFile`.
+    ///
     /// Wire method: `session.workspaces.createFile`.
     pub async fn create_file(&self, params: WorkspacesCreateFileRequest) -> Result<(), Error> {
         let mut wire_params = serde_json::to_value(params)?;

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -92,6 +92,79 @@ function xmlDocComment(description: string | undefined, indent: string): string[
     ];
 }
 
+function xmlDocElement(tagName: string, description: string | undefined, indent: string): string[] {
+    if (!description) return [];
+    const escaped = ensureTrailingPunctuation(escapeXml(description.trim()));
+    const lines = escaped.split(/\r?\n/);
+    if (lines.length === 1) {
+        return [`${indent}/// <${tagName}>${lines[0]}</${tagName}>`];
+    }
+    return [
+        `${indent}/// <${tagName}>`,
+        ...lines.map((line) => `${indent}/// ${line}`),
+        `${indent}/// </${tagName}>`,
+    ];
+}
+
+function xmlDocNamedElement(
+    tagName: string,
+    name: string,
+    description: string | undefined,
+    indent: string,
+    escapeDescription = true
+): string[] {
+    if (!description) return [];
+    const preparedDescription = escapeDescription ? escapeXml(description.trim()) : description.trim();
+    const lines = ensureTrailingPunctuation(preparedDescription).split(/\r?\n/);
+    const escapedName = escapeXml(name);
+    if (lines.length === 1) {
+        return [`${indent}/// <${tagName} name="${escapedName}">${lines[0]}</${tagName}>`];
+    }
+    return [
+        `${indent}/// <${tagName} name="${escapedName}">`,
+        ...lines.map((line) => `${indent}/// ${line}`),
+        `${indent}/// </${tagName}>`,
+    ];
+}
+
+function rpcResultDescription(method: RpcMethod, resultSchema: JSONSchema7 | undefined): string | undefined {
+    if (isVoidSchema(resultSchema)) return undefined;
+    return method.result?.description ?? resultSchema?.description;
+}
+
+function rpcParamsDescription(method: RpcMethod, effectiveParams: JSONSchema7 | undefined): string | undefined {
+    return method.params?.description ?? effectiveParams?.description;
+}
+
+function fallbackParameterDescription(name: string): string {
+    return name === "request" ? "The request parameters." : `The ${name} parameter.`;
+}
+
+function pushRpcMethodXmlDocs(
+    lines: string[],
+    method: RpcMethod,
+    indent: string,
+    parameterDescriptions: Array<{ name: string; description?: string; escapeDescription?: boolean }>,
+    resultSchema: JSONSchema7 | undefined
+): void {
+    lines.push(...xmlDocComment(method.description ?? `Calls "${method.rpcMethod}".`, indent));
+    for (const parameter of parameterDescriptions) {
+        lines.push(
+            ...xmlDocNamedElement(
+                "param",
+                parameter.name,
+                parameter.description ?? fallbackParameterDescription(parameter.name),
+                indent,
+                parameter.escapeDescription
+            )
+        );
+    }
+    lines.push(...xmlDocElement("returns", rpcResultDescription(method, resultSchema), indent));
+}
+
+const CANCELLATION_TOKEN_DESCRIPTION =
+    'The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.';
+
 /** Like xmlDocComment but skips XML escaping — use only for codegen-controlled strings that already contain valid XML tags. */
 function rawXmlDocSummary(text: string, indent: string): string[] {
     const line = ensureTrailingPunctuation(text.trim());
@@ -1658,17 +1731,9 @@ function emitServerInstanceMethod(
         if (reqClass) classes.push(reqClass);
     }
 
-    lines.push("");
-    lines.push(`${indent}/// <summary>Calls "${method.rpcMethod}".</summary>`);
-    if (method.stability === "experimental" && !groupExperimental) {
-        pushExperimentalAttribute(lines, indent);
-    }
-    if (method.deprecated && !groupDeprecated) {
-        pushObsoleteAttributes(lines, indent);
-    }
-
     const sigParams: string[] = [];
     const bodyAssignments: string[] = [];
+    const parameterDescriptions: Array<{ name: string; description?: string; escapeDescription?: boolean }> = [];
 
     for (const [pName, pSchema] of paramEntries) {
         if (typeof pSchema !== "object") continue;
@@ -1679,11 +1744,25 @@ function emitServerInstanceMethod(
             : schemaTypeToCSharp(jsonSchema, isReq, rpcKnownTypes);
         sigParams.push(`${csType} ${pName}${isReq ? "" : " = null"}`);
         bodyAssignments.push(`${toPascalCase(pName)} = ${pName}`);
+        parameterDescriptions.push({ name: pName, description: jsonSchema.description });
     }
     sigParams.push("CancellationToken cancellationToken = default");
+    parameterDescriptions.push({
+        name: "cancellationToken",
+        description: CANCELLATION_TOKEN_DESCRIPTION,
+        escapeDescription: false,
+    });
 
     const taskType = !isVoidSchema(resultSchema) ? `Task<${resultClassName}>` : "Task";
     const localRequestName = localRequestVariableName(paramEntries);
+    lines.push("");
+    pushRpcMethodXmlDocs(lines, method, indent, parameterDescriptions, resultSchema);
+    if (method.stability === "experimental" && !groupExperimental) {
+        pushExperimentalAttribute(lines, indent);
+    }
+    if (method.deprecated && !groupDeprecated) {
+        pushObsoleteAttributes(lines, indent);
+    }
     lines.push(`${indent}${methodVisibility} async ${taskType} ${methodName}Async(${sigParams.join(", ")})`);
     lines.push(`${indent}{`);
     if (requestClassName && bodyAssignments.length > 0) {
@@ -1783,18 +1862,13 @@ function emitSessionMethod(key: string, method: RpcMethod, lines: string[], clas
         }
     }
 
-    lines.push("", `${indent}/// <summary>Calls "${method.rpcMethod}".</summary>`);
-    if (method.stability === "experimental" && !groupExperimental) {
-        pushExperimentalAttribute(lines, indent);
-    }
-    if (method.deprecated && !groupDeprecated) {
-        pushObsoleteAttributes(lines, indent);
-    }
     const sigParams: string[] = [];
     const bodyAssignments = [`SessionId = _sessionId`];
+    const parameterDescriptions: Array<{ name: string; description?: string; escapeDescription?: boolean }> = [];
 
     if (useRequestParameter) {
         sigParams.push(`${requestClassName}? request = null`);
+        parameterDescriptions.push({ name: "request", description: rpcParamsDescription(method, effectiveParams) });
         for (const [pName] of paramEntries) {
             bodyAssignments.push(`${toPascalCase(pName)} = request?.${toPascalCase(pName)}`);
         }
@@ -1805,12 +1879,26 @@ function emitSessionMethod(key: string, method: RpcMethod, lines: string[], clas
             const csType = resolveRpcType(pSchema as JSONSchema7, isReq, requestClassName, toPascalCase(pName), classes);
             sigParams.push(`${csType} ${pName}${isReq ? "" : " = null"}`);
             bodyAssignments.push(`${toPascalCase(pName)} = ${pName}`);
+            parameterDescriptions.push({ name: pName, description: (pSchema as JSONSchema7).description });
         }
     }
     sigParams.push("CancellationToken cancellationToken = default");
+    parameterDescriptions.push({
+        name: "cancellationToken",
+        description: CANCELLATION_TOKEN_DESCRIPTION,
+        escapeDescription: false,
+    });
 
     const taskType = !isVoidSchema(resultSchema) ? `Task<${resultClassName}>` : "Task";
     const localRequestName = localRequestVariableName(paramEntries, useRequestParameter);
+    lines.push("");
+    pushRpcMethodXmlDocs(lines, method, indent, parameterDescriptions, resultSchema);
+    if (method.stability === "experimental" && !groupExperimental) {
+        pushExperimentalAttribute(lines, indent);
+    }
+    if (method.deprecated && !groupDeprecated) {
+        pushObsoleteAttributes(lines, indent);
+    }
     lines.push(`${indent}${methodVisibility} async ${taskType} ${methodName}Async(${sigParams.join(", ")})`);
     lines.push(`${indent}{`, `${indent}    var ${localRequestName} = new ${wireRequestClassName} { ${bodyAssignments.join(", ")} };`);
     if (!isVoidSchema(resultSchema)) {
@@ -1920,7 +2008,16 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>,
             const hasParams = !!effectiveParams?.properties && Object.keys(effectiveParams.properties).length > 0;
             const resultSchema = getMethodResultSchema(method);
             const taskType = resultTaskType(method);
-            lines.push(`    /// <summary>Handles "${method.rpcMethod}".</summary>`);
+            pushRpcMethodXmlDocs(
+                lines,
+                method,
+                "    ",
+                [
+                    ...(hasParams ? [{ name: "request", description: rpcParamsDescription(method, effectiveParams) }] : []),
+                    { name: "cancellationToken", description: CANCELLATION_TOKEN_DESCRIPTION, escapeDescription: false },
+                ],
+                resultSchema
+            );
             if (method.stability === "experimental" && !groupExperimental) {
                 pushExperimentalAttribute(lines, "    ");
             }

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -71,6 +71,10 @@ function escapeXml(text: string): string {
     return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
+function escapeXmlAttribute(text: string): string {
+    return escapeXml(text).replace(/"/g, "&quot;").replace(/'/g, "&apos;");
+}
+
 /** Ensures text ends with sentence-ending punctuation. */
 function ensureTrailingPunctuation(text: string): string {
     const trimmed = text.trimEnd();
@@ -116,7 +120,7 @@ function xmlDocNamedElement(
     if (!description) return [];
     const preparedDescription = escapeDescription ? escapeXml(description.trim()) : description.trim();
     const lines = ensureTrailingPunctuation(preparedDescription).split(/\r?\n/);
-    const escapedName = escapeXml(name);
+    const escapedName = escapeXmlAttribute(name);
     if (lines.length === 1) {
         return [`${indent}/// <${tagName} name="${escapedName}">${lines[0]}</${tagName}>`];
     }
@@ -145,9 +149,10 @@ function pushRpcMethodXmlDocs(
     method: RpcMethod,
     indent: string,
     parameterDescriptions: Array<{ name: string; description?: string; escapeDescription?: boolean }>,
-    resultSchema: JSONSchema7 | undefined
+    resultSchema: JSONSchema7 | undefined,
+    summaryFallback?: string
 ): void {
-    lines.push(...xmlDocComment(method.description ?? `Calls "${method.rpcMethod}".`, indent));
+    lines.push(...xmlDocComment(method.description ?? summaryFallback ?? `Calls "${method.rpcMethod}".`, indent));
     for (const parameter of parameterDescriptions) {
         lines.push(
             ...xmlDocNamedElement(
@@ -2016,7 +2021,8 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>,
                     ...(hasParams ? [{ name: "request", description: rpcParamsDescription(method, effectiveParams) }] : []),
                     { name: "cancellationToken", description: CANCELLATION_TOKEN_DESCRIPTION, escapeDescription: false },
                 ],
-                resultSchema
+                resultSchema,
+                `Handles "${method.rpcMethod}".`
             );
             if (method.stability === "experimental" && !groupExperimental) {
                 pushExperimentalAttribute(lines, "    ");

--- a/scripts/codegen/go.ts
+++ b/scripts/codegen/go.ts
@@ -163,6 +163,46 @@ function pushGoExperimentalMethodComment(lines: string[], methodName: string, in
     pushGoComment(lines, `Experimental: ${methodName} is an experimental API and may change or be removed in future versions.`, indent);
 }
 
+function lowerFirst(value: string): string {
+    if (value.length === 0) return value;
+    return value.charAt(0).toLowerCase() + value.slice(1);
+}
+
+function goMethodDocSummary(methodName: string, method: RpcMethod): string {
+    const description = method.description?.trim();
+    if (!description) return `${methodName} calls ${method.rpcMethod}.`;
+    if (description.startsWith(methodName)) return description;
+    return `${methodName} ${lowerFirst(description)}`;
+}
+
+function goRpcResultDescription(method: RpcMethod, resultSchema: JSONSchema7 | undefined): string | undefined {
+    if (isVoidSchema(resultSchema)) return undefined;
+    return method.result?.description ?? resultSchema?.description;
+}
+
+function goRpcParamsDescription(method: RpcMethod, effectiveParams: JSONSchema7 | undefined): string | undefined {
+    return method.params?.description ?? effectiveParams?.description;
+}
+
+function pushGoRpcMethodComment(
+    lines: string[],
+    methodName: string,
+    method: RpcMethod,
+    resultSchema: JSONSchema7 | undefined,
+    paramsDescription?: string,
+    indent = ""
+): void {
+    const paragraphs = [goMethodDocSummary(methodName, method), `RPC method: ${method.rpcMethod}.`];
+    if (paramsDescription) {
+        paragraphs.push(`Parameters: ${paramsDescription}`);
+    }
+    const resultDescription = goRpcResultDescription(method, resultSchema);
+    if (resultDescription) {
+        paragraphs.push(`Returns: ${resultDescription}`);
+    }
+    pushGoComment(lines, paragraphs.join("\n\n"), indent);
+}
+
 function goCommentLines(text: string, indent = "", wrap = true): string[] {
     const prefix = `${indent}//`;
     const lines: string[] = [];
@@ -3721,6 +3761,13 @@ function emitMethod(lines: string[], receiver: string, name: string, method: Rpc
     const clientRef = isWrapper ? "a.common.client" : "a.client";
     const sessionIDRef = isWrapper ? "a.common.sessionID" : "a.sessionID";
 
+    pushGoRpcMethodComment(
+        lines,
+        methodName,
+        method,
+        resultSchema,
+        hasParams ? goRpcParamsDescription(method, effectiveParams) : undefined
+    );
     if (method.deprecated && !groupDeprecated) {
         pushGoComment(lines, `Deprecated: ${methodName} is deprecated and will be removed in a future version.`);
     }
@@ -3834,6 +3881,15 @@ function emitClientSessionApiRegistration(lines: string[], clientSchema: Record<
         }
         lines.push(`type ${interfaceName} interface {`);
         for (const method of methods) {
+            const resultSchema = getMethodResultSchema(method);
+            pushGoRpcMethodComment(
+                lines,
+                clientHandlerMethodName(method.rpcMethod),
+                method,
+                resultSchema,
+                goRpcParamsDescription(method, getMethodParamsSchema(method)),
+                "\t"
+            );
             if (method.deprecated && !groupDeprecated) {
                 pushGoComment(lines, `Deprecated: ${clientHandlerMethodName(method.rpcMethod)} is deprecated and will be removed in a future version.`, "\t");
             }
@@ -3841,7 +3897,6 @@ function emitClientSessionApiRegistration(lines: string[], clientSchema: Record<
                 pushGoExperimentalMethodComment(lines, clientHandlerMethodName(method.rpcMethod), "\t");
             }
             const paramsType = resolveType(goParamsTypeName(method));
-            const resultSchema = getMethodResultSchema(method);
             const nullableInner = resultSchema ? getNullableInner(resultSchema) : undefined;
             const resultType = nullableInner
                 ? resolveType(goNullableResultTypeName(method, nullableInner))

--- a/scripts/codegen/go.ts
+++ b/scripts/codegen/go.ts
@@ -168,9 +168,9 @@ function lowerFirst(value: string): string {
     return value.charAt(0).toLowerCase() + value.slice(1);
 }
 
-function goMethodDocSummary(methodName: string, method: RpcMethod): string {
+function goMethodDocSummary(methodName: string, method: RpcMethod, fallbackVerb = "calls"): string {
     const description = method.description?.trim();
-    if (!description) return `${methodName} calls ${method.rpcMethod}.`;
+    if (!description) return `${methodName} ${fallbackVerb} ${method.rpcMethod}.`;
     if (description.startsWith(methodName)) return description;
     return `${methodName} ${lowerFirst(description)}`;
 }
@@ -190,9 +190,10 @@ function pushGoRpcMethodComment(
     method: RpcMethod,
     resultSchema: JSONSchema7 | undefined,
     paramsDescription?: string,
-    indent = ""
+    indent = "",
+    fallbackVerb = "calls"
 ): void {
-    const paragraphs = [goMethodDocSummary(methodName, method), `RPC method: ${method.rpcMethod}.`];
+    const paragraphs = [goMethodDocSummary(methodName, method, fallbackVerb), `RPC method: ${method.rpcMethod}.`];
     if (paramsDescription) {
         paragraphs.push(`Parameters: ${paramsDescription}`);
     }
@@ -3888,7 +3889,8 @@ function emitClientSessionApiRegistration(lines: string[], clientSchema: Record<
                 method,
                 resultSchema,
                 goRpcParamsDescription(method, getMethodParamsSchema(method)),
-                "\t"
+                "\t",
+                "handles"
             );
             if (method.deprecated && !groupDeprecated) {
                 pushGoComment(lines, `Deprecated: ${clientHandlerMethodName(method.rpcMethod)} is deprecated and will be removed in a future version.`, "\t");

--- a/scripts/codegen/python.ts
+++ b/scripts/codegen/python.ts
@@ -277,6 +277,48 @@ function pyDocstringLiteral(text: string): string {
     return JSON.stringify(normalized);
 }
 
+function rpcResultDescription(method: RpcMethod, resultSchema: JSONSchema7 | undefined): string | undefined {
+    if (isVoidSchema(resultSchema)) return undefined;
+    return method.result?.description ?? resultSchema?.description;
+}
+
+function rpcParamsDescription(method: RpcMethod, effectiveParams: JSONSchema7 | undefined): string | undefined {
+    return method.params?.description ?? effectiveParams?.description;
+}
+
+function pushPyRpcMethodDocstring(
+    lines: string[],
+    indent: string,
+    method: RpcMethod,
+    options: {
+        paramsName?: string;
+        paramsDescription?: string;
+        resultDescription?: string;
+        deprecated?: boolean;
+        experimental?: boolean;
+        internal?: boolean;
+    } = {}
+): void {
+    const sections: string[] = [method.description ?? `Calls ${method.rpcMethod}.`];
+    if (options.paramsName && options.paramsDescription) {
+        sections.push(`Args:\n    ${options.paramsName}: ${options.paramsDescription}`);
+    }
+    if (options.resultDescription) {
+        sections.push(`Returns:\n    ${options.resultDescription}`);
+    }
+    if (options.deprecated) {
+        sections.push("Deprecated:\n    This API is deprecated and will be removed in a future version.");
+    }
+    if (options.experimental) {
+        sections.push("Warning:\n    This API is experimental and may change or be removed in future versions.");
+    }
+    if (options.internal) {
+        sections.push("Internal SDK API; not part of the public surface.");
+    }
+
+    lines.push(`${indent}${pyDocstringLiteral(sections.join("\n\n"))}`);
+}
+
 function modernizePython(code: string): string {
     // Replace Optional[X] with X | None (handles arbitrarily nested brackets)
     code = replaceBalancedBrackets(code, "Optional", (inner) => `${inner} | None`);
@@ -2463,15 +2505,14 @@ function emitMethod(lines: string[], name: string, method: RpcMethod, isSession:
 
     lines.push(sig);
 
-    if (method.deprecated && !groupDeprecated) {
-        lines.push(`        """.. deprecated:: This API is deprecated and will be removed in a future version."""`);
-    }
-    if (method.stability === "experimental" && !groupExperimental) {
-        lines.push(`        """.. warning:: This API is experimental and may change or be removed in future versions."""`);
-    }
-    if (method.visibility === "internal") {
-        lines.push(`        """:meta private: Internal SDK API; not part of the public surface."""`);
-    }
+    pushPyRpcMethodDocstring(lines, "        ", method, {
+        paramsName: hasParams ? "params" : undefined,
+        paramsDescription: rpcParamsDescription(method, effectiveParams),
+        resultDescription: rpcResultDescription(method, resultSchema),
+        deprecated: method.deprecated && !groupDeprecated,
+        experimental: method.stability === "experimental" && !groupExperimental,
+        internal: method.visibility === "internal",
+    });
 
     // Deserialize helper
     const innerTypeName = hasNullableResult ? resolveType(pythonResultTypeName(method, nullableInner)) : resultType;
@@ -2606,12 +2647,13 @@ function emitClientSessionHandlerMethod(
         resultType = "None";
     }
     lines.push(`    async def ${toSnakeCase(name)}(self, params: ${paramsType}) -> ${resultType}:`);
-    if (method.deprecated && !groupDeprecated) {
-        lines.push(`        """.. deprecated:: This API is deprecated and will be removed in a future version."""`);
-    }
-    if (method.stability === "experimental" && !groupExperimental) {
-        lines.push(`        """.. warning:: This API is experimental and may change or be removed in future versions."""`);
-    }
+    pushPyRpcMethodDocstring(lines, "        ", method, {
+        paramsName: "params",
+        paramsDescription: rpcParamsDescription(method, getMethodParamsSchema(method)),
+        resultDescription: rpcResultDescription(method, resultSchema),
+        deprecated: method.deprecated && !groupDeprecated,
+        experimental: method.stability === "experimental" && !groupExperimental,
+    });
     lines.push(`        pass`);
 }
 

--- a/scripts/codegen/python.ts
+++ b/scripts/codegen/python.ts
@@ -307,13 +307,13 @@ function pushPyRpcMethodDocstring(
         sections.push(`Returns:\n    ${options.resultDescription}`);
     }
     if (options.deprecated) {
-        sections.push("Deprecated:\n    This API is deprecated and will be removed in a future version.");
+        sections.push(".. deprecated:: This API is deprecated and will be removed in a future version.");
     }
     if (options.experimental) {
-        sections.push("Warning:\n    This API is experimental and may change or be removed in future versions.");
+        sections.push(".. warning:: This API is experimental and may change or be removed in future versions.");
     }
     if (options.internal) {
-        sections.push("Internal SDK API; not part of the public surface.");
+        sections.push(":meta private:\n\nInternal SDK API; not part of the public surface.");
     }
 
     lines.push(`${indent}${pyDocstringLiteral(sections.join("\n\n"))}`);

--- a/scripts/codegen/rust.ts
+++ b/scripts/codegen/rust.ts
@@ -432,6 +432,58 @@ function pushRustExperimentalDocs(
 	lines.push(`${indent}/// </div>`);
 }
 
+function pushRustDoc(lines: string[], text: string | undefined, indent = ""): void {
+	if (!text) return;
+	for (const paragraph of text.trim().split(/\r?\n/)) {
+		if (paragraph.trim().length === 0) {
+			lines.push(`${indent}///`);
+		} else {
+			lines.push(`${indent}/// ${paragraph.trim()}`);
+		}
+	}
+}
+
+function rustRpcResultDescription(
+	method: RpcMethod,
+	resultSchema: JSONSchema7 | undefined,
+): string | undefined {
+	if (isVoidSchema(resultSchema)) return undefined;
+	return method.result?.description ?? resultSchema?.description;
+}
+
+function rustRpcParamsDescription(
+	method: RpcMethod,
+	resolvedParams: JSONSchema7 | undefined,
+): string | undefined {
+	return method.params?.description ?? resolvedParams?.description;
+}
+
+function rustRpcMethodDocs(
+	method: RpcMethod,
+	resultSchema: JSONSchema7 | undefined,
+	paramsDescription: string | undefined,
+	includeParams: boolean,
+): string[] {
+	const docs: string[] = [];
+	pushRustDoc(docs, method.description ?? `Calls \`${method.rpcMethod}\`.`, "    ");
+	docs.push("    ///");
+	docs.push(`    /// Wire method: \`${method.rpcMethod}\`.`);
+	if (includeParams && paramsDescription) {
+		docs.push("    ///");
+		docs.push("    /// # Parameters");
+		docs.push("    ///");
+		pushRustDoc(docs, `* \`params\` - ${paramsDescription}`, "    ");
+	}
+	const resultDescription = rustRpcResultDescription(method, resultSchema);
+	if (resultDescription) {
+		docs.push("    ///");
+		docs.push("    /// # Returns");
+		docs.push("    ///");
+		pushRustDoc(docs, resultDescription, "    ");
+	}
+	return docs;
+}
+
 // ── Type resolution ─────────────────────────────────────────────────────────
 
 function rustRefTypeName(ref: string, definitions?: DefinitionCollections): string {
@@ -1104,13 +1156,23 @@ function collectRpcMethods(
 	return methods;
 }
 
-function rustParamsTypeName(method: RpcMethod, ctx: RustCodegenCtx): string {
-	if (method.params?.$ref && parseExternalSchemaRef(method.params.$ref)) {
-		recordExternalRustTypeRef(method.params.$ref, ctx);
-		return rustRefTypeName(method.params.$ref);
+function rustParamsTypeName(
+	method: RpcMethod,
+	context: DefinitionCollections | RustCodegenCtx,
+): string {
+	const ctx = "externalTypeRefs" in context ? context : undefined;
+	const defCollections = ctx?.definitions ?? context;
+	const params = method.params as (JSONSchema7 & { $ref?: string }) | undefined;
+	if (typeof params?.$ref === "string") {
+		if (ctx) {
+			recordExternalRustTypeRef(params.$ref, ctx);
+		}
+		return rustRefTypeName(params.$ref, defCollections);
 	}
+
+	const resolved = params ? resolveSchema(params, defCollections) : undefined;
 	return getRpcSchemaTypeName(
-		method.params,
+		resolved ?? params,
 		`${toPascalCase(method.rpcMethod)}Params`,
 	);
 }
@@ -1124,6 +1186,66 @@ function rustResultTypeName(method: RpcMethod, ctx: RustCodegenCtx): string {
 		method.result,
 		`${toPascalCase(method.rpcMethod)}Result`,
 	);
+}
+
+function asGeneratedObjectSchema(
+	schema: JSONSchema7,
+	defCollections: DefinitionCollections,
+): JSONSchema7 | undefined {
+	const resolved = resolveObjectSchema(schema, defCollections);
+	if (!resolved || !isObjectSchema(resolved)) return undefined;
+
+	return {
+		...resolved,
+		title: resolved.title ?? schema.title,
+		description: schema.description ?? resolved.description,
+	};
+}
+
+function getMethodParamsObjectSchema(
+	method: RpcMethod,
+	defCollections: DefinitionCollections,
+	isSession: boolean,
+): JSONSchema7 | undefined {
+	if (!method.params) return undefined;
+
+	const resolved = asGeneratedObjectSchema(method.params, defCollections);
+	if (!resolved) return undefined;
+
+	const properties = { ...(resolved.properties ?? {}) };
+	if (isSession) {
+		delete properties.sessionId;
+	}
+
+	if (Object.keys(properties).length === 0) return undefined;
+
+	const required = (resolved.required ?? [])
+		.filter((name) => !isSession || name !== "sessionId")
+		.filter((name) => Object.prototype.hasOwnProperty.call(properties, name));
+
+	const schema: JSONSchema7 = {
+		...resolved,
+		properties,
+		description: method.params.description ?? resolved.description,
+	};
+
+	if (required.length > 0) {
+		schema.required = required;
+	} else {
+		delete schema.required;
+	}
+
+	return schema;
+}
+
+function isNullableParamsSchema(
+	params: JSONSchema7,
+	defCollections: DefinitionCollections,
+): boolean {
+	if (getNullableInner(params)) return true;
+
+	const resolved = resolveSchema(params, defCollections);
+	return !!resolved && !!getNullableInner(resolved);
 }
 
 function generateApiTypesCode(apiSchema: ApiSchema): string {
@@ -1146,24 +1268,35 @@ function generateApiTypesCode(apiSchema: ApiSchema): string {
 				schema.description,
 				isSchemaExperimental(schema),
 			);
+		} else if (asGeneratedObjectSchema(schema, defCollections)) {
+			emitRustStruct(
+				name,
+				asGeneratedObjectSchema(schema, defCollections)!,
+				ctx,
+				schema.description,
+			);
 		} else if (getUnionVariants(schema)) {
 			tryEmitRustUnion(schema, name, "", ctx);
-		} else if (isObjectSchema(schema)) {
-			emitRustStruct(name, schema, ctx, schema.description);
 		}
 	}
 
 	// Collect all RPC methods and generate request/response types
-	const allMethods: RpcMethod[] = [];
-	for (const group of [
-		apiSchema.server,
-		apiSchema.session,
-		apiSchema.clientSession,
+	const methodEntries: { method: RpcMethod; isSession: boolean }[] = [];
+	for (const { group, isSession } of [
+		{ group: apiSchema.server, isSession: false },
+		{ group: apiSchema.session, isSession: true },
+		{ group: apiSchema.clientSession, isSession: false },
 	]) {
 		if (group) {
-			allMethods.push(...collectRpcMethods(group as Record<string, unknown>));
+			methodEntries.push(
+				...collectRpcMethods(group as Record<string, unknown>).map((method) => ({
+					method,
+					isSession,
+				})),
+			);
 		}
 	}
+	const allMethods = methodEntries.map(({ method }) => method);
 
 	// RPC method name constants
 	const methodConstLines: string[] = [];
@@ -1180,14 +1313,24 @@ function generateApiTypesCode(apiSchema: ApiSchema): string {
 	methodConstLines.push("}");
 
 	// Generate param/result types for each method
-	for (const method of allMethods) {
-		if (
-			method.params &&
-			isObjectSchema(method.params) &&
-			!isVoidSchema(method.params)
-		) {
+	for (const { method, isSession } of methodEntries) {
+		const paramsSchema = getMethodParamsObjectSchema(
+			method,
+			defCollections,
+			isSession,
+		);
+		const sessionWireParamsSchema = isSession && !paramsSchema && method.params
+			? asGeneratedObjectSchema(method.params, defCollections)
+			: undefined;
+		const generatedParamsSchema = paramsSchema ?? sessionWireParamsSchema;
+		if (generatedParamsSchema) {
 			const paramsName = rustParamsTypeName(method, ctx);
-			emitRustStruct(paramsName, method.params, ctx, method.params.description);
+			emitRustStruct(
+				paramsName,
+				generatedParamsSchema,
+				ctx,
+				generatedParamsSchema.description,
+			);
 		}
 		if (method.result && !isVoidSchema(method.result)) {
 			const resultName = rustResultTypeName(method, ctx);
@@ -1319,29 +1462,22 @@ function getMethodParamsInfo(
 	isSession: boolean,
 ): { hasParams: boolean; optional: boolean; typeName: string | null } {
 	if (!method.params) return { hasParams: false, optional: false, typeName: null };
-	const inline = method.params as JSONSchema7 & { $ref?: string };
-	const resolved = resolveObjectSchema(inline, defCollections) ??
-		resolveSchema(inline, defCollections);
-	if (!resolved) return { hasParams: false, optional: false, typeName: null };
+	const paramsSchema = getMethodParamsObjectSchema(
+		method,
+		defCollections,
+		isSession,
+	);
+	if (!paramsSchema) return { hasParams: false, optional: false, typeName: null };
 
-	let typeName: string | null = null;
-	if (typeof inline.$ref === "string") {
-		typeName = refTypeName(inline.$ref, defCollections);
-	} else if (typeof resolved.title === "string") {
-		typeName = resolved.title;
-	} else if (typeof inline.title === "string") {
-		typeName = inline.title;
-	}
+	const typeName = rustParamsTypeName(method, defCollections);
 
-	const allProps = Object.keys(resolved.properties || {});
-	const props = isSession
-		? allProps.filter((p) => p !== "sessionId")
-		: allProps;
+	const props = Object.keys(paramsSchema.properties || {});
 	if (props.length === 0) return { hasParams: false, optional: false, typeName: null };
 	if (!typeName) return { hasParams: false, optional: false, typeName: null };
-	const required = new Set(resolved.required || []);
+	const required = new Set(paramsSchema.required || []);
 	const hasRequiredParams = props.some((p) => required.has(p));
-	const optional = !!getNullableInner(inline) && !hasRequiredParams;
+	const optional = isNullableParamsSchema(method.params, defCollections) &&
+		!hasRequiredParams;
 	return { hasParams: true, optional, typeName };
 }
 
@@ -1489,52 +1625,67 @@ function emitNamespaceMethod(
 	const paramsInfo = getMethodParamsInfo(method, defCollections, isSession);
 	const hasParams = paramsInfo.hasParams;
 	const paramsTypeName = paramsInfo.typeName;
+	const resolvedParams = method.params
+		? (resolveObjectSchema(method.params, defCollections) ??
+			resolveSchema(method.params, defCollections) ??
+			method.params)
+		: undefined;
 
 	const resultTypeName = getResultTypeName(method, defCollections);
+	const resultSchema = method.result
+		? (resolveSchema(method.result, defCollections) ?? method.result)
+		: undefined;
 	const returnType = resultTypeName ? resultTypeName : "()";
 	const resultIsVoid = resultTypeName === null;
 
-	const docs: string[] = [];
-	docs.push(`    /// Wire method: \`${wireMethod}\`.`);
-	if (method.deprecated) docs.push(...rustDeprecatedAttributes("    "));
-	const stability = method.stability;
-	if (stability === "experimental") {
-		docs.push(`    ///`);
-		docs.push(
-			`    /// <div class="warning">`,
+	const buildDocs = (includeParams: boolean): string[] => {
+		const docs = rustRpcMethodDocs(
+			method,
+			resultSchema,
+			rustRpcParamsDescription(method, resolvedParams),
+			includeParams,
 		);
-		docs.push(
-			`    ///`,
-		);
-		docs.push(
-			`    /// **Experimental.** This API is part of an experimental wire-protocol surface`,
-		);
-		docs.push(
-			`    /// and may change or be removed in future SDK or CLI releases. Pin both the`,
-		);
-		docs.push(
-			`    /// SDK and CLI versions if your code depends on it.`,
-		);
-		docs.push(
-			`    ///`,
-		);
-		docs.push(
-			`    /// </div>`,
-		);
-	} else if (stability && stability !== "stable") {
-		docs.push(`    /// Stability: \`${stability}\`.`);
-	}
+		if (method.deprecated) docs.push(...rustDeprecatedAttributes("    "));
+		const stability = method.stability;
+		if (stability === "experimental") {
+			docs.push(`    ///`);
+			docs.push(
+				`    /// <div class="warning">`,
+			);
+			docs.push(
+				`    ///`,
+			);
+			docs.push(
+				`    /// **Experimental.** This API is part of an experimental wire-protocol surface`,
+			);
+			docs.push(
+				`    /// and may change or be removed in future SDK or CLI releases. Pin both the`,
+			);
+			docs.push(
+				`    /// SDK and CLI versions if your code depends on it.`,
+			);
+			docs.push(
+				`    ///`,
+			);
+			docs.push(
+				`    /// </div>`,
+			);
+		} else if (stability && stability !== "stable") {
+			docs.push(`    /// Stability: \`${stability}\`.`);
+		}
+		return docs;
+	};
 
 	const paramArg = hasParams ? `, params: ${paramsTypeName}` : "";
 
-	out.push(...docs);
 	if (hasParams && paramsInfo.optional) {
+		out.push(...buildDocs(false));
 		out.push(
 			`    pub async fn ${fnName}(&self) -> Result<${returnType}, Error> {`,
 		);
 		pushNamespaceMethodBody(out, constName, isSession, false, resultIsVoid);
 		out.push("");
-		out.push(...docs);
+		out.push(...buildDocs(true));
 		out.push(
 			`    pub async fn ${fnName}_with_params(&self, params: ${paramsTypeName}) -> Result<${returnType}, Error> {`,
 		);
@@ -1543,6 +1694,7 @@ function emitNamespaceMethod(
 		return;
 	}
 
+	out.push(...buildDocs(hasParams));
 	out.push(
 		`    pub async fn ${fnName}(&self${paramArg}) -> Result<${returnType}, Error> {`,
 	);

--- a/scripts/codegen/typescript.ts
+++ b/scripts/codegen/typescript.ts
@@ -46,6 +46,65 @@ function tsExperimentalJSDoc(indent = ""): string {
     return `${indent}${TS_EXPERIMENTAL_JSDOC}`;
 }
 
+function sanitizeJsDocText(text: string): string {
+    return text.trim().replace(/\*\//g, "* /");
+}
+
+function pushTsJsDoc(lines: string[], indent: string, entries: string[]): void {
+    const cleaned = entries.map(sanitizeJsDocText).filter((entry) => entry.length > 0);
+    if (cleaned.length === 0) return;
+
+    lines.push(`${indent}/**`);
+    for (const [index, entry] of cleaned.entries()) {
+        if (index > 0) {
+            lines.push(`${indent} *`);
+        }
+        for (const line of entry.split(/\r?\n/)) {
+            lines.push(`${indent} * ${line}`);
+        }
+    }
+    lines.push(`${indent} */`);
+}
+
+function rpcResultDescription(method: RpcMethod): string | undefined {
+    const resultSchema = getMethodResultSchema(method);
+    if (isVoidSchema(resultSchema)) return undefined;
+    return method.result?.description ?? resultSchema?.description;
+}
+
+function rpcParamsDescription(method: RpcMethod, effectiveParams: JSONSchema7 | undefined): string | undefined {
+    return method.params?.description ?? effectiveParams?.description;
+}
+
+function pushTsRpcMethodJsDoc(
+    lines: string[],
+    indent: string,
+    method: RpcMethod,
+    options: {
+        paramsName?: string;
+        paramsDescription?: string;
+        includeDeprecated?: boolean;
+        includeExperimental?: boolean;
+    } = {}
+): void {
+    const entries: string[] = [];
+    entries.push(method.description ?? `Calls \`${method.rpcMethod}\`.`);
+    if (options.paramsName && options.paramsDescription) {
+        entries.push(`@param ${options.paramsName} ${options.paramsDescription}`);
+    }
+    const resultDescription = rpcResultDescription(method);
+    if (resultDescription) {
+        entries.push(`@returns ${resultDescription}`);
+    }
+    if (options.includeDeprecated) {
+        entries.push("@deprecated");
+    }
+    if (options.includeExperimental) {
+        entries.push("@experimental");
+    }
+    pushTsJsDoc(lines, indent, entries);
+}
+
 function toPascalCase(s: string): string {
     return s.charAt(0).toUpperCase() + s.slice(1);
 }
@@ -635,12 +694,12 @@ function emitGroup(
                 }
             }
 
-            if ((value as RpcMethod).deprecated && !parentDeprecated) {
-                lines.push(`${indent}/** @deprecated */`);
-            }
-            if ((value as RpcMethod).stability === "experimental" && !parentExperimental) {
-                lines.push(tsExperimentalJSDoc(indent));
-            }
+            pushTsRpcMethodJsDoc(lines, indent, value, {
+                paramsName: sigParams.length > 0 ? "params" : undefined,
+                paramsDescription: rpcParamsDescription(value, effectiveParams),
+                includeDeprecated: (value as RpcMethod).deprecated && !parentDeprecated,
+                includeExperimental: (value as RpcMethod).stability === "experimental" && !parentExperimental,
+            });
             lines.push(`${indent}${key}: async (${sigParams.join(", ")}): Promise<${resultType}> =>`);
             lines.push(`${indent}    connection.sendRequest("${rpcMethod}", ${bodyArg}),`);
         } else if (typeof value === "object" && value !== null) {
@@ -711,6 +770,7 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>)
     for (const [groupName, methods] of groups) {
         const interfaceName = toPascalCase(groupName) + "Handler";
         const groupDeprecated = isNodeFullyDeprecated(clientSchema[groupName] as Record<string, unknown>);
+        const groupExperimental = isNodeFullyExperimental(clientSchema[groupName] as Record<string, unknown>);
         if (groupDeprecated) {
             lines.push(`/** @deprecated Handler for \`${groupName}\` client session API methods. */`);
         } else {
@@ -723,9 +783,12 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>)
             const pType = hasParams ? paramsTypeName(method) : "";
             const rType = tsResultType(method);
 
-            if (method.deprecated && !groupDeprecated) {
-                lines.push(`    /** @deprecated */`);
-            }
+            pushTsRpcMethodJsDoc(lines, "    ", method, {
+                paramsName: hasParams ? "params" : undefined,
+                paramsDescription: rpcParamsDescription(method, getMethodParamsSchema(method)),
+                includeDeprecated: method.deprecated && !groupDeprecated,
+                includeExperimental: method.stability === "experimental" && !groupExperimental,
+            });
             if (hasParams) {
                 lines.push(`    ${name}(params: ${pType}): Promise<${rType}>;`);
             } else {

--- a/scripts/codegen/typescript.ts
+++ b/scripts/codegen/typescript.ts
@@ -81,6 +81,7 @@ function pushTsRpcMethodJsDoc(
     indent: string,
     method: RpcMethod,
     options: {
+        summaryFallback?: string;
         paramsName?: string;
         paramsDescription?: string;
         includeDeprecated?: boolean;
@@ -88,7 +89,7 @@ function pushTsRpcMethodJsDoc(
     } = {}
 ): void {
     const entries: string[] = [];
-    entries.push(method.description ?? `Calls \`${method.rpcMethod}\`.`);
+    entries.push(method.description ?? options.summaryFallback ?? `Calls \`${method.rpcMethod}\`.`);
     if (options.paramsName && options.paramsDescription) {
         entries.push(`@param ${options.paramsName} ${options.paramsDescription}`);
     }
@@ -784,6 +785,7 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>)
             const rType = tsResultType(method);
 
             pushTsRpcMethodJsDoc(lines, "    ", method, {
+                summaryFallback: `Handles \`${method.rpcMethod}\`.`,
                 paramsName: hasParams ? "params" : undefined,
                 paramsDescription: rpcParamsDescription(method, getMethodParamsSchema(method)),
                 includeDeprecated: method.deprecated && !groupDeprecated,

--- a/scripts/codegen/utils.ts
+++ b/scripts/codegen/utils.ts
@@ -251,6 +251,7 @@ export async function writeGeneratedFile(relativePath: string, content: string):
 
 export interface RpcMethod {
     rpcMethod: string;
+    description?: string;
     params: JSONSchema7 | null;
     result: JSONSchema7 | null;
     stability?: string;


### PR DESCRIPTION
Copilot API schemas now carry method, parameter, and result descriptions. This updates the SDK generators so generated API docs use those schema descriptions instead of generic RPC wording across languages.

## Summary

- Emit method, parameter, and return documentation for generated RPC wrappers and client-session handler surfaces in TypeScript, C#, Python, Go, and Rust.
- Use result descriptions for return docs, including C# XML `<returns>` comments, and emit complete C# `<param>` docs with the standard `CancellationToken` XML reference text.
- Preserve Rust session-only wire parameter structs while keeping public session RPC wrapper methods parameterless, then refresh generated outputs from the current schema.

## Validation

- `npm run typecheck`
- `dotnet build test\GitHub.Copilot.SDK.Test.csproj --no-restore`
- `python -m py_compile python\copilot\generated\rpc.py python\copilot\generated\session_events.py`
- `go test ./... -run '^$'`
- `cargo check --all-features`