### PR TITLE
Hide deprecated APIs where supported

### DIFF
--- a/dotnet/src/Generated/SessionEvents.cs
+++ b/dotnet/src/Generated/SessionEvents.cs
@@ -1976,6 +1976,7 @@ public partial class AssistantMessageData
     public double? OutputTokens { get; set; }
 
     /// <summary>Tool call ID of the parent tool invocation when this event originates from a sub-agent.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This member is deprecated and will be removed in a future version.")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("parentToolCallId")]
@@ -2037,6 +2038,7 @@ public partial class AssistantMessageDeltaData
     public required string MessageId { get; set; }
 
     /// <summary>Tool call ID of the parent tool invocation when this event originates from a sub-agent.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This member is deprecated and will be removed in a future version.")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("parentToolCallId")]
@@ -2114,6 +2116,7 @@ public partial class AssistantUsageData
     public double? OutputTokens { get; set; }
 
     /// <summary>Parent tool call ID when this usage originates from a sub-agent.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This member is deprecated and will be removed in a future version.")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("parentToolCallId")]
@@ -2232,6 +2235,7 @@ public partial class ToolExecutionStartData
     public string? McpToolName { get; set; }
 
     /// <summary>Tool call ID of the parent tool invocation when this event originates from a sub-agent.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This member is deprecated and will be removed in a future version.")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("parentToolCallId")]
@@ -2299,6 +2303,7 @@ public partial class ToolExecutionCompleteData
     public string? Model { get; set; }
 
     /// <summary>Tool call ID of the parent tool invocation when this event originates from a sub-agent.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This member is deprecated and will be removed in a future version.")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("parentToolCallId")]

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -157,6 +157,7 @@ public class CopilotClientOptions
     /// <summary>
     /// Obsolete. This option has no effect.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("AutoRestart has no effect and will be removed in a future release.")]
     public bool AutoRestart { get; set; }
     /// <summary>
@@ -537,14 +538,17 @@ public readonly struct PermissionRequestResultKind : IEquatable<PermissionReques
     public static PermissionRequestResultKind NoResult { get; } = new("no-result");
 
     /// <summary>Deprecated. Use <see cref="Rejected"/> instead.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("Use Rejected instead.")]
     public static PermissionRequestResultKind DeniedInteractivelyByUser => Rejected;
 
     /// <summary>Deprecated. Use <see cref="UserNotAvailable"/> instead.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("Use UserNotAvailable instead.")]
     public static PermissionRequestResultKind DeniedCouldNotRequestFromUser => UserNotAvailable;
 
     /// <summary>Deprecated. Use <see cref="UserNotAvailable"/> instead.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("Use UserNotAvailable instead.")]
     public static PermissionRequestResultKind DeniedByRules => UserNotAvailable;
 

--- a/rust/src/generated/session_events.rs
+++ b/rust/src/generated/session_events.rs
@@ -1119,6 +1119,7 @@ pub struct AssistantMessageData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output_tokens: Option<f64>,
     /// Tool call ID of the parent tool invocation when this event originates from a sub-agent
+    #[doc(hidden)]
     #[deprecated]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_tool_call_id: Option<String>,
@@ -1162,6 +1163,7 @@ pub struct AssistantMessageDeltaData {
     /// Message ID this delta belongs to, matching the corresponding assistant.message event
     pub message_id: String,
     /// Tool call ID of the parent tool invocation when this event originates from a sub-agent
+    #[doc(hidden)]
     #[deprecated]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_tool_call_id: Option<String>,
@@ -1261,6 +1263,7 @@ pub struct AssistantUsageData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output_tokens: Option<f64>,
     /// Parent tool call ID when this usage originates from a sub-agent
+    #[doc(hidden)]
     #[deprecated]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_tool_call_id: Option<String>,
@@ -1345,6 +1348,7 @@ pub struct ToolExecutionStartData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mcp_tool_name: Option<String>,
     /// Tool call ID of the parent tool invocation when this event originates from a sub-agent
+    #[doc(hidden)]
     #[deprecated]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_tool_call_id: Option<String>,
@@ -1547,6 +1551,7 @@ pub struct ToolExecutionCompleteData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     /// Tool call ID of the parent tool invocation when this event originates from a sub-agent
+    #[doc(hidden)]
     #[deprecated]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_tool_call_id: Option<String>,

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -355,6 +355,7 @@ const COPYRIGHT = `/*-----------------------------------------------------------
  *--------------------------------------------------------------------------------------------*/`;
 
 const EXPERIMENTAL_ATTRIBUTE = "[Experimental(Diagnostics.Experimental)]";
+const EDITOR_BROWSABLE_NEVER_ATTRIBUTE = "[EditorBrowsable(EditorBrowsableState.Never)]";
 const OBSOLETE_ATTRIBUTE = `[Obsolete("This member is deprecated and will be removed in a future version.")]`;
 const STRING_ENUM_RESERVED_MEMBER_NAMES = new Set(["Value", "Equals", "GetHashCode", "ToString", "Converter"]);
 
@@ -364,6 +365,21 @@ function experimentalAttribute(indent = ""): string {
 
 function pushExperimentalAttribute(lines: string[], indent = ""): void {
     lines.push(experimentalAttribute(indent));
+}
+
+function obsoleteAttributes(indent = ""): string[] {
+    return [
+        `${indent}${EDITOR_BROWSABLE_NEVER_ATTRIBUTE}`,
+        `${indent}${OBSOLETE_ATTRIBUTE}`,
+    ];
+}
+
+function obsoleteAttributeBlock(indent = ""): string {
+    return obsoleteAttributes(indent).join("\n");
+}
+
+function pushObsoleteAttributes(lines: string[], indent = ""): void {
+    lines.push(...obsoleteAttributes(indent));
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
@@ -404,7 +420,7 @@ function getOrCreateEnum(
     const lines: string[] = [];
     lines.push(...xmlDocEnumComment(description, ""));
     if (experimental) pushExperimentalAttribute(lines);
-    if (deprecated) lines.push(OBSOLETE_ATTRIBUTE);
+    if (deprecated) pushObsoleteAttributes(lines);
     lines.push(`[JsonConverter(typeof(Converter))]`);
     lines.push(`[DebuggerDisplay("{Value,nq}")]`);
     lines.push(`public readonly struct ${enumName} : IEquatable<${enumName}>`);
@@ -616,7 +632,7 @@ function generateFlattenedBooleanDiscriminatedClass(
         lines.push("");
         lines.push(...xmlDocPropertyComment(info.schema.description, propName, "    "));
         lines.push(...emitDataAnnotations(info.schema, "    "));
-        if (isSchemaDeprecated(info.schema)) lines.push(`    ${OBSOLETE_ATTRIBUTE}`);
+        if (isSchemaDeprecated(info.schema)) pushObsoleteAttributes(lines, "    ");
         if (isDurationProperty(info.schema)) lines.push(`    [JsonConverter(typeof(MillisecondsTimeSpanConverter))]`);
         if (!isReq) lines.push(`    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`);
         lines.push(`    [JsonPropertyName("${propName}")]`);
@@ -696,7 +712,7 @@ function generateDerivedClass(
 
     lines.push(...xmlDocCommentWithFallback(schema.description, `The <c>${escapeXml(discriminatorValue)}</c> variant of <see cref="${baseClassName}"/>.`, ""));
     if (isSchemaExperimental(schema)) pushExperimentalAttribute(lines);
-    if (isSchemaDeprecated(schema)) lines.push(OBSOLETE_ATTRIBUTE);
+    if (isSchemaDeprecated(schema)) pushObsoleteAttributes(lines);
     lines.push(`public partial class ${className} : ${baseClassName}`);
     lines.push(`{`);
     lines.push(`    /// <inheritdoc />`);
@@ -715,7 +731,7 @@ function generateDerivedClass(
 
             lines.push(...xmlDocPropertyComment((propSchema as JSONSchema7).description, propName, "    "));
             lines.push(...emitDataAnnotations(propSchema as JSONSchema7, "    "));
-            if (isSchemaDeprecated(propSchema as JSONSchema7)) lines.push(`    ${OBSOLETE_ATTRIBUTE}`);
+            if (isSchemaDeprecated(propSchema as JSONSchema7)) pushObsoleteAttributes(lines, "    ");
             if (isDurationProperty(propSchema as JSONSchema7)) lines.push(`    [JsonConverter(typeof(MillisecondsTimeSpanConverter))]`);
             if (!isReq) lines.push(`    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`);
             lines.push(`    [JsonPropertyName("${propName}")]`);
@@ -928,7 +944,7 @@ function generateNestedClass(
     const lines: string[] = [];
     lines.push(...xmlDocCommentWithFallback(schema.description, `Nested data type for <c>${className}</c>.`, ""));
     if (isSchemaExperimental(schema)) pushExperimentalAttribute(lines);
-    if (isSchemaDeprecated(schema)) lines.push(OBSOLETE_ATTRIBUTE);
+    if (isSchemaDeprecated(schema)) pushObsoleteAttributes(lines);
     lines.push(`public partial class ${className}`, `{`);
 
     for (const [propName, propSchema] of Object.entries(schema.properties || {}).sort(([a], [b]) => a.localeCompare(b))) {
@@ -940,7 +956,7 @@ function generateNestedClass(
 
         lines.push(...xmlDocPropertyComment(prop.description, propName, "    "));
         lines.push(...emitDataAnnotations(prop, "    "));
-        if (isSchemaDeprecated(prop)) lines.push(`    ${OBSOLETE_ATTRIBUTE}`);
+        if (isSchemaDeprecated(prop)) pushObsoleteAttributes(lines, "    ");
         if (isDurationProperty(prop)) lines.push(`    [JsonConverter(typeof(MillisecondsTimeSpanConverter))]`);
         if (!isReq) lines.push(`    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`);
         lines.push(`    [JsonPropertyName("${propName}")]`);
@@ -1070,7 +1086,7 @@ function generateDataClass(variant: EventVariant, knownTypes: Map<string, string
         pushExperimentalAttribute(lines);
     }
     if (isSchemaDeprecated(variant.dataSchema)) {
-        lines.push(OBSOLETE_ATTRIBUTE);
+        pushObsoleteAttributes(lines);
     }
     lines.push(`public partial class ${variant.dataClassName}`, `{`);
 
@@ -1082,7 +1098,7 @@ function generateDataClass(variant: EventVariant, knownTypes: Map<string, string
 
         lines.push(...xmlDocPropertyComment((propSchema as JSONSchema7).description, propName, "    "));
         lines.push(...emitDataAnnotations(propSchema as JSONSchema7, "    "));
-        if (isSchemaDeprecated(propSchema as JSONSchema7)) lines.push(`    ${OBSOLETE_ATTRIBUTE}`);
+        if (isSchemaDeprecated(propSchema as JSONSchema7)) pushObsoleteAttributes(lines, "    ");
         if (isDurationProperty(propSchema as JSONSchema7)) lines.push(`    [JsonConverter(typeof(MillisecondsTimeSpanConverter))]`);
         if (!isReq) lines.push(`    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`);
         lines.push(`    [JsonPropertyName("${propName}")]`);
@@ -1114,7 +1130,7 @@ function emitSessionEventEnvelopeProperty(
 
     lines.push(...xmlDocPropertyComment(property.schema.description, property.name, "    "));
     lines.push(...emitDataAnnotations(property.schema, "    "));
-    if (isSchemaDeprecated(property.schema)) lines.push(`    ${OBSOLETE_ATTRIBUTE}`);
+    if (isSchemaDeprecated(property.schema)) pushObsoleteAttributes(lines, "    ");
     if (isDurationProperty(property.schema)) lines.push(`    [JsonConverter(typeof(MillisecondsTimeSpanConverter))]`);
     if (!property.required) lines.push(`    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`);
     lines.push(`    [JsonPropertyName("${property.name}")]`);
@@ -1447,7 +1463,7 @@ function emitRpcClass(
         pushExperimentalAttribute(lines);
     }
     if (isSchemaDeprecated(schema) || isSchemaDeprecated(effectiveSchema)) {
-        lines.push(OBSOLETE_ATTRIBUTE);
+        pushObsoleteAttributes(lines);
     }
     lines.push(`${visibility} sealed class ${className}`, `{`);
 
@@ -1462,7 +1478,7 @@ function emitRpcClass(
 
         lines.push(...xmlDocPropertyComment(prop.description, propName, "    "));
         lines.push(...emitDataAnnotations(prop, "    "));
-        if (isSchemaDeprecated(prop)) lines.push(`    ${OBSOLETE_ATTRIBUTE}`);
+        if (isSchemaDeprecated(prop)) pushObsoleteAttributes(lines, "    ");
         if (isDurationProperty(prop)) lines.push(`    [JsonConverter(typeof(MillisecondsTimeSpanConverter))]`);
         lines.push(`    [JsonPropertyName("${propName}")]`);
 
@@ -1562,7 +1578,7 @@ function emitServerApiClass(className: string, node: Record<string, unknown>, cl
         pushExperimentalAttribute(lines);
     }
     if (groupDeprecated) {
-        lines.push(OBSOLETE_ATTRIBUTE);
+        pushObsoleteAttributes(lines);
     }
     lines.push(`public sealed class ${className}`);
     lines.push(`{`);
@@ -1648,7 +1664,7 @@ function emitServerInstanceMethod(
         pushExperimentalAttribute(lines, indent);
     }
     if (method.deprecated && !groupDeprecated) {
-        lines.push(`${indent}${OBSOLETE_ATTRIBUTE}`);
+        pushObsoleteAttributes(lines, indent);
     }
 
     const sigParams: string[] = [];
@@ -1772,7 +1788,7 @@ function emitSessionMethod(key: string, method: RpcMethod, lines: string[], clas
         pushExperimentalAttribute(lines, indent);
     }
     if (method.deprecated && !groupDeprecated) {
-        lines.push(`${indent}${OBSOLETE_ATTRIBUTE}`);
+        pushObsoleteAttributes(lines, indent);
     }
     const sigParams: string[] = [];
     const bodyAssignments = [`SessionId = _sessionId`];
@@ -1810,7 +1826,7 @@ function emitSessionApiClass(className: string, node: Record<string, unknown>, c
     const groupExperimental = isNodeFullyExperimental(node);
     const groupDeprecated = isNodeFullyDeprecated(node);
     const experimentalAttr = groupExperimental ? `${experimentalAttribute()}\n` : "";
-    const deprecatedAttr = groupDeprecated ? `${OBSOLETE_ATTRIBUTE}\n` : "";
+    const deprecatedAttr = groupDeprecated ? `${obsoleteAttributeBlock()}\n` : "";
     const subGroups = Object.entries(node).filter(([, v]) => typeof v === "object" && v !== null && !isRpcMethod(v));
 
     const lines = [`/// <summary>Provides session-scoped ${displayName} APIs.</summary>`, `${experimentalAttr}${deprecatedAttr}public sealed class ${className}`, `{`, `    private readonly JsonRpc _rpc;`, `    private readonly string _sessionId;`, ""];
@@ -1895,7 +1911,7 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>,
             pushExperimentalAttribute(lines);
         }
         if (groupDeprecated) {
-            lines.push(OBSOLETE_ATTRIBUTE);
+            pushObsoleteAttributes(lines);
         }
         lines.push(`public interface ${interfaceName}`);
         lines.push(`{`);
@@ -1909,7 +1925,7 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>,
                 pushExperimentalAttribute(lines, "    ");
             }
             if (method.deprecated && !groupDeprecated) {
-                lines.push(`    ${OBSOLETE_ATTRIBUTE}`);
+                pushObsoleteAttributes(lines, "    ");
             }
             if (hasParams) {
                 lines.push(`    ${taskType} ${clientHandlerMethodName(method.rpcMethod)}(${paramsTypeName(method)} request, CancellationToken cancellationToken = default);`);

--- a/scripts/codegen/rust.ts
+++ b/scripts/codegen/rust.ts
@@ -58,6 +58,10 @@ const EXTERNAL_SCHEMA_RUST_TYPE_MODULE: Record<string, Record<string, string>> =
 	},
 };
 
+function rustDeprecatedAttributes(indent = ""): string[] {
+	return [`${indent}#[doc(hidden)]`, `${indent}#[deprecated]`];
+}
+
 /**
  * JSON property names that should be emitted as a hand-authored newtype rather
  * than `String`. The newtype is `#[serde(transparent)]`, so the wire format is
@@ -700,7 +704,7 @@ function emitRustStruct(
 	}
 	pushRustExperimentalDocs(lines, isSchemaExperimental(schema));
 	if (isSchemaDeprecated(schema)) {
-		lines.push("#[deprecated]");
+		lines.push(...rustDeprecatedAttributes());
 	}
 
 	// Resolve field types up-front so we can decide whether `Default` can be
@@ -745,7 +749,7 @@ function emitRustStruct(
 			}
 		}
 		if (isSchemaDeprecated(prop)) {
-			lines.push("    #[deprecated]");
+			lines.push(...rustDeprecatedAttributes("    "));
 		}
 
 		// Determine if an explicit rename is needed. `rename_all = "camelCase"` on
@@ -1492,7 +1496,7 @@ function emitNamespaceMethod(
 
 	const docs: string[] = [];
 	docs.push(`    /// Wire method: \`${wireMethod}\`.`);
-	if (method.deprecated) docs.push(`    #[deprecated]`);
+	if (method.deprecated) docs.push(...rustDeprecatedAttributes("    "));
 	const stability = method.stability;
 	if (stability === "experimental") {
 		docs.push(`    ///`);


### PR DESCRIPTION
Deprecated APIs should remain source-compatible, but they do not need to stay prominent in generated docs and editor completion lists where a language has a safe hiding mechanism.

This updates the C# and Rust generators to hide deprecated schema-driven APIs while preserving their existing deprecation diagnostics:

- C# now emits `[EditorBrowsable(EditorBrowsableState.Never)]` together with `[Obsolete(...)]` for generated deprecated APIs, and applies the same hiding attribute to hand-authored deprecated options and aliases.
- Rust now emits `#[doc(hidden)]` together with `#[deprecated]` for generated deprecated structs, fields, and RPC methods.
- TypeScript, Python, and Go are intentionally left as deprecation-only because their comparable mechanisms are either doc-tool-specific or would require changing the public API shape.

Validation:
- `cd scripts/codegen && npm run generate:csharp && npm run generate:rust`
- `cd rust && cargo +nightly-2026-04-14 fmt --check && cargo check --all-features`
- `cd dotnet && dotnet build src\GitHub.Copilot.SDK.csproj --nologo --verbosity minimal`
- `cd dotnet && dotnet test test\GitHub.Copilot.SDK.Test.csproj --nologo --verbosity minimal --filter FullyQualifiedName~Unit`

Generated by Copilot.