### PR TITLE
Add remote_session field to all SDK SessionConfig types

### DIFF
--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -629,6 +629,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 Tracestate: tracestate,
                 ModelCapabilities: config.ModelCapabilities,
                 GitHubToken: config.GitHubToken,
+                RemoteSession: config.RemoteSession,
                 InstructionDirectories: config.InstructionDirectories);
 
             var rpcTimestamp = Stopwatch.GetTimestamp();
@@ -786,6 +787,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 Tracestate: tracestate,
                 ModelCapabilities: config.ModelCapabilities,
                 GitHubToken: config.GitHubToken,
+                RemoteSession: config.RemoteSession,
                 ContinuePendingWork: config.ContinuePendingWork,
                 InstructionDirectories: config.InstructionDirectories);
 
@@ -1981,6 +1983,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         string? Tracestate = null,
         ModelCapabilitiesOverride? ModelCapabilities = null,
         string? GitHubToken = null,
+        RemoteSessionMode? RemoteSession = null,
         IList<string>? InstructionDirectories = null);
 
     internal record ToolDefinition(
@@ -2041,6 +2044,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         string? Tracestate = null,
         ModelCapabilitiesOverride? ModelCapabilities = null,
         string? GitHubToken = null,
+        RemoteSessionMode? RemoteSession = null,
         bool? ContinuePendingWork = null,
         IList<string>? InstructionDirectories = null);
 

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -2028,6 +2028,7 @@ public class SessionConfig
         ReasoningEffort = other.ReasoningEffort;
         CreateSessionFsHandler = other.CreateSessionFsHandler;
         GitHubToken = other.GitHubToken;
+        RemoteSession = other.RemoteSession;
         SessionId = other.SessionId;
         SkillDirectories = other.SkillDirectories is not null ? [.. other.SkillDirectories] : null;
         InstructionDirectories = other.InstructionDirectories is not null ? [.. other.InstructionDirectories] : null;
@@ -2254,6 +2255,16 @@ public class SessionConfig
     public string? GitHubToken { get; set; }
 
     /// <summary>
+    /// Per-session remote behavior control:
+    /// <list type="bullet">
+    /// <item><description><c>"off"</c> — local only, no remote export (default)</description></item>
+    /// <item><description><c>"export"</c> — export session events to GitHub without enabling remote steering</description></item>
+    /// <item><description><c>"on"</c> — export to GitHub AND enable remote steering</description></item>
+    /// </list>
+    /// </summary>
+    public RemoteSessionMode? RemoteSession { get; set; }
+
+    /// <summary>
     /// Creates a shallow clone of this <see cref="SessionConfig"/> instance.
     /// </summary>
     /// <remarks>
@@ -2319,6 +2330,7 @@ public class ResumeSessionConfig
         ReasoningEffort = other.ReasoningEffort;
         CreateSessionFsHandler = other.CreateSessionFsHandler;
         GitHubToken = other.GitHubToken;
+        RemoteSession = other.RemoteSession;
         SkillDirectories = other.SkillDirectories is not null ? [.. other.SkillDirectories] : null;
         InstructionDirectories = other.InstructionDirectories is not null ? [.. other.InstructionDirectories] : null;
         Streaming = other.Streaming;
@@ -2554,6 +2566,12 @@ public class ResumeSessionConfig
     /// and stores it on the session for content exclusion, model routing, and quota checks.
     /// </summary>
     public string? GitHubToken { get; set; }
+
+    /// <summary>
+    /// Per-session remote behavior control.
+    /// See <see cref="SessionConfig.RemoteSession"/> for details.
+    /// </summary>
+    public RemoteSessionMode? RemoteSession { get; set; }
 
     /// <summary>
     /// Creates a shallow clone of this <see cref="ResumeSessionConfig"/> instance.

--- a/go/client.go
+++ b/go/client.go
@@ -645,6 +645,7 @@ func (c *Client) CreateSession(ctx context.Context, config *SessionConfig) (*Ses
 	req.DisabledSkills = config.DisabledSkills
 	req.InfiniteSessions = config.InfiniteSessions
 	req.GitHubToken = config.GitHubToken
+	req.RemoteSession = config.RemoteSession
 
 	if len(config.Commands) > 0 {
 		cmds := make([]wireCommand, 0, len(config.Commands))
@@ -848,6 +849,7 @@ func (c *Client) ResumeSessionWithOptions(ctx context.Context, sessionID string,
 	req.DisabledSkills = config.DisabledSkills
 	req.InfiniteSessions = config.InfiniteSessions
 	req.GitHubToken = config.GitHubToken
+	req.RemoteSession = config.RemoteSession
 	req.RequestPermission = Bool(true)
 
 	if len(config.Commands) > 0 {

--- a/go/types.go
+++ b/go/types.go
@@ -680,6 +680,11 @@ type SessionConfig struct {
 	// When provided, the session authenticates as the token's owner instead of
 	// using the global client-level auth.
 	GitHubToken string `json:"-"`
+	// RemoteSession controls per-session remote behavior:
+	//   - "off" — local only, no remote export (default)
+	//   - "export" — export session events to GitHub without enabling remote steering
+	//   - "on" — export to GitHub AND enable remote steering
+	RemoteSession rpc.RemoteSessionMode
 }
 type Tool struct {
 	Name                 string         `json:"name"`
@@ -891,6 +896,9 @@ type ResumeSessionConfig struct {
 	// When provided, the session authenticates as the token's owner instead of
 	// using the global client-level auth.
 	GitHubToken string `json:"-"`
+	// RemoteSession controls per-session remote behavior.
+	// See SessionConfig.RemoteSession for details.
+	RemoteSession rpc.RemoteSessionMode
 	// DisableResume, when true, skips emitting the session.resume event.
 	// Useful for reconnecting to a session without triggering resume-related side effects.
 	DisableResume bool
@@ -1142,6 +1150,7 @@ type createSessionRequest struct {
 	Commands                       []wireCommand                  `json:"commands,omitempty"`
 	RequestElicitation             *bool                          `json:"requestElicitation,omitempty"`
 	GitHubToken                    string                         `json:"gitHubToken,omitempty"`
+	RemoteSession                  rpc.RemoteSessionMode          `json:"remoteSession,omitempty"`
 	Traceparent                    string                         `json:"traceparent,omitempty"`
 	Tracestate                     string                         `json:"tracestate,omitempty"`
 }
@@ -1196,6 +1205,7 @@ type resumeSessionRequest struct {
 	Commands                       []wireCommand                  `json:"commands,omitempty"`
 	RequestElicitation             *bool                          `json:"requestElicitation,omitempty"`
 	GitHubToken                    string                         `json:"gitHubToken,omitempty"`
+	RemoteSession                  rpc.RemoteSessionMode          `json:"remoteSession,omitempty"`
 	Traceparent                    string                         `json:"traceparent,omitempty"`
 	Tracestate                     string                         `json:"tracestate,omitempty"`
 }

--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -835,6 +835,7 @@ export class CopilotClient {
                 disabledSkills: config.disabledSkills,
                 infiniteSessions: config.infiniteSessions,
                 gitHubToken: config.gitHubToken,
+                remoteSession: config.remoteSession,
             });
 
             const { workspacePath, capabilities } = response as {
@@ -990,6 +991,7 @@ export class CopilotClient {
                 disableResume: config.disableResume,
                 continuePendingWork: config.continuePendingWork,
                 gitHubToken: config.gitHubToken,
+                remoteSession: config.remoteSession,
             });
 
             const { workspacePath, capabilities } = response as {

--- a/nodejs/src/index.ts
+++ b/nodejs/src/index.ts
@@ -56,6 +56,7 @@ export type {
     PermissionRequest,
     PermissionRequestResult,
     ProviderConfig,
+    RemoteSessionMode,
     ResumeSessionConfig,
     SectionOverride,
     SectionOverrideAction,

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -10,6 +10,8 @@
 import type { SessionFsProvider } from "./sessionFsProvider.js";
 import type { SessionEvent as GeneratedSessionEvent } from "./generated/session-events.js";
 import type { CopilotSession } from "./session.js";
+import type { RemoteSessionMode } from "./generated/rpc.js";
+export type { RemoteSessionMode } from "./generated/rpc.js";
 export type SessionEvent = GeneratedSessionEvent;
 export type { SessionFsProvider } from "./sessionFsProvider.js";
 export { createSessionFsAdapter } from "./sessionFsProvider.js";
@@ -1478,6 +1480,14 @@ export interface SessionConfig {
     gitHubToken?: string;
 
     /**
+     * Per-session remote behavior control:
+     * - `"off"` — local only, no remote export (default)
+     * - `"export"` — export session events to GitHub without enabling remote steering
+     * - `"on"` — export to GitHub AND enable remote steering
+     */
+    remoteSession?: RemoteSessionMode;
+
+    /**
      * Optional event handler that is registered on the session before the
      * session.create RPC is issued. This guarantees that early events emitted
      * by the CLI during session creation (e.g. session.start) are delivered to
@@ -1531,6 +1541,7 @@ export type ResumeSessionConfig = Pick<
     | "disabledSkills"
     | "infiniteSessions"
     | "gitHubToken"
+    | "remoteSession"
     | "onEvent"
     | "createSessionFsHandler"
 > & {

--- a/python/copilot/__init__.py
+++ b/python/copilot/__init__.py
@@ -11,6 +11,7 @@ from .client import (
     ModelLimitsOverride,
     ModelSupportsOverride,
     ModelVisionLimitsOverride,
+    RemoteSessionMode,
     SubprocessConfig,
 )
 from .session import (
@@ -67,6 +68,7 @@ __all__ = [
     "ModelSupportsOverride",
     "ModelVisionLimitsOverride",
     "ProviderConfig",
+    "RemoteSessionMode",
     "SessionCapabilities",
     "SessionFsConfig",
     "SessionFsFileInfo",

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -38,6 +38,7 @@ from ._telemetry import get_trace_context, trace_context
 from .generated.rpc import (
     ClientSessionApiHandlers,
     ConnectRequest,
+    RemoteSessionMode,
     ServerRpc,
     _InternalServerRpc,
     register_client_session_api_handlers,
@@ -1326,6 +1327,7 @@ class CopilotClient:
         on_auto_mode_switch: AutoModeSwitchHandler | None = None,
         create_session_fs_handler: CreateSessionFsHandler | None = None,
         github_token: str | None = None,
+        remote_session: RemoteSessionMode | None = None,
     ) -> CopilotSession:
         """
         Create a new conversation session with the Copilot CLI.
@@ -1478,6 +1480,10 @@ class CopilotClient:
         # Add GitHub token for per-session authentication
         if github_token is not None:
             payload["gitHubToken"] = github_token
+
+        # Add remote session mode if provided
+        if remote_session is not None:
+            payload["remoteSession"] = remote_session.value
 
         # Add working directory if provided
         if working_directory:
@@ -1686,6 +1692,7 @@ class CopilotClient:
         on_auto_mode_switch: AutoModeSwitchHandler | None = None,
         create_session_fs_handler: CreateSessionFsHandler | None = None,
         github_token: str | None = None,
+        remote_session: RemoteSessionMode | None = None,
         continue_pending_work: bool | None = None,
     ) -> CopilotSession:
         """
@@ -1856,6 +1863,10 @@ class CopilotClient:
         # Add GitHub token for per-session authentication
         if github_token is not None:
             payload["gitHubToken"] = github_token
+
+        # Add remote session mode if provided
+        if remote_session is not None:
+            payload["remoteSession"] = remote_session.value
 
         if working_directory:
             payload["workingDirectory"] = working_directory

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1081,6 +1081,13 @@ pub struct SessionConfig {
     /// quota checks for *this session*.
     #[serde(rename = "gitHubToken", skip_serializing_if = "Option::is_none")]
     pub github_token: Option<String>,
+    /// Per-session remote behavior control:
+    /// - `Off` — local only, no remote export (default)
+    /// - `Export` — export session events to GitHub without
+    ///   enabling remote steering
+    /// - `On` — export to GitHub AND enable remote steering
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_session: Option<crate::generated::api_types::RemoteSessionMode>,
     /// Forward sub-agent streaming events to this connection. When false,
     /// only non-streaming sub-agent events and `subagent.*` lifecycle events
     /// are delivered. Defaults to true on the CLI.
@@ -1152,6 +1159,7 @@ impl std::fmt::Debug for SessionConfig {
                 "github_token",
                 &self.github_token.as_ref().map(|_| "<redacted>"),
             )
+            .field("remote_session", &self.remote_session)
             .field(
                 "include_sub_agent_streaming_events",
                 &self.include_sub_agent_streaming_events,
@@ -1211,6 +1219,7 @@ impl Default for SessionConfig {
             config_dir: None,
             working_directory: None,
             github_token: None,
+            remote_session: None,
             include_sub_agent_streaming_events: None,
             commands: None,
             session_fs_provider: None,
@@ -1528,6 +1537,15 @@ impl SessionConfig {
         self.include_sub_agent_streaming_events = Some(include);
         self
     }
+
+    /// Set per-session remote behavior.
+    pub fn with_remote_session(
+        mut self,
+        mode: crate::generated::api_types::RemoteSessionMode,
+    ) -> Self {
+        self.remote_session = Some(mode);
+        self
+    }
 }
 
 /// Configuration for resuming an existing session via the `session.resume` RPC.
@@ -1639,6 +1657,10 @@ pub struct ResumeSessionConfig {
     /// [`SessionConfig::github_token`].
     #[serde(rename = "gitHubToken", skip_serializing_if = "Option::is_none")]
     pub github_token: Option<String>,
+    /// Per-session remote behavior control on resume. See
+    /// [`SessionConfig::remote_session`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_session: Option<crate::generated::api_types::RemoteSessionMode>,
     /// Forward sub-agent streaming events to this connection on resume.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub include_sub_agent_streaming_events: Option<bool>,
@@ -1712,6 +1734,7 @@ impl std::fmt::Debug for ResumeSessionConfig {
                 "github_token",
                 &self.github_token.as_ref().map(|_| "<redacted>"),
             )
+            .field("remote_session", &self.remote_session)
             .field(
                 "include_sub_agent_streaming_events",
                 &self.include_sub_agent_streaming_events,
@@ -1770,6 +1793,7 @@ impl ResumeSessionConfig {
             config_dir: None,
             working_directory: None,
             github_token: None,
+            remote_session: None,
             include_sub_agent_streaming_events: None,
             commands: None,
             session_fs_provider: None,
@@ -2051,6 +2075,15 @@ impl ResumeSessionConfig {
     /// Forward sub-agent streaming events to this connection on resume.
     pub fn with_include_sub_agent_streaming_events(mut self, include: bool) -> Self {
         self.include_sub_agent_streaming_events = Some(include);
+        self
+    }
+
+    /// Set per-session remote behavior on resume.
+    pub fn with_remote_session(
+        mut self,
+        mode: crate::generated::api_types::RemoteSessionMode,
+    ) -> Self {
+        self.remote_session = Some(mode);
         self
     }
 

--- a/rust/tests/session_test.rs
+++ b/rust/tests/session_test.rs
@@ -2597,6 +2597,8 @@ fn session_config_serializes_bucket_b_fields() {
         cfg.github_token = Some("ghs_secret".to_string());
         cfg.include_sub_agent_streaming_events = Some(false);
         cfg.enable_session_telemetry = Some(false);
+        cfg.remote_session =
+            Some(github_copilot_sdk::generated::api_types::RemoteSessionMode::Export);
         cfg
     };
     let json = serde_json::to_value(&cfg).unwrap();
@@ -2606,6 +2608,7 @@ fn session_config_serializes_bucket_b_fields() {
     assert_eq!(json["gitHubToken"], "ghs_secret");
     assert_eq!(json["includeSubAgentStreamingEvents"], false);
     assert_eq!(json["enableSessionTelemetry"], false);
+    assert_eq!(json["remoteSession"], "export");
 
     // Debug never leaks the token.
     let debug = format!("{cfg:?}");
@@ -2617,6 +2620,7 @@ fn session_config_serializes_bucket_b_fields() {
     assert!(empty.get("sessionId").is_none());
     assert!(empty.get("gitHubToken").is_none());
     assert!(empty.get("enableSessionTelemetry").is_none());
+    assert!(empty.get("remoteSession").is_none());
 }
 
 #[test]
@@ -2631,6 +2635,7 @@ fn resume_session_config_serializes_bucket_b_fields() {
     cfg.github_token = Some("ghs_secret".to_string());
     cfg.include_sub_agent_streaming_events = Some(true);
     cfg.enable_session_telemetry = Some(false);
+    cfg.remote_session = Some(github_copilot_sdk::generated::api_types::RemoteSessionMode::On);
     let json = serde_json::to_value(&cfg).unwrap();
     assert_eq!(json["sessionId"], "sess-1");
     assert_eq!(json["workingDirectory"], "/tmp/work");
@@ -2638,6 +2643,12 @@ fn resume_session_config_serializes_bucket_b_fields() {
     assert_eq!(json["gitHubToken"], "ghs_secret");
     assert_eq!(json["includeSubAgentStreamingEvents"], true);
     assert_eq!(json["enableSessionTelemetry"], false);
+    assert_eq!(json["remoteSession"], "on");
+
+    // Unset remote_session is omitted on the wire.
+    let empty = ResumeSessionConfig::new(SessionId::from("sess-2"));
+    let empty_json = serde_json::to_value(&empty).unwrap();
+    assert!(empty_json.get("remoteSession").is_none());
 
     let debug = format!("{cfg:?}");
     assert!(!debug.contains("ghs_secret"), "leaked token: {debug}");


### PR DESCRIPTION
## Overview

### What

Adds a `remoteSession` / `remote_session` / `RemoteSession` field to both `SessionConfig` and `ResumeSessionConfig` across all SDK languages (Rust, Go, Node.js, Python, .NET), giving SDK clients explicit per-session control over remote behavior.

### Why

The runtime added support for a `remoteSession` parameter on `session.create` and `session.resume` in [copilot-agent-runtime#7673](https://github.com/github/copilot-agent-runtime/pull/7673), but the SDK hand-written types were never updated to expose it. The `RemoteSessionMode` type already exists in each SDK's generated types, so this wires it into the session config structs and create/resume payloads.

### Changes

- **Rust** (`rust/src/types.rs`) — Added `remote_session: Option<RemoteSessionMode>` field, Debug output, Default value, and `with_remote_session()` builder method to both `SessionConfig` and `ResumeSessionConfig`.
- **Go** (`go/types.go`, `go/client.go`) — Added `RemoteSession` field to `SessionConfig`, `ResumeSessionConfig`, and wire request structs; wired into create/resume payloads.
- **Node.js** (`nodejs/src/types.ts`, `nodejs/src/client.ts`, `nodejs/src/index.ts`) — Added `remoteSession?: RemoteSessionMode` to `SessionConfig` interface (picked into `ResumeSessionConfig`); wired into both payloads; exported the type.
- **Python** (`python/copilot/client.py`) — Added `remote_session: RemoteSessionMode | None` parameter to `create_session` and `resume_session`; wired into payloads using `.value` for wire serialization.
- **.NET** (`dotnet/src/Types.cs`, `dotnet/src/Client.cs`) — Added `RemoteSession` property to both config classes and clone constructors; added to wire records; wired into create/resume calls.

### Usage

```rust
// Rust
let config = SessionConfig::new(session_id)
    .with_remote_session(RemoteSessionMode::Export);
```

```go
// Go
config := copilot.SessionConfig{
    RemoteSession: rpc.RemoteSessionModeExport,
}
```

```typescript
// Node.js
const session = await client.createSession({
    remoteSession: "export",
});
```

```python
# Python
from copilot.generated.rpc import RemoteSessionMode
session = await client.create_session(
    remote_session=RemoteSessionMode.EXPORT,
)
```

```csharp
// .NET
var config = new SessionConfig { RemoteSession = RemoteSessionMode.Export };
```

### Downstream

This unblocks [github/github-app#4914](https://github.com/github/github-app/pull/4914) which needs to set `remoteSession: "export"` for all sessions.