### PR TITLE
fix(python): isolate per-entry parse failures in list_models() (#1302)

### DIFF
--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -2852,14 +2852,25 @@ class CopilotClient:
                 models_data = response.get("models", [])
                 models = []
                 for model_data in models_data:
+                    if not isinstance(model_data, dict):
+                        # Defensive: server should always send dicts here.
+                        # Skip and log rather than letting the inner assert
+                        # raise, for the same resilience reason as below.
+                        logger.warning(
+                            "Skipping non-dict entry in models.list response: %r",
+                            model_data,
+                        )
+                        continue
                     try:
                         models.append(ModelInfo.from_dict(model_data))
-                    except Exception as e:
+                    except (ValueError, TypeError, AssertionError) as e:
                         # Isolate per-entry parse failures so a single
                         # malformed model entry (e.g. backend schema drift
                         # on one model) does not take down list_models()
                         # for all consumers. See issue #1302.
-                        model_id = model_data.get("id") if isinstance(model_data, dict) else None
+                        # Catch only parse/shape-related exceptions; let
+                        # unexpected programmer errors propagate.
+                        model_id = model_data.get("id")
                         logger.warning(
                             "Skipping malformed model entry%s in models.list response: %s",
                             f" (id={model_id!r})" if model_id else "",

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -2813,6 +2813,11 @@ class CopilotClient:
         it is called instead of querying the CLI server. The handler may be sync
         or async.
 
+        Malformed entries in the server response (for example, a single model
+        whose schema drifts in a backwards-incompatible way) are logged at
+        ``WARNING`` level and skipped, so one bad entry will not fail the
+        entire call.
+
         Returns:
             A list of ModelInfo objects with model details.
 
@@ -2845,7 +2850,21 @@ class CopilotClient:
                 # Cache miss - fetch from backend while holding lock
                 response = await self._client.request("models.list", {})
                 models_data = response.get("models", [])
-                models = [ModelInfo.from_dict(model) for model in models_data]
+                models = []
+                for model_data in models_data:
+                    try:
+                        models.append(ModelInfo.from_dict(model_data))
+                    except Exception as e:
+                        # Isolate per-entry parse failures so a single
+                        # malformed model entry (e.g. backend schema drift
+                        # on one model) does not take down list_models()
+                        # for all consumers. See issue #1302.
+                        model_id = model_data.get("id") if isinstance(model_data, dict) else None
+                        logger.warning(
+                            "Skipping malformed model entry%s in models.list response: %s",
+                            f" (id={model_id!r})" if model_id else "",
+                            e,
+                        )
 
             # Update cache before releasing lock (copy to prevent external mutation)
             self._models_cache = list(models)

--- a/python/test_client.py
+++ b/python/test_client.py
@@ -1033,6 +1033,24 @@ class TestListModelsParserResilience:
         warnings = [r for r in caplog.records if r.levelname == "WARNING"]
         assert len(warnings) == 2
 
+    @pytest.mark.asyncio
+    async def test_unexpected_exceptions_propagate(self, monkeypatch):
+        # Programmer errors (e.g. AttributeError from a refactoring mistake)
+        # should NOT be swallowed by the per-entry try/except. Only
+        # parse/shape-related exceptions (ValueError/TypeError/AssertionError)
+        # are caught.
+        from copilot import client as client_mod
+
+        def boom(_obj):
+            raise AttributeError("simulated programmer error")
+
+        monkeypatch.setattr(client_mod.ModelInfo, "from_dict", staticmethod(boom))
+
+        client = self._make_client_with_fake_rpc([self._good_model("x")])
+
+        with pytest.raises(AttributeError, match="simulated programmer error"):
+            await client.list_models()
+
 
 class TestSessionConfigForwarding:
     @pytest.mark.asyncio

--- a/python/test_client.py
+++ b/python/test_client.py
@@ -946,6 +946,94 @@ class TestOnListModels:
         assert models == custom_models
 
 
+class TestListModelsParserResilience:
+    """Per-entry parse failures in models.list response should not take down
+    the whole call. See https://github.com/github/copilot-sdk/issues/1302."""
+
+    def _make_client_with_fake_rpc(self, models_data):
+        """Build a CopilotClient whose RPC layer returns the given models payload.
+
+        Avoids spawning the CLI subprocess; we drive list_models() directly
+        against a stand-in for the JSON-RPC client.
+        """
+
+        class _FakeRpcClient:
+            async def request(self, method, params):
+                assert method == "models.list", f"unexpected RPC: {method}"
+                return {"models": models_data}
+
+        client = CopilotClient(SubprocessConfig(cli_path=CLI_PATH))
+        client._client = _FakeRpcClient()  # type: ignore[assignment]
+        return client
+
+    def _good_model(self, model_id: str) -> dict:
+        return {
+            "id": model_id,
+            "name": model_id,
+            "capabilities": {
+                "supports": {"vision": False, "reasoning_effort": False},
+                "limits": {"max_context_window_tokens": 128000},
+            },
+        }
+
+    @pytest.mark.asyncio
+    async def test_skips_malformed_entry_and_returns_valid_ones(self, caplog):
+        # Mix of valid + malformed entries. Malformed ones are missing
+        # required fields (id/name/capabilities) which would otherwise raise
+        # ValueError from ModelInfo.from_dict and abort the whole call.
+        models_data = [
+            self._good_model("good-1"),
+            {"id": "bad-no-name", "capabilities": self._good_model("x")["capabilities"]},
+            self._good_model("good-2"),
+            {"name": "missing-everything-else"},
+        ]
+
+        client = self._make_client_with_fake_rpc(models_data)
+
+        with caplog.at_level("WARNING", logger="copilot.client"):
+            models = await client.list_models()
+
+        ids = [m.id for m in models]
+        assert ids == ["good-1", "good-2"]
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 2, (
+            f"expected one warning per malformed entry, got {len(warnings)}: "
+            f"{[r.getMessage() for r in warnings]}"
+        )
+        # The first warning should mention the id we did manage to extract.
+        assert "bad-no-name" in warnings[0].getMessage()
+
+    @pytest.mark.asyncio
+    async def test_all_malformed_returns_empty_list_without_raising(self):
+        models_data = [
+            {"id": "broken-1"},
+            {"id": "broken-2"},
+        ]
+        client = self._make_client_with_fake_rpc(models_data)
+
+        models = await client.list_models()
+        assert models == []
+
+    @pytest.mark.asyncio
+    async def test_empty_models_payload_returns_empty_list(self):
+        client = self._make_client_with_fake_rpc([])
+        models = await client.list_models()
+        assert models == []
+
+    @pytest.mark.asyncio
+    async def test_non_dict_entry_is_skipped_with_warning(self, caplog):
+        models_data = [self._good_model("ok"), "not-a-dict", 42]
+        client = self._make_client_with_fake_rpc(models_data)
+
+        with caplog.at_level("WARNING", logger="copilot.client"):
+            models = await client.list_models()
+
+        assert [m.id for m in models] == ["ok"]
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 2
+
+
 class TestSessionConfigForwarding:
     @pytest.mark.asyncio
     async def test_create_session_forwards_client_name(self):


### PR DESCRIPTION
Fixes #1302 (option 2 — per-entry isolation hardening).

## Summary

`CopilotClient.list_models()` parses the `models.list` response with a
list comprehension:

```python
models = [ModelInfo.from_dict(model) for model in models_data]
```

A single malformed entry raises and the whole call fails — the cache stays
empty, so every retry from a fresh session fails identically. The original
`multiplier`-required `ValueError` from #1302 is already fixed in
`main`, but the bot that triaged the issue endorsed implementing
[option 2](https://github.com/github/copilot-sdk/issues/1302#issuecomment-4460331009)
as a follow-up so future schema drift on individual models can't take down
`list_models()` for every consumer.

## What changed

`python/copilot/client.py` — wrap each `ModelInfo.from_dict(model)` in
`try/except` inside the RPC path:
- Log a `WARNING` (with model id when available) for each malformed entry.
- Skip and continue parsing the rest.
- Custom `on_list_models` handlers are unaffected.

Docstring updated to document the new resilience behavior.

## Why Python only

- **Node.js** casts the response (`as { models: ModelInfo[] }`) — no eager parse.
- **Go** uses `json.Unmarshal` — missing fields become Go zero values.
- **.NET / Rust** rely on their own deserializers with similar semantics.

Only the Python SDK has a hand-rolled per-entry parser that raises on
missing fields, so per-entry isolation is the Python-specific gap.

## Tests

New `TestListModelsParserResilience` class in `python/test_client.py` with 4 unit tests:

1. `test_skips_malformed_entry_and_returns_valid_ones` — mixed payload returns only the valid models, with one warning per skipped entry.
2. `test_all_malformed_returns_empty_list_without_raising` — all-broken payload returns `[]` instead of raising.
3. `test_empty_models_payload_returns_empty_list` — empty payload still returns `[]`.
4. `test_non_dict_entry_is_skipped_with_warning` — non-dict entries (string, int) are skipped without crashing.

Tests use a small `_FakeRpcClient` stub so they don't need to spawn the CLI subprocess.

## Validation

```
$ pytest test_client.py
56 passed
$ ruff check copilot/client.py test_client.py
All checks passed!
$ ruff format --check copilot/client.py test_client.py
2 files already formatted
```

`ty check` reports the same 37 pre-existing diagnostics on
`main` and on this branch — no new type errors introduced.

## Compatibility

- ✅ Backwards compatible — return type is still `list[ModelInfo]`.
- ✅ No public API changes.
- ✅ Custom `on_list_models` handlers behave identically.
- ✅ Cache semantics unchanged: a successful (possibly partial) RPC response
  is still cached; the cache is still cleared on disconnect.
