### PR TITLE
Fix shared schema comparison for Go codegen

### DIFF
--- a/nodejs/test/shared-codegen.test.ts
+++ b/nodejs/test/shared-codegen.test.ts
@@ -36,6 +36,7 @@ describe("shared schema definition codegen utilities", () => {
                 ReasoningSummary: {
                     type: "string",
                     enum: ["concise", "detailed"],
+                    description: "Reasoning summary mode used for model calls.",
                 },
                 SharedPayload: {
                     type: "object",
@@ -74,6 +75,7 @@ describe("shared schema definition codegen utilities", () => {
                 ReasoningSummary: {
                     type: "string",
                     enum: ["concise", "detailed"],
+                    description: "Reasoning summary mode to request for supported model clients.",
                 },
                 SharedPayload: {
                     type: "object",

--- a/scripts/codegen/utils.ts
+++ b/scripts/codegen/utils.ts
@@ -998,7 +998,9 @@ function normalizeDefinitionForComparison(definition: JSONSchema7Definition): un
 
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(definition as Record<string, unknown>)) {
-        if (key === "$ref" && typeof value === "string") {
+        if (key === "description" || key === "markdownDescription") {
+            continue;
+        } else if (key === "$ref" && typeof value === "string") {
             const localRef = parseLocalDefinitionRef(value);
             result[key] = localRef ? `#/definitions/${localRef}` : value;
         } else if (Array.isArray(value)) {


### PR DESCRIPTION
Schema definitions shared between `api.schema.json` and `session-events.schema.json` can have identical wire shapes but different documentation. With the 1.0.49-0 Copilot runtime schemas, that caused Go codegen to miss `ReasoningSummary` as shared and emit duplicate declarations in the rpc package.

This updates shared-definition comparison to ignore documentation-only metadata (`description` and `markdownDescription`) while preserving the existing structural comparison for refs, enum values, and object shapes. The regression test now covers a shared enum with intentionally different descriptions.