### PR TITLE
Make tool callbacks optional across SDKs

### DIFF
--- a/dotnet/GitHub.Copilot.SDK.slnx
+++ b/dotnet/GitHub.Copilot.SDK.slnx
@@ -10,7 +10,4 @@
   <Folder Name="/test/">
     <Project Path="test/GitHub.Copilot.SDK.Test.csproj" />
   </Folder>
-  <Folder Name="/samples/">
-    <Project Path="samples/Chat.csproj" />
-  </Folder>
 </Solution>

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -10,13 +10,18 @@ SDK for programmatic control of GitHub Copilot CLI.
 dotnet add package GitHub.Copilot.SDK
 ```
 
-## Run the Sample
+## Run the Samples
 
 Try the interactive chat sample (from the repo root):
 
 ```bash
-cd dotnet/samples
-dotnet run
+dotnet run --file dotnet/samples/Chat.cs
+```
+
+The manual permission/tool-result resume sample can be run the same way:
+
+```bash
+dotnet run --file dotnet/samples/ManualToolResume.cs
 ```
 
 ## Quick Start
@@ -28,7 +33,7 @@ using GitHub.Copilot.SDK;
 await using var client = new CopilotClient();
 await client.StartAsync();
 
-// Create a session (OnPermissionRequest is required)
+// Create a session (OnPermissionRequest is optional; ApproveAll allows every tool)
 await using var session = await client.CreateSessionAsync(new SessionConfig
 {
     Model = "gpt-5",
@@ -105,14 +110,14 @@ Create a new conversation session.
 - `SessionId` - Custom session ID
 - `Model` - Model to use ("gpt-5", "claude-sonnet-4.5", etc.)
 - `ReasoningEffort` - Reasoning effort level for models that support it ("low", "medium", "high", "xhigh"). Use `ListModelsAsync()` to check which models support this option.
-- `Tools` - Custom tools exposed to the CLI
+- `Tools` - Custom tool declarations exposed to the CLI. Declarations without an invocable `AIFunction` are left pending for manual resolution.
 - `SystemMessage` - System message customization
 - `AvailableTools` - List of tool names to allow
 - `ExcludedTools` - List of tool names to disable
 - `Provider` - Custom API provider configuration (BYOK)
 - `Streaming` - Enable streaming of response chunks (default: false)
 - `InfiniteSessions` - Configure automatic context compaction (see below)
-- `OnPermissionRequest` - **Required.** Handler called before each tool execution to approve or deny it. Use `PermissionHandler.ApproveAll` to allow everything, or provide a custom function for fine-grained control. See [Permission Handling](#permission-handling) section.
+- `OnPermissionRequest` - Optional handler called before each tool execution to approve or deny it. When omitted, permission requests are emitted as events and left pending for manual resolution. Use `PermissionHandler.ApproveAll` to allow everything, or provide a custom function for fine-grained control. See [Permission Handling](#permission-handling) section.
 - `OnUserInputRequest` - Handler for user input requests from the agent (enables ask_user tool). See [User Input Requests](#user-input-requests) section.
 - `Hooks` - Hook handlers for session lifecycle events. See [Session Hooks](#session-hooks) section.
 
@@ -122,7 +127,7 @@ Resume an existing session. Returns the session with `WorkspacePath` populated i
 
 **ResumeSessionConfig:**
 
-- `OnPermissionRequest` - **Required.** Handler called before each tool execution to approve or deny it. See [Permission Handling](#permission-handling) section.
+- `OnPermissionRequest` - Optional handler called before each tool execution to approve or deny it. See [Permission Handling](#permission-handling) section.
 
 ##### `PingAsync(string? message = null): Task<PingResponse>`
 
@@ -726,7 +731,7 @@ No extra dependencies — uses built-in `System.Diagnostics.Activity`.
 
 ## Permission Handling
 
-An `OnPermissionRequest` handler is **required** whenever you create or resume a session. The handler is called before the agent executes each tool (file writes, shell commands, custom tools, etc.) and must return a decision.
+An `OnPermissionRequest` handler is optional when you create or resume a session. When provided, it is called before the agent executes each tool (file writes, shell commands, custom tools, etc.) and returns a decision. When omitted, permission requests are emitted as events and left pending for the consumer to resolve with the pending permission RPC.
 
 ### Approve All (simplest)
 
@@ -789,7 +794,7 @@ var session = await client.CreateSessionAsync(new SessionConfig
 
 ### Resuming Sessions
 
-Pass `OnPermissionRequest` when resuming a session too — it is required:
+You may pass `OnPermissionRequest` when resuming a session too:
 
 ```csharp
 var session = await client.ResumeSessionAsync("session-id", new ResumeSessionConfig

--- a/dotnet/samples/Chat.cs
+++ b/dotnet/samples/Chat.cs
@@ -1,3 +1,5 @@
+#:project ../src/GitHub.Copilot.SDK.csproj
+
 using GitHub.Copilot.SDK;
 
 await using var client = new CopilotClient();

--- a/dotnet/samples/Chat.csproj
+++ b/dotnet/samples/Chat.csproj
@@ -1,9 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\src\GitHub.Copilot.SDK.csproj" />
-  </ItemGroup>
-</Project>

--- a/dotnet/samples/ManualToolResume.cs
+++ b/dotnet/samples/ManualToolResume.cs
@@ -1,0 +1,92 @@
+#:project ../src/GitHub.Copilot.SDK.csproj
+
+using System.ComponentModel;
+using GitHub.Copilot.SDK;
+using GitHub.Copilot.SDK.Rpc;
+using Microsoft.Extensions.AI;
+
+var tool = ManualToolDeclaration();
+
+// 1. Create a session with a declaration-only tool, then stop after the permission prompt.
+await using CopilotClient client1 = new();
+await using var session1 = await client1.CreateSessionAsync(new() { Tools = [tool] });
+
+// Subscribe before sending so the permission event cannot be missed.
+var permissionRequested = WaitForEventAsync<PermissionRequestedEvent>(session1);
+await session1.SendAsync(new MessageOptions
+{
+    Prompt = "Use the manual_resume_status tool with id 'alpha', then tell me the status.",
+});
+
+var permissionEvent = await permissionRequested;
+await client1.ForceStopAsync();
+
+await PauseAsync();
+
+// 2. Resume pending work and grant permission to invoke the tool.
+await using CopilotClient client2 = new();
+await using var session2 = await client2.ResumeSessionAsync(session1.SessionId, new()
+{
+    Tools = [tool],
+    ContinuePendingWork = true,
+});
+
+// Subscribe before approving so the external tool request cannot be missed.
+var toolRequested = WaitForEventAsync<ExternalToolRequestedEvent>(
+    session2,
+    evt => evt.Data.ToolName == "manual_resume_status");
+
+await session2.Rpc.Permissions.HandlePendingPermissionRequestAsync(
+    permissionEvent.Data.RequestId,
+    new PermissionDecisionApproveOnce());
+
+var toolEvent = await toolRequested;
+await client2.ForceStopAsync();
+
+await PauseAsync();
+
+// 3. Resume again and manually provide the pending tool result.
+await using var client3 = new CopilotClient();
+await using var session3 = await client3.ResumeSessionAsync(session1.SessionId, new ResumeSessionConfig
+{
+    Tools = [tool],
+    ContinuePendingWork = true,
+});
+
+var assistantMessage = WaitForEventAsync<AssistantMessageEvent>(session3);
+await session3.Rpc.Tools.HandlePendingToolCallAsync(
+    toolEvent.Data.RequestId,
+    result: "MANUAL_STATUS_READY");
+
+var answer = await assistantMessage;
+Console.WriteLine(answer.Data.Content);
+
+static Task PauseAsync()
+{
+    Console.WriteLine("Simulating time passing...\n");
+    return Task.Delay(TimeSpan.FromSeconds(1));
+}
+
+static AIFunctionDeclaration ManualToolDeclaration() =>
+    AIFunctionFactory.Create(
+        ([Description("Identifier to look up")] string id) => $"not used: {id}",
+        "manual_resume_status",
+        "Looks up a status value. The SDK consumer supplies the result manually.")
+    // Remove the invocable callback so the SDK leaves tool execution pending.
+    .AsDeclarationOnly();
+
+static async Task<T> WaitForEventAsync<T>(CopilotSession session, Func<T, bool>? predicate = null)
+    where T : SessionEvent
+{
+    var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+    IDisposable? subscription = null;
+    subscription = session.On(evt =>
+    {
+        if (evt is T typed && (predicate?.Invoke(typed) ?? true))
+        {
+            subscription?.Dispose();
+            tcs.TrySetResult(typed);
+        }
+    });
+    return await tcs.Task.WaitAsync(TimeSpan.FromMinutes(2));
+}

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -508,7 +508,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     /// <summary>
     /// Creates a new Copilot session with the specified configuration.
     /// </summary>
-    /// <param name="config">Configuration for the session, including the required <see cref="SessionConfig.OnPermissionRequest"/> handler.</param>
+    /// <param name="config">Configuration for the session.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
     /// <returns>A task that resolves to provide the <see cref="CopilotSession"/>.</returns>
     /// <remarks>
@@ -533,13 +533,6 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     public async Task<CopilotSession> CreateSessionAsync(SessionConfig config, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(config);
-
-        if (config.OnPermissionRequest == null)
-        {
-            throw new ArgumentException(
-                "An OnPermissionRequest handler is required when creating a session. " +
-                "For example, to allow all permissions, use CreateSessionAsync(new() { OnPermissionRequest = PermissionHandler.ApproveAll });");
-        }
 
         var connection = await EnsureConnectedAsync(cancellationToken);
         var totalTimestamp = Stopwatch.GetTimestamp();
@@ -670,10 +663,9 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     /// Resumes an existing Copilot session with the specified configuration.
     /// </summary>
     /// <param name="sessionId">The ID of the session to resume.</param>
-    /// <param name="config">Configuration for the resumed session, including the required <see cref="ResumeSessionConfig.OnPermissionRequest"/> handler.</param>
+    /// <param name="config">Configuration for the resumed session.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
     /// <returns>A task that resolves to provide the <see cref="CopilotSession"/>.</returns>
-    /// <exception cref="ArgumentException">Thrown when <see cref="ResumeSessionConfig.OnPermissionRequest"/> is not set.</exception>
     /// <exception cref="InvalidOperationException">Thrown when the session does not exist or the client is not connected.</exception>
     /// <remarks>
     /// This allows you to continue a previous conversation, maintaining all conversation history.
@@ -696,13 +688,6 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     {
         ArgumentNullException.ThrowIfNull(sessionId);
         ArgumentNullException.ThrowIfNull(config);
-
-        if (config.OnPermissionRequest == null)
-        {
-            throw new ArgumentException(
-                "An OnPermissionRequest handler is required when resuming a session. " +
-                "For example, to allow all permissions, use new() { OnPermissionRequest = PermissionHandler.ApproveAll }.");
-        }
 
         var connection = await EnsureConnectedAsync(cancellationToken);
         var totalTimestamp = Stopwatch.GetTimestamp();
@@ -1853,6 +1838,8 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             var session = client.GetSession(sessionId) ?? throw new ArgumentException($"Unknown session {sessionId}");
             if (session.GetTool(toolName) is not { } tool)
             {
+                // Support for not providing the tool handler is only available in the v3+ model.
+                // For v2, it must have been provided.
                 return new ToolCallResponseV2(new ToolResultObject
                 {
                     TextResultForLlm = $"Tool '{toolName}' is not supported.",
@@ -2012,7 +1999,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         bool? OverridesBuiltInTool = null,
         bool? SkipPermission = null)
     {
-        public static ToolDefinition FromAIFunction(AIFunction function)
+        public static ToolDefinition FromAIFunction(AIFunctionDeclaration function)
         {
             var overrides = function.AdditionalProperties.TryGetValue(CopilotTool.OverridesBuiltInToolKey, out var val) && val is true;
             var skipPerm = function.AdditionalProperties.TryGetValue(CopilotTool.SkipPermissionKey, out var skipVal) && skipVal is true;

--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -425,17 +425,20 @@ public sealed partial class CopilotSession : IAsyncDisposable
     /// <summary>
     /// Registers custom tool handlers for this session.
     /// </summary>
-    /// <param name="tools">A collection of AI functions that can be invoked by the assistant.</param>
+    /// <param name="tools">A collection of AI function declarations available to the assistant.</param>
     /// <remarks>
-    /// Tools allow the assistant to execute custom functions. When the assistant invokes a tool,
-    /// the corresponding handler is called with the tool arguments.
+    /// Tools backed by an <see cref="AIFunction"/> are invoked automatically. Declaration-only tools are
+    /// left pending for the client to resolve via the external tool request event.
     /// </remarks>
-    internal void RegisterTools(ICollection<AIFunction> tools)
+    internal void RegisterTools(ICollection<AIFunctionDeclaration> tools)
     {
         _toolHandlers.Clear();
         foreach (var tool in tools)
         {
-            _toolHandlers.Add(tool.Name, tool);
+            if (tool.GetService<AIFunction>() is { } function)
+            {
+                _toolHandlers.Add(tool.Name, function);
+            }
         }
     }
 
@@ -457,7 +460,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
     /// When the assistant needs permission to perform certain actions (e.g., file operations),
     /// this handler is called to approve or deny the request.
     /// </remarks>
-    internal void RegisterPermissionHandler(PermissionRequestHandler handler)
+    internal void RegisterPermissionHandler(PermissionRequestHandler? handler)
     {
         _permissionHandler = handler;
     }

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -2158,9 +2158,11 @@ public class SessionConfig
     public bool? EnableConfigDiscovery { get; set; }
 
     /// <summary>
-    /// Custom tool functions available to the language model during the session.
+    /// Custom tool declarations available to the language model during the session.
+    /// Declarations backed by an <see cref="AIFunction"/> are invoked automatically; declarations without one
+    /// are left for the client to handle via external tool request events.
     /// </summary>
-    public ICollection<AIFunction>? Tools { get; set; }
+    public ICollection<AIFunctionDeclaration>? Tools { get; set; }
     /// <summary>
     /// System message configuration for the session.
     /// </summary>
@@ -2429,9 +2431,11 @@ public class ResumeSessionConfig
     public string? Model { get; set; }
 
     /// <summary>
-    /// Custom tool functions available to the language model during the resumed session.
+    /// Custom tool declarations available to the language model during the resumed session.
+    /// Declarations backed by an <see cref="AIFunction"/> are invoked automatically; declarations without one
+    /// are left for the client to handle via external tool request events.
     /// </summary>
-    public ICollection<AIFunction>? Tools { get; set; }
+    public ICollection<AIFunctionDeclaration>? Tools { get; set; }
 
     /// <summary>
     /// System message configuration.

--- a/dotnet/test/E2E/ClientE2ETests.cs
+++ b/dotnet/test/E2E/ClientE2ETests.cs
@@ -181,27 +181,24 @@ public class ClientE2ETests
     [Theory]
     [InlineData(true)]   // stdio transport
     [InlineData(false)]  // TCP transport
-    public async Task Should_Throw_When_CreateSession_Called_Without_PermissionHandler(bool useStdio)
+    public async Task Should_Allow_CreateSession_Called_Without_PermissionHandler(bool useStdio)
     {
-        using var client = new CopilotClient(new CopilotClientOptions { UseStdio = useStdio });
+        await using var client = new CopilotClient(new CopilotClientOptions { UseStdio = useStdio });
+        await using var session = await client.CreateSessionAsync(new SessionConfig());
 
-        var ex = await Assert.ThrowsAsync<ArgumentException>(() => client.CreateSessionAsync(new SessionConfig()));
-
-        Assert.Contains("OnPermissionRequest", ex.Message);
-        Assert.Contains("is required", ex.Message);
+        Assert.NotNull(session.SessionId);
     }
 
     [Theory]
     [InlineData(true)]   // stdio transport
     [InlineData(false)]  // TCP transport
-    public async Task Should_Throw_When_ResumeSession_Called_Without_PermissionHandler(bool useStdio)
+    public async Task Should_Allow_ResumeSession_Called_Without_PermissionHandler(bool useStdio)
     {
-        using var client = new CopilotClient(new CopilotClientOptions { UseStdio = useStdio });
+        await using var client = new CopilotClient(new CopilotClientOptions { UseStdio = useStdio });
+        await using var originalSession = await client.CreateSessionAsync(new SessionConfig());
+        await using var resumedSession = await client.ResumeSessionAsync(originalSession.SessionId, new());
 
-        var ex = await Assert.ThrowsAsync<ArgumentException>(() => client.ResumeSessionAsync("some-session-id", new()));
-
-        Assert.Contains("OnPermissionRequest", ex.Message);
-        Assert.Contains("is required", ex.Message);
+        Assert.Equal(originalSession.SessionId, resumedSession.SessionId);
     }
 
     [Theory]

--- a/go/README.md
+++ b/go/README.md
@@ -19,6 +19,12 @@ cd go/samples
 go run chat.go
 ```
 
+The manual permission/tool-result resume sample can be run from the same directory:
+
+```bash
+go run ./manual_tool_resume
+```
+
 ## Quick Start
 
 ```go
@@ -44,7 +50,7 @@ func main() {
     }
     defer client.Stop()
 
-    // Create a session (OnPermissionRequest is required)
+    // Create a session (OnPermissionRequest is optional; ApproveAll allows every tool)
     session, err := client.CreateSession(context.Background(), &copilot.SessionConfig{
         Model:               "gpt-5",
         OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
@@ -156,7 +162,7 @@ Event types: `SessionLifecycleCreated`, `SessionLifecycleDeleted`, `SessionLifec
 - `Provider` (\*ProviderConfig): Custom API provider configuration (BYOK). See [Custom Providers](#custom-providers) section.
 - `Streaming` (bool): Enable streaming delta events
 - `InfiniteSessions` (\*InfiniteSessionConfig): Automatic context compaction configuration
-- `OnPermissionRequest` (PermissionHandlerFunc): **Required.** Handler called before each tool execution to approve or deny it. Use `copilot.PermissionHandler.ApproveAll` to allow everything, or provide a custom function for fine-grained control. See [Permission Handling](#permission-handling) section.
+- `OnPermissionRequest` (PermissionHandlerFunc): Optional handler called before each tool execution to approve or deny it. When nil, permission requests are emitted as events and left pending for manual resolution. Use `copilot.PermissionHandler.ApproveAll` to allow everything, or provide a custom function for fine-grained control. See [Permission Handling](#permission-handling) section.
 - `OnUserInputRequest` (UserInputHandler): Handler for user input requests from the agent (enables ask_user tool). See [User Input Requests](#user-input-requests) section.
 - `Hooks` (\*SessionHooks): Hook handlers for session lifecycle events. See [Session Hooks](#session-hooks) section.
 - `Commands` ([]CommandDefinition): Slash-commands registered for this session. See [Commands](#commands) section.
@@ -164,7 +170,7 @@ Event types: `SessionLifecycleCreated`, `SessionLifecycleDeleted`, `SessionLifec
 
 **ResumeSessionConfig:**
 
-- `OnPermissionRequest` (PermissionHandlerFunc): **Required.** Handler called before each tool execution to approve or deny it. See [Permission Handling](#permission-handling) section.
+- `OnPermissionRequest` (PermissionHandlerFunc): Optional handler called before each tool execution to approve or deny it. See [Permission Handling](#permission-handling) section.
 - `Tools` ([]Tool): Tools to expose when resuming
 - `ReasoningEffort` (string): Reasoning effort level for models that support it
 - `Provider` (\*ProviderConfig): Custom API provider configuration (BYOK). See [Custom Providers](#custom-providers) section.
@@ -569,7 +575,7 @@ Dependency: `go.opentelemetry.io/otel`
 
 ## Permission Handling
 
-An `OnPermissionRequest` handler is **required** whenever you create or resume a session. The handler is called before the agent executes each tool (file writes, shell commands, custom tools, etc.) and must return a decision.
+An `OnPermissionRequest` handler is optional when you create or resume a session. When provided, it is called before the agent executes each tool (file writes, shell commands, custom tools, etc.) and returns a decision. When nil, permission requests are emitted as events and left pending for the consumer to resolve with the pending permission RPC.
 
 ### Approve All (simplest)
 
@@ -626,7 +632,7 @@ session, err := client.CreateSession(context.Background(), &copilot.SessionConfi
 
 ### Resuming Sessions
 
-Pass `OnPermissionRequest` when resuming a session too — it is required:
+You may pass `OnPermissionRequest` when resuming a session too:
 
 ```go
 session, err := client.ResumeSession(context.Background(), sessionID, &copilot.ResumeSessionConfig{

--- a/go/client.go
+++ b/go/client.go
@@ -555,16 +555,15 @@ func (c *Client) ensureConnected(ctx context.Context) error {
 // If the client is not connected and AutoStart is enabled, this will automatically
 // start the connection.
 //
-// The config parameter is required and must include an OnPermissionRequest handler.
+// The config parameter is optional. If no OnPermissionRequest handler is provided,
+// permission requests are surfaced as events for the caller to resolve manually.
 //
 // Returns the created session or an error if session creation fails.
 //
 // Example:
 //
 //	// Basic session
-//	session, err := client.CreateSession(context.Background(), &copilot.SessionConfig{
-//	    OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
-//	})
+//	session, err := client.CreateSession(context.Background(), nil)
 //
 //	// Session with model and tools
 //	session, err := client.CreateSession(context.Background(), &copilot.SessionConfig{
@@ -610,8 +609,8 @@ func extractTransformCallbacks(config *SystemMessageConfig) (*SystemMessageConfi
 }
 
 func (c *Client) CreateSession(ctx context.Context, config *SessionConfig) (*Session, error) {
-	if config == nil || config.OnPermissionRequest == nil {
-		return nil, fmt.Errorf("an OnPermissionRequest handler is required when creating a session. For example, to allow all permissions, use &copilot.SessionConfig{OnPermissionRequest: copilot.PermissionHandler.ApproveAll}")
+	if config == nil {
+		config = &SessionConfig{}
 	}
 
 	if err := c.ensureConnected(ctx); err != nil {
@@ -766,8 +765,6 @@ func (c *Client) CreateSession(ctx context.Context, config *SessionConfig) (*Ses
 // ResumeSession resumes an existing conversation session by its ID.
 //
 // This is a convenience method that calls [Client.ResumeSessionWithOptions].
-// The config must include an OnPermissionRequest handler.
-//
 // Example:
 //
 //	session, err := client.ResumeSession(context.Background(), "session-123", &copilot.ResumeSessionConfig{
@@ -789,8 +786,8 @@ func (c *Client) ResumeSession(ctx context.Context, sessionID string, config *Re
 //	    Tools: []copilot.Tool{myNewTool},
 //	})
 func (c *Client) ResumeSessionWithOptions(ctx context.Context, sessionID string, config *ResumeSessionConfig) (*Session, error) {
-	if config == nil || config.OnPermissionRequest == nil {
-		return nil, fmt.Errorf("an OnPermissionRequest handler is required when resuming a session. For example, to allow all permissions, use &copilot.ResumeSessionConfig{OnPermissionRequest: copilot.PermissionHandler.ApproveAll}")
+	if config == nil {
+		config = &ResumeSessionConfig{}
 	}
 
 	if err := c.ensureConnected(ctx); err != nil {

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -656,42 +656,39 @@ func TestOverridesBuiltInTool(t *testing.T) {
 	})
 }
 
-func TestClient_CreateSession_RequiresPermissionHandler(t *testing.T) {
-	t.Run("returns error when config is nil", func(t *testing.T) {
-		client := NewClient(nil)
+func TestClient_CreateSession_AllowsMissingPermissionHandler(t *testing.T) {
+	t.Run("accepts nil config before connection validation", func(t *testing.T) {
+		client := NewClient(&ClientOptions{AutoStart: Bool(false)})
 		_, err := client.CreateSession(t.Context(), nil)
 		if err == nil {
-			t.Fatal("Expected error when OnPermissionRequest is nil")
+			t.Fatal("Expected error when client is not connected")
 		}
-		matched, _ := regexp.MatchString("OnPermissionRequest.*is required", err.Error())
-		if !matched {
-			t.Errorf("Expected error about OnPermissionRequest being required, got: %v", err)
+		if strings.Contains(err.Error(), "OnPermissionRequest") {
+			t.Errorf("Did not expect permission handler validation error, got: %v", err)
 		}
 	})
 
-	t.Run("returns error when OnPermissionRequest is not set", func(t *testing.T) {
-		client := NewClient(nil)
+	t.Run("accepts missing OnPermissionRequest before connection validation", func(t *testing.T) {
+		client := NewClient(&ClientOptions{AutoStart: Bool(false)})
 		_, err := client.CreateSession(t.Context(), &SessionConfig{})
 		if err == nil {
-			t.Fatal("Expected error when OnPermissionRequest is nil")
+			t.Fatal("Expected error when client is not connected")
 		}
-		matched, _ := regexp.MatchString("OnPermissionRequest.*is required", err.Error())
-		if !matched {
-			t.Errorf("Expected error about OnPermissionRequest being required, got: %v", err)
+		if strings.Contains(err.Error(), "OnPermissionRequest") {
+			t.Errorf("Did not expect permission handler validation error, got: %v", err)
 		}
 	})
 }
 
-func TestClient_ResumeSession_RequiresPermissionHandler(t *testing.T) {
-	t.Run("returns error when config is nil", func(t *testing.T) {
-		client := NewClient(nil)
+func TestClient_ResumeSession_AllowsMissingPermissionHandler(t *testing.T) {
+	t.Run("accepts nil config before connection validation", func(t *testing.T) {
+		client := NewClient(&ClientOptions{AutoStart: Bool(false)})
 		_, err := client.ResumeSessionWithOptions(t.Context(), "some-id", nil)
 		if err == nil {
-			t.Fatal("Expected error when OnPermissionRequest is nil")
+			t.Fatal("Expected error when client is not connected")
 		}
-		matched, _ := regexp.MatchString("OnPermissionRequest.*is required", err.Error())
-		if !matched {
-			t.Errorf("Expected error about OnPermissionRequest being required, got: %v", err)
+		if strings.Contains(err.Error(), "OnPermissionRequest") {
+			t.Errorf("Did not expect permission handler validation error, got: %v", err)
 		}
 	})
 }

--- a/go/samples/manual_tool_resume/main.go
+++ b/go/samples/manual_tool_resume/main.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	copilot "github.com/github/copilot-sdk/go"
+	"github.com/github/copilot-sdk/go/rpc"
+)
+
+const timeout = 2 * time.Minute
+
+func manualTool() copilot.Tool {
+	return copilot.Tool{
+		Name:        "manual_resume_status",
+		Description: "Looks up a status value. The SDK consumer supplies the result manually.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"id": map[string]any{
+					"type":        "string",
+					"description": "Identifier to look up",
+				},
+			},
+			"required": []string{"id"},
+		},
+		// No Handler: the SDK exposes the declaration and leaves execution pending.
+	}
+}
+
+func newClient() *copilot.Client {
+	cliPath := filepath.Join("..", "..", "nodejs", "node_modules", "@github", "copilot", "index.js")
+	return copilot.NewClient(&copilot.ClientOptions{CLIPath: cliPath})
+}
+
+func watchPermission(session *copilot.Session) (<-chan *copilot.PermissionRequestedData, func()) {
+	ch := make(chan *copilot.PermissionRequestedData, 1)
+	unsubscribe := session.On(func(event copilot.SessionEvent) {
+		if data, ok := event.Data.(*copilot.PermissionRequestedData); ok {
+			ch <- data
+		}
+	})
+	return ch, unsubscribe
+}
+
+func receivePermission(ctx context.Context, ch <-chan *copilot.PermissionRequestedData) (*copilot.PermissionRequestedData, error) {
+	select {
+	case data := <-ch:
+		return data, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func watchTool(session *copilot.Session) (<-chan *copilot.ExternalToolRequestedData, func()) {
+	ch := make(chan *copilot.ExternalToolRequestedData, 1)
+	unsubscribe := session.On(func(event copilot.SessionEvent) {
+		if data, ok := event.Data.(*copilot.ExternalToolRequestedData); ok && data.ToolName == "manual_resume_status" {
+			ch <- data
+		}
+	})
+	return ch, unsubscribe
+}
+
+func receiveTool(ctx context.Context, ch <-chan *copilot.ExternalToolRequestedData) (*copilot.ExternalToolRequestedData, error) {
+	select {
+	case data := <-ch:
+		return data, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func watchAssistant(session *copilot.Session) (<-chan string, func()) {
+	ch := make(chan string, 1)
+	unsubscribe := session.On(func(event copilot.SessionEvent) {
+		if data, ok := event.Data.(*copilot.AssistantMessageData); ok {
+			ch <- data.Content
+		}
+	})
+	return ch, unsubscribe
+}
+
+func receiveAssistant(ctx context.Context, ch <-chan string) (string, error) {
+	select {
+	case content := <-ch:
+		return content, nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+func pause() {
+	fmt.Println("Simulating time passing...")
+	fmt.Println()
+	time.Sleep(time.Second)
+}
+
+func main() {
+	ctx := context.Background()
+	tool := manualTool()
+
+	// 1. Create a session with a declaration-only tool, then stop after the permission prompt.
+	client1 := newClient()
+	if err := client1.Start(ctx); err != nil {
+		panic(err)
+	}
+	session1, err := client1.CreateSession(ctx, &copilot.SessionConfig{
+		Tools: []copilot.Tool{tool},
+	})
+	if err != nil {
+		panic(err)
+	}
+	sessionID := session1.SessionID
+
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	// Subscribe before sending so the permission event cannot be missed.
+	permissionCh, unsubscribePermission := watchPermission(session1)
+	if _, err := session1.Send(ctx, copilot.MessageOptions{
+		Prompt: "Use the manual_resume_status tool with id 'alpha', then tell me the status.",
+	}); err != nil {
+		unsubscribePermission()
+		cancel()
+		panic(err)
+	}
+	permission, err := receivePermission(waitCtx, permissionCh)
+	unsubscribePermission()
+	if err != nil {
+		cancel()
+		panic(err)
+	}
+	cancel()
+	client1.ForceStop()
+	pause()
+
+	// 2. Resume pending work and grant permission to invoke the tool.
+	client2 := newClient()
+	if err := client2.Start(ctx); err != nil {
+		panic(err)
+	}
+	session2, err := client2.ResumeSession(ctx, sessionID, &copilot.ResumeSessionConfig{
+		Tools:               []copilot.Tool{tool},
+		ContinuePendingWork: true,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	waitCtx, cancel = context.WithTimeout(ctx, timeout)
+	// Subscribe before approving so the external tool request cannot be missed.
+	toolCh, unsubscribeTool := watchTool(session2)
+	if _, err := session2.RPC.Permissions.HandlePendingPermissionRequest(ctx, &rpc.PermissionDecisionRequest{
+		RequestID: permission.RequestID,
+		Result:    &rpc.PermissionDecisionApproveOnce{},
+	}); err != nil {
+		unsubscribeTool()
+		cancel()
+		panic(err)
+	}
+	toolRequest, err := receiveTool(waitCtx, toolCh)
+	unsubscribeTool()
+	if err != nil {
+		cancel()
+		panic(err)
+	}
+	cancel()
+	client2.ForceStop()
+	pause()
+
+	// 3. Resume again and manually provide the pending tool result.
+	client3 := newClient()
+	if err := client3.Start(ctx); err != nil {
+		panic(err)
+	}
+	session3, err := client3.ResumeSession(ctx, sessionID, &copilot.ResumeSessionConfig{
+		Tools:               []copilot.Tool{tool},
+		ContinuePendingWork: true,
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer client3.ForceStop()
+
+	waitCtx, cancel = context.WithTimeout(ctx, timeout)
+	defer cancel()
+	answerCh, unsubscribeAssistant := watchAssistant(session3)
+	defer unsubscribeAssistant()
+	if _, err := session3.RPC.Tools.HandlePendingToolCall(ctx, &rpc.HandlePendingToolCallRequest{
+		RequestID: toolRequest.RequestID,
+		Result:    rpc.ExternalToolStringResult("MANUAL_STATUS_READY"),
+	}); err != nil {
+		panic(err)
+	}
+
+	answer, err := receiveAssistant(waitCtx, answerCh)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+	fmt.Println(answer)
+}

--- a/go/session.go
+++ b/go/session.go
@@ -283,8 +283,8 @@ func (s *Session) On(handler SessionEventHandler) func() {
 
 // registerTools registers tool handlers for this session.
 //
-// Tools allow the assistant to execute custom functions. When the assistant
-// invokes a tool, the corresponding handler is called with the tool arguments.
+// Tools with handlers allow the assistant to execute custom functions automatically.
+// Declaration-only tools are surfaced as events and left pending for the consumer.
 //
 // This method is internal and typically called when creating a session with tools.
 func (s *Session) registerTools(tools []Tool) {

--- a/go/types.go
+++ b/go/types.go
@@ -613,7 +613,8 @@ type SessionConfig struct {
 	// Custom instruction files (.github/copilot-instructions.md, AGENTS.md, etc.) are
 	// always loaded from the working directory regardless of this setting.
 	EnableConfigDiscovery bool
-	// Tools exposes caller-implemented tools to the CLI
+	// Tools exposes caller-implemented tools to the CLI. A Tool with a nil Handler
+	// is declaration-only; the consumer must resolve its calls via pending tool RPCs.
 	Tools []Tool
 	// SystemMessage configures system message customization
 	SystemMessage *SystemMessageConfig
@@ -623,8 +624,9 @@ type SessionConfig struct {
 	// ExcludedTools is a list of tool names to disable. All other tools remain available.
 	// Ignored if AvailableTools is specified.
 	ExcludedTools []string
-	// OnPermissionRequest is a handler for permission requests from the server.
-	// This field is required; use PermissionHandler.ApproveAll to allow all permissions.
+	// OnPermissionRequest is an optional handler for permission requests from the server.
+	// When nil, permission requests are surfaced as events and left pending for the
+	// consumer to resolve via pending permission RPCs.
 	OnPermissionRequest PermissionHandlerFunc
 	// OnUserInputRequest is a handler for user input requests from the agent (enables ask_user tool)
 	OnUserInputRequest UserInputHandler
@@ -717,7 +719,9 @@ type Tool struct {
 	Parameters           map[string]any `json:"parameters,omitempty"`
 	OverridesBuiltInTool bool           `json:"overridesBuiltInTool,omitempty"`
 	SkipPermission       bool           `json:"skipPermission,omitempty"`
-	Handler              ToolHandler    `json:"-"`
+	// Handler is optional. When nil, the SDK exposes the tool declaration but does
+	// not automatically invoke it.
+	Handler ToolHandler `json:"-"`
 }
 
 // ToolInvocation describes a tool call initiated by Copilot
@@ -845,7 +849,8 @@ type ResumeSessionConfig struct {
 	ClientName string
 	// Model to use for this session. Can change the model when resuming.
 	Model string
-	// Tools exposes caller-implemented tools to the CLI
+	// Tools exposes caller-implemented tools to the CLI. A Tool with a nil Handler
+	// is declaration-only; the consumer must resolve its calls via pending tool RPCs.
 	Tools []Tool
 	// SystemMessage configures system message customization
 	SystemMessage *SystemMessageConfig
@@ -870,8 +875,9 @@ type ResumeSessionConfig struct {
 	// ReasoningEffort level for models that support it.
 	// Valid values: "low", "medium", "high", "xhigh"
 	ReasoningEffort string
-	// OnPermissionRequest is a handler for permission requests from the server.
-	// This field is required; use PermissionHandler.ApproveAll to allow all permissions.
+	// OnPermissionRequest is an optional handler for permission requests from the server.
+	// When nil, permission requests are surfaced as events and left pending for the
+	// consumer to resolve via pending permission RPCs.
 	OnPermissionRequest PermissionHandlerFunc
 	// OnUserInputRequest is a handler for user input requests from the agent (enables ask_user tool)
 	OnUserInputRequest UserInputHandler

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -32,7 +32,7 @@ import { CopilotClient, approveAll } from "@github/copilot-sdk";
 const client = new CopilotClient();
 await client.start();
 
-// Create a session (onPermissionRequest is required)
+// Create a session (onPermissionRequest is optional; approveAll allows every tool)
 const session = await client.createSession({
     model: "gpt-5",
     onPermissionRequest: approveAll,
@@ -115,11 +115,11 @@ Create a new conversation session.
 - `sessionId?: string` - Custom session ID.
 - `model?: string` - Model to use ("gpt-5", "claude-sonnet-4.5", etc.). **Required when using custom provider.**
 - `reasoningEffort?: "low" | "medium" | "high" | "xhigh"` - Reasoning effort level for models that support it. Use `listModels()` to check which models support this option.
-- `tools?: Tool[]` - Custom tools exposed to the CLI
+- `tools?: Tool[]` - Custom tools exposed to the CLI. Tools without `handler` are declaration-only and must be resolved via pending tool-call RPCs.
 - `systemMessage?: SystemMessageConfig` - System message customization (see below)
 - `infiniteSessions?: InfiniteSessionConfig` - Configure automatic context compaction (see below)
 - `provider?: ProviderConfig` - Custom API provider configuration (BYOK - Bring Your Own Key). See [Custom Providers](#custom-providers) section.
-- `onPermissionRequest: PermissionHandler` - **Required.** Handler called before each tool execution to approve or deny it. Use `approveAll` to allow everything, or provide a custom function for fine-grained control. See [Permission Handling](#permission-handling) section.
+- `onPermissionRequest?: PermissionHandler` - Optional handler called before each tool execution to approve or deny it. When omitted, permission requests are emitted as events and left pending for manual resolution. Use `approveAll` to allow everything, or provide a custom function for fine-grained control. See [Permission Handling](#permission-handling) section.
 - `onUserInputRequest?: UserInputHandler` - Handler for user input requests from the agent. Enables the `ask_user` tool. See [User Input Requests](#user-input-requests) section.
 - `onElicitationRequest?: ElicitationHandler` - Handler for elicitation requests dispatched by the server. Enables this client to present form-based UI dialogs on behalf of the agent or other session participants. See [Elicitation Requests](#elicitation-requests) section.
 - `hooks?: SessionHooks` - Hook handlers for session lifecycle events. See [Session Hooks](#session-hooks) section.
@@ -802,7 +802,7 @@ Inbound trace context from the CLI is available on the `ToolInvocation` object p
 
 ## Permission Handling
 
-An `onPermissionRequest` handler is **required** whenever you create or resume a session. The handler is called before the agent executes each tool (file writes, shell commands, custom tools, etc.) and must return a decision.
+An `onPermissionRequest` handler is optional when you create or resume a session. When provided, it is called before the agent executes each tool (file writes, shell commands, custom tools, etc.) and returns a decision. When omitted, permission requests are emitted as events and left pending for the consumer to resolve with the pending permission RPC.
 
 ### Approve All (simplest)
 
@@ -865,7 +865,7 @@ const session = await client.createSession({
 
 ### Resuming Sessions
 
-Pass `onPermissionRequest` when resuming a session too — it is required:
+You may pass `onPermissionRequest` when resuming a session too:
 
 ```typescript
 const session = await client.resumeSession("session-id", {

--- a/nodejs/samples/manual-tool-resume.ts
+++ b/nodejs/samples/manual-tool-resume.ts
@@ -1,0 +1,92 @@
+import {
+    CopilotClient,
+    defineTool,
+    type CopilotSession,
+    type SessionEvent,
+} from "@github/copilot-sdk";
+import { z } from "zod";
+
+type EventOfType<T extends SessionEvent["type"]> = Extract<SessionEvent, { type: T }>;
+
+function waitForEvent<T extends SessionEvent["type"]>(
+    session: CopilotSession,
+    type: T,
+    predicate?: (event: EventOfType<T>) => boolean
+): Promise<EventOfType<T>> {
+    return new Promise((resolve) => {
+        const unsubscribe = session.on(type, (event) => {
+            const typed = event as EventOfType<T>;
+            if (!predicate || predicate(typed)) {
+                unsubscribe();
+                resolve(typed);
+            }
+        });
+    });
+}
+
+async function pause() {
+    console.log("Simulating time passing...\n");
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+}
+
+const tool = defineTool("manual_resume_status", {
+    description: "Looks up a status value. The SDK consumer supplies the result manually.",
+    parameters: z.object({
+        id: z.string().describe("Identifier to look up"),
+    }),
+    // No handler: the SDK exposes the declaration and leaves execution pending.
+});
+
+// 1. Create a session with a declaration-only tool, then stop after the permission prompt.
+const client1 = new CopilotClient();
+const session1 = await client1.createSession({ tools: [tool] });
+
+// Subscribe before sending so the permission event cannot be missed.
+const permissionRequested = waitForEvent(session1, "permission.requested");
+await session1.send({
+    prompt: "Use the manual_resume_status tool with id 'alpha', then tell me the status.",
+});
+
+const permissionEvent = await permissionRequested;
+await client1.forceStop();
+await pause();
+
+// 2. Resume pending work and grant permission to invoke the tool.
+const client2 = new CopilotClient();
+const session2 = await client2.resumeSession(session1.sessionId, {
+    tools: [tool],
+    continuePendingWork: true,
+});
+
+// Subscribe before approving so the external tool request cannot be missed.
+const toolRequested = waitForEvent(
+    session2,
+    "external_tool.requested",
+    (event) => event.data.toolName === "manual_resume_status"
+);
+
+await session2.rpc.permissions.handlePendingPermissionRequest({
+    requestId: permissionEvent.data.requestId,
+    result: { kind: "approve-once" },
+});
+
+const toolEvent = await toolRequested;
+await client2.forceStop();
+await pause();
+
+// 3. Resume again and manually provide the pending tool result.
+const client3 = new CopilotClient();
+const session3 = await client3.resumeSession(session1.sessionId, {
+    tools: [tool],
+    continuePendingWork: true,
+});
+
+const assistantMessage = waitForEvent(session3, "assistant.message");
+await session3.rpc.tools.handlePendingToolCall({
+    requestId: toolEvent.data.requestId,
+    result: "MANUAL_STATUS_READY",
+});
+
+const answer = await assistantMessage;
+console.log(answer.data.content);
+await client3.forceStop();

--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -723,12 +723,6 @@ export class CopilotClient {
      * ```
      */
     async createSession(config: SessionConfig): Promise<CopilotSession> {
-        if (!config?.onPermissionRequest) {
-            throw new Error(
-                "An onPermissionRequest handler is required when creating a session. For example, to allow all permissions, use { onPermissionRequest: approveAll }."
-            );
-        }
-
         if (!this.connection) {
             if (this.options.autoStart) {
                 await this.start();
@@ -879,12 +873,6 @@ export class CopilotClient {
      * ```
      */
     async resumeSession(sessionId: string, config: ResumeSessionConfig): Promise<CopilotSession> {
-        if (!config?.onPermissionRequest) {
-            throw new Error(
-                "An onPermissionRequest handler is required when resuming a session. For example, to allow all permissions, use { onPermissionRequest: approveAll }."
-            );
-        }
-
         if (!this.connection) {
             if (this.options.autoStart) {
                 await this.start();

--- a/nodejs/src/session.ts
+++ b/nodejs/src/session.ts
@@ -580,8 +580,8 @@ export class CopilotSession {
     /**
      * Registers custom tool handlers for this session.
      *
-     * Tools allow the assistant to execute custom functions. When the assistant
-     * invokes a tool, the corresponding handler is called with the tool arguments.
+     * Tools with handlers allow the assistant to execute custom functions automatically.
+     * Declaration-only tools are surfaced as events and left pending for the consumer.
      *
      * @param tools - An array of tool definitions with their handlers, or undefined to clear all tools
      * @internal This method is typically called internally when creating a session with tools.
@@ -593,7 +593,9 @@ export class CopilotSession {
         }
 
         for (const tool of tools) {
-            this.toolHandlers.set(tool.name, tool.handler);
+            if (tool.handler) {
+                this.toolHandlers.set(tool.name, tool.handler);
+            }
         }
     }
 

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -393,12 +393,16 @@ export interface ZodSchema<T = unknown> {
  * - A Zod schema (provides type inference for handler)
  * - A raw JSON schema object
  * - Omitted (no parameters)
+ *
+ * If `handler` is omitted, the SDK exposes the declaration but does not
+ * automatically invoke the tool. Consumers can resolve tool calls by observing
+ * external tool request events and calling the pending-tool RPC.
  */
 export interface Tool<TArgs = unknown> {
     name: string;
     description?: string;
     parameters?: ZodSchema<TArgs> | Record<string, unknown>;
-    handler: ToolHandler<TArgs>;
+    handler?: ToolHandler<TArgs>;
     /**
      * When true, explicitly indicates this tool is intended to override a built-in tool
      * of the same name. If not set and the name clashes with a built-in tool, the runtime
@@ -420,7 +424,7 @@ export function defineTool<T = unknown>(
     config: {
         description?: string;
         parameters?: ZodSchema<T> | Record<string, unknown>;
-        handler: ToolHandler<T>;
+        handler?: ToolHandler<T>;
         overridesBuiltInTool?: boolean;
         skipPermission?: boolean;
     }
@@ -1335,7 +1339,8 @@ export interface SessionConfig {
     enableConfigDiscovery?: boolean;
 
     /**
-     * Tools exposed to the CLI server
+     * Tools exposed to the CLI server. Tools without a handler are declaration-only
+     * and must be resolved by the consumer via pending external tool request RPCs.
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     tools?: Tool<any>[];
@@ -1382,10 +1387,11 @@ export interface SessionConfig {
     enableSessionTelemetry?: boolean;
 
     /**
-     * Handler for permission requests from the server.
-     * When provided, the server will call this handler to request permission for operations.
+     * Optional handler for permission requests from the server.
+     * When omitted, permission requests are surfaced as events and left pending for
+     * the consumer to resolve via the pending permission RPC.
      */
-    onPermissionRequest: PermissionHandler;
+    onPermissionRequest?: PermissionHandler;
 
     /**
      * Handler for user input requests from the agent.

--- a/nodejs/test/client.test.ts
+++ b/nodejs/test/client.test.ts
@@ -1,40 +1,27 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { approveAll, CopilotClient, type ModelInfo } from "../src/index.js";
+import { CopilotSession } from "../src/session.js";
 import { defaultJoinSessionPermissionHandler } from "../src/types.js";
 
 // This file is for unit tests. Where relevant, prefer to add e2e tests in e2e/*.test.ts instead
 
 describe("CopilotClient", () => {
-    it("throws when createSession is called without onPermissionRequest", async () => {
-        const client = new CopilotClient();
-        await client.start();
-        onTestFinished(() => client.forceStop());
+    it("allows createSession without onPermissionRequest", async () => {
+        const client = new CopilotClient({ autoStart: false });
 
-        await expect((client as any).createSession({})).rejects.toThrow(
-            /onPermissionRequest.*is required/
-        );
+        await expect(client.createSession({})).rejects.toThrow(/Client not connected/);
     });
 
-    it("throws when resumeSession is called without onPermissionRequest", async () => {
-        const client = new CopilotClient();
-        await client.start();
-        onTestFinished(() => client.forceStop());
+    it("allows resumeSession without onPermissionRequest", async () => {
+        const client = new CopilotClient({ autoStart: false });
 
-        const session = await client.createSession({ onPermissionRequest: approveAll });
-        await expect((client as any).resumeSession(session.sessionId, {})).rejects.toThrow(
-            /onPermissionRequest.*is required/
-        );
+        await expect(client.resumeSession("session-1", {})).rejects.toThrow(/Client not connected/);
     });
 
     it("does not respond to v3 permission requests when handler returns no-result", async () => {
-        const client = new CopilotClient();
-        await client.start();
-        onTestFinished(() => client.forceStop());
-
-        const session = await client.createSession({
-            onPermissionRequest: () => ({ kind: "no-result" }),
-        });
+        const session = new CopilotSession("session-1", {} as any);
+        session.registerPermissionHandler(() => ({ kind: "no-result" }));
         const spy = vi.spyOn(session.rpc.permissions, "handlePendingPermissionRequest");
 
         await (session as any)._executePermissionAndRespond("request-1", { kind: "write" });
@@ -43,13 +30,10 @@ describe("CopilotClient", () => {
     });
 
     it("throws when a v2 permission handler returns no-result", async () => {
+        const session = new CopilotSession("session-1", {} as any);
+        session.registerPermissionHandler(() => ({ kind: "no-result" }));
         const client = new CopilotClient();
-        await client.start();
-        onTestFinished(() => client.forceStop());
-
-        const session = await client.createSession({
-            onPermissionRequest: () => ({ kind: "no-result" }),
-        });
+        (client as any).sessions.set(session.sessionId, session);
 
         await expect(
             (client as any).handlePermissionRequestV2({

--- a/python/README.md
+++ b/python/README.md
@@ -72,7 +72,7 @@ async def main():
     client = CopilotClient()
     await client.start()
 
-    # Create a session (on_permission_request is required)
+    # Create a session (on_permission_request is optional; approve_all allows every tool)
     session = await client.create_session(
         on_permission_request=PermissionHandler.approve_all,
         model="gpt-5",
@@ -175,12 +175,12 @@ These are passed as keyword arguments to `create_session()`:
 - `model` (str): Model to use ("gpt-5", "claude-sonnet-4.5", etc.). **Required when using custom provider.**
 - `reasoning_effort` (str): Reasoning effort level for models that support it ("low", "medium", "high", "xhigh"). Use `list_models()` to check which models support this option.
 - `session_id` (str): Custom session ID
-- `tools` (list): Custom tools exposed to the CLI
+- `tools` (list): Custom tools exposed to the CLI. Tools with `handler=None` are declaration-only and must be resolved via pending tool-call RPCs.
 - `system_message` (SystemMessageConfig): System message configuration
 - `streaming` (bool): Enable streaming delta events
 - `provider` (ProviderConfig): Custom API provider configuration (BYOK). See [Custom Providers](#custom-providers) section.
 - `infinite_sessions` (InfiniteSessionConfig): Automatic context compaction configuration
-- `on_permission_request` (callable): **Required.** Handler called before each tool execution to approve or deny it. Use `PermissionHandler.approve_all` to allow everything, or provide a custom function for fine-grained control. See [Permission Handling](#permission-handling) section.
+- `on_permission_request` (callable): Optional handler called before each tool execution to approve or deny it. When omitted, permission requests are emitted as events and left pending for manual resolution. Use `PermissionHandler.approve_all` to allow everything, or provide a custom function for fine-grained control. See [Permission Handling](#permission-handling) section.
 - `on_user_input_request` (callable): Handler for user input requests from the agent (enables ask_user tool). See [User Input Requests](#user-input-requests) section.
 - `hooks` (SessionHooks): Hook handlers for session lifecycle events. See [Session Hooks](#session-hooks) section.
 
@@ -279,7 +279,17 @@ async with await client.create_session(
     ...
 ```
 
-The SDK automatically handles `tool.call`, executes your handler (sync or async), and responds with the final result when the tool completes.
+The SDK automatically handles `tool.call`, executes your handler (sync or async), and responds with the final result when the tool completes. If a tool has no handler, it is exposed as a declaration only; observe `external_tool.requested` events and resolve the call with the pending tool RPC.
+
+You can also create a declaration-only tool with generated Pydantic parameters:
+
+```python
+tool = define_tool(
+    "lookup_issue",
+    description="Fetch issue details from our tracker",
+    params_type=LookupIssueParams,
+)
+```
 
 #### Overriding Built-in Tools
 
@@ -544,7 +554,7 @@ Install with telemetry extras: `pip install copilot-sdk[telemetry]` (provides `o
 
 ## Permission Handling
 
-An `on_permission_request` handler is **required** whenever you create or resume a session. The handler is called before the agent executes each tool (file writes, shell commands, custom tools, etc.) and must return a decision.
+An `on_permission_request` handler is optional when you create or resume a session. When provided, it is called before the agent executes each tool (file writes, shell commands, custom tools, etc.) and returns a decision. When omitted, permission requests are emitted as events and left pending for the consumer to resolve with the pending permission RPC.
 
 ### Approve All (simplest)
 
@@ -621,7 +631,7 @@ async def on_permission_request(
 
 ### Resuming Sessions
 
-Pass `on_permission_request` when resuming a session too — it is required:
+You may pass `on_permission_request` when resuming a session too:
 
 ```python
 session = await client.resume_session(

--- a/python/copilot/__init__.py
+++ b/python/copilot/__init__.py
@@ -43,7 +43,14 @@ from .session_fs_provider import (
     SessionFsProvider,
     create_session_fs_adapter,
 )
-from .tools import convert_mcp_call_tool_result, define_tool
+from .tools import (
+    Tool,
+    ToolBinaryResult,
+    ToolInvocation,
+    ToolResult,
+    convert_mcp_call_tool_result,
+    define_tool,
+)
 
 __version__ = "0.1.0"
 
@@ -81,6 +88,10 @@ __all__ = [
     "SessionUiApi",
     "SessionUiCapabilities",
     "SubprocessConfig",
+    "Tool",
+    "ToolBinaryResult",
+    "ToolInvocation",
+    "ToolResult",
     "convert_mcp_call_tool_result",
     "define_tool",
 ]

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -1322,7 +1322,7 @@ class CopilotClient:
     async def create_session(
         self,
         *,
-        on_permission_request: _PermissionHandlerFn,
+        on_permission_request: _PermissionHandlerFn | None = None,
         model: str | None = None,
         session_id: str | None = None,
         client_name: str | None = None,
@@ -1367,8 +1367,9 @@ class CopilotClient:
         automatically start the connection.
 
         Args:
-            on_permission_request: Handler for permission requests. Use
-                ``PermissionHandler.approve_all`` to allow all permissions.
+            on_permission_request: Optional handler for permission requests. When
+                omitted, permission requests are surfaced as events and left pending
+                for the consumer to resolve via the pending permission RPC.
             model: The model to use for the session (e.g. ``"gpt-4"``).
             session_id: Optional session ID. If not provided, a UUID is generated.
             client_name: Optional client name for identification.
@@ -1429,7 +1430,7 @@ class CopilotClient:
 
         Raises:
             RuntimeError: If the client is not connected and auto_start is disabled.
-            ValueError: If ``on_permission_request`` is not a valid callable.
+            ValueError: If ``on_permission_request`` is provided but not callable.
 
         Example:
             >>> session = await client.create_session(
@@ -1443,11 +1444,8 @@ class CopilotClient:
             ...     streaming=True,
             ... )
         """
-        if not on_permission_request or not callable(on_permission_request):
-            raise ValueError(
-                "A valid on_permission_request handler is required. "
-                "Use PermissionHandler.approve_all or provide a custom handler."
-            )
+        if on_permission_request is not None and not callable(on_permission_request):
+            raise ValueError("on_permission_request must be callable when provided.")
         if not self._client:
             if self._auto_start:
                 await self.start()
@@ -1696,7 +1694,7 @@ class CopilotClient:
         self,
         session_id: str,
         *,
-        on_permission_request: _PermissionHandlerFn,
+        on_permission_request: _PermissionHandlerFn | None = None,
         model: str | None = None,
         client_name: str | None = None,
         reasoning_effort: ReasoningEffort | None = None,
@@ -1741,8 +1739,9 @@ class CopilotClient:
 
         Args:
             session_id: The ID of the session to resume.
-            on_permission_request: Handler for permission requests. Use
-                ``PermissionHandler.approve_all`` to allow all permissions.
+            on_permission_request: Optional handler for permission requests. When
+                omitted, permission requests are surfaced as events and left pending
+                for the consumer to resolve via the pending permission RPC.
             model: The model to use for the resumed session.
             client_name: Optional client name for identification.
             reasoning_effort: Reasoning effort level for the model.
@@ -1818,11 +1817,8 @@ class CopilotClient:
             ...     tools=[my_new_tool],
             ... )
         """
-        if not on_permission_request or not callable(on_permission_request):
-            raise ValueError(
-                "A valid on_permission_request handler is required. "
-                "Use PermissionHandler.approve_all or provide a custom handler."
-            )
+        if on_permission_request is not None and not callable(on_permission_request):
+            raise ValueError("on_permission_request must be callable when provided.")
         if not self._client:
             if self._auto_start:
                 await self.start()

--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -918,8 +918,9 @@ class SessionConfig(TypedDict, total=False):
     # List of tool names to disable. Applies to all tools including custom tools
     # registered via tools=. Ignored if available_tools is set.
     excluded_tools: list[str]
-    # Handler for permission requests from the server
-    on_permission_request: _PermissionHandlerFn
+    # Optional handler for permission requests from the server. When omitted,
+    # requests are surfaced as events and left pending for manual resolution.
+    on_permission_request: _PermissionHandlerFn | None
     # Handler for user input requests from the agent (enables ask_user tool)
     on_user_input_request: UserInputHandler
     # Hook handlers for intercepting session lifecycle events
@@ -1014,7 +1015,9 @@ class ResumeSessionConfig(TypedDict, total=False):
     enable_session_telemetry: bool
     # Reasoning effort level for models that support it.
     reasoning_effort: ReasoningEffort
-    on_permission_request: _PermissionHandlerFn
+    # Optional handler for permission requests from the server. When omitted,
+    # requests are surfaced as events and left pending for manual resolution.
+    on_permission_request: _PermissionHandlerFn | None
     # Handler for user input requestsfrom the agent (enables ask_user tool)
     on_user_input_request: UserInputHandler
     # Hook handlers for intercepting session lifecycle events
@@ -1882,8 +1885,8 @@ class CopilotSession:
         """
         Register custom tool handlers for this session.
 
-        Tools allow the assistant to execute custom functions. When the assistant
-        invokes a tool, the corresponding handler is called with the tool arguments.
+        Tools with handlers allow the assistant to execute custom functions automatically.
+        Declaration-only tools are surfaced as events and left pending for the consumer.
 
         Note:
             This method is internal. Tools are typically registered when creating

--- a/python/copilot/tools.py
+++ b/python/copilot/tools.py
@@ -58,7 +58,7 @@ ToolHandler = Callable[[ToolInvocation], ToolResult | Awaitable[ToolResult]]
 class Tool:
     name: str
     description: str
-    handler: ToolHandler
+    handler: ToolHandler | None = None
     parameters: dict[str, Any] | None = None
     overrides_built_in_tool: bool = False
     skip_permission: bool = False
@@ -76,6 +76,18 @@ def define_tool(
     overrides_built_in_tool: bool = False,
     skip_permission: bool = False,
 ) -> Callable[[Callable[..., Any]], Tool]: ...
+
+
+@overload
+def define_tool(
+    name: str,
+    *,
+    description: str | None = None,
+    params_type: type[T],
+    handler: None = None,
+    overrides_built_in_tool: bool = False,
+    skip_permission: bool = False,
+) -> Tool: ...
 
 
 @overload
@@ -122,6 +134,14 @@ def define_tool(
             description="Fetch issue details",
             handler=lambda params, inv: fetch_issue(params.id).summary,
             params_type=LookupIssueParams
+        )
+
+    Declaration-only usage:
+
+        tool = define_tool(
+            "lookup_issue",
+            description="Fetch issue details",
+            params_type=LookupIssueParams,
         )
 
     Args:
@@ -220,6 +240,18 @@ def define_tool(
         if name is None:
             raise ValueError("name is required when using define_tool with handler=")
         return decorator(handler)
+
+    # If a parameter model is provided without a handler, expose a declaration-only tool.
+    if name is not None and params_type is not None:
+        schema = params_type.model_json_schema() if _is_pydantic_model(params_type) else None
+        return Tool(
+            name=name,
+            description=description or "",
+            parameters=schema,
+            handler=None,
+            overrides_built_in_tool=overrides_built_in_tool,
+            skip_permission=skip_permission,
+        )
 
     # Otherwise return decorator for @define_tool(...) usage
     return decorator

--- a/python/copilot/tools.py
+++ b/python/copilot/tools.py
@@ -75,7 +75,8 @@ def define_tool(
     description: str | None = None,
     overrides_built_in_tool: bool = False,
     skip_permission: bool = False,
-) -> Callable[[Callable[..., Any]], Tool]: ...
+) -> Callable[[Callable[..., Any]], Tool]:
+    pass
 
 
 @overload
@@ -87,7 +88,8 @@ def define_tool(
     handler: None = None,
     overrides_built_in_tool: bool = False,
     skip_permission: bool = False,
-) -> Tool: ...
+) -> Tool:
+    pass
 
 
 @overload
@@ -99,7 +101,8 @@ def define_tool(
     params_type: type[T],
     overrides_built_in_tool: bool = False,
     skip_permission: bool = False,
-) -> Tool: ...
+) -> Tool:
+    pass
 
 
 def define_tool(

--- a/python/e2e/test_client_e2e.py
+++ b/python/e2e/test_client_e2e.py
@@ -248,39 +248,31 @@ class TestClient:
             await client.force_stop()
 
     @pytest.mark.asyncio
-    async def test_should_throw_when_create_session_called_without_permission_handler(self):
-        """`create_session` requires an `on_permission_request` handler."""
+    async def test_should_create_session_without_permission_handler(self):
+        """`create_session` allows omitting an `on_permission_request` handler."""
         client = CopilotClient(SubprocessConfig(cli_path=CLI_PATH, use_stdio=True))
 
         try:
             await client.start()
-            with pytest.raises((TypeError, ValueError)) as exc_info:
-                await client.create_session()  # type: ignore[call-arg]
+            session = await client.create_session()
 
-            message = str(exc_info.value)
-            # Accept either 'on_permission_request' missing-arg or runtime validation error.
-            assert "on_permission_request" in message or "permission" in message.lower(), (
-                f"Expected message to reference permission handler, got: {message}"
-            )
+            assert session.session_id
 
             await client.stop()
         finally:
             await client.force_stop()
 
     @pytest.mark.asyncio
-    async def test_should_throw_when_resume_session_called_without_permission_handler(self):
-        """`resume_session` requires an `on_permission_request` handler."""
+    async def test_should_resume_session_without_permission_handler(self):
+        """`resume_session` allows omitting an `on_permission_request` handler."""
         client = CopilotClient(SubprocessConfig(cli_path=CLI_PATH, use_stdio=True))
 
         try:
             await client.start()
-            with pytest.raises((TypeError, ValueError)) as exc_info:
-                await client.resume_session("some-session-id")  # type: ignore[call-arg]
+            session = await client.create_session()
+            resumed = await client.resume_session(session.session_id)
 
-            message = str(exc_info.value)
-            assert "on_permission_request" in message or "permission" in message.lower(), (
-                f"Expected message to reference permission handler, got: {message}"
-            )
+            assert resumed.session_id == session.session_id
 
             await client.stop()
         finally:

--- a/python/samples/manual_tool_resume.py
+++ b/python/samples/manual_tool_resume.py
@@ -1,0 +1,120 @@
+import asyncio
+from typing import TypeVar
+
+from copilot import CopilotClient, Tool
+from copilot.generated.rpc import HandlePendingToolCallRequest, PermissionDecisionRequest
+from copilot.generated.session_events import (
+    AssistantMessageData,
+    ExternalToolRequestedData,
+    PermissionRequestedData,
+    SessionEvent,
+)
+
+T = TypeVar("T")
+
+
+def watch_event(session, data_type: type[T], predicate=None) -> asyncio.Future:
+    loop = asyncio.get_running_loop()
+    future = loop.create_future()
+
+    def on_event(event):
+        if isinstance(event.data, data_type) and (predicate is None or predicate(event.data)):
+            unsubscribe()
+            future.set_result(event)
+
+    unsubscribe = session.on(on_event)
+    return future
+
+
+async def wait_for_event(future: asyncio.Future) -> SessionEvent:
+    return await asyncio.wait_for(future, timeout=120)
+
+
+async def pause():
+    print("Simulating time passing...\n")
+    await asyncio.sleep(1)
+
+
+tool = Tool(
+    name="manual_resume_status",
+    description="Looks up a status value. The SDK consumer supplies the result manually.",
+    parameters={
+        "type": "object",
+        "properties": {
+            "id": {"type": "string", "description": "Identifier to look up"},
+        },
+        "required": ["id"],
+    },
+    # No handler: the SDK exposes the declaration and leaves execution pending.
+)
+
+
+async def main():
+    # 1. Create a session with a declaration-only tool, then stop after the permission prompt.
+    client1 = CopilotClient()
+    await client1.start()
+    session1 = await client1.create_session(tools=[tool])
+
+    # Subscribe before sending so the permission event cannot be missed.
+    permission_requested = watch_event(session1, PermissionRequestedData)
+    await session1.send(
+        "Use the manual_resume_status tool with id 'alpha', then tell me the status."
+    )
+
+    permission_event = await wait_for_event(permission_requested)
+    await client1.force_stop()
+    await pause()
+
+    # 2. Resume pending work and grant permission to invoke the tool.
+    client2 = CopilotClient()
+    await client2.start()
+    session2 = await client2.resume_session(
+        session1.session_id,
+        tools=[tool],
+        continue_pending_work=True,
+    )
+
+    # Subscribe before approving so the external tool request cannot be missed.
+    tool_requested = watch_event(
+        session2,
+        ExternalToolRequestedData,
+        lambda data: data.tool_name == "manual_resume_status",
+    )
+
+    await session2.rpc.permissions.handle_pending_permission_request(
+        PermissionDecisionRequest.from_dict(
+            {
+                "requestId": permission_event.data.request_id,
+                "result": {"kind": "approve-once"},
+            }
+        )
+    )
+
+    tool_event = await wait_for_event(tool_requested)
+    await client2.force_stop()
+    await pause()
+
+    # 3. Resume again and manually provide the pending tool result.
+    client3 = CopilotClient()
+    await client3.start()
+    session3 = await client3.resume_session(
+        session1.session_id,
+        tools=[tool],
+        continue_pending_work=True,
+    )
+
+    assistant_message = watch_event(session3, AssistantMessageData)
+    await session3.rpc.tools.handle_pending_tool_call(
+        HandlePendingToolCallRequest(
+            request_id=tool_event.data.request_id,
+            result="MANUAL_STATUS_READY",
+        )
+    )
+
+    answer = await wait_for_event(assistant_message)
+    print(answer.data.content)
+    await client3.force_stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/test_client.py
+++ b/python/test_client.py
@@ -23,24 +23,24 @@ from copilot.session import PermissionHandler, PermissionRequestResult
 from e2e.testharness import CLI_PATH
 
 
-class TestPermissionHandlerRequired:
+class TestPermissionHandlerOptional:
     @pytest.mark.asyncio
-    async def test_create_session_raises_without_permission_handler(self):
+    async def test_create_session_allows_missing_permission_handler(self):
         client = CopilotClient(SubprocessConfig(cli_path=CLI_PATH))
         await client.start()
         try:
-            with pytest.raises(TypeError, match="on_permission_request"):
-                await client.create_session()  # type: ignore[call-arg]
+            session = await client.create_session()
+            assert session.session_id
         finally:
             await client.force_stop()
 
     @pytest.mark.asyncio
-    async def test_create_session_raises_with_none_permission_handler(self):
+    async def test_create_session_allows_none_permission_handler(self):
         client = CopilotClient(SubprocessConfig(cli_path=CLI_PATH))
         await client.start()
         try:
-            with pytest.raises(ValueError, match="on_permission_request handler is required"):
-                await client.create_session(on_permission_request=None)  # type: ignore[arg-type]
+            session = await client.create_session(on_permission_request=None)
+            assert session.session_id
         finally:
             await client.force_stop()
 
@@ -65,15 +65,15 @@ class TestPermissionHandlerRequired:
             await client.force_stop()
 
     @pytest.mark.asyncio
-    async def test_resume_session_raises_without_permission_handler(self):
+    async def test_resume_session_allows_none_permission_handler(self):
         client = CopilotClient(SubprocessConfig(cli_path=CLI_PATH))
         await client.start()
         try:
             session = await client.create_session(
                 on_permission_request=PermissionHandler.approve_all
             )
-            with pytest.raises(ValueError, match="on_permission_request.*is required"):
-                await client.resume_session(session.session_id, on_permission_request=None)
+            resumed = await client.resume_session(session.session_id, on_permission_request=None)
+            assert resumed.session_id == session.session_id
         finally:
             await client.force_stop()
 

--- a/python/test_tools.py
+++ b/python/test_tools.py
@@ -221,6 +221,22 @@ class TestDefineTool:
         )
         assert result.text_result_for_llm == "HELLO"
 
+    def test_function_style_can_create_declaration_only_tool(self):
+        class Params(BaseModel):
+            value: str = Field(description="Value to look up")
+
+        tool = define_tool(
+            "my_tool",
+            description="My tool",
+            params_type=Params,
+        )
+
+        assert tool.name == "my_tool"
+        assert tool.description == "My tool"
+        assert tool.handler is None
+        assert tool.parameters is not None
+        assert tool.parameters["properties"]["value"]["description"] == "Value to look up"
+
     def test_function_style_requires_name(self):
         class Params(BaseModel):
             value: str

--- a/rust/README.md
+++ b/rust/README.md
@@ -68,15 +68,15 @@ client.stop().await?;
 
 **`ClientOptions`:**
 
-| Field | Type | Description |
-|---|---|---|
-| `program` | `CliProgram` | `Resolve` (default: auto-detect) or `Path(PathBuf)` (explicit) |
-| `prefix_args` | `Vec<OsString>` | Args before `--server` (e.g. script path for node) |
-| `cwd` | `PathBuf` | Working directory for CLI process |
-| `env` | `Vec<(OsString, OsString)>` | Environment variables for CLI process |
-| `env_remove` | `Vec<OsString>` | Environment variables to remove |
-| `extra_args` | `Vec<String>` | Extra CLI flags |
-| `transport` | `Transport` | `Stdio` (default), `Tcp { port }`, or `External { host, port }` |
+| Field         | Type                        | Description                                                     |
+| ------------- | --------------------------- | --------------------------------------------------------------- |
+| `program`     | `CliProgram`                | `Resolve` (default: auto-detect) or `Path(PathBuf)` (explicit)  |
+| `prefix_args` | `Vec<OsString>`             | Args before `--server` (e.g. script path for node)              |
+| `cwd`         | `PathBuf`                   | Working directory for CLI process                               |
+| `env`         | `Vec<(OsString, OsString)>` | Environment variables for CLI process                           |
+| `env_remove`  | `Vec<OsString>`             | Environment variables to remove                                 |
+| `extra_args`  | `Vec<String>`               | Extra CLI flags                                                 |
+| `transport`   | `Transport`                 | `Stdio` (default), `Tcp { port }`, or `External { host, port }` |
 
 With the default `CliProgram::Resolve`, `Client::start()` automatically resolves the binary via `github_copilot_sdk::resolve::copilot_binary()` — checking `COPILOT_CLI_PATH`, the [embedded CLI](#embedded-cli), and then the system PATH. Use `CliProgram::Path(path)` to skip resolution.
 
@@ -180,7 +180,7 @@ maintenance.
 
 Implement this trait to control how a session responds to CLI events. Two styles are supported:
 
-**1. Per-event methods (recommended).** Override only the callbacks you care about; every method has a safe default (permission → deny, user input → none, external tool → "no handler", elicitation → cancel, exit plan → default). This is the `serenity::EventHandler` pattern.
+**1. Per-event methods (recommended).** Override only the callbacks you care about; every method has a safe default (permission → deny, user input → none, external tool → "no handler", elicitation → cancel, exit plan → default). When no handler is installed on a session, the SDK uses `NoopHandler`, which leaves permission and external tool requests pending for manual resolution. This is the `serenity::EventHandler` pattern.
 
 ```rust,ignore
 use async_trait::async_trait;
@@ -429,7 +429,7 @@ Reach for the `ToolHandler` trait directly when you need shared state across mul
 
 ### Permission Policies
 
-Set a permission policy directly on `SessionConfig` with the chainable builders. They wrap whatever handler you've installed (defaulting to `DenyAllHandler` if none) so only permission requests are intercepted; every other event flows through unchanged.
+Set a permission policy directly on `SessionConfig` with the chainable builders. They wrap whatever handler you've installed (defaulting to `NoopHandler` if none) so only permission requests are intercepted; every other event flows through unchanged.
 
 ```rust,ignore
 let session = client
@@ -723,20 +723,20 @@ none of them are scheduled for removal.
 
 ## Layout
 
-| File | Description |
-|---|---|
-| `lib.rs` | `Client`, `ClientOptions`, `CliProgram`, `Transport`, `Error` |
-| `session.rs` | `Session` struct, event loop, `send`/`send_and_wait`, `Client::create_session`/`resume_session` |
+| File              | Description                                                                                                                |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `lib.rs`          | `Client`, `ClientOptions`, `CliProgram`, `Transport`, `Error`                                                              |
+| `session.rs`      | `Session` struct, event loop, `send`/`send_and_wait`, `Client::create_session`/`resume_session`                            |
 | `subscription.rs` | `EventSubscription` / `LifecycleSubscription` (`Stream`-able observer handles for `subscribe()` / `subscribe_lifecycle()`) |
-| `handler.rs` | `SessionHandler` trait, `HandlerEvent`/`HandlerResponse` enums, `ApproveAllHandler` |
-| `hooks.rs` | `SessionHooks` trait, `HookEvent`/`HookOutput` enums, typed hook inputs/outputs |
-| `transforms.rs` | `SystemMessageTransform` trait, section-level system message customization |
-| `tool.rs` | `ToolHandler` trait, `ToolHandlerRouter`, `schema_for::<T>()` (with `derive` feature) |
-| `types.rs` | CLI protocol types (`SessionId`, `SessionEvent`, `SessionConfig`, `Tool`, etc.) |
-| `resolve.rs` | Binary resolution (`copilot_binary`, `node_binary`, `extended_path`) |
-| `embeddedcli.rs` | Embedded CLI extraction (`embedded-cli` feature) |
-| `router.rs` | Internal per-session event demux |
-| `jsonrpc.rs` | Internal Content-Length framed JSON-RPC transport |
+| `handler.rs`      | `SessionHandler` trait, `HandlerEvent`/`HandlerResponse` enums, `ApproveAllHandler`, `DenyAllHandler`, `NoopHandler`       |
+| `hooks.rs`        | `SessionHooks` trait, `HookEvent`/`HookOutput` enums, typed hook inputs/outputs                                            |
+| `transforms.rs`   | `SystemMessageTransform` trait, section-level system message customization                                                 |
+| `tool.rs`         | `ToolHandler` trait, `ToolHandlerRouter`, `schema_for::<T>()` (with `derive` feature)                                      |
+| `types.rs`        | CLI protocol types (`SessionId`, `SessionEvent`, `SessionConfig`, `Tool`, etc.)                                            |
+| `resolve.rs`      | Binary resolution (`copilot_binary`, `node_binary`, `extended_path`)                                                       |
+| `embeddedcli.rs`  | Embedded CLI extraction (`embedded-cli` feature)                                                                           |
+| `router.rs`       | Internal per-session event demux                                                                                           |
+| `jsonrpc.rs`      | Internal Content-Length framed JSON-RPC transport                                                                          |
 
 ## Embedded CLI
 
@@ -770,10 +770,10 @@ Supported: `darwin-arm64`, `darwin-x64`, `linux-x64`, `linux-arm64`, `win32-x64`
 
 No features are enabled by default — the bare SDK resolves the CLI from `COPILOT_CLI_PATH` or the system PATH without pulling in additional feature-gated dependencies.
 
-| Feature | Default | Description |
-|---|---|---|
-| `embedded-cli` | — | Build-time CLI embedding via `COPILOT_CLI_VERSION` (adds `sha2`, `zstd`). Enable when you need to ship a self-contained binary with a pinned CLI version. |
-| `derive` | — | `schema_for::<T>()` for generating JSON Schema from Rust types (adds `schemars`). Enable when defining [tool parameters](#tool-registration). |
+| Feature        | Default | Description                                                                                                                                               |
+| -------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `embedded-cli` | —       | Build-time CLI embedding via `COPILOT_CLI_VERSION` (adds `sha2`, `zstd`). Enable when you need to ship a self-contained binary with a pinned CLI version. |
+| `derive`       | —       | `schema_for::<T>()` for generating JSON Schema from Rust types (adds `schemars`). Enable when defining [tool parameters](#tool-registration).             |
 
 ```toml
 # These examples use registry syntax for illustration; until the crate is

--- a/rust/examples/manual_tool_resume.rs
+++ b/rust/examples/manual_tool_resume.rs
@@ -1,0 +1,151 @@
+//! Demonstrates manually resolving permission and external tool requests across resumes.
+
+use std::time::Duration;
+
+use github_copilot_sdk::generated::api_types::{
+    HandlePendingToolCallRequest, PermissionDecision, PermissionDecisionApproveOnce,
+    PermissionDecisionApproveOnceKind, PermissionDecisionRequest,
+};
+use github_copilot_sdk::generated::session_events::{
+    AssistantMessageData, ExternalToolRequestedData, PermissionRequestedData, SessionEventType,
+};
+use github_copilot_sdk::{
+    Client, ClientOptions, EventSubscription, RecvError, ResumeSessionConfig, SessionConfig,
+};
+use serde_json::json;
+
+const TOOL_NAME: &str = "manual_resume_status";
+
+fn manual_tool() -> github_copilot_sdk::Tool {
+    // No handler is registered for this tool, so the SDK leaves execution pending.
+    github_copilot_sdk::Tool::new(TOOL_NAME)
+        .with_description("Looks up a status value. The SDK consumer supplies the result manually.")
+        .with_parameters(json!({
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Identifier to look up"
+                }
+            },
+            "required": ["id"]
+        }))
+}
+
+async fn wait_for_permission(
+    events: &mut EventSubscription,
+) -> Result<PermissionRequestedData, RecvError> {
+    loop {
+        let event = events.recv().await?;
+        if event.parsed_type() == SessionEventType::PermissionRequested
+            && let Some(data) = event.typed_data::<PermissionRequestedData>()
+        {
+            return Ok(data);
+        }
+    }
+}
+
+async fn wait_for_tool(
+    events: &mut EventSubscription,
+) -> Result<ExternalToolRequestedData, RecvError> {
+    loop {
+        let event = events.recv().await?;
+        if event.parsed_type() == SessionEventType::ExternalToolRequested
+            && let Some(data) = event.typed_data::<ExternalToolRequestedData>()
+            && data.tool_name == TOOL_NAME
+        {
+            return Ok(data);
+        }
+    }
+}
+
+async fn wait_for_assistant(events: &mut EventSubscription) -> Result<String, RecvError> {
+    loop {
+        let event = events.recv().await?;
+        if event.parsed_type() == SessionEventType::AssistantMessage
+            && let Some(data) = event.typed_data::<AssistantMessageData>()
+        {
+            return Ok(data.content);
+        }
+    }
+}
+
+async fn pause() {
+    println!("Simulating time passing...\n");
+    tokio::time::sleep(Duration::from_secs(1)).await;
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let tool = manual_tool();
+
+    // 1. Create a session with a declaration-only tool, then stop after the permission prompt.
+    let client1 = Client::start(ClientOptions::default()).await?;
+    let session1 = client1
+        .create_session(SessionConfig::default().with_tools([tool.clone()]))
+        .await?;
+    let session_id = session1.id().clone();
+
+    // Subscribe before sending so the permission event cannot be missed.
+    let mut permission_events = session1.subscribe();
+    session1
+        .send("Use the manual_resume_status tool with id 'alpha', then tell me the status.")
+        .await?;
+
+    let permission = wait_for_permission(&mut permission_events).await?;
+    client1.force_stop();
+    pause().await;
+
+    // 2. Resume pending work and grant permission to invoke the tool.
+    let client2 = Client::start(ClientOptions::default()).await?;
+    let session2 = client2
+        .resume_session(
+            ResumeSessionConfig::new(session_id.clone())
+                .with_tools([tool.clone()])
+                .with_continue_pending_work(true),
+        )
+        .await?;
+
+    // Subscribe before approving so the external tool request cannot be missed.
+    let mut tool_events = session2.subscribe();
+    session2
+        .rpc()
+        .permissions()
+        .handle_pending_permission_request(PermissionDecisionRequest {
+            request_id: permission.request_id,
+            result: PermissionDecision::ApproveOnce(PermissionDecisionApproveOnce {
+                kind: PermissionDecisionApproveOnceKind::ApproveOnce,
+            }),
+        })
+        .await?;
+
+    let tool_request = wait_for_tool(&mut tool_events).await?;
+    client2.force_stop();
+    pause().await;
+
+    // 3. Resume again and manually provide the pending tool result.
+    let client3 = Client::start(ClientOptions::default()).await?;
+    let session3 = client3
+        .resume_session(
+            ResumeSessionConfig::new(session_id)
+                .with_tools([tool])
+                .with_continue_pending_work(true),
+        )
+        .await?;
+
+    let mut assistant_events = session3.subscribe();
+    session3
+        .rpc()
+        .tools()
+        .handle_pending_tool_call(HandlePendingToolCallRequest {
+            request_id: tool_request.request_id,
+            result: Some(json!("MANUAL_STATUS_READY")),
+            error: None,
+        })
+        .await?;
+
+    let answer = wait_for_assistant(&mut assistant_events).await?;
+    println!("{answer}");
+    client3.force_stop();
+    Ok(())
+}

--- a/rust/src/handler.rs
+++ b/rust/src/handler.rs
@@ -98,6 +98,8 @@ pub enum HandlerEvent {
 pub enum HandlerResponse {
     /// No response needed (used for fire-and-forget `SessionEvent`s).
     Ok,
+    /// Do not send a response. The consumer will resolve the pending request out-of-band.
+    NoResult,
     /// Permission decision.
     Permission(PermissionResult),
     /// User input response (or `None` to signal no input available).
@@ -230,7 +232,7 @@ pub enum AutoModeSwitchResponse {
 ///
 /// # Default behavior
 ///
-/// - Permission requests → **denied** (safe default).
+/// - Permission requests → **denied**.
 /// - User input → `None` (no answer available).
 /// - External tool calls → failure result with "no handler registered".
 /// - Elicitation → `"cancel"`.
@@ -460,10 +462,8 @@ impl SessionHandler for ApproveAllHandler {
 /// A [`SessionHandler`] that denies all permission requests and otherwise
 /// relies on the trait's default fallback responses for every other event
 /// (e.g. tool invocations return "unhandled", elicitations cancel, plan-mode
-/// prompts decline). This is the safe default used when no handler is set on
-/// [`SessionConfig::handler`](crate::types::SessionConfig::handler) — sessions
-/// will not stall on permission prompts (they're denied immediately) but no
-/// privileged actions will be taken without an explicit opt-in.
+/// prompts decline). Use this when a session should never wait for manual
+/// permission approval.
 #[derive(Debug, Clone)]
 pub struct DenyAllHandler;
 
@@ -471,6 +471,41 @@ pub struct DenyAllHandler;
 impl SessionHandler for DenyAllHandler {
     // All defaults are already safe: permissions deny, everything else is a
     // sensible fallback. We just reuse them here for clarity.
+}
+
+/// A [`SessionHandler`] that leaves permission requests and external tool calls pending.
+///
+/// This is the default used when no handler is set on
+/// [`SessionConfig::handler`](crate::types::SessionConfig::handler). It lets consumers
+/// observe `permission.requested` and `external_tool.requested` events and later resolve
+/// them with the corresponding pending-request RPC methods.
+#[derive(Debug, Clone)]
+pub struct NoopHandler;
+
+#[async_trait]
+impl SessionHandler for NoopHandler {
+    async fn on_event(&self, event: HandlerEvent) -> HandlerResponse {
+        match event {
+            HandlerEvent::SessionEvent { .. } => HandlerResponse::Ok,
+            HandlerEvent::PermissionRequest { .. } => {
+                HandlerResponse::Permission(PermissionResult::NoResult)
+            }
+            HandlerEvent::UserInput { .. } => HandlerResponse::UserInput(None),
+            HandlerEvent::ExternalTool { .. } => HandlerResponse::NoResult,
+            HandlerEvent::ElicitationRequest { .. } => {
+                HandlerResponse::Elicitation(ElicitationResult {
+                    action: "cancel".to_string(),
+                    content: None,
+                })
+            }
+            HandlerEvent::ExitPlanMode { .. } => {
+                HandlerResponse::ExitPlanMode(ExitPlanModeResult::default())
+            }
+            HandlerEvent::AutoModeSwitch { .. } => {
+                HandlerResponse::AutoModeSwitch(AutoModeSwitchResponse::No)
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -585,6 +620,36 @@ mod tests {
             }
             other => panic!("unexpected response: {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn noop_handler_leaves_permission_and_external_tool_pending() {
+        let h = NoopHandler;
+        let permission = h
+            .on_event(HandlerEvent::PermissionRequest {
+                session_id: SessionId::from("s1".to_string()),
+                request_id: RequestId::new("r1"),
+                data: perm_data(),
+            })
+            .await;
+        assert!(matches!(
+            permission,
+            HandlerResponse::Permission(PermissionResult::NoResult)
+        ));
+
+        let tool = h
+            .on_event(HandlerEvent::ExternalTool {
+                invocation: crate::types::ToolInvocation {
+                    session_id: SessionId::from("s1".to_string()),
+                    tool_call_id: "tc1".to_string(),
+                    tool_name: "manual".to_string(),
+                    arguments: Value::Null,
+                    traceparent: None,
+                    tracestate: None,
+                },
+            })
+            .await;
+        assert!(matches!(tool, HandlerResponse::NoResult));
     }
 
     #[tokio::test]

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -31,7 +31,8 @@ use crate::types::{
     ElicitationResult, ExitPlanModeData, GetMessagesResponse, InputOptions, MessageOptions,
     PermissionRequestData, RequestId, ResumeSessionConfig, SectionOverride, SessionCapabilities,
     SessionConfig, SessionEvent, SessionId, SetModelOptions, SystemMessageConfig, ToolInvocation,
-    ToolResult, ToolResultResponse, TraceContext, ensure_attachment_display_names,
+    ToolResult, ToolResultExpanded, ToolResultResponse, TraceContext,
+    ensure_attachment_display_names,
 };
 use crate::{Client, Error, JsonRpcResponse, SessionError, SessionEventNotification, error_codes};
 
@@ -750,14 +751,14 @@ impl Client {
     /// the session.
     ///
     /// If [`handler`](SessionConfig::handler) is `None`, the session uses
-    /// [`DenyAllHandler`](crate::handler::DenyAllHandler) — permission
-    /// requests are denied; other events are no-ops.
+    /// [`NoopHandler`](crate::handler::NoopHandler) — permission requests and
+    /// external tool calls are left pending for the consumer to resolve.
     pub async fn create_session(&self, mut config: SessionConfig) -> Result<Session, Error> {
         let total_start = Instant::now();
         let handler = config
             .handler
             .take()
-            .unwrap_or_else(|| Arc::new(crate::handler::DenyAllHandler));
+            .unwrap_or_else(|| Arc::new(crate::handler::NoopHandler));
         let hooks = config.hooks_handler.take();
         let transforms = config.transform.take();
         let tools_count = config.tools.as_ref().map_or(0, Vec::len);
@@ -878,7 +879,7 @@ impl Client {
         let handler = config
             .handler
             .take()
-            .unwrap_or_else(|| Arc::new(crate::handler::DenyAllHandler));
+            .unwrap_or_else(|| Arc::new(crate::handler::NoopHandler));
         let hooks = config.hooks_handler.take();
         let transforms = config.transform.take();
         let tools_count = config.tools.as_ref().map_or(0, Vec::len);
@@ -1105,10 +1106,9 @@ fn pending_permission_result_kind(response: &HandlerResponse) -> &'static str {
     match response {
         HandlerResponse::Permission(PermissionResult::Approved) => "approve-once",
         HandlerResponse::Permission(PermissionResult::Denied) => "reject",
-        HandlerResponse::Permission(PermissionResult::NoResult) => "no-result",
         // Fallback to "user-not-available" for UserNotAvailable, Deferred (when
         // forced through this path), Custom (handled separately upstream), and
-        // any non-permission HandlerResponse that gets here defensively.
+        // any non-permission/no-result HandlerResponse that gets here defensively.
         _ => "user-not-available",
     }
 }
@@ -1156,12 +1156,46 @@ fn direct_permission_payload(response: &HandlerResponse) -> Value {
             permission_request_response(&HandlerResponse::Permission(PermissionResult::Approved)),
         )
         .expect("serializing direct permission response should succeed"),
-        HandlerResponse::Permission(PermissionResult::NoResult)
-        | HandlerResponse::Permission(PermissionResult::UserNotAvailable) => serde_json::json!({
+        HandlerResponse::Permission(
+            PermissionResult::NoResult | PermissionResult::UserNotAvailable,
+        ) => serde_json::json!({
             "kind": pending_permission_result_kind(response),
         }),
         _ => serde_json::to_value(permission_request_response(response))
             .expect("serializing direct permission response should succeed"),
+    }
+}
+
+fn tool_failure_result(message: impl Into<String>) -> ToolResult {
+    let message = message.into();
+    ToolResult::Expanded(ToolResultExpanded {
+        text_result_for_llm: message.clone(),
+        result_type: "failure".to_string(),
+        binary_results_for_llm: None,
+        session_log: None,
+        error: Some(message),
+        tool_telemetry: None,
+    })
+}
+
+fn notification_tool_payload(response: HandlerResponse) -> Option<Value> {
+    match response {
+        HandlerResponse::ToolResult(result) => {
+            Some(serde_json::to_value(result).unwrap_or(Value::Null))
+        }
+        HandlerResponse::NoResult => None,
+        _ => Some(
+            serde_json::to_value(tool_failure_result("Unexpected handler response"))
+                .unwrap_or(Value::Null),
+        ),
+    }
+}
+
+fn direct_tool_result(response: HandlerResponse) -> ToolResult {
+    match response {
+        HandlerResponse::ToolResult(result) => result,
+        HandlerResponse::NoResult => tool_failure_result("No tool handler available"),
+        _ => tool_failure_result("Unexpected handler response"),
     }
 }
 
@@ -1437,11 +1471,9 @@ async fn handle_notification(
                         tool_name = %tool_name,
                         "ToolHandler::call dispatch"
                     );
-                    let tool_result = match response {
-                        HandlerResponse::ToolResult(r) => r,
-                        _ => ToolResult::Text("Unexpected handler response".to_string()),
+                    let Some(result_value) = notification_tool_payload(response) else {
+                        return;
                     };
-                    let result_value = serde_json::to_value(&tool_result).unwrap_or(Value::Null);
                     let rpc_start = Instant::now();
                     let _ = client
                         .call(
@@ -1731,10 +1763,7 @@ async fn handle_request(
                 tool_name = %tool_name,
                 "ToolHandler::call dispatch"
             );
-            let tool_result = match response {
-                HandlerResponse::ToolResult(r) => r,
-                _ => ToolResult::Text("Unexpected handler response".to_string()),
-            };
+            let tool_result = direct_tool_result(response);
             let rpc_response = JsonRpcResponse {
                 jsonrpc: "2.0".to_string(),
                 id: request.id,
@@ -2177,6 +2206,12 @@ mod tests {
         assert_eq!(
             direct_permission_payload(&HandlerResponse::Permission(PermissionResult::Deferred)),
             json!({ "kind": "approve-once" })
+        );
+
+        // NoResult -> direct RPC cannot be left pending, so report no user.
+        assert_eq!(
+            direct_permission_payload(&HandlerResponse::Permission(PermissionResult::NoResult)),
+            json!({ "kind": "user-not-available" })
         );
 
         // Approved/Denied → existing kind-only shape.

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1032,7 +1032,7 @@ pub struct SessionConfig {
     /// Custom system message configuration.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_message: Option<SystemMessageConfig>,
-    /// Client-defined tools to expose to the agent.
+    /// Client-defined tool declarations to expose to the agent.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<Tool>>,
     /// Allowlist of built-in tool names the agent may use.
@@ -1058,8 +1058,8 @@ pub struct SessionConfig {
     pub request_user_input: Option<bool>,
     /// Enable `permission.request` JSON-RPC calls from the CLI. Defaults
     /// to `Some(true)` via [`SessionConfig::default`]; the default
-    /// [`DenyAllHandler`](crate::handler::DenyAllHandler) refuses all
-    /// requests so the wire surface is safe out-of-the-box.
+    /// [`NoopHandler`](crate::handler::NoopHandler) leaves requests pending
+    /// for the consumer to resolve.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_permission: Option<bool>,
     /// Enable `exitPlanMode.request` JSON-RPC calls for plan approval.
@@ -1171,9 +1171,9 @@ pub struct SessionConfig {
     #[serde(skip)]
     pub session_fs_provider: Option<Arc<dyn SessionFsProvider>>,
     /// Session-level event handler. The default is
-    /// [`DenyAllHandler`](crate::handler::DenyAllHandler) — permission
-    /// requests are denied; other events are no-ops. Use
-    /// [`with_handler`](Self::with_handler) to install a custom handler.
+    /// [`NoopHandler`](crate::handler::NoopHandler) — permission requests
+    /// and external tool calls are left pending for the consumer to resolve.
+    /// Use [`with_handler`](Self::with_handler) to install a custom handler.
     #[serde(skip)]
     pub handler: Option<Arc<dyn SessionHandler>>,
     /// Session lifecycle hook handler (pre/post tool use, session
@@ -1247,12 +1247,11 @@ impl std::fmt::Debug for SessionConfig {
 }
 
 impl Default for SessionConfig {
-    /// Permission and elicitation flows are enabled by default. With
-    /// Rust's trait-based handlers, the SDK installs `DenyAllHandler` when
-    /// no handler is provided, so these flags being `Some(true)` means the
-    /// wire surface advertises the capabilities — and the default handler
-    /// safely refuses requests. Callers that want the wire surface fully
-    /// disabled set these explicitly to `Some(false)`.
+    /// Permission and elicitation flows are enabled by default. When no handler
+    /// is provided, the SDK installs `NoopHandler`, so permission and external
+    /// tool requests remain pending until the consumer responds out-of-band.
+    /// Callers that want the wire surface fully disabled set these explicitly
+    /// to `Some(false)`.
     fn default() -> Self {
         Self {
             session_id: None,
@@ -1342,9 +1341,8 @@ impl SessionConfig {
     /// handler unchanged.
     ///
     /// If no handler has been installed via [`with_handler`](Self::with_handler),
-    /// wraps a [`DenyAllHandler`](crate::handler::DenyAllHandler) — useful
-    /// when you only care about permission policy and want the trait
-    /// fallback responses for everything else.
+    /// wraps a [`NoopHandler`](crate::handler::NoopHandler), so declaration-only
+    /// tools remain pending for manual resolution.
     ///
     /// Order-independent: `with_handler(...).approve_all_permissions()` and
     /// `approve_all_permissions().with_handler(...)` are NOT equivalent —
@@ -1355,7 +1353,7 @@ impl SessionConfig {
         let inner = self
             .handler
             .take()
-            .unwrap_or_else(|| Arc::new(crate::handler::DenyAllHandler));
+            .unwrap_or_else(|| Arc::new(crate::handler::NoopHandler));
         self.handler = Some(crate::permission::approve_all(inner));
         self
     }
@@ -1367,7 +1365,7 @@ impl SessionConfig {
         let inner = self
             .handler
             .take()
-            .unwrap_or_else(|| Arc::new(crate::handler::DenyAllHandler));
+            .unwrap_or_else(|| Arc::new(crate::handler::NoopHandler));
         self.handler = Some(crate::permission::deny_all(inner));
         self
     }
@@ -1384,7 +1382,7 @@ impl SessionConfig {
         let inner = self
             .handler
             .take()
-            .unwrap_or_else(|| Arc::new(crate::handler::DenyAllHandler));
+            .unwrap_or_else(|| Arc::new(crate::handler::NoopHandler));
         self.handler = Some(crate::permission::approve_if(inner, predicate));
         self
     }
@@ -1646,7 +1644,7 @@ pub struct ResumeSessionConfig {
     /// across CLI process restarts.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_message: Option<SystemMessageConfig>,
-    /// Client-defined tools to re-supply on resume.
+    /// Client-defined tool declarations to re-supply on resume.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<Tool>>,
     /// Allowlist of tool names the agent may use.
@@ -1667,7 +1665,8 @@ pub struct ResumeSessionConfig {
     /// Enable the ask_user tool.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_user_input: Option<bool>,
-    /// Enable permission request RPCs.
+    /// Enable permission request RPCs. When no handler is set, permission requests
+    /// remain pending until the consumer responds out-of-band.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_permission: Option<bool>,
     /// Enable exit-plan-mode request RPCs.
@@ -1920,7 +1919,7 @@ impl ResumeSessionConfig {
         let inner = self
             .handler
             .take()
-            .unwrap_or_else(|| Arc::new(crate::handler::DenyAllHandler));
+            .unwrap_or_else(|| Arc::new(crate::handler::NoopHandler));
         self.handler = Some(crate::permission::approve_all(inner));
         self
     }
@@ -1932,7 +1931,7 @@ impl ResumeSessionConfig {
         let inner = self
             .handler
             .take()
-            .unwrap_or_else(|| Arc::new(crate::handler::DenyAllHandler));
+            .unwrap_or_else(|| Arc::new(crate::handler::NoopHandler));
         self.handler = Some(crate::permission::deny_all(inner));
         self
     }
@@ -1946,7 +1945,7 @@ impl ResumeSessionConfig {
         let inner = self
             .handler
             .take()
-            .unwrap_or_else(|| Arc::new(crate::handler::DenyAllHandler));
+            .unwrap_or_else(|| Arc::new(crate::handler::NoopHandler));
         self.handler = Some(crate::permission::approve_if(inner, predicate));
         self
     }
@@ -3935,8 +3934,8 @@ mod permission_builder_tests {
     }
 
     #[tokio::test]
-    async fn session_config_approve_all_defaults_to_deny_inner() {
-        // Without with_handler, the wrap defaults to DenyAllHandler. The
+    async fn session_config_approve_all_defaults_to_noop_inner() {
+        // Without with_handler, the wrap defaults to NoopHandler. The
         // approve-all wrap intercepts permission events, so they're still
         // approved -- the inner handler is consulted only for other events.
         let cfg = SessionConfig::default().approve_all_permissions();


### PR DESCRIPTION
Tools previously assumed SDK-managed callbacks were always available, which made it difficult for consumers to pause/resume work and manually resolve permission or external tool requests from events. This PR makes callback-backed execution optional while preserving the existing automatic behavior whenever a callback or handler is supplied.

## Summary

- Allows create/resume sessions to omit permission handlers so permission requests can remain pending for manual resolution.
- Supports declaration-only external tools across .NET, Node, Python, Go, and Rust while still auto-invoking tools with callbacks.
- Adds end-to-end manual permission/tool-result resume samples for every SDK.
- Updates docs and focused tests to cover both SDK-managed callbacks and consumer-managed pending request flows.

## Notes

The .NET samples are file-based apps using `dotnet run --file`, so the existing chat sample and new manual resume sample can live side by side without project glob conflicts.

## Validation

- `dotnet build dotnet\GitHub.Copilot.SDK.slnx --nologo`
- `dotnet build dotnet\samples\Chat.cs --nologo`
- `dotnet build dotnet\samples\ManualToolResume.cs --nologo`
- `cd nodejs && npm run typecheck -- --pretty false`
- `cd python && python -m py_compile samples\manual_tool_resume.py`
- `cd go\samples && go test ./...`
- `cd rust && cargo check --all-features --example manual_tool_resume`