### PR TITLE
Fix Python Quick Start example to compile with current SDK

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -28,12 +28,16 @@ import asyncio
 
 from copilot import CopilotClient
 from copilot.generated.session_events import AssistantMessageData, SessionIdleData
+from copilot.session import PermissionHandler
 
 async def main():
     # Client automatically starts on enter and cleans up on exit
     async with CopilotClient() as client:
         # Create a session with automatic cleanup
-        async with await client.create_session(model="gpt-5") as session:
+        async with await client.create_session(
+            on_permission_request=PermissionHandler.approve_all,
+            model="gpt-5",
+        ) as session:
             # Wait for response using session.idle event
             done = asyncio.Event()
 
@@ -113,7 +117,10 @@ from copilot import CopilotClient, SubprocessConfig
 from copilot.session import PermissionHandler
 
 async with CopilotClient() as client:
-    async with await client.create_session(model="gpt-5") as session:
+    async with await client.create_session(
+        on_permission_request=PermissionHandler.approve_all,
+        model="gpt-5",
+    ) as session:
         def on_event(event):
             print(f"Event: {event.type}")
 


### PR DESCRIPTION
The Quick Start snippet in `python/README.md` was the first thing a new user copy-pasted, and it failed immediately with:

```
TypeError: CopilotClient.create_session() missing 1 required keyword-only argument: 'on_permission_request'
```

`CopilotClient.create_session` declares `on_permission_request` as a required keyword-only parameter (no default), but the snippet called `create_session(model="gpt-5")` without it.

## Fix

`python/README.md` only — no source changes.

- Quick Start example: add `from copilot.session import PermissionHandler` and pass `on_permission_request=PermissionHandler.approve_all`.
- API Reference example directly below: same one-line fix. `PermissionHandler` was already imported there, but the call still omitted the kwarg, so it would have failed the same way.

Kept `model="gpt-5"` instead of changing the model name — the bug was the missing permission handler, not the model, and `"gpt-5"` is what the rest of the README uses.

## Validation

- Both snippets pass `python -m py_compile` and `ast.parse`.
- Both calls successfully `inspect.signature.bind()` against the real `CopilotClient.create_session` signature (no missing required kwargs, no unknown kwargs).
- Reproduced the original `TypeError` against the unpatched snippet and confirmed the patched snippet no longer raises it.

Fixes #1079