### PR TITLE
Fix Python from_dict() round-trip for optional fields with schema defaults

### DIFF
--- a/nodejs/test/python-codegen.test.ts
+++ b/nodejs/test/python-codegen.test.ts
@@ -74,11 +74,13 @@ describe("python session event codegen", () => {
         );
         expect(code).toContain("def to_timedelta_int(x: timedelta) -> int:");
         expect(code).toContain(
-            'action = from_union([from_none, lambda x: parse_enum(SessionSyntheticDataAction, x)], obj.get("action", "store"))'
+            'action = from_union([from_none, lambda x: parse_enum(SessionSyntheticDataAction, x)], obj.get("action"))'
         );
         expect(code).toContain(
-            'summary = from_union([from_none, from_str], obj.get("summary", ""))'
+            'summary = from_union([from_none, from_str], obj.get("summary"))'
         );
+        expect(code).not.toContain('obj.get("action", "store")');
+        expect(code).not.toContain('obj.get("summary", "")');
         expect(code).toContain("uri: str");
         expect(code).toContain("pattern: str");
         expect(code).toContain("payload: str");

--- a/nodejs/test/python-codegen.test.ts
+++ b/nodejs/test/python-codegen.test.ts
@@ -76,9 +76,7 @@ describe("python session event codegen", () => {
         expect(code).toContain(
             'action = from_union([from_none, lambda x: parse_enum(SessionSyntheticDataAction, x)], obj.get("action"))'
         );
-        expect(code).toContain(
-            'summary = from_union([from_none, from_str], obj.get("summary"))'
-        );
+        expect(code).toContain('summary = from_union([from_none, from_str], obj.get("summary"))');
         expect(code).not.toContain('obj.get("action", "store")');
         expect(code).not.toContain('obj.get("summary", "")');
         expect(code).toContain("uri: str");

--- a/python/copilot/generated/session_events.py
+++ b/python/copilot/generated/session_events.py
@@ -5245,3 +5245,4 @@ def session_event_from_dict(s: Any) -> SessionEvent:
 
 def session_event_to_dict(x: SessionEvent) -> Any:
     return x.to_dict()
+

--- a/python/copilot/generated/session_events.py
+++ b/python/copilot/generated/session_events.py
@@ -1879,7 +1879,7 @@ class PermissionPromptRequest:
         assert isinstance(obj, dict)
         kind = parse_enum(PermissionPromptRequestKind, obj.get("kind"))
         access_kind = from_union([from_none, lambda x: parse_enum(PermissionPromptRequestPathAccessKind, x)], obj.get("accessKind"))
-        action = from_union([from_none, lambda x: parse_enum(PermissionRequestMemoryAction, x)], obj.get("action", "store"))
+        action = from_union([from_none, lambda x: parse_enum(PermissionRequestMemoryAction, x)], obj.get("action"))
         args = from_union([from_none, lambda x: x], obj.get("args"))
         can_offer_session_approval = from_union([from_none, from_bool], obj.get("canOfferSessionApproval"))
         capabilities = from_union([from_none, lambda x: from_list(from_str, x)], obj.get("capabilities"))
@@ -2044,7 +2044,7 @@ class PermissionRequest:
     def from_dict(obj: Any) -> "PermissionRequest":
         assert isinstance(obj, dict)
         kind = parse_enum(PermissionRequestKind, obj.get("kind"))
-        action = from_union([from_none, lambda x: parse_enum(PermissionRequestMemoryAction, x)], obj.get("action", "store"))
+        action = from_union([from_none, lambda x: parse_enum(PermissionRequestMemoryAction, x)], obj.get("action"))
         args = obj.get("args")
         can_offer_session_approval = from_union([from_none, from_bool], obj.get("canOfferSessionApproval"))
         capabilities = from_union([from_none, lambda x: from_list(from_str, x)], obj.get("capabilities"))
@@ -3280,7 +3280,7 @@ class SessionTaskCompleteData:
     def from_dict(obj: Any) -> "SessionTaskCompleteData":
         assert isinstance(obj, dict)
         success = from_union([from_none, from_bool], obj.get("success"))
-        summary = from_union([from_none, from_str], obj.get("summary", ""))
+        summary = from_union([from_none, from_str], obj.get("summary"))
         return SessionTaskCompleteData(
             success=success,
             summary=summary,
@@ -5245,4 +5245,3 @@ def session_event_from_dict(s: Any) -> SessionEvent:
 
 def session_event_to_dict(x: SessionEvent) -> Any:
     return x.to_dict()
-

--- a/python/test_event_forward_compatibility.py
+++ b/python/test_event_forward_compatibility.py
@@ -17,7 +17,10 @@ from copilot.generated.session_events import (
     ElicitationCompletedAction,
     ElicitationRequestedMode,
     ElicitationRequestedSchema,
+    PermissionPromptRequest,
+    PermissionPromptRequestKind,
     PermissionRequest,
+    PermissionRequestKind,
     PermissionRequestMemoryAction,
     SessionEventType,
     SessionTaskCompleteData,
@@ -137,10 +140,49 @@ class TestEventForwardCompatibility:
         constructed = Data(arguments={"tool_call_id": "call-1"})
         assert constructed.to_dict() == {"arguments": {"tool_call_id": "call-1"}}
 
-    def test_schema_defaults_are_applied_for_missing_optional_fields(self):
-        """Generated event models should honor primitive schema defaults during parsing."""
-        request = PermissionRequest.from_dict({"kind": "memory", "fact": "remember this"})
-        assert request.action == PermissionRequestMemoryAction.STORE
+    def test_missing_optional_fields_remain_none_after_parsing(self):
+        """Generated event models should leave missing optional fields as None.
 
+        Regression test for github/copilot-sdk issues #1139, #1140, and #1141:
+        the Python codegen previously baked JSON Schema `default` values into
+        ``obj.get(key, default)`` for optional fields, so ``from_dict()`` returned
+        the schema default instead of ``None`` and broke ``from_dict(to_dict(x))``
+        round-trips for instances where the field was ``None``.
+        """
+        # #1141: PermissionRequest.action defaults to None when missing.
+        request = PermissionRequest.from_dict({"kind": "memory", "fact": "remember this"})
+        assert request.action is None
+        assert PermissionRequestMemoryAction.STORE.value == "store"  # sanity
+
+        # #1140: PermissionPromptRequest.action defaults to None when missing.
+        prompt_request = PermissionPromptRequest.from_dict({"kind": "memory"})
+        assert prompt_request.action is None
+
+        # #1139: SessionTaskCompleteData.summary defaults to None when missing.
         task_complete = SessionTaskCompleteData.from_dict({"success": True})
-        assert task_complete.summary == ""
+        assert task_complete.summary is None
+
+        # Explicit JSON null should also map to None.
+        task_complete_null = SessionTaskCompleteData.from_dict({"success": True, "summary": None})
+        assert task_complete_null.summary is None
+
+    def test_optional_fields_round_trip_none(self):
+        """``from_dict(to_dict(x))`` should equal ``x`` when optional fields are None.
+
+        Regression test for github/copilot-sdk issues #1139, #1140, and #1141.
+        """
+        # #1139: SessionTaskCompleteData round-trip with summary=None.
+        task = SessionTaskCompleteData(success=None, summary=None)
+        assert SessionTaskCompleteData.from_dict(task.to_dict()) == task
+
+        # #1140: PermissionPromptRequest round-trip with action=None.
+        prompt = PermissionPromptRequest(kind=PermissionPromptRequestKind.MEMORY)
+        assert prompt.action is None
+        assert "action" not in prompt.to_dict()
+        assert PermissionPromptRequest.from_dict(prompt.to_dict()) == prompt
+
+        # #1141: PermissionRequest round-trip with action=None.
+        permission = PermissionRequest(kind=PermissionRequestKind.MEMORY)
+        assert permission.action is None
+        assert "action" not in permission.to_dict()
+        assert PermissionRequest.from_dict(permission.to_dict()) == permission

--- a/scripts/codegen/python.ts
+++ b/scripts/codegen/python.ts
@@ -918,22 +918,6 @@ function isPyBase64StringSchema(schema: JSONSchema7): boolean {
     return schema.format === "byte" || (schema as Record<string, unknown>).contentEncoding === "base64";
 }
 
-function toPythonLiteral(value: unknown): string | undefined {
-    if (typeof value === "string") {
-        return JSON.stringify(value);
-    }
-    if (typeof value === "number") {
-        return Number.isFinite(value) ? String(value) : undefined;
-    }
-    if (typeof value === "boolean") {
-        return value ? "True" : "False";
-    }
-    if (value === null) {
-        return "None";
-    }
-    return undefined;
-}
-
 function extractPyEventVariants(schema: JSONSchema7): PyEventVariant[] {
     const definitionCollections = collectDefinitionCollections(schema as Record<string, unknown>);
     return getSessionEventVariantSchemas(schema, definitionCollections)
@@ -1492,9 +1476,6 @@ function emitPyClass(
             fieldName: toSnakeCase(propName),
             isRequired,
             resolved,
-            defaultLiteral: isRequired ? undefined : toPythonLiteral(
-                propSchema.default ?? resolveSchema(propSchema, ctx.definitions)?.default
-            ),
         };
     });
 
@@ -1536,9 +1517,7 @@ function emitPyClass(
     lines.push(`    def from_dict(obj: Any) -> "${typeName}":`);
     lines.push(`        assert isinstance(obj, dict)`);
     for (const field of fieldInfos) {
-        const sourceExpr = field.defaultLiteral
-            ? `obj.get(${JSON.stringify(field.jsonName)}, ${field.defaultLiteral})`
-            : `obj.get(${JSON.stringify(field.jsonName)})`;
+        const sourceExpr = `obj.get(${JSON.stringify(field.jsonName)})`;
         lines.push(
             `        ${field.fieldName} = ${field.resolved.fromExpr(sourceExpr)}`
         );
@@ -1655,9 +1634,6 @@ function emitPyFlatDiscriminatedUnion(
             fieldName: toSnakeCase(propName),
             isRequired: requiredInAll,
             resolved,
-            defaultLiteral: requiredInAll ? undefined : toPythonLiteral(
-                propSchema.default ?? resolveSchema(propSchema, ctx.definitions)?.default
-            ),
         };
     });
 
@@ -1683,9 +1659,7 @@ function emitPyFlatDiscriminatedUnion(
     lines.push(`    def from_dict(obj: Any) -> "${typeName}":`);
     lines.push(`        assert isinstance(obj, dict)`);
     for (const field of fieldInfos) {
-        const sourceExpr = field.defaultLiteral
-            ? `obj.get(${JSON.stringify(field.jsonName)}, ${field.defaultLiteral})`
-            : `obj.get(${JSON.stringify(field.jsonName)})`;
+        const sourceExpr = `obj.get(${JSON.stringify(field.jsonName)})`;
         lines.push(
             `        ${field.fieldName} = ${field.resolved.fromExpr(sourceExpr)}`
         );


### PR DESCRIPTION
Fixes #1139.
Fixes #1140.
Fixes #1141.

## Why

`from_dict(to_dict(x))` was not the identity for three generated Python dataclasses whenever the affected optional field was `None`. The dataclass declares the field as `T | None = None` and `to_dict()` omits it when `None`, but `from_dict()` was substituting the JSON-Schema `default` value when the key was missing, silently mutating unset fields:

- `SessionTaskCompleteData.summary`: `None` → `""`
- `PermissionPromptRequest.action`: `None` → `PermissionPromptRequestMemoryAction.STORE`
- `PermissionRequest.action`: `None` → `PermissionRequestMemoryAction.STORE`

Any code that round-trips events (caching, replay, audit logs, dedup) or pattern-matches on `None` to mean "absent" was getting the wrong answer end-to-end. The bug was reproducible on `main` as of today.

## What changed

Root cause is in `scripts/codegen/python.ts`: for optional fields with a schema `default`, the codegen was emitting `obj.get("key", "<default>")`, then passing that into `from_union([from_none, parse_X], ...)`, which happily parsed the default and returned it. The dataclass default and the wire default were inconsistent, so the round-trip broke.

- Dropped the `defaultLiteral` mechanism from both `emitPyClass` and `emitPyFlatDiscriminatedUnion`. `from_dict()` now uniformly emits `obj.get(key)`, so missing/null keys flow through `from_none` and land at the dataclass-declared `None`. Removed the now-unused `toPythonLiteral` helper.
- Regenerated `python/copilot/generated/session_events.py` via `npm run generate:python`. Exactly three call sites changed, all matching the bug reports.
- Flipped the two codegen-level assertions in `nodejs/test/python-codegen.test.ts` that previously locked in the buggy output, and added negative assertions to prevent regression at the generator level.
- Replaced `test_schema_defaults_are_applied_for_missing_optional_fields` in `python/test_event_forward_compatibility.py` (which asserted the bug as expected behavior) with two regression tests covering missing-key parsing, explicit-null parsing, and the full `from_dict(to_dict(x))` round-trip for all three affected classes.

## Surface area / non-obvious notes

- Other languages (Go, .NET, Rust, TypeScript) are not affected. Their generators never read `propSchema.default` to construct deserialization fallbacks; they use real nullable types end-to-end.
- Grep on the post-fix generated `session_events.py` and `rpc.py` confirms zero remaining `obj.get("...", "...")` patterns, so no other class was silently relying on baked-in schema defaults.
- The `test_schema_defaults_are_applied_for_missing_optional_fields` test was the only consumer in the repo of the old behavior. Nothing in runtime code depended on `request.action == STORE` or `task_complete.summary == ""` for unset fields.
- JSON Schema `default` is an annotation, not validation behavior, so applying it only during deserialization while ignoring it in the dataclass field and in `to_dict()` was internally inconsistent. This change makes Python deserialization symmetric with serialization and with the in-memory default.

## Validation

- `python -m pytest test_event_forward_compatibility.py` -> 10/10 pass (including new regression tests).
- Broader Python suite: 136/136 non-E2E tests pass.
- `npx vitest run` on `python-codegen.test.ts` and other non-CLI test files: pass.
- `ruff check`, `ruff format --check`, `ty check copilot`, `tsc --noEmit`, `eslint`: clean.
- Manual reproduction of each issue's repro script on unmodified `main` (changes stashed) confirms the bug; with the fix applied, all three round-trip with `equal? True`.

Independent review by the `code-review` agent on `claude-opus-4.7-xhigh` found no significant issues and confirmed both codegen paths and the test coverage.