### PR TITLE
Add netstandard and net10 targets to C# SDK

### DIFF
--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>14</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -6,11 +6,17 @@
 
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.2.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.102" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.2" />
+    <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Text.Json" Version="10.0.2" />
+    <PackageVersion Include="System.Threading.Channels" Version="10.0.2" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/dotnet/samples/Chat.csproj
+++ b/dotnet/samples/Chat.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -9,6 +9,7 @@ using System.Collections.Concurrent;
 using System.Data;
 using System.Diagnostics;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -1239,7 +1240,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
             if (!string.IsNullOrEmpty(stderrOutput))
             {
-                throw new IOException(FormatCliExitedMessage("CLI process exited unexpectedly.", stderrOutput), ex);
+                throw new IOException(FormatCliExitedMessage("CLI process exited unexpectedly.", stderrOutput!), ex);
             }
             throw new IOException($"Communication error with Copilot CLI: {ex.Message}", ex);
         }
@@ -1560,7 +1561,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         // Always use portable RID (e.g., linux-x64) to match the build-time placement,
         // since distro-specific RIDs (e.g., ubuntu.24.04-x64) are normalized at build time.
         var rid = GetPortableRid()
-            ?? Path.GetFileName(System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier);
+            ?? Path.GetFileName(RuntimeInformation.RuntimeIdentifier);
         searchedPath = Path.Combine(AppContext.BaseDirectory, "runtimes", rid, "native", binaryName);
         return File.Exists(searchedPath) ? searchedPath : null;
     }
@@ -2143,8 +2144,14 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     [JsonSerializable(typeof(UserInputResponse))]
     internal partial class ClientJsonContext : JsonSerializerContext;
 
+#if NET8_0_OR_GREATER
     [GeneratedRegex(@"listening on port ([0-9]+)", RegexOptions.IgnoreCase)]
     private static partial Regex ListeningOnPortRegex();
+#else
+    private static readonly Regex s_listeningOnPortRegex = new(@"listening on port ([0-9]+)", RegexOptions.IgnoreCase);
+
+    private static Regex ListeningOnPortRegex() => s_listeningOnPortRegex;
+#endif
 }
 
 /// <summary>

--- a/dotnet/src/GitHub.Copilot.SDK.csproj
+++ b/dotnet/src/GitHub.Copilot.SDK.csproj
@@ -19,6 +19,7 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <_CopilotCliVersionTarget>_GetCopilotCliVersion</_CopilotCliVersionTarget>
     </PropertyGroup>
 
   <PropertyGroup>
@@ -59,11 +60,14 @@
     </ItemGroup>
 
     <!-- Generate version props file at build time (gitignored) -->
-    <Target Name="_GenerateVersionProps" BeforeTargets="_DownloadCopilotCli;BeforeBuild;Pack">
+    <Target Name="_GetCopilotCliVersion" Condition="'$(CopilotCliVersion)' == ''">
         <Exec Command="node -e &quot;console.log(require('./nodejs/package-lock.json').packages['node_modules/@github/copilot'].version)&quot;" WorkingDirectory="$(MSBuildThisFileDirectory)../.." ConsoleToMSBuild="true" StandardOutputImportance="low">
             <Output TaskParameter="ConsoleOutput" PropertyName="CopilotCliVersion" />
         </Exec>
         <Error Condition="'$(CopilotCliVersion)' == ''" Text="CopilotCliVersion could not be read from nodejs/package-lock.json" />
+    </Target>
+
+    <Target Name="_GenerateVersionProps" DependsOnTargets="_GetCopilotCliVersion" BeforeTargets="Pack">
         <PropertyGroup>
             <_VersionPropsContent>
                 <![CDATA[<Project>

--- a/dotnet/src/GitHub.Copilot.SDK.csproj
+++ b/dotnet/src/GitHub.Copilot.SDK.csproj
@@ -40,7 +40,7 @@
         <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
     </ItemGroup>
 
-    <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
+    <ItemGroup Condition="'$(TargetFramework)' != '' and !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
         <PackageReference Include="System.Text.Json" />
     </ItemGroup>
 

--- a/dotnet/src/GitHub.Copilot.SDK.csproj
+++ b/dotnet/src/GitHub.Copilot.SDK.csproj
@@ -59,7 +59,7 @@
     </ItemGroup>
 
     <!-- Generate version props file at build time (gitignored) -->
-    <Target Name="_GenerateVersionProps" BeforeTargets="BeforeBuild;Pack">
+    <Target Name="_GenerateVersionProps" BeforeTargets="BeforeBuild;Pack" Condition="'$(TargetFramework)' == 'net8.0'">
         <Exec Command="node -e &quot;console.log(require('./nodejs/package-lock.json').packages['node_modules/@github/copilot'].version)&quot;" WorkingDirectory="$(MSBuildThisFileDirectory)../.." ConsoleToMSBuild="true" StandardOutputImportance="low">
             <Output TaskParameter="ConsoleOutput" PropertyName="CopilotCliVersion" />
         </Exec>

--- a/dotnet/src/GitHub.Copilot.SDK.csproj
+++ b/dotnet/src/GitHub.Copilot.SDK.csproj
@@ -59,7 +59,7 @@
     </ItemGroup>
 
     <!-- Generate version props file at build time (gitignored) -->
-    <Target Name="_GenerateVersionProps" BeforeTargets="BeforeBuild;Pack" Condition="'$(TargetFramework)' == 'net8.0'">
+    <Target Name="_GenerateVersionProps" BeforeTargets="_DownloadCopilotCli;BeforeBuild;Pack">
         <Exec Command="node -e &quot;console.log(require('./nodejs/package-lock.json').packages['node_modules/@github/copilot'].version)&quot;" WorkingDirectory="$(MSBuildThisFileDirectory)../.." ConsoleToMSBuild="true" StandardOutputImportance="low">
             <Output TaskParameter="ConsoleOutput" PropertyName="CopilotCliVersion" />
         </Exec>

--- a/dotnet/src/GitHub.Copilot.SDK.csproj
+++ b/dotnet/src/GitHub.Copilot.SDK.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFrameworks>net8.0;net10.0;netstandard2.0</TargetFrameworks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <Version>0.1.0</Version>
         <Description>SDK for programmatic control of GitHub Copilot CLI</Description>
@@ -13,7 +14,7 @@
         <RepositoryUrl>https://github.com/github/copilot-sdk</RepositoryUrl>
         <PackageIcon>copilot.png</PackageIcon>
         <PackageTags>github;copilot;sdk;jsonrpc;agent</PackageTags>
-        <IsAotCompatible>true</IsAotCompatible>
+        <IsAotCompatible Condition="'$(TargetFramework)' != 'netstandard2.0'">true</IsAotCompatible>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -37,7 +38,24 @@
         <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
+    </ItemGroup>
+
+    <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
         <PackageReference Include="System.Text.Json" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+        <PackageReference Include="System.Collections.Immutable" />
+        <PackageReference Include="System.ComponentModel.Annotations" />
+        <PackageReference Include="System.Memory" />
+        <PackageReference Include="System.Threading.Channels" />
+        <PackageReference Include="System.Threading.Tasks.Extensions" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+        <Compile Remove="Polyfills\**\*.cs" />
+        <Compile Include="Polyfills\IsExternalInit.cs" />
     </ItemGroup>
 
     <!-- Generate version props file at build time (gitignored) -->

--- a/dotnet/src/JsonRpc.cs
+++ b/dotnet/src/JsonRpc.cs
@@ -5,7 +5,6 @@
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using System.Text;
@@ -609,12 +608,11 @@ internal sealed partial class JsonRpc : IDisposable
             return null;
         }
 
-        if (result is not null && registration.ReturnsValueTaskOfT)
+        if (result is not null && registration.ValueTaskAsTaskMethod is { } valueTaskAsTaskMethod)
         {
-            var resultType = result.GetType();
-            var asTask = (Task)resultType.GetMethod("AsTask")!.Invoke(result, null)!;
+            var asTask = (Task)valueTaskAsTaskMethod.Invoke(result, null)!;
             await asTask.ConfigureAwait(false);
-            return asTask.GetType().GetProperty("Result")!.GetValue(asTask);
+            return registration.TaskResultGetter!.Invoke(asTask, null);
         }
 
         return result;
@@ -756,6 +754,9 @@ internal sealed partial class JsonRpc : IDisposable
 
     private sealed class PendingRequest() : TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously);
 
+    private static readonly MethodInfo s_taskGetResult = typeof(Task<>).GetProperty(nameof(Task<int>.Result), BindingFlags.Instance | BindingFlags.Public)!.GetMethod!;
+    private static readonly MethodInfo s_valueTaskAsTask = typeof(ValueTask<>).GetMethod(nameof(ValueTask<int>.AsTask), BindingFlags.Instance | BindingFlags.Public)!;
+
     private sealed class MethodRegistration
     {
         public MethodRegistration(Delegate handler, bool singleObjectParam)
@@ -763,15 +764,32 @@ internal sealed partial class JsonRpc : IDisposable
             Handler = handler;
             SingleObjectParam = singleObjectParam;
             Parameters = handler.Method.GetParameters();
-            ReturnsValueTaskOfT =
-                handler.Method.ReturnType.IsGenericType &&
-                handler.Method.ReturnType.GetGenericTypeDefinition() == typeof(ValueTask<>);
+            var returnType = handler.Method.ReturnType;
+            if (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(ValueTask<>))
+            {
+                ValueTaskAsTaskMethod = GetMethodFromGenericMethodDefinition(returnType, s_valueTaskAsTask);
+                TaskResultGetter = GetMethodFromGenericMethodDefinition(ValueTaskAsTaskMethod.ReturnType, s_taskGetResult);
+            }
         }
 
         public Delegate Handler { get; }
         public bool SingleObjectParam { get; }
         public ParameterInfo[] Parameters { get; }
-        public bool ReturnsValueTaskOfT { get; }
+        public MethodInfo? ValueTaskAsTaskMethod { get; }
+        public MethodInfo? TaskResultGetter { get; }
+    }
+
+    private static MethodInfo GetMethodFromGenericMethodDefinition(Type specializedType, MethodInfo genericMethodDefinition)
+    {
+        Debug.Assert(
+            specializedType.IsGenericType && specializedType.GetGenericTypeDefinition() == genericMethodDefinition.DeclaringType,
+            "Generic member definition doesn't match type.");
+#if NET8_0_OR_GREATER
+        return (MethodInfo)specializedType.GetMemberWithSameMetadataDefinitionAs(genericMethodDefinition);
+#else
+        const BindingFlags All = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance;
+        return specializedType.GetMethods(All).First(m => m.MetadataToken == genericMethodDefinition.MetadataToken);
+#endif
     }
 
     [JsonSourceGenerationOptions(

--- a/dotnet/src/Polyfills/ArrayBufferWriter.cs
+++ b/dotnet/src/Polyfills/ArrayBufferWriter.cs
@@ -1,0 +1,92 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+namespace System.Buffers;
+
+internal sealed class ArrayBufferWriter<T> : IBufferWriter<T>
+{
+    private const int DefaultInitialBufferSize = 256;
+    private T[] _buffer;
+    private int _index;
+
+    public ArrayBufferWriter()
+        : this(DefaultInitialBufferSize)
+    {
+    }
+
+    public ArrayBufferWriter(int initialCapacity)
+    {
+        if (initialCapacity < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(initialCapacity));
+        }
+
+        _buffer = initialCapacity == 0 ? [] : new T[initialCapacity];
+    }
+
+    public ReadOnlyMemory<T> WrittenMemory => _buffer.AsMemory(0, _index);
+
+    public ReadOnlySpan<T> WrittenSpan => _buffer.AsSpan(0, _index);
+
+    public int WrittenCount => _index;
+
+    public int Capacity => _buffer.Length;
+
+    public int FreeCapacity => _buffer.Length - _index;
+
+    public void Clear()
+    {
+        _buffer.AsSpan(0, _index).Clear();
+        _index = 0;
+    }
+
+    public void Advance(int count)
+    {
+        if (count < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count));
+        }
+
+        if (count > FreeCapacity)
+        {
+            throw new InvalidOperationException("Cannot advance past the end of the buffer.");
+        }
+
+        _index += count;
+    }
+
+    public Memory<T> GetMemory(int sizeHint = 0)
+    {
+        CheckAndResizeBuffer(sizeHint);
+        return _buffer.AsMemory(_index);
+    }
+
+    public Span<T> GetSpan(int sizeHint = 0)
+    {
+        CheckAndResizeBuffer(sizeHint);
+        return _buffer.AsSpan(_index);
+    }
+
+    private void CheckAndResizeBuffer(int sizeHint)
+    {
+        if (sizeHint < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sizeHint));
+        }
+
+        if (sizeHint == 0)
+        {
+            sizeHint = 1;
+        }
+
+        if (sizeHint <= FreeCapacity)
+        {
+            return;
+        }
+
+        var growBy = Math.Max(sizeHint, _buffer.Length);
+        var newSize = checked(_buffer.Length + growBy);
+        Array.Resize(ref _buffer, newSize);
+    }
+}

--- a/dotnet/src/Polyfills/BclAttributes.cs
+++ b/dotnet/src/Polyfills/BclAttributes.cs
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+namespace System.Runtime.CompilerServices;
+
+[AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+internal sealed class CallerArgumentExpressionAttribute : Attribute
+{
+    public CallerArgumentExpressionAttribute(string parameterName) => ParameterName = parameterName;
+
+    public string ParameterName { get; }
+}
+
+[AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+internal sealed class CompilerFeatureRequiredAttribute : Attribute
+{
+    public const string RefStructs = nameof(RefStructs);
+    public const string RequiredMembers = nameof(RequiredMembers);
+
+    public CompilerFeatureRequiredAttribute(string featureName) => FeatureName = featureName;
+
+    public string FeatureName { get; }
+
+    public bool IsOptional { get; set; }
+}
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+internal sealed class RequiredMemberAttribute : Attribute;

--- a/dotnet/src/Polyfills/CodeAnalysisAttributes.cs
+++ b/dotnet/src/Polyfills/CodeAnalysisAttributes.cs
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+namespace System.Diagnostics.CodeAnalysis;
+
+[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Interface | AttributeTargets.Delegate, AllowMultiple = false, Inherited = false)]
+internal sealed class ExperimentalAttribute : Attribute
+{
+    public ExperimentalAttribute(string diagnosticId) => DiagnosticId = diagnosticId;
+
+    public string DiagnosticId { get; }
+
+    public string? UrlFormat { get; set; }
+}
+
+[AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+internal sealed class NotNullWhenAttribute : Attribute
+{
+    public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+    public bool ReturnValue { get; }
+}
+
+[AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+internal sealed class SetsRequiredMembersAttribute : Attribute;
+
+[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+internal sealed class StringSyntaxAttribute : Attribute
+{
+    public const string Uri = nameof(Uri);
+
+    public StringSyntaxAttribute(string syntax)
+    {
+        Syntax = syntax;
+        Arguments = [];
+    }
+
+    public StringSyntaxAttribute(string syntax, params object?[] arguments)
+    {
+        Syntax = syntax;
+        Arguments = arguments;
+    }
+
+    public string Syntax { get; }
+
+    public object?[] Arguments { get; }
+}
+
+[AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+internal sealed class UnconditionalSuppressMessageAttribute : Attribute
+{
+    public UnconditionalSuppressMessageAttribute(string category, string checkId)
+    {
+        Category = category;
+        CheckId = checkId;
+    }
+
+    public string Category { get; }
+
+    public string CheckId { get; }
+
+    public string? Scope { get; set; }
+
+    public string? Target { get; set; }
+
+    public string? MessageId { get; set; }
+
+    public string? Justification { get; set; }
+}

--- a/dotnet/src/Polyfills/DataAnnotationsAttributes.cs
+++ b/dotnet/src/Polyfills/DataAnnotationsAttributes.cs
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+namespace System.ComponentModel.DataAnnotations;
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+internal sealed class Base64StringAttribute : ValidationAttribute
+{
+    public override bool IsValid(object? value)
+    {
+        if (value is null)
+        {
+            return true;
+        }
+
+        if (value is not string text)
+        {
+            return false;
+        }
+
+        try
+        {
+            Convert.FromBase64String(text);
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+}

--- a/dotnet/src/Polyfills/DownlevelExtensions.cs
+++ b/dotnet/src/Polyfills/DownlevelExtensions.cs
@@ -442,8 +442,8 @@ namespace System.Net.Sockets
                 throw new OperationCanceledException(cancellationToken);
             }
 
-                await task.ConfigureAwait(false);
-            }
+            await task.ConfigureAwait(false);
+        }
 
         private static bool IsFatal(Exception exception) =>
             exception is OutOfMemoryException or StackOverflowException or AccessViolationException or AppDomainUnloadedException;

--- a/dotnet/src/Polyfills/DownlevelExtensions.cs
+++ b/dotnet/src/Polyfills/DownlevelExtensions.cs
@@ -316,16 +316,7 @@ namespace System.Diagnostics
                     }
                 }
             }
-            catch (ObjectDisposedException)
-            {
-            }
-            catch (InvalidOperationException)
-            {
-            }
-            catch (Win32Exception)
-            {
-            }
-            catch (PlatformNotSupportedException)
+            catch (Exception ex) when (ex is ObjectDisposedException or InvalidOperationException or Win32Exception or PlatformNotSupportedException)
             {
             }
 

--- a/dotnet/src/Polyfills/DownlevelExtensions.cs
+++ b/dotnet/src/Polyfills/DownlevelExtensions.cs
@@ -1,0 +1,485 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+using System.Buffers;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System
+{
+    internal static class DownlevelArgumentNullExceptionExtensions
+    {
+        extension(ArgumentNullException)
+        {
+            public static void ThrowIfNull(object? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+            {
+                if (argument is null)
+                {
+                    throw new ArgumentNullException(paramName);
+                }
+            }
+        }
+    }
+
+    internal static class DownlevelArgumentExceptionExtensions
+    {
+        extension(ArgumentException)
+        {
+            public static void ThrowIfNullOrWhiteSpace(string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+            {
+                if (argument is null)
+                {
+                    throw new ArgumentNullException(paramName);
+                }
+
+                if (string.IsNullOrWhiteSpace(argument))
+                {
+                    throw new ArgumentException("The value cannot be an empty string or composed entirely of whitespace.", paramName);
+                }
+            }
+        }
+    }
+
+    internal static class DownlevelDateTimeExtensions
+    {
+        extension(DateTime)
+        {
+            public static DateTime UnixEpoch => new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        }
+    }
+
+    internal static class DownlevelDateTimeOffsetExtensions
+    {
+        extension(DateTimeOffset)
+        {
+            public static DateTimeOffset UnixEpoch => new(0, TimeSpan.Zero);
+        }
+    }
+
+    internal static class DownlevelIntExtensions
+    {
+        extension(int)
+        {
+            public static bool TryParse(ReadOnlySpan<byte> utf8Text, NumberStyles style, IFormatProvider? provider, out int result)
+            {
+                if (style == NumberStyles.None)
+                {
+                    return TryParseNonNegativeInt32(utf8Text, out result);
+                }
+
+                return int.TryParse(Encoding.UTF8.GetString(utf8Text.ToArray()), style, provider, out result);
+            }
+        }
+
+        private static bool TryParseNonNegativeInt32(ReadOnlySpan<byte> utf8Text, out int result)
+        {
+            if (utf8Text.IsEmpty)
+            {
+                result = 0;
+                return false;
+            }
+
+            var value = 0;
+            foreach (var c in utf8Text)
+            {
+                var digit = c - (byte)'0';
+                if ((uint)digit > 9)
+                {
+                    result = 0;
+                    return false;
+                }
+
+                if (value > (int.MaxValue - digit) / 10)
+                {
+                    result = 0;
+                    return false;
+                }
+
+                value = (value * 10) + digit;
+            }
+
+            result = value;
+            return true;
+        }
+    }
+
+    internal static class DownlevelOperatingSystemExtensions
+    {
+        extension(OperatingSystem)
+        {
+            public static bool IsWindows() => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+            public static bool IsLinux() => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+
+            public static bool IsMacOS() => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        }
+    }
+
+    internal static class DownlevelDisposableExtensions
+    {
+        extension(IDisposable disposable)
+        {
+            public ValueTask DisposeAsync()
+            {
+                disposable.Dispose();
+                return default;
+            }
+        }
+    }
+}
+
+namespace System.Collections.Generic
+{
+    internal static class DownlevelKeyValuePairExtensions
+    {
+        extension<TKey, TValue>(KeyValuePair<TKey, TValue> pair)
+        {
+            public void Deconstruct(out TKey key, out TValue value)
+            {
+                key = pair.Key;
+                value = pair.Value;
+            }
+        }
+    }
+}
+
+namespace System.Diagnostics
+{
+    internal static class DownlevelStopwatchExtensions
+    {
+        extension(Stopwatch)
+        {
+            public static TimeSpan GetElapsedTime(long startingTimestamp) =>
+                GetElapsedTime(startingTimestamp, Stopwatch.GetTimestamp());
+
+            public static TimeSpan GetElapsedTime(long startingTimestamp, long endingTimestamp)
+            {
+                var elapsedTicks = endingTimestamp - startingTimestamp;
+                return TimeSpan.FromTicks((long)(elapsedTicks * ((double)TimeSpan.TicksPerSecond / Stopwatch.Frequency)));
+            }
+        }
+    }
+
+    internal static class DownlevelProcessExtensions
+    {
+        extension(Process process)
+        {
+            public void Kill(bool entireProcessTree)
+            {
+                if (entireProcessTree && OperatingSystem.IsWindows())
+                {
+                    using var taskKill = Process.Start(new ProcessStartInfo
+                    {
+                        FileName = "taskkill.exe",
+                        Arguments = string.Format(CultureInfo.InvariantCulture, "/PID {0} /T /F", process.Id),
+                        CreateNoWindow = true,
+                        RedirectStandardError = true,
+                        RedirectStandardOutput = true,
+                        UseShellExecute = false,
+                    });
+
+                    if (taskKill is not null &&
+                        taskKill.WaitForExit(milliseconds: 30_000) &&
+                        (taskKill.ExitCode == 0 || process.HasExited))
+                    {
+                        return;
+                    }
+                }
+
+                if (!process.HasExited)
+                {
+                    process.Kill();
+                }
+            }
+
+            public Task WaitForExitAsync(Threading.CancellationToken cancellationToken = default)
+            {
+                if (process.HasExited)
+                {
+                    return Task.CompletedTask;
+                }
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return Task.FromCanceled(cancellationToken);
+                }
+
+                var completion = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                EventHandler handler = (_, _) => completion.TrySetResult(null);
+                process.EnableRaisingEvents = true;
+                process.Exited += handler;
+
+                if (process.HasExited)
+                {
+                    completion.TrySetResult(null);
+                }
+
+                var cancellationRegistration = cancellationToken.CanBeCanceled
+                    ? cancellationToken.Register(static state => ((TaskCompletionSource<object?>)state!).TrySetCanceled(), completion)
+                    : default;
+
+                return WaitForExitAsyncCore(process, completion.Task, handler, cancellationRegistration);
+            }
+        }
+
+        private static async Task WaitForExitAsyncCore(
+            Process process,
+            Task waitTask,
+            EventHandler handler,
+            Threading.CancellationTokenRegistration cancellationRegistration)
+        {
+            try
+            {
+                await waitTask.ConfigureAwait(false);
+            }
+            finally
+            {
+                process.Exited -= handler;
+                cancellationRegistration.Dispose();
+            }
+        }
+    }
+}
+
+namespace System.IO
+{
+    internal static class DownlevelStreamExtensions
+    {
+        extension(Stream stream)
+        {
+            public ValueTask<int> ReadAsync(Memory<byte> buffer, Threading.CancellationToken cancellationToken = default)
+            {
+                if (MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> segment))
+                {
+                    return new ValueTask<int>(stream.ReadAsync(segment.Array!, segment.Offset, segment.Count, cancellationToken));
+                }
+
+                return ReadAsyncSlow(stream, buffer, cancellationToken);
+            }
+
+            public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, Threading.CancellationToken cancellationToken = default)
+            {
+                if (MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> segment))
+                {
+                    return new ValueTask(stream.WriteAsync(segment.Array!, segment.Offset, segment.Count, cancellationToken));
+                }
+
+                return WriteAsyncSlow(stream, buffer, cancellationToken);
+            }
+
+            public async ValueTask ReadExactlyAsync(Memory<byte> buffer, Threading.CancellationToken cancellationToken = default)
+            {
+                var totalRead = 0;
+                while (totalRead < buffer.Length)
+                {
+                    var bytesRead = await stream.ReadAsync(buffer.Slice(totalRead), cancellationToken).ConfigureAwait(false);
+                    if (bytesRead <= 0)
+                    {
+                        throw new EndOfStreamException();
+                    }
+
+                    totalRead += bytesRead;
+                }
+            }
+        }
+
+        private static async ValueTask<int> ReadAsyncSlow(Stream stream, Memory<byte> buffer, Threading.CancellationToken cancellationToken)
+        {
+            var rented = ArrayPool<byte>.Shared.Rent(buffer.Length);
+            try
+            {
+                var bytesRead = await stream.ReadAsync(rented, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+                rented.AsMemory(0, bytesRead).CopyTo(buffer);
+                return bytesRead;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+
+        private static async ValueTask WriteAsyncSlow(Stream stream, ReadOnlyMemory<byte> buffer, Threading.CancellationToken cancellationToken)
+        {
+            var rented = ArrayPool<byte>.Shared.Rent(buffer.Length);
+            try
+            {
+                buffer.CopyTo(rented);
+                await stream.WriteAsync(rented, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+    }
+
+    internal static class DownlevelTextReaderExtensions
+    {
+        extension(TextReader reader)
+        {
+            public Task<string?> ReadLineAsync(Threading.CancellationToken cancellationToken)
+            {
+                var task = reader.ReadLineAsync();
+                return cancellationToken.CanBeCanceled
+                    ? WaitAsync(task, cancellationToken)
+                    : task;
+            }
+        }
+
+        private static async Task<T> WaitAsync<T>(Task<T> task, Threading.CancellationToken cancellationToken)
+        {
+            if (task.IsCompleted || !cancellationToken.CanBeCanceled)
+            {
+                return await task.ConfigureAwait(false);
+            }
+
+            var cancellationTask = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var registration = cancellationToken.Register(static state => ((TaskCompletionSource<object?>)state!).TrySetCanceled(), cancellationTask);
+            if (await Task.WhenAny(task, cancellationTask.Task).ConfigureAwait(false) != task)
+            {
+                throw new OperationCanceledException(cancellationToken);
+            }
+
+            return await task.ConfigureAwait(false);
+        }
+    }
+}
+
+namespace System.Net.Sockets
+{
+    internal static class DownlevelSocketExtensions
+    {
+        extension(Socket socket)
+        {
+            public Task ConnectAsync(string host, int port, Threading.CancellationToken cancellationToken)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return Task.FromCanceled(cancellationToken);
+                }
+
+                var completion = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var connectState = new SocketConnectState(socket, completion);
+                try
+                {
+                    socket.BeginConnect(
+                        host,
+                        port,
+                        static asyncResult =>
+                        {
+                            var connectState = (SocketConnectState)asyncResult.AsyncState!;
+                            try
+                            {
+                                connectState.Socket.EndConnect(asyncResult);
+                                connectState.Completion.TrySetResult(null);
+                            }
+                            catch (Exception ex)
+                            {
+                                connectState.Completion.TrySetException(ex);
+                            }
+                        },
+                        connectState);
+                }
+                catch (Exception ex)
+                {
+                    completion.TrySetException(ex);
+                }
+
+                return cancellationToken.CanBeCanceled
+                    ? WaitAsync(completion.Task, socket.Dispose, cancellationToken)
+                    : completion.Task;
+            }
+        }
+
+        private static async Task WaitAsync(Task task, Action cancellationAction, Threading.CancellationToken cancellationToken)
+        {
+            if (task.IsCompleted)
+            {
+                await task.ConfigureAwait(false);
+                return;
+            }
+
+            var cancellationTask = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var registration = cancellationToken.Register(
+                static state =>
+                {
+                    var cancellationState = (CancellationState)state!;
+                    cancellationState.CancellationAction();
+                    cancellationState.Completion.TrySetCanceled();
+                },
+                new CancellationState(cancellationTask, cancellationAction));
+
+            if (await Task.WhenAny(task, cancellationTask.Task).ConfigureAwait(false) != task)
+            {
+                throw new OperationCanceledException(cancellationToken);
+            }
+
+            await task.ConfigureAwait(false);
+        }
+
+        private sealed record CancellationState(TaskCompletionSource<object?> Completion, Action CancellationAction);
+
+        private sealed record SocketConnectState(Socket Socket, TaskCompletionSource<object?> Completion);
+    }
+}
+
+namespace System.Runtime.InteropServices
+{
+    internal static class DownlevelRuntimeInformationExtensions
+    {
+        extension(RuntimeInformation)
+        {
+            public static string RuntimeIdentifier
+            {
+                get
+                {
+                    var os = OperatingSystem.IsWindows() ? "win" :
+                        OperatingSystem.IsLinux() ? "linux" :
+                        OperatingSystem.IsMacOS() ? "osx" :
+                        RuntimeInformation.OSDescription.ToLowerInvariant().Replace(' ', '-');
+
+                    var arch = RuntimeInformation.OSArchitecture switch
+                    {
+                        Architecture.X64 => "x64",
+                        Architecture.X86 => "x86",
+                        Architecture.Arm => "arm",
+                        Architecture.Arm64 => "arm64",
+                        _ => RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant(),
+                    };
+
+                    return $"{os}-{arch}";
+                }
+            }
+        }
+    }
+}
+
+namespace System.Threading
+{
+    internal static class DownlevelCancellationTokenRegistrationExtensions
+    {
+        extension(CancellationTokenRegistration registration)
+        {
+            public ValueTask DisposeAsync()
+            {
+                registration.Dispose();
+                return default;
+            }
+        }
+    }
+}
+
+namespace System.Threading.Tasks
+{
+    internal static class DownlevelValueTaskExtensions
+    {
+        extension(ValueTask)
+        {
+            public static ValueTask<T> FromResult<T>(T result) => new(result);
+        }
+    }
+}

--- a/dotnet/src/Polyfills/DownlevelExtensions.cs
+++ b/dotnet/src/Polyfills/DownlevelExtensions.cs
@@ -316,12 +316,12 @@ namespace System.Diagnostics
                     }
                 }
             }
-                catch (ObjectDisposedException)
-                {
-                }
-                catch (InvalidOperationException)
-                {
-                }
+            catch (ObjectDisposedException)
+            {
+            }
+            catch (InvalidOperationException)
+            {
+            }
             catch (Win32Exception)
             {
             }

--- a/dotnet/src/Polyfills/DownlevelExtensions.cs
+++ b/dotnet/src/Polyfills/DownlevelExtensions.cs
@@ -232,6 +232,7 @@ namespace System.Diagnostics
             EventHandler handler,
             Threading.CancellationTokenRegistration cancellationRegistration)
         {
+            using var _ = cancellationRegistration;
             try
             {
                 await waitTask.ConfigureAwait(false);
@@ -239,7 +240,6 @@ namespace System.Diagnostics
             finally
             {
                 process.Exited -= handler;
-                cancellationRegistration.Dispose();
             }
         }
     }
@@ -377,14 +377,38 @@ namespace System.Net.Sockets
                                 connectState.Socket.EndConnect(asyncResult);
                                 connectState.Completion.TrySetResult(null);
                             }
-                            catch (Exception ex)
+                            catch (SocketException ex)
+                            {
+                                connectState.Completion.TrySetException(ex);
+                            }
+                            catch (ObjectDisposedException ex)
+                            {
+                                connectState.Completion.TrySetException(ex);
+                            }
+                            catch (InvalidOperationException ex)
+                            {
+                                connectState.Completion.TrySetException(ex);
+                            }
+                            catch (Exception ex) when (!IsFatal(ex))
                             {
                                 connectState.Completion.TrySetException(ex);
                             }
                         },
                         connectState);
                 }
-                catch (Exception ex)
+                catch (SocketException ex)
+                {
+                    completion.TrySetException(ex);
+                }
+                catch (ObjectDisposedException ex)
+                {
+                    completion.TrySetException(ex);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    completion.TrySetException(ex);
+                }
+                catch (Exception ex) when (!IsFatal(ex))
                 {
                     completion.TrySetException(ex);
                 }
@@ -418,8 +442,11 @@ namespace System.Net.Sockets
                 throw new OperationCanceledException(cancellationToken);
             }
 
-            await task.ConfigureAwait(false);
-        }
+                await task.ConfigureAwait(false);
+            }
+
+        private static bool IsFatal(Exception exception) =>
+            exception is OutOfMemoryException or StackOverflowException or AccessViolationException or AppDomainUnloadedException;
 
         private sealed record CancellationState(TaskCompletionSource<object?> Completion, Action CancellationAction);
 

--- a/dotnet/src/Polyfills/DownlevelExtensions.cs
+++ b/dotnet/src/Polyfills/DownlevelExtensions.cs
@@ -5,6 +5,7 @@
 using System.Buffers;
 using System.ComponentModel;
 using System.Globalization;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -265,17 +266,9 @@ namespace System.Diagnostics
                         childProcess.Kill();
                     }
                 }
-                catch (ArgumentException)
+                catch (Exception ex) when (ex is ArgumentException or InvalidOperationException or Win32Exception or PlatformNotSupportedException)
                 {
-                }
-                catch (InvalidOperationException)
-                {
-                }
-                catch (Win32Exception)
-                {
-                }
-                catch (PlatformNotSupportedException)
-                {
+                    IgnoreBestEffortProcessException(ex);
                 }
             }
         }
@@ -308,20 +301,26 @@ namespace System.Diagnostics
                     return childProcessIds;
                 }
 
-                foreach (var line in output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
-                {
-                    if (int.TryParse(line, NumberStyles.None, CultureInfo.InvariantCulture, out var childProcessId))
-                    {
-                        childProcessIds.Add(childProcessId);
-                    }
-                }
+                childProcessIds.AddRange(
+                    output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+                        .Select(static line =>
+                        {
+                            var success = int.TryParse(line, NumberStyles.None, CultureInfo.InvariantCulture, out var childProcessId);
+                            return (success, childProcessId);
+                        })
+                        .Where(static result => result.success)
+                        .Select(static result => result.childProcessId));
             }
             catch (Exception ex) when (ex is ObjectDisposedException or InvalidOperationException or Win32Exception or PlatformNotSupportedException)
             {
+                IgnoreBestEffortProcessException(ex);
             }
 
             return childProcessIds;
         }
+
+        private static void IgnoreBestEffortProcessException(Exception exception) =>
+            Debug.WriteLine(exception.ToString());
     }
 }
 

--- a/dotnet/src/Polyfills/DownlevelExtensions.cs
+++ b/dotnet/src/Polyfills/DownlevelExtensions.cs
@@ -3,6 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System.Buffers;
+using System.ComponentModel;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -56,7 +57,7 @@ namespace System
     {
         extension(DateTimeOffset)
         {
-            public static DateTimeOffset UnixEpoch => new(0, TimeSpan.Zero);
+            public static DateTimeOffset UnixEpoch => new(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
         }
     }
 
@@ -170,23 +171,30 @@ namespace System.Diagnostics
         {
             public void Kill(bool entireProcessTree)
             {
-                if (entireProcessTree && OperatingSystem.IsWindows())
+                if (entireProcessTree)
                 {
-                    using var taskKill = Process.Start(new ProcessStartInfo
+                    if (OperatingSystem.IsWindows())
                     {
-                        FileName = "taskkill.exe",
-                        Arguments = string.Format(CultureInfo.InvariantCulture, "/PID {0} /T /F", process.Id),
-                        CreateNoWindow = true,
-                        RedirectStandardError = true,
-                        RedirectStandardOutput = true,
-                        UseShellExecute = false,
-                    });
+                        using var taskKill = Process.Start(new ProcessStartInfo
+                        {
+                            FileName = "taskkill.exe",
+                            Arguments = string.Format(CultureInfo.InvariantCulture, "/PID {0} /T /F", process.Id),
+                            CreateNoWindow = true,
+                            RedirectStandardError = true,
+                            RedirectStandardOutput = true,
+                            UseShellExecute = false,
+                        });
 
-                    if (taskKill is not null &&
-                        taskKill.WaitForExit(milliseconds: 30_000) &&
-                        (taskKill.ExitCode == 0 || process.HasExited))
+                        if (taskKill is not null &&
+                            taskKill.WaitForExit(milliseconds: 30_000) &&
+                            (taskKill.ExitCode == 0 || process.HasExited))
+                        {
+                            return;
+                        }
+                    }
+                    else
                     {
-                        return;
+                        KillDescendantProcesses(process.Id);
                     }
                 }
 
@@ -241,6 +249,87 @@ namespace System.Diagnostics
             {
                 process.Exited -= handler;
             }
+        }
+
+        private static void KillDescendantProcesses(int parentProcessId)
+        {
+            foreach (var childProcessId in GetChildProcessIds(parentProcessId))
+            {
+                KillDescendantProcesses(childProcessId);
+
+                try
+                {
+                    using var childProcess = Process.GetProcessById(childProcessId);
+                    if (!childProcess.HasExited)
+                    {
+                        childProcess.Kill();
+                    }
+                }
+                catch (ArgumentException)
+                {
+                }
+                catch (InvalidOperationException)
+                {
+                }
+                catch (Win32Exception)
+                {
+                }
+                catch (PlatformNotSupportedException)
+                {
+                }
+            }
+        }
+
+        private static List<int> GetChildProcessIds(int parentProcessId)
+        {
+            var childProcessIds = new List<int>();
+
+            try
+            {
+                using var pgrep = Process.Start(new ProcessStartInfo
+                {
+                    FileName = "pgrep",
+                    Arguments = string.Format(CultureInfo.InvariantCulture, "-P {0}", parentProcessId),
+                    CreateNoWindow = true,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                });
+
+                if (pgrep is null)
+                {
+                    return childProcessIds;
+                }
+
+                var output = pgrep.StandardOutput.ReadToEnd();
+                if (!pgrep.WaitForExit(milliseconds: 5_000))
+                {
+                    pgrep.Kill();
+                    return childProcessIds;
+                }
+
+                foreach (var line in output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+                {
+                    if (int.TryParse(line, NumberStyles.None, CultureInfo.InvariantCulture, out var childProcessId))
+                    {
+                        childProcessIds.Add(childProcessId);
+                    }
+                }
+            }
+                catch (ObjectDisposedException)
+                {
+                }
+                catch (InvalidOperationException)
+                {
+                }
+            catch (Win32Exception)
+            {
+            }
+            catch (PlatformNotSupportedException)
+            {
+            }
+
+            return childProcessIds;
         }
     }
 }

--- a/dotnet/src/Polyfills/IsExternalInit.cs
+++ b/dotnet/src/Polyfills/IsExternalInit.cs
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+#if NET8_0_OR_GREATER
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.CompilerServices.IsExternalInit))]
+#else
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Reserved to be used by the compiler for tracking metadata.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+internal static class IsExternalInit;
+#endif

--- a/dotnet/src/Polyfills/TaskCompletionSource.cs
+++ b/dotnet/src/Polyfills/TaskCompletionSource.cs
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+namespace System.Threading.Tasks;
+
+internal sealed class TaskCompletionSource : TaskCompletionSource<object?>
+{
+    public TaskCompletionSource()
+    {
+    }
+
+    public TaskCompletionSource(TaskCreationOptions creationOptions)
+        : base(creationOptions)
+    {
+    }
+
+    public new Task Task => base.Task;
+
+    public void SetResult() => base.SetResult(null);
+
+    public bool TrySetResult() => base.TrySetResult(null);
+}

--- a/dotnet/src/Polyfills/Utf8.cs
+++ b/dotnet/src/Polyfills/Utf8.cs
@@ -17,6 +17,17 @@ internal static class Utf8
             return false;
         }
 
+        if (byteCount == value.Length)
+        {
+            for (var i = 0; i < value.Length; i++)
+            {
+                destination[i] = (byte)value[i];
+            }
+
+            bytesWritten = byteCount;
+            return true;
+        }
+
         var bytes = Encoding.UTF8.GetBytes(value);
         bytes.CopyTo(destination);
         bytesWritten = byteCount;

--- a/dotnet/src/Polyfills/Utf8.cs
+++ b/dotnet/src/Polyfills/Utf8.cs
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+using System.Text;
+
+namespace System.Text.Unicode;
+
+internal static class Utf8
+{
+    public static bool TryWrite(Span<byte> destination, string value, out int bytesWritten)
+    {
+        var byteCount = Encoding.UTF8.GetByteCount(value);
+        if (byteCount > destination.Length)
+        {
+            bytesWritten = 0;
+            return false;
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(value);
+        bytes.CopyTo(destination);
+        bytesWritten = byteCount;
+        return true;
+    }
+}

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -28,7 +28,7 @@ internal static class GeneratedStringEnumJson
             throw new JsonException($"Expected a non-empty string token when reading {typeToConvert.Name}.");
         }
 
-        return value;
+        return value!;
     }
 
     internal static void WriteValue(Utf8JsonWriter writer, string value, Type typeToConvert)

--- a/dotnet/src/build/GitHub.Copilot.SDK.targets
+++ b/dotnet/src/build/GitHub.Copilot.SDK.targets
@@ -75,7 +75,7 @@
   <!-- Download and extract CLI binary.
        Skipped when CopilotCliBinaryPath is set (consumer supplied the binary)
        or when CopilotSkipCliDownload=true (consumer opted out entirely). -->
-  <Target Name="_DownloadCopilotCli" BeforeTargets="BeforeBuild" Condition="'$(TargetFramework)' != '' And '$(CopilotCliBinaryPath)' == '' And '$(CopilotSkipCliDownload)' != 'true' And '$(_CopilotPlatform)' != ''">
+  <Target Name="_DownloadCopilotCli" DependsOnTargets="$(_CopilotCliVersionTarget)" BeforeTargets="BeforeBuild" Condition="'$(TargetFramework)' != '' And '$(CopilotCliBinaryPath)' == '' And '$(CopilotSkipCliDownload)' != 'true' And '$(_CopilotPlatform)' != ''">
     <Error Condition="'$(CopilotCliVersion)' == ''" Text="CopilotCliVersion is not set. The GitHub.Copilot.SDK.props file may be missing from the NuGet package." />
 
     <!-- Compute paths using version (now available) -->

--- a/dotnet/src/build/GitHub.Copilot.SDK.targets
+++ b/dotnet/src/build/GitHub.Copilot.SDK.targets
@@ -75,7 +75,7 @@
   <!-- Download and extract CLI binary.
        Skipped when CopilotCliBinaryPath is set (consumer supplied the binary)
        or when CopilotSkipCliDownload=true (consumer opted out entirely). -->
-  <Target Name="_DownloadCopilotCli" BeforeTargets="BeforeBuild" Condition="'$(CopilotCliBinaryPath)' == '' And '$(CopilotSkipCliDownload)' != 'true' And '$(_CopilotPlatform)' != ''">
+  <Target Name="_DownloadCopilotCli" BeforeTargets="BeforeBuild" Condition="'$(TargetFramework)' != '' And '$(CopilotCliBinaryPath)' == '' And '$(CopilotSkipCliDownload)' != 'true' And '$(_CopilotPlatform)' != ''">
     <Error Condition="'$(CopilotCliVersion)' == ''" Text="CopilotCliVersion is not set. The GitHub.Copilot.SDK.props file may be missing from the NuGet package." />
 
     <!-- Compute paths using version (now available) -->
@@ -114,7 +114,7 @@
        Runs whenever we have a binary to place in the output: either the user provided
        CopilotCliBinaryPath, or the default download path is in effect. Skipped only
        when CopilotSkipCliDownload=true and no CopilotCliBinaryPath was supplied. -->
-  <Target Name="_CopyCopilotCliToOutput" AfterTargets="Build" DependsOnTargets="_DownloadCopilotCli" Condition="('$(CopilotCliBinaryPath)' != '' Or '$(CopilotSkipCliDownload)' != 'true') And '$(_CopilotPlatform)' != ''">
+  <Target Name="_CopyCopilotCliToOutput" AfterTargets="Build" DependsOnTargets="_DownloadCopilotCli" Condition="'$(TargetFramework)' != '' And ('$(CopilotCliBinaryPath)' != '' Or '$(CopilotSkipCliDownload)' != 'true') And '$(_CopilotPlatform)' != ''">
     <PropertyGroup>
       <_CopilotCacheDir Condition="'$(_CopilotCacheDir)' == ''">$(IntermediateOutputPath)copilot-cli\$(CopilotCliVersion)\$(_CopilotPlatform)</_CopilotCacheDir>
       <_CopilotCliBinaryPath Condition="'$(_CopilotCliBinaryPath)' == ''">$(_CopilotCacheDir)\$(_CopilotBinary)</_CopilotCliBinaryPath>
@@ -127,7 +127,7 @@
 
   <!-- Register CLI binary as content so it flows through project references.
        Same gating semantics as _CopyCopilotCliToOutput. -->
-  <Target Name="_RegisterCopilotCliForCopy" BeforeTargets="GetCopyToOutputDirectoryItems" DependsOnTargets="_DownloadCopilotCli" Condition="('$(CopilotCliBinaryPath)' != '' Or '$(CopilotSkipCliDownload)' != 'true') And '$(_CopilotPlatform)' != ''">
+  <Target Name="_RegisterCopilotCliForCopy" BeforeTargets="GetCopyToOutputDirectoryItems" DependsOnTargets="_DownloadCopilotCli" Condition="'$(TargetFramework)' != '' And ('$(CopilotCliBinaryPath)' != '' Or '$(CopilotSkipCliDownload)' != 'true') And '$(_CopilotPlatform)' != ''">
     <PropertyGroup>
       <_CopilotCacheDir Condition="'$(_CopilotCacheDir)' == ''">$(IntermediateOutputPath)copilot-cli\$(CopilotCliVersion)\$(_CopilotPlatform)</_CopilotCacheDir>
       <_CopilotCliBinaryPath Condition="'$(_CopilotCliBinaryPath)' == ''">$(_CopilotCacheDir)\$(_CopilotBinary)</_CopilotCliBinaryPath>

--- a/dotnet/test/GitHub.Copilot.SDK.Test.csproj
+++ b/dotnet/test/GitHub.Copilot.SDK.Test.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">net8.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);GHCP001</NoWarn>
@@ -9,11 +11,8 @@
   <PropertyGroup>
     <!--
       Disable STJ reflection-based serialization to help validate NativeAOT.
-      If in the future this test project targets multiple TFMs, this should be
-      made conditional for a subset of those TFMs in order to test with both
-      false and the default of true.
       -->
-    <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+    <JsonSerializerIsReflectionEnabledByDefault Condition="'$(TargetFramework)' == 'net8.0'">false</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,6 +30,15 @@
 
   <ItemGroup>
     <ProjectReference Include="../src/GitHub.Copilot.SDK.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Compile Remove="ConnectionTokenTests.cs" />
+    <Compile Remove="E2E\**\*.cs" />
+    <Compile Remove="Harness\**\*.cs" />
+    <Compile Include="..\src\Polyfills\BclAttributes.cs" Link="Polyfills\BclAttributes.cs" />
+    <Compile Include="..\src\Polyfills\DownlevelExtensions.cs" Link="Polyfills\DownlevelExtensions.cs" />
+    <Compile Include="..\src\Polyfills\IsExternalInit.cs" Link="Polyfills\IsExternalInit.cs" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/test/Unit/JsonRpcTests.cs
+++ b/dotnet/test/Unit/JsonRpcTests.cs
@@ -234,7 +234,15 @@ public class JsonRpcTests
         public override int Read(byte[] buffer, int offset, int count) =>
             ReadAsync(buffer.AsMemory(offset, count)).AsTask().GetAwaiter().GetResult();
 
-        public override async ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default)
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+#if NET8_0_OR_GREATER
+        public override
+#else
+        internal
+#endif
+        async ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default)
         {
             while (true)
             {
@@ -242,13 +250,14 @@ public class JsonRpcTests
                 {
                     if (_buffer.Count > 0)
                     {
-                        var count = Math.Min(destination.Length, _buffer.Count);
-                        for (var i = 0; i < count; i++)
+                        var bytesRead = Math.Min(destination.Length, _buffer.Count);
+                        var span = destination.Span;
+                        for (var i = 0; i < bytesRead; i++)
                         {
-                            destination.Span[i] = _buffer.Dequeue();
+                            span[i] = _buffer.Dequeue();
                         }
 
-                        return count;
+                        return bytesRead;
                     }
 
                     if (_completed)
@@ -264,11 +273,19 @@ public class JsonRpcTests
         public override void Write(byte[] buffer, int offset, int count) =>
             WriteAsync(buffer.AsMemory(offset, count)).AsTask().GetAwaiter().GetResult();
 
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            WriteAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+#if NET8_0_OR_GREATER
+        public override
+#else
+        internal
+#endif
+        ValueTask WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
         {
             var peer = _peer ?? throw new ObjectDisposedException(nameof(InMemoryDuplexStream));
             peer.Enqueue(source.Span);
-            return ValueTask.CompletedTask;
+            return default;
         }
 
         public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();

--- a/dotnet/test/Unit/SerializationTests.cs
+++ b/dotnet/test/Unit/SerializationTests.cs
@@ -5,6 +5,9 @@
 using Xunit;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+#if !NET8_0_OR_GREATER
+using System.Runtime.Serialization;
+#endif
 using GitHub.Copilot.SDK.Rpc;
 
 namespace GitHub.Copilot.SDK.Test.Unit;
@@ -299,7 +302,11 @@ public class SerializationTests
 
     private static object CreateInternalRequest(Type type, params (string Name, object? Value)[] properties)
     {
+#if NET8_0_OR_GREATER
         var instance = System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(type);
+#else
+        var instance = FormatterServices.GetUninitializedObject(type);
+#endif
 
         foreach (var (name, value) in properties)
         {


### PR DESCRIPTION
Adds downlevel and current-target coverage for the C# SDK so netstandard2.0 consumers can use the package while newer TFMs keep their modern framework-provided behavior.

## Summary
- Multi-targets the SDK for `net8.0`, `net10.0`, and `netstandard2.0`.
- Adds downlevel-only polyfills under `dotnet/src/Polyfills`, with extension members placed in the BCL namespaces they polyfill.
- Keeps `System.Text.Json` as a package dependency only for TFMs that are not compatible with the `net10.0` surface area.
- Uses a downlevel `Regex` fallback instead of a fake `GeneratedRegexAttribute`, and adds MCP-style `IsExternalInit` type forwarding.
- Updates JSON-RPC `ValueTask<T>` unwrapping to use declared return-type metadata, avoiding trim/AOT suppressions.
- Adds Windows-only `net472` test coverage so the `netstandard2.0` asset is exercised.

## Validation
- `dotnet build dotnet\src\GitHub.Copilot.SDK.csproj --no-restore --nologo --verbosity:minimal /tl:off`
- `dotnet test dotnet\test\GitHub.Copilot.SDK.Test.csproj --no-restore --nologo --verbosity:minimal /tl:off --filter "FullyQualifiedName!~E2E"`