### PR TITLE
Clean up more argument validation

### DIFF
--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -7,16 +7,15 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Collections.Concurrent;
-using System.Data;
 using System.Diagnostics;
 using System.Globalization;
 using System.Net.Sockets;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
-using static GitHub.Copilot.SDK.LoggingHelpers;
 
 namespace GitHub.Copilot.SDK;
 
@@ -62,7 +61,15 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     /// </summary>
     private const int MinProtocolVersion = 2;
 
-    private readonly ConcurrentDictionary<string, CopilotSession> _sessions = new();
+    /// <summary>
+    /// Provides a thread-safe collection of active Copilot sessions, indexed by session identifier.
+    /// </summary>
+    /// <remarks>
+    /// This maintains a strong reference to every <see cref="CopilotSession"/> created on this
+    /// <see cref="CopilotClient"/> that has not been explicitly disposed or removed.
+    /// </remarks>
+    internal readonly ConcurrentDictionary<string, CopilotSession> _sessions = new();
+
     private readonly CopilotClientOptions _options;
     private readonly ILogger _logger;
     private Task<Connection>? _connectionTask;
@@ -247,13 +254,13 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                     connection = await ConnectToServerAsync(cliProcess, portOrNull is null ? null : "localhost", portOrNull, stderrBuffer, ct);
                 }
 
-                LogTiming(_logger, LogLevel.Debug, null,
+                LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                     "CopilotClient.StartAsync transport setup complete. Elapsed={Elapsed}",
                     startTimestamp);
 
                 // Verify protocol version compatibility
                 await VerifyProtocolVersionAsync(connection, ct);
-                LogTiming(_logger, LogLevel.Debug, null,
+                LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                     "CopilotClient.StartAsync protocol verification complete. Elapsed={Elapsed}",
                     startTimestamp);
 
@@ -261,12 +268,12 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 await ConfigureSessionFsAsync(ct);
                 if (_options.SessionFs is not null)
                 {
-                    LogTiming(_logger, LogLevel.Debug, null,
+                    LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                         "CopilotClient.StartAsync session filesystem setup complete. Elapsed={Elapsed}",
                         sessionFsTimestamp);
                 }
 
-                LogTiming(_logger, LogLevel.Debug, null,
+                LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                     "CopilotClient.StartAsync complete. Elapsed={Elapsed}",
                     startTimestamp);
                 return connection;
@@ -275,7 +282,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             {
                 if (ex is not OperationCanceledException)
                 {
-                    LogTiming(_logger, LogLevel.Warning, ex,
+                    LoggingHelpers.LogTiming(_logger, LogLevel.Warning, ex,
                         "CopilotClient.StartAsync failed. Elapsed={Elapsed}",
                         startTimestamp);
                 }
@@ -321,23 +328,24 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     /// </example>
     public async Task StopAsync()
     {
-        var errors = new List<Exception>();
+        List<Exception>? errors = null;
 
-        foreach (var session in _sessions.Values.ToArray())
+        foreach (var (sessionId, _) in _sessions)
         {
-            try
+            if (_sessions.TryRemove(sessionId, out var session))
             {
-                await session.DisposeAsync();
-            }
-            catch (Exception ex)
-            {
-                errors.Add(new Exception($"Failed to dispose session {session.SessionId}: {ex.Message}", ex));
+                try
+                {
+                    await session.DisposeAsync();
+                }
+                catch (Exception ex)
+                {
+                    (errors ??= []).Add(new IOException($"Failed to dispose session {session.SessionId}: {ex.Message}", ex));
+                }
             }
         }
 
-        _sessions.Clear();
         await CleanupConnectionAsync(errors);
-        _connectionTask = null;
 
         ThrowErrors(errors);
     }
@@ -366,35 +374,37 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     /// </example>
     public async Task ForceStopAsync()
     {
-        var errors = new List<Exception>();
-
         _sessions.Clear();
-        await CleanupConnectionAsync(errors);
-        _connectionTask = null;
 
+        var errors = new List<Exception>();
+        await CleanupConnectionAsync(errors);
         ThrowErrors(errors);
     }
 
-    private static void ThrowErrors(List<Exception> errors)
+    private static void ThrowErrors(List<Exception>? errors)
     {
-        if (errors.Count == 1)
+        if (errors is not null)
         {
-            throw errors[0];
-        }
-        else if (errors.Count > 0)
-        {
-            throw new AggregateException(errors);
+            if (errors.Count == 1)
+            {
+                ExceptionDispatchInfo.Throw(errors[0]);
+            }
+
+            if (errors.Count > 0)
+            {
+                throw new AggregateException(errors);
+            }
         }
     }
 
     private async Task CleanupConnectionAsync(List<Exception>? errors)
     {
-        if (_connectionTask is null)
+        var connectionTask = _connectionTask;
+        if (connectionTask is null)
         {
             return;
         }
 
-        var connectionTask = _connectionTask;
         _connectionTask = null;
 
         Connection ctx;
@@ -559,7 +569,11 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         // Create and register the session before issuing the RPC so that
         // events emitted by the CLI (e.g. session.start) are not dropped.
         var setupTimestamp = Stopwatch.GetTimestamp();
-        var session = new CopilotSession(sessionId, connection.Rpc, _logger);
+        var session = new CopilotSession(
+            sessionId,
+            connection.Rpc,
+            _logger,
+            this);
         session.RegisterTools(config.Tools ?? []);
         session.RegisterPermissionHandler(config.OnPermissionRequest);
         session.RegisterCommands(config.Commands);
@@ -583,8 +597,8 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             session.On(config.OnEvent);
         }
         ConfigureSessionFsHandlers(session, config.CreateSessionFsHandler);
-        _sessions[sessionId] = session;
-        LogTiming(_logger, LogLevel.Debug, null,
+        RegisterSession(session);
+        LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
             "CopilotClient.CreateSessionAsync local setup complete. Elapsed={Elapsed}, SessionId={SessionId}, Tools={ToolsCount}, Commands={CommandsCount}, Hooks={HasHooks}",
             setupTimestamp,
             sessionId,
@@ -638,7 +652,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             var rpcTimestamp = Stopwatch.GetTimestamp();
             var response = await InvokeRpcAsync<CreateSessionResponse>(
                 connection.Rpc, "session.create", [request], cancellationToken);
-            LogTiming(_logger, LogLevel.Debug, null,
+            LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotClient.CreateSessionAsync session creation request completed successfully. Elapsed={Elapsed}, SessionId={SessionId}",
                 rpcTimestamp,
                 sessionId);
@@ -648,10 +662,10 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         }
         catch (Exception ex)
         {
-            _sessions.TryRemove(sessionId, out _);
+            session.RemoveFromClient();
             if (ex is not OperationCanceledException)
             {
-                LogTiming(_logger, LogLevel.Warning, ex,
+                LoggingHelpers.LogTiming(_logger, LogLevel.Warning, ex,
                     "CopilotClient.CreateSessionAsync failed. Elapsed={Elapsed}, SessionId={SessionId}",
                     totalTimestamp,
                     sessionId);
@@ -659,7 +673,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             throw;
         }
 
-        LogTiming(_logger, LogLevel.Debug, null,
+        LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
             "CopilotClient.CreateSessionAsync complete. Elapsed={Elapsed}, SessionId={SessionId}",
             totalTimestamp,
             sessionId);
@@ -720,7 +734,11 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         // Create and register the session before issuing the RPC so that
         // events emitted by the CLI (e.g. session.start) are not dropped.
         var setupTimestamp = Stopwatch.GetTimestamp();
-        var session = new CopilotSession(sessionId, connection.Rpc, _logger);
+        var session = new CopilotSession(
+            sessionId,
+            connection.Rpc,
+            _logger,
+            client: this);
         session.RegisterTools(config.Tools ?? []);
         session.RegisterPermissionHandler(config.OnPermissionRequest);
         session.RegisterCommands(config.Commands);
@@ -744,8 +762,8 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             session.On(config.OnEvent);
         }
         ConfigureSessionFsHandlers(session, config.CreateSessionFsHandler);
-        _sessions[sessionId] = session;
-        LogTiming(_logger, LogLevel.Debug, null,
+        RegisterSession(session);
+        LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
             "CopilotClient.ResumeSessionAsync local setup complete. Elapsed={Elapsed}, SessionId={SessionId}, Tools={ToolsCount}, Commands={CommandsCount}, Hooks={HasHooks}",
             setupTimestamp,
             sessionId,
@@ -800,7 +818,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             var rpcTimestamp = Stopwatch.GetTimestamp();
             var response = await InvokeRpcAsync<ResumeSessionResponse>(
                 connection.Rpc, "session.resume", [request], cancellationToken);
-            LogTiming(_logger, LogLevel.Debug, null,
+            LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotClient.ResumeSessionAsync session resume request completed successfully. Elapsed={Elapsed}, SessionId={SessionId}",
                 rpcTimestamp,
                 sessionId);
@@ -810,10 +828,10 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         }
         catch (Exception ex)
         {
-            _sessions.TryRemove(sessionId, out _);
+            session.RemoveFromClient();
             if (ex is not OperationCanceledException)
             {
-                LogTiming(_logger, LogLevel.Warning, ex,
+                LoggingHelpers.LogTiming(_logger, LogLevel.Warning, ex,
                     "CopilotClient.ResumeSessionAsync failed. Elapsed={Elapsed}, SessionId={SessionId}",
                     totalTimestamp,
                     sessionId);
@@ -821,7 +839,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             throw;
         }
 
-        LogTiming(_logger, LogLevel.Debug, null,
+        LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
             "CopilotClient.ResumeSessionAsync complete. Elapsed={Elapsed}, SessionId={SessionId}",
             totalTimestamp,
             sessionId);
@@ -919,31 +937,29 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         try
         {
             // Check cache (already inside lock)
-            if (_modelsCache is not null)
+            if (_modelsCache is null)
             {
-                return [.. _modelsCache]; // Return a copy to prevent cache mutation
+                IList<ModelInfo> models;
+                if (_onListModels is not null)
+                {
+                    // Use custom handler instead of CLI RPC
+                    models = await _onListModels(cancellationToken);
+                }
+                else
+                {
+                    var connection = await EnsureConnectedAsync(cancellationToken);
+
+                    // Cache miss - fetch from backend while holding lock
+                    var response = await InvokeRpcAsync<GetModelsResponse>(
+                        connection.Rpc, "models.list", [], cancellationToken);
+                    models = response.Models;
+                }
+
+                // Update cache before releasing lock (copy to prevent external mutation)
+                _modelsCache = [.. models];
             }
 
-            IList<ModelInfo> models;
-            if (_onListModels is not null)
-            {
-                // Use custom handler instead of CLI RPC
-                models = await _onListModels(cancellationToken);
-            }
-            else
-            {
-                var connection = await EnsureConnectedAsync(cancellationToken);
-
-                // Cache miss - fetch from backend while holding lock
-                var response = await InvokeRpcAsync<GetModelsResponse>(
-                    connection.Rpc, "models.list", [], cancellationToken);
-                models = response.Models;
-            }
-
-            // Update cache before releasing lock (copy to prevent external mutation)
-            _modelsCache = [.. models];
-
-            return [.. models]; // Return a copy to prevent cache mutation
+            return [.. _modelsCache]; // Return a copy to prevent cache mutation
         }
         finally
         {
@@ -1008,7 +1024,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             throw new InvalidOperationException($"Failed to delete session {sessionId}: {response.Error}");
         }
 
-        _sessions.TryRemove(sessionId, out _);
+        RemoveSession(sessionId);
     }
 
     /// <summary>
@@ -1228,14 +1244,24 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         }
     }
 
-    internal static async Task<T> InvokeRpcAsync<T>(JsonRpc rpc, string method, object?[]? args, CancellationToken cancellationToken)
+    internal static Task<T> InvokeRpcAsync<T>(JsonRpc rpc, string method, object?[]? args, CancellationToken cancellationToken)
     {
-        return await InvokeRpcAsync<T>(rpc, method, args, null, cancellationToken);
+        return InvokeRpcAsync<T>(rpc, method, args, null, cancellationToken);
     }
 
-    internal static async Task InvokeRpcAsync(JsonRpc rpc, string method, object?[]? args, CancellationToken cancellationToken)
+    internal static Task InvokeRpcAsync(JsonRpc rpc, string method, object?[]? args, CancellationToken cancellationToken)
     {
-        await InvokeRpcAsync<object>(rpc, method, args, null, cancellationToken);
+        return InvokeRpcAsync<object>(rpc, method, args, null, cancellationToken);
+    }
+
+    internal static Task<T> InvokeRpcAsync<T>(SessionRpc rpc, string method, object?[]? args, CancellationToken cancellationToken)
+    {
+        return InvokeRpcAsync<T>(rpc.Session.JsonRpc, method, args, cancellationToken);
+    }
+
+    internal static Task InvokeRpcAsync(SessionRpc rpc, string method, object?[]? args, CancellationToken cancellationToken)
+    {
+        return InvokeRpcAsync<object>(rpc, method, args, cancellationToken);
     }
 
     internal static async Task<T> InvokeRpcAsync<T>(JsonRpc rpc, string method, object?[]? args, StringBuilder? stderrBuffer, CancellationToken cancellationToken)
@@ -1376,7 +1402,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         }
 
         _negotiatedProtocolVersion = serverVersion.Value;
-        LogTiming(_logger, LogLevel.Debug, null,
+        LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
             "CopilotClient.VerifyProtocolVersionAsync protocol handshake complete. Elapsed={Elapsed}, ProtocolVersion={ProtocolVersion}, UsedFallbackPing={UsedFallbackPing}",
             handshakeTimestamp,
             serverVersion.Value,
@@ -1500,7 +1526,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             cliProcess = new Process { StartInfo = startInfo };
             var spawnTimestamp = Stopwatch.GetTimestamp();
             cliProcess.Start();
-            LogTiming(logger, LogLevel.Debug, null,
+            LoggingHelpers.LogTiming(logger, LogLevel.Debug, null,
                 "CopilotClient.StartCliServerAsync subprocess spawned. Elapsed={Elapsed}",
                 spawnTimestamp);
 
@@ -1550,7 +1576,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                     if (ListeningOnPortRegex().Match(line) is { Success: true } match)
                     {
                         detectedLocalhostTcpPort = int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
-                        LogTiming(logger, LogLevel.Debug, null,
+                        LoggingHelpers.LogTiming(logger, LogLevel.Debug, null,
                             "CopilotClient.StartCliServerAsync TCP port wait complete. Elapsed={Elapsed}, Port={Port}",
                             portWaitTimestamp,
                             detectedLocalhostTcpPort.Value);
@@ -1642,7 +1668,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 var tcpConnectTimestamp = Stopwatch.GetTimestamp();
                 LogConnectingToCliServer(_logger, tcpHost, tcpPort.Value);
                 await socket.ConnectAsync(tcpHost, tcpPort.Value, cancellationToken);
-                LogTiming(_logger, LogLevel.Debug, null,
+                LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                     "CopilotClient.ConnectToServerAsync TCP connect complete. Elapsed={Elapsed}, Host={Host}, Port={Port}",
                     tcpConnectTimestamp,
                     tcpHost,
@@ -1683,7 +1709,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             return session.ClientSessionApis;
         });
         rpc.StartListening();
-        LogTiming(_logger, LogLevel.Debug, null,
+        LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
             "CopilotClient.ConnectToServerAsync transport setup complete. Elapsed={Elapsed}",
             setupTimestamp);
 
@@ -1718,7 +1744,21 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
     internal CopilotSession? GetSession(string sessionId)
     {
-        return _sessions.TryGetValue(sessionId, out var session) ? session : null;
+        _sessions.TryGetValue(sessionId, out var session);
+        return session;
+    }
+
+    private void RegisterSession(CopilotSession session)
+    {
+        if (!_sessions.TryAdd(session.SessionId, session))
+        {
+            throw new InvalidOperationException($"Session {session.SessionId} is already in use on this {nameof(CopilotClient)}.");
+        }
+    }
+
+    private void RemoveSession(string sessionId)
+    {
+        _sessions.TryRemove(sessionId, out _);
     }
 
     /// <summary>
@@ -1894,7 +1934,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
                 var toolTimestamp = Stopwatch.GetTimestamp();
                 var result = await tool.InvokeAsync(aiFunctionArgs);
-                LogTiming(client._logger, LogLevel.Debug, null,
+                LoggingHelpers.LogTiming(client._logger, LogLevel.Debug, null,
                     "RpcHandler.OnToolCallV2 tool dispatch. Elapsed={Elapsed}, SessionId={SessionId}, ToolCallId={ToolCallId}, Tool={ToolName}",
                     toolTimestamp,
                     sessionId,

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -597,6 +597,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         }
         ConfigureSessionFsHandlers(session, config.CreateSessionFsHandler);
         RegisterSession(session);
+        session.StartProcessingEvents();
         LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
             "CopilotClient.CreateSessionAsync local setup complete. Elapsed={Elapsed}, SessionId={SessionId}, Tools={ToolsCount}, Commands={CommandsCount}, Hooks={HasHooks}",
             setupTimestamp,
@@ -762,6 +763,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         }
         ConfigureSessionFsHandlers(session, config.CreateSessionFsHandler);
         RegisterSession(session);
+        session.StartProcessingEvents();
         LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
             "CopilotClient.ResumeSessionAsync local setup complete. Elapsed={Elapsed}, SessionId={SessionId}, Tools={ToolsCount}, Commands={CommandsCount}, Hooks={HasHooks}",
             setupTimestamp,
@@ -1749,7 +1751,10 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
     private void RegisterSession(CopilotSession session)
     {
-        _sessions[session.SessionId] = session;
+        if (!_sessions.TryAdd(session.SessionId, session))
+        {
+            throw new InvalidOperationException($"Session '{session.SessionId}' is already tracked by this client.");
+        }
     }
 
     private void RemoveSession(string sessionId)

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -1750,10 +1750,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
     private void RegisterSession(CopilotSession session)
     {
-        if (!_sessions.TryAdd(session.SessionId, session))
-        {
-            throw new InvalidOperationException($"Session {session.SessionId} is already in use on this {nameof(CopilotClient)}.");
-        }
+        _sessions[session.SessionId] = session;
     }
 
     private void RemoveSession(string sessionId)

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -330,18 +330,15 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     {
         List<Exception> errors = [];
 
-        foreach (var (sessionId, _) in _sessions)
+        foreach (var session in _sessions.Values.ToArray())
         {
-            if (_sessions.TryRemove(sessionId, out var session))
+            try
             {
-                try
-                {
-                    await session.DisposeAsync();
-                }
-                catch (Exception ex)
-                {
-                    errors.Add(new IOException($"Failed to dispose session {session.SessionId}: {ex.Message}", ex));
-                }
+                await session.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                errors.Add(new IOException($"Failed to dispose session {session.SessionId}: {ex.Message}", ex));
             }
         }
 

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -328,7 +328,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     /// </example>
     public async Task StopAsync()
     {
-        List<Exception>? errors = null;
+        List<Exception> errors = [];
 
         foreach (var (sessionId, _) in _sessions)
         {
@@ -340,10 +340,12 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 }
                 catch (Exception ex)
                 {
-                    (errors ??= []).Add(new IOException($"Failed to dispose session {session.SessionId}: {ex.Message}", ex));
+                    errors.Add(new IOException($"Failed to dispose session {session.SessionId}: {ex.Message}", ex));
                 }
             }
         }
+
+        _sessions.Clear();
 
         await CleanupConnectionAsync(errors);
 

--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -14,6 +14,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 
 namespace GitHub.Copilot.SDK.Rpc;
 
@@ -5170,13 +5171,6 @@ public sealed class ServerRpc
     internal ServerRpc(JsonRpc rpc)
     {
         _rpc = rpc;
-        Models = new ServerModelsApi(rpc);
-        Tools = new ServerToolsApi(rpc);
-        Account = new ServerAccountApi(rpc);
-        Mcp = new ServerMcpApi(rpc);
-        Skills = new ServerSkillsApi(rpc);
-        SessionFs = new ServerSessionFsApi(rpc);
-        Sessions = new ServerSessionsApi(rpc);
     }
 
     /// <summary>Checks server responsiveness and returns protocol information.</summary>
@@ -5200,25 +5194,46 @@ public sealed class ServerRpc
     }
 
     /// <summary>Models APIs.</summary>
-    public ServerModelsApi Models { get; }
+    public ServerModelsApi Models =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_rpc), null) ??
+        field;
 
     /// <summary>Tools APIs.</summary>
-    public ServerToolsApi Tools { get; }
+    public ServerToolsApi Tools =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_rpc), null) ??
+        field;
 
     /// <summary>Account APIs.</summary>
-    public ServerAccountApi Account { get; }
+    public ServerAccountApi Account =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_rpc), null) ??
+        field;
 
     /// <summary>Mcp APIs.</summary>
-    public ServerMcpApi Mcp { get; }
+    public ServerMcpApi Mcp =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_rpc), null) ??
+        field;
 
     /// <summary>Skills APIs.</summary>
-    public ServerSkillsApi Skills { get; }
+    public ServerSkillsApi Skills =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_rpc), null) ??
+        field;
 
     /// <summary>SessionFs APIs.</summary>
-    public ServerSessionFsApi SessionFs { get; }
+    public ServerSessionFsApi SessionFs =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_rpc), null) ??
+        field;
 
     /// <summary>Sessions APIs.</summary>
-    public ServerSessionsApi Sessions { get; }
+    public ServerSessionsApi Sessions =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_rpc), null) ??
+        field;
 }
 
 /// <summary>Provides server-scoped Models APIs.</summary>
@@ -5292,7 +5307,6 @@ public sealed class ServerMcpApi
     internal ServerMcpApi(JsonRpc rpc)
     {
         _rpc = rpc;
-        Config = new ServerMcpConfigApi(rpc);
     }
 
     /// <summary>Discovers MCP servers from user, workspace, plugin, and builtin sources.</summary>
@@ -5306,7 +5320,10 @@ public sealed class ServerMcpApi
     }
 
     /// <summary>Config APIs.</summary>
-    public ServerMcpConfigApi Config { get; }
+    public ServerMcpConfigApi Config =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_rpc), null) ??
+        field;
 }
 
 /// <summary>Provides server-scoped McpConfig APIs.</summary>
@@ -5333,6 +5350,9 @@ public sealed class ServerMcpConfigApi
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task AddAsync(string name, object config, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(config);
+
         var request = new McpConfigAddRequest { Name = name, Config = config };
         await CopilotClient.InvokeRpcAsync(_rpc, "mcp.config.add", [request], cancellationToken);
     }
@@ -5343,6 +5363,9 @@ public sealed class ServerMcpConfigApi
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task UpdateAsync(string name, object config, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(config);
+
         var request = new McpConfigUpdateRequest { Name = name, Config = config };
         await CopilotClient.InvokeRpcAsync(_rpc, "mcp.config.update", [request], cancellationToken);
     }
@@ -5352,6 +5375,8 @@ public sealed class ServerMcpConfigApi
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task RemoveAsync(string name, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(name);
+
         var request = new McpConfigRemoveRequest { Name = name };
         await CopilotClient.InvokeRpcAsync(_rpc, "mcp.config.remove", [request], cancellationToken);
     }
@@ -5361,6 +5386,8 @@ public sealed class ServerMcpConfigApi
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task EnableAsync(IList<string> names, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(names);
+
         var request = new McpConfigEnableRequest { Names = names };
         await CopilotClient.InvokeRpcAsync(_rpc, "mcp.config.enable", [request], cancellationToken);
     }
@@ -5370,6 +5397,8 @@ public sealed class ServerMcpConfigApi
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task DisableAsync(IList<string> names, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(names);
+
         var request = new McpConfigDisableRequest { Names = names };
         await CopilotClient.InvokeRpcAsync(_rpc, "mcp.config.disable", [request], cancellationToken);
     }
@@ -5383,7 +5412,6 @@ public sealed class ServerSkillsApi
     internal ServerSkillsApi(JsonRpc rpc)
     {
         _rpc = rpc;
-        Config = new ServerSkillsConfigApi(rpc);
     }
 
     /// <summary>Discovers skills across global and project sources.</summary>
@@ -5398,7 +5426,10 @@ public sealed class ServerSkillsApi
     }
 
     /// <summary>Config APIs.</summary>
-    public ServerSkillsConfigApi Config { get; }
+    public ServerSkillsConfigApi Config =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_rpc), null) ??
+        field;
 }
 
 /// <summary>Provides server-scoped SkillsConfig APIs.</summary>
@@ -5416,6 +5447,8 @@ public sealed class ServerSkillsConfigApi
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task SetDisabledSkillsAsync(IList<string> disabledSkills, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(disabledSkills);
+
         var request = new SkillsConfigSetDisabledSkillsRequest { DisabledSkills = disabledSkills };
         await CopilotClient.InvokeRpcAsync(_rpc, "skills.config.setDisabledSkills", [request], cancellationToken);
     }
@@ -5439,6 +5472,9 @@ public sealed class ServerSessionFsApi
     /// <returns>Indicates whether the calling client was registered as the session filesystem provider.</returns>
     public async Task<SessionFsSetProviderResult> SetProviderAsync(string initialCwd, string sessionStatePath, SessionFsSetProviderConventions conventions, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(initialCwd);
+        ArgumentNullException.ThrowIfNull(sessionStatePath);
+
         var request = new SessionFsSetProviderRequest { InitialCwd = initialCwd, SessionStatePath = sessionStatePath, Conventions = conventions };
         return await CopilotClient.InvokeRpcAsync<SessionFsSetProviderResult>(_rpc, "sessionFs.setProvider", [request], cancellationToken);
     }
@@ -5463,6 +5499,8 @@ public sealed class ServerSessionsApi
     /// <returns>Identifier and optional friendly name assigned to the newly forked session.</returns>
     public async Task<SessionsForkResult> ForkAsync(string sessionId, string? toEventId = null, string? name = null, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(sessionId);
+
         var request = new SessionsForkRequest { SessionId = sessionId, ToEventId = toEventId, Name = name };
         return await CopilotClient.InvokeRpcAsync<SessionsForkResult>(_rpc, "sessions.fork", [request], cancellationToken);
     }
@@ -5473,6 +5511,8 @@ public sealed class ServerSessionsApi
     /// <returns>Remote session connection result.</returns>
     public async Task<RemoteSessionConnectionResult> ConnectAsync(string sessionId, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(sessionId);
+
         var request = new ConnectRemoteSessionParams { SessionId = sessionId };
         return await CopilotClient.InvokeRpcAsync<RemoteSessionConnectionResult>(_rpc, "sessions.connect", [request], cancellationToken);
     }
@@ -5481,109 +5521,155 @@ public sealed class ServerSessionsApi
 /// <summary>Provides typed session-scoped RPC methods.</summary>
 public sealed class SessionRpc
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal SessionRpc(JsonRpc rpc, string sessionId)
+    internal SessionRpc(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
-        Auth = new AuthApi(rpc, sessionId);
-        Model = new ModelApi(rpc, sessionId);
-        Mode = new ModeApi(rpc, sessionId);
-        Name = new NameApi(rpc, sessionId);
-        Plan = new PlanApi(rpc, sessionId);
-        Workspaces = new WorkspacesApi(rpc, sessionId);
-        Instructions = new InstructionsApi(rpc, sessionId);
-        Fleet = new FleetApi(rpc, sessionId);
-        Agent = new AgentApi(rpc, sessionId);
-        Tasks = new TasksApi(rpc, sessionId);
-        Skills = new SkillsApi(rpc, sessionId);
-        Mcp = new McpApi(rpc, sessionId);
-        Plugins = new PluginsApi(rpc, sessionId);
-        Extensions = new ExtensionsApi(rpc, sessionId);
-        Tools = new ToolsApi(rpc, sessionId);
-        Commands = new CommandsApi(rpc, sessionId);
-        Ui = new UiApi(rpc, sessionId);
-        Permissions = new PermissionsApi(rpc, sessionId);
-        Shell = new ShellApi(rpc, sessionId);
-        History = new HistoryApi(rpc, sessionId);
-        Usage = new UsageApi(rpc, sessionId);
-        Remote = new RemoteApi(rpc, sessionId);
+        _session = session;
     }
 
+    internal CopilotSession Session => _session;
+
     /// <summary>Auth APIs.</summary>
-    public AuthApi Auth { get; }
+    public AuthApi Auth =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Model APIs.</summary>
-    public ModelApi Model { get; }
+    public ModelApi Model =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Mode APIs.</summary>
-    public ModeApi Mode { get; }
+    public ModeApi Mode =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Name APIs.</summary>
-    public NameApi Name { get; }
+    public NameApi Name =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Plan APIs.</summary>
-    public PlanApi Plan { get; }
+    public PlanApi Plan =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Workspaces APIs.</summary>
-    public WorkspacesApi Workspaces { get; }
+    public WorkspacesApi Workspaces =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Instructions APIs.</summary>
-    public InstructionsApi Instructions { get; }
+    public InstructionsApi Instructions =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Fleet APIs.</summary>
-    public FleetApi Fleet { get; }
+    public FleetApi Fleet =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Agent APIs.</summary>
-    public AgentApi Agent { get; }
+    public AgentApi Agent =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Tasks APIs.</summary>
-    public TasksApi Tasks { get; }
+    public TasksApi Tasks =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Skills APIs.</summary>
-    public SkillsApi Skills { get; }
+    public SkillsApi Skills =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Mcp APIs.</summary>
-    public McpApi Mcp { get; }
+    public McpApi Mcp =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Plugins APIs.</summary>
-    public PluginsApi Plugins { get; }
+    public PluginsApi Plugins =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Extensions APIs.</summary>
-    public ExtensionsApi Extensions { get; }
+    public ExtensionsApi Extensions =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Tools APIs.</summary>
-    public ToolsApi Tools { get; }
+    public ToolsApi Tools =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Commands APIs.</summary>
-    public CommandsApi Commands { get; }
+    public CommandsApi Commands =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Ui APIs.</summary>
-    public UiApi Ui { get; }
+    public UiApi Ui =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Permissions APIs.</summary>
-    public PermissionsApi Permissions { get; }
+    public PermissionsApi Permissions =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Shell APIs.</summary>
-    public ShellApi Shell { get; }
+    public ShellApi Shell =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>History APIs.</summary>
-    public HistoryApi History { get; }
+    public HistoryApi History =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Usage APIs.</summary>
-    public UsageApi Usage { get; }
+    public UsageApi Usage =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Remote APIs.</summary>
-    public RemoteApi Remote { get; }
+    public RemoteApi Remote =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 
     /// <summary>Suspends the session while preserving persisted state for later resume.</summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task SuspendAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionSuspendRequest { SessionId = _sessionId };
-        await CopilotClient.InvokeRpcAsync(_rpc, "session.suspend", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionSuspendRequest { SessionId = _session.SessionId };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.suspend", [request], cancellationToken);
     }
 
     /// <summary>Emits a user-visible session log event.</summary>
@@ -5595,21 +5681,22 @@ public sealed class SessionRpc
     /// <returns>Identifier of the session event that was emitted for the log message.</returns>
     public async Task<LogResult> LogAsync(string message, SessionLogLevel? level = null, bool? ephemeral = null, string? url = null, CancellationToken cancellationToken = default)
     {
-        var request = new LogRequest { SessionId = _sessionId, Message = message, Level = level, Ephemeral = ephemeral, Url = url };
-        return await CopilotClient.InvokeRpcAsync<LogResult>(_rpc, "session.log", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(message);
+        _session.ThrowIfDisposed();
+
+        var request = new LogRequest { SessionId = _session.SessionId, Message = message, Level = level, Ephemeral = ephemeral, Url = url };
+        return await CopilotClient.InvokeRpcAsync<LogResult>(_session.Rpc, "session.log", [request], cancellationToken);
     }
 }
 
 /// <summary>Provides session-scoped Auth APIs.</summary>
 public sealed class AuthApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal AuthApi(JsonRpc rpc, string sessionId)
+    internal AuthApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Gets authentication status and account metadata for the session.</summary>
@@ -5617,21 +5704,21 @@ public sealed class AuthApi
     /// <returns>Authentication status and account metadata for the session.</returns>
     public async Task<SessionAuthStatus> GetStatusAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionAuthGetStatusRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<SessionAuthStatus>(_rpc, "session.auth.getStatus", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionAuthGetStatusRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<SessionAuthStatus>(_session.Rpc, "session.auth.getStatus", [request], cancellationToken);
     }
 }
 
 /// <summary>Provides session-scoped Model APIs.</summary>
 public sealed class ModelApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal ModelApi(JsonRpc rpc, string sessionId)
+    internal ModelApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Gets the currently selected model for the session.</summary>
@@ -5639,8 +5726,10 @@ public sealed class ModelApi
     /// <returns>The currently selected model for the session.</returns>
     public async Task<CurrentModel> GetCurrentAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionModelGetCurrentRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<CurrentModel>(_rpc, "session.model.getCurrent", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionModelGetCurrentRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<CurrentModel>(_session.Rpc, "session.model.getCurrent", [request], cancellationToken);
     }
 
     /// <summary>Switches the session to a model and optional reasoning configuration.</summary>
@@ -5652,21 +5741,22 @@ public sealed class ModelApi
     /// <returns>The model identifier active on the session after the switch.</returns>
     public async Task<ModelSwitchToResult> SwitchToAsync(string modelId, string? reasoningEffort = null, ReasoningSummary? reasoningSummary = null, ModelCapabilitiesOverride? modelCapabilities = null, CancellationToken cancellationToken = default)
     {
-        var request = new ModelSwitchToRequest { SessionId = _sessionId, ModelId = modelId, ReasoningEffort = reasoningEffort, ReasoningSummary = reasoningSummary, ModelCapabilities = modelCapabilities };
-        return await CopilotClient.InvokeRpcAsync<ModelSwitchToResult>(_rpc, "session.model.switchTo", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(modelId);
+        _session.ThrowIfDisposed();
+
+        var request = new ModelSwitchToRequest { SessionId = _session.SessionId, ModelId = modelId, ReasoningEffort = reasoningEffort, ReasoningSummary = reasoningSummary, ModelCapabilities = modelCapabilities };
+        return await CopilotClient.InvokeRpcAsync<ModelSwitchToResult>(_session.Rpc, "session.model.switchTo", [request], cancellationToken);
     }
 }
 
 /// <summary>Provides session-scoped Mode APIs.</summary>
 public sealed class ModeApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal ModeApi(JsonRpc rpc, string sessionId)
+    internal ModeApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Gets the current agent interaction mode.</summary>
@@ -5674,8 +5764,10 @@ public sealed class ModeApi
     /// <returns>The agent mode. Valid values: "interactive", "plan", "autopilot".</returns>
     public async Task<SessionMode> GetAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionModeGetRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<SessionMode>(_rpc, "session.mode.get", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionModeGetRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<SessionMode>(_session.Rpc, "session.mode.get", [request], cancellationToken);
     }
 
     /// <summary>Sets the current agent interaction mode.</summary>
@@ -5683,21 +5775,21 @@ public sealed class ModeApi
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task SetAsync(SessionMode mode, CancellationToken cancellationToken = default)
     {
-        var request = new ModeSetRequest { SessionId = _sessionId, Mode = mode };
-        await CopilotClient.InvokeRpcAsync(_rpc, "session.mode.set", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new ModeSetRequest { SessionId = _session.SessionId, Mode = mode };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.mode.set", [request], cancellationToken);
     }
 }
 
 /// <summary>Provides session-scoped Name APIs.</summary>
 public sealed class NameApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal NameApi(JsonRpc rpc, string sessionId)
+    internal NameApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Gets the session's friendly name.</summary>
@@ -5705,8 +5797,10 @@ public sealed class NameApi
     /// <returns>The session's friendly name, or null when not yet set.</returns>
     public async Task<NameGetResult> GetAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionNameGetRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<NameGetResult>(_rpc, "session.name.get", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionNameGetRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<NameGetResult>(_session.Rpc, "session.name.get", [request], cancellationToken);
     }
 
     /// <summary>Sets the session's friendly name.</summary>
@@ -5714,21 +5808,22 @@ public sealed class NameApi
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task SetAsync(string name, CancellationToken cancellationToken = default)
     {
-        var request = new NameSetRequest { SessionId = _sessionId, Name = name };
-        await CopilotClient.InvokeRpcAsync(_rpc, "session.name.set", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(name);
+        _session.ThrowIfDisposed();
+
+        var request = new NameSetRequest { SessionId = _session.SessionId, Name = name };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.name.set", [request], cancellationToken);
     }
 }
 
 /// <summary>Provides session-scoped Plan APIs.</summary>
 public sealed class PlanApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal PlanApi(JsonRpc rpc, string sessionId)
+    internal PlanApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Reads the session plan file from the workspace.</summary>
@@ -5736,8 +5831,10 @@ public sealed class PlanApi
     /// <returns>Existence, contents, and resolved path of the session plan file.</returns>
     public async Task<PlanReadResult> ReadAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionPlanReadRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<PlanReadResult>(_rpc, "session.plan.read", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionPlanReadRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<PlanReadResult>(_session.Rpc, "session.plan.read", [request], cancellationToken);
     }
 
     /// <summary>Writes new content to the session plan file.</summary>
@@ -5745,29 +5842,32 @@ public sealed class PlanApi
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task UpdateAsync(string content, CancellationToken cancellationToken = default)
     {
-        var request = new PlanUpdateRequest { SessionId = _sessionId, Content = content };
-        await CopilotClient.InvokeRpcAsync(_rpc, "session.plan.update", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(content);
+        _session.ThrowIfDisposed();
+
+        var request = new PlanUpdateRequest { SessionId = _session.SessionId, Content = content };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.plan.update", [request], cancellationToken);
     }
 
     /// <summary>Deletes the session plan file from the workspace.</summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task DeleteAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionPlanDeleteRequest { SessionId = _sessionId };
-        await CopilotClient.InvokeRpcAsync(_rpc, "session.plan.delete", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionPlanDeleteRequest { SessionId = _session.SessionId };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.plan.delete", [request], cancellationToken);
     }
 }
 
 /// <summary>Provides session-scoped Workspaces APIs.</summary>
 public sealed class WorkspacesApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal WorkspacesApi(JsonRpc rpc, string sessionId)
+    internal WorkspacesApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Gets current workspace metadata for the session.</summary>
@@ -5775,8 +5875,10 @@ public sealed class WorkspacesApi
     /// <returns>Current workspace metadata for the session, or null when not available.</returns>
     public async Task<WorkspacesGetWorkspaceResult> GetWorkspaceAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionWorkspacesGetWorkspaceRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<WorkspacesGetWorkspaceResult>(_rpc, "session.workspaces.getWorkspace", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionWorkspacesGetWorkspaceRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<WorkspacesGetWorkspaceResult>(_session.Rpc, "session.workspaces.getWorkspace", [request], cancellationToken);
     }
 
     /// <summary>Lists files stored in the session workspace files directory.</summary>
@@ -5784,8 +5886,10 @@ public sealed class WorkspacesApi
     /// <returns>Relative paths of files stored in the session workspace files directory.</returns>
     public async Task<WorkspacesListFilesResult> ListFilesAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionWorkspacesListFilesRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<WorkspacesListFilesResult>(_rpc, "session.workspaces.listFiles", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionWorkspacesListFilesRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<WorkspacesListFilesResult>(_session.Rpc, "session.workspaces.listFiles", [request], cancellationToken);
     }
 
     /// <summary>Reads a file from the session workspace files directory.</summary>
@@ -5794,8 +5898,11 @@ public sealed class WorkspacesApi
     /// <returns>Contents of the requested workspace file as a UTF-8 string.</returns>
     public async Task<WorkspacesReadFileResult> ReadFileAsync(string path, CancellationToken cancellationToken = default)
     {
-        var request = new WorkspacesReadFileRequest { SessionId = _sessionId, Path = path };
-        return await CopilotClient.InvokeRpcAsync<WorkspacesReadFileResult>(_rpc, "session.workspaces.readFile", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(path);
+        _session.ThrowIfDisposed();
+
+        var request = new WorkspacesReadFileRequest { SessionId = _session.SessionId, Path = path };
+        return await CopilotClient.InvokeRpcAsync<WorkspacesReadFileResult>(_session.Rpc, "session.workspaces.readFile", [request], cancellationToken);
     }
 
     /// <summary>Creates or overwrites a file in the session workspace files directory.</summary>
@@ -5804,21 +5911,23 @@ public sealed class WorkspacesApi
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task CreateFileAsync(string path, string content, CancellationToken cancellationToken = default)
     {
-        var request = new WorkspacesCreateFileRequest { SessionId = _sessionId, Path = path, Content = content };
-        await CopilotClient.InvokeRpcAsync(_rpc, "session.workspaces.createFile", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(content);
+        _session.ThrowIfDisposed();
+
+        var request = new WorkspacesCreateFileRequest { SessionId = _session.SessionId, Path = path, Content = content };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.workspaces.createFile", [request], cancellationToken);
     }
 }
 
 /// <summary>Provides session-scoped Instructions APIs.</summary>
 public sealed class InstructionsApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal InstructionsApi(JsonRpc rpc, string sessionId)
+    internal InstructionsApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Gets instruction sources loaded for the session.</summary>
@@ -5826,8 +5935,10 @@ public sealed class InstructionsApi
     /// <returns>Instruction sources loaded for the session, in merge order.</returns>
     public async Task<InstructionsGetSourcesResult> GetSourcesAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionInstructionsGetSourcesRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<InstructionsGetSourcesResult>(_rpc, "session.instructions.getSources", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionInstructionsGetSourcesRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<InstructionsGetSourcesResult>(_session.Rpc, "session.instructions.getSources", [request], cancellationToken);
     }
 }
 
@@ -5835,13 +5946,11 @@ public sealed class InstructionsApi
 [Experimental(Diagnostics.Experimental)]
 public sealed class FleetApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal FleetApi(JsonRpc rpc, string sessionId)
+    internal FleetApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Starts fleet mode by submitting the fleet orchestration prompt to the session.</summary>
@@ -5850,8 +5959,10 @@ public sealed class FleetApi
     /// <returns>Indicates whether fleet mode was successfully activated.</returns>
     public async Task<FleetStartResult> StartAsync(string? prompt = null, CancellationToken cancellationToken = default)
     {
-        var request = new FleetStartRequest { SessionId = _sessionId, Prompt = prompt };
-        return await CopilotClient.InvokeRpcAsync<FleetStartResult>(_rpc, "session.fleet.start", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new FleetStartRequest { SessionId = _session.SessionId, Prompt = prompt };
+        return await CopilotClient.InvokeRpcAsync<FleetStartResult>(_session.Rpc, "session.fleet.start", [request], cancellationToken);
     }
 }
 
@@ -5859,13 +5970,11 @@ public sealed class FleetApi
 [Experimental(Diagnostics.Experimental)]
 public sealed class AgentApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal AgentApi(JsonRpc rpc, string sessionId)
+    internal AgentApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Lists custom agents available to the session.</summary>
@@ -5873,8 +5982,10 @@ public sealed class AgentApi
     /// <returns>Custom agents available to the session.</returns>
     public async Task<AgentList> ListAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionAgentListRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<AgentList>(_rpc, "session.agent.list", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionAgentListRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<AgentList>(_session.Rpc, "session.agent.list", [request], cancellationToken);
     }
 
     /// <summary>Gets the currently selected custom agent for the session.</summary>
@@ -5882,8 +5993,10 @@ public sealed class AgentApi
     /// <returns>The currently selected custom agent, or null when using the default agent.</returns>
     public async Task<AgentGetCurrentResult> GetCurrentAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionAgentGetCurrentRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<AgentGetCurrentResult>(_rpc, "session.agent.getCurrent", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionAgentGetCurrentRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<AgentGetCurrentResult>(_session.Rpc, "session.agent.getCurrent", [request], cancellationToken);
     }
 
     /// <summary>Selects a custom agent for subsequent turns in the session.</summary>
@@ -5892,16 +6005,21 @@ public sealed class AgentApi
     /// <returns>The newly selected custom agent.</returns>
     public async Task<AgentSelectResult> SelectAsync(string name, CancellationToken cancellationToken = default)
     {
-        var request = new AgentSelectRequest { SessionId = _sessionId, Name = name };
-        return await CopilotClient.InvokeRpcAsync<AgentSelectResult>(_rpc, "session.agent.select", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(name);
+        _session.ThrowIfDisposed();
+
+        var request = new AgentSelectRequest { SessionId = _session.SessionId, Name = name };
+        return await CopilotClient.InvokeRpcAsync<AgentSelectResult>(_session.Rpc, "session.agent.select", [request], cancellationToken);
     }
 
     /// <summary>Clears the selected custom agent and returns the session to the default agent.</summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task DeselectAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionAgentDeselectRequest { SessionId = _sessionId };
-        await CopilotClient.InvokeRpcAsync(_rpc, "session.agent.deselect", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionAgentDeselectRequest { SessionId = _session.SessionId };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.agent.deselect", [request], cancellationToken);
     }
 
     /// <summary>Reloads custom agent definitions and returns the refreshed list.</summary>
@@ -5909,8 +6027,10 @@ public sealed class AgentApi
     /// <returns>Custom agents available to the session after reloading definitions from disk.</returns>
     public async Task<AgentReloadResult> ReloadAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionAgentReloadRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<AgentReloadResult>(_rpc, "session.agent.reload", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionAgentReloadRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<AgentReloadResult>(_session.Rpc, "session.agent.reload", [request], cancellationToken);
     }
 }
 
@@ -5918,13 +6038,11 @@ public sealed class AgentApi
 [Experimental(Diagnostics.Experimental)]
 public sealed class TasksApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal TasksApi(JsonRpc rpc, string sessionId)
+    internal TasksApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Starts a background agent task in the session.</summary>
@@ -5937,8 +6055,13 @@ public sealed class TasksApi
     /// <returns>Identifier assigned to the newly started background agent task.</returns>
     public async Task<TasksStartAgentResult> StartAgentAsync(string agentType, string prompt, string name, string? description = null, string? model = null, CancellationToken cancellationToken = default)
     {
-        var request = new TasksStartAgentRequest { SessionId = _sessionId, AgentType = agentType, Prompt = prompt, Name = name, Description = description, Model = model };
-        return await CopilotClient.InvokeRpcAsync<TasksStartAgentResult>(_rpc, "session.tasks.startAgent", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(agentType);
+        ArgumentNullException.ThrowIfNull(prompt);
+        ArgumentNullException.ThrowIfNull(name);
+        _session.ThrowIfDisposed();
+
+        var request = new TasksStartAgentRequest { SessionId = _session.SessionId, AgentType = agentType, Prompt = prompt, Name = name, Description = description, Model = model };
+        return await CopilotClient.InvokeRpcAsync<TasksStartAgentResult>(_session.Rpc, "session.tasks.startAgent", [request], cancellationToken);
     }
 
     /// <summary>Lists background tasks tracked by the session.</summary>
@@ -5946,8 +6069,10 @@ public sealed class TasksApi
     /// <returns>Background tasks currently tracked by the session.</returns>
     public async Task<TaskList> ListAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionTasksListRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<TaskList>(_rpc, "session.tasks.list", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionTasksListRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<TaskList>(_session.Rpc, "session.tasks.list", [request], cancellationToken);
     }
 
     /// <summary>Promotes an eligible synchronously-waited task so it continues running in the background.</summary>
@@ -5956,8 +6081,11 @@ public sealed class TasksApi
     /// <returns>Indicates whether the task was successfully promoted to background mode.</returns>
     public async Task<TasksPromoteToBackgroundResult> PromoteToBackgroundAsync(string id, CancellationToken cancellationToken = default)
     {
-        var request = new TasksPromoteToBackgroundRequest { SessionId = _sessionId, Id = id };
-        return await CopilotClient.InvokeRpcAsync<TasksPromoteToBackgroundResult>(_rpc, "session.tasks.promoteToBackground", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(id);
+        _session.ThrowIfDisposed();
+
+        var request = new TasksPromoteToBackgroundRequest { SessionId = _session.SessionId, Id = id };
+        return await CopilotClient.InvokeRpcAsync<TasksPromoteToBackgroundResult>(_session.Rpc, "session.tasks.promoteToBackground", [request], cancellationToken);
     }
 
     /// <summary>Cancels a background task.</summary>
@@ -5966,8 +6094,11 @@ public sealed class TasksApi
     /// <returns>Indicates whether the background task was successfully cancelled.</returns>
     public async Task<TasksCancelResult> CancelAsync(string id, CancellationToken cancellationToken = default)
     {
-        var request = new TasksCancelRequest { SessionId = _sessionId, Id = id };
-        return await CopilotClient.InvokeRpcAsync<TasksCancelResult>(_rpc, "session.tasks.cancel", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(id);
+        _session.ThrowIfDisposed();
+
+        var request = new TasksCancelRequest { SessionId = _session.SessionId, Id = id };
+        return await CopilotClient.InvokeRpcAsync<TasksCancelResult>(_session.Rpc, "session.tasks.cancel", [request], cancellationToken);
     }
 
     /// <summary>Removes a completed or cancelled background task from tracking.</summary>
@@ -5976,8 +6107,11 @@ public sealed class TasksApi
     /// <returns>Indicates whether the task was removed. False when the task does not exist or is still running/idle.</returns>
     public async Task<TasksRemoveResult> RemoveAsync(string id, CancellationToken cancellationToken = default)
     {
-        var request = new TasksRemoveRequest { SessionId = _sessionId, Id = id };
-        return await CopilotClient.InvokeRpcAsync<TasksRemoveResult>(_rpc, "session.tasks.remove", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(id);
+        _session.ThrowIfDisposed();
+
+        var request = new TasksRemoveRequest { SessionId = _session.SessionId, Id = id };
+        return await CopilotClient.InvokeRpcAsync<TasksRemoveResult>(_session.Rpc, "session.tasks.remove", [request], cancellationToken);
     }
 
     /// <summary>Sends a message to a background agent task.</summary>
@@ -5988,8 +6122,12 @@ public sealed class TasksApi
     /// <returns>Indicates whether the message was delivered, with an error message when delivery failed.</returns>
     public async Task<TasksSendMessageResult> SendMessageAsync(string id, string message, string? fromAgentId = null, CancellationToken cancellationToken = default)
     {
-        var request = new TasksSendMessageRequest { SessionId = _sessionId, Id = id, Message = message, FromAgentId = fromAgentId };
-        return await CopilotClient.InvokeRpcAsync<TasksSendMessageResult>(_rpc, "session.tasks.sendMessage", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(id);
+        ArgumentNullException.ThrowIfNull(message);
+        _session.ThrowIfDisposed();
+
+        var request = new TasksSendMessageRequest { SessionId = _session.SessionId, Id = id, Message = message, FromAgentId = fromAgentId };
+        return await CopilotClient.InvokeRpcAsync<TasksSendMessageResult>(_session.Rpc, "session.tasks.sendMessage", [request], cancellationToken);
     }
 }
 
@@ -5997,13 +6135,11 @@ public sealed class TasksApi
 [Experimental(Diagnostics.Experimental)]
 public sealed class SkillsApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal SkillsApi(JsonRpc rpc, string sessionId)
+    internal SkillsApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Lists skills available to the session.</summary>
@@ -6011,8 +6147,10 @@ public sealed class SkillsApi
     /// <returns>Skills available to the session, with their enabled state.</returns>
     public async Task<SkillList> ListAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionSkillsListRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<SkillList>(_rpc, "session.skills.list", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionSkillsListRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<SkillList>(_session.Rpc, "session.skills.list", [request], cancellationToken);
     }
 
     /// <summary>Enables a skill for the session.</summary>
@@ -6020,8 +6158,11 @@ public sealed class SkillsApi
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task EnableAsync(string name, CancellationToken cancellationToken = default)
     {
-        var request = new SkillsEnableRequest { SessionId = _sessionId, Name = name };
-        await CopilotClient.InvokeRpcAsync(_rpc, "session.skills.enable", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(name);
+        _session.ThrowIfDisposed();
+
+        var request = new SkillsEnableRequest { SessionId = _session.SessionId, Name = name };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.skills.enable", [request], cancellationToken);
     }
 
     /// <summary>Disables a skill for the session.</summary>
@@ -6029,8 +6170,11 @@ public sealed class SkillsApi
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task DisableAsync(string name, CancellationToken cancellationToken = default)
     {
-        var request = new SkillsDisableRequest { SessionId = _sessionId, Name = name };
-        await CopilotClient.InvokeRpcAsync(_rpc, "session.skills.disable", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(name);
+        _session.ThrowIfDisposed();
+
+        var request = new SkillsDisableRequest { SessionId = _session.SessionId, Name = name };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.skills.disable", [request], cancellationToken);
     }
 
     /// <summary>Reloads skill definitions for the session.</summary>
@@ -6038,8 +6182,10 @@ public sealed class SkillsApi
     /// <returns>Diagnostics from reloading skill definitions, with warnings and errors as separate lists.</returns>
     public async Task<SkillsLoadDiagnostics> ReloadAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionSkillsReloadRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<SkillsLoadDiagnostics>(_rpc, "session.skills.reload", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionSkillsReloadRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<SkillsLoadDiagnostics>(_session.Rpc, "session.skills.reload", [request], cancellationToken);
     }
 }
 
@@ -6047,14 +6193,11 @@ public sealed class SkillsApi
 [Experimental(Diagnostics.Experimental)]
 public sealed class McpApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal McpApi(JsonRpc rpc, string sessionId)
+    internal McpApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
-        Oauth = new McpOauthApi(rpc, sessionId);
+        _session = session;
     }
 
     /// <summary>Lists MCP servers configured for the session and their connection status.</summary>
@@ -6062,8 +6205,10 @@ public sealed class McpApi
     /// <returns>MCP servers configured for the session, with their connection status.</returns>
     public async Task<McpServerList> ListAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionMcpListRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<McpServerList>(_rpc, "session.mcp.list", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionMcpListRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<McpServerList>(_session.Rpc, "session.mcp.list", [request], cancellationToken);
     }
 
     /// <summary>Enables an MCP server for the session.</summary>
@@ -6071,8 +6216,11 @@ public sealed class McpApi
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task EnableAsync(string serverName, CancellationToken cancellationToken = default)
     {
-        var request = new McpEnableRequest { SessionId = _sessionId, ServerName = serverName };
-        await CopilotClient.InvokeRpcAsync(_rpc, "session.mcp.enable", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(serverName);
+        _session.ThrowIfDisposed();
+
+        var request = new McpEnableRequest { SessionId = _session.SessionId, ServerName = serverName };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.mcp.enable", [request], cancellationToken);
     }
 
     /// <summary>Disables an MCP server for the session.</summary>
@@ -6080,33 +6228,39 @@ public sealed class McpApi
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task DisableAsync(string serverName, CancellationToken cancellationToken = default)
     {
-        var request = new McpDisableRequest { SessionId = _sessionId, ServerName = serverName };
-        await CopilotClient.InvokeRpcAsync(_rpc, "session.mcp.disable", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(serverName);
+        _session.ThrowIfDisposed();
+
+        var request = new McpDisableRequest { SessionId = _session.SessionId, ServerName = serverName };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.mcp.disable", [request], cancellationToken);
     }
 
     /// <summary>Reloads MCP server connections for the session.</summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task ReloadAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionMcpReloadRequest { SessionId = _sessionId };
-        await CopilotClient.InvokeRpcAsync(_rpc, "session.mcp.reload", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionMcpReloadRequest { SessionId = _session.SessionId };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.mcp.reload", [request], cancellationToken);
     }
 
     /// <summary>Oauth APIs.</summary>
-    public McpOauthApi Oauth { get; }
+    public McpOauthApi Oauth =>
+        field ??
+        Interlocked.CompareExchange(ref field, new(_session), null) ??
+        field;
 }
 
 /// <summary>Provides session-scoped McpOauth APIs.</summary>
 [Experimental(Diagnostics.Experimental)]
 public sealed class McpOauthApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal McpOauthApi(JsonRpc rpc, string sessionId)
+    internal McpOauthApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Starts OAuth authentication for a remote MCP server.</summary>
@@ -6118,8 +6272,11 @@ public sealed class McpOauthApi
     /// <returns>OAuth authorization URL the caller should open, or empty when cached tokens already authenticated the server.</returns>
     public async Task<McpOauthLoginResult> LoginAsync(string serverName, bool? forceReauth = null, string? clientName = null, string? callbackSuccessMessage = null, CancellationToken cancellationToken = default)
     {
-        var request = new McpOauthLoginRequest { SessionId = _sessionId, ServerName = serverName, ForceReauth = forceReauth, ClientName = clientName, CallbackSuccessMessage = callbackSuccessMessage };
-        return await CopilotClient.InvokeRpcAsync<McpOauthLoginResult>(_rpc, "session.mcp.oauth.login", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(serverName);
+        _session.ThrowIfDisposed();
+
+        var request = new McpOauthLoginRequest { SessionId = _session.SessionId, ServerName = serverName, ForceReauth = forceReauth, ClientName = clientName, CallbackSuccessMessage = callbackSuccessMessage };
+        return await CopilotClient.InvokeRpcAsync<McpOauthLoginResult>(_session.Rpc, "session.mcp.oauth.login", [request], cancellationToken);
     }
 }
 
@@ -6127,13 +6284,11 @@ public sealed class McpOauthApi
 [Experimental(Diagnostics.Experimental)]
 public sealed class PluginsApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal PluginsApi(JsonRpc rpc, string sessionId)
+    internal PluginsApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Lists plugins installed for the session.</summary>
@@ -6141,8 +6296,10 @@ public sealed class PluginsApi
     /// <returns>Plugins installed for the session, with their enabled state and version metadata.</returns>
     public async Task<PluginList> ListAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionPluginsListRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<PluginList>(_rpc, "session.plugins.list", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionPluginsListRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<PluginList>(_session.Rpc, "session.plugins.list", [request], cancellationToken);
     }
 }
 
@@ -6150,13 +6307,11 @@ public sealed class PluginsApi
 [Experimental(Diagnostics.Experimental)]
 public sealed class ExtensionsApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal ExtensionsApi(JsonRpc rpc, string sessionId)
+    internal ExtensionsApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Lists extensions discovered for the session and their current status.</summary>
@@ -6164,8 +6319,10 @@ public sealed class ExtensionsApi
     /// <returns>Extensions discovered for the session, with their current status.</returns>
     public async Task<ExtensionList> ListAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionExtensionsListRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<ExtensionList>(_rpc, "session.extensions.list", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionExtensionsListRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<ExtensionList>(_session.Rpc, "session.extensions.list", [request], cancellationToken);
     }
 
     /// <summary>Enables an extension for the session.</summary>
@@ -6173,8 +6330,11 @@ public sealed class ExtensionsApi
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task EnableAsync(string id, CancellationToken cancellationToken = default)
     {
-        var request = new ExtensionsEnableRequest { SessionId = _sessionId, Id = id };
-        await CopilotClient.InvokeRpcAsync(_rpc, "session.extensions.enable", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(id);
+        _session.ThrowIfDisposed();
+
+        var request = new ExtensionsEnableRequest { SessionId = _session.SessionId, Id = id };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.extensions.enable", [request], cancellationToken);
     }
 
     /// <summary>Disables an extension for the session.</summary>
@@ -6182,29 +6342,32 @@ public sealed class ExtensionsApi
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task DisableAsync(string id, CancellationToken cancellationToken = default)
     {
-        var request = new ExtensionsDisableRequest { SessionId = _sessionId, Id = id };
-        await CopilotClient.InvokeRpcAsync(_rpc, "session.extensions.disable", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(id);
+        _session.ThrowIfDisposed();
+
+        var request = new ExtensionsDisableRequest { SessionId = _session.SessionId, Id = id };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.extensions.disable", [request], cancellationToken);
     }
 
     /// <summary>Reloads extension definitions and processes for the session.</summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task ReloadAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionExtensionsReloadRequest { SessionId = _sessionId };
-        await CopilotClient.InvokeRpcAsync(_rpc, "session.extensions.reload", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionExtensionsReloadRequest { SessionId = _session.SessionId };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.extensions.reload", [request], cancellationToken);
     }
 }
 
 /// <summary>Provides session-scoped Tools APIs.</summary>
 public sealed class ToolsApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal ToolsApi(JsonRpc rpc, string sessionId)
+    internal ToolsApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Provides the result for a pending external tool call.</summary>
@@ -6215,21 +6378,22 @@ public sealed class ToolsApi
     /// <returns>Indicates whether the external tool call result was handled successfully.</returns>
     public async Task<HandlePendingToolCallResult> HandlePendingToolCallAsync(string requestId, object? result = null, string? error = null, CancellationToken cancellationToken = default)
     {
-        var request = new HandlePendingToolCallRequest { SessionId = _sessionId, RequestId = requestId, Result = result, Error = error };
-        return await CopilotClient.InvokeRpcAsync<HandlePendingToolCallResult>(_rpc, "session.tools.handlePendingToolCall", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(requestId);
+        _session.ThrowIfDisposed();
+
+        var request = new HandlePendingToolCallRequest { SessionId = _session.SessionId, RequestId = requestId, Result = result, Error = error };
+        return await CopilotClient.InvokeRpcAsync<HandlePendingToolCallResult>(_session.Rpc, "session.tools.handlePendingToolCall", [request], cancellationToken);
     }
 }
 
 /// <summary>Provides session-scoped Commands APIs.</summary>
 public sealed class CommandsApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal CommandsApi(JsonRpc rpc, string sessionId)
+    internal CommandsApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Lists slash commands available in the session.</summary>
@@ -6238,8 +6402,10 @@ public sealed class CommandsApi
     /// <returns>Slash commands available in the session, after applying any include/exclude filters.</returns>
     public async Task<CommandList> ListAsync(CommandsListRequest? request = null, CancellationToken cancellationToken = default)
     {
-        var rpcRequest = new CommandsListRequestWithSession { SessionId = _sessionId, IncludeBuiltins = request?.IncludeBuiltins, IncludeSkills = request?.IncludeSkills, IncludeClientCommands = request?.IncludeClientCommands };
-        return await CopilotClient.InvokeRpcAsync<CommandList>(_rpc, "session.commands.list", [rpcRequest], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var rpcRequest = new CommandsListRequestWithSession { SessionId = _session.SessionId, IncludeBuiltins = request?.IncludeBuiltins, IncludeSkills = request?.IncludeSkills, IncludeClientCommands = request?.IncludeClientCommands };
+        return await CopilotClient.InvokeRpcAsync<CommandList>(_session.Rpc, "session.commands.list", [rpcRequest], cancellationToken);
     }
 
     /// <summary>Invokes a slash command in the session.</summary>
@@ -6249,8 +6415,11 @@ public sealed class CommandsApi
     /// <returns>Result of invoking the slash command (text output, prompt to send to the agent, or completion).</returns>
     public async Task<SlashCommandInvocationResult> InvokeAsync(string name, string? input = null, CancellationToken cancellationToken = default)
     {
-        var request = new CommandsInvokeRequest { SessionId = _sessionId, Name = name, Input = input };
-        return await CopilotClient.InvokeRpcAsync<SlashCommandInvocationResult>(_rpc, "session.commands.invoke", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(name);
+        _session.ThrowIfDisposed();
+
+        var request = new CommandsInvokeRequest { SessionId = _session.SessionId, Name = name, Input = input };
+        return await CopilotClient.InvokeRpcAsync<SlashCommandInvocationResult>(_session.Rpc, "session.commands.invoke", [request], cancellationToken);
     }
 
     /// <summary>Reports completion of a pending client-handled slash command.</summary>
@@ -6260,8 +6429,11 @@ public sealed class CommandsApi
     /// <returns>Indicates whether the pending client-handled command was completed successfully.</returns>
     public async Task<CommandsHandlePendingCommandResult> HandlePendingCommandAsync(string requestId, string? error = null, CancellationToken cancellationToken = default)
     {
-        var request = new CommandsHandlePendingCommandRequest { SessionId = _sessionId, RequestId = requestId, Error = error };
-        return await CopilotClient.InvokeRpcAsync<CommandsHandlePendingCommandResult>(_rpc, "session.commands.handlePendingCommand", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(requestId);
+        _session.ThrowIfDisposed();
+
+        var request = new CommandsHandlePendingCommandRequest { SessionId = _session.SessionId, RequestId = requestId, Error = error };
+        return await CopilotClient.InvokeRpcAsync<CommandsHandlePendingCommandResult>(_session.Rpc, "session.commands.handlePendingCommand", [request], cancellationToken);
     }
 
     /// <summary>Responds to a queued command request from the session.</summary>
@@ -6271,21 +6443,23 @@ public sealed class CommandsApi
     /// <returns>Indicates whether the queued-command response was accepted by the session.</returns>
     public async Task<CommandsRespondToQueuedCommandResult> RespondToQueuedCommandAsync(string requestId, QueuedCommandResult result, CancellationToken cancellationToken = default)
     {
-        var request = new CommandsRespondToQueuedCommandRequest { SessionId = _sessionId, RequestId = requestId, Result = result };
-        return await CopilotClient.InvokeRpcAsync<CommandsRespondToQueuedCommandResult>(_rpc, "session.commands.respondToQueuedCommand", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(requestId);
+        ArgumentNullException.ThrowIfNull(result);
+        _session.ThrowIfDisposed();
+
+        var request = new CommandsRespondToQueuedCommandRequest { SessionId = _session.SessionId, RequestId = requestId, Result = result };
+        return await CopilotClient.InvokeRpcAsync<CommandsRespondToQueuedCommandResult>(_session.Rpc, "session.commands.respondToQueuedCommand", [request], cancellationToken);
     }
 }
 
 /// <summary>Provides session-scoped Ui APIs.</summary>
 public sealed class UiApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal UiApi(JsonRpc rpc, string sessionId)
+    internal UiApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Requests structured input from a UI-capable client.</summary>
@@ -6295,8 +6469,12 @@ public sealed class UiApi
     /// <returns>The elicitation response (accept with form values, decline, or cancel).</returns>
     public async Task<UIElicitationResponse> ElicitationAsync(string message, UIElicitationSchema requestedSchema, CancellationToken cancellationToken = default)
     {
-        var request = new UIElicitationRequest { SessionId = _sessionId, Message = message, RequestedSchema = requestedSchema };
-        return await CopilotClient.InvokeRpcAsync<UIElicitationResponse>(_rpc, "session.ui.elicitation", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(message);
+        ArgumentNullException.ThrowIfNull(requestedSchema);
+        _session.ThrowIfDisposed();
+
+        var request = new UIElicitationRequest { SessionId = _session.SessionId, Message = message, RequestedSchema = requestedSchema };
+        return await CopilotClient.InvokeRpcAsync<UIElicitationResponse>(_session.Rpc, "session.ui.elicitation", [request], cancellationToken);
     }
 
     /// <summary>Provides the user response for a pending elicitation request.</summary>
@@ -6306,21 +6484,23 @@ public sealed class UiApi
     /// <returns>Indicates whether the elicitation response was accepted; false if it was already resolved by another client.</returns>
     public async Task<UIElicitationResult> HandlePendingElicitationAsync(string requestId, UIElicitationResponse result, CancellationToken cancellationToken = default)
     {
-        var request = new UIHandlePendingElicitationRequest { SessionId = _sessionId, RequestId = requestId, Result = result };
-        return await CopilotClient.InvokeRpcAsync<UIElicitationResult>(_rpc, "session.ui.handlePendingElicitation", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(requestId);
+        ArgumentNullException.ThrowIfNull(result);
+        _session.ThrowIfDisposed();
+
+        var request = new UIHandlePendingElicitationRequest { SessionId = _session.SessionId, RequestId = requestId, Result = result };
+        return await CopilotClient.InvokeRpcAsync<UIElicitationResult>(_session.Rpc, "session.ui.handlePendingElicitation", [request], cancellationToken);
     }
 }
 
 /// <summary>Provides session-scoped Permissions APIs.</summary>
 public sealed class PermissionsApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal PermissionsApi(JsonRpc rpc, string sessionId)
+    internal PermissionsApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Provides a decision for a pending tool permission request.</summary>
@@ -6330,8 +6510,12 @@ public sealed class PermissionsApi
     /// <returns>Indicates whether the permission decision was applied; false when the request was already resolved.</returns>
     public async Task<PermissionRequestResult> HandlePendingPermissionRequestAsync(string requestId, PermissionDecision result, CancellationToken cancellationToken = default)
     {
-        var request = new PermissionDecisionRequest { SessionId = _sessionId, RequestId = requestId, Result = result };
-        return await CopilotClient.InvokeRpcAsync<PermissionRequestResult>(_rpc, "session.permissions.handlePendingPermissionRequest", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(requestId);
+        ArgumentNullException.ThrowIfNull(result);
+        _session.ThrowIfDisposed();
+
+        var request = new PermissionDecisionRequest { SessionId = _session.SessionId, RequestId = requestId, Result = result };
+        return await CopilotClient.InvokeRpcAsync<PermissionRequestResult>(_session.Rpc, "session.permissions.handlePendingPermissionRequest", [request], cancellationToken);
     }
 
     /// <summary>Enables or disables automatic approval of tool permission requests for the session.</summary>
@@ -6340,8 +6524,10 @@ public sealed class PermissionsApi
     /// <returns>Indicates whether the operation succeeded.</returns>
     public async Task<PermissionsSetApproveAllResult> SetApproveAllAsync(bool enabled, CancellationToken cancellationToken = default)
     {
-        var request = new PermissionsSetApproveAllRequest { SessionId = _sessionId, Enabled = enabled };
-        return await CopilotClient.InvokeRpcAsync<PermissionsSetApproveAllResult>(_rpc, "session.permissions.setApproveAll", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new PermissionsSetApproveAllRequest { SessionId = _session.SessionId, Enabled = enabled };
+        return await CopilotClient.InvokeRpcAsync<PermissionsSetApproveAllResult>(_session.Rpc, "session.permissions.setApproveAll", [request], cancellationToken);
     }
 
     /// <summary>Clears session-scoped tool permission approvals.</summary>
@@ -6349,21 +6535,21 @@ public sealed class PermissionsApi
     /// <returns>Indicates whether the operation succeeded.</returns>
     public async Task<PermissionsResetSessionApprovalsResult> ResetSessionApprovalsAsync(CancellationToken cancellationToken = default)
     {
-        var request = new PermissionsResetSessionApprovalsRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<PermissionsResetSessionApprovalsResult>(_rpc, "session.permissions.resetSessionApprovals", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new PermissionsResetSessionApprovalsRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<PermissionsResetSessionApprovalsResult>(_session.Rpc, "session.permissions.resetSessionApprovals", [request], cancellationToken);
     }
 }
 
 /// <summary>Provides session-scoped Shell APIs.</summary>
 public sealed class ShellApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal ShellApi(JsonRpc rpc, string sessionId)
+    internal ShellApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Starts a shell command and streams output through session notifications.</summary>
@@ -6374,8 +6560,11 @@ public sealed class ShellApi
     /// <returns>Identifier of the spawned process, used to correlate streamed output and exit notifications.</returns>
     public async Task<ShellExecResult> ExecAsync(string command, string? cwd = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
-        var request = new ShellExecRequest { SessionId = _sessionId, Command = command, Cwd = cwd, Timeout = timeout };
-        return await CopilotClient.InvokeRpcAsync<ShellExecResult>(_rpc, "session.shell.exec", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(command);
+        _session.ThrowIfDisposed();
+
+        var request = new ShellExecRequest { SessionId = _session.SessionId, Command = command, Cwd = cwd, Timeout = timeout };
+        return await CopilotClient.InvokeRpcAsync<ShellExecResult>(_session.Rpc, "session.shell.exec", [request], cancellationToken);
     }
 
     /// <summary>Sends a signal to a shell process previously started via "shell.exec".</summary>
@@ -6385,8 +6574,11 @@ public sealed class ShellApi
     /// <returns>Indicates whether the signal was delivered; false if the process was unknown or already exited.</returns>
     public async Task<ShellKillResult> KillAsync(string processId, ShellKillSignal? signal = null, CancellationToken cancellationToken = default)
     {
-        var request = new ShellKillRequest { SessionId = _sessionId, ProcessId = processId, Signal = signal };
-        return await CopilotClient.InvokeRpcAsync<ShellKillResult>(_rpc, "session.shell.kill", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(processId);
+        _session.ThrowIfDisposed();
+
+        var request = new ShellKillRequest { SessionId = _session.SessionId, ProcessId = processId, Signal = signal };
+        return await CopilotClient.InvokeRpcAsync<ShellKillResult>(_session.Rpc, "session.shell.kill", [request], cancellationToken);
     }
 }
 
@@ -6394,13 +6586,11 @@ public sealed class ShellApi
 [Experimental(Diagnostics.Experimental)]
 public sealed class HistoryApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal HistoryApi(JsonRpc rpc, string sessionId)
+    internal HistoryApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Compacts the session history to reduce context usage.</summary>
@@ -6408,8 +6598,10 @@ public sealed class HistoryApi
     /// <returns>Compaction outcome with the number of tokens and messages removed and the resulting context window breakdown.</returns>
     public async Task<HistoryCompactResult> CompactAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionHistoryCompactRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<HistoryCompactResult>(_rpc, "session.history.compact", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionHistoryCompactRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<HistoryCompactResult>(_session.Rpc, "session.history.compact", [request], cancellationToken);
     }
 
     /// <summary>Truncates persisted session history to a specific event.</summary>
@@ -6418,8 +6610,11 @@ public sealed class HistoryApi
     /// <returns>Number of events that were removed by the truncation.</returns>
     public async Task<HistoryTruncateResult> TruncateAsync(string eventId, CancellationToken cancellationToken = default)
     {
-        var request = new HistoryTruncateRequest { SessionId = _sessionId, EventId = eventId };
-        return await CopilotClient.InvokeRpcAsync<HistoryTruncateResult>(_rpc, "session.history.truncate", [request], cancellationToken);
+        ArgumentNullException.ThrowIfNull(eventId);
+        _session.ThrowIfDisposed();
+
+        var request = new HistoryTruncateRequest { SessionId = _session.SessionId, EventId = eventId };
+        return await CopilotClient.InvokeRpcAsync<HistoryTruncateResult>(_session.Rpc, "session.history.truncate", [request], cancellationToken);
     }
 }
 
@@ -6427,13 +6622,11 @@ public sealed class HistoryApi
 [Experimental(Diagnostics.Experimental)]
 public sealed class UsageApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal UsageApi(JsonRpc rpc, string sessionId)
+    internal UsageApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Gets accumulated usage metrics for the session.</summary>
@@ -6441,8 +6634,10 @@ public sealed class UsageApi
     /// <returns>Accumulated session usage metrics, including premium request cost, token counts, model breakdown, and code-change totals.</returns>
     public async Task<UsageGetMetricsResult> GetMetricsAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionUsageGetMetricsRequest { SessionId = _sessionId };
-        return await CopilotClient.InvokeRpcAsync<UsageGetMetricsResult>(_rpc, "session.usage.getMetrics", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionUsageGetMetricsRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<UsageGetMetricsResult>(_session.Rpc, "session.usage.getMetrics", [request], cancellationToken);
     }
 }
 
@@ -6450,13 +6645,11 @@ public sealed class UsageApi
 [Experimental(Diagnostics.Experimental)]
 public sealed class RemoteApi
 {
-    private readonly JsonRpc _rpc;
-    private readonly string _sessionId;
+    private readonly CopilotSession _session;
 
-    internal RemoteApi(JsonRpc rpc, string sessionId)
+    internal RemoteApi(CopilotSession session)
     {
-        _rpc = rpc;
-        _sessionId = sessionId;
+        _session = session;
     }
 
     /// <summary>Enables remote session export or steering.</summary>
@@ -6465,16 +6658,20 @@ public sealed class RemoteApi
     /// <returns>GitHub URL for the session and a flag indicating whether remote steering is enabled.</returns>
     public async Task<RemoteEnableResult> EnableAsync(RemoteSessionMode? mode = null, CancellationToken cancellationToken = default)
     {
-        var request = new RemoteEnableRequest { SessionId = _sessionId, Mode = mode };
-        return await CopilotClient.InvokeRpcAsync<RemoteEnableResult>(_rpc, "session.remote.enable", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new RemoteEnableRequest { SessionId = _session.SessionId, Mode = mode };
+        return await CopilotClient.InvokeRpcAsync<RemoteEnableResult>(_session.Rpc, "session.remote.enable", [request], cancellationToken);
     }
 
     /// <summary>Disables remote session export and steering.</summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     public async Task DisableAsync(CancellationToken cancellationToken = default)
     {
-        var request = new SessionRemoteDisableRequest { SessionId = _sessionId };
-        await CopilotClient.InvokeRpcAsync(_rpc, "session.remote.disable", [request], cancellationToken);
+        _session.ThrowIfDisposed();
+
+        var request = new SessionRemoteDisableRequest { SessionId = _session.SessionId };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.remote.disable", [request], cancellationToken);
     }
 }
 

--- a/dotnet/src/Polyfills/DownlevelExtensions.cs
+++ b/dotnet/src/Polyfills/DownlevelExtensions.cs
@@ -25,6 +25,20 @@ namespace System
         }
     }
 
+    internal static class DownlevelObjectDisposedExceptionExtensions
+    {
+        extension(ObjectDisposedException)
+        {
+            public static void ThrowIf(bool condition, object instance)
+            {
+                if (condition)
+                {
+                    throw new ObjectDisposedException(instance?.GetType().FullName);
+                }
+            }
+        }
+    }
+
     internal static class DownlevelArgumentExceptionExtensions
     {
         extension(ArgumentException)
@@ -528,6 +542,20 @@ namespace System.Net.Sockets
         private sealed record CancellationState(TaskCompletionSource<object?> Completion, Action CancellationAction);
 
         private sealed record SocketConnectState(Socket Socket, TaskCompletionSource<object?> Completion);
+    }
+}
+
+namespace System.Runtime.ExceptionServices
+{
+    internal static class DownlevelExceptionDispatchInfoExtensions
+    {
+        extension(ExceptionDispatchInfo)
+        {
+            public static void Throw(Exception exception)
+            {
+                ExceptionDispatchInfo.Capture(exception).Throw();
+            }
+        }
     }
 }
 

--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -7,11 +7,11 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Threading.Channels;
-using static GitHub.Copilot.SDK.LoggingHelpers;
 
 namespace GitHub.Copilot.SDK;
 
@@ -58,8 +58,8 @@ public sealed partial class CopilotSession : IAsyncDisposable
 {
     private readonly Dictionary<string, AIFunction> _toolHandlers = [];
     private readonly Dictionary<string, CommandHandler> _commandHandlers = [];
-    private readonly JsonRpc _rpc;
     private readonly ILogger _logger;
+    private readonly CopilotClient _parentClient;
 
     private volatile PermissionRequestHandler? _permissionHandler;
     private volatile UserInputHandler? _userInputHandler;
@@ -70,9 +70,10 @@ public sealed partial class CopilotSession : IAsyncDisposable
 
     private SessionHooks? _hooks;
     private readonly SemaphoreSlim _hooksLock = new(1, 1);
+
     private Dictionary<string, Func<string, Task<string>>>? _transformCallbacks;
     private readonly SemaphoreSlim _transformCallbacksLock = new(1, 1);
-    private SessionRpc? _sessionRpc;
+
     private int _isDisposed;
 
     /// <summary>
@@ -92,7 +93,9 @@ public sealed partial class CopilotSession : IAsyncDisposable
     /// <summary>
     /// Gets the typed RPC client for session-scoped methods.
     /// </summary>
-    public SessionRpc Rpc => _sessionRpc ??= new SessionRpc(_rpc, SessionId);
+    public SessionRpc Rpc => field ?? Interlocked.CompareExchange(ref field, new(this), null) ?? field;
+
+    internal JsonRpc JsonRpc { get; }
 
     /// <summary>
     /// Gets the path to the session workspace directory when infinite sessions are enabled.
@@ -111,7 +114,11 @@ public sealed partial class CopilotSession : IAsyncDisposable
     /// Capabilities are populated from the session create/resume response and updated
     /// in real time via <c>capabilities.changed</c> events.
     /// </value>
-    public SessionCapabilities Capabilities { get; private set; } = new();
+    public SessionCapabilities Capabilities
+    {
+        get => field ?? Interlocked.CompareExchange(ref field, new(), null) ?? field;
+        private set;
+    }
 
     /// <summary>
     /// Gets the UI API for eliciting information from the user during this session.
@@ -125,7 +132,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
     /// if the host does not report elicitation support via <see cref="Capabilities"/>.
     /// Check <c>session.Capabilities.Ui?.Elicitation == true</c> before calling.
     /// </remarks>
-    public ISessionUiApi Ui { get; }
+    public ISessionUiApi Ui => field ?? Interlocked.CompareExchange(ref field, new SessionUiApiImpl(this), null) ?? field;
 
     internal ClientSessionApiHandlers ClientSessionApis { get; } = new();
 
@@ -135,25 +142,48 @@ public sealed partial class CopilotSession : IAsyncDisposable
     /// <param name="sessionId">The unique identifier for this session.</param>
     /// <param name="rpc">The JSON-RPC connection to the Copilot CLI.</param>
     /// <param name="logger">Logger for diagnostics.</param>
+    /// <param name="client">The owning client used to route session events.</param>
     /// <param name="workspacePath">The workspace path if infinite sessions are enabled.</param>
     /// <remarks>
     /// This constructor is internal. Use <see cref="CopilotClient.CreateSessionAsync"/> to create sessions.
     /// </remarks>
-    internal CopilotSession(string sessionId, JsonRpc rpc, ILogger logger, string? workspacePath = null)
+    internal CopilotSession(
+        string sessionId,
+        JsonRpc rpc,
+        ILogger logger,
+        CopilotClient client,
+        string? workspacePath = null)
     {
         SessionId = sessionId;
-        _rpc = rpc;
+        JsonRpc = rpc;
         _logger = logger;
+        _parentClient = client;
         WorkspacePath = workspacePath;
-        Ui = new SessionUiApiImpl(this);
 
         // Start the asynchronous processing loop.
         _ = ProcessEventsAsync();
     }
 
+    /// <summary>
+    /// Finalizes the session and releases the client's references to it.
+    /// </summary>
+    ~CopilotSession()
+    {
+        RemoveFromClient();
+    }
+
+    /// <summary>
+    /// Removes the current session from its parent client if it is no longer referenced or if the reference points to
+    /// this instance.
+    /// </summary>
+    internal void RemoveFromClient()
+    {
+        ((ICollection<KeyValuePair<string, CopilotSession>>)_parentClient._sessions).Remove(new(SessionId, this));
+    }
+
     private Task<T> InvokeRpcAsync<T>(string method, object?[]? args, CancellationToken cancellationToken)
     {
-        return CopilotClient.InvokeRpcAsync<T>(_rpc, method, args, cancellationToken);
+        return CopilotClient.InvokeRpcAsync<T>(JsonRpc, method, args, cancellationToken);
     }
 
     /// <summary>
@@ -187,6 +217,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
     public async Task<string> SendAsync(MessageOptions options, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(options);
+        ThrowIfDisposed();
 
         var (traceparent, tracestate) = TelemetryHelpers.GetTraceContext();
 
@@ -204,7 +235,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
         var rpcTimestamp = Stopwatch.GetTimestamp();
         var response = await InvokeRpcAsync<SendMessageResponse>(
             "session.send", [request], cancellationToken);
-        LogTiming(_logger, LogLevel.Debug, null,
+        LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
             "CopilotSession.SendAsync completed successfully. Elapsed={Elapsed}, SessionId={SessionId}, MessageId={MessageId}",
             rpcTimestamp,
             SessionId,
@@ -246,6 +277,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(options);
+        ThrowIfDisposed();
 
         var totalTimestamp = Stopwatch.GetTimestamp();
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(60);
@@ -262,7 +294,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
                     if (!firstAssistantMessageLogged)
                     {
                         firstAssistantMessageLogged = true;
-                        LogTiming(_logger, LogLevel.Debug, null,
+                        LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                             "CopilotSession.SendAndWaitAsync first assistant message. Elapsed={Elapsed}, SessionId={SessionId}",
                             totalTimestamp,
                             SessionId);
@@ -270,7 +302,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
                     break;
 
                 case SessionIdleEvent:
-                    LogTiming(_logger, LogLevel.Debug, null,
+                    LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                         "CopilotSession.SendAndWaitAsync idle received. Elapsed={Elapsed}, SessionId={SessionId}",
                         totalTimestamp,
                         SessionId);
@@ -301,7 +333,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
         try
         {
             var result = await tcs.Task;
-            LogTiming(_logger, LogLevel.Debug, null,
+            LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotSession.SendAndWaitAsync complete. Elapsed={Elapsed}, SessionId={SessionId}, CompletedBy={CompletedBy}, AssistantMessageReceived={AssistantMessageReceived}",
                 totalTimestamp,
                 SessionId,
@@ -311,7 +343,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
         }
         catch (Exception ex) when (ex is TimeoutException)
         {
-            LogTiming(_logger, LogLevel.Warning, ex,
+            LoggingHelpers.LogTiming(_logger, LogLevel.Warning, ex,
                 "CopilotSession.SendAndWaitAsync failed. Elapsed={Elapsed}, SessionId={SessionId}, CompletedBy={CompletedBy}",
                 totalTimestamp,
                 SessionId,
@@ -320,7 +352,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            LogTiming(_logger, LogLevel.Warning, ex,
+            LoggingHelpers.LogTiming(_logger, LogLevel.Warning, ex,
                 "CopilotSession.SendAndWaitAsync failed. Elapsed={Elapsed}, SessionId={SessionId}, CompletedBy={CompletedBy}",
                 totalTimestamp,
                 SessionId,
@@ -366,6 +398,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
     public IDisposable On(SessionEventHandler handler)
     {
         ArgumentNullException.ThrowIfNull(handler);
+        ThrowIfDisposed();
 
         ImmutableInterlocked.Update(ref _eventHandlers, array => array.Add(handler));
         return new ActionDisposable(() => ImmutableInterlocked.Update(ref _eventHandlers, array => array.Remove(handler)));
@@ -414,7 +447,8 @@ public sealed partial class CopilotSession : IAsyncDisposable
                     LogEventHandlerError(ex);
                 }
             }
-            LogTiming(_logger, LogLevel.Debug, null,
+
+            LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotSession.ProcessEventsAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}, EventType={EventType}",
                 dispatchTimestamp,
                 SessionId,
@@ -489,7 +523,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
 
         var permissionTimestamp = Stopwatch.GetTimestamp();
         var result = await handler(request, invocation);
-        LogTiming(_logger, LogLevel.Debug, null,
+        LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
             "CopilotSession.HandlePermissionRequestAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}",
             permissionTimestamp,
             SessionId);
@@ -601,7 +635,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
         }
         finally
         {
-            LogTiming(_logger, LogLevel.Debug, null,
+            LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotSession.HandleBroadcastEventAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}, EventType={EventType}",
                 dispatchTimestamp,
                 SessionId,
@@ -647,7 +681,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
 
             var toolTimestamp = Stopwatch.GetTimestamp();
             var result = await tool.InvokeAsync(aiFunctionArgs);
-            LogTiming(_logger, LogLevel.Debug, null,
+            LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotSession.ExecuteToolAndRespondAsync tool dispatch. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}, ToolCallId={ToolCallId}, Tool={ToolName}",
                 toolTimestamp,
                 SessionId,
@@ -659,7 +693,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
 
             var responseRpcTimestamp = Stopwatch.GetTimestamp();
             await Rpc.Tools.HandlePendingToolCallAsync(requestId, toolResultObject, error: null);
-            LogTiming(_logger, LogLevel.Debug, null,
+            LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotSession.ExecuteToolAndRespondAsync response sent successfully. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}, ToolCallId={ToolCallId}, Tool={ToolName}",
                 responseRpcTimestamp,
                 SessionId,
@@ -698,7 +732,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
 
             var permissionTimestamp = Stopwatch.GetTimestamp();
             var result = await handler(permissionRequest, invocation);
-            LogTiming(_logger, LogLevel.Debug, null,
+            LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotSession.ExecutePermissionAndRespondAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}",
                 permissionTimestamp,
                 SessionId,
@@ -709,7 +743,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
             }
             var responseRpcTimestamp = Stopwatch.GetTimestamp();
             await Rpc.Permissions.HandlePendingPermissionRequestAsync(requestId, new PermissionDecision { Kind = result.Kind.Value });
-            LogTiming(_logger, LogLevel.Debug, null,
+            LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotSession.ExecutePermissionAndRespondAsync response sent successfully. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}",
                 responseRpcTimestamp,
                 SessionId,
@@ -823,7 +857,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
                 CommandName = commandName,
                 Args = args
             });
-            LogTiming(_logger, LogLevel.Debug, null,
+            LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotSession.ExecuteCommandAndRespondAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}, Command={CommandName}",
                 commandTimestamp,
                 SessionId,
@@ -831,7 +865,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
                 commandName);
             var responseRpcTimestamp = Stopwatch.GetTimestamp();
             await Rpc.Commands.HandlePendingCommandAsync(requestId);
-            LogTiming(_logger, LogLevel.Debug, null,
+            LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotSession.ExecuteCommandAndRespondAsync response sent successfully. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}, Command={CommandName}",
                 responseRpcTimestamp,
                 SessionId,
@@ -867,7 +901,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
         {
             var elicitationTimestamp = Stopwatch.GetTimestamp();
             var result = await handler(context);
-            LogTiming(_logger, LogLevel.Debug, null,
+            LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotSession.HandleElicitationRequestAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}",
                 elicitationTimestamp,
                 SessionId,
@@ -878,7 +912,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
                 Action = result.Action,
                 Content = result.Content
             });
-            LogTiming(_logger, LogLevel.Debug, null,
+            LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotSession.HandleElicitationRequestAsync response sent successfully. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}",
                 responseRpcTimestamp,
                 SessionId,
@@ -921,20 +955,27 @@ public sealed partial class CopilotSession : IAsyncDisposable
     {
         public async Task<ElicitationResult> ElicitationAsync(ElicitationParams elicitationParams, CancellationToken cancellationToken)
         {
+            ArgumentNullException.ThrowIfNull(elicitationParams);
+            session.ThrowIfDisposed();
             session.AssertElicitation();
+
             var schema = new UIElicitationSchema
             {
                 Type = elicitationParams.RequestedSchema.Type,
                 Properties = elicitationParams.RequestedSchema.Properties,
                 Required = elicitationParams.RequestedSchema.Required
             };
+
             var result = await session.Rpc.Ui.ElicitationAsync(elicitationParams.Message, schema, cancellationToken);
             return new ElicitationResult { Action = result.Action, Content = result.Content };
         }
 
         public async Task<bool> ConfirmAsync(string message, CancellationToken cancellationToken)
         {
+            ArgumentNullException.ThrowIfNull(message);
+            session.ThrowIfDisposed();
             session.AssertElicitation();
+
             var schema = new UIElicitationSchema
             {
                 Type = "object",
@@ -944,6 +985,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
                 },
                 Required = ["confirmed"]
             };
+
             var result = await session.Rpc.Ui.ElicitationAsync(message, schema, cancellationToken);
             if (result.Action == UIElicitationResponseAction.Accept
                 && result.Content != null
@@ -957,12 +999,17 @@ public sealed partial class CopilotSession : IAsyncDisposable
                     _ => false
                 };
             }
+
             return false;
         }
 
         public async Task<string?> SelectAsync(string message, string[] options, CancellationToken cancellationToken)
         {
+            ArgumentNullException.ThrowIfNull(message);
+            ArgumentNullException.ThrowIfNull(options);
+            session.ThrowIfDisposed();
             session.AssertElicitation();
+
             var schema = new UIElicitationSchema
             {
                 Type = "object",
@@ -972,6 +1019,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
                 },
                 Required = ["selection"]
             };
+
             var result = await session.Rpc.Ui.ElicitationAsync(message, schema, cancellationToken);
             if (result.Action == UIElicitationResponseAction.Accept
                 && result.Content != null
@@ -984,12 +1032,16 @@ public sealed partial class CopilotSession : IAsyncDisposable
                     _ => val.ToString()
                 };
             }
+
             return null;
         }
 
         public async Task<string?> InputAsync(string message, InputOptions? options, CancellationToken cancellationToken)
         {
+            ArgumentNullException.ThrowIfNull(message);
+            session.ThrowIfDisposed();
             session.AssertElicitation();
+
             var field = new Dictionary<string, object> { ["type"] = "string" };
             if (options?.Title != null) field["title"] = options.Title;
             if (options?.Description != null) field["description"] = options.Description;
@@ -1004,6 +1056,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
                 Properties = new Dictionary<string, object> { ["value"] = field },
                 Required = ["value"]
             };
+
             var result = await session.Rpc.Ui.ElicitationAsync(message, schema, cancellationToken);
             if (result.Action == UIElicitationResponseAction.Accept
                 && result.Content != null
@@ -1016,6 +1069,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
                     _ => val.ToString()
                 };
             }
+
             return null;
         }
     }
@@ -1035,7 +1089,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
 
         var userInputTimestamp = Stopwatch.GetTimestamp();
         var response = await handler(request, invocation);
-        LogTiming(_logger, LogLevel.Debug, null,
+        LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
             "CopilotSession.HandleUserInputRequestAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}",
             userInputTimestamp,
             SessionId);
@@ -1058,7 +1112,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
         var invocation = new ExitPlanModeInvocation { SessionId = SessionId };
         var timestamp = Stopwatch.GetTimestamp();
         var response = await handler(request, invocation);
-        LogTiming(_logger, LogLevel.Debug, null,
+        LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
             "CopilotSession.HandleExitPlanModeRequestAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}",
             timestamp,
             SessionId);
@@ -1081,7 +1135,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
         var invocation = new AutoModeSwitchInvocation { SessionId = SessionId };
         var timestamp = Stopwatch.GetTimestamp();
         var response = await handler(request, invocation);
-        LogTiming(_logger, LogLevel.Debug, null,
+        LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
             "CopilotSession.HandleAutoModeSwitchRequestAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}",
             timestamp,
             SessionId);
@@ -1174,7 +1228,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
         }
         finally
         {
-            LogTiming(_logger, LogLevel.Debug, null,
+            LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotSession.HandleHooksInvokeAsync dispatch. Elapsed={Elapsed}, SessionId={SessionId}, Hook={HookType}",
                 hookTimestamp,
                 SessionId,
@@ -1272,11 +1326,13 @@ public sealed partial class CopilotSession : IAsyncDisposable
     /// </example>
     public async Task<IReadOnlyList<SessionEvent>> GetMessagesAsync(CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
+
         var response = await InvokeRpcAsync<GetMessagesResponse>(
             "session.getMessages", [new GetMessagesRequest { SessionId = SessionId }], cancellationToken);
 
         return response.Events
-            .Select(e => SessionEvent.FromJson(e.ToJsonString()))
+            .Select(static e => SessionEvent.FromJson(e.ToJsonString()))
             .OfType<SessionEvent>()
             .ToList();
     }
@@ -1306,8 +1362,9 @@ public sealed partial class CopilotSession : IAsyncDisposable
     /// </example>
     public async Task AbortAsync(CancellationToken cancellationToken = default)
     {
-        await InvokeRpcAsync<object>(
-            "session.abort", [new SessionAbortRequest { SessionId = SessionId }], cancellationToken);
+        ThrowIfDisposed();
+
+        await InvokeRpcAsync<object>("session.abort", [new SessionAbortRequest { SessionId = SessionId }], cancellationToken);
     }
 
     /// <summary>
@@ -1327,6 +1384,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
     public async Task SetModelAsync(string model, string? reasoningEffort, ModelCapabilitiesOverride? modelCapabilities = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(model);
+        ThrowIfDisposed();
 
         await Rpc.Model.SwitchToAsync(model, reasoningEffort, reasoningSummary: null, modelCapabilities: modelCapabilities, cancellationToken: cancellationToken);
     }
@@ -1336,6 +1394,8 @@ public sealed partial class CopilotSession : IAsyncDisposable
     /// </summary>
     public Task SetModelAsync(string model, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
+
         return SetModelAsync(model, reasoningEffort: null, modelCapabilities: null, cancellationToken);
     }
 
@@ -1360,6 +1420,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
     public async Task LogAsync(string message, SessionLogLevel? level = null, bool? ephemeral = null, string? url = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(message);
+        ThrowIfDisposed();
 
         await Rpc.LogAsync(message, level, ephemeral, url, cancellationToken);
     }
@@ -1403,6 +1464,9 @@ public sealed partial class CopilotSession : IAsyncDisposable
         {
             return;
         }
+
+        RemoveFromClient();
+        GC.SuppressFinalize(this);
 
         _eventChannel.Writer.TryComplete();
 
@@ -1473,36 +1537,41 @@ public sealed partial class CopilotSession : IAsyncDisposable
         public string SessionId { get; init; } = string.Empty;
     }
 
+    internal void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _isDisposed) != 0, this);
+    }
+
     [JsonSourceGenerationOptions(
         JsonSerializerDefaults.Web,
         AllowOutOfOrderMetadataProperties = true,
         NumberHandling = JsonNumberHandling.AllowReadingFromString,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonSerializable(typeof(AutoModeSwitchRequest))]
+    [JsonSerializable(typeof(AutoModeSwitchResponse))]
+    [JsonSerializable(typeof(Dictionary<string, SystemMessageTransformSection>))]
+    [JsonSerializable(typeof(ErrorOccurredHookInput))]
+    [JsonSerializable(typeof(ErrorOccurredHookOutput))]
+    [JsonSerializable(typeof(ExitPlanModeRequest))]
+    [JsonSerializable(typeof(ExitPlanModeResult))]
     [JsonSerializable(typeof(GetMessagesRequest))]
     [JsonSerializable(typeof(GetMessagesResponse))]
+    [JsonSerializable(typeof(PostToolUseHookInput))]
+    [JsonSerializable(typeof(PostToolUseHookOutput))]
+    [JsonSerializable(typeof(PreToolUseHookInput))]
+    [JsonSerializable(typeof(PreToolUseHookOutput))]
     [JsonSerializable(typeof(SendMessageRequest))]
     [JsonSerializable(typeof(SendMessageResponse))]
     [JsonSerializable(typeof(SessionAbortRequest))]
     [JsonSerializable(typeof(SessionDestroyRequest))]
-    [JsonSerializable(typeof(UserMessageAttachment))]
-    [JsonSerializable(typeof(AutoModeSwitchRequest))]
-    [JsonSerializable(typeof(AutoModeSwitchResponse))]
-    [JsonSerializable(typeof(ExitPlanModeRequest))]
-    [JsonSerializable(typeof(ExitPlanModeResult))]
-    [JsonSerializable(typeof(PreToolUseHookInput))]
-    [JsonSerializable(typeof(PreToolUseHookOutput))]
-    [JsonSerializable(typeof(PostToolUseHookInput))]
-    [JsonSerializable(typeof(PostToolUseHookOutput))]
-    [JsonSerializable(typeof(UserPromptSubmittedHookInput))]
-    [JsonSerializable(typeof(UserPromptSubmittedHookOutput))]
-    [JsonSerializable(typeof(SessionStartHookInput))]
-    [JsonSerializable(typeof(SessionStartHookOutput))]
     [JsonSerializable(typeof(SessionEndHookInput))]
     [JsonSerializable(typeof(SessionEndHookOutput))]
-    [JsonSerializable(typeof(ErrorOccurredHookInput))]
-    [JsonSerializable(typeof(ErrorOccurredHookOutput))]
-    [JsonSerializable(typeof(SystemMessageTransformSection))]
+    [JsonSerializable(typeof(SessionStartHookInput))]
+    [JsonSerializable(typeof(SessionStartHookOutput))]
     [JsonSerializable(typeof(SystemMessageTransformRpcResponse))]
-    [JsonSerializable(typeof(Dictionary<string, SystemMessageTransformSection>))]
+    [JsonSerializable(typeof(SystemMessageTransformSection))]
+    [JsonSerializable(typeof(UserMessageAttachment))]
+    [JsonSerializable(typeof(UserPromptSubmittedHookInput))]
+    [JsonSerializable(typeof(UserPromptSubmittedHookOutput))]
     internal partial class SessionJsonContext : JsonSerializerContext;
 }

--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -1464,9 +1464,6 @@ public sealed partial class CopilotSession : IAsyncDisposable
             return;
         }
 
-        RemoveFromClient();
-        GC.SuppressFinalize(this);
-
         _eventChannel.Writer.TryComplete();
 
         try
@@ -1481,6 +1478,11 @@ public sealed partial class CopilotSession : IAsyncDisposable
         catch (IOException)
         {
             // Connection is broken or closed
+        }
+        finally
+        {
+            RemoveFromClient();
+            GC.SuppressFinalize(this);
         }
 
         _eventHandlers = ImmutableInterlocked.InterlockedExchange(ref _eventHandlers, ImmutableArray<SessionEventHandler>.Empty);

--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -159,8 +159,6 @@ public sealed partial class CopilotSession : IAsyncDisposable
         _parentClient = client;
         WorkspacePath = workspacePath;
 
-        // Start the asynchronous processing loop.
-        _ = ProcessEventsAsync();
     }
 
     /// <summary>
@@ -178,6 +176,11 @@ public sealed partial class CopilotSession : IAsyncDisposable
     internal void RemoveFromClient()
     {
         ((ICollection<KeyValuePair<string, CopilotSession>>)_parentClient._sessions).Remove(new(SessionId, this));
+    }
+
+    internal void StartProcessingEvents()
+    {
+        _ = ProcessEventsAsync();
     }
 
     private Task<T> InvokeRpcAsync<T>(string method, object?[]? args, CancellationToken cancellationToken)

--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;

--- a/dotnet/test/E2E/ClientE2ETests.cs
+++ b/dotnet/test/E2E/ClientE2ETests.cs
@@ -189,14 +189,27 @@ public class ClientE2ETests
         Assert.NotNull(session.SessionId);
     }
 
-    [Theory]
-    [InlineData(true)]   // stdio transport
-    [InlineData(false)]  // TCP transport
-    public async Task Should_Allow_ResumeSession_Called_Without_PermissionHandler(bool useStdio)
+    [Fact]
+    public async Task Should_Allow_ResumeSession_Called_Without_PermissionHandler()
     {
-        await using var client = new CopilotClient(new CopilotClientOptions { UseStdio = useStdio });
+        const string connectionToken = "client-e2e-resume-token";
+
+        await using var client = new CopilotClient(new CopilotClientOptions
+        {
+            UseStdio = false,
+            TcpConnectionToken = connectionToken,
+        });
         await using var originalSession = await client.CreateSessionAsync(new SessionConfig());
-        await using var resumedSession = await client.ResumeSessionAsync(originalSession.SessionId, new());
+
+        var port = client.ActualPort
+            ?? throw new InvalidOperationException("Client must be using TCP transport to support multi-client resume.");
+
+        await using var resumeClient = new CopilotClient(new CopilotClientOptions
+        {
+            CliUrl = $"localhost:{port}",
+            TcpConnectionToken = connectionToken,
+        });
+        await using var resumedSession = await resumeClient.ResumeSessionAsync(originalSession.SessionId, new());
 
         Assert.Equal(originalSession.SessionId, resumedSession.SessionId);
     }

--- a/dotnet/test/E2E/ModeHandlersE2ETests.cs
+++ b/dotnet/test/E2E/ModeHandlersE2ETests.cs
@@ -57,7 +57,7 @@ public class ModeHandlersE2ETests(E2ETestFixture fixture, ITestOutputHelper outp
             Prompt = "Create a brief implementation plan for adding a greeting.txt file, then request approval with exit_plan_mode.",
         }, timeout: TimeSpan.FromSeconds(120));
 
-        var (request, invocation) = await handlerTask.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        var (request, invocation) = await handlerTask.Task.WaitAsync(TimeSpan.FromSeconds(30));
         Assert.Equal(session.SessionId, invocation.SessionId);
         Assert.Equal(summary, request.Summary);
         Assert.Equal(["interactive", "autopilot", "exit_only"], request.Actions);
@@ -124,7 +124,7 @@ public class ModeHandlersE2ETests(E2ETestFixture fixture, ITestOutputHelper outp
         });
         Assert.NotEmpty(messageId);
 
-        var (request, invocation) = await handlerTask.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        var (request, invocation) = await handlerTask.Task.WaitAsync(TimeSpan.FromSeconds(30));
         Assert.Equal(session.SessionId, invocation.SessionId);
         Assert.Equal("user_weekly_rate_limited", request.ErrorCode);
         Assert.Equal(1, request.RetryAfterSeconds);

--- a/dotnet/test/E2E/PermissionE2ETests.cs
+++ b/dotnet/test/E2E/PermissionE2ETests.cs
@@ -204,9 +204,10 @@ public partial class PermissionE2ETests(E2ETestFixture fixture, ITestOutputHelpe
         var session1 = await CreateSessionAsync();
         var sessionId = session1.SessionId;
         await session1.SendAndWaitAsync(new MessageOptions { Prompt = "What is 1+1?" });
+        await session1.DisposeAsync();
 
         // Resume with permission handler
-        var session2 = await ResumeSessionAsync(sessionId, new ResumeSessionConfig
+        var session2 = await Client.ResumeSessionAsync(sessionId, new ResumeSessionConfig
         {
             OnPermissionRequest = (request, invocation) =>
             {
@@ -221,6 +222,7 @@ public partial class PermissionE2ETests(E2ETestFixture fixture, ITestOutputHelpe
         });
 
         Assert.True(permissionRequestReceived, "Permission request should have been received");
+        await session2.DisposeAsync();
     }
 
     [Fact]
@@ -255,8 +257,9 @@ public partial class PermissionE2ETests(E2ETestFixture fixture, ITestOutputHelpe
         });
         var sessionId = session1.SessionId;
         await session1.SendAndWaitAsync(new MessageOptions { Prompt = "What is 1+1?" });
+        await session1.DisposeAsync();
 
-        var session2 = await ResumeSessionAsync(sessionId, new ResumeSessionConfig
+        var session2 = await Client.ResumeSessionAsync(sessionId, new ResumeSessionConfig
         {
             OnPermissionRequest = (_, _) =>
                 Task.FromResult(new PermissionRequestResult { Kind = PermissionRequestResultKind.UserNotAvailable })
@@ -279,6 +282,7 @@ public partial class PermissionE2ETests(E2ETestFixture fixture, ITestOutputHelpe
         });
 
         Assert.True(permissionDenied, "Expected a tool.execution_complete event with Permission denied result");
+        await session2.DisposeAsync();
     }
 
     [Fact]

--- a/dotnet/test/E2E/SessionE2ETests.cs
+++ b/dotnet/test/E2E/SessionE2ETests.cs
@@ -211,27 +211,13 @@ public class SessionE2ETests(E2ETestFixture fixture, ITestOutputHelper output) :
     }
 
     [Fact]
-    public async Task Should_Resume_A_Session_Using_The_Same_Client()
+    public async Task Should_Reject_Resuming_Active_Session_Using_The_Same_Client()
     {
         var session1 = await CreateSessionAsync();
         var sessionId = session1.SessionId;
 
-        await session1.SendAsync(new MessageOptions { Prompt = "What is 1+1?" });
-        var answer = await TestHelper.GetFinalAssistantMessageAsync(session1);
-        Assert.NotNull(answer);
-        Assert.Contains("2", answer!.Data.Content ?? string.Empty);
-
-        var session2 = await ResumeSessionAsync(sessionId);
-        Assert.Equal(sessionId, session2.SessionId);
-
-        var answer2 = await TestHelper.GetFinalAssistantMessageAsync(session2, alreadyIdle: true);
-        Assert.NotNull(answer2);
-        Assert.Contains("2", answer2!.Data.Content ?? string.Empty);
-
-        // Can continue the conversation statefully
-        var answer3 = await session2.SendAndWaitAsync(new MessageOptions { Prompt = "Now if you double that, what do you get?" });
-        Assert.NotNull(answer3);
-        Assert.Contains("4", answer3!.Data.Content ?? string.Empty);
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => ResumeSessionAsync(sessionId));
+        Assert.Contains(sessionId, exception.Message);
     }
 
     [Fact]

--- a/dotnet/test/E2E/SessionE2ETests.cs
+++ b/dotnet/test/E2E/SessionE2ETests.cs
@@ -216,7 +216,11 @@ public class SessionE2ETests(E2ETestFixture fixture, ITestOutputHelper output) :
         var session1 = await CreateSessionAsync();
         var sessionId = session1.SessionId;
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => ResumeSessionAsync(sessionId));
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Client.ResumeSessionAsync(sessionId, new ResumeSessionConfig
+            {
+                OnPermissionRequest = PermissionHandler.ApproveAll,
+            }));
         Assert.Contains(sessionId, exception.Message);
     }
 

--- a/dotnet/test/E2E/SessionE2ETests.cs
+++ b/dotnet/test/E2E/SessionE2ETests.cs
@@ -28,8 +28,7 @@ public class SessionE2ETests(E2ETestFixture fixture, ITestOutputHelper output) :
 
         await session.DisposeAsync();
 
-        var ex = await Assert.ThrowsAsync<IOException>(() => session.GetMessagesAsync());
-        Assert.Contains("not found", ex.Message, StringComparison.OrdinalIgnoreCase);
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => session.GetMessagesAsync());
     }
 
     [Fact]

--- a/dotnet/test/E2E/SessionMcpAndAgentConfigE2ETests.cs
+++ b/dotnet/test/E2E/SessionMcpAndAgentConfigE2ETests.cs
@@ -48,6 +48,7 @@ public class SessionMcpAndAgentConfigE2ETests(E2ETestFixture fixture, ITestOutpu
         var session1 = await CreateSessionAsync();
         var sessionId = session1.SessionId;
         await session1.SendAndWaitAsync(new MessageOptions { Prompt = "What is 1+1?" });
+        await session1.DisposeAsync();
 
         // Resume with MCP servers
         var mcpServers = new Dictionary<string, McpServerConfig>
@@ -141,6 +142,7 @@ public class SessionMcpAndAgentConfigE2ETests(E2ETestFixture fixture, ITestOutpu
         var session1 = await CreateSessionAsync();
         var sessionId = session1.SessionId;
         await session1.SendAndWaitAsync(new MessageOptions { Prompt = "What is 1+1?" });
+        await session1.DisposeAsync();
 
         // Resume with custom agents
         var customAgents = new List<CustomAgentConfig>

--- a/dotnet/test/Harness/E2ETestBase.cs
+++ b/dotnet/test/Harness/E2ETestBase.cs
@@ -82,11 +82,21 @@ public abstract class E2ETestBase : IClassFixture<E2ETestFixture>, IAsyncLifetim
     /// Resumes a session with a default config that approves all permissions.
     /// Convenience wrapper for E2E tests.
     /// </summary>
-    protected Task<CopilotSession> ResumeSessionAsync(string sessionId, ResumeSessionConfig? config = null)
+    protected async Task<CopilotSession> ResumeSessionAsync(string sessionId, ResumeSessionConfig? config = null)
     {
         config ??= new ResumeSessionConfig();
         config.OnPermissionRequest ??= PermissionHandler.ApproveAll;
-        return Client.ResumeSessionAsync(sessionId, config);
+
+        await Client.StartAsync();
+        var port = Client.ActualPort
+            ?? throw new InvalidOperationException("The shared E2E client must use TCP transport to support multi-client resume.");
+
+        var client = Ctx.CreateClient(options: new CopilotClientOptions
+        {
+            CliUrl = $"localhost:{port}",
+            TcpConnectionToken = E2ETestFixture.SharedTcpConnectionToken,
+        });
+        return await client.ResumeSessionAsync(sessionId, config);
     }
 
     protected static string GetSystemMessage(ParsedHttpExchange exchange)

--- a/dotnet/test/Harness/E2ETestFixture.cs
+++ b/dotnet/test/Harness/E2ETestFixture.cs
@@ -9,13 +9,18 @@ namespace GitHub.Copilot.SDK.Test;
 
 public class E2ETestFixture : IAsyncLifetime
 {
+    internal const string SharedTcpConnectionToken = "e2e-shared-token";
+
     public E2ETestContext Ctx { get; private set; } = null!;
     public CopilotClient Client { get; private set; } = null!;
 
     public async Task InitializeAsync()
     {
         Ctx = await E2ETestContext.CreateAsync();
-        Client = Ctx.CreateClient(persistent: true);
+        Client = Ctx.CreateClient(useStdio: false, options: new CopilotClientOptions
+        {
+            TcpConnectionToken = SharedTcpConnectionToken,
+        }, persistent: true);
     }
 
     public async Task DisposeAsync()

--- a/dotnet/test/Unit/ClientSessionLifetimeTests.cs
+++ b/dotnet/test/Unit/ClientSessionLifetimeTests.cs
@@ -115,30 +115,25 @@ public sealed class ClientSessionLifetimeTests
     }
 
     [Fact]
-    public async Task Disposing_Replaced_Session_Does_Not_Remove_Current_SameId_Session()
+    public async Task ResumeSessionAsync_Throws_When_Same_Client_Already_Tracks_Session()
     {
         await using var server = await FakeCopilotServer.StartAsync();
         await using var client = new CopilotClient(new CopilotClientOptions { CliUrl = server.Url });
 
         var sessionId = "same-session-id";
-        var oldSession = await client.CreateSessionAsync(new SessionConfig
+        await using var session = await client.CreateSessionAsync(new SessionConfig
         {
             SessionId = sessionId,
             OnPermissionRequest = PermissionHandler.ApproveAll
         });
         AssertSessionCount(client, sessions: 1);
 
-        var currentSession = await client.ResumeSessionAsync(sessionId, new ResumeSessionConfig
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => client.ResumeSessionAsync(sessionId, new ResumeSessionConfig
         {
             OnPermissionRequest = PermissionHandler.ApproveAll
-        });
+        }));
+        Assert.Contains(sessionId, exception.Message);
         AssertSessionCount(client, sessions: 1);
-
-        await oldSession.DisposeAsync();
-        AssertSessionCount(client, sessions: 1);
-
-        await currentSession.DisposeAsync();
-        AssertSessionCount(client, sessions: 0);
     }
 
     [Fact]

--- a/dotnet/test/Unit/ClientSessionLifetimeTests.cs
+++ b/dotnet/test/Unit/ClientSessionLifetimeTests.cs
@@ -67,7 +67,7 @@ public sealed class ClientSessionLifetimeTests
     }
 
     [Fact]
-    public async Task Disposing_Old_Session_Does_Not_Remove_Current_SameId_Session()
+    public async Task Disposing_Replaced_Session_Does_Not_Remove_Current_SameId_Session()
     {
         await using var server = await FakeCopilotServer.StartAsync();
         await using var client = new CopilotClient(new CopilotClientOptions { CliUrl = server.Url });
@@ -80,12 +80,8 @@ public sealed class ClientSessionLifetimeTests
         });
         AssertSessionCount(client, sessions: 1);
 
-        await client.DeleteSessionAsync(sessionId);
-        AssertSessionCount(client, sessions: 0);
-
-        var currentSession = await client.CreateSessionAsync(new SessionConfig
+        var currentSession = await client.ResumeSessionAsync(sessionId, new ResumeSessionConfig
         {
-            SessionId = sessionId,
             OnPermissionRequest = PermissionHandler.ApproveAll
         });
         AssertSessionCount(client, sessions: 1);
@@ -229,6 +225,7 @@ public sealed class ClientSessionLifetimeTests
                     ["version"] = "test"
                 },
                 "session.create" => CreateSessionResult(request),
+                "session.resume" => CreateSessionResult(request),
                 "session.send" => new Dictionary<string, object?>
                 {
                     ["messageId"] = "message-1"

--- a/dotnet/test/Unit/ClientSessionLifetimeTests.cs
+++ b/dotnet/test/Unit/ClientSessionLifetimeTests.cs
@@ -1,0 +1,398 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+#if NET8_0_OR_GREATER
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace GitHub.Copilot.SDK.Test.Unit;
+
+public sealed class ClientSessionLifetimeTests
+{
+    [Fact]
+    public async Task Dropped_Session_Remains_Rooted_By_Client()
+    {
+        await using var server = await FakeCopilotServer.StartAsync();
+        await using var client = new CopilotClient(new CopilotClientOptions { CliUrl = server.Url });
+
+        var weakSession = await CreateDroppedSessionAsync(client);
+
+        ForceCollect();
+
+        Assert.True(
+            weakSession.TryGetTarget(out _),
+            "CopilotClient should root created sessions until they are explicitly disposed or the client stops.");
+        AssertSessionCount(client, sessions: 1);
+        GC.KeepAlive(client);
+    }
+
+    [Fact]
+    public async Task Disposed_Session_Is_Removed_From_Client()
+    {
+        await using var server = await FakeCopilotServer.StartAsync();
+        await using var client = new CopilotClient(new CopilotClientOptions { CliUrl = server.Url });
+
+        var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            OnPermissionRequest = PermissionHandler.ApproveAll
+        });
+        AssertSessionCount(client, sessions: 1);
+
+        await session.DisposeAsync();
+
+        AssertSessionCount(client, sessions: 0);
+    }
+
+    [Fact]
+    public async Task StopAsync_Removes_Rooted_Sessions()
+    {
+        await using var server = await FakeCopilotServer.StartAsync();
+        await using var client = new CopilotClient(new CopilotClientOptions { CliUrl = server.Url });
+
+        _ = await client.CreateSessionAsync(new SessionConfig
+        {
+            OnPermissionRequest = PermissionHandler.ApproveAll
+        });
+        AssertSessionCount(client, sessions: 1);
+
+        await client.StopAsync();
+
+        AssertSessionCount(client, sessions: 0);
+    }
+
+    [Fact]
+    public async Task Disposing_Old_Session_Does_Not_Remove_Current_SameId_Session()
+    {
+        await using var server = await FakeCopilotServer.StartAsync();
+        await using var client = new CopilotClient(new CopilotClientOptions { CliUrl = server.Url });
+
+        var sessionId = "same-session-id";
+        var oldSession = await client.CreateSessionAsync(new SessionConfig
+        {
+            SessionId = sessionId,
+            OnPermissionRequest = PermissionHandler.ApproveAll
+        });
+        AssertSessionCount(client, sessions: 1);
+
+        await client.DeleteSessionAsync(sessionId);
+        AssertSessionCount(client, sessions: 0);
+
+        var currentSession = await client.CreateSessionAsync(new SessionConfig
+        {
+            SessionId = sessionId,
+            OnPermissionRequest = PermissionHandler.ApproveAll
+        });
+        AssertSessionCount(client, sessions: 1);
+
+        await oldSession.DisposeAsync();
+        AssertSessionCount(client, sessions: 1);
+
+        await currentSession.DisposeAsync();
+        AssertSessionCount(client, sessions: 0);
+    }
+
+    [Fact]
+    public async Task Generated_Session_Rpc_Throws_When_Session_Disposed()
+    {
+        await using var server = await FakeCopilotServer.StartAsync();
+        await using var client = new CopilotClient(new CopilotClientOptions { CliUrl = server.Url });
+
+        var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            OnPermissionRequest = PermissionHandler.ApproveAll
+        });
+        await session.DisposeAsync();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => session.Rpc.Model.GetCurrentAsync());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async Task<WeakReference<CopilotSession>> CreateDroppedSessionAsync(CopilotClient client)
+    {
+        var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            OnPermissionRequest = PermissionHandler.ApproveAll
+        });
+
+        return new WeakReference<CopilotSession>(session);
+    }
+
+    private static void ForceCollect()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+    }
+
+    private static void AssertSessionCount(CopilotClient client, int sessions)
+    {
+        Assert.Equal(sessions, GetPrivateDictionaryCount(client, "_sessions"));
+    }
+
+    private static int GetPrivateDictionaryCount(CopilotClient client, string fieldName)
+    {
+        var field = typeof(CopilotClient).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"Field '{fieldName}' was not found.");
+        var dictionary = field.GetValue(client)
+            ?? throw new InvalidOperationException($"Field '{fieldName}' was null.");
+        var count = dictionary.GetType().GetProperty("Count")
+            ?? throw new InvalidOperationException($"Field '{fieldName}' does not expose Count.");
+
+        return (int)count.GetValue(dictionary)!;
+    }
+
+    private sealed class FakeCopilotServer : IAsyncDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly SemaphoreSlim _writeLock = new(1, 1);
+        private readonly Task _serverTask;
+        private string? _lastSessionId;
+
+        private FakeCopilotServer(TcpListener listener)
+        {
+            _listener = listener;
+            _serverTask = RunAsync();
+        }
+
+        public string Url
+        {
+            get
+            {
+                var endpoint = (IPEndPoint)_listener.LocalEndpoint;
+                return $"http://127.0.0.1:{endpoint.Port}";
+            }
+        }
+
+        public static Task<FakeCopilotServer> StartAsync()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            return Task.FromResult(new FakeCopilotServer(listener));
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            _cts.Cancel();
+            _listener.Stop();
+
+            try
+            {
+                await _serverTask;
+            }
+            catch (Exception ex) when (ex is OperationCanceledException or ObjectDisposedException or IOException or SocketException)
+            {
+            }
+
+            _cts.Dispose();
+            _writeLock.Dispose();
+        }
+
+        private async Task RunAsync()
+        {
+            using var tcpClient = await _listener.AcceptTcpClientAsync(_cts.Token);
+            using var stream = tcpClient.GetStream();
+
+            while (!_cts.Token.IsCancellationRequested)
+            {
+                using var request = await ReadMessageAsync(stream, _cts.Token);
+                if (request is null)
+                {
+                    return;
+                }
+
+                await HandleRequestAsync(stream, request.RootElement, _cts.Token);
+            }
+        }
+
+        private async Task HandleRequestAsync(Stream stream, JsonElement request, CancellationToken cancellationToken)
+        {
+            if (!request.TryGetProperty("id", out var idElement))
+            {
+                return;
+            }
+
+            var id = idElement.Clone();
+            var method = request.GetProperty("method").GetString();
+            object? result = method switch
+            {
+                "connect" => new Dictionary<string, object?>
+                {
+                    ["ok"] = true,
+                    ["protocolVersion"] = 3,
+                    ["version"] = "test"
+                },
+                "session.create" => CreateSessionResult(request),
+                "session.send" => new Dictionary<string, object?>
+                {
+                    ["messageId"] = "message-1"
+                },
+                "session.delete" => new Dictionary<string, object?>
+                {
+                    ["success"] = true
+                },
+                "session.destroy" => new Dictionary<string, object?>(),
+                _ => throw new InvalidOperationException($"Unexpected RPC method '{method}'.")
+            };
+
+            await WriteMessageAsync(stream, new Dictionary<string, object?>
+            {
+                ["jsonrpc"] = "2.0",
+                ["id"] = id,
+                ["result"] = result
+            }, cancellationToken);
+        }
+
+        private Dictionary<string, object?> CreateSessionResult(JsonElement request)
+        {
+            _lastSessionId = request
+                .GetProperty("params")
+                .GetProperty("sessionId")
+                .GetString();
+
+            return new Dictionary<string, object?>
+            {
+                ["sessionId"] = _lastSessionId,
+                ["workspacePath"] = null,
+                ["capabilities"] = null
+            };
+        }
+
+        private async Task WriteMessageAsync(Stream stream, object payload, CancellationToken cancellationToken)
+        {
+            using var bodyStream = new MemoryStream();
+            using (var writer = new Utf8JsonWriter(bodyStream))
+            {
+                WriteJsonValue(writer, payload);
+            }
+
+            var body = bodyStream.ToArray();
+            var header = Encoding.ASCII.GetBytes($"Content-Length: {body.Length}\r\n\r\n");
+
+            await _writeLock.WaitAsync(cancellationToken);
+            try
+            {
+                await stream.WriteAsync(header, cancellationToken);
+                await stream.WriteAsync(body, cancellationToken);
+                await stream.FlushAsync(cancellationToken);
+            }
+            finally
+            {
+                _writeLock.Release();
+            }
+        }
+
+        private static void WriteJsonValue(Utf8JsonWriter writer, object? value)
+        {
+            switch (value)
+            {
+                case null:
+                    writer.WriteNullValue();
+                    break;
+
+                case string stringValue:
+                    writer.WriteStringValue(stringValue);
+                    break;
+
+                case bool boolValue:
+                    writer.WriteBooleanValue(boolValue);
+                    break;
+
+                case int intValue:
+                    writer.WriteNumberValue(intValue);
+                    break;
+
+                case long longValue:
+                    writer.WriteNumberValue(longValue);
+                    break;
+
+                case JsonElement jsonElement:
+                    jsonElement.WriteTo(writer);
+                    break;
+
+                case Dictionary<string, object?> dictionary:
+                    writer.WriteStartObject();
+                    foreach (var (propertyName, propertyValue) in dictionary)
+                    {
+                        writer.WritePropertyName(propertyName);
+                        WriteJsonValue(writer, propertyValue);
+                    }
+                    writer.WriteEndObject();
+                    break;
+
+                case object?[] array:
+                    writer.WriteStartArray();
+                    foreach (var item in array)
+                    {
+                        WriteJsonValue(writer, item);
+                    }
+                    writer.WriteEndArray();
+                    break;
+
+                default:
+                    throw new InvalidOperationException($"Unexpected JSON value type '{value.GetType().Name}'.");
+            }
+        }
+
+        private static async Task<JsonDocument?> ReadMessageAsync(Stream stream, CancellationToken cancellationToken)
+        {
+            var headerBytes = new List<byte>();
+            while (true)
+            {
+                var value = await ReadByteAsync(stream, cancellationToken);
+                if (value < 0)
+                {
+                    return null;
+                }
+
+                headerBytes.Add((byte)value);
+                var count = headerBytes.Count;
+                if (count >= 4 &&
+                    headerBytes[count - 4] == '\r' &&
+                    headerBytes[count - 3] == '\n' &&
+                    headerBytes[count - 2] == '\r' &&
+                    headerBytes[count - 1] == '\n')
+                {
+                    break;
+                }
+            }
+
+            var header = Encoding.ASCII.GetString([.. headerBytes]);
+            var contentLength = header
+                .Split(["\r\n"], StringSplitOptions.RemoveEmptyEntries)
+                .Select(line => line.Split(':', 2))
+                .Where(parts => parts.Length == 2 && parts[0].Equals("Content-Length", StringComparison.OrdinalIgnoreCase))
+                .Select(parts => int.Parse(parts[1].Trim(), System.Globalization.CultureInfo.InvariantCulture))
+                .Single();
+
+            var body = new byte[contentLength];
+            var offset = 0;
+            while (offset < body.Length)
+            {
+                var read = await stream.ReadAsync(body.AsMemory(offset, body.Length - offset), cancellationToken);
+                if (read == 0)
+                {
+                    return null;
+                }
+
+                offset += read;
+            }
+
+            return JsonDocument.Parse(body);
+        }
+
+        private static async Task<int> ReadByteAsync(Stream stream, CancellationToken cancellationToken)
+        {
+            var buffer = new byte[1];
+            var read = await stream.ReadAsync(buffer, cancellationToken);
+            return read == 0 ? -1 : buffer[0];
+        }
+    }
+}
+#endif

--- a/dotnet/test/Unit/ClientSessionLifetimeTests.cs
+++ b/dotnet/test/Unit/ClientSessionLifetimeTests.cs
@@ -50,6 +50,30 @@ public sealed class ClientSessionLifetimeTests
     }
 
     [Fact]
+    public async Task Disposing_Session_Remains_Rooted_Until_Destroy_Completes()
+    {
+        await using var server = await FakeCopilotServer.StartAsync();
+        server.DelayDestroy();
+        await using var client = new CopilotClient(new CopilotClientOptions { CliUrl = server.Url });
+
+        var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            OnPermissionRequest = PermissionHandler.ApproveAll
+        });
+        AssertSessionCount(client, sessions: 1);
+
+        var disposeTask = session.DisposeAsync().AsTask();
+        await server.DestroyStarted;
+
+        AssertSessionCount(client, sessions: 1);
+
+        server.CompleteDestroy();
+        await disposeTask;
+
+        AssertSessionCount(client, sessions: 0);
+    }
+
+    [Fact]
     public async Task StopAsync_Removes_Rooted_Sessions()
     {
         await using var server = await FakeCopilotServer.StartAsync();
@@ -62,6 +86,30 @@ public sealed class ClientSessionLifetimeTests
         AssertSessionCount(client, sessions: 1);
 
         await client.StopAsync();
+
+        AssertSessionCount(client, sessions: 0);
+    }
+
+    [Fact]
+    public async Task StopAsync_Keeps_Session_Rooted_Until_Destroy_Completes()
+    {
+        await using var server = await FakeCopilotServer.StartAsync();
+        server.DelayDestroy();
+        await using var client = new CopilotClient(new CopilotClientOptions { CliUrl = server.Url });
+
+        _ = await client.CreateSessionAsync(new SessionConfig
+        {
+            OnPermissionRequest = PermissionHandler.ApproveAll
+        });
+        AssertSessionCount(client, sessions: 1);
+
+        var stopTask = client.StopAsync();
+        await server.DestroyStarted;
+
+        AssertSessionCount(client, sessions: 1);
+
+        server.CompleteDestroy();
+        await stopTask;
 
         AssertSessionCount(client, sessions: 0);
     }
@@ -148,8 +196,11 @@ public sealed class ClientSessionLifetimeTests
         private readonly TcpListener _listener;
         private readonly CancellationTokenSource _cts = new();
         private readonly SemaphoreSlim _writeLock = new(1, 1);
+        private readonly TaskCompletionSource _destroyStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _allowDestroy = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly Task _serverTask;
         private string? _lastSessionId;
+        private bool _delayDestroy;
 
         private FakeCopilotServer(TcpListener listener)
         {
@@ -173,8 +224,21 @@ public sealed class ClientSessionLifetimeTests
             return Task.FromResult(new FakeCopilotServer(listener));
         }
 
+        public Task DestroyStarted => _destroyStarted.Task;
+
+        public void DelayDestroy()
+        {
+            _delayDestroy = true;
+        }
+
+        public void CompleteDestroy()
+        {
+            _allowDestroy.TrySetResult();
+        }
+
         public async ValueTask DisposeAsync()
         {
+            _allowDestroy.TrySetResult();
             _cts.Cancel();
             _listener.Stop();
 
@@ -234,7 +298,7 @@ public sealed class ClientSessionLifetimeTests
                 {
                     ["success"] = true
                 },
-                "session.destroy" => new Dictionary<string, object?>(),
+                "session.destroy" => await DestroySessionAsync(cancellationToken),
                 _ => throw new InvalidOperationException($"Unexpected RPC method '{method}'.")
             };
 
@@ -259,6 +323,17 @@ public sealed class ClientSessionLifetimeTests
                 ["workspacePath"] = null,
                 ["capabilities"] = null
             };
+        }
+
+        private async Task<Dictionary<string, object?>> DestroySessionAsync(CancellationToken cancellationToken)
+        {
+            if (_delayDestroy)
+            {
+                _destroyStarted.TrySetResult();
+                await _allowDestroy.Task.WaitAsync(cancellationToken);
+            }
+
+            return [];
         }
 
         private async Task WriteMessageAsync(Stream stream, object payload, CancellationToken cancellationToken)

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -251,6 +251,10 @@ function isNonNullableCSharpValueType(typeName: string): boolean {
     ].includes(typeName) || generatedEnums.has(typeName) || emittedRpcEnumResultTypes.has(typeName);
 }
 
+function requiresArgumentNullCheck(typeName: string, isRequired: boolean): boolean {
+    return isRequired && !typeName.endsWith("?") && !isNonNullableCSharpValueType(typeName);
+}
+
 async function formatCSharpFile(filePath: string): Promise<void> {
     try {
         const projectFile = path.join(REPO_ROOT, "dotnet/src/GitHub.Copilot.SDK.csproj");
@@ -1614,9 +1618,6 @@ function emitServerRpcClasses(node: Record<string, unknown>, classes: string[]):
     srLines.push(`    internal ServerRpc(JsonRpc rpc)`);
     srLines.push(`    {`);
     srLines.push(`        _rpc = rpc;`);
-    for (const [groupName] of groups) {
-        srLines.push(`        ${toPascalCase(groupName)} = new Server${toPascalCase(groupName)}Api(rpc);`);
-    }
     srLines.push(`    }`);
 
     // Top-level methods (like ping)
@@ -1627,9 +1628,15 @@ function emitServerRpcClasses(node: Record<string, unknown>, classes: string[]):
 
     // Group properties
     for (const [groupName] of groups) {
+        const propertyName = toPascalCase(groupName);
         srLines.push("");
-        srLines.push(`    /// <summary>${toPascalCase(groupName)} APIs.</summary>`);
-        srLines.push(`    public Server${toPascalCase(groupName)}Api ${toPascalCase(groupName)} { get; }`);
+        srLines.push(`    /// <summary>${propertyName} APIs.</summary>`);
+        srLines.push(
+            `    public Server${propertyName}Api ${propertyName} =>`,
+            `        field ??`,
+            `        Interlocked.CompareExchange(ref field, new(_rpc), null) ??`,
+            `        field;`
+        );
     }
 
     srLines.push(`}`);
@@ -1665,10 +1672,6 @@ function emitServerApiClass(className: string, node: Record<string, unknown>, cl
     lines.push(`    internal ${className}(JsonRpc rpc)`);
     lines.push(`    {`);
     lines.push(`        _rpc = rpc;`);
-    for (const [subGroupName] of subGroups) {
-        const subClassName = className.replace(/Api$/, "") + toPascalCase(subGroupName) + "Api";
-        lines.push(`        ${toPascalCase(subGroupName)} = new ${subClassName}(rpc);`);
-    }
     lines.push(`    }`);
 
     for (const [key, value] of Object.entries(node)) {
@@ -1678,9 +1681,15 @@ function emitServerApiClass(className: string, node: Record<string, unknown>, cl
 
     for (const [subGroupName] of subGroups) {
         const subClassName = className.replace(/Api$/, "") + toPascalCase(subGroupName) + "Api";
+        const propertyName = toPascalCase(subGroupName);
         lines.push("");
-        lines.push(`    /// <summary>${toPascalCase(subGroupName)} APIs.</summary>`);
-        lines.push(`    public ${subClassName} ${toPascalCase(subGroupName)} { get; }`);
+        lines.push(`    /// <summary>${propertyName} APIs.</summary>`);
+        lines.push(
+            `    public ${subClassName} ${propertyName} =>`,
+            `        field ??`,
+            `        Interlocked.CompareExchange(ref field, new(_rpc), null) ??`,
+            `        field;`
+        );
     }
 
     lines.push(`}`);
@@ -1738,6 +1747,7 @@ function emitServerInstanceMethod(
 
     const sigParams: string[] = [];
     const bodyAssignments: string[] = [];
+    const argumentNullChecks: string[] = [];
     const parameterDescriptions: Array<{ name: string; description?: string; escapeDescription?: boolean }> = [];
 
     for (const [pName, pSchema] of paramEntries) {
@@ -1749,6 +1759,9 @@ function emitServerInstanceMethod(
             : schemaTypeToCSharp(jsonSchema, isReq, rpcKnownTypes);
         sigParams.push(`${csType} ${pName}${isReq ? "" : " = null"}`);
         bodyAssignments.push(`${toPascalCase(pName)} = ${pName}`);
+        if (requiresArgumentNullCheck(csType, isReq)) {
+            argumentNullChecks.push(`${indent}    ArgumentNullException.ThrowIfNull(${pName});`);
+        }
         parameterDescriptions.push({ name: pName, description: jsonSchema.description });
     }
     sigParams.push("CancellationToken cancellationToken = default");
@@ -1770,6 +1783,10 @@ function emitServerInstanceMethod(
     }
     lines.push(`${indent}${methodVisibility} async ${taskType} ${methodName}Async(${sigParams.join(", ")})`);
     lines.push(`${indent}{`);
+    lines.push(...argumentNullChecks);
+    if (argumentNullChecks.length > 0) {
+        lines.push("");
+    }
     if (requestClassName && bodyAssignments.length > 0) {
         lines.push(`${indent}    var ${localRequestName} = new ${requestClassName} { ${bodyAssignments.join(", ")} };`);
         if (!isVoidSchema(resultSchema)) {
@@ -1792,11 +1809,21 @@ function emitSessionRpcClasses(node: Record<string, unknown>, classes: string[])
     const groups = Object.entries(node).filter(([, v]) => typeof v === "object" && v !== null && !isRpcMethod(v));
     const topLevelMethods = Object.entries(node).filter(([, v]) => isRpcMethod(v));
 
-    const srLines = [`/// <summary>Provides typed session-scoped RPC methods.</summary>`, `public sealed class SessionRpc`, `{`, `    private readonly JsonRpc _rpc;`, `    private readonly string _sessionId;`, ""];
-    srLines.push(`    internal SessionRpc(JsonRpc rpc, string sessionId)`, `    {`, `        _rpc = rpc;`, `        _sessionId = sessionId;`);
-    for (const [groupName] of groups) srLines.push(`        ${toPascalCase(groupName)} = new ${toPascalCase(groupName)}Api(rpc, sessionId);`);
+    const srLines = [`/// <summary>Provides typed session-scoped RPC methods.</summary>`, `public sealed class SessionRpc`, `{`, `    private readonly CopilotSession _session;`, ""];
+    srLines.push(`    internal SessionRpc(CopilotSession session)`, `    {`, `        _session = session;`);
     srLines.push(`    }`);
-    for (const [groupName] of groups) srLines.push("", `    /// <summary>${toPascalCase(groupName)} APIs.</summary>`, `    public ${toPascalCase(groupName)}Api ${toPascalCase(groupName)} { get; }`);
+    srLines.push("", `    internal CopilotSession Session => _session;`);
+    for (const [groupName] of groups) {
+        const propertyName = toPascalCase(groupName);
+        srLines.push(
+            "",
+            `    /// <summary>${propertyName} APIs.</summary>`,
+            `    public ${propertyName}Api ${propertyName} =>`,
+            `        field ??`,
+            `        Interlocked.CompareExchange(ref field, new(_session), null) ??`,
+            `        field;`
+        );
+    }
 
     // Emit top-level session RPC methods directly on the SessionRpc class
     const topLevelLines: string[] = [];
@@ -1868,7 +1895,8 @@ function emitSessionMethod(key: string, method: RpcMethod, lines: string[], clas
     }
 
     const sigParams: string[] = [];
-    const bodyAssignments = [`SessionId = _sessionId`];
+    const bodyAssignments = [`SessionId = _session.SessionId`];
+    const argumentNullChecks: string[] = [];
     const parameterDescriptions: Array<{ name: string; description?: string; escapeDescription?: boolean }> = [];
 
     if (useRequestParameter) {
@@ -1884,6 +1912,9 @@ function emitSessionMethod(key: string, method: RpcMethod, lines: string[], clas
             const csType = resolveRpcType(pSchema as JSONSchema7, isReq, requestClassName, toPascalCase(pName), classes);
             sigParams.push(`${csType} ${pName}${isReq ? "" : " = null"}`);
             bodyAssignments.push(`${toPascalCase(pName)} = ${pName}`);
+            if (requiresArgumentNullCheck(csType, isReq)) {
+                argumentNullChecks.push(`${indent}    ArgumentNullException.ThrowIfNull(${pName});`);
+            }
             parameterDescriptions.push({ name: pName, description: (pSchema as JSONSchema7).description });
         }
     }
@@ -1905,11 +1936,15 @@ function emitSessionMethod(key: string, method: RpcMethod, lines: string[], clas
         pushObsoleteAttributes(lines, indent);
     }
     lines.push(`${indent}${methodVisibility} async ${taskType} ${methodName}Async(${sigParams.join(", ")})`);
-    lines.push(`${indent}{`, `${indent}    var ${localRequestName} = new ${wireRequestClassName} { ${bodyAssignments.join(", ")} };`);
+    lines.push(`${indent}{`);
+    lines.push(...argumentNullChecks);
+    lines.push(`${indent}    _session.ThrowIfDisposed();`);
+    lines.push("");
+    lines.push(`${indent}    var ${localRequestName} = new ${wireRequestClassName} { ${bodyAssignments.join(", ")} };`);
     if (!isVoidSchema(resultSchema)) {
-        lines.push(`${indent}    return await CopilotClient.InvokeRpcAsync<${resultClassName}>(_rpc, "${method.rpcMethod}", [${localRequestName}], cancellationToken);`, `${indent}}`);
+        lines.push(`${indent}    return await CopilotClient.InvokeRpcAsync<${resultClassName}>(_session.Rpc, "${method.rpcMethod}", [${localRequestName}], cancellationToken);`, `${indent}}`);
     } else {
-        lines.push(`${indent}    await CopilotClient.InvokeRpcAsync(_rpc, "${method.rpcMethod}", [${localRequestName}], cancellationToken);`, `${indent}}`);
+        lines.push(`${indent}    await CopilotClient.InvokeRpcAsync(_session.Rpc, "${method.rpcMethod}", [${localRequestName}], cancellationToken);`, `${indent}}`);
     }
 }
 
@@ -1922,12 +1957,8 @@ function emitSessionApiClass(className: string, node: Record<string, unknown>, c
     const deprecatedAttr = groupDeprecated ? `${obsoleteAttributeBlock()}\n` : "";
     const subGroups = Object.entries(node).filter(([, v]) => typeof v === "object" && v !== null && !isRpcMethod(v));
 
-    const lines = [`/// <summary>Provides session-scoped ${displayName} APIs.</summary>`, `${experimentalAttr}${deprecatedAttr}public sealed class ${className}`, `{`, `    private readonly JsonRpc _rpc;`, `    private readonly string _sessionId;`, ""];
-    lines.push(`    internal ${className}(JsonRpc rpc, string sessionId)`, `    {`, `        _rpc = rpc;`, `        _sessionId = sessionId;`);
-    for (const [subGroupName] of subGroups) {
-        const subClassName = className.replace(/Api$/, "") + toPascalCase(subGroupName) + "Api";
-        lines.push(`        ${toPascalCase(subGroupName)} = new ${subClassName}(rpc, sessionId);`);
-    }
+    const lines = [`/// <summary>Provides session-scoped ${displayName} APIs.</summary>`, `${experimentalAttr}${deprecatedAttr}public sealed class ${className}`, `{`, `    private readonly CopilotSession _session;`, ""];
+    lines.push(`    internal ${className}(CopilotSession session)`, `    {`, `        _session = session;`);
     lines.push(`    }`);
 
     for (const [key, value] of Object.entries(node)) {
@@ -1937,9 +1968,15 @@ function emitSessionApiClass(className: string, node: Record<string, unknown>, c
 
     for (const [subGroupName] of subGroups) {
         const subClassName = className.replace(/Api$/, "") + toPascalCase(subGroupName) + "Api";
+        const propertyName = toPascalCase(subGroupName);
         lines.push("");
-        lines.push(`    /// <summary>${toPascalCase(subGroupName)} APIs.</summary>`);
-        lines.push(`    public ${subClassName} ${toPascalCase(subGroupName)} { get; }`);
+        lines.push(`    /// <summary>${propertyName} APIs.</summary>`);
+        lines.push(
+            `    public ${subClassName} ${propertyName} =>`,
+            `        field ??`,
+            `        Interlocked.CompareExchange(ref field, new(_session), null) ??`,
+            `        field;`
+        );
     }
 
     lines.push(`}`);
@@ -2139,6 +2176,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 
 namespace GitHub.Copilot.SDK.Rpc;
 `);

--- a/test/harness/replayingCapiProxy.test.ts
+++ b/test/harness/replayingCapiProxy.test.ts
@@ -454,6 +454,48 @@ Always include PINEAPPLE_COCONUT_42.
     expect(toolMessages[1].content).toBe("[beta result]");
   });
 
+  test("normalizes read_agent timing metadata", async () => {
+    const requestBody = JSON.stringify({
+      messages: [
+        { role: "user", content: "Help me" },
+        {
+          role: "assistant",
+          tool_calls: [
+            {
+              id: "tc1",
+              type: "function",
+              function: {
+                name: "read_agent",
+                arguments: '{"agent_id":"read-file","wait":true}',
+              },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "tc1",
+          content:
+            "Agent completed. agent_id: read-file, agent_type: explore, status: completed, description: Reading subagent-test.txt, elapsed: 1.25s, total_turns: 0, duration: 2s\n\nDone.",
+        },
+      ],
+    });
+    const responseBody = JSON.stringify({
+      choices: [{ message: { role: "assistant", content: "Done" } }],
+    });
+
+    const outputPath = await createProxy([
+      { url: "/chat/completions", requestBody, responseBody },
+    ]);
+
+    const result = await readYamlOutput(outputPath);
+    const toolMessage = result.conversations[0].messages.find(
+      (m) => m.role === "tool",
+    );
+    expect(toolMessage?.content).toBe(
+      "Agent completed. agent_id: read-file, agent_type: explore, status: completed, description: Reading subagent-test.txt, elapsed: 0s, total_turns: 0, duration: 0s\n\nDone.",
+    );
+  });
+
   test("normalizes GitHub CLI proxy auth failures", async () => {
     const requestBody = JSON.stringify({
       messages: [

--- a/test/harness/replayingCapiProxy.ts
+++ b/test/harness/replayingCapiProxy.ts
@@ -55,6 +55,7 @@ export class ReplayingCapiProxy extends CapturingHttpProxy {
   private defaultToolResultNormalizers: ToolResultNormalizer[] = [
     { toolName: "*", normalizer: normalizeLargeOutputFilepaths },
     { toolName: "*", normalizer: normalizeGhAuthMessages },
+    { toolName: "read_agent", normalizer: normalizeReadAgentTimings },
   ];
 
   /**
@@ -1119,6 +1120,12 @@ function normalizeGh401AuthMessages(result: string): string {
   }
 
   return changed ? normalizedLines.join("\n") : result;
+}
+
+function normalizeReadAgentTimings(result: string): string {
+  return result
+    .replace(/\belapsed: \d+(?:\.\d+)?s\b/g, "elapsed: 0s")
+    .replace(/\bduration: \d+(?:\.\d+)?s\b/g, "duration: 0s");
 }
 
 // Transforms a single OpenAI-style inbound response message into normalized form


### PR DESCRIPTION
Clean up argument validation and disposal handling in CopilotClient/Session and the various generated Rpc wrappers. Also lazily allocate lots of objects.