### PR TITLE
Use 32-bit types for bounded schema integers

### DIFF
--- a/nodejs/test/shared-codegen.test.ts
+++ b/nodejs/test/shared-codegen.test.ts
@@ -5,10 +5,58 @@ import {
     collectReachableDefinitionNames,
     findSharedSchemaDefinitions,
     inlineExternalSchemaDefinitions,
+    isIntegerSchemaBoundedToInt32,
     rewriteSharedDefinitionReferences,
 } from "../../scripts/codegen/utils.ts";
 
 describe("shared schema definition codegen utilities", () => {
+    it("detects integer schemas bounded to the 32-bit signed range", () => {
+        expect(
+            isIntegerSchemaBoundedToInt32({
+                type: "integer",
+                minimum: -2147483648,
+                maximum: 2147483647,
+            })
+        ).toBe(true);
+        expect(
+            isIntegerSchemaBoundedToInt32({
+                type: "integer",
+                minimum: 0,
+                maximum: 100,
+            })
+        ).toBe(true);
+        expect(isIntegerSchemaBoundedToInt32({ type: "integer", maximum: 100 })).toBe(false);
+        expect(isIntegerSchemaBoundedToInt32({ type: "integer", minimum: 0 })).toBe(false);
+        expect(
+            isIntegerSchemaBoundedToInt32({
+                type: "integer",
+                minimum: -2147483649,
+                maximum: 100,
+            })
+        ).toBe(false);
+        expect(
+            isIntegerSchemaBoundedToInt32({
+                type: "integer",
+                minimum: 0,
+                maximum: 2147483648,
+            })
+        ).toBe(false);
+        expect(
+            isIntegerSchemaBoundedToInt32({
+                type: "integer",
+                minimum: 0.5,
+                maximum: 100,
+            })
+        ).toBe(false);
+        expect(
+            isIntegerSchemaBoundedToInt32({
+                type: "integer",
+                minimum: 0,
+                maximum: 100.5,
+            })
+        ).toBe(false);
+    });
+
     it("rewrites reachable identical shared definitions without enum-only assumptions", () => {
         const sessionSchema: JSONSchema7 = {
             definitions: {

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -28,6 +28,7 @@ import {
     resolveSchema,
     refTypeName,
     isRpcMethod,
+    isIntegerSchemaBoundedToInt32,
     isNodeFullyExperimental,
     isNodeFullyDeprecated,
     isSchemaDeprecated,
@@ -305,7 +306,11 @@ function schemaTypeToCSharp(schema: JSONSchema7, required: boolean, knownTypes: 
             if (format === "duration") {
                 return "TimeSpan?";
             }
-            return nonNullTypes[0] === "integer" ? "long?" : "double?";
+            if (nonNullTypes[0] === "integer") {
+                const integerType = isIntegerSchemaBoundedToInt32(schema) ? "int" : "long";
+                return `${integerType}?`;
+            }
+            return "double?";
         }
     }
     if (type === "string") {
@@ -317,7 +322,10 @@ function schemaTypeToCSharp(schema: JSONSchema7, required: boolean, knownTypes: 
         if (format === "duration") {
             return required ? "TimeSpan" : "TimeSpan?";
         }
-        if (type === "integer") return required ? "long" : "long?";
+        if (type === "integer") {
+            const integerType = isIntegerSchemaBoundedToInt32(schema) ? "int" : "long";
+            return required ? integerType : `${integerType}?`;
+        }
         return required ? "double" : "double?";
     }
     if (type === "boolean") return required ? "bool" : "bool?";

--- a/scripts/codegen/go.ts
+++ b/scripts/codegen/go.ts
@@ -26,6 +26,7 @@ import {
     getSessionEventVariantSchemas,
     getSharedSessionEventEnvelopeProperties,
     hasSchemaPayload,
+    isIntegerSchemaBoundedToInt32,
     isNodeFullyDeprecated,
     isNodeFullyExperimental,
     isRpcMethod,
@@ -852,7 +853,10 @@ function resolveGoPropertyType(
         return isRequired ? "string" : "*string";
     }
     if (type === "number") return isRequired ? "float64" : "*float64";
-    if (type === "integer") return isRequired ? "int64" : "*int64";
+    if (type === "integer") {
+        const integerType = isIntegerSchemaBoundedToInt32(propSchema) ? "int32" : "int64";
+        return isRequired ? integerType : `*${integerType}`;
+    }
     if (type === "boolean") return isRequired ? "bool" : "*bool";
 
     // Array type
@@ -2294,7 +2298,7 @@ function goPrimitiveSchemaGoType(schema: JSONSchema7, ctx: GoCodegenCtx): string
     const resolved = resolveSchema(schema, ctx.definitions) ?? schema;
     switch (resolved.type) {
         case "boolean": return "bool";
-        case "integer": return "int64";
+        case "integer": return isIntegerSchemaBoundedToInt32(resolved) ? "int32" : "int64";
         case "number": return "float64";
         case "string": return "string";
         default: return undefined;

--- a/scripts/codegen/rust.ts
+++ b/scripts/codegen/rust.ts
@@ -29,6 +29,7 @@ import {
 	getNullableInner,
 	getRpcSchemaTypeName,
 	getSessionEventsSchemaPath,
+	isIntegerSchemaBoundedToInt32,
 	isObjectSchema,
 	isRpcMethod,
 	isSchemaDeprecated,
@@ -663,7 +664,12 @@ function resolveRustType(
 		return wrapOption("String", isRequired);
 	}
 	if (schemaType === "number") return wrapOption("f64", isRequired);
-	if (schemaType === "integer") return wrapOption("i64", isRequired);
+	if (schemaType === "integer") {
+		return wrapOption(
+			isIntegerSchemaBoundedToInt32(propSchema) ? "i32" : "i64",
+			isRequired,
+		);
+	}
 	if (schemaType === "boolean") return wrapOption("bool", isRequired);
 
 	// Array

--- a/scripts/codegen/utils.ts
+++ b/scripts/codegen/utils.ts
@@ -326,6 +326,22 @@ export function cloneSchemaForCodegen<T>(value: T): T {
     return value;
 }
 
+const INT32_MIN = -(2 ** 31);
+const INT32_MAX = 2 ** 31 - 1;
+
+function isIntegerValue(value: unknown): value is number {
+    return Number.isInteger(value);
+}
+
+export function isIntegerSchemaBoundedToInt32(schema: JSONSchema7): boolean {
+    return (
+        isIntegerValue(schema.minimum) &&
+        isIntegerValue(schema.maximum) &&
+        schema.minimum >= INT32_MIN &&
+        schema.maximum <= INT32_MAX
+    );
+}
+
 export function stableStringify(value: unknown): string {
     if (Array.isArray(value)) {
         return `[${value.map((item) => stableStringify(item)).join(",")}]`;


### PR DESCRIPTION
Schema integer fields that explicitly constrain both their minimum and maximum to the signed 32-bit range can use narrower SDK types without losing protocol fidelity. This updates the shared codegen logic to detect those bounded integer schemas and applies that decision in the C#, Go, and Rust generators.

The current checked-in schemas do not contain any integer field with both bounds set, so regenerating the SDK outputs does not change generated files today. The change is covered by a focused codegen utility test, including fractional bounds that should not qualify.