### PR TITLE
Fix .NET E2E auth setup

### DIFF
--- a/dotnet/test/E2E/ClientE2ETests.cs
+++ b/dotnet/test/E2E/ClientE2ETests.cs
@@ -2,6 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
+using GitHub.Copilot.SDK.Test.Harness;
 using Xunit;
 
 namespace GitHub.Copilot.SDK.Test.E2E;
@@ -194,9 +195,9 @@ public class ClientE2ETests
     {
         const string connectionToken = "client-e2e-resume-token";
 
-        await using var client = new CopilotClient(new CopilotClientOptions
+        await using var ctx = await E2ETestContext.CreateAsync();
+        await using var client = ctx.CreateClient(useStdio: false, options: new CopilotClientOptions
         {
-            UseStdio = false,
             TcpConnectionToken = connectionToken,
         });
         await using var originalSession = await client.CreateSessionAsync(new SessionConfig());
@@ -204,7 +205,7 @@ public class ClientE2ETests
         var port = client.ActualPort
             ?? throw new InvalidOperationException("Client must be using TCP transport to support multi-client resume.");
 
-        await using var resumeClient = new CopilotClient(new CopilotClientOptions
+        await using var resumeClient = ctx.CreateClient(options: new CopilotClientOptions
         {
             CliUrl = $"localhost:{port}",
             TcpConnectionToken = connectionToken,

--- a/dotnet/test/E2E/PerSessionAuthE2ETests.cs
+++ b/dotnet/test/E2E/PerSessionAuthE2ETests.cs
@@ -20,9 +20,33 @@ public class PerSessionAuthE2ETests(E2ETestFixture fixture, ITestOutputHelper ou
         {
             ["COPILOT_DEBUG_GITHUB_API_URL"] = Ctx.ProxyUrl,
         };
-        // Disable the harness's auto-injected fake GITHUB_TOKEN so the per-session
-        // auth tests can validate session-scoped tokens (including the no-token case).
+        // Disable the harness's auto-injected client token so the per-session
+        // auth tests validate only session-scoped tokens.
         return Ctx.CreateClient(options: new CopilotClientOptions { Environment = env }, autoInjectGitHubToken: false);
+    }
+
+    private CopilotClient CreateNoAuthTestClient()
+    {
+        var env = WithoutAuthEnv(Ctx.GetEnvironment());
+        env["COPILOT_DEBUG_GITHUB_API_URL"] = Ctx.ProxyUrl;
+
+        return Ctx.CreateClient(options: new CopilotClientOptions
+        {
+            Environment = env,
+            UseLoggedInUser = false,
+        }, autoInjectGitHubToken: false);
+    }
+
+    private static Dictionary<string, string> WithoutAuthEnv(IReadOnlyDictionary<string, string> env)
+    {
+        var result = new Dictionary<string, string>(env)
+        {
+            ["COPILOT_SDK_AUTH_TOKEN"] = "",
+            ["GH_TOKEN"] = "",
+            ["GITHUB_TOKEN"] = "",
+        };
+
+        return result;
     }
 
     private async Task SetupCopilotUsersAsync()
@@ -91,15 +115,15 @@ public class PerSessionAuthE2ETests(E2ETestFixture fixture, ITestOutputHelper ou
     [Fact]
     public async Task ShouldBeUnauthenticatedWithoutToken()
     {
-        await using var session = await AuthClient.CreateSessionAsync(new SessionConfig
+        var noAuthClient = CreateNoAuthTestClient();
+
+        await using var session = await noAuthClient.CreateSessionAsync(new SessionConfig
         {
             OnPermissionRequest = PermissionHandler.ApproveAll,
         });
 
         var status = await session.Rpc.Auth.GetStatusAsync();
         // Without a per-session GitHub token, there is no per-session identity.
-        // In CI the process-level fake token may still authenticate globally,
-        // so we check Login rather than IsAuthenticated.
         Assert.True(string.IsNullOrEmpty(status.Login), $"Expected no per-session login without token, got {status.Login}");
     }
 


### PR DESCRIPTION
The live runtime can resolve process-level auth differently from the replayed SDK test harness, which caused .NET E2E tests to fail when no per-session token or authenticated resume context was explicitly configured.

## Summary
- Run the per-session no-token auth case with a dedicated no-auth client that clears ambient auth token variables and disables logged-in-user fallback.
- Run the resume-without-permission-handler test through the E2E context so the TCP server and resume client share the expected test auth/proxy setup while still exercising a missing permission handler.

## Validation
- `dotnet test dotnet\test\GitHub.Copilot.SDK.Test.csproj --filter "FullyQualifiedName~PerSessionAuthE2ETests" --no-restore --logger "console;verbosity=minimal"`
- `dotnet test dotnet\test\GitHub.Copilot.SDK.Test.csproj --filter "FullyQualifiedName~ClientE2ETests.Should_Allow_ResumeSession_Called_Without_PermissionHandler" --no-restore --logger "console;verbosity=minimal"`