### PR TITLE
Fix hook snapshot for runtime replay

### DIFF
--- a/go/internal/e2e/builtin_tools_e2e_test.go
+++ b/go/internal/e2e/builtin_tools_e2e_test.go
@@ -241,6 +241,7 @@ func assistantContent(t *testing.T, event *copilot.SessionEvent) string {
 
 	if event == nil {
 		t.Fatal("Expected assistant message, got nil")
+		return ""
 	}
 	data, ok := event.Data.(*copilot.AssistantMessageData)
 	if !ok {

--- a/go/internal/e2e/client_options_e2e_test.go
+++ b/go/internal/e2e/client_options_e2e_test.go
@@ -217,6 +217,7 @@ func TestClientOptionsE2E(t *testing.T) {
 		}
 		if createReq == nil {
 			t.Fatalf("session.create request was not captured. Captured requests: %+v", updated.Requests)
+			return
 		}
 		params, ok := createReq.Params.(map[string]any)
 		if !ok {

--- a/go/internal/e2e/event_fidelity_e2e_test.go
+++ b/go/internal/e2e/event_fidelity_e2e_test.go
@@ -54,6 +54,7 @@ func TestEventFidelityE2E(t *testing.T) {
 
 		if usageEvent == nil {
 			t.Fatalf("Expected at least one assistant.usage event; events=%v", eventFidelityTypes(snapshot))
+			return
 		}
 		if usageEvent.Model == "" {
 			t.Errorf("Expected assistant.usage event to have a non-empty model field, got %#v", usageEvent)
@@ -110,6 +111,7 @@ func TestEventFidelityE2E(t *testing.T) {
 
 		if usageInfo == nil {
 			t.Fatalf("Expected at least one session.usage_info event; events=%v", eventFidelityTypes(snapshot))
+			return
 		}
 		if usageInfo.CurrentTokens <= 0 {
 			t.Errorf("Expected session.usage_info.currentTokens > 0, got %v", usageInfo.CurrentTokens)
@@ -460,6 +462,7 @@ func TestEventFidelityE2E(t *testing.T) {
 		assistantEvent := firstAssistantMessageEventFidelityData(snapshot)
 		if assistantEvent == nil {
 			t.Fatalf("Expected at least one assistant.message event; events=%v", eventFidelityTypes(snapshot))
+			return
 		}
 		if assistantEvent.MessageID == "" {
 			t.Fatalf("Expected assistant.message messageId, got %#v", assistantEvent)

--- a/go/internal/e2e/multi_client_e2e_test.go
+++ b/go/internal/e2e/multi_client_e2e_test.go
@@ -377,6 +377,7 @@ func TestMultiClientE2E(t *testing.T) {
 		}
 		if response1 == nil {
 			t.Fatalf("Expected response with content")
+			return
 		}
 		rd1, ok := response1.Data.(*copilot.AssistantMessageData)
 		if !ok {
@@ -394,6 +395,7 @@ func TestMultiClientE2E(t *testing.T) {
 		}
 		if response2 == nil {
 			t.Fatalf("Expected response with content")
+			return
 		}
 		rd2, ok := response2.Data.(*copilot.AssistantMessageData)
 		if !ok {
@@ -450,6 +452,7 @@ func TestMultiClientE2E(t *testing.T) {
 		}
 		if stableResponse == nil {
 			t.Fatalf("Expected response with content")
+			return
 		}
 		srd, ok := stableResponse.Data.(*copilot.AssistantMessageData)
 		if !ok {
@@ -467,6 +470,7 @@ func TestMultiClientE2E(t *testing.T) {
 		}
 		if ephemeralResponse == nil {
 			t.Fatalf("Expected response with content")
+			return
 		}
 		erd, ok := ephemeralResponse.Data.(*copilot.AssistantMessageData)
 		if !ok {
@@ -497,6 +501,7 @@ func TestMultiClientE2E(t *testing.T) {
 		}
 		if afterResponse == nil {
 			t.Fatalf("Expected response with content")
+			return
 		}
 		ard, ok := afterResponse.Data.(*copilot.AssistantMessageData)
 		if !ok {

--- a/go/internal/e2e/pending_work_resume_e2e_test.go
+++ b/go/internal/e2e/pending_work_resume_e2e_test.go
@@ -539,6 +539,7 @@ func TestPendingWorkResumeE2E(t *testing.T) {
 		}
 		if resumeEvent == nil {
 			t.Fatal("Expected a session.resume event")
+			return
 		}
 		if resumeEvent.ContinuePendingWork == nil || *resumeEvent.ContinuePendingWork != false {
 			t.Errorf("Expected ContinuePendingWork=false in resume event, got %v", resumeEvent.ContinuePendingWork)
@@ -634,6 +635,7 @@ func TestPendingWorkResumeE2E(t *testing.T) {
 		}
 		if resumeEvent == nil {
 			t.Fatal("Expected a session.resume event")
+			return
 		}
 		if resumeEvent.ContinuePendingWork == nil || *resumeEvent.ContinuePendingWork != true {
 			t.Errorf("Expected ContinuePendingWork=true in resume event, got %v", resumeEvent.ContinuePendingWork)

--- a/go/internal/e2e/rpc_event_side_effects_e2e_test.go
+++ b/go/internal/e2e/rpc_event_side_effects_e2e_test.go
@@ -175,6 +175,7 @@ func TestRpcEventSideEffectsE2E(t *testing.T) {
 		userEvent := firstUserMessageEvent(messages)
 		if userEvent == nil {
 			t.Fatal("Expected at least one user.message in persisted history")
+			return
 		}
 		targetEventID := userEvent.ID
 
@@ -230,6 +231,7 @@ func TestRpcEventSideEffectsE2E(t *testing.T) {
 		userEvent := firstUserMessageEvent(messages)
 		if userEvent == nil {
 			t.Fatal("Expected at least one user.message in persisted history")
+			return
 		}
 
 		truncateResult, err := session.RPC.History.Truncate(t.Context(), &rpc.HistoryTruncateRequest{EventID: userEvent.ID})

--- a/go/internal/e2e/rpc_server_e2e_test.go
+++ b/go/internal/e2e/rpc_server_e2e_test.go
@@ -180,6 +180,7 @@ func TestRpcServerE2E(t *testing.T) {
 		discovered := findServerSkill(skills.Skills, skillName)
 		if discovered == nil {
 			t.Fatalf("Expected to discover skill %q", skillName)
+			return
 		}
 		if discovered.Description != "Skill discovered by server-scoped RPC tests." {
 			t.Errorf("Expected description to match, got %q", discovered.Description)
@@ -211,6 +212,7 @@ func TestRpcServerE2E(t *testing.T) {
 		disabledSkill := findServerSkill(disabled.Skills, skillName)
 		if disabledSkill == nil {
 			t.Fatalf("Expected to find skill %q after disable", skillName)
+			return
 		}
 		if disabledSkill.Enabled {
 			t.Errorf("Expected skill %q to be Enabled=false after global disable", skillName)

--- a/go/internal/e2e/rpc_session_state_e2e_test.go
+++ b/go/internal/e2e/rpc_session_state_e2e_test.go
@@ -319,6 +319,7 @@ func TestRpcSessionStateE2E(t *testing.T) {
 		}
 		if fork == nil {
 			t.Fatal("Expected non-nil fork result")
+			return
 		}
 		if strings.TrimSpace(fork.SessionID) == "" {
 			t.Fatal("Expected non-empty fork session id")
@@ -379,6 +380,7 @@ func TestRpcSessionStateE2E(t *testing.T) {
 		}
 		if secondUserEvent == nil {
 			t.Fatal("Expected the second user.message in persisted history")
+			return
 		}
 		boundaryEventID := secondUserEvent.ID
 

--- a/go/internal/e2e/session_e2e_test.go
+++ b/go/internal/e2e/session_e2e_test.go
@@ -989,6 +989,7 @@ func TestSessionE2E(t *testing.T) {
 
 		if metadata == nil {
 			t.Fatal("Expected metadata to be non-nil")
+			return
 		}
 
 		if metadata.SessionID != session.SessionID {
@@ -1043,6 +1044,7 @@ func TestSessionE2E(t *testing.T) {
 
 		if lastSessionID == nil {
 			t.Fatal("Expected last session ID to be non-nil")
+			return
 		}
 
 		if *lastSessionID != session.SessionID {
@@ -1561,6 +1563,7 @@ func TestSessionMessageOptionsE2E(t *testing.T) {
 		}
 		if userMsg == nil {
 			t.Fatal("No user.message event found")
+			return
 		}
 		if userMsg.Content != "Say mode ok." {
 			t.Errorf("Expected Content 'Say mode ok.', got %q", userMsg.Content)

--- a/go/internal/e2e/skills_e2e_test.go
+++ b/go/internal/e2e/skills_e2e_test.go
@@ -298,6 +298,7 @@ func TestSkillsE2E(t *testing.T) {
 		}
 		if discovered == nil {
 			t.Fatalf("Expected to discover skill %q via EnableConfigDiscovery", skillName)
+			return
 		}
 		if !discovered.Enabled {
 			t.Error("Expected discovered skill to be Enabled=true")

--- a/go/internal/e2e/subagent_hooks_e2e_test.go
+++ b/go/internal/e2e/subagent_hooks_e2e_test.go
@@ -75,6 +75,7 @@ func TestSubagentHooksE2E(t *testing.T) {
 		}
 		if taskPre == nil {
 			t.Fatal("preToolUse should fire for the parent's 'task' tool call")
+			return
 		}
 
 		// Sub-agent tool hooks fire for "view"

--- a/go/internal/e2e/tools_e2e_test.go
+++ b/go/internal/e2e/tools_e2e_test.go
@@ -234,6 +234,7 @@ func TestToolsE2E(t *testing.T) {
 
 		if answer == nil {
 			t.Fatalf("Expected assistant message with content")
+			return
 		}
 		ad, ok := answer.Data.(*copilot.AssistantMessageData)
 		if !ok {

--- a/test/snapshots/hooks_extended/should_allow_pretooluse_to_return_modifiedargs_and_suppressoutput.yaml
+++ b/test/snapshots/hooks_extended/should_allow_pretooluse_to_return_modifiedargs_and_suppressoutput.yaml
@@ -48,3 +48,29 @@ conversations:
         content: modified by hook
       - role: assistant
         content: 'The echo_value returned: **"modified by hook"**'
+  - messages:
+      - role: system
+        content: ${system}
+      - role: user
+        content: Call echo_value with value 'original', then reply with the result.
+      - role: assistant
+        content: I'll call echo_value with 'original' for you.
+        tool_calls:
+          - id: toolcall_0
+            type: function
+            function:
+              name: report_intent
+              arguments: '{"intent":"Calling echo_value"}'
+          - id: toolcall_1
+            type: function
+            function:
+              name: echo_value
+              arguments: '{"value":"original"}'
+      - role: tool
+        tool_call_id: toolcall_0
+        content: Intent logged
+      - role: tool
+        tool_call_id: toolcall_1
+        content: modified by hook
+      - role: assistant
+        content: 'The echo_value returned: **"modified by hook"**'


### PR DESCRIPTION
The live runtime now preserves the original tool-call arguments in one pre-tool-use history shape while still applying the hook-modified arguments to the tool result. The shared hooks_extended replay fixture only covered the older shape, so the C# SDK test failed when run against copilot-agent-runtime.

This adds the alternate cached conversation to the shared snapshot while keeping the existing one, so C#, Node, Go, Python, and Rust E2E tests can replay both valid histories.

Validation:
- Focused hook replay checks passed for C#, Node, Go, Python, and Rust.
- C# SDK net8.0 suite passed against `D:\repos\copilot-agent-runtime\dist-cli\index.js`: 470 total, 468 passed, 2 skipped.