### PR TITLE
Emit regex attributes from C# codegen

### DIFF
--- a/dotnet/src/Polyfills/CodeAnalysisAttributes.cs
+++ b/dotnet/src/Polyfills/CodeAnalysisAttributes.cs
@@ -30,6 +30,8 @@ internal sealed class StringSyntaxAttribute : Attribute
 {
     public const string Uri = nameof(Uri);
 
+    public const string Regex = nameof(Regex);
+
     public StringSyntaxAttribute(string syntax)
     {
         Syntax = syntax;

--- a/nodejs/test/python-codegen.test.ts
+++ b/nodejs/test/python-codegen.test.ts
@@ -455,3 +455,41 @@ describe("enum value description codegen", () => {
         expect(code).toContain('    #[serde(rename = "beta")]\n    Beta,');
     });
 });
+
+describe("csharp session event codegen", () => {
+    it("emits regular expression attributes for regex format properties with patterns", () => {
+        const schema: JSONSchema7 = {
+            definitions: {
+                SessionEvent: {
+                    anyOf: [
+                        {
+                            type: "object",
+                            required: ["type", "data"],
+                            properties: {
+                                type: { const: "session.synthetic" },
+                                data: {
+                                    type: "object",
+                                    required: ["pattern"],
+                                    properties: {
+                                        pattern: {
+                                            type: "string",
+                                            format: "regex",
+                                            pattern: "^foo\\d+$",
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        };
+
+        const code = generateCSharpSessionEventsCode(schema);
+
+        expect(code).toContain(`    [StringSyntax(StringSyntaxAttribute.Regex)]
+    [RegularExpression("^foo\\\\d+$")]
+    [JsonPropertyName("pattern")]`);
+        expect(code.split(`[RegularExpression("^foo\\\\d+$")]`)).toHaveLength(2);
+    });
+});

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -376,9 +376,12 @@ function emitDataAnnotations(schema: JSONSchema7, indent: string): string[] {
         attrs.push(`${indent}[StringSyntax(StringSyntaxAttribute.Uri)]`);
     }
 
-    // [StringSyntax(StringSyntaxAttribute.Regex)] for format: "regex"
+    // [StringSyntax(StringSyntaxAttribute.Regex)] and [RegularExpression] for format: "regex"
     if (format === "regex") {
         attrs.push(`${indent}[StringSyntax(StringSyntaxAttribute.Regex)]`);
+        if (typeof schema.pattern === "string") {
+            attrs.push(`${indent}[RegularExpression("${escapeCSharpStringLiteral(schema.pattern)}")]`);
+        }
     }
 
     // [Base64String] for base64-encoded string properties
@@ -407,10 +410,9 @@ function emitDataAnnotations(schema: JSONSchema7, indent: string): string[] {
         }
     }
 
-    // [RegularExpression] for pattern
-    if (typeof schema.pattern === "string") {
-        const escaped = schema.pattern.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-        attrs.push(`${indent}[RegularExpression("${escaped}")]`);
+    // [RegularExpression] for pattern constraints on non-regex-format properties
+    if (format !== "regex" && typeof schema.pattern === "string") {
+        attrs.push(`${indent}[RegularExpression("${escapeCSharpStringLiteral(schema.pattern)}")]`);
     }
 
     // [MinLength] / [MaxLength] for string constraints


### PR DESCRIPTION
JSON Schema `format: "regex"` marks properties whose value is a regex. The C# SDK should surface that validation metadata so generated DTOs match schema constraints.

## Summary
- Emit `[RegularExpression("...")]` alongside `[StringSyntax(StringSyntaxAttribute.Regex)]` when a regex-format property supplies a pattern.
- Preserve existing `[RegularExpression]` emission for non-regex-format `pattern` constraints without duplicating attributes.
- Add the downlevel `StringSyntaxAttribute.Regex` polyfill constant needed by netstandard2.0 builds.
- Add a codegen unit test covering regex-format attribute emission and escaping.

## Validation
- `npm test -- python-codegen.test.ts`
- `npm run typecheck`
- `dotnet build dotnet\src\GitHub.Copilot.SDK.csproj --nologo --verbosity:minimal`
- `npm run generate:csharp`