### PR TITLE
Port validation and lifecycle fixes to Node, Python, and Go

### DIFF
--- a/go/client.go
+++ b/go/client.go
@@ -417,23 +417,15 @@ func (c *Client) Start(ctx context.Context) error {
 func (c *Client) Stop() error {
 	var errs []error
 
-	// Disconnect all active sessions
-	c.sessionsMux.Lock()
-	sessions := make([]*Session, 0, len(c.sessions))
-	for _, session := range c.sessions {
-		sessions = append(sessions, session)
-	}
-	c.sessionsMux.Unlock()
-
-	for _, session := range sessions {
+	for _, session := range c.snapshotSessions() {
 		if err := session.Disconnect(); err != nil {
 			errs = append(errs, fmt.Errorf("failed to disconnect session %s: %w", session.SessionID, err))
 		}
 	}
 
-	c.sessionsMux.Lock()
-	c.sessions = make(map[string]*Session)
-	c.sessionsMux.Unlock()
+	for _, session := range c.clearSessions() {
+		session.markDisconnected()
+	}
 
 	c.startStopMux.Lock()
 	defer c.startStopMux.Unlock()
@@ -504,10 +496,9 @@ func (c *Client) ForceStop() {
 		p.Kill()
 	}
 
-	// Clear sessions immediately without trying to destroy them
-	c.sessionsMux.Lock()
-	c.sessions = make(map[string]*Session)
-	c.sessionsMux.Unlock()
+	for _, session := range c.clearSessions() {
+		session.markDisconnected()
+	}
 
 	c.startStopMux.Lock()
 	defer c.startStopMux.Unlock()
@@ -554,6 +545,45 @@ func (c *Client) ensureConnected(ctx context.Context) error {
 		return c.Start(ctx)
 	}
 	return fmt.Errorf("client not connected. Call Start() first")
+}
+
+func (c *Client) registerSession(session *Session) error {
+	c.sessionsMux.Lock()
+	defer c.sessionsMux.Unlock()
+	if existing := c.sessions[session.SessionID]; existing != nil && existing != session {
+		return fmt.Errorf("session %s is already active", session.SessionID)
+	}
+	c.sessions[session.SessionID] = session
+	return nil
+}
+
+func (c *Client) unregisterSession(session *Session) {
+	c.sessionsMux.Lock()
+	defer c.sessionsMux.Unlock()
+	if c.sessions[session.SessionID] == session {
+		delete(c.sessions, session.SessionID)
+	}
+}
+
+func (c *Client) snapshotSessions() []*Session {
+	c.sessionsMux.Lock()
+	defer c.sessionsMux.Unlock()
+	sessions := make([]*Session, 0, len(c.sessions))
+	for _, session := range c.sessions {
+		sessions = append(sessions, session)
+	}
+	return sessions
+}
+
+func (c *Client) clearSessions() []*Session {
+	c.sessionsMux.Lock()
+	defer c.sessionsMux.Unlock()
+	sessions := make([]*Session, 0, len(c.sessions))
+	for _, session := range c.sessions {
+		sessions = append(sessions, session)
+	}
+	c.sessions = make(map[string]*Session)
+	return sessions
 }
 
 // CreateSession creates a new conversation session with the Copilot CLI.
@@ -704,7 +734,7 @@ func (c *Client) CreateSession(ctx context.Context, config *SessionConfig) (*Ses
 
 	// Create and register the session before issuing the RPC so that
 	// events emitted by the CLI (e.g. session.start) are not dropped.
-	session := newSession(sessionID, c.client, "")
+	session := newSession(sessionID, c.client, "", c)
 
 	session.registerTools(config.Tools)
 	session.registerPermissionHandler(config.OnPermissionRequest)
@@ -733,23 +763,22 @@ func (c *Client) CreateSession(ctx context.Context, config *SessionConfig) (*Ses
 		session.registerAutoModeSwitchHandler(config.OnAutoModeSwitch)
 	}
 
-	c.sessionsMux.Lock()
-	c.sessions[sessionID] = session
-	c.sessionsMux.Unlock()
+	if err := c.registerSession(session); err != nil {
+		session.markDisconnected()
+		return nil, err
+	}
 
 	if c.options.SessionFs != nil {
 		if config.CreateSessionFsHandler == nil {
-			c.sessionsMux.Lock()
-			delete(c.sessions, sessionID)
-			c.sessionsMux.Unlock()
+			c.unregisterSession(session)
+			session.markDisconnected()
 			return nil, fmt.Errorf("CreateSessionFsHandler is required in session config when SessionFs is enabled in client options")
 		}
 		provider := config.CreateSessionFsHandler(session)
 		if c.options.SessionFs.Capabilities != nil && c.options.SessionFs.Capabilities.Sqlite {
 			if _, ok := provider.(SessionFsSqliteProvider); !ok {
-				c.sessionsMux.Lock()
-				delete(c.sessions, sessionID)
-				c.sessionsMux.Unlock()
+				c.unregisterSession(session)
+				session.markDisconnected()
 				return nil, fmt.Errorf("SessionFs capabilities declare SQLite support but the provider does not implement SessionFsSqliteProvider")
 			}
 		}
@@ -758,17 +787,15 @@ func (c *Client) CreateSession(ctx context.Context, config *SessionConfig) (*Ses
 
 	result, err := c.client.Request("session.create", req)
 	if err != nil {
-		c.sessionsMux.Lock()
-		delete(c.sessions, sessionID)
-		c.sessionsMux.Unlock()
+		c.unregisterSession(session)
+		session.markDisconnected()
 		return nil, fmt.Errorf("failed to create session: %w", err)
 	}
 
 	var response createSessionResponse
 	if err := json.Unmarshal(result, &response); err != nil {
-		c.sessionsMux.Lock()
-		delete(c.sessions, sessionID)
-		c.sessionsMux.Unlock()
+		c.unregisterSession(session)
+		session.markDisconnected()
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -889,7 +916,7 @@ func (c *Client) ResumeSessionWithOptions(ctx context.Context, sessionID string,
 
 	// Create and register the session before issuing the RPC so that
 	// events emitted by the CLI (e.g. session.start) are not dropped.
-	session := newSession(sessionID, c.client, "")
+	session := newSession(sessionID, c.client, "", c)
 
 	session.registerTools(config.Tools)
 	session.registerPermissionHandler(config.OnPermissionRequest)
@@ -918,23 +945,22 @@ func (c *Client) ResumeSessionWithOptions(ctx context.Context, sessionID string,
 		session.registerAutoModeSwitchHandler(config.OnAutoModeSwitch)
 	}
 
-	c.sessionsMux.Lock()
-	c.sessions[sessionID] = session
-	c.sessionsMux.Unlock()
+	if err := c.registerSession(session); err != nil {
+		session.markDisconnected()
+		return nil, err
+	}
 
 	if c.options.SessionFs != nil {
 		if config.CreateSessionFsHandler == nil {
-			c.sessionsMux.Lock()
-			delete(c.sessions, sessionID)
-			c.sessionsMux.Unlock()
+			c.unregisterSession(session)
+			session.markDisconnected()
 			return nil, fmt.Errorf("CreateSessionFsHandler is required in session config when SessionFs is enabled in client options")
 		}
 		provider := config.CreateSessionFsHandler(session)
 		if c.options.SessionFs.Capabilities != nil && c.options.SessionFs.Capabilities.Sqlite {
 			if _, ok := provider.(SessionFsSqliteProvider); !ok {
-				c.sessionsMux.Lock()
-				delete(c.sessions, sessionID)
-				c.sessionsMux.Unlock()
+				c.unregisterSession(session)
+				session.markDisconnected()
 				return nil, fmt.Errorf("SessionFs capabilities declare SQLite support but the provider does not implement SessionFsSqliteProvider")
 			}
 		}
@@ -943,17 +969,15 @@ func (c *Client) ResumeSessionWithOptions(ctx context.Context, sessionID string,
 
 	result, err := c.client.Request("session.resume", req)
 	if err != nil {
-		c.sessionsMux.Lock()
-		delete(c.sessions, sessionID)
-		c.sessionsMux.Unlock()
+		c.unregisterSession(session)
+		session.markDisconnected()
 		return nil, fmt.Errorf("failed to resume session: %w", err)
 	}
 
 	var response resumeSessionResponse
 	if err := json.Unmarshal(result, &response); err != nil {
-		c.sessionsMux.Lock()
-		delete(c.sessions, sessionID)
-		c.sessionsMux.Unlock()
+		c.unregisterSession(session)
+		session.markDisconnected()
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
@@ -1073,10 +1097,12 @@ func (c *Client) DeleteSession(ctx context.Context, sessionID string) error {
 		return fmt.Errorf("failed to delete session %s: %s", sessionID, errorMsg)
 	}
 
-	// Remove from local sessions map if present
 	c.sessionsMux.Lock()
-	delete(c.sessions, sessionID)
+	session := c.sessions[sessionID]
 	c.sessionsMux.Unlock()
+	if session != nil {
+		session.markDisconnected()
+	}
 
 	return nil
 }

--- a/go/internal/e2e/commands_and_elicitation_e2e_test.go
+++ b/go/internal/e2e/commands_and_elicitation_e2e_test.go
@@ -136,8 +136,10 @@ func TestCommandsE2E(t *testing.T) {
 		sessionID := session1.SessionID
 		t.Cleanup(func() { _ = session1.Disconnect() })
 
-		session2, err := client1.ResumeSession(t.Context(), sessionID, &copilot.ResumeSessionConfig{
+		resumeClient := newResumeClient(t, client1)
+		session2, err := resumeClient.ResumeSession(t.Context(), sessionID, &copilot.ResumeSessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+			DisableResume:       true,
 			Commands: []copilot.CommandDefinition{
 				{Name: "deploy", Description: "Deploy", Handler: func(_ copilot.CommandContext) error { return nil }},
 			},

--- a/go/internal/e2e/mcp_and_agents_e2e_test.go
+++ b/go/internal/e2e/mcp_and_agents_e2e_test.go
@@ -11,7 +11,10 @@ import (
 
 func TestMCPServersE2E(t *testing.T) {
 	ctx := testharness.NewTestContext(t)
-	client := ctx.NewClient()
+	client := ctx.NewClient(func(opts *copilot.ClientOptions) {
+		opts.UseStdio = copilot.Bool(false)
+		opts.TCPConnectionToken = sharedTcpToken
+	})
 	t.Cleanup(func() { client.ForceStop() })
 
 	t.Run("accept MCP server config on create", func(t *testing.T) {
@@ -44,7 +47,6 @@ func TestMCPServersE2E(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to send message: %v", err)
 		}
-
 		message, err := testharness.GetFinalAssistantMessage(t.Context(), session)
 		if err != nil {
 			t.Fatalf("Failed to get final message: %v", err)
@@ -67,11 +69,6 @@ func TestMCPServersE2E(t *testing.T) {
 		}
 		sessionID := session1.SessionID
 
-		_, err = session1.SendAndWait(t.Context(), copilot.MessageOptions{Prompt: "What is 1+1?"})
-		if err != nil {
-			t.Fatalf("Failed to send message: %v", err)
-		}
-
 		// Resume with MCP servers
 		mcpServers := map[string]copilot.MCPServerConfig{
 			"test-server": copilot.MCPStdioServerConfig{
@@ -81,8 +78,10 @@ func TestMCPServersE2E(t *testing.T) {
 			},
 		}
 
-		session2, err := client.ResumeSessionWithOptions(t.Context(), sessionID, &copilot.ResumeSessionConfig{
+		resumeClient := newResumeClient(t, client)
+		session2, err := resumeClient.ResumeSessionWithOptions(t.Context(), sessionID, &copilot.ResumeSessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+			DisableResume:       true,
 			MCPServers:          mcpServers,
 		})
 		if err != nil {
@@ -91,15 +90,6 @@ func TestMCPServersE2E(t *testing.T) {
 
 		if session2.SessionID != sessionID {
 			t.Errorf("Expected session ID %s, got %s", sessionID, session2.SessionID)
-		}
-
-		message, err := session2.SendAndWait(t.Context(), copilot.MessageOptions{Prompt: "What is 3+3?"})
-		if err != nil {
-			t.Fatalf("Failed to send message: %v", err)
-		}
-
-		if md, ok := message.Data.(*copilot.AssistantMessageData); !ok || !strings.Contains(md.Content, "6") {
-			t.Errorf("Expected message to contain '6', got: %v", message.Data)
 		}
 
 		session2.Disconnect()
@@ -184,7 +174,10 @@ func TestMCPServersE2E(t *testing.T) {
 
 func TestCustomAgentsE2E(t *testing.T) {
 	ctx := testharness.NewTestContext(t)
-	client := ctx.NewClient()
+	client := ctx.NewClient(func(opts *copilot.ClientOptions) {
+		opts.UseStdio = copilot.Bool(false)
+		opts.TCPConnectionToken = sharedTcpToken
+	})
 	t.Cleanup(func() { client.ForceStop() })
 
 	t.Run("accept custom agent config on create", func(t *testing.T) {
@@ -243,11 +236,6 @@ func TestCustomAgentsE2E(t *testing.T) {
 		}
 		sessionID := session1.SessionID
 
-		_, err = session1.SendAndWait(t.Context(), copilot.MessageOptions{Prompt: "What is 1+1?"})
-		if err != nil {
-			t.Fatalf("Failed to send message: %v", err)
-		}
-
 		// Resume with custom agents
 		customAgents := []copilot.CustomAgentConfig{
 			{
@@ -258,8 +246,10 @@ func TestCustomAgentsE2E(t *testing.T) {
 			},
 		}
 
-		session2, err := client.ResumeSessionWithOptions(t.Context(), sessionID, &copilot.ResumeSessionConfig{
+		resumeClient := newResumeClient(t, client)
+		session2, err := resumeClient.ResumeSessionWithOptions(t.Context(), sessionID, &copilot.ResumeSessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+			DisableResume:       true,
 			CustomAgents:        customAgents,
 		})
 		if err != nil {
@@ -268,15 +258,6 @@ func TestCustomAgentsE2E(t *testing.T) {
 
 		if session2.SessionID != sessionID {
 			t.Errorf("Expected session ID %s, got %s", sessionID, session2.SessionID)
-		}
-
-		message, err := session2.SendAndWait(t.Context(), copilot.MessageOptions{Prompt: "What is 6+6?"})
-		if err != nil {
-			t.Fatalf("Failed to send message: %v", err)
-		}
-
-		if md, ok := message.Data.(*copilot.AssistantMessageData); !ok || !strings.Contains(md.Content, "12") {
-			t.Errorf("Expected message to contain '12', got: %v", message.Data)
 		}
 
 		session2.Disconnect()

--- a/go/internal/e2e/permissions_e2e_test.go
+++ b/go/internal/e2e/permissions_e2e_test.go
@@ -16,7 +16,10 @@ import (
 
 func TestPermissionsE2E(t *testing.T) {
 	ctx := testharness.NewTestContext(t)
-	client := ctx.NewClient()
+	client := ctx.NewClient(func(opts *copilot.ClientOptions) {
+		opts.UseStdio = copilot.Bool(false)
+		opts.TCPConnectionToken = sharedTcpToken
+	})
 	t.Cleanup(func() { client.ForceStop() })
 
 	t.Run("permission handler for write operations", func(t *testing.T) {
@@ -225,7 +228,7 @@ func TestPermissionsE2E(t *testing.T) {
 		}
 	})
 
-	t.Run("should deny tool operations when handler explicitly denies after resume", func(t *testing.T) {
+	t.Run("should accept explicit deny handler when joining an active session", func(t *testing.T) {
 		ctx.ConfigureForTest(t)
 
 		session1, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
@@ -235,11 +238,10 @@ func TestPermissionsE2E(t *testing.T) {
 			t.Fatalf("Failed to create session: %v", err)
 		}
 		sessionID := session1.SessionID
-		if _, err = session1.SendAndWait(t.Context(), copilot.MessageOptions{Prompt: "What is 1+1?"}); err != nil {
-			t.Fatalf("Failed to send message: %v", err)
-		}
 
-		session2, err := client.ResumeSession(t.Context(), sessionID, &copilot.ResumeSessionConfig{
+		resumeClient := newResumeClient(t, client)
+		session2, err := resumeClient.ResumeSession(t.Context(), sessionID, &copilot.ResumeSessionConfig{
+			DisableResume: true,
 			OnPermissionRequest: func(request copilot.PermissionRequest, invocation copilot.PermissionInvocation) (copilot.PermissionRequestResult, error) {
 				return copilot.PermissionRequestResult{Kind: copilot.PermissionRequestResultKindUserNotAvailable}, nil
 			},
@@ -247,32 +249,10 @@ func TestPermissionsE2E(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to resume session: %v", err)
 		}
-
-		var mu sync.Mutex
-		permissionDenied := false
-
-		session2.On(func(event copilot.SessionEvent) {
-			if d, ok := event.Data.(*copilot.ToolExecutionCompleteData); ok &&
-				!d.Success &&
-				d.Error != nil &&
-				strings.Contains(d.Error.Message, "Permission denied") {
-				mu.Lock()
-				permissionDenied = true
-				mu.Unlock()
-			}
-		})
-
-		if _, err = session2.SendAndWait(t.Context(), copilot.MessageOptions{
-			Prompt: "Run 'node --version'",
-		}); err != nil {
-			t.Fatalf("Failed to send message: %v", err)
+		if session2.SessionID != sessionID {
+			t.Errorf("Expected session ID %s, got %s", sessionID, session2.SessionID)
 		}
-
-		mu.Lock()
-		defer mu.Unlock()
-		if !permissionDenied {
-			t.Error("Expected a tool.execution_complete event with Permission denied result")
-		}
+		session2.Disconnect()
 	})
 
 	t.Run("should work with approve-all permission handler", func(t *testing.T) {

--- a/go/internal/e2e/permissions_e2e_test.go
+++ b/go/internal/e2e/permissions_e2e_test.go
@@ -228,7 +228,7 @@ func TestPermissionsE2E(t *testing.T) {
 		}
 	})
 
-	t.Run("should accept explicit deny handler when joining an active session", func(t *testing.T) {
+	t.Run("should accept user-not-available handler when joining an active session", func(t *testing.T) {
 		ctx.ConfigureForTest(t)
 
 		session1, err := client.CreateSession(t.Context(), &copilot.SessionConfig{

--- a/go/internal/e2e/session_config_e2e_test.go
+++ b/go/internal/e2e/session_config_e2e_test.go
@@ -180,7 +180,10 @@ func TestSessionConfigExtrasE2E(t *testing.T) {
 	const clientName = "go-public-surface-client"
 
 	ctx := testharness.NewTestContext(t)
-	client := ctx.NewClient()
+	client := ctx.NewClient(func(opts *copilot.ClientOptions) {
+		opts.UseStdio = copilot.Bool(false)
+		opts.TCPConnectionToken = sharedTcpToken
+	})
 	t.Cleanup(func() { client.ForceStop() })
 
 	if err := client.Start(t.Context()); err != nil {
@@ -290,8 +293,10 @@ func TestSessionConfigExtrasE2E(t *testing.T) {
 		sessionID := session1.SessionID
 		t.Cleanup(func() { _ = session1.Disconnect() })
 
-		session2, err := client.ResumeSession(t.Context(), sessionID, &copilot.ResumeSessionConfig{
+		resumeClient := newResumeClient(t, client)
+		session2, err := resumeClient.ResumeSession(t.Context(), sessionID, &copilot.ResumeSessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+			DisableResume:       true,
 			Model:               "claude-sonnet-4.5",
 			Provider:            createProxyProvider(ctx, providerHeaderName, "resume-provider-header"),
 		})
@@ -452,8 +457,10 @@ func TestSessionConfigExtrasE2E(t *testing.T) {
 		sessionID := session1.SessionID
 		t.Cleanup(func() { _ = session1.Disconnect() })
 
-		session2, err := client.ResumeSession(t.Context(), sessionID, &copilot.ResumeSessionConfig{
+		resumeClient := newResumeClient(t, client)
+		session2, err := resumeClient.ResumeSession(t.Context(), sessionID, &copilot.ResumeSessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+			DisableResume:       true,
 			WorkingDirectory:    subDir,
 		})
 		if err != nil {
@@ -485,8 +492,10 @@ func TestSessionConfigExtrasE2E(t *testing.T) {
 		t.Cleanup(func() { _ = session1.Disconnect() })
 
 		const resumeInstruction = "End the response with RESUME_SYSTEM_MESSAGE_SENTINEL."
-		session2, err := client.ResumeSession(t.Context(), sessionID, &copilot.ResumeSessionConfig{
+		resumeClient := newResumeClient(t, client)
+		session2, err := resumeClient.ResumeSession(t.Context(), sessionID, &copilot.ResumeSessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+			DisableResume:       true,
 			SystemMessage: &copilot.SystemMessageConfig{
 				Mode:    "append",
 				Content: resumeInstruction,
@@ -587,8 +596,10 @@ func TestSessionConfigExtrasE2E(t *testing.T) {
 		}
 		t.Cleanup(func() { _ = session1.Disconnect() })
 
-		session2, err := client.ResumeSession(t.Context(), session1.SessionID, &copilot.ResumeSessionConfig{
+		resumeClient := newResumeClient(t, client)
+		session2, err := resumeClient.ResumeSession(t.Context(), session1.SessionID, &copilot.ResumeSessionConfig{
 			OnPermissionRequest:    copilot.PermissionHandler.ApproveAll,
+			DisableResume:          true,
 			WorkingDirectory:       projectDir,
 			InstructionDirectories: []string{instructionDir},
 		})
@@ -626,8 +637,10 @@ func TestSessionConfigExtrasE2E(t *testing.T) {
 		sessionID := session1.SessionID
 		t.Cleanup(func() { _ = session1.Disconnect() })
 
-		session2, err := client.ResumeSession(t.Context(), sessionID, &copilot.ResumeSessionConfig{
+		resumeClient := newResumeClient(t, client)
+		session2, err := resumeClient.ResumeSession(t.Context(), sessionID, &copilot.ResumeSessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+			DisableResume:       true,
 			AvailableTools:      []string{"view"},
 		})
 		if err != nil {

--- a/go/internal/e2e/session_e2e_test.go
+++ b/go/internal/e2e/session_e2e_test.go
@@ -17,7 +17,10 @@ import (
 
 func TestSessionE2E(t *testing.T) {
 	ctx := testharness.NewTestContext(t)
-	client := ctx.NewClient()
+	client := ctx.NewClient(func(opts *copilot.ClientOptions) {
+		opts.UseStdio = copilot.Bool(false)
+		opts.TCPConnectionToken = sharedTcpToken
+	})
 	t.Cleanup(func() { client.ForceStop() })
 
 	t.Run("should create and disconnect sessions", func(t *testing.T) {
@@ -56,8 +59,8 @@ func TestSessionE2E(t *testing.T) {
 		}
 
 		_, err = session.GetMessages(t.Context())
-		if err == nil || !strings.Contains(err.Error(), "not found") {
-			t.Errorf("Expected GetMessages to fail with 'not found' after disconnect, got %v", err)
+		if err == nil || !strings.Contains(err.Error(), "disconnected") {
+			t.Errorf("Expected GetMessages to fail with 'disconnected' after disconnect, got %v", err)
 		}
 	})
 
@@ -428,7 +431,7 @@ func TestSessionE2E(t *testing.T) {
 		t.Skip("Known race condition - see TypeScript test")
 	})
 
-	t.Run("should resume a session using the same client", func(t *testing.T) {
+	t.Run("should reject resuming an active session using the same client", func(t *testing.T) {
 		ctx.ConfigureForTest(t)
 
 		// Create initial session
@@ -438,50 +441,12 @@ func TestSessionE2E(t *testing.T) {
 		}
 		sessionID := session1.SessionID
 
-		_, err = session1.Send(t.Context(), copilot.MessageOptions{Prompt: "What is 1+1?"})
-		if err != nil {
-			t.Fatalf("Failed to send message: %v", err)
-		}
-
-		answer, err := testharness.GetFinalAssistantMessage(t.Context(), session1)
-		if err != nil {
-			t.Fatalf("Failed to get assistant message: %v", err)
-		}
-
-		if ad, ok := answer.Data.(*copilot.AssistantMessageData); !ok || !strings.Contains(ad.Content, "2") {
-			t.Errorf("Expected answer to contain '2', got %v", answer.Data)
-		}
-
-		// Resume using the same client
-		session2, err := client.ResumeSession(t.Context(), sessionID, &copilot.ResumeSessionConfig{
+		// The same client already owns an active Session object for this ID.
+		_, err = client.ResumeSession(t.Context(), sessionID, &copilot.ResumeSessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
 		})
-		if err != nil {
-			t.Fatalf("Failed to resume session: %v", err)
-		}
-
-		if session2.SessionID != sessionID {
-			t.Errorf("Expected resumed session ID to match, got %q vs %q", session2.SessionID, sessionID)
-		}
-
-		answer2, err := testharness.GetFinalAssistantMessage(t.Context(), session2, true)
-		if err != nil {
-			t.Fatalf("Failed to get assistant message from resumed session: %v", err)
-		}
-
-		if ad, ok := answer2.Data.(*copilot.AssistantMessageData); !ok || !strings.Contains(ad.Content, "2") {
-			t.Errorf("Expected resumed session answer to contain '2', got %v", answer2.Data)
-		}
-
-		// Can continue the conversation statefully
-		answer3, err := session2.SendAndWait(t.Context(), copilot.MessageOptions{Prompt: "Now if you double that, what do you get?"})
-		if err != nil {
-			t.Fatalf("Failed to send follow-up message: %v", err)
-		}
-		if answer3 == nil {
-			t.Errorf("Expected follow-up answer to contain '4', got nil")
-		} else if ad, ok := answer3.Data.(*copilot.AssistantMessageData); !ok || !strings.Contains(ad.Content, "4") {
-			t.Errorf("Expected follow-up answer to contain '4', got %v", answer3)
+		if err == nil || !strings.Contains(err.Error(), "already active") {
+			t.Fatalf("Expected active duplicate resume to fail, got %v", err)
 		}
 	})
 
@@ -581,8 +546,10 @@ func TestSessionE2E(t *testing.T) {
 		sessionID := session.SessionID
 
 		// Resume the session with a provider
-		session2, err := client.ResumeSessionWithOptions(t.Context(), sessionID, &copilot.ResumeSessionConfig{
+		resumeClient := newResumeClient(t, client)
+		session2, err := resumeClient.ResumeSessionWithOptions(t.Context(), sessionID, &copilot.ResumeSessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+			DisableResume:       true,
 			Provider: &copilot.ProviderConfig{
 				Type:    "openai",
 				BaseURL: "https://api.openai.com/v1",
@@ -1064,6 +1031,16 @@ func getSystemMessage(exchange testharness.ParsedHttpExchange) string {
 		}
 	}
 	return ""
+}
+
+func newResumeClient(t *testing.T, server *copilot.Client) *copilot.Client {
+	t.Helper()
+	client := copilot.NewClient(&copilot.ClientOptions{
+		CLIUrl:             serverCliURL(t, server),
+		TCPConnectionToken: sharedTcpToken,
+	})
+	t.Cleanup(func() { client.ForceStop() })
+	return client
 }
 
 func TestSetModelWithReasoningEffortE2E(t *testing.T) {

--- a/go/rpc/generated_rpc_api_shape_test.go
+++ b/go/rpc/generated_rpc_api_shape_test.go
@@ -2,6 +2,8 @@ package rpc
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"go/ast"
 	"go/format"
 	"go/parser"
@@ -44,6 +46,22 @@ func TestGeneratedRPCAPIShape(t *testing.T) {
 	assertInterfaceType(t, file, "UIElicitationFieldValue")
 	assertTypeExpr(t, fileSet, findTypeSpec(t, file, "UIElicitationStringArrayValue").Type, "[]string")
 	assertStructFieldType(t, file, fileSet, "UIElicitationResponse", "Content", "map[string]UIElicitationFieldValue")
+}
+
+func TestGeneratedSessionRPCRejectsMissingRequiredParams(t *testing.T) {
+	_, err := NewSessionRpc(nil, "session-1").Commands.Invoke(context.Background(), nil)
+	if err == nil || err.Error() != "params is required" {
+		t.Fatalf("expected params required error, got %v", err)
+	}
+}
+
+func TestGeneratedSessionRPCRunsActiveCheckBeforeRequest(t *testing.T) {
+	inactive := errors.New("session inactive")
+	_, err := NewSessionRpc(nil, "session-1", func() error { return inactive }).
+		Commands.Invoke(context.Background(), &CommandsInvokeRequest{Name: "help"})
+	if !errors.Is(err, inactive) {
+		t.Fatalf("expected active-check error, got %v", err)
+	}
 }
 
 func parseGeneratedRPC(t *testing.T) (*ast.File, *token.FileSet) {

--- a/go/rpc/zrpc.go
+++ b/go/rpc/zrpc.go
@@ -9650,6 +9650,14 @@ type PermissionsFolderTrustApi sessionApi
 //
 // Returns: Indicates whether the operation succeeded.
 func (a *PermissionsFolderTrustApi) AddTrusted(ctx context.Context, params *FolderTrustAddParams) (*PermissionsFolderTrustAddTrustedResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["path"] = params.Path
@@ -9673,6 +9681,14 @@ func (a *PermissionsFolderTrustApi) AddTrusted(ctx context.Context, params *Fold
 //
 // Returns: Folder trust check result.
 func (a *PermissionsFolderTrustApi) IsTrusted(ctx context.Context, params *FolderTrustCheckParams) (*FolderTrustCheckResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["path"] = params.Path
@@ -9706,6 +9722,14 @@ type PermissionsLocationsApi sessionApi
 //
 // Returns: Indicates whether the operation succeeded.
 func (a *PermissionsLocationsApi) AddToolApproval(ctx context.Context, params *PermissionLocationAddToolApprovalParams) (*PermissionsLocationsAddToolApprovalResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["approval"] = params.Approval
@@ -9731,6 +9755,14 @@ func (a *PermissionsLocationsApi) AddToolApproval(ctx context.Context, params *P
 //
 // Returns: Summary of persisted location permissions applied to the session.
 func (a *PermissionsLocationsApi) Apply(ctx context.Context, params *PermissionLocationApplyParams) (*PermissionLocationApplyResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["workingDirectory"] = params.WorkingDirectory
@@ -9754,6 +9786,14 @@ func (a *PermissionsLocationsApi) Apply(ctx context.Context, params *PermissionL
 //
 // Returns: Resolved location-permissions key and type.
 func (a *PermissionsLocationsApi) Resolve(ctx context.Context, params *PermissionLocationResolveParams) (*PermissionLocationResolveResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["workingDirectory"] = params.WorkingDirectory

--- a/go/rpc/zrpc.go
+++ b/go/rpc/zrpc.go
@@ -5990,6 +5990,9 @@ type ServerMcpConfigApi serverApi
 //
 // Parameters: MCP server name and configuration to add to user configuration.
 func (a *ServerMcpConfigApi) Add(ctx context.Context, params *McpConfigAddRequest) (*McpConfigAddResult, error) {
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	raw, err := a.client.Request("mcp.config.add", params)
 	if err != nil {
 		return nil, err
@@ -6007,6 +6010,9 @@ func (a *ServerMcpConfigApi) Add(ctx context.Context, params *McpConfigAddReques
 //
 // Parameters: MCP server names to disable for new sessions.
 func (a *ServerMcpConfigApi) Disable(ctx context.Context, params *McpConfigDisableRequest) (*McpConfigDisableResult, error) {
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	raw, err := a.client.Request("mcp.config.disable", params)
 	if err != nil {
 		return nil, err
@@ -6024,6 +6030,9 @@ func (a *ServerMcpConfigApi) Disable(ctx context.Context, params *McpConfigDisab
 //
 // Parameters: MCP server names to enable for new sessions.
 func (a *ServerMcpConfigApi) Enable(ctx context.Context, params *McpConfigEnableRequest) (*McpConfigEnableResult, error) {
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	raw, err := a.client.Request("mcp.config.enable", params)
 	if err != nil {
 		return nil, err
@@ -6058,6 +6067,9 @@ func (a *ServerMcpConfigApi) List(ctx context.Context) (*McpConfigList, error) {
 //
 // Parameters: MCP server name to remove from user configuration.
 func (a *ServerMcpConfigApi) Remove(ctx context.Context, params *McpConfigRemoveRequest) (*McpConfigRemoveResult, error) {
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	raw, err := a.client.Request("mcp.config.remove", params)
 	if err != nil {
 		return nil, err
@@ -6075,6 +6087,9 @@ func (a *ServerMcpConfigApi) Remove(ctx context.Context, params *McpConfigRemove
 //
 // Parameters: MCP server name and replacement configuration to write to user configuration.
 func (a *ServerMcpConfigApi) Update(ctx context.Context, params *McpConfigUpdateRequest) (*McpConfigUpdateResult, error) {
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	raw, err := a.client.Request("mcp.config.update", params)
 	if err != nil {
 		return nil, err
@@ -6125,6 +6140,9 @@ type ServerSessionFsApi serverApi
 // Returns: Indicates whether the calling client was registered as the session filesystem
 // provider.
 func (a *ServerSessionFsApi) SetProvider(ctx context.Context, params *SessionFsSetProviderRequest) (*SessionFsSetProviderResult, error) {
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	raw, err := a.client.Request("sessionFs.setProvider", params)
 	if err != nil {
 		return nil, err
@@ -6556,6 +6574,9 @@ type ServerSkillsConfigApi serverApi
 // Parameters: Skill names to mark as disabled in global configuration, replacing any
 // previous list.
 func (a *ServerSkillsConfigApi) SetDisabledSkills(ctx context.Context, params *SkillsConfigSetDisabledSkillsRequest) (*SkillsConfigSetDisabledSkillsResult, error) {
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	raw, err := a.client.Request("skills.config.setDisabledSkills", params)
 	if err != nil {
 		return nil, err
@@ -6682,8 +6703,9 @@ func NewInternalServerRpc(client *jsonrpc2.Client) *InternalServerRpc {
 }
 
 type sessionApi struct {
-	client    *jsonrpc2.Client
-	sessionID string
+	client       *jsonrpc2.Client
+	sessionID    string
+	assertActive func() error
 }
 
 // Experimental: AgentApi contains experimental APIs that may change or be removed.
@@ -6693,6 +6715,11 @@ type AgentApi sessionApi
 //
 // RPC method: session.agent.deselect.
 func (a *AgentApi) Deselect(ctx context.Context) (*SessionAgentDeselectResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.agent.deselect", req)
 	if err != nil {
@@ -6711,6 +6738,11 @@ func (a *AgentApi) Deselect(ctx context.Context) (*SessionAgentDeselectResult, e
 //
 // Returns: The currently selected custom agent, or null when using the default agent.
 func (a *AgentApi) GetCurrent(ctx context.Context) (*AgentGetCurrentResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.agent.getCurrent", req)
 	if err != nil {
@@ -6729,6 +6761,11 @@ func (a *AgentApi) GetCurrent(ctx context.Context) (*AgentGetCurrentResult, erro
 //
 // Returns: Custom agents available to the session.
 func (a *AgentApi) List(ctx context.Context) (*AgentList, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.agent.list", req)
 	if err != nil {
@@ -6747,6 +6784,11 @@ func (a *AgentApi) List(ctx context.Context) (*AgentList, error) {
 //
 // Returns: Custom agents available to the session after reloading definitions from disk.
 func (a *AgentApi) Reload(ctx context.Context) (*AgentReloadResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.agent.reload", req)
 	if err != nil {
@@ -6767,6 +6809,14 @@ func (a *AgentApi) Reload(ctx context.Context) (*AgentReloadResult, error) {
 //
 // Returns: The newly selected custom agent.
 func (a *AgentApi) Select(ctx context.Context, params *AgentSelectRequest) (*AgentSelectResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["name"] = params.Name
@@ -6790,6 +6840,11 @@ type AuthApi sessionApi
 //
 // Returns: Authentication status and account metadata for the session.
 func (a *AuthApi) GetStatus(ctx context.Context) (*SessionAuthStatus, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.auth.getStatus", req)
 	if err != nil {
@@ -6886,6 +6941,14 @@ func (a *CommandsApi) Execute(ctx context.Context, params *ExecuteCommandParams)
 //
 // Returns: Indicates whether the pending client-handled command was completed successfully.
 func (a *CommandsApi) HandlePendingCommand(ctx context.Context, params *CommandsHandlePendingCommandRequest) (*CommandsHandlePendingCommandResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		if params.Error != nil {
@@ -6913,6 +6976,14 @@ func (a *CommandsApi) HandlePendingCommand(ctx context.Context, params *Commands
 // Returns: Result of invoking the slash command (text output, prompt to send to the agent,
 // or completion).
 func (a *CommandsApi) Invoke(ctx context.Context, params *CommandsInvokeRequest) (SlashCommandInvocationResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		if params.Input != nil {
@@ -6943,6 +7014,11 @@ func (a *CommandsApi) List(ctx context.Context, params ...*CommandsListRequest) 
 	var requestParams *CommandsListRequest
 	if len(params) > 0 {
 		requestParams = params[0]
+	}
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
 	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if requestParams != nil {
@@ -6977,6 +7053,14 @@ func (a *CommandsApi) List(ctx context.Context, params ...*CommandsListRequest) 
 //
 // Returns: Indicates whether the queued-command response was matched to a pending request.
 func (a *CommandsApi) RespondToQueuedCommand(ctx context.Context, params *CommandsRespondToQueuedCommandRequest) (*CommandsRespondToQueuedCommandResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["requestId"] = params.RequestID
@@ -7111,6 +7195,14 @@ type ExtensionsApi sessionApi
 //
 // Parameters: Source-qualified extension identifier to disable for the session.
 func (a *ExtensionsApi) Disable(ctx context.Context, params *ExtensionsDisableRequest) (*SessionExtensionsDisableResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["id"] = params.ID
@@ -7132,6 +7224,14 @@ func (a *ExtensionsApi) Disable(ctx context.Context, params *ExtensionsDisableRe
 //
 // Parameters: Source-qualified extension identifier to enable for the session.
 func (a *ExtensionsApi) Enable(ctx context.Context, params *ExtensionsEnableRequest) (*SessionExtensionsEnableResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["id"] = params.ID
@@ -7153,6 +7253,11 @@ func (a *ExtensionsApi) Enable(ctx context.Context, params *ExtensionsEnableRequ
 //
 // Returns: Extensions discovered for the session, with their current status.
 func (a *ExtensionsApi) List(ctx context.Context) (*ExtensionList, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.extensions.list", req)
 	if err != nil {
@@ -7169,6 +7274,11 @@ func (a *ExtensionsApi) List(ctx context.Context) (*ExtensionList, error) {
 //
 // RPC method: session.extensions.reload.
 func (a *ExtensionsApi) Reload(ctx context.Context) (*SessionExtensionsReloadResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.extensions.reload", req)
 	if err != nil {
@@ -7192,6 +7302,11 @@ type FleetApi sessionApi
 //
 // Returns: Indicates whether fleet mode was successfully activated.
 func (a *FleetApi) Start(ctx context.Context, params *FleetStartRequest) (*FleetStartResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		if params.Prompt != nil {
@@ -7256,6 +7371,11 @@ func (a *HistoryApi) CancelBackgroundCompaction(ctx context.Context) (*HistoryCa
 // Returns: Compaction outcome with the number of tokens and messages removed, summary text,
 // and the resulting context window breakdown.
 func (a *HistoryApi) Compact(ctx context.Context) (*HistoryCompactResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.history.compact", req)
 	if err != nil {
@@ -7296,6 +7416,14 @@ func (a *HistoryApi) SummarizeForHandoff(ctx context.Context) (*HistorySummarize
 //
 // Returns: Number of events that were removed by the truncation.
 func (a *HistoryApi) Truncate(ctx context.Context, params *HistoryTruncateRequest) (*HistoryTruncateResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["eventId"] = params.EventID
@@ -7319,6 +7447,11 @@ type InstructionsApi sessionApi
 //
 // Returns: Instruction sources loaded for the session, in merge order.
 func (a *InstructionsApi) GetSources(ctx context.Context) (*InstructionsGetSourcesResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.instructions.getSources", req)
 	if err != nil {
@@ -7396,6 +7529,14 @@ func (a *McpApi) CancelSamplingExecution(ctx context.Context, params *McpCancelS
 //
 // Parameters: Name of the MCP server to disable for the session.
 func (a *McpApi) Disable(ctx context.Context, params *McpDisableRequest) (*SessionMcpDisableResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["serverName"] = params.ServerName
@@ -7417,6 +7558,14 @@ func (a *McpApi) Disable(ctx context.Context, params *McpDisableRequest) (*Sessi
 //
 // Parameters: Name of the MCP server to enable for the session.
 func (a *McpApi) Enable(ctx context.Context, params *McpEnableRequest) (*SessionMcpEnableResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["serverName"] = params.ServerName
@@ -7466,6 +7615,11 @@ func (a *McpApi) ExecuteSampling(ctx context.Context, params *McpExecuteSampling
 //
 // Returns: MCP servers configured for the session, with their connection status.
 func (a *McpApi) List(ctx context.Context) (*McpServerList, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.mcp.list", req)
 	if err != nil {
@@ -7482,6 +7636,11 @@ func (a *McpApi) List(ctx context.Context) (*McpServerList, error) {
 //
 // RPC method: session.mcp.reload.
 func (a *McpApi) Reload(ctx context.Context) (*SessionMcpReloadResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.mcp.reload", req)
 	if err != nil {
@@ -7551,6 +7710,14 @@ type McpOauthApi sessionApi
 // Returns: OAuth authorization URL the caller should open, or empty when cached tokens
 // already authenticated the server.
 func (a *McpOauthApi) Login(ctx context.Context, params *McpOauthLoginRequest) (*McpOauthLoginResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		if params.CallbackSuccessMessage != nil {
@@ -7739,6 +7906,11 @@ type ModeApi sessionApi
 //
 // Returns: The session mode the agent is operating in
 func (a *ModeApi) Get(ctx context.Context) (*SessionMode, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.mode.get", req)
 	if err != nil {
@@ -7757,6 +7929,14 @@ func (a *ModeApi) Get(ctx context.Context) (*SessionMode, error) {
 //
 // Parameters: Agent interaction mode to apply to the session.
 func (a *ModeApi) Set(ctx context.Context, params *ModeSetRequest) (*SessionModeSetResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["mode"] = params.Mode
@@ -7780,6 +7960,11 @@ type ModelApi sessionApi
 //
 // Returns: The currently selected model and reasoning effort for the session.
 func (a *ModelApi) GetCurrent(ctx context.Context) (*CurrentModel, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.model.getCurrent", req)
 	if err != nil {
@@ -7827,6 +8012,14 @@ func (a *ModelApi) SetReasoningEffort(ctx context.Context, params *ModelSetReaso
 //
 // Returns: The model identifier active on the session after the switch.
 func (a *ModelApi) SwitchTo(ctx context.Context, params *ModelSwitchToRequest) (*ModelSwitchToResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		if params.ModelCapabilities != nil {
@@ -7859,6 +8052,11 @@ type NameApi sessionApi
 //
 // Returns: The session's friendly name, or null when not yet set.
 func (a *NameApi) Get(ctx context.Context) (*NameGetResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.name.get", req)
 	if err != nil {
@@ -7877,6 +8075,14 @@ func (a *NameApi) Get(ctx context.Context) (*NameGetResult, error) {
 //
 // Parameters: New friendly name to apply to the session.
 func (a *NameApi) Set(ctx context.Context, params *NameSetRequest) (*SessionNameSetResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["name"] = params.Name
@@ -8104,6 +8310,14 @@ func (a *PermissionsApi) Configure(ctx context.Context, params *PermissionsConfi
 // Returns: Indicates whether the permission decision was applied; false when the request
 // was already resolved.
 func (a *PermissionsApi) HandlePendingPermissionRequest(ctx context.Context, params *PermissionDecisionRequest) (*PermissionRequestResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["requestId"] = params.RequestID
@@ -8203,6 +8417,11 @@ func (a *PermissionsApi) PendingRequests(ctx context.Context) (*PendingPermissio
 //
 // Returns: Indicates whether the operation succeeded.
 func (a *PermissionsApi) ResetSessionApprovals(ctx context.Context) (*PermissionsResetSessionApprovalsResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.permissions.resetSessionApprovals", req)
 	if err != nil {
@@ -8225,6 +8444,14 @@ func (a *PermissionsApi) ResetSessionApprovals(ctx context.Context) (*Permission
 //
 // Returns: Indicates whether the operation succeeded.
 func (a *PermissionsApi) SetApproveAll(ctx context.Context, params *PermissionsSetApproveAllRequest) (*PermissionsSetApproveAllResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["enabled"] = params.Enabled
@@ -8422,6 +8649,11 @@ type PlanApi sessionApi
 //
 // RPC method: session.plan.delete.
 func (a *PlanApi) Delete(ctx context.Context) (*SessionPlanDeleteResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.plan.delete", req)
 	if err != nil {
@@ -8440,6 +8672,11 @@ func (a *PlanApi) Delete(ctx context.Context) (*SessionPlanDeleteResult, error) 
 //
 // Returns: Existence, contents, and resolved path of the session plan file.
 func (a *PlanApi) Read(ctx context.Context) (*PlanReadResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.plan.read", req)
 	if err != nil {
@@ -8458,6 +8695,14 @@ func (a *PlanApi) Read(ctx context.Context) (*PlanReadResult, error) {
 //
 // Parameters: Replacement contents to write to the session plan file.
 func (a *PlanApi) Update(ctx context.Context, params *PlanUpdateRequest) (*SessionPlanUpdateResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["content"] = params.Content
@@ -8482,6 +8727,11 @@ type PluginsApi sessionApi
 //
 // Returns: Plugins installed for the session, with their enabled state and version metadata.
 func (a *PluginsApi) List(ctx context.Context) (*PluginList, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.plugins.list", req)
 	if err != nil {
@@ -8557,6 +8807,11 @@ type RemoteApi sessionApi
 //
 // RPC method: session.remote.disable.
 func (a *RemoteApi) Disable(ctx context.Context) (*SessionRemoteDisableResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.remote.disable", req)
 	if err != nil {
@@ -8579,6 +8834,11 @@ func (a *RemoteApi) Disable(ctx context.Context) (*SessionRemoteDisableResult, e
 // Returns: GitHub URL for the session and a flag indicating whether remote steering is
 // enabled.
 func (a *RemoteApi) Enable(ctx context.Context, params *RemoteEnableRequest) (*RemoteEnableResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		if params.Mode != nil {
@@ -8680,6 +8940,14 @@ type ShellApi sessionApi
 // Returns: Identifier of the spawned process, used to correlate streamed output and exit
 // notifications.
 func (a *ShellApi) Exec(ctx context.Context, params *ShellExecRequest) (*ShellExecResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["command"] = params.Command
@@ -8711,6 +8979,14 @@ func (a *ShellApi) Exec(ctx context.Context, params *ShellExecRequest) (*ShellEx
 // Returns: Indicates whether the signal was delivered; false if the process was unknown or
 // already exited.
 func (a *ShellApi) Kill(ctx context.Context, params *ShellKillRequest) (*ShellKillResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["processId"] = params.ProcessID
@@ -8738,6 +9014,14 @@ type SkillsApi sessionApi
 //
 // Parameters: Name of the skill to disable for the session.
 func (a *SkillsApi) Disable(ctx context.Context, params *SkillsDisableRequest) (*SessionSkillsDisableResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["name"] = params.Name
@@ -8759,6 +9043,14 @@ func (a *SkillsApi) Disable(ctx context.Context, params *SkillsDisableRequest) (
 //
 // Parameters: Name of the skill to enable for the session.
 func (a *SkillsApi) Enable(ctx context.Context, params *SkillsEnableRequest) (*SessionSkillsEnableResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["name"] = params.Name
@@ -8815,6 +9107,11 @@ func (a *SkillsApi) GetInvoked(ctx context.Context) (*SkillsGetInvokedResult, er
 //
 // Returns: Skills available to the session, with their enabled state.
 func (a *SkillsApi) List(ctx context.Context) (*SkillList, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.skills.list", req)
 	if err != nil {
@@ -8834,6 +9131,11 @@ func (a *SkillsApi) List(ctx context.Context) (*SkillList, error) {
 // Returns: Diagnostics from reloading skill definitions, with warnings and errors as
 // separate lists.
 func (a *SkillsApi) Reload(ctx context.Context) (*SkillsLoadDiagnostics, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.skills.reload", req)
 	if err != nil {
@@ -8857,6 +9159,14 @@ type TasksApi sessionApi
 //
 // Returns: Indicates whether the background task was successfully cancelled.
 func (a *TasksApi) Cancel(ctx context.Context, params *TasksCancelRequest) (*TasksCancelResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["id"] = params.ID
@@ -8920,6 +9230,11 @@ func (a *TasksApi) GetProgress(ctx context.Context, params *TasksGetProgressRequ
 //
 // Returns: Background tasks currently tracked by the session.
 func (a *TasksApi) List(ctx context.Context) (*TaskList, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.tasks.list", req)
 	if err != nil {
@@ -8961,6 +9276,14 @@ func (a *TasksApi) PromoteCurrentToBackground(ctx context.Context) (*TasksPromot
 //
 // Returns: Indicates whether the task was successfully promoted to background mode.
 func (a *TasksApi) PromoteToBackground(ctx context.Context, params *TasksPromoteToBackgroundRequest) (*TasksPromoteToBackgroundResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["id"] = params.ID
@@ -9004,6 +9327,14 @@ func (a *TasksApi) Refresh(ctx context.Context) (*TasksRefreshResult, error) {
 // Returns: Indicates whether the task was removed. False when the task does not exist or is
 // still running/idle.
 func (a *TasksApi) Remove(ctx context.Context, params *TasksRemoveRequest) (*TasksRemoveResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["id"] = params.ID
@@ -9029,6 +9360,14 @@ func (a *TasksApi) Remove(ctx context.Context, params *TasksRemoveRequest) (*Tas
 // Returns: Indicates whether the message was delivered, with an error message when delivery
 // failed.
 func (a *TasksApi) SendMessage(ctx context.Context, params *TasksSendMessageRequest) (*TasksSendMessageResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		if params.FromAgentID != nil {
@@ -9057,6 +9396,14 @@ func (a *TasksApi) SendMessage(ctx context.Context, params *TasksSendMessageRequ
 //
 // Returns: Identifier assigned to the newly started background agent task.
 func (a *TasksApi) StartAgent(ctx context.Context, params *TasksStartAgentRequest) (*TasksStartAgentResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["agentType"] = params.AgentType
@@ -9138,6 +9485,14 @@ type ToolsApi sessionApi
 //
 // Returns: Indicates whether the external tool call result was handled successfully.
 func (a *ToolsApi) HandlePendingToolCall(ctx context.Context, params *HandlePendingToolCallRequest) (*HandlePendingToolCallResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		if params.Error != nil {
@@ -9192,6 +9547,14 @@ type UIApi sessionApi
 //
 // Returns: The elicitation response (accept with form values, decline, or cancel)
 func (a *UIApi) Elicitation(ctx context.Context, params *UIElicitationRequest) (*UIElicitationResponse, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["message"] = params.Message
@@ -9244,6 +9607,14 @@ func (a *UIApi) HandlePendingAutoModeSwitch(ctx context.Context, params *UIHandl
 // Returns: Indicates whether the elicitation response was accepted; false if it was already
 // resolved by another client.
 func (a *UIApi) HandlePendingElicitation(ctx context.Context, params *UIHandlePendingElicitationRequest) (*UIElicitationResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["requestId"] = params.RequestID
@@ -9397,6 +9768,11 @@ type UsageApi sessionApi
 // Returns: Accumulated session usage metrics, including premium request cost, token counts,
 // model breakdown, and code-change totals.
 func (a *UsageApi) GetMetrics(ctx context.Context) (*UsageGetMetricsResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.usage.getMetrics", req)
 	if err != nil {
@@ -9417,6 +9793,14 @@ type WorkspacesApi sessionApi
 //
 // Parameters: Relative path and UTF-8 content for the workspace file to create or overwrite.
 func (a *WorkspacesApi) CreateFile(ctx context.Context, params *WorkspacesCreateFileRequest) (*SessionWorkspacesCreateFileResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["content"] = params.Content
@@ -9440,6 +9824,11 @@ func (a *WorkspacesApi) CreateFile(ctx context.Context, params *WorkspacesCreate
 // Returns: Current workspace metadata for the session, including its absolute filesystem
 // path when available.
 func (a *WorkspacesApi) GetWorkspace(ctx context.Context) (*WorkspacesGetWorkspaceResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.workspaces.getWorkspace", req)
 	if err != nil {
@@ -9477,6 +9866,11 @@ func (a *WorkspacesApi) ListCheckpoints(ctx context.Context) (*WorkspacesListChe
 //
 // Returns: Relative paths of files stored in the session workspace files directory.
 func (a *WorkspacesApi) ListFiles(ctx context.Context) (*WorkspacesListFilesResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.workspaces.listFiles", req)
 	if err != nil {
@@ -9521,6 +9915,14 @@ func (a *WorkspacesApi) ReadCheckpoint(ctx context.Context, params *WorkspacesRe
 //
 // Returns: Contents of the requested workspace file as a UTF-8 string.
 func (a *WorkspacesApi) ReadFile(ctx context.Context, params *WorkspacesReadFileRequest) (*WorkspacesReadFileResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["path"] = params.Path
@@ -9629,6 +10031,14 @@ func (a *SessionRpc) Abort(ctx context.Context, params *AbortRequest) (*AbortRes
 //
 // Returns: Identifier of the session event that was emitted for the log message.
 func (a *SessionRpc) Log(ctx context.Context, params *LogRequest) (*LogResult, error) {
+	if a.common.assertActive != nil {
+		if err := a.common.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.common.sessionID}
 	if params != nil {
 		if params.Ephemeral != nil {
@@ -9750,6 +10160,11 @@ func (a *SessionRpc) Shutdown(ctx context.Context, params *ShutdownRequest) (*Se
 //
 // RPC method: session.suspend.
 func (a *SessionRpc) Suspend(ctx context.Context) (*SessionSuspendResult, error) {
+	if a.common.assertActive != nil {
+		if err := a.common.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.common.sessionID}
 	raw, err := a.common.client.Request("session.suspend", req)
 	if err != nil {
@@ -9762,9 +10177,13 @@ func (a *SessionRpc) Suspend(ctx context.Context) (*SessionSuspendResult, error)
 	return &result, nil
 }
 
-func NewSessionRpc(client *jsonrpc2.Client, sessionID string) *SessionRpc {
+func NewSessionRpc(client *jsonrpc2.Client, sessionID string, assertActive ...func() error) *SessionRpc {
 	r := &SessionRpc{}
-	r.common = sessionApi{client: client, sessionID: sessionID}
+	var assertActiveFn func() error
+	if len(assertActive) > 0 {
+		assertActiveFn = assertActive[0]
+	}
+	r.common = sessionApi{client: client, sessionID: sessionID, assertActive: assertActiveFn}
 	r.Agent = (*AgentApi)(&r.common)
 	r.Auth = (*AuthApi)(&r.common)
 	r.Commands = (*CommandsApi)(&r.common)

--- a/go/rpc/zrpc.go
+++ b/go/rpc/zrpc.go
@@ -6166,6 +6166,9 @@ type ServerSessionsApi serverApi
 //
 // Returns: Map of sessionId -> bytes freed by removing the session's workspace directory.
 func (a *ServerSessionsApi) BulkDelete(ctx context.Context, params *SessionsBulkDeleteRequest) (*SessionBulkDeleteResult, error) {
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	raw, err := a.client.Request("sessions.bulkDelete", params)
 	if err != nil {
 		return nil, err
@@ -6186,6 +6189,9 @@ func (a *ServerSessionsApi) BulkDelete(ctx context.Context, params *SessionsBulk
 //
 // Returns: Session IDs from the input set that are currently in use by another process.
 func (a *ServerSessionsApi) CheckInUse(ctx context.Context, params *SessionsCheckInUseRequest) (*SessionsCheckInUseResult, error) {
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	raw, err := a.client.Request("sessions.checkInUse", params)
 	if err != nil {
 		return nil, err
@@ -6248,6 +6254,9 @@ func (a *ServerSessionsApi) Connect(ctx context.Context, params *ConnectRemoteSe
 // Returns: The same metadata records, with summary and context fields backfilled where
 // available.
 func (a *ServerSessionsApi) EnrichMetadata(ctx context.Context, params *SessionsEnrichMetadataRequest) (*SessionEnrichMetadataResult, error) {
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	raw, err := a.client.Request("sessions.enrichMetadata", params)
 	if err != nil {
 		return nil, err
@@ -6268,6 +6277,9 @@ func (a *ServerSessionsApi) EnrichMetadata(ctx context.Context, params *Sessions
 //
 // Returns: Session ID matching the prefix, omitted when no unique match exists.
 func (a *ServerSessionsApi) FindByPrefix(ctx context.Context, params *SessionsFindByPrefixRequest) (*SessionsFindByPrefixResult, error) {
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	raw, err := a.client.Request("sessions.findByPrefix", params)
 	if err != nil {
 		return nil, err
@@ -6287,6 +6299,9 @@ func (a *ServerSessionsApi) FindByPrefix(ctx context.Context, params *SessionsFi
 //
 // Returns: ID of the local session bound to the given GitHub task, or omitted when none.
 func (a *ServerSessionsApi) FindByTaskId(ctx context.Context, params *SessionsFindByTaskIDRequest) (*SessionsFindByTaskIDResult, error) {
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	raw, err := a.client.Request("sessions.findByTaskId", params)
 	if err != nil {
 		return nil, err
@@ -6447,6 +6462,9 @@ func (a *ServerSessionsApi) LoadDeferredRepoHooks(ctx context.Context, params *S
 // Returns: Outcome of the prune operation: deleted IDs, dry-run candidates, skipped IDs,
 // total bytes freed, and the dry-run flag.
 func (a *ServerSessionsApi) PruneOld(ctx context.Context, params *SessionsPruneOldRequest) (*SessionPruneResult, error) {
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	raw, err := a.client.Request("sessions.pruneOld", params)
 	if err != nil {
 		return nil, err
@@ -6532,6 +6550,9 @@ func (a *ServerSessionsApi) Save(ctx context.Context, params *SessionsSaveReques
 // subsequent hook reloads see the new set; already-running sessions keep their existing
 // hook installation until the next reload.
 func (a *ServerSessionsApi) SetAdditionalPlugins(ctx context.Context, params *SessionsSetAdditionalPluginsRequest) (*SessionsSetAdditionalPluginsResult, error) {
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	raw, err := a.client.Request("sessions.setAdditionalPlugins", params)
 	if err != nil {
 		return nil, err
@@ -6867,6 +6888,11 @@ func (a *AuthApi) GetStatus(ctx context.Context) (*SessionAuthStatus, error) {
 //
 // Returns: Indicates whether the credential update succeeded.
 func (a *AuthApi) SetCredentials(ctx context.Context, params *SessionSetCredentialsParams) (*SessionSetCredentialsResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		if params.Credentials != nil {
@@ -6894,6 +6920,14 @@ type CommandsApi sessionApi
 //
 // Returns: Indicates whether the command was accepted into the local execution queue.
 func (a *CommandsApi) Enqueue(ctx context.Context, params *EnqueueCommandParams) (*EnqueueCommandResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["command"] = params.Command
@@ -6917,6 +6951,14 @@ func (a *CommandsApi) Enqueue(ctx context.Context, params *EnqueueCommandParams)
 //
 // Returns: Error message produced while executing the command, if any.
 func (a *CommandsApi) Execute(ctx context.Context, params *ExecuteCommandParams) (*ExecuteCommandResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["args"] = params.Args
@@ -7090,6 +7132,11 @@ type EventLogApi sessionApi
 // Returns: Batch of session events returned by a read, with cursor and continuation
 // metadata.
 func (a *EventLogApi) Read(ctx context.Context, params *EventLogReadRequest) (*EventsReadResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		if params.AgentScope != nil {
@@ -7127,6 +7174,14 @@ func (a *EventLogApi) Read(ctx context.Context, params *EventLogReadRequest) (*E
 //
 // Returns: Opaque handle representing an event-type interest registration.
 func (a *EventLogApi) RegisterInterest(ctx context.Context, params *RegisterEventInterestParams) (*RegisterEventInterestResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["eventType"] = params.EventType
@@ -7150,6 +7205,14 @@ func (a *EventLogApi) RegisterInterest(ctx context.Context, params *RegisterEven
 //
 // Returns: Indicates whether the operation succeeded.
 func (a *EventLogApi) ReleaseInterest(ctx context.Context, params *ReleaseEventInterestParams) (*EventLogReleaseInterestResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["handle"] = params.Handle
@@ -7174,6 +7237,11 @@ func (a *EventLogApi) ReleaseInterest(ctx context.Context, params *ReleaseEventI
 // through the entire persisted history (which would happen if `read` were called without a
 // cursor on a long-lived session).
 func (a *EventLogApi) Tail(ctx context.Context) (*EventLogTailResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.eventLog.tail", req)
 	if err != nil {
@@ -7333,6 +7401,11 @@ type HistoryApi sessionApi
 //
 // Returns: Indicates whether an in-progress manual compaction was aborted.
 func (a *HistoryApi) AbortManualCompaction(ctx context.Context) (*HistoryAbortManualCompactionResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.history.abortManualCompaction", req)
 	if err != nil {
@@ -7352,6 +7425,11 @@ func (a *HistoryApi) AbortManualCompaction(ctx context.Context) (*HistoryAbortMa
 //
 // Returns: Indicates whether an in-progress background compaction was cancelled.
 func (a *HistoryApi) CancelBackgroundCompaction(ctx context.Context) (*HistoryCancelBackgroundCompactionResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.history.cancelBackgroundCompaction", req)
 	if err != nil {
@@ -7395,6 +7473,11 @@ func (a *HistoryApi) Compact(ctx context.Context) (*HistoryCompactResult, error)
 //
 // Returns: Markdown summary of the conversation context (empty when not available).
 func (a *HistoryApi) SummarizeForHandoff(ctx context.Context) (*HistorySummarizeForHandoffResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.history.summarizeForHandoff", req)
 	if err != nil {
@@ -7473,6 +7556,11 @@ type LspApi sessionApi
 //
 // Parameters: Parameters for (re)loading the merged LSP configuration set.
 func (a *LspApi) Initialize(ctx context.Context, params *LspInitializeRequest) (*SessionLspInitializeResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		if params.Force != nil {
@@ -7508,6 +7596,14 @@ type McpApi sessionApi
 // Returns: Indicates whether an in-flight sampling execution with the given requestId was
 // found and cancelled.
 func (a *McpApi) CancelSamplingExecution(ctx context.Context, params *McpCancelSamplingExecutionParams) (*McpCancelSamplingExecutionResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["requestId"] = params.RequestID
@@ -7591,6 +7687,14 @@ func (a *McpApi) Enable(ctx context.Context, params *McpEnableRequest) (*Session
 // Returns: Outcome of an MCP sampling execution: success result, failure error, or
 // cancellation.
 func (a *McpApi) ExecuteSampling(ctx context.Context, params *McpExecuteSamplingParams) (*McpSamplingExecutionResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["mcpRequestId"] = params.McpRequestID
@@ -7660,6 +7764,11 @@ func (a *McpApi) Reload(ctx context.Context) (*SessionMcpReloadResult, error) {
 // Returns: Indicates whether the auto-managed `github` MCP server was removed (false when
 // nothing to remove).
 func (a *McpApi) RemoveGitHub(ctx context.Context) (*McpRemoveGitHubResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.mcp.removeGitHub", req)
 	if err != nil {
@@ -7682,6 +7791,14 @@ func (a *McpApi) RemoveGitHub(ctx context.Context) (*McpRemoveGitHubResult, erro
 //
 // Returns: Env-value mode recorded on the session after the update.
 func (a *McpApi) SetEnvValueMode(ctx context.Context, params *McpSetEnvValueModeParams) (*McpSetEnvValueModeResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["mode"] = params.Mode
@@ -7760,6 +7877,14 @@ type MetadataApi sessionApi
 // Returns: Token breakdown for the session's current context window, or null if
 // uninitialized.
 func (a *MetadataApi) ContextInfo(ctx context.Context, params *MetadataContextInfoRequest) (*MetadataContextInfoResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["outputTokenLimit"] = params.OutputTokenLimit
@@ -7787,6 +7912,11 @@ func (a *MetadataApi) ContextInfo(ctx context.Context, params *MetadataContextIn
 // Returns: Indicates whether the local session is currently processing a turn or background
 // continuation.
 func (a *MetadataApi) IsProcessing(ctx context.Context) (*MetadataIsProcessingResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.metadata.isProcessing", req)
 	if err != nil {
@@ -7811,6 +7941,14 @@ func (a *MetadataApi) IsProcessing(ctx context.Context) (*MetadataIsProcessingRe
 // resume, before the next agent turn fires `session.context_info_changed` events. Returns
 // zeros for an empty session.
 func (a *MetadataApi) RecomputeContextTokens(ctx context.Context, params *MetadataRecomputeContextTokensRequest) (*MetadataRecomputeContextTokensResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["modelId"] = params.ModelID
@@ -7838,6 +7976,14 @@ func (a *MetadataApi) RecomputeContextTokens(ctx context.Context, params *Metada
 // UI) can react. Use this when the host has detected a cwd/branch/repo change outside the
 // session's normal lifecycle (e.g., after a shell command in interactive mode).
 func (a *MetadataApi) RecordContextChange(ctx context.Context, params *MetadataRecordContextChangeRequest) (*MetadataRecordContextChangeResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["context"] = params.Context
@@ -7864,6 +8010,14 @@ func (a *MetadataApi) RecordContextChange(ctx context.Context, params *MetadataR
 // `process.chdir` and any related side-effects (file index, etc.); this method only updates
 // the session's own recorded path.
 func (a *MetadataApi) SetWorkingDirectory(ctx context.Context, params *MetadataSetWorkingDirectoryRequest) (*MetadataSetWorkingDirectoryResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["workingDirectory"] = params.WorkingDirectory
@@ -7886,6 +8040,11 @@ func (a *MetadataApi) SetWorkingDirectory(ctx context.Context, params *MetadataS
 //
 // Returns: Point-in-time snapshot of slow-changing session identifier and state fields
 func (a *MetadataApi) Snapshot(ctx context.Context) (*SessionMetadataSnapshot, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.metadata.snapshot", req)
 	if err != nil {
@@ -7988,6 +8147,14 @@ func (a *ModelApi) GetCurrent(ctx context.Context) (*CurrentModel, error) {
 // `switchTo` instead when you also need to change the model. The runtime stores the effort
 // on the session and applies it to subsequent turns.
 func (a *ModelApi) SetReasoningEffort(ctx context.Context, params *ModelSetReasoningEffortRequest) (*ModelSetReasoningEffortResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["reasoningEffort"] = params.ReasoningEffort
@@ -8108,6 +8275,14 @@ func (a *NameApi) Set(ctx context.Context, params *NameSetRequest) (*SessionName
 //
 // Returns: Indicates whether the auto-generated summary was applied as the session's name.
 func (a *NameApi) SetAuto(ctx context.Context, params *NameSetAutoRequest) (*NameSetAutoResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["summary"] = params.Summary
@@ -8134,6 +8309,11 @@ type OptionsApi sessionApi
 //
 // Returns: Indicates whether the session options patch was applied successfully.
 func (a *OptionsApi) Update(ctx context.Context, params *SessionUpdateOptionsParams) (*SessionUpdateOptionsResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		if params.AdditionalContentExclusionPolicies != nil {
@@ -8268,6 +8448,11 @@ type PermissionsApi sessionApi
 //
 // Returns: Indicates whether the operation succeeded.
 func (a *PermissionsApi) Configure(ctx context.Context, params *PermissionsConfigureParams) (*PermissionsConfigureResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		if params.AdditionalContentExclusionPolicies != nil {
@@ -8343,6 +8528,14 @@ func (a *PermissionsApi) HandlePendingPermissionRequest(ctx context.Context, par
 //
 // Returns: Indicates whether the operation succeeded.
 func (a *PermissionsApi) ModifyRules(ctx context.Context, params *PermissionsModifyRulesParams) (*PermissionsModifyRulesResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		if params.Add != nil {
@@ -8377,6 +8570,14 @@ func (a *PermissionsApi) ModifyRules(ctx context.Context, params *PermissionsMod
 //
 // Returns: Indicates whether the operation succeeded.
 func (a *PermissionsApi) NotifyPromptShown(ctx context.Context, params *PermissionPromptShownNotification) (*PermissionsNotifyPromptShownResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["message"] = params.Message
@@ -8399,6 +8600,11 @@ func (a *PermissionsApi) NotifyPromptShown(ctx context.Context, params *Permissi
 //
 // Returns: List of pending permission requests reconstructed from event history.
 func (a *PermissionsApi) PendingRequests(ctx context.Context) (*PendingPermissionRequestList, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.permissions.pendingRequests", req)
 	if err != nil {
@@ -8479,6 +8685,14 @@ func (a *PermissionsApi) SetApproveAll(ctx context.Context, params *PermissionsS
 //
 // Returns: Indicates whether the operation succeeded.
 func (a *PermissionsApi) SetRequired(ctx context.Context, params *PermissionsSetRequiredRequest) (*PermissionsSetRequiredResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["required"] = params.Required
@@ -8504,6 +8718,14 @@ type PermissionsPathsApi sessionApi
 //
 // Returns: Indicates whether the operation succeeded.
 func (a *PermissionsPathsApi) Add(ctx context.Context, params *PermissionPathsAddParams) (*PermissionsPathsAddResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["path"] = params.Path
@@ -8528,6 +8750,14 @@ func (a *PermissionsPathsApi) Add(ctx context.Context, params *PermissionPathsAd
 //
 // Returns: Indicates whether the supplied path is within the session's allowed directories.
 func (a *PermissionsPathsApi) IsPathWithinAllowedDirectories(ctx context.Context, params *PermissionPathsAllowedCheckParams) (*PermissionPathsAllowedCheckResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["path"] = params.Path
@@ -8552,6 +8782,14 @@ func (a *PermissionsPathsApi) IsPathWithinAllowedDirectories(ctx context.Context
 //
 // Returns: Indicates whether the supplied path is within the session's workspace directory.
 func (a *PermissionsPathsApi) IsPathWithinWorkspace(ctx context.Context, params *PermissionPathsWorkspaceCheckParams) (*PermissionPathsWorkspaceCheckResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["path"] = params.Path
@@ -8573,6 +8811,11 @@ func (a *PermissionsPathsApi) IsPathWithinWorkspace(ctx context.Context, params 
 //
 // Returns: Snapshot of the session's allow-listed directories and primary working directory.
 func (a *PermissionsPathsApi) List(ctx context.Context) (*PermissionPathsList, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.permissions.paths.list", req)
 	if err != nil {
@@ -8594,6 +8837,14 @@ func (a *PermissionsPathsApi) List(ctx context.Context) (*PermissionPathsList, e
 //
 // Returns: Indicates whether the operation succeeded.
 func (a *PermissionsPathsApi) UpdatePrimary(ctx context.Context, params *PermissionPathsUpdatePrimaryParams) (*PermissionsPathsUpdatePrimaryResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["path"] = params.Path
@@ -8624,6 +8875,14 @@ type PermissionsUrlsApi sessionApi
 //
 // Returns: Indicates whether the operation succeeded.
 func (a *PermissionsUrlsApi) SetUnrestrictedMode(ctx context.Context, params *PermissionUrlsSetUnrestrictedModeParams) (*PermissionsUrlsSetUnrestrictedModeResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["enabled"] = params.Enabled
@@ -8751,6 +9010,11 @@ type QueueApi sessionApi
 //
 // RPC method: session.queue.clear.
 func (a *QueueApi) Clear(ctx context.Context) (*SessionQueueClearResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.queue.clear", req)
 	if err != nil {
@@ -8770,6 +9034,11 @@ func (a *QueueApi) Clear(ctx context.Context) (*SessionQueueClearResult, error) 
 //
 // Returns: Snapshot of the session's pending queued items and immediate-steering messages.
 func (a *QueueApi) PendingItems(ctx context.Context) (*QueuePendingItemsResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.queue.pendingItems", req)
 	if err != nil {
@@ -8788,6 +9057,11 @@ func (a *QueueApi) PendingItems(ctx context.Context) (*QueuePendingItemsResult, 
 //
 // Returns: Indicates whether a user-facing pending item was removed.
 func (a *QueueApi) RemoveMostRecent(ctx context.Context) (*QueueRemoveMostRecentResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.queue.removeMostRecent", req)
 	if err != nil {
@@ -8868,6 +9142,14 @@ func (a *RemoteApi) Enable(ctx context.Context, params *RemoteEnableRequest) (*R
 // Used by the host (CLI / SDK consumer) when it has just finished enabling or disabling
 // steering on a remote exporter that the runtime does not directly own.
 func (a *RemoteApi) NotifySteerableChanged(ctx context.Context, params *RemoteNotifySteerableChangedRequest) (*RemoteNotifySteerableChangedResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["remoteSteerable"] = params.RemoteSteerable
@@ -8892,6 +9174,11 @@ type ScheduleApi sessionApi
 //
 // Returns: Snapshot of the currently active recurring prompts for this session.
 func (a *ScheduleApi) List(ctx context.Context) (*ScheduleList, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.schedule.list", req)
 	if err != nil {
@@ -8913,6 +9200,14 @@ func (a *ScheduleApi) List(ctx context.Context) (*ScheduleList, error) {
 // Returns: Remove a scheduled prompt by id. The result entry is omitted if the id was
 // unknown.
 func (a *ScheduleApi) Stop(ctx context.Context, params *ScheduleStopRequest) (*ScheduleStopResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["id"] = params.ID
@@ -9070,6 +9365,11 @@ func (a *SkillsApi) Enable(ctx context.Context, params *SkillsEnableRequest) (*S
 //
 // RPC method: session.skills.ensureLoaded.
 func (a *SkillsApi) EnsureLoaded(ctx context.Context) (*SessionSkillsEnsureLoadedResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.skills.ensureLoaded", req)
 	if err != nil {
@@ -9089,6 +9389,11 @@ func (a *SkillsApi) EnsureLoaded(ctx context.Context) (*SessionSkillsEnsureLoade
 // Returns: Skills invoked during this session, ordered by invocation time (most recent
 // last).
 func (a *SkillsApi) GetInvoked(ctx context.Context) (*SkillsGetInvokedResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.skills.getInvoked", req)
 	if err != nil {
@@ -9189,6 +9494,11 @@ func (a *TasksApi) Cancel(ctx context.Context, params *TasksCancelRequest) (*Tas
 //
 // Returns: The first sync-waiting task that can currently be promoted to background mode.
 func (a *TasksApi) GetCurrentPromotable(ctx context.Context) (*TasksGetCurrentPromotableResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.tasks.getCurrentPromotable", req)
 	if err != nil {
@@ -9209,6 +9519,14 @@ func (a *TasksApi) GetCurrentPromotable(ctx context.Context) (*TasksGetCurrentPr
 //
 // Returns: Progress information for the task, or null when no task with that ID is tracked.
 func (a *TasksApi) GetProgress(ctx context.Context, params *TasksGetProgressRequest) (*TasksGetProgressResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["id"] = params.ID
@@ -9255,6 +9573,11 @@ func (a *TasksApi) List(ctx context.Context) (*TaskList, error) {
 // Returns: The promoted task as it now exists in background mode, omitted if no promotable
 // task was waiting.
 func (a *TasksApi) PromoteCurrentToBackground(ctx context.Context) (*TasksPromoteCurrentToBackgroundResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.tasks.promoteCurrentToBackground", req)
 	if err != nil {
@@ -9306,6 +9629,11 @@ func (a *TasksApi) PromoteToBackground(ctx context.Context, params *TasksPromote
 // Returns: Refresh metadata for any detached background shells the runtime knows about. Use
 // after a long pause to pick up exit/output state for shells running outside the agent loop.
 func (a *TasksApi) Refresh(ctx context.Context) (*TasksRefreshResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.tasks.refresh", req)
 	if err != nil {
@@ -9436,6 +9764,11 @@ func (a *TasksApi) StartAgent(ctx context.Context, params *TasksStartAgentReques
 // drained or after an internal timeout (default 10 minutes; configurable via
 // COPILOT_TASK_WAIT_TIMEOUT_SECONDS).
 func (a *TasksApi) WaitForPending(ctx context.Context) (*TasksWaitForPendingResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.tasks.waitForPending", req)
 	if err != nil {
@@ -9459,6 +9792,14 @@ type TelemetryApi sessionApi
 // Parameters: Feature override key/value pairs to attach to subsequent telemetry events
 // from this session.
 func (a *TelemetryApi) SetFeatureOverrides(ctx context.Context, params *TelemetrySetFeatureOverridesRequest) (*SessionTelemetrySetFeatureOverridesResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["features"] = params.Features
@@ -9524,6 +9865,11 @@ func (a *ToolsApi) HandlePendingToolCall(ctx context.Context, params *HandlePend
 // Default base-class implementation is a no-op for sessions that don't support tool
 // validation.
 func (a *ToolsApi) InitializeAndValidate(ctx context.Context) (*ToolsInitializeAndValidateResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.tools.initializeAndValidate", req)
 	if err != nil {
@@ -9581,6 +9927,14 @@ func (a *UIApi) Elicitation(ctx context.Context, params *UIElicitationRequest) (
 //
 // Returns: Indicates whether the pending UI request was resolved by this call.
 func (a *UIApi) HandlePendingAutoModeSwitch(ctx context.Context, params *UIHandlePendingAutoModeSwitchRequest) (*UIHandlePendingResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["requestId"] = params.RequestID
@@ -9641,6 +9995,14 @@ func (a *UIApi) HandlePendingElicitation(ctx context.Context, params *UIHandlePe
 //
 // Returns: Indicates whether the pending UI request was resolved by this call.
 func (a *UIApi) HandlePendingExitPlanMode(ctx context.Context, params *UIHandlePendingExitPlanModeRequest) (*UIHandlePendingResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["requestId"] = params.RequestID
@@ -9667,6 +10029,14 @@ func (a *UIApi) HandlePendingExitPlanMode(ctx context.Context, params *UIHandleP
 //
 // Returns: Indicates whether the pending UI request was resolved by this call.
 func (a *UIApi) HandlePendingSampling(ctx context.Context, params *UIHandlePendingSamplingRequest) (*UIHandlePendingResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["requestId"] = params.RequestID
@@ -9694,6 +10064,14 @@ func (a *UIApi) HandlePendingSampling(ctx context.Context, params *UIHandlePendi
 //
 // Returns: Indicates whether the pending UI request was resolved by this call.
 func (a *UIApi) HandlePendingUserInput(ctx context.Context, params *UIHandlePendingUserInputRequest) (*UIHandlePendingResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["requestId"] = params.RequestID
@@ -9720,6 +10098,11 @@ func (a *UIApi) HandlePendingUserInput(ctx context.Context, params *UIHandlePend
 // this registration solely tells the server bridge to skip its own dispatch (so a remote
 // client doesn't race the in-process handler for the same requestId).
 func (a *UIApi) RegisterDirectAutoModeSwitchHandler(ctx context.Context) (*UIRegisterDirectAutoModeSwitchHandlerResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.ui.registerDirectAutoModeSwitchHandler", req)
 	if err != nil {
@@ -9743,6 +10126,14 @@ func (a *UIApi) RegisterDirectAutoModeSwitchHandler(ctx context.Context) (*UIReg
 // Returns: Indicates whether the handle was active and the registration count was
 // decremented.
 func (a *UIApi) UnregisterDirectAutoModeSwitchHandler(ctx context.Context, params *UIUnregisterDirectAutoModeSwitchHandlerRequest) (*UIUnregisterDirectAutoModeSwitchHandlerResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["handle"] = params.Handle
@@ -9848,6 +10239,11 @@ func (a *WorkspacesApi) GetWorkspace(ctx context.Context) (*WorkspacesGetWorkspa
 // Returns: Workspace checkpoints in chronological order; empty when the workspace is not
 // enabled.
 func (a *WorkspacesApi) ListCheckpoints(ctx context.Context) (*WorkspacesListCheckpointsResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	raw, err := a.client.Request("session.workspaces.listCheckpoints", req)
 	if err != nil {
@@ -9892,6 +10288,14 @@ func (a *WorkspacesApi) ListFiles(ctx context.Context) (*WorkspacesListFilesResu
 // Returns: Checkpoint content as a UTF-8 string, or null when the checkpoint or workspace
 // is missing.
 func (a *WorkspacesApi) ReadCheckpoint(ctx context.Context, params *WorkspacesReadCheckpointRequest) (*WorkspacesReadCheckpointResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["number"] = params.Number
@@ -9946,6 +10350,14 @@ func (a *WorkspacesApi) ReadFile(ctx context.Context, params *WorkspacesReadFile
 //
 // Returns: Descriptor for the saved paste file, or null when the workspace is unavailable.
 func (a *WorkspacesApi) SaveLargePaste(ctx context.Context, params *WorkspacesSaveLargePasteRequest) (*WorkspacesSaveLargePasteResult, error) {
+	if a.assertActive != nil {
+		if err := a.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["content"] = params.Content
@@ -10005,6 +10417,11 @@ type SessionRpc struct {
 //
 // Returns: Result of aborting the current turn
 func (a *SessionRpc) Abort(ctx context.Context, params *AbortRequest) (*AbortResult, error) {
+	if a.common.assertActive != nil {
+		if err := a.common.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.common.sessionID}
 	if params != nil {
 		if params.Reason != nil {
@@ -10077,6 +10494,14 @@ func (a *SessionRpc) Log(ctx context.Context, params *LogRequest) (*LogResult, e
 //
 // Returns: Result of sending a user message
 func (a *SessionRpc) Send(ctx context.Context, params *SendRequest) (*SendResult, error) {
+	if a.common.assertActive != nil {
+		if err := a.common.assertActive(); err != nil {
+			return nil, err
+		}
+	}
+	if params == nil {
+		return nil, errors.New("params is required")
+	}
 	req := map[string]any{"sessionId": a.common.sessionID}
 	if params != nil {
 		if params.AgentMode != nil {
@@ -10136,6 +10561,11 @@ func (a *SessionRpc) Send(ctx context.Context, params *SendRequest) (*SendResult
 //
 // Parameters: Parameters for shutting down the session
 func (a *SessionRpc) Shutdown(ctx context.Context, params *ShutdownRequest) (*SessionShutdownResult, error) {
+	if a.common.assertActive != nil {
+		if err := a.common.assertActive(); err != nil {
+			return nil, err
+		}
+	}
 	req := map[string]any{"sessionId": a.common.sessionID}
 	if params != nil {
 		if params.Reason != nil {

--- a/go/session.go
+++ b/go/session.go
@@ -267,6 +267,7 @@ func (s *Session) SendAndWait(ctx context.Context, options MessageOptions) (*Ses
 //
 // The returned function can be called to unsubscribe the handler. It is safe
 // to call the unsubscribe function multiple times.
+// Panics if the session has been disconnected.
 //
 // Example:
 //
@@ -282,6 +283,10 @@ func (s *Session) SendAndWait(ctx context.Context, options MessageOptions) (*Ses
 //	// Later, to stop receiving events:
 //	unsubscribe()
 func (s *Session) On(handler SessionEventHandler) func() {
+	if err := s.assertActive(); err != nil {
+		panic(err)
+	}
+
 	s.handlerMutex.Lock()
 	defer s.handlerMutex.Unlock()
 

--- a/go/session.go
+++ b/go/session.go
@@ -82,7 +82,8 @@ type Session struct {
 	// eventCh serializes user event handler dispatch. dispatchEvent enqueues;
 	// a single goroutine (processEvents) dequeues and invokes handlers in FIFO order.
 	eventCh   chan SessionEvent
-	closeOnce sync.Once // guards eventCh close so Disconnect is safe to call more than once
+	eventMu   sync.RWMutex // coordinates sends with closing eventCh
+	closeOnce sync.Once    // guards eventCh close so Disconnect is safe to call more than once
 	stateMu   sync.Mutex
 	closed    bool
 	closing   chan struct{}
@@ -948,14 +949,17 @@ func fromRPCContent(value rpc.UIElicitationFieldValue) any {
 func (s *Session) dispatchEvent(event SessionEvent) {
 	go s.handleBroadcastEvent(event)
 
-	// Send to the event channel in a closure with a recover guard.
-	// Disconnect closes eventCh, and in Go sending on a closed channel
-	// panics — there is no non-panicking send primitive. We only want
-	// to suppress that specific panic; other panics are not expected here.
-	func() {
-		defer func() { recover() }()
-		s.eventCh <- event
-	}()
+	s.eventMu.RLock()
+	defer s.eventMu.RUnlock()
+
+	s.stateMu.Lock()
+	closed := s.closed
+	s.stateMu.Unlock()
+	if closed {
+		return
+	}
+
+	s.eventCh <- event
 }
 
 // processEvents is the single consumer goroutine for the event channel.
@@ -1273,7 +1277,9 @@ func (s *Session) markDisconnected() {
 	s.closed = true
 	s.stateMu.Unlock()
 
+	s.eventMu.Lock()
 	s.closeOnce.Do(func() { close(s.eventCh) })
+	s.eventMu.Unlock()
 
 	s.handlerMutex.Lock()
 	s.handlers = nil

--- a/go/session.go
+++ b/go/session.go
@@ -53,6 +53,7 @@ type Session struct {
 	SessionID             string
 	workspacePath         string
 	client                *jsonrpc2.Client
+	owner                 *Client
 	clientSessionApis     *rpc.ClientSessionApiHandlers
 	handlers              []sessionHandler
 	nextHandlerID         uint64
@@ -82,6 +83,10 @@ type Session struct {
 	// a single goroutine (processEvents) dequeues and invokes handlers in FIFO order.
 	eventCh   chan SessionEvent
 	closeOnce sync.Once // guards eventCh close so Disconnect is safe to call more than once
+	stateMu   sync.Mutex
+	closed    bool
+	closing   chan struct{}
+	closeErr  error
 
 	// RPC provides typed session-scoped RPC methods.
 	RPC *rpc.SessionRpc
@@ -95,20 +100,30 @@ func (s *Session) WorkspacePath() string {
 }
 
 // newSession creates a new session wrapper with the given session ID and client.
-func newSession(sessionID string, client *jsonrpc2.Client, workspacePath string) *Session {
+func newSession(sessionID string, client *jsonrpc2.Client, workspacePath string, owner *Client) *Session {
 	s := &Session{
 		SessionID:         sessionID,
 		workspacePath:     workspacePath,
 		client:            client,
+		owner:             owner,
 		clientSessionApis: &rpc.ClientSessionApiHandlers{},
 		handlers:          make([]sessionHandler, 0),
 		toolHandlers:      make(map[string]ToolHandler),
 		commandHandlers:   make(map[string]CommandHandler),
 		eventCh:           make(chan SessionEvent, 128),
-		RPC:               rpc.NewSessionRpc(client, sessionID),
 	}
+	s.RPC = rpc.NewSessionRpc(client, sessionID, s.assertActive)
 	go s.processEvents()
 	return s
+}
+
+func (s *Session) assertActive() error {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	if s.closed {
+		return fmt.Errorf("session has been disconnected")
+	}
+	return nil
 }
 
 // Send sends a message to this session and waits for the response.
@@ -134,6 +149,9 @@ func newSession(sessionID string, client *jsonrpc2.Client, workspacePath string)
 //	    log.Printf("Failed to send message: %v", err)
 //	}
 func (s *Session) Send(ctx context.Context, options MessageOptions) (string, error) {
+	if err := s.assertActive(); err != nil {
+		return "", err
+	}
 	traceparent, tracestate := getTraceContext(ctx)
 	req := sessionSendRequest{
 		SessionID:      s.SessionID,
@@ -187,6 +205,9 @@ func (s *Session) Send(ctx context.Context, options MessageOptions) (string, err
 //	    }
 //	}
 func (s *Session) SendAndWait(ctx context.Context, options MessageOptions) (*SessionEvent, error) {
+	if err := s.assertActive(); err != nil {
+		return nil, err
+	}
 	if _, ok := ctx.Deadline(); !ok {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, 60*time.Second)
@@ -752,6 +773,9 @@ func (s *Session) UI() *SessionUI {
 
 // assertElicitation checks that the host supports elicitation and returns an error if not.
 func (s *Session) assertElicitation() error {
+	if err := s.assertActive(); err != nil {
+		return err
+	}
 	caps := s.Capabilities()
 	if caps.UI == nil || !caps.UI.Elicitation {
 		return fmt.Errorf("elicitation is not supported by the host; check session.Capabilities().UI.Elicitation before calling UI methods")
@@ -1168,6 +1192,9 @@ func rpcPermissionDecisionFromKind(kind rpc.PermissionDecisionKind) rpc.Permissi
 //	    }
 //	}
 func (s *Session) GetMessages(ctx context.Context) ([]SessionEvent, error) {
+	if err := s.assertActive(); err != nil {
+		return nil, err
+	}
 
 	result, err := s.client.Request("session.getMessages", sessionGetMessagesRequest{SessionID: s.SessionID})
 	if err != nil {
@@ -1204,14 +1231,50 @@ func (s *Session) GetMessages(ctx context.Context) ([]SessionEvent, error) {
 //	    log.Printf("Failed to disconnect session: %v", err)
 //	}
 func (s *Session) Disconnect() error {
+	s.stateMu.Lock()
+	if s.closed {
+		s.stateMu.Unlock()
+		return nil
+	}
+	if s.closing != nil {
+		closing := s.closing
+		s.stateMu.Unlock()
+		<-closing
+		return s.closeErr
+	}
+	s.closing = make(chan struct{})
+	closing := s.closing
+	s.stateMu.Unlock()
+
+	err := s.disconnectCore()
+
+	s.stateMu.Lock()
+	s.closeErr = err
+	close(closing)
+	s.stateMu.Unlock()
+	return err
+}
+
+func (s *Session) disconnectCore() error {
+	defer s.markDisconnected()
 	_, err := s.client.Request("session.destroy", sessionDestroyRequest{SessionID: s.SessionID})
 	if err != nil {
 		return fmt.Errorf("failed to disconnect session: %w", err)
 	}
+	return nil
+}
+
+func (s *Session) markDisconnected() {
+	s.stateMu.Lock()
+	if s.closed {
+		s.stateMu.Unlock()
+		return
+	}
+	s.closed = true
+	s.stateMu.Unlock()
 
 	s.closeOnce.Do(func() { close(s.eventCh) })
 
-	// Clear handlers
 	s.handlerMutex.Lock()
 	s.handlers = nil
 	s.handlerMutex.Unlock()
@@ -1232,7 +1295,29 @@ func (s *Session) Disconnect() error {
 	s.elicitationHandler = nil
 	s.elicitationMu.Unlock()
 
-	return nil
+	s.userInputMux.Lock()
+	s.userInputHandler = nil
+	s.userInputMux.Unlock()
+
+	s.exitPlanModeMu.Lock()
+	s.exitPlanModeHandler = nil
+	s.exitPlanModeMu.Unlock()
+
+	s.autoModeSwitchMu.Lock()
+	s.autoModeSwitchHandler = nil
+	s.autoModeSwitchMu.Unlock()
+
+	s.hooksMux.Lock()
+	s.hooks = nil
+	s.hooksMux.Unlock()
+
+	s.transformMu.Lock()
+	s.transformCallbacks = nil
+	s.transformMu.Unlock()
+
+	if s.owner != nil {
+		s.owner.unregisterSession(s)
+	}
 }
 
 // Deprecated: Use [Session.Disconnect] instead. Destroy will be removed in a future release.
@@ -1265,6 +1350,9 @@ func (s *Session) Destroy() error {
 //	    log.Printf("Failed to abort: %v", err)
 //	}
 func (s *Session) Abort(ctx context.Context) error {
+	if err := s.assertActive(); err != nil {
+		return err
+	}
 	_, err := s.client.Request("session.abort", sessionAbortRequest{SessionID: s.SessionID})
 	if err != nil {
 		return fmt.Errorf("failed to abort session: %w", err)
@@ -1294,6 +1382,9 @@ type SetModelOptions struct {
 //	    log.Printf("Failed to set model: %v", err)
 //	}
 func (s *Session) SetModel(ctx context.Context, model string, opts *SetModelOptions) error {
+	if err := s.assertActive(); err != nil {
+		return err
+	}
 	params := &rpc.ModelSwitchToRequest{ModelID: model}
 	if opts != nil {
 		params.ReasoningEffort = opts.ReasoningEffort
@@ -1334,6 +1425,9 @@ type LogOptions struct {
 //	// Ephemeral message (not persisted)
 //	session.Log(ctx, "Working...", &copilot.LogOptions{Ephemeral: copilot.Bool(true)})
 func (s *Session) Log(ctx context.Context, message string, opts *LogOptions) error {
+	if err := s.assertActive(); err != nil {
+		return err
+	}
 	params := &rpc.LogRequest{Message: message}
 
 	if opts != nil {

--- a/go/session_test.go
+++ b/go/session_test.go
@@ -280,6 +280,23 @@ func TestSession_On(t *testing.T) {
 			t.Errorf("Expected 2 events dispatched, got %d", eventCount.Load())
 		}
 	})
+
+	t.Run("panics after disconnect", func(t *testing.T) {
+		session := newSession("session-1", nil, "", nil)
+		session.markDisconnected()
+
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("expected On to panic after disconnect")
+			}
+			if !strings.Contains(fmt.Sprint(r), "session has been disconnected") {
+				t.Fatalf("expected disconnected panic, got %v", r)
+			}
+		}()
+
+		session.On(func(SessionEvent) {})
+	})
 }
 
 func TestSession_CommandRouting(t *testing.T) {

--- a/go/session_test.go
+++ b/go/session_test.go
@@ -46,6 +46,55 @@ func TestRPCPermissionDecisionFromKindPreservesUnknownKind(t *testing.T) {
 	}
 }
 
+func TestSessionLifecycleCleanup(t *testing.T) {
+	client := NewClient(nil)
+	session := newSession("session-1", nil, "", client)
+
+	if err := client.registerSession(session); err != nil {
+		t.Fatalf("register session: %v", err)
+	}
+
+	session.markDisconnected()
+
+	if _, ok := client.sessions["session-1"]; ok {
+		t.Fatal("expected disconnected session to unregister from client")
+	}
+	if err := session.assertActive(); err == nil {
+		t.Fatal("expected disconnected session to reject further use")
+	}
+}
+
+func TestSessionLifecycleCleanupDoesNotRemoveReplacement(t *testing.T) {
+	client := NewClient(nil)
+	stale := newSession("session-1", nil, "", client)
+	replacement := newSession("session-1", nil, "", client)
+	client.sessions["session-1"] = replacement
+
+	stale.markDisconnected()
+
+	if got := client.sessions["session-1"]; got != replacement {
+		t.Fatalf("expected replacement session to remain registered, got %#v", got)
+	}
+
+	replacement.markDisconnected()
+}
+
+func TestClientRegisterSessionRejectsDuplicateActiveSession(t *testing.T) {
+	client := NewClient(nil)
+	first := newSession("session-1", nil, "", client)
+	second := newSession("session-1", nil, "", client)
+
+	if err := client.registerSession(first); err != nil {
+		t.Fatalf("register first session: %v", err)
+	}
+	if err := client.registerSession(second); err == nil || !strings.Contains(err.Error(), "already active") {
+		t.Fatalf("expected duplicate active session error, got %v", err)
+	}
+
+	first.markDisconnected()
+	second.markDisconnected()
+}
+
 func TestSession_On(t *testing.T) {
 	t.Run("multiple handlers all receive events", func(t *testing.T) {
 		session, cleanup := newTestSession()

--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -450,6 +450,20 @@ export class CopilotClient {
         }
     }
 
+    private registerSession(session: CopilotSession): void {
+        const existing = this.sessions.get(session.sessionId);
+        if (existing && existing !== session) {
+            throw new Error(`Session ${session.sessionId} is already active.`);
+        }
+        this.sessions.set(session.sessionId, session);
+    }
+
+    private unregisterSession(session: CopilotSession): void {
+        if (this.sessions.get(session.sessionId) === session) {
+            this.sessions.delete(session.sessionId);
+        }
+    }
+
     private setupSessionFs(
         session: CopilotSession,
         config: { createSessionFsHandler?: (session: CopilotSession) => SessionFsProvider }
@@ -551,37 +565,25 @@ export class CopilotClient {
     async stop(): Promise<Error[]> {
         const errors: Error[] = [];
 
-        // Disconnect all active sessions with retry logic
-        for (const session of this.sessions.values()) {
+        // Disconnect a stable snapshot so per-session cleanup can mutate the map safely.
+        for (const session of [...this.sessions.values()]) {
             const sessionId = session.sessionId;
-            let lastError: Error | null = null;
-
-            // Try up to 3 times with exponential backoff
-            for (let attempt = 1; attempt <= 3; attempt++) {
-                try {
-                    await session.disconnect();
-                    lastError = null;
-                    break; // Success
-                } catch (error) {
-                    lastError = error instanceof Error ? error : new Error(String(error));
-
-                    if (attempt < 3) {
-                        // Exponential backoff: 100ms, 200ms
-                        const delay = 100 * Math.pow(2, attempt - 1);
-                        await new Promise((resolve) => setTimeout(resolve, delay));
-                    }
-                }
-            }
-
-            if (lastError) {
+            try {
+                await session.disconnect();
+            } catch (error) {
+                const disconnectError = error instanceof Error ? error : new Error(String(error));
                 errors.push(
                     new Error(
-                        `Failed to disconnect session ${sessionId} after 3 attempts: ${lastError.message}`
+                        `Failed to disconnect session ${sessionId}: ${disconnectError.message}`
                     )
                 );
             }
         }
+        const remainingSessions = [...this.sessions.values()];
         this.sessions.clear();
+        for (const session of remainingSessions) {
+            session._markDisconnected();
+        }
 
         // Close connection
         if (this.connection) {
@@ -596,6 +598,7 @@ export class CopilotClient {
             }
             this.connection = null;
             this._rpc = null;
+            this._internalRpc = null;
         }
 
         // Clear models cache
@@ -668,6 +671,10 @@ export class CopilotClient {
     async forceStop(): Promise<void> {
         this.forceStopping = true;
 
+        for (const session of this.sessions.values()) {
+            session._markDisconnected();
+        }
+
         // Clear sessions immediately without trying to destroy them
         this.sessions.clear();
 
@@ -680,6 +687,7 @@ export class CopilotClient {
             }
             this.connection = null;
             this._rpc = null;
+            this._internalRpc = null;
         }
 
         // Clear models cache
@@ -761,7 +769,8 @@ export class CopilotClient {
             sessionId,
             this.connection!,
             undefined,
-            this.onGetTraceContext
+            this.onGetTraceContext,
+            (session) => this.unregisterSession(session)
         );
         session.registerTools(config.tools);
         session.registerCommands(config.commands);
@@ -793,10 +802,10 @@ export class CopilotClient {
         if (config.onEvent) {
             session.on(config.onEvent);
         }
-        this.sessions.set(sessionId, session);
-        this.setupSessionFs(session, config);
+        this.registerSession(session);
 
         try {
+            this.setupSessionFs(session, config);
             const response = await this.connection!.sendRequest("session.create", {
                 ...(await getTraceContext(this.onGetTraceContext)),
                 model: config.model,
@@ -853,7 +862,8 @@ export class CopilotClient {
             session["_workspacePath"] = workspacePath;
             session.setCapabilities(capabilities);
         } catch (e) {
-            this.sessions.delete(sessionId);
+            this.unregisterSession(session);
+            session._markDisconnected();
             throw e;
         }
 
@@ -899,7 +909,8 @@ export class CopilotClient {
             sessionId,
             this.connection!,
             undefined,
-            this.onGetTraceContext
+            this.onGetTraceContext,
+            (session) => this.unregisterSession(session)
         );
         session.registerTools(config.tools);
         session.registerCommands(config.commands);
@@ -931,10 +942,10 @@ export class CopilotClient {
         if (config.onEvent) {
             session.on(config.onEvent);
         }
-        this.sessions.set(sessionId, session);
-        this.setupSessionFs(session, config);
+        this.registerSession(session);
 
         try {
+            this.setupSessionFs(session, config);
             const response = await this.connection!.sendRequest("session.resume", {
                 ...(await getTraceContext(this.onGetTraceContext)),
                 sessionId,
@@ -993,7 +1004,8 @@ export class CopilotClient {
             session["_workspacePath"] = workspacePath;
             session.setCapabilities(capabilities);
         } catch (e) {
-            this.sessions.delete(sessionId);
+            this.unregisterSession(session);
+            session._markDisconnected();
             throw e;
         }
 
@@ -1245,7 +1257,12 @@ export class CopilotClient {
         }
 
         // Remove from local sessions map if present
-        this.sessions.delete(sessionId);
+        const session = this.sessions.get(sessionId);
+        if (session) {
+            session._markDisconnected();
+        } else {
+            this.sessions.delete(sessionId);
+        }
     }
 
     /**

--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -8711,8 +8711,9 @@ export function createServerRpc(connection: MessageConnection) {
          *
          * @returns Server liveness response, including the echoed message, current server timestamp, and protocol version.
          */
-        ping: async (params: PingRequest): Promise<PingResult> =>
-            connection.sendRequest("ping", params),
+        ping: async (params?: PingRequest): Promise<PingResult> => {
+            return connection.sendRequest("ping", (params ?? {}));
+        },
         models: {
             /**
              * Lists Copilot models available to the authenticated user.
@@ -8721,8 +8722,9 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns List of Copilot models available to the resolved user, including capabilities and billing metadata.
              */
-            list: async (params: ModelsListRequest): Promise<ModelList> =>
-                connection.sendRequest("models.list", params),
+            list: async (params?: ModelsListRequest): Promise<ModelList> => {
+                return connection.sendRequest("models.list", (params ?? {}));
+            },
         },
         tools: {
             /**
@@ -8732,8 +8734,9 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Built-in tools available for the requested model, with their parameters and instructions.
              */
-            list: async (params: ToolsListRequest): Promise<ToolList> =>
-                connection.sendRequest("tools.list", params),
+            list: async (params?: ToolsListRequest): Promise<ToolList> => {
+                return connection.sendRequest("tools.list", (params ?? {}));
+            },
         },
         account: {
             /**
@@ -8743,8 +8746,9 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Quota usage snapshots for the resolved user, keyed by quota type.
              */
-            getQuota: async (params: AccountGetQuotaRequest): Promise<AccountGetQuotaResult> =>
-                connection.sendRequest("account.getQuota", params),
+            getQuota: async (params?: AccountGetQuotaRequest): Promise<AccountGetQuotaResult> => {
+                return connection.sendRequest("account.getQuota", (params ?? {}));
+            },
         },
         mcp: {
             config: {
@@ -8753,43 +8757,64 @@ export function createServerRpc(connection: MessageConnection) {
                  *
                  * @returns User-configured MCP servers, keyed by server name.
                  */
-                list: async (): Promise<McpConfigList> =>
-                    connection.sendRequest("mcp.config.list", {}),
+                list: async (): Promise<McpConfigList> => {
+                    return connection.sendRequest("mcp.config.list", {});
+                },
                 /**
                  * Adds an MCP server to user configuration.
                  *
                  * @param params MCP server name and configuration to add to user configuration.
                  */
-                add: async (params: McpConfigAddRequest): Promise<void> =>
-                    connection.sendRequest("mcp.config.add", params),
+                add: async (params: McpConfigAddRequest): Promise<void> => {
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("mcp.config.add", params);
+                },
                 /**
                  * Updates an MCP server in user configuration.
                  *
                  * @param params MCP server name and replacement configuration to write to user configuration.
                  */
-                update: async (params: McpConfigUpdateRequest): Promise<void> =>
-                    connection.sendRequest("mcp.config.update", params),
+                update: async (params: McpConfigUpdateRequest): Promise<void> => {
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("mcp.config.update", params);
+                },
                 /**
                  * Removes an MCP server from user configuration.
                  *
                  * @param params MCP server name to remove from user configuration.
                  */
-                remove: async (params: McpConfigRemoveRequest): Promise<void> =>
-                    connection.sendRequest("mcp.config.remove", params),
+                remove: async (params: McpConfigRemoveRequest): Promise<void> => {
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("mcp.config.remove", params);
+                },
                 /**
                  * Enables MCP servers in user configuration for new sessions.
                  *
                  * @param params MCP server names to enable for new sessions.
                  */
-                enable: async (params: McpConfigEnableRequest): Promise<void> =>
-                    connection.sendRequest("mcp.config.enable", params),
+                enable: async (params: McpConfigEnableRequest): Promise<void> => {
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("mcp.config.enable", params);
+                },
                 /**
                  * Disables MCP servers in user configuration for new sessions.
                  *
                  * @param params MCP server names to disable for new sessions.
                  */
-                disable: async (params: McpConfigDisableRequest): Promise<void> =>
-                    connection.sendRequest("mcp.config.disable", params),
+                disable: async (params: McpConfigDisableRequest): Promise<void> => {
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("mcp.config.disable", params);
+                },
             },
             /**
              * Discovers MCP servers from user, workspace, plugin, and builtin sources.
@@ -8798,8 +8823,9 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns MCP servers discovered from user, workspace, plugin, and built-in sources.
              */
-            discover: async (params: McpDiscoverRequest): Promise<McpDiscoverResult> =>
-                connection.sendRequest("mcp.discover", params),
+            discover: async (params?: McpDiscoverRequest): Promise<McpDiscoverResult> => {
+                return connection.sendRequest("mcp.discover", (params ?? {}));
+            },
         },
         skills: {
             config: {
@@ -8808,8 +8834,12 @@ export function createServerRpc(connection: MessageConnection) {
                  *
                  * @param params Skill names to mark as disabled in global configuration, replacing any previous list.
                  */
-                setDisabledSkills: async (params: SkillsConfigSetDisabledSkillsRequest): Promise<void> =>
-                    connection.sendRequest("skills.config.setDisabledSkills", params),
+                setDisabledSkills: async (params: SkillsConfigSetDisabledSkillsRequest): Promise<void> => {
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("skills.config.setDisabledSkills", params);
+                },
             },
             /**
              * Discovers skills across global and project sources.
@@ -8818,8 +8848,9 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Skills discovered across global and project sources.
              */
-            discover: async (params: SkillsDiscoverRequest): Promise<ServerSkillList> =>
-                connection.sendRequest("skills.discover", params),
+            discover: async (params?: SkillsDiscoverRequest): Promise<ServerSkillList> => {
+                return connection.sendRequest("skills.discover", (params ?? {}));
+            },
         },
         sessionFs: {
             /**
@@ -8829,8 +8860,12 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Indicates whether the calling client was registered as the session filesystem provider.
              */
-            setProvider: async (params: SessionFsSetProviderRequest): Promise<SessionFsSetProviderResult> =>
-                connection.sendRequest("sessionFs.setProvider", params),
+            setProvider: async (params: SessionFsSetProviderRequest): Promise<SessionFsSetProviderResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("sessionFs.setProvider", params);
+            },
         },
         /** @experimental */
         sessions: {
@@ -8841,8 +8876,9 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Identifier and optional friendly name assigned to the newly forked session.
              */
-            fork: async (params: SessionsForkRequest): Promise<SessionsForkResult> =>
-                connection.sendRequest("sessions.fork", params),
+            fork: async (params?: SessionsForkRequest): Promise<SessionsForkResult> => {
+                return connection.sendRequest("sessions.fork", (params ?? {}));
+            },
             /**
              * Connects to an existing remote session and exposes it as an SDK session.
              *
@@ -8850,8 +8886,9 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Remote session connection result.
              */
-            connect: async (params: ConnectRemoteSessionParams): Promise<RemoteSessionConnectionResult> =>
-                connection.sendRequest("sessions.connect", params),
+            connect: async (params?: ConnectRemoteSessionParams): Promise<RemoteSessionConnectionResult> => {
+                return connection.sendRequest("sessions.connect", (params ?? {}));
+            },
             /**
              * Lists persisted sessions, optionally filtered by working-directory context.
              *
@@ -8859,8 +8896,9 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Persisted sessions matching the filter, ordered most-recently-modified first.
              */
-            list: async (params: SessionsListRequest): Promise<SessionList> =>
-                connection.sendRequest("sessions.list", params),
+            list: async (params?: SessionsListRequest): Promise<SessionList> => {
+                return connection.sendRequest("sessions.list", (params ?? {}));
+            },
             /**
              * Finds the local session bound to a GitHub task ID, if any.
              *
@@ -8868,8 +8906,12 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns ID of the local session bound to the given GitHub task, or omitted when none.
              */
-            findByTaskId: async (params: SessionsFindByTaskIDRequest): Promise<SessionsFindByTaskIDResult> =>
-                connection.sendRequest("sessions.findByTaskId", params),
+            findByTaskId: async (params: SessionsFindByTaskIDRequest): Promise<SessionsFindByTaskIDResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("sessions.findByTaskId", params);
+            },
             /**
              * Resolves a UUID prefix to a unique session ID, if exactly one session matches.
              *
@@ -8877,8 +8919,12 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Session ID matching the prefix, omitted when no unique match exists.
              */
-            findByPrefix: async (params: SessionsFindByPrefixRequest): Promise<SessionsFindByPrefixResult> =>
-                connection.sendRequest("sessions.findByPrefix", params),
+            findByPrefix: async (params: SessionsFindByPrefixRequest): Promise<SessionsFindByPrefixResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("sessions.findByPrefix", params);
+            },
             /**
              * Returns the most-relevant prior session for a given working-directory context.
              *
@@ -8886,8 +8932,9 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Most-relevant session ID for the supplied context, or omitted when no sessions exist.
              */
-            getLastForContext: async (params: SessionsGetLastForContextRequest): Promise<SessionsGetLastForContextResult> =>
-                connection.sendRequest("sessions.getLastForContext", params),
+            getLastForContext: async (params?: SessionsGetLastForContextRequest): Promise<SessionsGetLastForContextResult> => {
+                return connection.sendRequest("sessions.getLastForContext", (params ?? {}));
+            },
             /**
              * Computes the absolute path to a session's persisted events.jsonl file.
              *
@@ -8895,15 +8942,17 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Absolute path to the session's events.jsonl file on disk.
              */
-            getEventFilePath: async (params: SessionsGetEventFilePathRequest): Promise<SessionsGetEventFilePathResult> =>
-                connection.sendRequest("sessions.getEventFilePath", params),
+            getEventFilePath: async (params?: SessionsGetEventFilePathRequest): Promise<SessionsGetEventFilePathResult> => {
+                return connection.sendRequest("sessions.getEventFilePath", (params ?? {}));
+            },
             /**
              * Returns the on-disk byte size of each session's workspace directory.
              *
              * @returns Map of sessionId -> on-disk size in bytes for each session's workspace directory.
              */
-            getSizes: async (): Promise<SessionSizes> =>
-                connection.sendRequest("sessions.getSizes", {}),
+            getSizes: async (): Promise<SessionSizes> => {
+                return connection.sendRequest("sessions.getSizes", {});
+            },
             /**
              * Returns the subset of the supplied session IDs that are currently held by another running process.
              *
@@ -8911,8 +8960,12 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Session IDs from the input set that are currently in use by another process.
              */
-            checkInUse: async (params: SessionsCheckInUseRequest): Promise<SessionsCheckInUseResult> =>
-                connection.sendRequest("sessions.checkInUse", params),
+            checkInUse: async (params: SessionsCheckInUseRequest): Promise<SessionsCheckInUseResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("sessions.checkInUse", params);
+            },
             /**
              * Returns a session's persisted remote-steerable flag, if any has been recorded.
              *
@@ -8920,8 +8973,9 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns The session's persisted remote-steerable flag, or omitted when no value has been persisted.
              */
-            getPersistedRemoteSteerable: async (params: SessionsGetPersistedRemoteSteerableRequest): Promise<SessionsGetPersistedRemoteSteerableResult> =>
-                connection.sendRequest("sessions.getPersistedRemoteSteerable", params),
+            getPersistedRemoteSteerable: async (params?: SessionsGetPersistedRemoteSteerableRequest): Promise<SessionsGetPersistedRemoteSteerableResult> => {
+                return connection.sendRequest("sessions.getPersistedRemoteSteerable", (params ?? {}));
+            },
             /**
              * Closes a session: emits shutdown, flushes pending events, releases the in-use lock, and disposes the active session.
              *
@@ -8929,8 +8983,9 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Closes a session: emits shutdown, flushes pending events to disk, releases the in-use lock, disposes the active session. Idempotent: succeeds even if the session is not currently active.
              */
-            close: async (params: SessionsCloseRequest): Promise<SessionsCloseResult> =>
-                connection.sendRequest("sessions.close", params),
+            close: async (params?: SessionsCloseRequest): Promise<SessionsCloseResult> => {
+                return connection.sendRequest("sessions.close", (params ?? {}));
+            },
             /**
              * Closes, deactivates, and deletes a set of sessions, returning the bytes freed per session.
              *
@@ -8938,8 +8993,12 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Map of sessionId -> bytes freed by removing the session's workspace directory.
              */
-            bulkDelete: async (params: SessionsBulkDeleteRequest): Promise<SessionBulkDeleteResult> =>
-                connection.sendRequest("sessions.bulkDelete", params),
+            bulkDelete: async (params: SessionsBulkDeleteRequest): Promise<SessionBulkDeleteResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("sessions.bulkDelete", params);
+            },
             /**
              * Deletes sessions older than the given threshold, with optional dry-run and exclusion list.
              *
@@ -8947,8 +9006,12 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Outcome of the prune operation: deleted IDs, dry-run candidates, skipped IDs, total bytes freed, and the dry-run flag.
              */
-            pruneOld: async (params: SessionsPruneOldRequest): Promise<SessionPruneResult> =>
-                connection.sendRequest("sessions.pruneOld", params),
+            pruneOld: async (params: SessionsPruneOldRequest): Promise<SessionPruneResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("sessions.pruneOld", params);
+            },
             /**
              * Flushes a session's pending events to disk.
              *
@@ -8956,8 +9019,9 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Flush a session's pending events to disk. No-op when no writer exists for the session (e.g., already closed).
              */
-            save: async (params: SessionsSaveRequest): Promise<SessionsSaveResult> =>
-                connection.sendRequest("sessions.save", params),
+            save: async (params?: SessionsSaveRequest): Promise<SessionsSaveResult> => {
+                return connection.sendRequest("sessions.save", (params ?? {}));
+            },
             /**
              * Releases the in-use lock held by this process for a session.
              *
@@ -8965,8 +9029,9 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Release the in-use lock held by this process for the given session. No-op when this process does not currently hold a lock for the session.
              */
-            releaseLock: async (params: SessionsReleaseLockRequest): Promise<SessionsReleaseLockResult> =>
-                connection.sendRequest("sessions.releaseLock", params),
+            releaseLock: async (params?: SessionsReleaseLockRequest): Promise<SessionsReleaseLockResult> => {
+                return connection.sendRequest("sessions.releaseLock", (params ?? {}));
+            },
             /**
              * Backfills missing summary and context fields on the supplied session metadata records.
              *
@@ -8974,8 +9039,12 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns The same metadata records, with summary and context fields backfilled where available.
              */
-            enrichMetadata: async (params: SessionsEnrichMetadataRequest): Promise<SessionEnrichMetadataResult> =>
-                connection.sendRequest("sessions.enrichMetadata", params),
+            enrichMetadata: async (params: SessionsEnrichMetadataRequest): Promise<SessionEnrichMetadataResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("sessions.enrichMetadata", params);
+            },
             /**
              * Reloads user, plugin, and (optionally) repo hooks on the active session.
              *
@@ -8983,8 +9052,9 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Reload all hooks (user, plugin, optionally repo) and apply them to the active session. Call after installing or removing plugins so their hooks take effect immediately. No-op when no active session matches the given sessionId.
              */
-            reloadPluginHooks: async (params: SessionsReloadPluginHooksRequest): Promise<SessionsReloadPluginHooksResult> =>
-                connection.sendRequest("sessions.reloadPluginHooks", params),
+            reloadPluginHooks: async (params?: SessionsReloadPluginHooksRequest): Promise<SessionsReloadPluginHooksResult> => {
+                return connection.sendRequest("sessions.reloadPluginHooks", (params ?? {}));
+            },
             /**
              * Loads previously-deferred repo-level hooks on the active session, returning queued startup prompts.
              *
@@ -8992,8 +9062,9 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Queued repo-level startup prompts and the total hook command count after loading.
              */
-            loadDeferredRepoHooks: async (params: SessionsLoadDeferredRepoHooksRequest): Promise<SessionLoadDeferredRepoHooksResult> =>
-                connection.sendRequest("sessions.loadDeferredRepoHooks", params),
+            loadDeferredRepoHooks: async (params?: SessionsLoadDeferredRepoHooksRequest): Promise<SessionLoadDeferredRepoHooksResult> => {
+                return connection.sendRequest("sessions.loadDeferredRepoHooks", (params ?? {}));
+            },
             /**
              * Replaces the manager-wide additional plugins registered with the session manager.
              *
@@ -9001,8 +9072,12 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Replace the manager-wide additional plugins. New session creations and subsequent hook reloads see the new set; already-running sessions keep their existing hook installation until the next reload.
              */
-            setAdditionalPlugins: async (params: SessionsSetAdditionalPluginsRequest): Promise<SessionsSetAdditionalPluginsResult> =>
-                connection.sendRequest("sessions.setAdditionalPlugins", params),
+            setAdditionalPlugins: async (params: SessionsSetAdditionalPluginsRequest): Promise<SessionsSetAdditionalPluginsResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("sessions.setAdditionalPlugins", params);
+            },
         },
     };
 }
@@ -9021,21 +9096,24 @@ export function createInternalServerRpc(connection: MessageConnection) {
          *
          * @returns Handshake result reporting the server's protocol version and package version on success.
          */
-        connect: async (params: ConnectRequest): Promise<ConnectResult> =>
-            connection.sendRequest("connect", params),
+        connect: async (params?: ConnectRequest): Promise<ConnectResult> => {
+            return connection.sendRequest("connect", (params ?? {}));
+        },
     };
 }
 
 /** Create typed session-scoped RPC methods. */
-export function createSessionRpc(connection: MessageConnection, sessionId: string) {
+export function createSessionRpc(connection: MessageConnection, sessionId: string, assertActive?: () => void) {
     return {
         /**
          * Suspends the session while preserving persisted state for later resume.
          *
          * @experimental
          */
-        suspend: async (): Promise<void> =>
-            connection.sendRequest("session.suspend", { sessionId }),
+        suspend: async (): Promise<void> => {
+            assertActive?.();
+            return connection.sendRequest("session.suspend", { sessionId });
+        },
         /**
          * Sends a user message to the session and returns its message ID.
          *
@@ -9045,8 +9123,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
          *
          * @experimental
          */
-        send: async (params: SendRequest): Promise<SendResult> =>
-            connection.sendRequest("session.send", { sessionId, ...params }),
+        send: async (params: SendRequest): Promise<SendResult> => {
+            assertActive?.();
+            if (params == null) {
+                throw new TypeError("params is required");
+            }
+            return connection.sendRequest("session.send", { sessionId, ...params });
+        },
         /**
          * Aborts the current agent turn.
          *
@@ -9056,8 +9139,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
          *
          * @experimental
          */
-        abort: async (params: AbortRequest): Promise<AbortResult> =>
-            connection.sendRequest("session.abort", { sessionId, ...params }),
+        abort: async (params?: AbortRequest): Promise<AbortResult> => {
+            assertActive?.();
+            return connection.sendRequest("session.abort", { sessionId, ...params });
+        },
         /**
          * Shuts down the session and persists its final state. Awaits any deferred sessionEnd hooks before resolving so user-supplied hook scripts complete before the runtime tears down.
          *
@@ -9065,8 +9150,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
          *
          * @experimental
          */
-        shutdown: async (params: ShutdownRequest): Promise<void> =>
-            connection.sendRequest("session.shutdown", { sessionId, ...params }),
+        shutdown: async (params?: ShutdownRequest): Promise<void> => {
+            assertActive?.();
+            return connection.sendRequest("session.shutdown", { sessionId, ...params });
+        },
         /** @experimental */
         auth: {
             /**
@@ -9074,8 +9161,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Authentication status and account metadata for the session.
              */
-            getStatus: async (): Promise<SessionAuthStatus> =>
-                connection.sendRequest("session.auth.getStatus", { sessionId }),
+            getStatus: async (): Promise<SessionAuthStatus> => {
+                assertActive?.();
+                return connection.sendRequest("session.auth.getStatus", { sessionId });
+            },
             /**
              * Updates the session's auth credentials used for outbound model and API requests.
              *
@@ -9083,8 +9172,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the credential update succeeded.
              */
-            setCredentials: async (params: SessionSetCredentialsParams): Promise<SessionSetCredentialsResult> =>
-                connection.sendRequest("session.auth.setCredentials", { sessionId, ...params }),
+            setCredentials: async (params?: SessionSetCredentialsParams): Promise<SessionSetCredentialsResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.auth.setCredentials", { sessionId, ...params });
+            },
         },
         /** @experimental */
         model: {
@@ -9093,8 +9184,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns The currently selected model and reasoning effort for the session.
              */
-            getCurrent: async (): Promise<CurrentModel> =>
-                connection.sendRequest("session.model.getCurrent", { sessionId }),
+            getCurrent: async (): Promise<CurrentModel> => {
+                assertActive?.();
+                return connection.sendRequest("session.model.getCurrent", { sessionId });
+            },
             /**
              * Switches the session to a model and optional reasoning configuration.
              *
@@ -9102,8 +9195,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns The model identifier active on the session after the switch.
              */
-            switchTo: async (params: ModelSwitchToRequest): Promise<ModelSwitchToResult> =>
-                connection.sendRequest("session.model.switchTo", { sessionId, ...params }),
+            switchTo: async (params: ModelSwitchToRequest): Promise<ModelSwitchToResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.model.switchTo", { sessionId, ...params });
+            },
             /**
              * Updates the session's reasoning effort without changing the selected model.
              *
@@ -9111,8 +9209,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Update the session's reasoning effort without changing the selected model. Use `switchTo` instead when you also need to change the model. The runtime stores the effort on the session and applies it to subsequent turns.
              */
-            setReasoningEffort: async (params: ModelSetReasoningEffortRequest): Promise<ModelSetReasoningEffortResult> =>
-                connection.sendRequest("session.model.setReasoningEffort", { sessionId, ...params }),
+            setReasoningEffort: async (params: ModelSetReasoningEffortRequest): Promise<ModelSetReasoningEffortResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.model.setReasoningEffort", { sessionId, ...params });
+            },
         },
         /** @experimental */
         mode: {
@@ -9121,15 +9224,22 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns The session mode the agent is operating in
              */
-            get: async (): Promise<SessionMode> =>
-                connection.sendRequest("session.mode.get", { sessionId }),
+            get: async (): Promise<SessionMode> => {
+                assertActive?.();
+                return connection.sendRequest("session.mode.get", { sessionId });
+            },
             /**
              * Sets the current agent interaction mode.
              *
              * @param params Agent interaction mode to apply to the session.
              */
-            set: async (params: ModeSetRequest): Promise<void> =>
-                connection.sendRequest("session.mode.set", { sessionId, ...params }),
+            set: async (params: ModeSetRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.mode.set", { sessionId, ...params });
+            },
         },
         /** @experimental */
         name: {
@@ -9138,15 +9248,22 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns The session's friendly name, or null when not yet set.
              */
-            get: async (): Promise<NameGetResult> =>
-                connection.sendRequest("session.name.get", { sessionId }),
+            get: async (): Promise<NameGetResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.name.get", { sessionId });
+            },
             /**
              * Sets the session's friendly name.
              *
              * @param params New friendly name to apply to the session.
              */
-            set: async (params: NameSetRequest): Promise<void> =>
-                connection.sendRequest("session.name.set", { sessionId, ...params }),
+            set: async (params: NameSetRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.name.set", { sessionId, ...params });
+            },
             /**
              * Persists an auto-generated session summary as the session's name when no user-set name exists.
              *
@@ -9154,8 +9271,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the auto-generated summary was applied as the session's name.
              */
-            setAuto: async (params: NameSetAutoRequest): Promise<NameSetAutoResult> =>
-                connection.sendRequest("session.name.setAuto", { sessionId, ...params }),
+            setAuto: async (params: NameSetAutoRequest): Promise<NameSetAutoResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.name.setAuto", { sessionId, ...params });
+            },
         },
         /** @experimental */
         plan: {
@@ -9164,20 +9286,29 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Existence, contents, and resolved path of the session plan file.
              */
-            read: async (): Promise<PlanReadResult> =>
-                connection.sendRequest("session.plan.read", { sessionId }),
+            read: async (): Promise<PlanReadResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.plan.read", { sessionId });
+            },
             /**
              * Writes new content to the session plan file.
              *
              * @param params Replacement contents to write to the session plan file.
              */
-            update: async (params: PlanUpdateRequest): Promise<void> =>
-                connection.sendRequest("session.plan.update", { sessionId, ...params }),
+            update: async (params: PlanUpdateRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.plan.update", { sessionId, ...params });
+            },
             /**
              * Deletes the session plan file from the workspace.
              */
-            delete: async (): Promise<void> =>
-                connection.sendRequest("session.plan.delete", { sessionId }),
+            delete: async (): Promise<void> => {
+                assertActive?.();
+                return connection.sendRequest("session.plan.delete", { sessionId });
+            },
         },
         /** @experimental */
         workspaces: {
@@ -9186,15 +9317,19 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Current workspace metadata for the session, including its absolute filesystem path when available.
              */
-            getWorkspace: async (): Promise<WorkspacesGetWorkspaceResult> =>
-                connection.sendRequest("session.workspaces.getWorkspace", { sessionId }),
+            getWorkspace: async (): Promise<WorkspacesGetWorkspaceResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.workspaces.getWorkspace", { sessionId });
+            },
             /**
              * Lists files stored in the session workspace files directory.
              *
              * @returns Relative paths of files stored in the session workspace files directory.
              */
-            listFiles: async (): Promise<WorkspacesListFilesResult> =>
-                connection.sendRequest("session.workspaces.listFiles", { sessionId }),
+            listFiles: async (): Promise<WorkspacesListFilesResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.workspaces.listFiles", { sessionId });
+            },
             /**
              * Reads a file from the session workspace files directory.
              *
@@ -9202,22 +9337,34 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Contents of the requested workspace file as a UTF-8 string.
              */
-            readFile: async (params: WorkspacesReadFileRequest): Promise<WorkspacesReadFileResult> =>
-                connection.sendRequest("session.workspaces.readFile", { sessionId, ...params }),
+            readFile: async (params: WorkspacesReadFileRequest): Promise<WorkspacesReadFileResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.workspaces.readFile", { sessionId, ...params });
+            },
             /**
              * Creates or overwrites a file in the session workspace files directory.
              *
              * @param params Relative path and UTF-8 content for the workspace file to create or overwrite.
              */
-            createFile: async (params: WorkspacesCreateFileRequest): Promise<void> =>
-                connection.sendRequest("session.workspaces.createFile", { sessionId, ...params }),
+            createFile: async (params: WorkspacesCreateFileRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.workspaces.createFile", { sessionId, ...params });
+            },
             /**
              * Lists workspace checkpoints in chronological order.
              *
              * @returns Workspace checkpoints in chronological order; empty when the workspace is not enabled.
              */
-            listCheckpoints: async (): Promise<WorkspacesListCheckpointsResult> =>
-                connection.sendRequest("session.workspaces.listCheckpoints", { sessionId }),
+            listCheckpoints: async (): Promise<WorkspacesListCheckpointsResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.workspaces.listCheckpoints", { sessionId });
+            },
             /**
              * Reads the content of a workspace checkpoint by number.
              *
@@ -9225,8 +9372,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Checkpoint content as a UTF-8 string, or null when the checkpoint or workspace is missing.
              */
-            readCheckpoint: async (params: WorkspacesReadCheckpointRequest): Promise<WorkspacesReadCheckpointResult> =>
-                connection.sendRequest("session.workspaces.readCheckpoint", { sessionId, ...params }),
+            readCheckpoint: async (params: WorkspacesReadCheckpointRequest): Promise<WorkspacesReadCheckpointResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.workspaces.readCheckpoint", { sessionId, ...params });
+            },
             /**
              * Saves pasted content as a UTF-8 file in the session workspace.
              *
@@ -9234,8 +9386,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Descriptor for the saved paste file, or null when the workspace is unavailable.
              */
-            saveLargePaste: async (params: WorkspacesSaveLargePasteRequest): Promise<WorkspacesSaveLargePasteResult> =>
-                connection.sendRequest("session.workspaces.saveLargePaste", { sessionId, ...params }),
+            saveLargePaste: async (params: WorkspacesSaveLargePasteRequest): Promise<WorkspacesSaveLargePasteResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.workspaces.saveLargePaste", { sessionId, ...params });
+            },
         },
         /** @experimental */
         instructions: {
@@ -9244,8 +9401,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Instruction sources loaded for the session, in merge order.
              */
-            getSources: async (): Promise<InstructionsGetSourcesResult> =>
-                connection.sendRequest("session.instructions.getSources", { sessionId }),
+            getSources: async (): Promise<InstructionsGetSourcesResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.instructions.getSources", { sessionId });
+            },
         },
         /** @experimental */
         fleet: {
@@ -9256,8 +9415,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether fleet mode was successfully activated.
              */
-            start: async (params: FleetStartRequest): Promise<FleetStartResult> =>
-                connection.sendRequest("session.fleet.start", { sessionId, ...params }),
+            start: async (params?: FleetStartRequest): Promise<FleetStartResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.fleet.start", { sessionId, ...params });
+            },
         },
         /** @experimental */
         agent: {
@@ -9266,15 +9427,19 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Custom agents available to the session.
              */
-            list: async (): Promise<AgentList> =>
-                connection.sendRequest("session.agent.list", { sessionId }),
+            list: async (): Promise<AgentList> => {
+                assertActive?.();
+                return connection.sendRequest("session.agent.list", { sessionId });
+            },
             /**
              * Gets the currently selected custom agent for the session.
              *
              * @returns The currently selected custom agent, or null when using the default agent.
              */
-            getCurrent: async (): Promise<AgentGetCurrentResult> =>
-                connection.sendRequest("session.agent.getCurrent", { sessionId }),
+            getCurrent: async (): Promise<AgentGetCurrentResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.agent.getCurrent", { sessionId });
+            },
             /**
              * Selects a custom agent for subsequent turns in the session.
              *
@@ -9282,20 +9447,29 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns The newly selected custom agent.
              */
-            select: async (params: AgentSelectRequest): Promise<AgentSelectResult> =>
-                connection.sendRequest("session.agent.select", { sessionId, ...params }),
+            select: async (params: AgentSelectRequest): Promise<AgentSelectResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.agent.select", { sessionId, ...params });
+            },
             /**
              * Clears the selected custom agent and returns the session to the default agent.
              */
-            deselect: async (): Promise<void> =>
-                connection.sendRequest("session.agent.deselect", { sessionId }),
+            deselect: async (): Promise<void> => {
+                assertActive?.();
+                return connection.sendRequest("session.agent.deselect", { sessionId });
+            },
             /**
              * Reloads custom agent definitions and returns the refreshed list.
              *
              * @returns Custom agents available to the session after reloading definitions from disk.
              */
-            reload: async (): Promise<AgentReloadResult> =>
-                connection.sendRequest("session.agent.reload", { sessionId }),
+            reload: async (): Promise<AgentReloadResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.agent.reload", { sessionId });
+            },
         },
         /** @experimental */
         tasks: {
@@ -9306,29 +9480,40 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Identifier assigned to the newly started background agent task.
              */
-            startAgent: async (params: TasksStartAgentRequest): Promise<TasksStartAgentResult> =>
-                connection.sendRequest("session.tasks.startAgent", { sessionId, ...params }),
+            startAgent: async (params: TasksStartAgentRequest): Promise<TasksStartAgentResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.tasks.startAgent", { sessionId, ...params });
+            },
             /**
              * Lists background tasks tracked by the session.
              *
              * @returns Background tasks currently tracked by the session.
              */
-            list: async (): Promise<TaskList> =>
-                connection.sendRequest("session.tasks.list", { sessionId }),
+            list: async (): Promise<TaskList> => {
+                assertActive?.();
+                return connection.sendRequest("session.tasks.list", { sessionId });
+            },
             /**
              * Refreshes metadata for any detached background shells the runtime knows about.
              *
              * @returns Refresh metadata for any detached background shells the runtime knows about. Use after a long pause to pick up exit/output state for shells running outside the agent loop.
              */
-            refresh: async (): Promise<TasksRefreshResult> =>
-                connection.sendRequest("session.tasks.refresh", { sessionId }),
+            refresh: async (): Promise<TasksRefreshResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.tasks.refresh", { sessionId });
+            },
             /**
              * Waits for all in-flight background tasks and any follow-up turns to settle.
              *
              * @returns Wait until all in-flight background tasks (agents + shells) and any follow-up turns scheduled by their completions have settled. Returns when the runtime is fully drained or after an internal timeout (default 10 minutes; configurable via COPILOT_TASK_WAIT_TIMEOUT_SECONDS).
              */
-            waitForPending: async (): Promise<TasksWaitForPendingResult> =>
-                connection.sendRequest("session.tasks.waitForPending", { sessionId }),
+            waitForPending: async (): Promise<TasksWaitForPendingResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.tasks.waitForPending", { sessionId });
+            },
             /**
              * Returns progress information for a background task by ID.
              *
@@ -9336,15 +9521,22 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Progress information for the task, or null when no task with that ID is tracked.
              */
-            getProgress: async (params: TasksGetProgressRequest): Promise<TasksGetProgressResult> =>
-                connection.sendRequest("session.tasks.getProgress", { sessionId, ...params }),
+            getProgress: async (params: TasksGetProgressRequest): Promise<TasksGetProgressResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.tasks.getProgress", { sessionId, ...params });
+            },
             /**
              * Returns the first sync-waiting task that can currently be promoted to background mode.
              *
              * @returns The first sync-waiting task that can currently be promoted to background mode.
              */
-            getCurrentPromotable: async (): Promise<TasksGetCurrentPromotableResult> =>
-                connection.sendRequest("session.tasks.getCurrentPromotable", { sessionId }),
+            getCurrentPromotable: async (): Promise<TasksGetCurrentPromotableResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.tasks.getCurrentPromotable", { sessionId });
+            },
             /**
              * Promotes an eligible synchronously-waited task so it continues running in the background.
              *
@@ -9352,15 +9544,22 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the task was successfully promoted to background mode.
              */
-            promoteToBackground: async (params: TasksPromoteToBackgroundRequest): Promise<TasksPromoteToBackgroundResult> =>
-                connection.sendRequest("session.tasks.promoteToBackground", { sessionId, ...params }),
+            promoteToBackground: async (params: TasksPromoteToBackgroundRequest): Promise<TasksPromoteToBackgroundResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.tasks.promoteToBackground", { sessionId, ...params });
+            },
             /**
              * Atomically promotes the first promotable sync-waiting task to background mode and returns it.
              *
              * @returns The promoted task as it now exists in background mode, omitted if no promotable task was waiting.
              */
-            promoteCurrentToBackground: async (): Promise<TasksPromoteCurrentToBackgroundResult> =>
-                connection.sendRequest("session.tasks.promoteCurrentToBackground", { sessionId }),
+            promoteCurrentToBackground: async (): Promise<TasksPromoteCurrentToBackgroundResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.tasks.promoteCurrentToBackground", { sessionId });
+            },
             /**
              * Cancels a background task.
              *
@@ -9368,8 +9567,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the background task was successfully cancelled.
              */
-            cancel: async (params: TasksCancelRequest): Promise<TasksCancelResult> =>
-                connection.sendRequest("session.tasks.cancel", { sessionId, ...params }),
+            cancel: async (params: TasksCancelRequest): Promise<TasksCancelResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.tasks.cancel", { sessionId, ...params });
+            },
             /**
              * Removes a completed or cancelled background task from tracking.
              *
@@ -9377,8 +9581,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the task was removed. False when the task does not exist or is still running/idle.
              */
-            remove: async (params: TasksRemoveRequest): Promise<TasksRemoveResult> =>
-                connection.sendRequest("session.tasks.remove", { sessionId, ...params }),
+            remove: async (params: TasksRemoveRequest): Promise<TasksRemoveResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.tasks.remove", { sessionId, ...params });
+            },
             /**
              * Sends a message to a background agent task.
              *
@@ -9386,8 +9595,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the message was delivered, with an error message when delivery failed.
              */
-            sendMessage: async (params: TasksSendMessageRequest): Promise<TasksSendMessageResult> =>
-                connection.sendRequest("session.tasks.sendMessage", { sessionId, ...params }),
+            sendMessage: async (params: TasksSendMessageRequest): Promise<TasksSendMessageResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.tasks.sendMessage", { sessionId, ...params });
+            },
         },
         /** @experimental */
         skills: {
@@ -9396,41 +9610,59 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Skills available to the session, with their enabled state.
              */
-            list: async (): Promise<SkillList> =>
-                connection.sendRequest("session.skills.list", { sessionId }),
+            list: async (): Promise<SkillList> => {
+                assertActive?.();
+                return connection.sendRequest("session.skills.list", { sessionId });
+            },
             /**
              * Returns the skills that have been invoked during this session.
              *
              * @returns Skills invoked during this session, ordered by invocation time (most recent last).
              */
-            getInvoked: async (): Promise<SkillsGetInvokedResult> =>
-                connection.sendRequest("session.skills.getInvoked", { sessionId }),
+            getInvoked: async (): Promise<SkillsGetInvokedResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.skills.getInvoked", { sessionId });
+            },
             /**
              * Enables a skill for the session.
              *
              * @param params Name of the skill to enable for the session.
              */
-            enable: async (params: SkillsEnableRequest): Promise<void> =>
-                connection.sendRequest("session.skills.enable", { sessionId, ...params }),
+            enable: async (params: SkillsEnableRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.skills.enable", { sessionId, ...params });
+            },
             /**
              * Disables a skill for the session.
              *
              * @param params Name of the skill to disable for the session.
              */
-            disable: async (params: SkillsDisableRequest): Promise<void> =>
-                connection.sendRequest("session.skills.disable", { sessionId, ...params }),
+            disable: async (params: SkillsDisableRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.skills.disable", { sessionId, ...params });
+            },
             /**
              * Reloads skill definitions for the session.
              *
              * @returns Diagnostics from reloading skill definitions, with warnings and errors as separate lists.
              */
-            reload: async (): Promise<SkillsLoadDiagnostics> =>
-                connection.sendRequest("session.skills.reload", { sessionId }),
+            reload: async (): Promise<SkillsLoadDiagnostics> => {
+                assertActive?.();
+                return connection.sendRequest("session.skills.reload", { sessionId });
+            },
             /**
              * Ensures the session's skill definitions have been loaded from disk.
              */
-            ensureLoaded: async (): Promise<void> =>
-                connection.sendRequest("session.skills.ensureLoaded", { sessionId }),
+            ensureLoaded: async (): Promise<void> => {
+                assertActive?.();
+                return connection.sendRequest("session.skills.ensureLoaded", { sessionId });
+            },
         },
         /** @experimental */
         mcp: {
@@ -9439,27 +9671,41 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns MCP servers configured for the session, with their connection status.
              */
-            list: async (): Promise<McpServerList> =>
-                connection.sendRequest("session.mcp.list", { sessionId }),
+            list: async (): Promise<McpServerList> => {
+                assertActive?.();
+                return connection.sendRequest("session.mcp.list", { sessionId });
+            },
             /**
              * Enables an MCP server for the session.
              *
              * @param params Name of the MCP server to enable for the session.
              */
-            enable: async (params: McpEnableRequest): Promise<void> =>
-                connection.sendRequest("session.mcp.enable", { sessionId, ...params }),
+            enable: async (params: McpEnableRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.mcp.enable", { sessionId, ...params });
+            },
             /**
              * Disables an MCP server for the session.
              *
              * @param params Name of the MCP server to disable for the session.
              */
-            disable: async (params: McpDisableRequest): Promise<void> =>
-                connection.sendRequest("session.mcp.disable", { sessionId, ...params }),
+            disable: async (params: McpDisableRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.mcp.disable", { sessionId, ...params });
+            },
             /**
              * Reloads MCP server connections for the session.
              */
-            reload: async (): Promise<void> =>
-                connection.sendRequest("session.mcp.reload", { sessionId }),
+            reload: async (): Promise<void> => {
+                assertActive?.();
+                return connection.sendRequest("session.mcp.reload", { sessionId });
+            },
             /**
              * Runs an MCP sampling inference on behalf of an MCP server.
              *
@@ -9467,8 +9713,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Outcome of an MCP sampling execution: success result, failure error, or cancellation.
              */
-            executeSampling: async (params: McpExecuteSamplingParams): Promise<McpSamplingExecutionResult> =>
-                connection.sendRequest("session.mcp.executeSampling", { sessionId, ...params }),
+            executeSampling: async (params: McpExecuteSamplingParams): Promise<McpSamplingExecutionResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.mcp.executeSampling", { sessionId, ...params });
+            },
             /**
              * Cancels an in-flight MCP sampling execution by request ID.
              *
@@ -9476,8 +9727,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether an in-flight sampling execution with the given requestId was found and cancelled.
              */
-            cancelSamplingExecution: async (params: McpCancelSamplingExecutionParams): Promise<McpCancelSamplingExecutionResult> =>
-                connection.sendRequest("session.mcp.cancelSamplingExecution", { sessionId, ...params }),
+            cancelSamplingExecution: async (params: McpCancelSamplingExecutionParams): Promise<McpCancelSamplingExecutionResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.mcp.cancelSamplingExecution", { sessionId, ...params });
+            },
             /**
              * Sets how environment-variable values supplied to MCP servers are resolved (direct or indirect).
              *
@@ -9485,15 +9741,22 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Env-value mode recorded on the session after the update.
              */
-            setEnvValueMode: async (params: McpSetEnvValueModeParams): Promise<McpSetEnvValueModeResult> =>
-                connection.sendRequest("session.mcp.setEnvValueMode", { sessionId, ...params }),
+            setEnvValueMode: async (params: McpSetEnvValueModeParams): Promise<McpSetEnvValueModeResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.mcp.setEnvValueMode", { sessionId, ...params });
+            },
             /**
              * Removes the auto-managed `github` MCP server when present.
              *
              * @returns Indicates whether the auto-managed `github` MCP server was removed (false when nothing to remove).
              */
-            removeGitHub: async (): Promise<McpRemoveGitHubResult> =>
-                connection.sendRequest("session.mcp.removeGitHub", { sessionId }),
+            removeGitHub: async (): Promise<McpRemoveGitHubResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.mcp.removeGitHub", { sessionId });
+            },
             /** @experimental */
             oauth: {
                 /**
@@ -9503,8 +9766,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                  *
                  * @returns OAuth authorization URL the caller should open, or empty when cached tokens already authenticated the server.
                  */
-                login: async (params: McpOauthLoginRequest): Promise<McpOauthLoginResult> =>
-                    connection.sendRequest("session.mcp.oauth.login", { sessionId, ...params }),
+                login: async (params: McpOauthLoginRequest): Promise<McpOauthLoginResult> => {
+                    assertActive?.();
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("session.mcp.oauth.login", { sessionId, ...params });
+                },
             },
         },
         /** @experimental */
@@ -9514,8 +9782,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Plugins installed for the session, with their enabled state and version metadata.
              */
-            list: async (): Promise<PluginList> =>
-                connection.sendRequest("session.plugins.list", { sessionId }),
+            list: async (): Promise<PluginList> => {
+                assertActive?.();
+                return connection.sendRequest("session.plugins.list", { sessionId });
+            },
         },
         /** @experimental */
         options: {
@@ -9526,8 +9796,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the session options patch was applied successfully.
              */
-            update: async (params: SessionUpdateOptionsParams): Promise<SessionUpdateOptionsResult> =>
-                connection.sendRequest("session.options.update", { sessionId, ...params }),
+            update: async (params?: SessionUpdateOptionsParams): Promise<SessionUpdateOptionsResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.options.update", { sessionId, ...params });
+            },
         },
         /** @experimental */
         lsp: {
@@ -9536,8 +9808,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @param params Parameters for (re)loading the merged LSP configuration set.
              */
-            initialize: async (params: LspInitializeRequest): Promise<void> =>
-                connection.sendRequest("session.lsp.initialize", { sessionId, ...params }),
+            initialize: async (params?: LspInitializeRequest): Promise<void> => {
+                assertActive?.();
+                return connection.sendRequest("session.lsp.initialize", { sessionId, ...params });
+            },
         },
         /** @experimental */
         extensions: {
@@ -9546,27 +9820,41 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Extensions discovered for the session, with their current status.
              */
-            list: async (): Promise<ExtensionList> =>
-                connection.sendRequest("session.extensions.list", { sessionId }),
+            list: async (): Promise<ExtensionList> => {
+                assertActive?.();
+                return connection.sendRequest("session.extensions.list", { sessionId });
+            },
             /**
              * Enables an extension for the session.
              *
              * @param params Source-qualified extension identifier to enable for the session.
              */
-            enable: async (params: ExtensionsEnableRequest): Promise<void> =>
-                connection.sendRequest("session.extensions.enable", { sessionId, ...params }),
+            enable: async (params: ExtensionsEnableRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.extensions.enable", { sessionId, ...params });
+            },
             /**
              * Disables an extension for the session.
              *
              * @param params Source-qualified extension identifier to disable for the session.
              */
-            disable: async (params: ExtensionsDisableRequest): Promise<void> =>
-                connection.sendRequest("session.extensions.disable", { sessionId, ...params }),
+            disable: async (params: ExtensionsDisableRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.extensions.disable", { sessionId, ...params });
+            },
             /**
              * Reloads extension definitions and processes for the session.
              */
-            reload: async (): Promise<void> =>
-                connection.sendRequest("session.extensions.reload", { sessionId }),
+            reload: async (): Promise<void> => {
+                assertActive?.();
+                return connection.sendRequest("session.extensions.reload", { sessionId });
+            },
         },
         /** @experimental */
         tools: {
@@ -9577,15 +9865,22 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the external tool call result was handled successfully.
              */
-            handlePendingToolCall: async (params: HandlePendingToolCallRequest): Promise<HandlePendingToolCallResult> =>
-                connection.sendRequest("session.tools.handlePendingToolCall", { sessionId, ...params }),
+            handlePendingToolCall: async (params: HandlePendingToolCallRequest): Promise<HandlePendingToolCallResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.tools.handlePendingToolCall", { sessionId, ...params });
+            },
             /**
              * Resolves, builds, and validates the runtime tool list for the session.
              *
              * @returns Resolve, build, and validate the runtime tool list for this session. Subagent sessions and consumer flows that need an initialized tool set before `send` invoke this. Default base-class implementation is a no-op for sessions that don't support tool validation.
              */
-            initializeAndValidate: async (): Promise<ToolsInitializeAndValidateResult> =>
-                connection.sendRequest("session.tools.initializeAndValidate", { sessionId }),
+            initializeAndValidate: async (): Promise<ToolsInitializeAndValidateResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.tools.initializeAndValidate", { sessionId });
+            },
         },
         /** @experimental */
         commands: {
@@ -9596,8 +9891,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Slash commands available in the session, after applying any include/exclude filters.
              */
-            list: async (params?: CommandsListRequest): Promise<CommandList> =>
-                connection.sendRequest("session.commands.list", { sessionId, ...params }),
+            list: async (params?: CommandsListRequest): Promise<CommandList> => {
+                assertActive?.();
+                return connection.sendRequest("session.commands.list", { sessionId, ...params });
+            },
             /**
              * Invokes a slash command in the session.
              *
@@ -9605,8 +9902,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Result of invoking the slash command (text output, prompt to send to the agent, or completion).
              */
-            invoke: async (params: CommandsInvokeRequest): Promise<SlashCommandInvocationResult> =>
-                connection.sendRequest("session.commands.invoke", { sessionId, ...params }),
+            invoke: async (params: CommandsInvokeRequest): Promise<SlashCommandInvocationResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.commands.invoke", { sessionId, ...params });
+            },
             /**
              * Reports completion of a pending client-handled slash command.
              *
@@ -9614,8 +9916,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the pending client-handled command was completed successfully.
              */
-            handlePendingCommand: async (params: CommandsHandlePendingCommandRequest): Promise<CommandsHandlePendingCommandResult> =>
-                connection.sendRequest("session.commands.handlePendingCommand", { sessionId, ...params }),
+            handlePendingCommand: async (params: CommandsHandlePendingCommandRequest): Promise<CommandsHandlePendingCommandResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.commands.handlePendingCommand", { sessionId, ...params });
+            },
             /**
              * Executes a slash command synchronously and returns any error.
              *
@@ -9623,8 +9930,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Error message produced while executing the command, if any.
              */
-            execute: async (params: ExecuteCommandParams): Promise<ExecuteCommandResult> =>
-                connection.sendRequest("session.commands.execute", { sessionId, ...params }),
+            execute: async (params: ExecuteCommandParams): Promise<ExecuteCommandResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.commands.execute", { sessionId, ...params });
+            },
             /**
              * Enqueues a slash command for FIFO processing on the local session.
              *
@@ -9632,8 +9944,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the command was accepted into the local execution queue.
              */
-            enqueue: async (params: EnqueueCommandParams): Promise<EnqueueCommandResult> =>
-                connection.sendRequest("session.commands.enqueue", { sessionId, ...params }),
+            enqueue: async (params: EnqueueCommandParams): Promise<EnqueueCommandResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.commands.enqueue", { sessionId, ...params });
+            },
             /**
              * Reports whether the host actually executed a queued command and whether to continue processing.
              *
@@ -9641,8 +9958,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the queued-command response was matched to a pending request.
              */
-            respondToQueuedCommand: async (params: CommandsRespondToQueuedCommandRequest): Promise<CommandsRespondToQueuedCommandResult> =>
-                connection.sendRequest("session.commands.respondToQueuedCommand", { sessionId, ...params }),
+            respondToQueuedCommand: async (params: CommandsRespondToQueuedCommandRequest): Promise<CommandsRespondToQueuedCommandResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.commands.respondToQueuedCommand", { sessionId, ...params });
+            },
         },
         /** @experimental */
         telemetry: {
@@ -9651,8 +9973,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @param params Feature override key/value pairs to attach to subsequent telemetry events from this session.
              */
-            setFeatureOverrides: async (params: TelemetrySetFeatureOverridesRequest): Promise<void> =>
-                connection.sendRequest("session.telemetry.setFeatureOverrides", { sessionId, ...params }),
+            setFeatureOverrides: async (params: TelemetrySetFeatureOverridesRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.telemetry.setFeatureOverrides", { sessionId, ...params });
+            },
         },
         /** @experimental */
         ui: {
@@ -9663,8 +9990,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns The elicitation response (accept with form values, decline, or cancel)
              */
-            elicitation: async (params: UIElicitationRequest): Promise<UIElicitationResponse> =>
-                connection.sendRequest("session.ui.elicitation", { sessionId, ...params }),
+            elicitation: async (params: UIElicitationRequest): Promise<UIElicitationResponse> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.ui.elicitation", { sessionId, ...params });
+            },
             /**
              * Provides the user response for a pending elicitation request.
              *
@@ -9672,8 +10004,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the elicitation response was accepted; false if it was already resolved by another client.
              */
-            handlePendingElicitation: async (params: UIHandlePendingElicitationRequest): Promise<UIElicitationResult> =>
-                connection.sendRequest("session.ui.handlePendingElicitation", { sessionId, ...params }),
+            handlePendingElicitation: async (params: UIHandlePendingElicitationRequest): Promise<UIElicitationResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.ui.handlePendingElicitation", { sessionId, ...params });
+            },
             /**
              * Resolves a pending `user_input.requested` event with the user's response.
              *
@@ -9681,8 +10018,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the pending UI request was resolved by this call.
              */
-            handlePendingUserInput: async (params: UIHandlePendingUserInputRequest): Promise<UIHandlePendingResult> =>
-                connection.sendRequest("session.ui.handlePendingUserInput", { sessionId, ...params }),
+            handlePendingUserInput: async (params: UIHandlePendingUserInputRequest): Promise<UIHandlePendingResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.ui.handlePendingUserInput", { sessionId, ...params });
+            },
             /**
              * Resolves a pending `sampling.requested` event with a sampling result, or rejects it.
              *
@@ -9690,8 +10032,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the pending UI request was resolved by this call.
              */
-            handlePendingSampling: async (params: UIHandlePendingSamplingRequest): Promise<UIHandlePendingResult> =>
-                connection.sendRequest("session.ui.handlePendingSampling", { sessionId, ...params }),
+            handlePendingSampling: async (params: UIHandlePendingSamplingRequest): Promise<UIHandlePendingResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.ui.handlePendingSampling", { sessionId, ...params });
+            },
             /**
              * Resolves a pending `auto_mode_switch.requested` event with the user's accept/decline decision.
              *
@@ -9699,8 +10046,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the pending UI request was resolved by this call.
              */
-            handlePendingAutoModeSwitch: async (params: UIHandlePendingAutoModeSwitchRequest): Promise<UIHandlePendingResult> =>
-                connection.sendRequest("session.ui.handlePendingAutoModeSwitch", { sessionId, ...params }),
+            handlePendingAutoModeSwitch: async (params: UIHandlePendingAutoModeSwitchRequest): Promise<UIHandlePendingResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.ui.handlePendingAutoModeSwitch", { sessionId, ...params });
+            },
             /**
              * Resolves a pending `exit_plan_mode.requested` event with the user's response.
              *
@@ -9708,15 +10060,22 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the pending UI request was resolved by this call.
              */
-            handlePendingExitPlanMode: async (params: UIHandlePendingExitPlanModeRequest): Promise<UIHandlePendingResult> =>
-                connection.sendRequest("session.ui.handlePendingExitPlanMode", { sessionId, ...params }),
+            handlePendingExitPlanMode: async (params: UIHandlePendingExitPlanModeRequest): Promise<UIHandlePendingResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.ui.handlePendingExitPlanMode", { sessionId, ...params });
+            },
             /**
              * Registers an in-process handler for auto-mode-switch requests so the server bridge skips dispatch.
              *
              * @returns Register an in-process handler for `auto_mode_switch.requested` events. The caller still attaches the actual listener via the standard event-subscription mechanism; this registration solely tells the server bridge to skip its own dispatch (so a remote client doesn't race the in-process handler for the same requestId).
              */
-            registerDirectAutoModeSwitchHandler: async (): Promise<UIRegisterDirectAutoModeSwitchHandlerResult> =>
-                connection.sendRequest("session.ui.registerDirectAutoModeSwitchHandler", { sessionId }),
+            registerDirectAutoModeSwitchHandler: async (): Promise<UIRegisterDirectAutoModeSwitchHandlerResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.ui.registerDirectAutoModeSwitchHandler", { sessionId });
+            },
             /**
              * Unregisters a previously-registered in-process auto-mode-switch handler by its opaque handle.
              *
@@ -9724,8 +10083,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the handle was active and the registration count was decremented.
              */
-            unregisterDirectAutoModeSwitchHandler: async (params: UIUnregisterDirectAutoModeSwitchHandlerRequest): Promise<UIUnregisterDirectAutoModeSwitchHandlerResult> =>
-                connection.sendRequest("session.ui.unregisterDirectAutoModeSwitchHandler", { sessionId, ...params }),
+            unregisterDirectAutoModeSwitchHandler: async (params: UIUnregisterDirectAutoModeSwitchHandlerRequest): Promise<UIUnregisterDirectAutoModeSwitchHandlerResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.ui.unregisterDirectAutoModeSwitchHandler", { sessionId, ...params });
+            },
         },
         /** @experimental */
         permissions: {
@@ -9736,8 +10100,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the operation succeeded.
              */
-            configure: async (params: PermissionsConfigureParams): Promise<PermissionsConfigureResult> =>
-                connection.sendRequest("session.permissions.configure", { sessionId, ...params }),
+            configure: async (params?: PermissionsConfigureParams): Promise<PermissionsConfigureResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.permissions.configure", { sessionId, ...params });
+            },
             /**
              * Provides a decision for a pending tool permission request.
              *
@@ -9745,15 +10111,22 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the permission decision was applied; false when the request was already resolved.
              */
-            handlePendingPermissionRequest: async (params: PermissionDecisionRequest): Promise<PermissionRequestResult> =>
-                connection.sendRequest("session.permissions.handlePendingPermissionRequest", { sessionId, ...params }),
+            handlePendingPermissionRequest: async (params: PermissionDecisionRequest): Promise<PermissionRequestResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.permissions.handlePendingPermissionRequest", { sessionId, ...params });
+            },
             /**
              * Reconstructs the set of pending tool permission requests from the session's event history.
              *
              * @returns List of pending permission requests reconstructed from event history.
              */
-            pendingRequests: async (): Promise<PendingPermissionRequestList> =>
-                connection.sendRequest("session.permissions.pendingRequests", { sessionId }),
+            pendingRequests: async (): Promise<PendingPermissionRequestList> => {
+                assertActive?.();
+                return connection.sendRequest("session.permissions.pendingRequests", { sessionId });
+            },
             /**
              * Enables or disables automatic approval of tool permission requests for the session.
              *
@@ -9761,8 +10134,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the operation succeeded.
              */
-            setApproveAll: async (params: PermissionsSetApproveAllRequest): Promise<PermissionsSetApproveAllResult> =>
-                connection.sendRequest("session.permissions.setApproveAll", { sessionId, ...params }),
+            setApproveAll: async (params: PermissionsSetApproveAllRequest): Promise<PermissionsSetApproveAllResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.permissions.setApproveAll", { sessionId, ...params });
+            },
             /**
              * Adds or removes session-scoped or location-scoped permission rules.
              *
@@ -9770,8 +10148,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the operation succeeded.
              */
-            modifyRules: async (params: PermissionsModifyRulesParams): Promise<PermissionsModifyRulesResult> =>
-                connection.sendRequest("session.permissions.modifyRules", { sessionId, ...params }),
+            modifyRules: async (params: PermissionsModifyRulesParams): Promise<PermissionsModifyRulesResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.permissions.modifyRules", { sessionId, ...params });
+            },
             /**
              * Sets whether the client wants permission prompts bridged into session events.
              *
@@ -9779,15 +10162,22 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the operation succeeded.
              */
-            setRequired: async (params: PermissionsSetRequiredRequest): Promise<PermissionsSetRequiredResult> =>
-                connection.sendRequest("session.permissions.setRequired", { sessionId, ...params }),
+            setRequired: async (params: PermissionsSetRequiredRequest): Promise<PermissionsSetRequiredResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.permissions.setRequired", { sessionId, ...params });
+            },
             /**
              * Clears session-scoped tool permission approvals.
              *
              * @returns Indicates whether the operation succeeded.
              */
-            resetSessionApprovals: async (): Promise<PermissionsResetSessionApprovalsResult> =>
-                connection.sendRequest("session.permissions.resetSessionApprovals", { sessionId }),
+            resetSessionApprovals: async (): Promise<PermissionsResetSessionApprovalsResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.permissions.resetSessionApprovals", { sessionId });
+            },
             /**
              * Notifies the runtime that a permission prompt UI has been shown to the user.
              *
@@ -9795,8 +10185,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the operation succeeded.
              */
-            notifyPromptShown: async (params: PermissionPromptShownNotification): Promise<PermissionsNotifyPromptShownResult> =>
-                connection.sendRequest("session.permissions.notifyPromptShown", { sessionId, ...params }),
+            notifyPromptShown: async (params: PermissionPromptShownNotification): Promise<PermissionsNotifyPromptShownResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.permissions.notifyPromptShown", { sessionId, ...params });
+            },
             /** @experimental */
             paths: {
                 /**
@@ -9804,8 +10199,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                  *
                  * @returns Snapshot of the session's allow-listed directories and primary working directory.
                  */
-                list: async (): Promise<PermissionPathsList> =>
-                    connection.sendRequest("session.permissions.paths.list", { sessionId }),
+                list: async (): Promise<PermissionPathsList> => {
+                    assertActive?.();
+                    return connection.sendRequest("session.permissions.paths.list", { sessionId });
+                },
                 /**
                  * Adds a directory to the session's allow-list.
                  *
@@ -9813,8 +10210,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                  *
                  * @returns Indicates whether the operation succeeded.
                  */
-                add: async (params: PermissionPathsAddParams): Promise<PermissionsPathsAddResult> =>
-                    connection.sendRequest("session.permissions.paths.add", { sessionId, ...params }),
+                add: async (params: PermissionPathsAddParams): Promise<PermissionsPathsAddResult> => {
+                    assertActive?.();
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("session.permissions.paths.add", { sessionId, ...params });
+                },
                 /**
                  * Updates the session's primary working directory used by the permission policy.
                  *
@@ -9822,8 +10224,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                  *
                  * @returns Indicates whether the operation succeeded.
                  */
-                updatePrimary: async (params: PermissionPathsUpdatePrimaryParams): Promise<PermissionsPathsUpdatePrimaryResult> =>
-                    connection.sendRequest("session.permissions.paths.updatePrimary", { sessionId, ...params }),
+                updatePrimary: async (params: PermissionPathsUpdatePrimaryParams): Promise<PermissionsPathsUpdatePrimaryResult> => {
+                    assertActive?.();
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("session.permissions.paths.updatePrimary", { sessionId, ...params });
+                },
                 /**
                  * Reports whether a path falls within any of the session's allowed directories.
                  *
@@ -9831,8 +10238,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                  *
                  * @returns Indicates whether the supplied path is within the session's allowed directories.
                  */
-                isPathWithinAllowedDirectories: async (params: PermissionPathsAllowedCheckParams): Promise<PermissionPathsAllowedCheckResult> =>
-                    connection.sendRequest("session.permissions.paths.isPathWithinAllowedDirectories", { sessionId, ...params }),
+                isPathWithinAllowedDirectories: async (params: PermissionPathsAllowedCheckParams): Promise<PermissionPathsAllowedCheckResult> => {
+                    assertActive?.();
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("session.permissions.paths.isPathWithinAllowedDirectories", { sessionId, ...params });
+                },
                 /**
                  * Reports whether a path falls within the session's workspace (primary) directory.
                  *
@@ -9840,8 +10252,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                  *
                  * @returns Indicates whether the supplied path is within the session's workspace directory.
                  */
-                isPathWithinWorkspace: async (params: PermissionPathsWorkspaceCheckParams): Promise<PermissionPathsWorkspaceCheckResult> =>
-                    connection.sendRequest("session.permissions.paths.isPathWithinWorkspace", { sessionId, ...params }),
+                isPathWithinWorkspace: async (params: PermissionPathsWorkspaceCheckParams): Promise<PermissionPathsWorkspaceCheckResult> => {
+                    assertActive?.();
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("session.permissions.paths.isPathWithinWorkspace", { sessionId, ...params });
+                },
             },
             /** @experimental */
             locations: {
@@ -9852,8 +10269,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                  *
                  * @returns Resolved location-permissions key and type.
                  */
-                resolve: async (params: PermissionLocationResolveParams): Promise<PermissionLocationResolveResult> =>
-                    connection.sendRequest("session.permissions.locations.resolve", { sessionId, ...params }),
+                resolve: async (params: PermissionLocationResolveParams): Promise<PermissionLocationResolveResult> => {
+                    assertActive?.();
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("session.permissions.locations.resolve", { sessionId, ...params });
+                },
                 /**
                  * Applies persisted location-scoped tool approvals and allowed directories for a working directory to this session's permission service.
                  *
@@ -9861,8 +10283,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                  *
                  * @returns Summary of persisted location permissions applied to the session.
                  */
-                apply: async (params: PermissionLocationApplyParams): Promise<PermissionLocationApplyResult> =>
-                    connection.sendRequest("session.permissions.locations.apply", { sessionId, ...params }),
+                apply: async (params: PermissionLocationApplyParams): Promise<PermissionLocationApplyResult> => {
+                    assertActive?.();
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("session.permissions.locations.apply", { sessionId, ...params });
+                },
                 /**
                  * Persists a tool approval for a permission location and applies its rules to this session's live permission service.
                  *
@@ -9870,8 +10297,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                  *
                  * @returns Indicates whether the operation succeeded.
                  */
-                addToolApproval: async (params: PermissionLocationAddToolApprovalParams): Promise<PermissionsLocationsAddToolApprovalResult> =>
-                    connection.sendRequest("session.permissions.locations.addToolApproval", { sessionId, ...params }),
+                addToolApproval: async (params: PermissionLocationAddToolApprovalParams): Promise<PermissionsLocationsAddToolApprovalResult> => {
+                    assertActive?.();
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("session.permissions.locations.addToolApproval", { sessionId, ...params });
+                },
             },
             /** @experimental */
             folderTrust: {
@@ -9882,8 +10314,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                  *
                  * @returns Folder trust check result.
                  */
-                isTrusted: async (params: FolderTrustCheckParams): Promise<FolderTrustCheckResult> =>
-                    connection.sendRequest("session.permissions.folderTrust.isTrusted", { sessionId, ...params }),
+                isTrusted: async (params: FolderTrustCheckParams): Promise<FolderTrustCheckResult> => {
+                    assertActive?.();
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("session.permissions.folderTrust.isTrusted", { sessionId, ...params });
+                },
                 /**
                  * Adds a folder to the user's trusted folders list.
                  *
@@ -9891,8 +10328,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                  *
                  * @returns Indicates whether the operation succeeded.
                  */
-                addTrusted: async (params: FolderTrustAddParams): Promise<PermissionsFolderTrustAddTrustedResult> =>
-                    connection.sendRequest("session.permissions.folderTrust.addTrusted", { sessionId, ...params }),
+                addTrusted: async (params: FolderTrustAddParams): Promise<PermissionsFolderTrustAddTrustedResult> => {
+                    assertActive?.();
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("session.permissions.folderTrust.addTrusted", { sessionId, ...params });
+                },
             },
             /** @experimental */
             urls: {
@@ -9903,8 +10345,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                  *
                  * @returns Indicates whether the operation succeeded.
                  */
-                setUnrestrictedMode: async (params: PermissionUrlsSetUnrestrictedModeParams): Promise<PermissionsUrlsSetUnrestrictedModeResult> =>
-                    connection.sendRequest("session.permissions.urls.setUnrestrictedMode", { sessionId, ...params }),
+                setUnrestrictedMode: async (params: PermissionUrlsSetUnrestrictedModeParams): Promise<PermissionsUrlsSetUnrestrictedModeResult> => {
+                    assertActive?.();
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("session.permissions.urls.setUnrestrictedMode", { sessionId, ...params });
+                },
             },
         },
         /**
@@ -9916,8 +10363,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
          *
          * @experimental
          */
-        log: async (params: LogRequest): Promise<LogResult> =>
-            connection.sendRequest("session.log", { sessionId, ...params }),
+        log: async (params: LogRequest): Promise<LogResult> => {
+            assertActive?.();
+            if (params == null) {
+                throw new TypeError("params is required");
+            }
+            return connection.sendRequest("session.log", { sessionId, ...params });
+        },
         /** @experimental */
         metadata: {
             /**
@@ -9925,15 +10377,19 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Point-in-time snapshot of slow-changing session identifier and state fields
              */
-            snapshot: async (): Promise<SessionMetadataSnapshot> =>
-                connection.sendRequest("session.metadata.snapshot", { sessionId }),
+            snapshot: async (): Promise<SessionMetadataSnapshot> => {
+                assertActive?.();
+                return connection.sendRequest("session.metadata.snapshot", { sessionId });
+            },
             /**
              * Reports whether the local session is currently processing user/agent messages.
              *
              * @returns Indicates whether the local session is currently processing a turn or background continuation.
              */
-            isProcessing: async (): Promise<MetadataIsProcessingResult> =>
-                connection.sendRequest("session.metadata.isProcessing", { sessionId }),
+            isProcessing: async (): Promise<MetadataIsProcessingResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.metadata.isProcessing", { sessionId });
+            },
             /**
              * Returns the token breakdown for the session's current context window for a given model.
              *
@@ -9941,8 +10397,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Token breakdown for the session's current context window, or null if uninitialized.
              */
-            contextInfo: async (params: MetadataContextInfoRequest): Promise<MetadataContextInfoResult> =>
-                connection.sendRequest("session.metadata.contextInfo", { sessionId, ...params }),
+            contextInfo: async (params: MetadataContextInfoRequest): Promise<MetadataContextInfoResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.metadata.contextInfo", { sessionId, ...params });
+            },
             /**
              * Records a working-directory/git context change and emits a `session.context_changed` event.
              *
@@ -9950,8 +10411,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Notify the session that its working directory context has changed. Emits a `session.context_changed` event so consumers (telemetry, OTel tracker, ACP, the timeline UI) can react. Use this when the host has detected a cwd/branch/repo change outside the session's normal lifecycle (e.g., after a shell command in interactive mode).
              */
-            recordContextChange: async (params: MetadataRecordContextChangeRequest): Promise<MetadataRecordContextChangeResult> =>
-                connection.sendRequest("session.metadata.recordContextChange", { sessionId, ...params }),
+            recordContextChange: async (params: MetadataRecordContextChangeRequest): Promise<MetadataRecordContextChangeResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.metadata.recordContextChange", { sessionId, ...params });
+            },
             /**
              * Updates the session's recorded working directory.
              *
@@ -9959,8 +10425,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Update the session's working directory. Used by the host when the user explicitly changes cwd (e.g., the `/cd` slash command). The host is responsible for `process.chdir` and any related side-effects (file index, etc.); this method only updates the session's own recorded path.
              */
-            setWorkingDirectory: async (params: MetadataSetWorkingDirectoryRequest): Promise<MetadataSetWorkingDirectoryResult> =>
-                connection.sendRequest("session.metadata.setWorkingDirectory", { sessionId, ...params }),
+            setWorkingDirectory: async (params: MetadataSetWorkingDirectoryRequest): Promise<MetadataSetWorkingDirectoryResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.metadata.setWorkingDirectory", { sessionId, ...params });
+            },
             /**
              * Re-tokenizes the session's existing messages against a model and returns aggregate token totals.
              *
@@ -9968,8 +10439,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Re-tokenize the session's existing messages against `modelId` and return the token totals. Useful for hosts that want an initial estimate of context usage on session resume, before the next agent turn fires `session.context_info_changed` events. Returns zeros for an empty session.
              */
-            recomputeContextTokens: async (params: MetadataRecomputeContextTokensRequest): Promise<MetadataRecomputeContextTokensResult> =>
-                connection.sendRequest("session.metadata.recomputeContextTokens", { sessionId, ...params }),
+            recomputeContextTokens: async (params: MetadataRecomputeContextTokensRequest): Promise<MetadataRecomputeContextTokensResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.metadata.recomputeContextTokens", { sessionId, ...params });
+            },
         },
         /** @experimental */
         shell: {
@@ -9980,8 +10456,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Identifier of the spawned process, used to correlate streamed output and exit notifications.
              */
-            exec: async (params: ShellExecRequest): Promise<ShellExecResult> =>
-                connection.sendRequest("session.shell.exec", { sessionId, ...params }),
+            exec: async (params: ShellExecRequest): Promise<ShellExecResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.shell.exec", { sessionId, ...params });
+            },
             /**
              * Sends a signal to a shell process previously started via "shell.exec".
              *
@@ -9989,8 +10470,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the signal was delivered; false if the process was unknown or already exited.
              */
-            kill: async (params: ShellKillRequest): Promise<ShellKillResult> =>
-                connection.sendRequest("session.shell.kill", { sessionId, ...params }),
+            kill: async (params: ShellKillRequest): Promise<ShellKillResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.shell.kill", { sessionId, ...params });
+            },
         },
         /** @experimental */
         history: {
@@ -9999,8 +10485,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Compaction outcome with the number of tokens and messages removed, summary text, and the resulting context window breakdown.
              */
-            compact: async (): Promise<HistoryCompactResult> =>
-                connection.sendRequest("session.history.compact", { sessionId }),
+            compact: async (): Promise<HistoryCompactResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.history.compact", { sessionId });
+            },
             /**
              * Truncates persisted session history to a specific event.
              *
@@ -10008,29 +10496,40 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Number of events that were removed by the truncation.
              */
-            truncate: async (params: HistoryTruncateRequest): Promise<HistoryTruncateResult> =>
-                connection.sendRequest("session.history.truncate", { sessionId, ...params }),
+            truncate: async (params: HistoryTruncateRequest): Promise<HistoryTruncateResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.history.truncate", { sessionId, ...params });
+            },
             /**
              * Cancels any in-progress background compaction on a local session.
              *
              * @returns Indicates whether an in-progress background compaction was cancelled.
              */
-            cancelBackgroundCompaction: async (): Promise<HistoryCancelBackgroundCompactionResult> =>
-                connection.sendRequest("session.history.cancelBackgroundCompaction", { sessionId }),
+            cancelBackgroundCompaction: async (): Promise<HistoryCancelBackgroundCompactionResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.history.cancelBackgroundCompaction", { sessionId });
+            },
             /**
              * Aborts any in-progress manual compaction on a local session.
              *
              * @returns Indicates whether an in-progress manual compaction was aborted.
              */
-            abortManualCompaction: async (): Promise<HistoryAbortManualCompactionResult> =>
-                connection.sendRequest("session.history.abortManualCompaction", { sessionId }),
+            abortManualCompaction: async (): Promise<HistoryAbortManualCompactionResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.history.abortManualCompaction", { sessionId });
+            },
             /**
              * Produces a markdown summary of the session's conversation context for hand-off scenarios.
              *
              * @returns Markdown summary of the conversation context (empty when not available).
              */
-            summarizeForHandoff: async (): Promise<HistorySummarizeForHandoffResult> =>
-                connection.sendRequest("session.history.summarizeForHandoff", { sessionId }),
+            summarizeForHandoff: async (): Promise<HistorySummarizeForHandoffResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.history.summarizeForHandoff", { sessionId });
+            },
         },
         /** @experimental */
         queue: {
@@ -10039,20 +10538,26 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Snapshot of the session's pending queued items and immediate-steering messages.
              */
-            pendingItems: async (): Promise<QueuePendingItemsResult> =>
-                connection.sendRequest("session.queue.pendingItems", { sessionId }),
+            pendingItems: async (): Promise<QueuePendingItemsResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.queue.pendingItems", { sessionId });
+            },
             /**
              * Removes the most recently queued user-facing item (LIFO).
              *
              * @returns Indicates whether a user-facing pending item was removed.
              */
-            removeMostRecent: async (): Promise<QueueRemoveMostRecentResult> =>
-                connection.sendRequest("session.queue.removeMostRecent", { sessionId }),
+            removeMostRecent: async (): Promise<QueueRemoveMostRecentResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.queue.removeMostRecent", { sessionId });
+            },
             /**
              * Clears all pending queued items on the local session.
              */
-            clear: async (): Promise<void> =>
-                connection.sendRequest("session.queue.clear", { sessionId }),
+            clear: async (): Promise<void> => {
+                assertActive?.();
+                return connection.sendRequest("session.queue.clear", { sessionId });
+            },
         },
         /** @experimental */
         eventLog: {
@@ -10063,15 +10568,19 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Batch of session events returned by a read, with cursor and continuation metadata.
              */
-            read: async (params: EventLogReadRequest): Promise<EventsReadResult> =>
-                connection.sendRequest("session.eventLog.read", { sessionId, ...params }),
+            read: async (params?: EventLogReadRequest): Promise<EventsReadResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.eventLog.read", { sessionId, ...params });
+            },
             /**
              * Returns a snapshot of the current tail cursor without consuming events.
              *
              * @returns Snapshot of the current tail cursor without returning any events. Use this when a consumer wants to subscribe to live events going forward without first paginating through the entire persisted history (which would happen if `read` were called without a cursor on a long-lived session).
              */
-            tail: async (): Promise<EventLogTailResult> =>
-                connection.sendRequest("session.eventLog.tail", { sessionId }),
+            tail: async (): Promise<EventLogTailResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.eventLog.tail", { sessionId });
+            },
             /**
              * Registers consumer interest in an event type for runtime gating purposes.
              *
@@ -10079,8 +10588,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Opaque handle representing an event-type interest registration.
              */
-            registerInterest: async (params: RegisterEventInterestParams): Promise<RegisterEventInterestResult> =>
-                connection.sendRequest("session.eventLog.registerInterest", { sessionId, ...params }),
+            registerInterest: async (params: RegisterEventInterestParams): Promise<RegisterEventInterestResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.eventLog.registerInterest", { sessionId, ...params });
+            },
             /**
              * Releases a consumer's previously-registered interest in an event type.
              *
@@ -10088,8 +10602,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the operation succeeded.
              */
-            releaseInterest: async (params: ReleaseEventInterestParams): Promise<EventLogReleaseInterestResult> =>
-                connection.sendRequest("session.eventLog.releaseInterest", { sessionId, ...params }),
+            releaseInterest: async (params: ReleaseEventInterestParams): Promise<EventLogReleaseInterestResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.eventLog.releaseInterest", { sessionId, ...params });
+            },
         },
         /** @experimental */
         usage: {
@@ -10098,8 +10617,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Accumulated session usage metrics, including premium request cost, token counts, model breakdown, and code-change totals.
              */
-            getMetrics: async (): Promise<UsageGetMetricsResult> =>
-                connection.sendRequest("session.usage.getMetrics", { sessionId }),
+            getMetrics: async (): Promise<UsageGetMetricsResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.usage.getMetrics", { sessionId });
+            },
         },
         /** @experimental */
         remote: {
@@ -10110,13 +10631,17 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns GitHub URL for the session and a flag indicating whether remote steering is enabled.
              */
-            enable: async (params: RemoteEnableRequest): Promise<RemoteEnableResult> =>
-                connection.sendRequest("session.remote.enable", { sessionId, ...params }),
+            enable: async (params?: RemoteEnableRequest): Promise<RemoteEnableResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.remote.enable", { sessionId, ...params });
+            },
             /**
              * Disables remote session export and steering.
              */
-            disable: async (): Promise<void> =>
-                connection.sendRequest("session.remote.disable", { sessionId }),
+            disable: async (): Promise<void> => {
+                assertActive?.();
+                return connection.sendRequest("session.remote.disable", { sessionId });
+            },
             /**
              * Persists a remote-steerability change emitted by the host as a session event.
              *
@@ -10124,8 +10649,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Persist a steerability change as a `session.remote_steerable_changed` event. Used by the host (CLI / SDK consumer) when it has just finished enabling or disabling steering on a remote exporter that the runtime does not directly own.
              */
-            notifySteerableChanged: async (params: RemoteNotifySteerableChangedRequest): Promise<RemoteNotifySteerableChangedResult> =>
-                connection.sendRequest("session.remote.notifySteerableChanged", { sessionId, ...params }),
+            notifySteerableChanged: async (params: RemoteNotifySteerableChangedRequest): Promise<RemoteNotifySteerableChangedResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.remote.notifySteerableChanged", { sessionId, ...params });
+            },
         },
         /** @experimental */
         schedule: {
@@ -10134,8 +10664,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Snapshot of the currently active recurring prompts for this session.
              */
-            list: async (): Promise<ScheduleList> =>
-                connection.sendRequest("session.schedule.list", { sessionId }),
+            list: async (): Promise<ScheduleList> => {
+                assertActive?.();
+                return connection.sendRequest("session.schedule.list", { sessionId });
+            },
             /**
              * Removes a scheduled prompt by id.
              *
@@ -10143,8 +10675,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Remove a scheduled prompt by id. The result entry is omitted if the id was unknown.
              */
-            stop: async (params: ScheduleStopRequest): Promise<ScheduleStopResult> =>
-                connection.sendRequest("session.schedule.stop", { sessionId, ...params }),
+            stop: async (params: ScheduleStopRequest): Promise<ScheduleStopResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.schedule.stop", { sessionId, ...params });
+            },
         },
     };
 }

--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -5,30 +5,8 @@
 
 import type { MessageConnection } from "vscode-jsonrpc/node.js";
 
-import type { AbortReason, EmbeddedBlobResourceContents, EmbeddedTextResourceContents, McpServerSource, McpServerStatus, PermissionPromptRequest, PermissionRule, ReasoningSummary, SessionEvent, SessionMode, ShutdownType, SkillSource, UserToolSessionApproval } from "./session-events.js";
+import type { EmbeddedBlobResourceContents, EmbeddedTextResourceContents, McpServerSource, McpServerStatus, ReasoningSummary, SessionMode, SkillSource } from "./session-events.js";
 
-/**
- * Where the agent definition was loaded from
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "AgentInfoSource".
- */
-/** @experimental */
-export type AgentInfoSource = "user" | "project" | "inherited" | "remote" | "plugin" | "builtin";
-/**
- * The new auth credentials to install on the session. When omitted or `undefined`, the call is a no-op and the session's existing credentials are preserved. The runtime stores the value verbatim and uses it for outbound model/API requests; it does NOT re-validate or re-fetch the associated Copilot user response. Several variants carry secret material; treat this method's params as containing secrets at rest and in transit.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "AuthInfo".
- */
-export type AuthInfo =
-  | HMACAuthInfo
-  | EnvAuthInfo
-  | TokenAuthInfo
-  | CopilotApiTokenAuthInfo
-  | UserAuthInfo
-  | GhCliAuthInfo
-  | ApiKeyAuthInfo;
 /**
  * Authentication type
  *
@@ -51,7 +29,7 @@ export type SlashCommandKind = "builtin" | "skill" | "client";
  */
 export type SlashCommandInputCompletion = "directory";
 /**
- * Result of the queued command execution.
+ * Result of the queued command execution
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "QueuedCommandResult".
@@ -79,30 +57,6 @@ export type ContentFilterMode = "none" | "markdown" | "hidden_characters";
  * via the `definition` "DiscoveredMcpServerType".
  */
 export type DiscoveredMcpServerType = "stdio" | "http" | "sse" | "memory";
-/**
- * Either '*' to receive all event types, or a non-empty list of event types to receive
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "EventLogTypes".
- */
-/** @experimental */
-export type EventLogTypes = "*" | [string, ...string[]];
-/**
- * Agent-scope filter: 'primary' returns only main-agent events plus events whose type starts with 'subagent.' (matching the typed-subscription default behavior); 'all' returns events from all agents (matching wildcard-subscription behavior). Default is 'all' to preserve wildcard semantics for catch-up callers.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "EventsAgentScope".
- */
-/** @experimental */
-export type EventsAgentScope = "primary" | "all";
-/**
- * Cursor status: 'ok' means the cursor was applied successfully; 'expired' means the cursor referred to an event that no longer exists in history (e.g. truncated or compacted away) and the read started from the beginning of the remaining history.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "EventsCursorStatus".
- */
-/** @experimental */
-export type EventsCursorStatus = "ok" | "expired";
 /**
  * Discovery source: project (.github/extensions/) or user (~/.copilot/extensions/)
  *
@@ -174,38 +128,19 @@ export type FilterMapping =
     }
   | ContentFilterMode;
 /**
- * Source for direct repo installs (when marketplace is empty)
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "InstalledPluginSource".
- */
-/** @experimental */
-export type InstalledPluginSource =
-  | string
-  | InstalledPluginSourceGithub
-  | InstalledPluginSourceUrl
-  | InstalledPluginSourceLocal;
-/**
  * Category of instruction source — used for merge logic
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "InstructionsSourcesType".
  */
-export type InstructionsSourcesType =
-  | "home"
-  | "repo"
-  | "model"
-  | "vscode"
-  | "nested-agents"
-  | "child-instructions"
-  | "plugin";
+export type InstructionsSourcesType = "home" | "repo" | "model" | "vscode" | "nested-agents" | "child-instructions";
 /**
  * Where this source lives — used for UI grouping
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "InstructionsSourcesLocation".
  */
-export type InstructionsSourcesLocation = "user" | "repository" | "working-directory" | "plugin";
+export type InstructionsSourcesLocation = "user" | "repository" | "working-directory";
 /**
  * Log severity level. Determines how the message is displayed in the timeline. Defaults to "info".
  *
@@ -235,91 +170,6 @@ export type McpServerConfigHttpType = "http" | "sse";
  */
 export type McpServerConfigHttpOauthGrantType = "authorization_code" | "client_credentials";
 /**
- * Outcome of the sampling inference. 'success' produced a response; 'failure' encountered an error (including agent-side rejection by content filter or criteria); 'cancelled' the caller cancelled this execution via cancelSamplingExecution.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "McpSamplingExecutionAction".
- */
-/** @experimental */
-export type McpSamplingExecutionAction = "success" | "failure" | "cancelled";
-/**
- * How environment-variable values supplied to MCP servers are resolved. "direct" passes literal string values; "indirect" treats values as references (e.g. names of environment variables on the host) that the runtime resolves before launch. Defaults to the runtime's startup mode; clients that intentionally launch MCP servers with literal values (e.g. CLI prompt mode and ACP) set this to "direct".
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "McpSetEnvValueModeDetails".
- */
-/** @experimental */
-export type McpSetEnvValueModeDetails = "direct" | "indirect";
-/**
- * Token breakdown for the current context window, or null if the session has not yet been initialized (no system prompt or tool metadata cached).
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionContextInfo".
- */
-/** @experimental */
-export type SessionContextInfo = {
-  /**
-   * The model used for token counting
-   */
-  modelName: string;
-  /**
-   * Tokens consumed by the system prompt
-   */
-  systemTokens: number;
-  /**
-   * Tokens consumed by user/assistant/tool messages
-   */
-  conversationTokens: number;
-  /**
-   * Tokens consumed by tool definitions sent to the model (excludes deferred tools)
-   */
-  toolDefinitionsTokens: number;
-  /**
-   * Sum of system, conversation and tool-definition tokens
-   */
-  totalTokens: number;
-  /**
-   * Maximum prompt tokens allowed by the model (or DEFAULT_TOKEN_LIMIT if unspecified)
-   */
-  promptTokenLimit: number;
-  /**
-   * Token count at which background compaction starts (configurable percentage of promptTokenLimit)
-   */
-  compactionThreshold: number;
-  /**
-   * Total context limit for /context display. promptTokenLimit + min(32k or 64k, outputTokenLimit) depending on model.
-   */
-  limit: number;
-  /**
-   * Output reserve plus tokens after the buffer-exhaustion blocking threshold (default 95%)
-   */
-  bufferTokens: number;
-} | null;
-/**
- * Hosting platform type of the repository
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionWorkingDirectoryContextHostType".
- */
-/** @experimental */
-export type SessionWorkingDirectoryContextHostType = "github" | "ado";
-/**
- * The current agent mode for this session (e.g., 'interactive', 'plan', 'autopilot')
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "MetadataSnapshotCurrentMode".
- */
-/** @experimental */
-export type MetadataSnapshotCurrentMode = "interactive" | "plan" | "autopilot";
-/**
- * Whether the remote task originated from Copilot Coding Agent (cca) or a CLI `--remote` invocation.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "MetadataSnapshotRemoteMetadataTaskType".
- */
-/** @experimental */
-export type MetadataSnapshotRemoteMetadataTaskType = "cca" | "cli";
-/**
  * Current policy state for this model
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -341,15 +191,7 @@ export type ModelPickerCategory = "lightweight" | "versatile" | "powerful";
  */
 export type ModelPickerPriceCategory = "low" | "medium" | "high" | "very_high";
 /**
- * How env values are passed to MCP servers (`direct` inlines literal values; `indirect` resolves at launch).
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "OptionsUpdateEnvValueMode".
- */
-/** @experimental */
-export type OptionsUpdateEnvValueMode = "direct" | "indirect";
-/**
- * The client's response to the pending permission prompt
+ * Decision to apply to a pending permission request.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "PermissionDecision".
@@ -360,18 +202,9 @@ export type PermissionDecision =
   | PermissionDecisionApproveForLocation
   | PermissionDecisionApprovePermanently
   | PermissionDecisionReject
-  | PermissionDecisionUserNotAvailable
-  | PermissionDecisionApproved
-  | PermissionDecisionApprovedForSession
-  | PermissionDecisionApprovedForLocation
-  | PermissionDecisionCancelled
-  | PermissionDecisionDeniedByRules
-  | PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser
-  | PermissionDecisionDeniedInteractivelyByUser
-  | PermissionDecisionDeniedByContentExclusionPolicy
-  | PermissionDecisionDeniedByPermissionRequestHook;
+  | PermissionDecisionUserNotAvailable;
 /**
- * Session-scoped approval to remember (tool prompts only; omitted for path/url prompts)
+ * The approval to add as a session-scoped rule
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "PermissionDecisionApproveForSessionApproval".
@@ -387,7 +220,7 @@ export type PermissionDecisionApproveForSessionApproval =
   | PermissionDecisionApproveForSessionApprovalExtensionManagement
   | PermissionDecisionApproveForSessionApprovalExtensionPermissionAccess;
 /**
- * Approval to persist for this location
+ * The approval to persist for this location
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "PermissionDecisionApproveForLocationApproval".
@@ -403,35 +236,6 @@ export type PermissionDecisionApproveForLocationApproval =
   | PermissionDecisionApproveForLocationApprovalExtensionManagement
   | PermissionDecisionApproveForLocationApprovalExtensionPermissionAccess;
 /**
- * Allowed values for the `PermissionsConfigureAdditionalContentExclusionPolicyScope` enumeration.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionsConfigureAdditionalContentExclusionPolicyScope".
- */
-export type PermissionsConfigureAdditionalContentExclusionPolicyScope = "repo" | "all";
-/**
- * Whether the change applies to ephemeral session-scoped rules (cleared at session end) or to location-scoped rules persisted via the location-permissions config file.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionsModifyRulesScope".
- */
-export type PermissionsModifyRulesScope = "session" | "location";
-/**
- * Optional source for allow-all telemetry. Defaults to `rpc` when omitted for SDK callers.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionsSetApproveAllSource".
- */
-export type PermissionsSetApproveAllSource = "cli_flag" | "slash_command" | "autopilot_confirmation" | "rpc";
-/**
- * Whether this item is a queued user message or a queued slash command / model change
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "QueuePendingItemsKind".
- */
-/** @experimental */
-export type QueuePendingItemsKind = "message" | "command";
-/**
  * Per-session remote mode. "off" disables remote, "export" exports session events to GitHub without enabling remote steering, "on" enables both export and remote steering.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -439,47 +243,6 @@ export type QueuePendingItemsKind = "message" | "command";
  */
 /** @experimental */
 export type RemoteSessionMode = "off" | "export" | "on";
-/**
- * The UI mode the agent was in when this message was sent. Defaults to the session's current mode.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SendAgentMode".
- */
-export type SendAgentMode = "interactive" | "plan" | "autopilot" | "shell";
-/**
- * A user message attachment — a file, directory, code selection, blob, or GitHub reference
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SendAttachment".
- */
-export type SendAttachment =
-  | SendAttachmentFile
-  | SendAttachmentDirectory
-  | SendAttachmentSelection
-  | SendAttachmentGithubReference
-  | SendAttachmentBlob;
-/**
- * Type of GitHub reference
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SendAttachmentGithubReferenceType".
- */
-export type SendAttachmentGithubReferenceType = "issue" | "pr" | "discussion";
-/**
- * How to deliver the message. `enqueue` (default) appends to the message queue. `immediate` interjects during an in-progress turn.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SendMode".
- */
-export type SendMode = "enqueue" | "immediate";
-/**
- * Repository host type
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionContextHostType".
- */
-/** @experimental */
-export type SessionContextHostType = "github" | "ado";
 /**
  * Error classification
  *
@@ -508,63 +271,6 @@ export type SessionFsSetProviderConventions = "windows" | "posix";
  * via the `definition` "SessionFsSqliteQueryType".
  */
 export type SessionFsSqliteQueryType = "exec" | "query" | "run";
-/**
- * Source descriptor for direct repo installs (when marketplace is empty)
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionInstalledPluginSource".
- */
-/** @experimental */
-export type SessionInstalledPluginSource =
-  | string
-  | SessionInstalledPluginSourceGithub
-  | SessionInstalledPluginSourceUrl
-  | SessionInstalledPluginSourceLocal;
-/**
- * Public-facing workspace metadata for this session, or null if the session has no associated workspace. Excludes runtime-internal fields (GitHub IDs, summary count, internal flags).
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "WorkspaceSummary".
- */
-/** @experimental */
-export type WorkspaceSummary = {
-  /**
-   * Workspace identifier (1:1 with sessionId)
-   */
-  id: string;
-  /**
-   * Current working directory at session start
-   */
-  cwd?: string;
-  /**
-   * Resolved git root for cwd, if any
-   */
-  git_root?: string;
-  /**
-   * Repository identifier in 'owner/repo' or 'org/project/repo' format, if any
-   */
-  repository?: string;
-  /**
-   * Repository host type, if known
-   */
-  host_type?: "github" | "ado";
-  /**
-   * Branch checked out at session start, if any
-   */
-  branch?: string;
-  /**
-   * Display name for the session, if set
-   */
-  name?: string;
-  /**
-   * ISO 8601 timestamp when the workspace was created
-   */
-  created_at?: string;
-  /**
-   * ISO 8601 timestamp when the workspace was last updated
-   */
-  updated_at?: string;
-} | null;
 /**
  * Signal to send (default: SIGTERM)
  *
@@ -599,51 +305,6 @@ export type TaskStatus = "running" | "idle" | "completed" | "failed" | "cancelle
 /** @experimental */
 export type TaskExecutionMode = "sync" | "background";
 /**
- * Schema for the `TaskAgentProgress` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "TaskAgentProgress".
- */
-/** @experimental */
-export type TaskAgentProgress =
-  | {
-      /**
-       * Progress kind
-       */
-      type: "agent";
-      /**
-       * Recent tool execution events converted to display lines
-       */
-      recentActivity: {
-        /**
-         * Display message, e.g., "▸ bash", "✓ edit src/foo.ts"
-         */
-        message: string;
-        /**
-         * ISO 8601 timestamp when this event occurred
-         */
-        timestamp: string;
-      }[];
-      /**
-       * The most recent intent reported by the agent
-       */
-      latestIntent?: string;
-    }
-  | {
-      /**
-       * Progress kind
-       */
-      type: "shell";
-      /**
-       * Recent stdout/stderr lines from the running shell command
-       */
-      recentOutput: string;
-      /**
-       * Process ID when available
-       */
-      pid?: number;
-    };
-/**
  * Schema for the `TaskInfo` type.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -659,29 +320,6 @@ export type TaskInfo = TaskAgentInfo | TaskShellInfo;
  */
 /** @experimental */
 export type TaskShellInfoAttachmentMode = "attached" | "detached";
-/**
- * Progress information for the task, discriminated by type. Returns null when no task with this ID is currently tracked.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "TaskProgress".
- */
-/** @experimental */
-export type TaskProgress = TaskAgentProgress | TaskShellProgress;
-/**
- * Schema for the `TaskShellProgress` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "TaskShellProgress".
- */
-/** @experimental */
-export type TaskShellProgress = null;
-/**
- * User's choice for auto-mode switching: yes (allow this turn), yes_always (allow + persist as setting), or no (decline).
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "UIAutoModeSwitchResponse".
- */
-export type UIAutoModeSwitchResponse = "yes" | "yes_always" | "no";
 /**
  * Schema for the `UIElicitationFieldValue` type.
  *
@@ -727,39 +365,6 @@ export type UIElicitationSchemaPropertyNumberType = "number" | "integer";
  * via the `definition` "UIElicitationResponseAction".
  */
 export type UIElicitationResponseAction = "accept" | "decline" | "cancel";
-/**
- * The action the user selected. Defaults to 'autopilot' when autoApproveEdits is true, otherwise 'interactive'.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "UIExitPlanModeAction".
- */
-export type UIExitPlanModeAction = "exit_only" | "interactive" | "autopilot" | "autopilot_fleet";
-
-/**
- * Parameters for aborting the current turn
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "AbortRequest".
- */
-export interface AbortRequest {
-  reason?: AbortReason;
-}
-/**
- * Result of aborting the current turn
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "AbortResult".
- */
-export interface AbortResult {
-  /**
-   * Whether the abort completed successfully
-   */
-  success: boolean;
-  /**
-   * Error message if the abort failed
-   */
-  error?: string;
-}
 
 export interface AccountGetQuotaRequest {
   /**
@@ -858,33 +463,6 @@ export interface AgentInfo {
    * Absolute local file path of the agent definition. Only set for file-based agents loaded from disk; remote agents do not have a path.
    */
   path?: string;
-  /**
-   * Stable identifier for selection. For most agents this is the same as `name`; for plugin/builtin agents it may differ. Always populated; defaults to `name` when no distinct id was assigned.
-   */
-  id: string;
-  source?: AgentInfoSource;
-  /**
-   * Whether the agent can be selected directly by the user. Agents marked `false` are subagent-only.
-   */
-  userInvocable?: boolean;
-  /**
-   * Allowed tool names for this agent. Empty array means none; omitted means inherit defaults.
-   */
-  tools?: string[];
-  /**
-   * Preferred model id for this agent. When omitted, inherits the outer agent's model.
-   */
-  model?: string;
-  /**
-   * MCP server configurations attached to this agent, keyed by server name. Server config shape mirrors the MCP `mcpServers` schema.
-   */
-  mcpServers?: {
-    [k: string]: unknown | undefined;
-  };
-  /**
-   * Skill names preloaded into this agent's context. Omitted means none.
-   */
-  skills?: string[];
 }
 /**
  * Custom agents available to the session.
@@ -934,333 +512,6 @@ export interface AgentSelectRequest {
 /** @experimental */
 export interface AgentSelectResult {
   agent: AgentInfo;
-}
-/**
- * Schema for the `ApiKeyAuthInfo` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "ApiKeyAuthInfo".
- */
-export interface ApiKeyAuthInfo {
-  /**
-   * API-key authentication for non-GitHub LLM providers (e.g. when running BYOM-style).
-   */
-  type: "api-key";
-  /**
-   * The API key. Treat as a secret.
-   */
-  apiKey: string;
-  /**
-   * Authentication host.
-   */
-  host: string;
-  copilotUser?: CopilotUserResponse;
-}
-/**
- * Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this verbatim and does not re-fetch when set.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "CopilotUserResponse".
- */
-export interface CopilotUserResponse {
-  login?: string;
-  access_type_sku?: string;
-  analytics_tracking_id?: string;
-  assigned_date?:
-    | (
-        | {
-            [k: string]: unknown | undefined;
-          }
-        | string
-      )
-    | null;
-  can_signup_for_limited?: boolean;
-  chat_enabled?: boolean;
-  copilot_plan?: string;
-  copilotignore_enabled?: boolean;
-  endpoints?: CopilotUserResponseEndpoints;
-  organization_login_list?: string[];
-  organization_list?:
-    | (
-        | {
-            [k: string]: unknown | undefined;
-          }
-        | ({
-            login?:
-              | (
-                  | {
-                      [k: string]: unknown | undefined;
-                    }
-                  | string
-                )
-              | null;
-            name?:
-              | (
-                  | {
-                      [k: string]: unknown | undefined;
-                    }
-                  | string
-                )
-              | null;
-          } | null)[]
-      )
-    | null;
-  codex_agent_enabled?: boolean;
-  is_mcp_enabled?:
-    | (
-        | {
-            [k: string]: unknown | undefined;
-          }
-        | boolean
-      )
-    | null;
-  quota_reset_date?: string;
-  quota_snapshots?: CopilotUserResponseQuotaSnapshots;
-  restricted_telemetry?: boolean;
-  token_based_billing?: boolean;
-  quota_reset_date_utc?: string;
-  limited_user_quotas?: {
-    [k: string]: number | undefined;
-  };
-  limited_user_reset_date?: string;
-  monthly_quotas?: {
-    [k: string]: number | undefined;
-  };
-  cloud_session_storage_enabled?: boolean;
-  cli_remote_control_enabled?: boolean;
-}
-/**
- * Schema for the `CopilotUserResponseEndpoints` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "CopilotUserResponseEndpoints".
- */
-export interface CopilotUserResponseEndpoints {
-  api?: string;
-  "origin-tracker"?: string;
-  proxy?: string;
-  telemetry?: string;
-}
-/**
- * Schema for the `CopilotUserResponseQuotaSnapshots` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "CopilotUserResponseQuotaSnapshots".
- */
-export interface CopilotUserResponseQuotaSnapshots {
-  chat?: CopilotUserResponseQuotaSnapshotsChat;
-  completions?: CopilotUserResponseQuotaSnapshotsCompletions;
-  premium_interactions?: CopilotUserResponseQuotaSnapshotsPremiumInteractions;
-  [k: string]:
-    | ({
-        entitlement?: number;
-        overage_count?: number;
-        overage_permitted?: boolean;
-        percent_remaining?: number;
-        quota_id?: string;
-        quota_remaining?: number;
-        remaining?: number;
-        unlimited?: boolean;
-        timestamp_utc?: string;
-        has_quota?: boolean;
-        quota_reset_at?: number;
-        token_based_billing?: boolean;
-      } | null)
-    | undefined;
-}
-/**
- * Schema for the `CopilotUserResponseQuotaSnapshotsChat` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "CopilotUserResponseQuotaSnapshotsChat".
- */
-export interface CopilotUserResponseQuotaSnapshotsChat {
-  entitlement?: number;
-  overage_count?: number;
-  overage_permitted?: boolean;
-  percent_remaining?: number;
-  quota_id?: string;
-  quota_remaining?: number;
-  remaining?: number;
-  unlimited?: boolean;
-  timestamp_utc?: string;
-  has_quota?: boolean;
-  quota_reset_at?: number;
-  token_based_billing?: boolean;
-}
-/**
- * Schema for the `CopilotUserResponseQuotaSnapshotsCompletions` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "CopilotUserResponseQuotaSnapshotsCompletions".
- */
-export interface CopilotUserResponseQuotaSnapshotsCompletions {
-  entitlement?: number;
-  overage_count?: number;
-  overage_permitted?: boolean;
-  percent_remaining?: number;
-  quota_id?: string;
-  quota_remaining?: number;
-  remaining?: number;
-  unlimited?: boolean;
-  timestamp_utc?: string;
-  has_quota?: boolean;
-  quota_reset_at?: number;
-  token_based_billing?: boolean;
-}
-/**
- * Schema for the `CopilotUserResponseQuotaSnapshotsPremiumInteractions` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "CopilotUserResponseQuotaSnapshotsPremiumInteractions".
- */
-export interface CopilotUserResponseQuotaSnapshotsPremiumInteractions {
-  entitlement?: number;
-  overage_count?: number;
-  overage_permitted?: boolean;
-  percent_remaining?: number;
-  quota_id?: string;
-  quota_remaining?: number;
-  remaining?: number;
-  unlimited?: boolean;
-  timestamp_utc?: string;
-  has_quota?: boolean;
-  quota_reset_at?: number;
-  token_based_billing?: boolean;
-}
-/**
- * Schema for the `HMACAuthInfo` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "HMACAuthInfo".
- */
-export interface HMACAuthInfo {
-  /**
-   * HMAC-based authentication used by GitHub-internal services.
-   */
-  type: "hmac";
-  /**
-   * Authentication host. HMAC auth always targets the public GitHub host.
-   */
-  host: "https://github.com";
-  /**
-   * HMAC secret used to sign requests.
-   */
-  hmac: string;
-  copilotUser?: CopilotUserResponse;
-}
-/**
- * Schema for the `EnvAuthInfo` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "EnvAuthInfo".
- */
-export interface EnvAuthInfo {
-  /**
-   * Personal access token (PAT) or server-to-server token sourced from an environment variable.
-   */
-  type: "env";
-  /**
-   * Authentication host (e.g. https://github.com or a GHES host).
-   */
-  host: string;
-  /**
-   * User login associated with the token. Undefined for server-to-server tokens (those starting with `ghs_`).
-   */
-  login?: string;
-  /**
-   * The token value itself. Treat as a secret.
-   */
-  token: string;
-  /**
-   * Name of the environment variable the token was sourced from.
-   */
-  envVar: string;
-  copilotUser?: CopilotUserResponse;
-}
-/**
- * Schema for the `TokenAuthInfo` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "TokenAuthInfo".
- */
-export interface TokenAuthInfo {
-  /**
-   * SDK-side token authentication; the host configured the token directly via the SDK.
-   */
-  type: "token";
-  /**
-   * Authentication host.
-   */
-  host: string;
-  /**
-   * The token value itself. Treat as a secret.
-   */
-  token: string;
-  copilotUser?: CopilotUserResponse;
-}
-/**
- * Schema for the `CopilotApiTokenAuthInfo` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "CopilotApiTokenAuthInfo".
- */
-export interface CopilotApiTokenAuthInfo {
-  /**
-   * Direct Copilot API authentication via the `GITHUB_COPILOT_API_TOKEN` + `COPILOT_API_URL` environment-variable pair. The token itself is read from the environment by the runtime, not carried in this struct.
-   */
-  type: "copilot-api-token";
-  /**
-   * Authentication host (always the public GitHub host).
-   */
-  host: "https://github.com";
-  copilotUser?: CopilotUserResponse;
-}
-/**
- * Schema for the `UserAuthInfo` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "UserAuthInfo".
- */
-export interface UserAuthInfo {
-  /**
-   * OAuth user authentication. The token itself is held in the runtime's secret token store (keyed by host+login) and is NOT carried in this struct.
-   */
-  type: "user";
-  /**
-   * Authentication host.
-   */
-  host: string;
-  /**
-   * OAuth user login.
-   */
-  login: string;
-  copilotUser?: CopilotUserResponse;
-}
-/**
- * Schema for the `GhCliAuthInfo` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "GhCliAuthInfo".
- */
-export interface GhCliAuthInfo {
-  /**
-   * Authentication via the `gh` CLI's saved credentials.
-   */
-  type: "gh-cli";
-  /**
-   * Authentication host.
-   */
-  host: string;
-  /**
-   * User login as reported by `gh auth status`.
-   */
-  login: string;
-  /**
-   * The token returned by `gh auth token`. Treat as a secret.
-   */
-  token: string;
-  copilotUser?: CopilotUserResponse;
 }
 /**
  * Slash commands available in the session, after applying any include/exclude filters.
@@ -1390,14 +641,14 @@ export interface CommandsListRequest {
   includeClientCommands?: boolean;
 }
 /**
- * Queued-command request ID and the result indicating whether the host executed it (and whether to stop processing further queued commands).
+ * Queued command request ID and the result indicating whether the client handled it.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "CommandsRespondToQueuedCommandRequest".
  */
 export interface CommandsRespondToQueuedCommandRequest {
   /**
-   * Request ID from the `command.queued` event the host is responding to.
+   * Request ID from the queued command event
    */
   requestId: string;
   result: QueuedCommandResult;
@@ -1410,11 +661,11 @@ export interface CommandsRespondToQueuedCommandRequest {
  */
 export interface QueuedCommandHandled {
   /**
-   * The host actually executed the queued command.
+   * The command was handled
    */
   handled: true;
   /**
-   * When true, the runtime will not process subsequent queued commands until a new request comes in.
+   * If true, stop processing remaining queued items
    */
   stopProcessingQueue?: boolean;
 }
@@ -1426,19 +677,19 @@ export interface QueuedCommandHandled {
  */
 export interface QueuedCommandNotHandled {
   /**
-   * The host did not execute the queued command. Unblocks the queue without claiming the command was processed (e.g. when the handler threw before completing).
+   * The command was not handled
    */
   handled: false;
 }
 /**
- * Indicates whether the queued-command response was matched to a pending request.
+ * Indicates whether the queued-command response was accepted by the session.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "CommandsRespondToQueuedCommandResult".
  */
 export interface CommandsRespondToQueuedCommandResult {
   /**
-   * Whether a pending queued command with the given request ID was found and resolved. False when the request was already resolved, cancelled, or unknown.
+   * Whether the response was accepted (false if the requestId was not found or already resolved)
    */
   success: boolean;
 }
@@ -1558,7 +809,7 @@ export interface ConnectResult {
   version: string;
 }
 /**
- * The currently selected model and reasoning effort for the session.
+ * The currently selected model for the session.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "CurrentModel".
@@ -1568,10 +819,6 @@ export interface CurrentModel {
    * Currently active model identifier
    */
   modelId?: string;
-  /**
-   * Reasoning effort level currently applied to the active model, when one is set. Reads `Session.getReasoningEffort()` synchronously after `getSelectedModel()` resolves so the two values are reported as a snapshot.
-   */
-  reasoningEffort?: string;
 }
 /**
  * Schema for the `DiscoveredMcpServer` type.
@@ -1590,129 +837,6 @@ export interface DiscoveredMcpServer {
    * Whether the server is enabled (not in the disabled list)
    */
   enabled: boolean;
-}
-/**
- * Slash-prefixed command string to enqueue for FIFO processing.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "EnqueueCommandParams".
- */
-export interface EnqueueCommandParams {
-  /**
-   * Slash-prefixed command string to enqueue, e.g. '/compact' or '/model gpt-4'. Queued FIFO with any in-flight items; if the session is idle, processing kicks off immediately.
-   */
-  command: string;
-}
-/**
- * Indicates whether the command was accepted into the local execution queue.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "EnqueueCommandResult".
- */
-export interface EnqueueCommandResult {
-  /**
-   * True when the command was accepted into the local execution queue. False when the call targets a session that does not support local command queueing (e.g. remote sessions).
-   */
-  queued: boolean;
-}
-/**
- * Cursor, batch size, and optional long-poll/filter parameters for reading session events.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "EventLogReadRequest".
- */
-/** @experimental */
-export interface EventLogReadRequest {
-  /**
-   * Opaque cursor returned by a previous read. Omit on the first call to start from the beginning of the session's persisted history.
-   */
-  cursor?: string;
-  /**
-   * Maximum number of events to return in this batch (1–1000, default 200).
-   */
-  max?: number;
-  /**
-   * Milliseconds to wait for new events when the cursor is at the tail of history. 0 (default) returns immediately even if no events are available. Capped at 30000ms. Ephemeral events that arrive during the wait are delivered in this batch but are NOT replayable on a subsequent read (use a non-zero waitMs in your next call to capture future ephemerals as they happen).
-   */
-  waitMs?: number;
-  types?: EventLogTypes;
-  agentScope?: EventsAgentScope;
-}
-/**
- * Indicates whether the operation succeeded.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "EventLogReleaseInterestResult".
- */
-/** @experimental */
-export interface EventLogReleaseInterestResult {
-  /**
-   * Whether the operation succeeded
-   */
-  success: boolean;
-}
-/**
- * Snapshot of the current tail cursor without returning any events. Use this when a consumer wants to subscribe to live events going forward without first paginating through the entire persisted history (which would happen if `read` were called without a cursor on a long-lived session).
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "EventLogTailResult".
- */
-/** @experimental */
-export interface EventLogTailResult {
-  /**
-   * Opaque cursor pointing at the current tail of the session's persisted-events history. Pass back to `read` to receive only events that arrive AFTER this snapshot. When the session has no events, this returns the same sentinel as an unset cursor (i.e. equivalent to omitting the cursor on a first read).
-   */
-  cursor: string;
-}
-/**
- * Batch of session events returned by a read, with cursor and continuation metadata.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "EventsReadResult".
- */
-/** @experimental */
-export interface EventsReadResult {
-  /**
-   * Events are delivered in two batches per read: persisted events first (in append order), then ephemeral events (in seq order). When `waitMs > 0` and the catch-up batches were empty, post-wait events follow the same two-batch ordering. Persisted and ephemeral events do not interleave within a single read.
-   */
-  events: SessionEvent[];
-  /**
-   * Opaque cursor for the next read. Pass back unchanged in the next read.cursor to continue from where this read left off. Always present, even when no events were returned.
-   */
-  cursor: string;
-  /**
-   * True when the read returned `max` events and more events are available immediately. When false, the next read with a non-zero `waitMs` will block until a new event arrives or the wait expires.
-   */
-  hasMore: boolean;
-  cursorStatus: EventsCursorStatus;
-}
-/**
- * Slash command name and argument string to execute synchronously.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "ExecuteCommandParams".
- */
-export interface ExecuteCommandParams {
-  /**
-   * Name of the slash command to invoke (without the leading '/').
-   */
-  commandName: string;
-  /**
-   * Argument string to pass to the command (empty string if none).
-   */
-  args: string;
-}
-/**
- * Error message produced while executing the command, if any.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "ExecuteCommandResult".
- */
-export interface ExecuteCommandResult {
-  /**
-   * Error message produced while executing the command, if any. Omitted when the handler succeeded.
-   */
-  error?: string;
 }
 /**
  * Schema for the `Extension` type.
@@ -2046,32 +1170,6 @@ export interface HandlePendingToolCallResult {
   success: boolean;
 }
 /**
- * Indicates whether an in-progress manual compaction was aborted.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "HistoryAbortManualCompactionResult".
- */
-/** @experimental */
-export interface HistoryAbortManualCompactionResult {
-  /**
-   * Whether an in-progress manual compaction was aborted. False when no manual compaction was running, when its abort controller was already aborted, or when the session is remote.
-   */
-  aborted: boolean;
-}
-/**
- * Indicates whether an in-progress background compaction was cancelled.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "HistoryCancelBackgroundCompactionResult".
- */
-/** @experimental */
-export interface HistoryCancelBackgroundCompactionResult {
-  /**
-   * Whether an in-progress background compaction was cancelled. False when no compaction was running, when the session is remote, or when the underlying processor was unavailable.
-   */
-  cancelled: boolean;
-}
-/**
  * Post-compaction context window usage breakdown
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -2105,7 +1203,7 @@ export interface HistoryCompactContextWindow {
   toolDefinitionsTokens?: number;
 }
 /**
- * Compaction outcome with the number of tokens and messages removed, summary text, and the resulting context window breakdown.
+ * Compaction outcome with the number of tokens and messages removed and the resulting context window breakdown.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "HistoryCompactResult".
@@ -2124,24 +1222,7 @@ export interface HistoryCompactResult {
    * Number of messages removed during compaction
    */
   messagesRemoved: number;
-  /**
-   * Summary text produced by compaction. Omitted when compaction did not produce a summary (e.g. failure path).
-   */
-  summaryContent?: string;
   contextWindow?: HistoryCompactContextWindow;
-}
-/**
- * Markdown summary of the conversation context (empty when not available).
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "HistorySummarizeForHandoffResult".
- */
-/** @experimental */
-export interface HistorySummarizeForHandoffResult {
-  /**
-   * Markdown summary of the conversation context produced by an LLM. Empty string when there are no messages or when the session does not support local summarization.
-   */
-  summary: string;
 }
 /**
  * Identifier of the event to truncate to; this event and all later events are removed.
@@ -2168,86 +1249,6 @@ export interface HistoryTruncateResult {
    * Number of events that were removed
    */
   eventsRemoved: number;
-}
-/**
- * Schema for the `InstalledPlugin` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "InstalledPlugin".
- */
-/** @experimental */
-export interface InstalledPlugin {
-  /**
-   * Plugin name
-   */
-  name: string;
-  /**
-   * Marketplace the plugin came from (empty string for direct repo installs)
-   */
-  marketplace: string;
-  /**
-   * Version installed (if available)
-   */
-  version?: string;
-  /**
-   * Installation timestamp
-   */
-  installed_at: string;
-  /**
-   * Whether the plugin is currently enabled
-   */
-  enabled: boolean;
-  /**
-   * Path where the plugin is cached locally
-   */
-  cache_path?: string;
-  source?: InstalledPluginSource;
-}
-/**
- * Schema for the `InstalledPluginSourceGithub` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "InstalledPluginSourceGithub".
- */
-/** @experimental */
-export interface InstalledPluginSourceGithub {
-  /**
-   * Constant value. Always "github".
-   */
-  source: "github";
-  repo: string;
-  ref?: string;
-  path?: string;
-}
-/**
- * Schema for the `InstalledPluginSourceUrl` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "InstalledPluginSourceUrl".
- */
-/** @experimental */
-export interface InstalledPluginSourceUrl {
-  /**
-   * Constant value. Always "url".
-   */
-  source: "url";
-  url: string;
-  ref?: string;
-  path?: string;
-}
-/**
- * Schema for the `InstalledPluginSourceLocal` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "InstalledPluginSourceLocal".
- */
-/** @experimental */
-export interface InstalledPluginSourceLocal {
-  /**
-   * Constant value. Always "local".
-   */
-  source: "local";
-  path: string;
 }
 /**
  * Instruction sources loaded for the session, in merge order.
@@ -2287,20 +1288,16 @@ export interface InstructionsSources {
   type: InstructionsSourcesType;
   location: InstructionsSourcesLocation;
   /**
-   * Glob pattern(s) from frontmatter — when set, this instruction applies only to matching files
+   * Glob pattern from frontmatter — when set, this instruction applies only to matching files
    */
-  applyTo?: string[];
+  applyTo?: string;
   /**
    * Short description (body after frontmatter) for use in instruction tables
    */
   description?: string;
-  /**
-   * When true, this source starts disabled and must be toggled on by the user
-   */
-  defaultDisabled?: boolean;
 }
 /**
- * Message text, optional severity level, persistence flag, optional follow-up URL, and optional tip.
+ * Message text, optional severity level, persistence flag, and optional follow-up URL.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "LogRequest".
@@ -2312,10 +1309,6 @@ export interface LogRequest {
   message: string;
   level?: SessionLogLevel;
   /**
-   * Domain category for this log entry (e.g., "mcp", "subscription", "policy", "model"). Maps to `infoType`/`warningType`/`errorType` on the emitted event. Defaults to "notification".
-   */
-  type?: string;
-  /**
    * When true, the message is transient and not persisted to the session event log on disk
    */
   ephemeral?: boolean;
@@ -2323,10 +1316,6 @@ export interface LogRequest {
    * Optional URL the user can open in their browser for more details
    */
   url?: string;
-  /**
-   * Optional actionable tip displayed alongside the message. Only honored on `level: "info"`.
-   */
-  tip?: string;
 }
 /**
  * Identifier of the session event that was emitted for the log message.
@@ -2339,53 +1328,6 @@ export interface LogResult {
    * The unique identifier of the emitted session event
    */
   eventId: string;
-}
-/**
- * Parameters for (re)loading the merged LSP configuration set.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "LspInitializeRequest".
- */
-/** @experimental */
-export interface LspInitializeRequest {
-  /**
-   * Working directory used to load project-level LSP configs. Defaults to the session working directory when omitted.
-   */
-  workingDirectory?: string;
-  /**
-   * Git root used as the boundary when traversing for project-level LSP configs (supports monorepos).
-   */
-  gitRoot?: string;
-  /**
-   * Force re-initialization even when LSP configs were already loaded for the working directory.
-   */
-  force?: boolean;
-}
-/**
- * The requestId previously passed to executeSampling that should be cancelled.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "McpCancelSamplingExecutionParams".
- */
-/** @experimental */
-export interface McpCancelSamplingExecutionParams {
-  /**
-   * The requestId previously passed to executeSampling that should be cancelled
-   */
-  requestId: string;
-}
-/**
- * Indicates whether an in-flight sampling execution with the given requestId was found and cancelled.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "McpCancelSamplingExecutionResult".
- */
-/** @experimental */
-export interface McpCancelSamplingExecutionResult {
-  /**
-   * True if an in-flight execution with the given requestId was found and signalled to cancel. False when no such execution is in flight (already completed, never started, or cancelled by another caller).
-   */
-  cancelled: boolean;
 }
 /**
  * MCP server name and configuration to add to user configuration.
@@ -2607,48 +1549,6 @@ export interface McpEnableRequest {
   serverName: string;
 }
 /**
- * Identifiers and raw MCP CreateMessageRequest params used to run a sampling inference.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "McpExecuteSamplingParams".
- */
-/** @experimental */
-export interface McpExecuteSamplingParams {
-  /**
-   * Caller-provided unique identifier for this sampling execution. Use this same ID with cancelSamplingExecution to cancel the in-flight call. Must be unique within the session for the lifetime of the call.
-   */
-  requestId: string;
-  /**
-   * Name of the MCP server that initiated the sampling request
-   */
-  serverName: string;
-  /**
-   * The original MCP JSON-RPC request ID (string or number). Used by the runtime to correlate the inference with the originating MCP request for telemetry; this is distinct from `requestId` (which is the schema-level cancellation handle).
-   */
-  mcpRequestId: string | number;
-  request: McpExecuteSamplingRequest;
-}
-/**
- * Raw MCP CreateMessageRequest params, as received in the `sampling.requested` event. Treated as opaque at the schema layer; the runtime converts the embedded MCP messages into the OpenAI chat-completion shape internally.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "McpExecuteSamplingRequest".
- */
-/** @experimental */
-export interface McpExecuteSamplingRequest {
-  [k: string]: unknown | undefined;
-}
-/**
- * MCP CreateMessageResult payload (with optional 'tools' extension), present when action='success'. Treated as opaque at the schema layer; consumers should construct/consume it per the MCP CreateMessageResult shape.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "McpExecuteSamplingResult".
- */
-/** @experimental */
-export interface McpExecuteSamplingResult {
-  [k: string]: unknown | undefined;
-}
-/**
  * Remote MCP server name and optional overrides controlling reauthentication, OAuth client display name, and the callback success-page copy.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -2687,34 +1587,6 @@ export interface McpOauthLoginResult {
   authorizationUrl?: string;
 }
 /**
- * Indicates whether the auto-managed `github` MCP server was removed (false when nothing to remove).
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "McpRemoveGitHubResult".
- */
-/** @experimental */
-export interface McpRemoveGitHubResult {
-  /**
-   * True when the auto-managed `github` MCP server was removed; false when no removal happened (e.g. user has explicitly configured a `github` server, or the server was not registered).
-   */
-  removed: boolean;
-}
-/**
- * Outcome of an MCP sampling execution: success result, failure error, or cancellation.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "McpSamplingExecutionResult".
- */
-/** @experimental */
-export interface McpSamplingExecutionResult {
-  action: McpSamplingExecutionAction;
-  result?: McpExecuteSamplingResult;
-  /**
-   * Error description, present when action='failure'.
-   */
-  error?: string;
-}
-/**
  * Schema for the `McpServer` type.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -2745,229 +1617,6 @@ export interface McpServerList {
    * Configured MCP servers
    */
   servers: McpServer[];
-}
-/**
- * Mode controlling how MCP server env values are resolved (`direct` or `indirect`).
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "McpSetEnvValueModeParams".
- */
-/** @experimental */
-export interface McpSetEnvValueModeParams {
-  mode: McpSetEnvValueModeDetails;
-}
-/**
- * Env-value mode recorded on the session after the update.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "McpSetEnvValueModeResult".
- */
-/** @experimental */
-export interface McpSetEnvValueModeResult {
-  mode: McpSetEnvValueModeDetails;
-}
-/**
- * Model identifier and token limits used to compute the context-info breakdown.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "MetadataContextInfoRequest".
- */
-/** @experimental */
-export interface MetadataContextInfoRequest {
-  /**
-   * Maximum prompt tokens allowed by the target model. Pass 0 to use the runtime default.
-   */
-  promptTokenLimit: number;
-  /**
-   * Maximum output tokens allowed by the target model. Pass 0 if unknown.
-   */
-  outputTokenLimit: number;
-  /**
-   * Model identifier used for tokenization. Omit to use the session default. Used both for token counting and to compute display values.
-   */
-  selectedModel?: string;
-}
-/**
- * Token breakdown for the session's current context window, or null if uninitialized.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "MetadataContextInfoResult".
- */
-/** @experimental */
-export interface MetadataContextInfoResult {
-  /**
-   * Token breakdown for the current context window, or null if the session has not yet been initialized (no system prompt or tool metadata cached).
-   */
-  contextInfo?: SessionContextInfo | null;
-}
-/**
- * Indicates whether the local session is currently processing a turn or background continuation.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "MetadataIsProcessingResult".
- */
-/** @experimental */
-export interface MetadataIsProcessingResult {
-  /**
-   * Whether the session is currently processing user/agent messages. False for non-local sessions (which don't run a local agentic loop). Reflects an in-flight turn or background continuation.
-   */
-  processing: boolean;
-}
-/**
- * Model identifier to use when re-tokenizing the session's existing messages.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "MetadataRecomputeContextTokensRequest".
- */
-/** @experimental */
-export interface MetadataRecomputeContextTokensRequest {
-  /**
-   * Model identifier used for tokenization. The runtime token-counts both chat-context and system-context messages against this model.
-   */
-  modelId: string;
-}
-/**
- * Re-tokenize the session's existing messages against `modelId` and return the token totals. Useful for hosts that want an initial estimate of context usage on session resume, before the next agent turn fires `session.context_info_changed` events. Returns zeros for an empty session.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "MetadataRecomputeContextTokensResult".
- */
-/** @experimental */
-export interface MetadataRecomputeContextTokensResult {
-  /**
-   * Sum of tokens across chat-context and system-context messages currently held by the session.
-   */
-  totalTokens: number;
-  /**
-   * Tokens contributed by user/assistant/tool messages (excludes system/developer prompts).
-   */
-  messagesTokenCount: number;
-  /**
-   * Tokens contributed by system/developer prompt snapshots.
-   */
-  systemTokenCount: number;
-}
-/**
- * Updated working-directory/git context to record on the session.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "MetadataRecordContextChangeRequest".
- */
-/** @experimental */
-export interface MetadataRecordContextChangeRequest {
-  context: SessionWorkingDirectoryContext;
-}
-/**
- * Updated working directory and git context. Emitted as the new payload of `session.context_changed`.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionWorkingDirectoryContext".
- */
-/** @experimental */
-export interface SessionWorkingDirectoryContext {
-  /**
-   * Current working directory path
-   */
-  cwd: string;
-  /**
-   * Root directory of the git repository, resolved via git rev-parse
-   */
-  gitRoot?: string;
-  /**
-   * Repository identifier derived from the git remote URL ("owner/name" for GitHub, "org/project/repo" for Azure DevOps)
-   */
-  repository?: string;
-  hostType?: SessionWorkingDirectoryContextHostType;
-  /**
-   * Raw host string from the git remote URL (e.g. "github.com", "dev.azure.com")
-   */
-  repositoryHost?: string;
-  /**
-   * Current git branch name
-   */
-  branch?: string;
-  /**
-   * Head commit of the current git branch
-   */
-  headCommit?: string;
-  /**
-   * Merge-base commit SHA (fork point from the remote default branch)
-   */
-  baseCommit?: string;
-}
-/**
- * Notify the session that its working directory context has changed. Emits a `session.context_changed` event so consumers (telemetry, OTel tracker, ACP, the timeline UI) can react. Use this when the host has detected a cwd/branch/repo change outside the session's normal lifecycle (e.g., after a shell command in interactive mode).
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "MetadataRecordContextChangeResult".
- */
-/** @experimental */
-export interface MetadataRecordContextChangeResult {}
-/**
- * Absolute path to set as the session's new working directory.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "MetadataSetWorkingDirectoryRequest".
- */
-/** @experimental */
-export interface MetadataSetWorkingDirectoryRequest {
-  /**
-   * Absolute path to set as the session's working directory. The runtime updates the session's recorded cwd so subsequent operations (shell tools, file lookups, telemetry) anchor to it.
-   */
-  workingDirectory: string;
-}
-/**
- * Update the session's working directory. Used by the host when the user explicitly changes cwd (e.g., the `/cd` slash command). The host is responsible for `process.chdir` and any related side-effects (file index, etc.); this method only updates the session's own recorded path.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "MetadataSetWorkingDirectoryResult".
- */
-/** @experimental */
-export interface MetadataSetWorkingDirectoryResult {
-  /**
-   * Working directory after the update
-   */
-  workingDirectory: string;
-}
-/**
- * Remote-session-specific metadata. Populated only when `isRemote` is true. Fields are immutable for the lifetime of the session.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "MetadataSnapshotRemoteMetadata".
- */
-/** @experimental */
-export interface MetadataSnapshotRemoteMetadata {
-  /**
-   * The original resource identifier (task ID or PR node ID), preserved across event-replay reconstructions. Falls back to `sessionId` when absent.
-   */
-  resourceId?: string;
-  repository: MetadataSnapshotRemoteMetadataRepository;
-  /**
-   * The pull request number the remote session is associated with, if any.
-   */
-  pullRequestNumber?: number;
-  taskType?: MetadataSnapshotRemoteMetadataTaskType;
-}
-/**
- * The repository the remote session targets.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "MetadataSnapshotRemoteMetadataRepository".
- */
-/** @experimental */
-export interface MetadataSnapshotRemoteMetadataRepository {
-  /**
-   * The GitHub owner (user or organization) of the target repository.
-   */
-  owner: string;
-  /**
-   * The GitHub repository name (without owner).
-   */
-  name: string;
-  /**
-   * The branch the remote session is operating on.
-   */
-  branch: string;
 }
 /**
  * Schema for the `Model` type.
@@ -3194,30 +1843,6 @@ export interface ModelList {
    */
   models: Model[];
 }
-/**
- * Reasoning effort level to apply to the currently selected model.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "ModelSetReasoningEffortRequest".
- */
-export interface ModelSetReasoningEffortRequest {
-  /**
-   * Reasoning effort level to apply to the currently selected model. The host is responsible for validating the value against the model's supported levels before calling.
-   */
-  reasoningEffort: string;
-}
-/**
- * Update the session's reasoning effort without changing the selected model. Use `switchTo` instead when you also need to change the model. The runtime stores the effort on the session and applies it to subsequent turns.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "ModelSetReasoningEffortResult".
- */
-export interface ModelSetReasoningEffortResult {
-  /**
-   * Reasoning effort level recorded on the session after the update
-   */
-  reasoningEffort: string;
-}
 
 export interface ModelsListRequest {
   /**
@@ -3277,30 +1902,6 @@ export interface NameGetResult {
   name: string | null;
 }
 /**
- * Auto-generated session summary to apply as the session's name when no user-set name exists.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "NameSetAutoRequest".
- */
-export interface NameSetAutoRequest {
-  /**
-   * Auto-generated session summary. Empty/whitespace-only values are ignored; values are trimmed before persisting.
-   */
-  summary: string;
-}
-/**
- * Indicates whether the auto-generated summary was applied as the session's name.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "NameSetAutoResult".
- */
-export interface NameSetAutoResult {
-  /**
-   * Whether the auto-generated summary was persisted. False if the session already has a user-set name, the summary normalized to empty, or the session does not have a workspace.
-   */
-  applied: boolean;
-}
-/**
  * New friendly name to apply to the session.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -3313,31 +1914,6 @@ export interface NameSetRequest {
   name: string;
 }
 /**
- * Schema for the `PendingPermissionRequest` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PendingPermissionRequest".
- */
-export interface PendingPermissionRequest {
-  /**
-   * Unique identifier for the pending permission request
-   */
-  requestId: string;
-  request: PermissionPromptRequest;
-}
-/**
- * List of pending permission requests reconstructed from event history.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PendingPermissionRequestList".
- */
-export interface PendingPermissionRequestList {
-  /**
-   * Pending permission prompts reconstructed from the session's event history. Equivalent to the set of `permission.requested` events that have not yet been followed by a matching `permission.completed` event. Used by clients (e.g. the CLI) to hydrate UI for prompts that were emitted before the client attached to the session.
-   */
-  items: PendingPermissionRequest[];
-}
-/**
  * Schema for the `PermissionDecisionApproveOnce` type.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -3345,7 +1921,7 @@ export interface PendingPermissionRequestList {
  */
 export interface PermissionDecisionApproveOnce {
   /**
-   * Approve this single request only
+   * The permission request was approved for this one instance
    */
   kind: "approve-once";
 }
@@ -3357,12 +1933,12 @@ export interface PermissionDecisionApproveOnce {
  */
 export interface PermissionDecisionApproveForSession {
   /**
-   * Approve and remember for the rest of the session
+   * Approved and remembered for the rest of the session
    */
   kind: "approve-for-session";
   approval?: PermissionDecisionApproveForSessionApproval;
   /**
-   * URL domain to approve for the rest of the session (URL prompts only)
+   * The URL domain to approve for this session
    */
   domain?: string;
 }
@@ -3510,12 +2086,12 @@ export interface PermissionDecisionApproveForSessionApprovalExtensionPermissionA
  */
 export interface PermissionDecisionApproveForLocation {
   /**
-   * Approve and persist for this project location
+   * Approved and persisted for this project location
    */
   kind: "approve-for-location";
   approval: PermissionDecisionApproveForLocationApproval;
   /**
-   * Location key (git root or cwd) to persist the approval to
+   * The location key (git root or cwd) to persist the approval to
    */
   locationKey: string;
 }
@@ -3663,11 +2239,11 @@ export interface PermissionDecisionApproveForLocationApprovalExtensionPermission
  */
 export interface PermissionDecisionApprovePermanently {
   /**
-   * Approve and persist across sessions (URL prompts only)
+   * Approved and persisted across sessions
    */
   kind: "approve-permanently";
   /**
-   * URL domain to approve permanently
+   * The URL domain to approve permanently
    */
   domain: string;
 }
@@ -3679,11 +2255,11 @@ export interface PermissionDecisionApprovePermanently {
  */
 export interface PermissionDecisionReject {
   /**
-   * Reject the request
+   * Denied by the user during an interactive prompt
    */
   kind: "reject";
   /**
-   * Optional feedback explaining the rejection
+   * Optional feedback from the user explaining the denial
    */
   feedback?: string;
 }
@@ -3695,155 +2271,9 @@ export interface PermissionDecisionReject {
  */
 export interface PermissionDecisionUserNotAvailable {
   /**
-   * No user is available to confirm the request
+   * Denied because user confirmation was unavailable
    */
   kind: "user-not-available";
-}
-/**
- * Schema for the `PermissionDecisionApproved` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionDecisionApproved".
- */
-export interface PermissionDecisionApproved {
-  /**
-   * The permission request was approved
-   */
-  kind: "approved";
-}
-/**
- * Schema for the `PermissionDecisionApprovedForSession` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionDecisionApprovedForSession".
- */
-export interface PermissionDecisionApprovedForSession {
-  /**
-   * Approved and remembered for the rest of the session
-   */
-  kind: "approved-for-session";
-  approval: UserToolSessionApproval;
-}
-/**
- * Schema for the `PermissionDecisionApprovedForLocation` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionDecisionApprovedForLocation".
- */
-export interface PermissionDecisionApprovedForLocation {
-  /**
-   * Approved and persisted for this project location
-   */
-  kind: "approved-for-location";
-  approval: UserToolSessionApproval;
-  /**
-   * The location key (git root or cwd) to persist the approval to
-   */
-  locationKey: string;
-}
-/**
- * Schema for the `PermissionDecisionCancelled` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionDecisionCancelled".
- */
-export interface PermissionDecisionCancelled {
-  /**
-   * The permission request was cancelled before a response was used
-   */
-  kind: "cancelled";
-  /**
-   * Optional explanation of why the request was cancelled
-   */
-  reason?: string;
-}
-/**
- * Schema for the `PermissionDecisionDeniedByRules` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionDecisionDeniedByRules".
- */
-export interface PermissionDecisionDeniedByRules {
-  /**
-   * Denied because approval rules explicitly blocked it
-   */
-  kind: "denied-by-rules";
-  /**
-   * Rules that denied the request
-   */
-  rules: PermissionRule[];
-}
-/**
- * Schema for the `PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser".
- */
-export interface PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser {
-  /**
-   * Denied because no approval rule matched and user confirmation was unavailable
-   */
-  kind: "denied-no-approval-rule-and-could-not-request-from-user";
-}
-/**
- * Schema for the `PermissionDecisionDeniedInteractivelyByUser` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionDecisionDeniedInteractivelyByUser".
- */
-export interface PermissionDecisionDeniedInteractivelyByUser {
-  /**
-   * Denied by the user during an interactive prompt
-   */
-  kind: "denied-interactively-by-user";
-  /**
-   * Optional feedback from the user explaining the denial
-   */
-  feedback?: string;
-  /**
-   * Whether to force-reject the current agent turn
-   */
-  forceReject?: boolean;
-}
-/**
- * Schema for the `PermissionDecisionDeniedByContentExclusionPolicy` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionDecisionDeniedByContentExclusionPolicy".
- */
-export interface PermissionDecisionDeniedByContentExclusionPolicy {
-  /**
-   * Denied by the organization's content exclusion policy
-   */
-  kind: "denied-by-content-exclusion-policy";
-  /**
-   * File path that triggered the exclusion
-   */
-  path: string;
-  /**
-   * Human-readable explanation of why the path was excluded
-   */
-  message: string;
-}
-/**
- * Schema for the `PermissionDecisionDeniedByPermissionRequestHook` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionDecisionDeniedByPermissionRequestHook".
- */
-export interface PermissionDecisionDeniedByPermissionRequestHook {
-  /**
-   * Denied by a permission request hook registered by an extension or plugin
-   */
-  kind: "denied-by-permission-request-hook";
-  /**
-   * Optional message from the hook explaining the denial
-   */
-  message?: string;
-  /**
-   * Whether to interrupt the current agent turn
-   */
-  interrupt?: boolean;
 }
 /**
  * Pending permission request ID and the decision to apply (approve/reject and scope).
@@ -3859,130 +2289,6 @@ export interface PermissionDecisionRequest {
   result: PermissionDecision;
 }
 /**
- * Directory path to add to the session's allowed directories.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionPathsAddParams".
- */
-export interface PermissionPathsAddParams {
-  /**
-   * Directory to add to the allow-list. The runtime resolves and validates the path before adding.
-   */
-  path: string;
-}
-/**
- * Path to evaluate against the session's allowed directories.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionPathsAllowedCheckParams".
- */
-export interface PermissionPathsAllowedCheckParams {
-  /**
-   * Path to check against the session's allowed directories
-   */
-  path: string;
-}
-/**
- * Indicates whether the supplied path is within the session's allowed directories.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionPathsAllowedCheckResult".
- */
-export interface PermissionPathsAllowedCheckResult {
-  /**
-   * Whether the path is within the session's allowed directories
-   */
-  allowed: boolean;
-}
-/**
- * If specified, replaces the session's path-permission policy. The runtime constructs the appropriate PathManager based on these inputs (rooted at the session's working directory). Omit to leave the current path policy unchanged.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionPathsConfig".
- */
-export interface PermissionPathsConfig {
-  /**
-   * If true, the runtime allows access to all paths without prompting. Equivalent to constructing an UnrestrictedPathManager.
-   */
-  unrestricted?: boolean;
-  /**
-   * Additional directories to allow tool access to (in addition to the session's working directory). When `unrestricted` is true, these are still pre-populated on the UnrestrictedPathManager so they remain visible via getDirectories() (e.g. for @-mention completion).
-   */
-  additionalDirectories?: string[];
-  /**
-   * Whether to include the system temp directory in the allowed list (defaults to true). Ignored when `unrestricted` is true.
-   */
-  includeTempDirectory?: boolean;
-  /**
-   * Workspace root path (special-cased to be allowed even before the directory exists). Ignored when `unrestricted` is true.
-   */
-  workspacePath?: string;
-}
-/**
- * Snapshot of the session's allow-listed directories and primary working directory.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionPathsList".
- */
-export interface PermissionPathsList {
-  /**
-   * All directories currently allowed for tool access on this session.
-   */
-  directories: string[];
-  /**
-   * The primary working directory for this session.
-   */
-  primary: string;
-}
-/**
- * Directory path to set as the session's new primary working directory.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionPathsUpdatePrimaryParams".
- */
-export interface PermissionPathsUpdatePrimaryParams {
-  /**
-   * Directory to set as the new primary working directory for the session's permission policy.
-   */
-  path: string;
-}
-/**
- * Path to evaluate against the session's workspace (primary) directory.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionPathsWorkspaceCheckParams".
- */
-export interface PermissionPathsWorkspaceCheckParams {
-  /**
-   * Path to check against the session workspace directory
-   */
-  path: string;
-}
-/**
- * Indicates whether the supplied path is within the session's workspace directory.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionPathsWorkspaceCheckResult".
- */
-export interface PermissionPathsWorkspaceCheckResult {
-  /**
-   * Whether the path is within the session workspace directory
-   */
-  allowed: boolean;
-}
-/**
- * Notification payload describing the permission prompt that the client just rendered.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionPromptShownNotification".
- */
-export interface PermissionPromptShownNotification {
-  /**
-   * Human-readable description of the prompt the user is being asked to approve. Used by the runtime to fire the registered `permission_prompt` notification hook (e.g. terminal bell, desktop notification).
-   */
-  message: string;
-}
-/**
  * Indicates whether the permission decision was applied; false when the request was already resolved.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -3994,191 +2300,6 @@ export interface PermissionRequestResult {
    */
   success: boolean;
 }
-/**
- * If specified, replaces the session's approved/denied permission rules. Omit to leave the current rules unchanged.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionRulesSet".
- */
-export interface PermissionRulesSet {
-  /**
-   * Rules that auto-approve matching requests
-   */
-  approved: PermissionRule[];
-  /**
-   * Rules that auto-deny matching requests
-   */
-  denied: PermissionRule[];
-}
-/**
- * Schema for the `PermissionsConfigureAdditionalContentExclusionPolicy` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionsConfigureAdditionalContentExclusionPolicy".
- */
-export interface PermissionsConfigureAdditionalContentExclusionPolicy {
-  rules: PermissionsConfigureAdditionalContentExclusionPolicyRule[];
-  last_updated_at: string | number;
-  scope: PermissionsConfigureAdditionalContentExclusionPolicyScope;
-  [k: string]: unknown | undefined;
-}
-/**
- * Schema for the `PermissionsConfigureAdditionalContentExclusionPolicyRule` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionsConfigureAdditionalContentExclusionPolicyRule".
- */
-export interface PermissionsConfigureAdditionalContentExclusionPolicyRule {
-  paths: string[];
-  ifAnyMatch?: string[];
-  ifNoneMatch?: string[];
-  source: PermissionsConfigureAdditionalContentExclusionPolicyRuleSource;
-  [k: string]: unknown | undefined;
-}
-/**
- * Schema for the `PermissionsConfigureAdditionalContentExclusionPolicyRuleSource` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionsConfigureAdditionalContentExclusionPolicyRuleSource".
- */
-export interface PermissionsConfigureAdditionalContentExclusionPolicyRuleSource {
-  name: string;
-  type: string;
-}
-/**
- * Patch of permission policy fields to apply (omit a field to leave it unchanged).
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionsConfigureParams".
- */
-export interface PermissionsConfigureParams {
-  /**
-   * If specified, sets whether tool permission requests are auto-approved without prompting. Omit to leave the current value unchanged.
-   */
-  approveAllToolPermissionRequests?: boolean;
-  /**
-   * If specified, sets whether path/URL read permission requests are auto-approved. Omit to leave the current value unchanged.
-   */
-  approveAllReadPermissionRequests?: boolean;
-  rules?: PermissionRulesSet;
-  paths?: PermissionPathsConfig;
-  urls?: PermissionUrlsConfig;
-  /**
-   * If specified, replaces the host-supplied GitHub Content Exclusion policies on the session (combined with natively-discovered policies when evaluating tool/file access). Omit to leave the current policies unchanged.
-   */
-  additionalContentExclusionPolicies?: PermissionsConfigureAdditionalContentExclusionPolicy[];
-}
-/**
- * If specified, replaces the session's URL-permission policy. The runtime constructs a fresh DefaultUrlManager based on these inputs. Omit to leave the current URL policy unchanged.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionUrlsConfig".
- */
-export interface PermissionUrlsConfig {
-  /**
-   * If true, the runtime allows access to all URLs without prompting. Initial allow-list is ignored when this is true.
-   */
-  unrestricted?: boolean;
-  /**
-   * Initial list of allowed URL/domain patterns. Patterns may include path components. Ignored when `unrestricted` is true.
-   */
-  initialAllowed?: string[];
-}
-/**
- * Indicates whether the operation succeeded.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionsConfigureResult".
- */
-export interface PermissionsConfigureResult {
-  /**
-   * Whether the operation succeeded
-   */
-  success: boolean;
-}
-/**
- * Scope and add/remove instructions for modifying session- or location-scoped permission rules.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionsModifyRulesParams".
- */
-export interface PermissionsModifyRulesParams {
-  scope: PermissionsModifyRulesScope;
-  /**
-   * Rules to add to the scope. Applied before `remove`/`removeAll`.
-   */
-  add?: PermissionRule[];
-  /**
-   * Specific rules to remove from the scope. Ignored when `removeAll` is true.
-   */
-  remove?: PermissionRule[];
-  /**
-   * When true, removes every rule currently in the scope (after any `add` is applied). Useful for clearing the location scope wholesale.
-   */
-  removeAll?: boolean;
-}
-/**
- * Indicates whether the operation succeeded.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionsModifyRulesResult".
- */
-export interface PermissionsModifyRulesResult {
-  /**
-   * Whether the operation succeeded
-   */
-  success: boolean;
-}
-/**
- * Indicates whether the operation succeeded.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionsNotifyPromptShownResult".
- */
-export interface PermissionsNotifyPromptShownResult {
-  /**
-   * Whether the operation succeeded
-   */
-  success: boolean;
-}
-/**
- * Indicates whether the operation succeeded.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionsPathsAddResult".
- */
-export interface PermissionsPathsAddResult {
-  /**
-   * Whether the operation succeeded
-   */
-  success: boolean;
-}
-/**
- * No parameters; returns the session's allow-listed directories.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionsPathsListRequest".
- */
-export interface PermissionsPathsListRequest {}
-/**
- * Indicates whether the operation succeeded.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionsPathsUpdatePrimaryResult".
- */
-export interface PermissionsPathsUpdatePrimaryResult {
-  /**
-   * Whether the operation succeeded
-   */
-  success: boolean;
-}
-/**
- * No parameters; returns currently-pending permission requests for the session.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionsPendingRequestsRequest".
- */
-export interface PermissionsPendingRequestsRequest {}
 /**
  * No parameters; clears all session-scoped tool permission approvals.
  *
@@ -4199,7 +2320,7 @@ export interface PermissionsResetSessionApprovalsResult {
   success: boolean;
 }
 /**
- * Allow-all toggle for tool permission requests, with an optional telemetry source.
+ * Whether to auto-approve all tool permission requests for the rest of the session.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "PermissionsSetApproveAllRequest".
@@ -4209,7 +2330,6 @@ export interface PermissionsSetApproveAllRequest {
    * Whether to auto-approve all tool permission requests
    */
   enabled: boolean;
-  source?: PermissionsSetApproveAllSource;
 }
 /**
  * Indicates whether the operation succeeded.
@@ -4224,54 +2344,6 @@ export interface PermissionsSetApproveAllResult {
   success: boolean;
 }
 /**
- * Toggles whether permission prompts should be bridged into session events for this client.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionsSetRequiredRequest".
- */
-export interface PermissionsSetRequiredRequest {
-  /**
-   * Whether the client wants `permission.requested` events bridged from the session-owned permission service. CLI clients that render prompt UI set this to `true` for as long as their listener is mounted; headless callers leave it unset (the default is `false`).
-   */
-  required: boolean;
-}
-/**
- * Indicates whether the operation succeeded.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionsSetRequiredResult".
- */
-export interface PermissionsSetRequiredResult {
-  /**
-   * Whether the operation succeeded
-   */
-  success: boolean;
-}
-/**
- * Indicates whether the operation succeeded.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionsUrlsSetUnrestrictedModeResult".
- */
-export interface PermissionsUrlsSetUnrestrictedModeResult {
-  /**
-   * Whether the operation succeeded
-   */
-  success: boolean;
-}
-/**
- * Whether the URL-permission policy should run in unrestricted mode.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "PermissionUrlsSetUnrestrictedModeParams".
- */
-export interface PermissionUrlsSetUnrestrictedModeParams {
-  /**
-   * Whether to allow access to all URLs without prompting. Toggles the runtime's URL-permission policy in place.
-   */
-  enabled: boolean;
-}
-/**
  * Optional message to echo back to the caller.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -4284,7 +2356,7 @@ export interface PingRequest {
   message?: string;
 }
 /**
- * Server liveness response, including the echoed message, current server timestamp, and protocol version.
+ * Server liveness response, including the echoed message, current timestamp, and protocol version.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "PingResult".
@@ -4295,9 +2367,9 @@ export interface PingResult {
    */
   message: string;
   /**
-   * ISO 8601 timestamp when the server handled the ping
+   * Server timestamp in milliseconds
    */
-  timestamp: string;
+  timestamp: number;
   /**
    * Server protocol version number
    */
@@ -4374,89 +2446,6 @@ export interface PluginList {
   plugins: Plugin[];
 }
 /**
- * Schema for the `QueuePendingItems` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "QueuePendingItems".
- */
-/** @experimental */
-export interface QueuePendingItems {
-  kind: QueuePendingItemsKind;
-  /**
-   * Human-readable text to display for this queue entry in the UI
-   */
-  displayText: string;
-}
-/**
- * Snapshot of the session's pending queued items and immediate-steering messages.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "QueuePendingItemsResult".
- */
-/** @experimental */
-export interface QueuePendingItemsResult {
-  /**
-   * Pending queued items in submission order. Includes user messages, queued slash commands, and queued model changes; omits internal system items.
-   */
-  items: QueuePendingItems[];
-  /**
-   * Display text for messages currently in the immediate steering queue (interjections sent during a running turn).
-   */
-  steeringMessages: string[];
-}
-/**
- * Indicates whether a user-facing pending item was removed.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "QueueRemoveMostRecentResult".
- */
-/** @experimental */
-export interface QueueRemoveMostRecentResult {
-  /**
-   * True if a user-facing pending item was removed (LIFO across both queues); false when no removable items remained.
-   */
-  removed: boolean;
-}
-/**
- * Event type to register consumer interest for, used by runtime gating logic.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "RegisterEventInterestParams".
- */
-/** @experimental */
-export interface RegisterEventInterestParams {
-  /**
-   * The event type the consumer wants the runtime to treat as 'observed' for behavior-switching gating. Some runtime code paths inspect whether any consumer is interested in a specific event type and choose a different implementation accordingly (e.g. `mcp.oauth_required`: when interest is registered the runtime delegates the full interactive OAuth flow to the consumer; when no interest is registered the runtime installs a browserless fallback that silently reuses cached tokens). SDK clients that long-poll events do NOT automatically appear as listeners to these gating checks — they must explicitly call `registerInterest` for each event type they want the runtime to count as having a consumer. Multiple registrations for the same event type from the same or different consumers are tracked independently and must each be released. See: `mcp.oauth_required`, `sampling.requested`, `auto_mode_switch.requested`, `user_input.requested`, `elicitation.requested`, `command.queued`, `exit_plan_mode.requested`.
-   */
-  eventType: string;
-}
-/**
- * Opaque handle representing an event-type interest registration.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "RegisterEventInterestResult".
- */
-/** @experimental */
-export interface RegisterEventInterestResult {
-  /**
-   * Opaque handle for this registration. Pass to releaseInterest to release. Each call to registerInterest produces a fresh handle, even when the same eventType is registered multiple times.
-   */
-  handle: string;
-}
-/**
- * Opaque handle previously returned by `registerInterest` to release.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "ReleaseEventInterestParams".
- */
-/** @experimental */
-export interface ReleaseEventInterestParams {
-  /**
-   * Handle returned by a previous `registerInterest` call. Idempotent: releasing an unknown or already-released handle is a no-op (returns success). When the last outstanding handle for an event type is released, the runtime reverts to its 'no consumer' code path for that event type.
-   */
-  handle: string;
-}
-/**
  * Optional remote session mode ("off", "export", or "on"); defaults to enabling both export and remote steering.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -4484,27 +2473,6 @@ export interface RemoteEnableResult {
   remoteSteerable: boolean;
 }
 /**
- * New remote-steerability state to persist as a `session.remote_steerable_changed` event.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "RemoteNotifySteerableChangedRequest".
- */
-/** @experimental */
-export interface RemoteNotifySteerableChangedRequest {
-  /**
-   * Whether the session now supports remote steering via GitHub. The runtime persists this as a `session.remote_steerable_changed` event so resume/replay sees the up-to-date capability.
-   */
-  remoteSteerable: boolean;
-}
-/**
- * Persist a steerability change as a `session.remote_steerable_changed` event. Used by the host (CLI / SDK consumer) when it has just finished enabling or disabling steering on a remote exporter that the runtime does not directly own.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "RemoteNotifySteerableChangedResult".
- */
-/** @experimental */
-export interface RemoteNotifySteerableChangedResult {}
-/**
  * Remote session connection result.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -4517,322 +2485,6 @@ export interface RemoteSessionConnectionResult {
    */
   sessionId: string;
   metadata: ConnectedRemoteSessionMetadata;
-}
-/**
- * Schema for the `ScheduleEntry` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "ScheduleEntry".
- */
-/** @experimental */
-export interface ScheduleEntry {
-  /**
-   * Sequential id assigned by the runtime within the session. Stable across resumes (rebuilt from the event log).
-   */
-  id: number;
-  /**
-   * Interval between scheduled ticks, in milliseconds.
-   */
-  intervalMs: number;
-  /**
-   * Prompt text that gets enqueued on every tick.
-   */
-  prompt: string;
-  /**
-   * Whether the schedule re-arms after each tick (`/every`) or fires once (`/after`).
-   */
-  recurring: boolean;
-  /**
-   * Display-only label for the prompt as shown in the UI (e.g. `/skill-name` for a skill-invocation schedule). The actual enqueued prompt is `prompt`.
-   */
-  displayPrompt?: string;
-  /**
-   * ISO 8601 timestamp when the next tick is scheduled to fire.
-   */
-  nextRunAt: string;
-}
-/**
- * Snapshot of the currently active recurring prompts for this session.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "ScheduleList".
- */
-/** @experimental */
-export interface ScheduleList {
-  /**
-   * Active scheduled prompts, ordered by id.
-   */
-  entries: ScheduleEntry[];
-}
-/**
- * Identifier of the scheduled prompt to remove.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "ScheduleStopRequest".
- */
-/** @experimental */
-export interface ScheduleStopRequest {
-  /**
-   * Id of the scheduled prompt to remove.
-   */
-  id: number;
-}
-/**
- * Remove a scheduled prompt by id. The result entry is omitted if the id was unknown.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "ScheduleStopResult".
- */
-/** @experimental */
-export interface ScheduleStopResult {
-  entry?: ScheduleEntry;
-}
-/**
- * File attachment
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SendAttachmentFile".
- */
-export interface SendAttachmentFile {
-  /**
-   * Attachment type discriminator
-   */
-  type: "file";
-  /**
-   * Absolute file path
-   */
-  path: string;
-  /**
-   * User-facing display name for the attachment
-   */
-  displayName: string;
-  lineRange?: SendAttachmentFileLineRange;
-}
-/**
- * Optional line range to scope the attachment to a specific section of the file
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SendAttachmentFileLineRange".
- */
-export interface SendAttachmentFileLineRange {
-  /**
-   * Start line number (1-based)
-   */
-  start: number;
-  /**
-   * End line number (1-based, inclusive)
-   */
-  end: number;
-}
-/**
- * Directory attachment
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SendAttachmentDirectory".
- */
-export interface SendAttachmentDirectory {
-  /**
-   * Attachment type discriminator
-   */
-  type: "directory";
-  /**
-   * Absolute directory path
-   */
-  path: string;
-  /**
-   * User-facing display name for the attachment
-   */
-  displayName: string;
-}
-/**
- * Code selection attachment from an editor
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SendAttachmentSelection".
- */
-export interface SendAttachmentSelection {
-  /**
-   * Attachment type discriminator
-   */
-  type: "selection";
-  /**
-   * Absolute path to the file containing the selection
-   */
-  filePath: string;
-  /**
-   * User-facing display name for the selection
-   */
-  displayName: string;
-  /**
-   * The selected text content
-   */
-  text: string;
-  selection: SendAttachmentSelectionDetails;
-}
-/**
- * Position range of the selection within the file
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SendAttachmentSelectionDetails".
- */
-export interface SendAttachmentSelectionDetails {
-  start: SendAttachmentSelectionDetailsStart;
-  end: SendAttachmentSelectionDetailsEnd;
-}
-/**
- * Start position of the selection
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SendAttachmentSelectionDetailsStart".
- */
-export interface SendAttachmentSelectionDetailsStart {
-  /**
-   * Start line number (0-based)
-   */
-  line: number;
-  /**
-   * Start character offset within the line (0-based)
-   */
-  character: number;
-}
-/**
- * End position of the selection
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SendAttachmentSelectionDetailsEnd".
- */
-export interface SendAttachmentSelectionDetailsEnd {
-  /**
-   * End line number (0-based)
-   */
-  line: number;
-  /**
-   * End character offset within the line (0-based)
-   */
-  character: number;
-}
-/**
- * GitHub issue, pull request, or discussion reference
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SendAttachmentGithubReference".
- */
-export interface SendAttachmentGithubReference {
-  /**
-   * Attachment type discriminator
-   */
-  type: "github_reference";
-  /**
-   * Issue, pull request, or discussion number
-   */
-  number: number;
-  /**
-   * Title of the referenced item
-   */
-  title: string;
-  referenceType: SendAttachmentGithubReferenceType;
-  /**
-   * Current state of the referenced item (e.g., open, closed, merged)
-   */
-  state: string;
-  /**
-   * URL to the referenced item on GitHub
-   */
-  url: string;
-}
-/**
- * Blob attachment with inline base64-encoded data
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SendAttachmentBlob".
- */
-export interface SendAttachmentBlob {
-  /**
-   * Attachment type discriminator
-   */
-  type: "blob";
-  /**
-   * Base64-encoded content
-   */
-  data: string;
-  /**
-   * MIME type of the inline data
-   */
-  mimeType: string;
-  /**
-   * User-facing display name for the attachment
-   */
-  displayName?: string;
-}
-/**
- * Parameters for sending a user message to the session
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SendRequest".
- */
-export interface SendRequest {
-  /**
-   * The user message text
-   */
-  prompt: string;
-  /**
-   * If provided, this is shown in the timeline instead of `prompt`
-   */
-  displayPrompt?: string;
-  /**
-   * Optional attachments (files, directories, selections, blobs, GitHub references) to include with the message
-   */
-  attachments?: SendAttachment[];
-  mode?: SendMode;
-  /**
-   * If true, adds the message to the front of the queue instead of the end
-   */
-  prepend?: boolean;
-  /**
-   * If false, this message will not trigger a Premium Request Unit charge. User messages default to billable.
-   */
-  billable?: boolean;
-  /**
-   * If set, the request will fail if the named tool is not available when this message is among the user messages at the start of the current exchange
-   */
-  requiredTool?: string;
-  /**
-   * Optional provenance tag copied to the resulting user.message event. Supported values are `system`, `command-*`, and `schedule-*`.
-   */
-  source?: {
-    [k: string]: unknown | undefined;
-  };
-  agentMode?: SendAgentMode;
-  /**
-   * Custom HTTP headers to include in outbound model requests for this turn. Merged with session-level provider headers; per-turn headers augment and overwrite session-level headers with the same key.
-   */
-  requestHeaders?: {
-    [k: string]: string | undefined;
-  };
-  /**
-   * W3C Trace Context traceparent header for distributed tracing of this agent turn
-   */
-  traceparent?: string;
-  /**
-   * W3C Trace Context tracestate header for distributed tracing
-   */
-  tracestate?: string;
-  /**
-   * If true, await completion of the agentic loop for this message before returning. Defaults to false (fire-and-forget). When true, the result still contains the same `messageId`; the caller can rely on the agent having processed the message before the call resolves.
-   */
-  wait?: boolean;
-}
-/**
- * Result of sending a user message
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SendResult".
- */
-export interface SendResult {
-  /**
-   * Unique identifier assigned to the message
-   */
-  messageId: string;
 }
 /**
  * Schema for the `ServerSkill` type.
@@ -4907,98 +2559,6 @@ export interface SessionAuthStatus {
    * Copilot plan tier (e.g., individual_pro, business)
    */
   copilotPlan?: string;
-}
-/**
- * Map of sessionId -> bytes freed by removing the session's workspace directory.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionBulkDeleteResult".
- */
-/** @experimental */
-export interface SessionBulkDeleteResult {
-  /**
-   * Map of sessionId -> bytes freed by removing the session's workspace directory. Sessions whose deletion failed are omitted from this map (failures are logged on the server but not surfaced per-id; check the map for absent IDs to detect them).
-   */
-  freedBytes: {
-    [k: string]: number | undefined;
-  };
-}
-/**
- * Schema for the `SessionContext` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionContext".
- */
-/** @experimental */
-export interface SessionContext {
-  /**
-   * Most recent working directory for this session
-   */
-  cwd: string;
-  /**
-   * Git repository root, if the cwd was inside a git repo
-   */
-  gitRoot?: string;
-  /**
-   * Repository slug in `owner/name` form, when known
-   */
-  repository?: string;
-  hostType?: SessionContextHostType;
-  /**
-   * Active git branch
-   */
-  branch?: string;
-}
-/**
- * The same metadata records, with summary and context fields backfilled where available.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionEnrichMetadataResult".
- */
-/** @experimental */
-export interface SessionEnrichMetadataResult {
-  /**
-   * Same records, with summary and context backfilled
-   */
-  sessions: SessionMetadata[];
-}
-/**
- * Schema for the `SessionMetadata` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionMetadata".
- */
-/** @experimental */
-export interface SessionMetadata {
-  /**
-   * Stable session identifier
-   */
-  sessionId: string;
-  /**
-   * Session creation time as an ISO 8601 timestamp
-   */
-  startTime: string;
-  /**
-   * Last-modified time of the session's persisted state, as ISO 8601
-   */
-  modifiedTime: string;
-  /**
-   * Short summary of the session, when one has been derived
-   */
-  summary?: string;
-  /**
-   * Optional human-friendly name set via /rename
-   */
-  name?: string;
-  /**
-   * True for remote (GitHub) sessions; false for local
-   */
-  isRemote: boolean;
-  context?: SessionContext;
-  /**
-   * GitHub task ID, when this local session is bound to one. Only present for local sessions exported to remote control.
-   */
-  mcTaskId?: string;
 }
 /**
  * File path, content to append, and optional mode for the client-provided session filesystem.
@@ -5332,7 +2892,7 @@ export interface SessionFsSqliteQueryResult {
    */
   rowsAffected: number;
   /**
-   * SQLite last_insert_rowid() value for INSERT.
+   * Last inserted row ID (for INSERT)
    */
   lastInsertRowid?: number;
   error?: SessionFsError;
@@ -5407,346 +2967,6 @@ export interface SessionFsWriteFileRequest {
   mode?: number;
 }
 /**
- * Schema for the `SessionInstalledPlugin` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionInstalledPlugin".
- */
-/** @experimental */
-export interface SessionInstalledPlugin {
-  /**
-   * Plugin name
-   */
-  name: string;
-  /**
-   * Marketplace the plugin came from (empty string for direct repo installs)
-   */
-  marketplace: string;
-  /**
-   * Installed version, if known
-   */
-  version?: string;
-  /**
-   * Installation timestamp (ISO-8601)
-   */
-  installed_at: string;
-  /**
-   * Whether the plugin is currently enabled
-   */
-  enabled: boolean;
-  /**
-   * Path where the plugin is cached locally
-   */
-  cache_path?: string;
-  source?: SessionInstalledPluginSource;
-}
-/**
- * Schema for the `SessionInstalledPluginSourceGithub` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionInstalledPluginSourceGithub".
- */
-/** @experimental */
-export interface SessionInstalledPluginSourceGithub {
-  /**
-   * Constant value. Always "github".
-   */
-  source: "github";
-  repo: string;
-  ref?: string;
-  path?: string;
-}
-/**
- * Schema for the `SessionInstalledPluginSourceUrl` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionInstalledPluginSourceUrl".
- */
-/** @experimental */
-export interface SessionInstalledPluginSourceUrl {
-  /**
-   * Constant value. Always "url".
-   */
-  source: "url";
-  url: string;
-  ref?: string;
-  path?: string;
-}
-/**
- * Schema for the `SessionInstalledPluginSourceLocal` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionInstalledPluginSourceLocal".
- */
-/** @experimental */
-export interface SessionInstalledPluginSourceLocal {
-  /**
-   * Constant value. Always "local".
-   */
-  source: "local";
-  path: string;
-}
-/**
- * Persisted sessions matching the filter, ordered most-recently-modified first.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionList".
- */
-/** @experimental */
-export interface SessionList {
-  /**
-   * Sessions ordered most-recently-modified first
-   */
-  sessions: SessionMetadata[];
-}
-/**
- * Queued repo-level startup prompts and the total hook command count after loading.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionLoadDeferredRepoHooksResult".
- */
-/** @experimental */
-export interface SessionLoadDeferredRepoHooksResult {
-  /**
-   * Repo-level startup prompts queued from repo hook configs. Empty on resume, when no repo configs were pending, or when disableAllHooks is set.
-   */
-  startupPrompts: string[];
-  /**
-   * Total hook command count (user + plugin + repo) loaded for the session by this call. Captured atomically with startupPrompts so callers don't need to read a separate counter.
-   */
-  hookCount: number;
-}
-/**
- * Point-in-time snapshot of slow-changing session identifier and state fields
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionMetadataSnapshot".
- */
-/** @experimental */
-export interface SessionMetadataSnapshot {
-  /**
-   * The unique identifier of the session
-   */
-  sessionId: string;
-  /**
-   * ISO 8601 timestamp of when the session started
-   */
-  startTime: string;
-  /**
-   * ISO 8601 timestamp of when the session's persisted state was last modified on disk. For new sessions, equals startTime. For resumed sessions, reflects the previous modification time at construction.
-   */
-  modifiedTime: string;
-  /**
-   * Whether this is a remote session (i.e., one whose runtime executes elsewhere and is steered through this process)
-   */
-  isRemote: boolean;
-  /**
-   * True when the session was detected to be in use by another process at construction time. Local consumers may surface a confirmation prompt before fully attaching. Always false for new sessions.
-   */
-  alreadyInUse: boolean;
-  /**
-   * Absolute path to the session's workspace directory on disk, or null if the session has no associated workspace
-   */
-  workspacePath: string | null;
-  /**
-   * User-provided name supplied at session construction (via `--name`), if any. Immutable after construction.
-   */
-  initialName?: string;
-  remoteMetadata?: MetadataSnapshotRemoteMetadata;
-  /**
-   * Short human-readable summary of the session, if known. Omitted when no summary has been generated.
-   */
-  summary?: string;
-  /**
-   * Absolute path to the session's current working directory
-   */
-  workingDirectory: string;
-  currentMode: MetadataSnapshotCurrentMode;
-  /**
-   * Currently selected model identifier, if any
-   */
-  selectedModel?: string;
-  /**
-   * Public-facing workspace metadata for this session, or null if the session has no associated workspace. Excludes runtime-internal fields (GitHub IDs, summary count, internal flags).
-   */
-  workspace?: WorkspaceSummary | null;
-}
-/**
- * Outcome of the prune operation: deleted IDs, dry-run candidates, skipped IDs, total bytes freed, and the dry-run flag.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionPruneResult".
- */
-/** @experimental */
-export interface SessionPruneResult {
-  /**
-   * Session IDs that were deleted (always empty in dry-run mode)
-   */
-  deleted: string[];
-  /**
-   * Session IDs that would be deleted in dry-run mode (always empty otherwise)
-   */
-  candidates: string[];
-  /**
-   * Session IDs that were skipped (e.g., named sessions)
-   */
-  skipped: string[];
-  /**
-   * Total bytes freed (actual when not dry-run, projected when dry-run)
-   */
-  freedBytes: number;
-  /**
-   * True when no deletions were actually performed
-   */
-  dryRun: boolean;
-}
-/**
- * Session IDs to close, deactivate, and delete from disk.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsBulkDeleteRequest".
- */
-/** @experimental */
-export interface SessionsBulkDeleteRequest {
-  /**
-   * Session IDs to close, deactivate, and delete from disk
-   */
-  sessionIds: string[];
-}
-/**
- * Session IDs to test for live in-use locks.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsCheckInUseRequest".
- */
-/** @experimental */
-export interface SessionsCheckInUseRequest {
-  /**
-   * Session IDs to test for live in-use locks
-   */
-  sessionIds: string[];
-}
-/**
- * Session IDs from the input set that are currently in use by another process.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsCheckInUseResult".
- */
-/** @experimental */
-export interface SessionsCheckInUseResult {
-  /**
-   * Session IDs from the input set that are currently held by another running process via an alive lock file
-   */
-  inUse: string[];
-}
-/**
- * Session ID to close.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsCloseRequest".
- */
-/** @experimental */
-export interface SessionsCloseRequest {
-  /**
-   * Session ID to close
-   */
-  sessionId: string;
-}
-/**
- * Closes a session: emits shutdown, flushes pending events to disk, releases the in-use lock, disposes the active session. Idempotent: succeeds even if the session is not currently active.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsCloseResult".
- */
-/** @experimental */
-export interface SessionsCloseResult {}
-/**
- * Session metadata records to enrich with summary and context information.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsEnrichMetadataRequest".
- */
-/** @experimental */
-export interface SessionsEnrichMetadataRequest {
-  /**
-   * Session metadata records to enrich. Records that already have summary and context are returned unchanged.
-   */
-  sessions: SessionMetadata[];
-}
-/**
- * New auth credentials to install on the session. Omit to leave credentials unchanged.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionSetCredentialsParams".
- */
-export interface SessionSetCredentialsParams {
-  credentials?: AuthInfo;
-}
-/**
- * Indicates whether the credential update succeeded.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionSetCredentialsResult".
- */
-export interface SessionSetCredentialsResult {
-  /**
-   * Whether the operation succeeded
-   */
-  success: boolean;
-}
-/**
- * UUID prefix to resolve to a unique session ID.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsFindByPrefixRequest".
- */
-/** @experimental */
-export interface SessionsFindByPrefixRequest {
-  /**
-   * UUID prefix (>=7 hex chars, <36 chars). Returns the unique session ID, or undefined when there is no match or the prefix matches multiple sessions.
-   */
-  prefix: string;
-}
-/**
- * Session ID matching the prefix, omitted when no unique match exists.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsFindByPrefixResult".
- */
-/** @experimental */
-export interface SessionsFindByPrefixResult {
-  /**
-   * Omitted when no unique session matches the prefix (no match or ambiguous)
-   */
-  sessionId?: string;
-}
-/**
- * GitHub task ID to look up.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsFindByTaskIDRequest".
- */
-/** @experimental */
-export interface SessionsFindByTaskIDRequest {
-  /**
-   * GitHub task ID to look up
-   */
-  taskId: string;
-}
-/**
- * ID of the local session bound to the given GitHub task, or omitted when none.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsFindByTaskIDResult".
- */
-/** @experimental */
-export interface SessionsFindByTaskIDResult {
-  /**
-   * Omitted when no local session is bound to that GitHub task
-   */
-  sessionId?: string;
-}
-/**
  * Source session identifier to fork from, optional event-ID boundary, and optional friendly name for the new session.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -5783,425 +3003,6 @@ export interface SessionsForkResult {
    * Friendly name assigned to the forked session, if any.
    */
   name?: string;
-}
-/**
- * Session ID whose event-log file path to compute.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsGetEventFilePathRequest".
- */
-/** @experimental */
-export interface SessionsGetEventFilePathRequest {
-  /**
-   * Session ID whose event-log file path to compute
-   */
-  sessionId: string;
-}
-/**
- * Absolute path to the session's events.jsonl file on disk.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsGetEventFilePathResult".
- */
-/** @experimental */
-export interface SessionsGetEventFilePathResult {
-  /**
-   * Absolute path to the session's events.jsonl file
-   */
-  filePath: string;
-}
-/**
- * Optional working-directory context used to score session relevance.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsGetLastForContextRequest".
- */
-/** @experimental */
-export interface SessionsGetLastForContextRequest {
-  context?: SessionContext;
-}
-/**
- * Most-relevant session ID for the supplied context, or omitted when no sessions exist.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsGetLastForContextResult".
- */
-/** @experimental */
-export interface SessionsGetLastForContextResult {
-  /**
-   * Most-relevant session ID for the supplied context, or omitted when no sessions exist
-   */
-  sessionId?: string;
-}
-/**
- * Session ID to look up the persisted remote-steerable flag for.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsGetPersistedRemoteSteerableRequest".
- */
-/** @experimental */
-export interface SessionsGetPersistedRemoteSteerableRequest {
-  /**
-   * Session ID to look up the persisted remote-steerable flag for
-   */
-  sessionId: string;
-}
-/**
- * The session's persisted remote-steerable flag, or omitted when no value has been persisted.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsGetPersistedRemoteSteerableResult".
- */
-/** @experimental */
-export interface SessionsGetPersistedRemoteSteerableResult {
-  /**
-   * The session's persisted remote-steerable flag if recorded; omitted when no value has been persisted
-   */
-  remoteSteerable?: boolean;
-}
-/**
- * Map of sessionId -> on-disk size in bytes for each session's workspace directory.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionSizes".
- */
-/** @experimental */
-export interface SessionSizes {
-  /**
-   * Map of sessionId -> on-disk size in bytes for the session's workspace directory
-   */
-  sizes: {
-    [k: string]: number | undefined;
-  };
-}
-/**
- * Optional metadata-load limit and context filter applied to the returned sessions.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsListRequest".
- */
-/** @experimental */
-export interface SessionsListRequest {
-  /**
-   * When provided, only the first N sessions (sorted by modification time, newest first) load full metadata; remaining sessions return basic info only. Use 0 to return only basic info for every session.
-   */
-  metadataLimit?: number;
-  /**
-   * Optional filter applied to the returned sessions
-   */
-  filter?: {
-    /**
-     * Match sessions whose context.cwd equals this value
-     */
-    cwd?: string;
-    /**
-     * Match sessions whose context.gitRoot equals this value
-     */
-    gitRoot?: string;
-    /**
-     * Match sessions whose context.repository equals this value
-     */
-    repository?: string;
-    /**
-     * Match sessions whose context.branch equals this value
-     */
-    branch?: string;
-  };
-}
-/**
- * Active session ID whose deferred repo-level hooks should be loaded.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsLoadDeferredRepoHooksRequest".
- */
-/** @experimental */
-export interface SessionsLoadDeferredRepoHooksRequest {
-  /**
-   * Active session ID whose deferred repo-level hooks should be loaded
-   */
-  sessionId: string;
-}
-/**
- * Age threshold and optional flags controlling which old sessions are pruned (or simulated when dryRun is true).
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsPruneOldRequest".
- */
-/** @experimental */
-export interface SessionsPruneOldRequest {
-  /**
-   * Delete sessions whose modifiedTime is at least this many days old
-   */
-  olderThanDays: number;
-  /**
-   * When true, only report what would be deleted without performing any deletion
-   */
-  dryRun?: boolean;
-  /**
-   * When true, named sessions (set via /rename) are also eligible for pruning
-   */
-  includeNamed?: boolean;
-  /**
-   * Session IDs that should never be considered for pruning
-   */
-  excludeSessionIds?: string[];
-}
-/**
- * Session ID whose in-use lock should be released.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsReleaseLockRequest".
- */
-/** @experimental */
-export interface SessionsReleaseLockRequest {
-  /**
-   * Session ID whose in-use lock should be released
-   */
-  sessionId: string;
-}
-/**
- * Release the in-use lock held by this process for the given session. No-op when this process does not currently hold a lock for the session.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsReleaseLockResult".
- */
-/** @experimental */
-export interface SessionsReleaseLockResult {}
-/**
- * Active session ID and an optional flag for deferring repo-level hooks until folder trust.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsReloadPluginHooksRequest".
- */
-/** @experimental */
-export interface SessionsReloadPluginHooksRequest {
-  /**
-   * Active session ID to reload hooks for
-   */
-  sessionId: string;
-  /**
-   * When true, skip repo-level hooks. Use before folder trust is confirmed; loadDeferredRepoHooks loads them post-trust.
-   */
-  deferRepoHooks?: boolean;
-}
-/**
- * Reload all hooks (user, plugin, optionally repo) and apply them to the active session. Call after installing or removing plugins so their hooks take effect immediately. No-op when no active session matches the given sessionId.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsReloadPluginHooksResult".
- */
-/** @experimental */
-export interface SessionsReloadPluginHooksResult {}
-/**
- * Session ID whose pending events should be flushed to disk.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsSaveRequest".
- */
-/** @experimental */
-export interface SessionsSaveRequest {
-  /**
-   * Session ID whose pending events should be flushed to disk
-   */
-  sessionId: string;
-}
-/**
- * Flush a session's pending events to disk. No-op when no writer exists for the session (e.g., already closed).
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsSaveResult".
- */
-/** @experimental */
-export interface SessionsSaveResult {}
-/**
- * Manager-wide additional plugins to register; replaces any previously-configured set.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsSetAdditionalPluginsRequest".
- */
-/** @experimental */
-export interface SessionsSetAdditionalPluginsRequest {
-  /**
-   * Manager-wide additional plugins to register. Replaces any previously-configured set. Pass an empty array to clear.
-   */
-  plugins: InstalledPlugin[];
-}
-/**
- * Replace the manager-wide additional plugins. New session creations and subsequent hook reloads see the new set; already-running sessions keep their existing hook installation until the next reload.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionsSetAdditionalPluginsResult".
- */
-/** @experimental */
-export interface SessionsSetAdditionalPluginsResult {}
-/**
- * Patch of mutable session options to apply to the running session.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionUpdateOptionsParams".
- */
-/** @experimental */
-export interface SessionUpdateOptionsParams {
-  /**
-   * The model ID to use for assistant turns.
-   */
-  model?: string;
-  /**
-   * Reasoning effort for the selected model (model-defined enum).
-   */
-  reasoningEffort?: string;
-  /**
-   * Identifier of the client driving the session.
-   */
-  clientName?: string;
-  /**
-   * Identifier sent to LSP-style integrations.
-   */
-  lspClientName?: string;
-  /**
-   * Stable integration identifier used for analytics and rate-limit attribution.
-   */
-  integrationId?: string;
-  /**
-   * Map of feature-flag IDs to their boolean enabled state.
-   */
-  featureFlags?: {
-    [k: string]: boolean | undefined;
-  };
-  /**
-   * Whether experimental capabilities are enabled.
-   */
-  isExperimentalMode?: boolean;
-  /**
-   * Custom model-provider configuration (BYOK). Opaque shape; see `ProviderConfig` in the runtime.
-   */
-  provider?: {
-    [k: string]: unknown | undefined;
-  };
-  /**
-   * Absolute working-directory path for shell tools.
-   */
-  workingDirectory?: string;
-  /**
-   * Allowlist of tool names available to this session.
-   */
-  availableTools?: string[];
-  /**
-   * Denylist of tool names for this session.
-   */
-  excludedTools?: string[];
-  /**
-   * Whether shell-script safety heuristics are enabled.
-   */
-  enableScriptSafety?: boolean;
-  /**
-   * Shell init profile (`None` or `NonInteractive`).
-   */
-  shellInitProfile?: string;
-  /**
-   * Per-shell process flags (e.g., `pwsh` arguments).
-   */
-  shellProcessFlags?: string[];
-  /**
-   * Sandbox configuration shape; opaque to SDK consumers. See `SandboxConfig` in the runtime.
-   */
-  sandboxConfig?: {
-    [k: string]: unknown | undefined;
-  };
-  /**
-   * Whether interactive shell sessions are logged.
-   */
-  logInteractiveShells?: boolean;
-  envValueMode?: OptionsUpdateEnvValueMode;
-  /**
-   * Additional directories to search for skills.
-   */
-  skillDirectories?: string[];
-  /**
-   * Skill IDs that should be excluded from this session.
-   */
-  disabledSkills?: string[];
-  /**
-   * Whether to discover custom instructions on demand after successful file views (AGENTS.md / CLAUDE.md / .github/copilot-instructions.md surfacing). Combined with `skipCustomInstructions` and the runtime-side `ON_DEMAND_INSTRUCTIONS` feature flag.
-   */
-  enableOnDemandInstructionDiscovery?: boolean;
-  /**
-   * Full set of installed plugins for the session. Replaces the existing list; the runtime invalidates the skills cache only when the list materially changes.
-   */
-  installedPlugins?: SessionInstalledPlugin[];
-  /**
-   * Whether to default custom agents to local-only execution.
-   */
-  customAgentsLocalOnly?: boolean;
-  /**
-   * Whether to skip loading custom instruction sources.
-   */
-  skipCustomInstructions?: boolean;
-  /**
-   * Instruction source IDs to exclude from the system prompt.
-   */
-  disabledInstructionSources?: string[];
-  /**
-   * Whether to include the `Co-authored-by` trailer in commit messages.
-   */
-  coauthorEnabled?: boolean;
-  /**
-   * Optional path for trajectory output.
-   */
-  trajectoryFile?: string;
-  /**
-   * Whether to stream model responses.
-   */
-  enableStreaming?: boolean;
-  /**
-   * Override URL for the Copilot API endpoint.
-   */
-  copilotUrl?: string;
-  /**
-   * Whether to disable the `ask_user` tool (encourages autonomous behavior).
-   */
-  askUserDisabled?: boolean;
-  /**
-   * Whether to allow auto-mode continuation across turns.
-   */
-  continueOnAutoMode?: boolean;
-  /**
-   * Whether the session is running in an interactive UI.
-   */
-  runningInInteractiveMode?: boolean;
-  /**
-   * Whether to surface reasoning-summary events from the model.
-   */
-  enableReasoningSummaries?: boolean;
-  /**
-   * Runtime context discriminator (e.g., `cli`, `actions`).
-   */
-  agentContext?: string;
-  /**
-   * Override directory for the session-events log. When unset, the runtime's default events log directory is used.
-   */
-  eventsLogDirectory?: string;
-  /**
-   * Additional content-exclusion policies to merge into the session's policy set. Opaque shape; see `ContentExclusionApiResponse` in the runtime.
-   */
-  additionalContentExclusionPolicies?: unknown[];
-  /**
-   * Whether to expose the `manage_schedule` tool to the agent. The runtime always owns the per-session schedule registry; this flag only controls tool exposure (typically gated to staff users).
-   */
-  manageScheduleEnabled?: boolean;
-}
-/**
- * Indicates whether the session options patch was applied successfully.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SessionUpdateOptionsResult".
- */
-/** @experimental */
-export interface SessionUpdateOptionsResult {
-  /**
-   * Whether the operation succeeded
-   */
-  success: boolean;
 }
 /**
  * Shell command to run, with optional working directory and timeout in milliseconds.
@@ -6261,19 +3062,6 @@ export interface ShellKillResult {
   killed: boolean;
 }
 /**
- * Parameters for shutting down the session
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "ShutdownRequest".
- */
-export interface ShutdownRequest {
-  type?: ShutdownType;
-  /**
-   * Optional human-readable reason. Typically the message of the error that triggered shutdown when type is 'error'.
-   */
-  reason?: string;
-}
-/**
  * Schema for the `Skill` type.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -6302,10 +3090,6 @@ export interface Skill {
    * Absolute path to the skill file
    */
   path?: string;
-  /**
-   * Name of the plugin that provides the skill, when source is 'plugin'
-   */
-  pluginName?: string;
 }
 /**
  * Skills available to the session, with their enabled state.
@@ -6373,48 +3157,6 @@ export interface SkillsEnableRequest {
    * Name of the skill to enable
    */
   name: string;
-}
-/**
- * Skills invoked during this session, ordered by invocation time (most recent last).
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SkillsGetInvokedResult".
- */
-/** @experimental */
-export interface SkillsGetInvokedResult {
-  /**
-   * Skills invoked during this session, ordered by invocation time (most recent last)
-   */
-  skills: SkillsInvokedSkill[];
-}
-/**
- * Schema for the `SkillsInvokedSkill` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "SkillsInvokedSkill".
- */
-/** @experimental */
-export interface SkillsInvokedSkill {
-  /**
-   * Unique identifier for the skill
-   */
-  name: string;
-  /**
-   * Path to the SKILL.md file
-   */
-  path: string;
-  /**
-   * Full content of the skill file
-   */
-  content: string;
-  /**
-   * Tools that should be auto-approved when this skill is active, captured at invocation time
-   */
-  allowedTools?: string[];
-  /**
-   * Turn number when the skill was invoked
-   */
-  invokedAtTurn: number;
 }
 /**
  * Diagnostics from reloading skill definitions, with warnings and errors as separate lists.
@@ -6669,52 +3411,6 @@ export interface TasksCancelResult {
   cancelled: boolean;
 }
 /**
- * The first sync-waiting task that can currently be promoted to background mode.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "TasksGetCurrentPromotableResult".
- */
-/** @experimental */
-export interface TasksGetCurrentPromotableResult {
-  task?: TaskInfo;
-}
-/**
- * Identifier of the background task to fetch progress for.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "TasksGetProgressRequest".
- */
-/** @experimental */
-export interface TasksGetProgressRequest {
-  /**
-   * Task identifier (agent ID or shell ID)
-   */
-  id: string;
-}
-/**
- * Progress information for the task, or null when no task with that ID is tracked.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "TasksGetProgressResult".
- */
-/** @experimental */
-export interface TasksGetProgressResult {
-  /**
-   * Progress information for the task, discriminated by type. Returns null when no task with this ID is currently tracked.
-   */
-  progress?: TaskProgress | null;
-}
-/**
- * The promoted task as it now exists in background mode, omitted if no promotable task was waiting.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "TasksPromoteCurrentToBackgroundResult".
- */
-/** @experimental */
-export interface TasksPromoteCurrentToBackgroundResult {
-  task?: TaskInfo;
-}
-/**
  * Identifier of the task to promote to background mode.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -6740,14 +3436,6 @@ export interface TasksPromoteToBackgroundResult {
    */
   promoted: boolean;
 }
-/**
- * Refresh metadata for any detached background shells the runtime knows about. Use after a long pause to pick up exit/output state for shells running outside the agent loop.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "TasksRefreshResult".
- */
-/** @experimental */
-export interface TasksRefreshResult {}
 /**
  * Identifier of the completed or cancelled task to remove from tracking.
  *
@@ -6855,29 +3543,6 @@ export interface TasksStartAgentResult {
   agentId: string;
 }
 /**
- * Wait until all in-flight background tasks (agents + shells) and any follow-up turns scheduled by their completions have settled. Returns when the runtime is fully drained or after an internal timeout (default 10 minutes; configurable via COPILOT_TASK_WAIT_TIMEOUT_SECONDS).
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "TasksWaitForPendingResult".
- */
-/** @experimental */
-export interface TasksWaitForPendingResult {}
-/**
- * Feature override key/value pairs to attach to subsequent telemetry events from this session.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "TelemetrySetFeatureOverridesRequest".
- */
-/** @experimental */
-export interface TelemetrySetFeatureOverridesRequest {
-  /**
-   * Override key/value pairs to attach to subsequent telemetry events from this session. Replaces any previously-set overrides.
-   */
-  features: {
-    [k: string]: string | undefined;
-  };
-}
-/**
  * Schema for the `Tool` type.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -6919,13 +3584,6 @@ export interface ToolList {
    */
   tools: Tool[];
 }
-/**
- * Resolve, build, and validate the runtime tool list for this session. Subagent sessions and consumer flows that need an initialized tool set before `send` invoke this. Default base-class implementation is a no-op for sessions that don't support tool validation.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "ToolsInitializeAndValidateResult".
- */
-export interface ToolsInitializeAndValidateResult {}
 /**
  * Optional model identifier whose tool overrides should be applied to the listing.
  *
@@ -7277,40 +3935,6 @@ export interface UIElicitationResult {
   success: boolean;
 }
 /**
- * Schema for the `UIExitPlanModeResponse` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "UIExitPlanModeResponse".
- */
-export interface UIExitPlanModeResponse {
-  /**
-   * Whether the plan was approved.
-   */
-  approved: boolean;
-  selectedAction?: UIExitPlanModeAction;
-  /**
-   * Whether subsequent edits should be auto-approved without confirmation.
-   */
-  autoApproveEdits?: boolean;
-  /**
-   * Feedback from the user when they declined the plan or requested changes.
-   */
-  feedback?: string;
-}
-/**
- * Request ID of a pending `auto_mode_switch.requested` event and the user's response.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "UIHandlePendingAutoModeSwitchRequest".
- */
-export interface UIHandlePendingAutoModeSwitchRequest {
-  /**
-   * The unique request ID from the auto_mode_switch.requested event
-   */
-  requestId: string;
-  response: UIAutoModeSwitchResponse;
-}
-/**
  * Pending elicitation request ID and the user's response (accept/decline/cancel + form values).
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -7322,118 +3946,6 @@ export interface UIHandlePendingElicitationRequest {
    */
   requestId: string;
   result: UIElicitationResponse;
-}
-/**
- * Request ID of a pending `exit_plan_mode.requested` event and the user's response.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "UIHandlePendingExitPlanModeRequest".
- */
-export interface UIHandlePendingExitPlanModeRequest {
-  /**
-   * The unique request ID from the exit_plan_mode.requested event
-   */
-  requestId: string;
-  response: UIExitPlanModeResponse;
-}
-/**
- * Indicates whether the pending UI request was resolved by this call.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "UIHandlePendingResult".
- */
-export interface UIHandlePendingResult {
-  /**
-   * True if the request was still pending and was resolved by this call. False if the request ID was unknown, already resolved by another client (e.g. GitHub), expired, or otherwise no longer pending.
-   */
-  success: boolean;
-}
-/**
- * Request ID of a pending `sampling.requested` event and an optional sampling result payload (omit to reject).
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "UIHandlePendingSamplingRequest".
- */
-export interface UIHandlePendingSamplingRequest {
-  /**
-   * The unique request ID from the sampling.requested event
-   */
-  requestId: string;
-  response?: UIHandlePendingSamplingResponse;
-}
-/**
- * Optional sampling result payload. Omit to reject/cancel the sampling request without providing a result.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "UIHandlePendingSamplingResponse".
- */
-export interface UIHandlePendingSamplingResponse {
-  [k: string]: unknown | undefined;
-}
-/**
- * Request ID of a pending `user_input.requested` event and the user's response.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "UIHandlePendingUserInputRequest".
- */
-export interface UIHandlePendingUserInputRequest {
-  /**
-   * The unique request ID from the user_input.requested event
-   */
-  requestId: string;
-  response: UIUserInputResponse;
-}
-/**
- * Schema for the `UIUserInputResponse` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "UIUserInputResponse".
- */
-export interface UIUserInputResponse {
-  /**
-   * The user's answer text
-   */
-  answer: string;
-  /**
-   * True if the user typed a freeform response, false if they selected a presented choice. Used by telemetry to differentiate between free text input and choice selection.
-   */
-  wasFreeform: boolean;
-}
-/**
- * Register an in-process handler for `auto_mode_switch.requested` events. The caller still attaches the actual listener via the standard event-subscription mechanism; this registration solely tells the server bridge to skip its own dispatch (so a remote client doesn't race the in-process handler for the same requestId).
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "UIRegisterDirectAutoModeSwitchHandlerResult".
- */
-export interface UIRegisterDirectAutoModeSwitchHandlerResult {
-  /**
-   * Opaque handle representing the registration. Pass this same handle to `unregisterDirectAutoModeSwitchHandler` when the in-process handler is no longer active. Multiple registrations are reference-counted; the server bridge will only dispatch auto-mode-switch requests when no handles are active.
-   */
-  handle: string;
-}
-/**
- * Opaque handle previously returned by `registerDirectAutoModeSwitchHandler` to release.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "UIUnregisterDirectAutoModeSwitchHandlerRequest".
- */
-export interface UIUnregisterDirectAutoModeSwitchHandlerRequest {
-  /**
-   * Handle previously returned by `registerDirectAutoModeSwitchHandler`
-   */
-  handle: string;
-}
-/**
- * Indicates whether the handle was active and the registration count was decremented.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "UIUnregisterDirectAutoModeSwitchHandlerResult".
- */
-export interface UIUnregisterDirectAutoModeSwitchHandlerResult {
-  /**
-   * True if the handle was active and decremented the counter; false if the handle was unknown.
-   */
-  unregistered: boolean;
 }
 /**
  * Accumulated session usage metrics, including premium request cost, token counts, model breakdown, and code-change totals.
@@ -7466,9 +3978,9 @@ export interface UsageGetMetricsResult {
    */
   totalApiDurationMs: number;
   /**
-   * ISO 8601 timestamp when the session started
+   * Session start timestamp (epoch milliseconds)
    */
-  sessionStartTime: string;
+  sessionStartTime: number;
   codeChanges: UsageMetricsCodeChanges;
   /**
    * Per-model token and request metrics, keyed by model identifier
@@ -7522,10 +4034,6 @@ export interface UsageMetricsCodeChanges {
    * Number of distinct files modified
    */
   filesModifiedCount: number;
-  /**
-   * Distinct file paths modified during the session
-   */
-  filesModified: string[];
 }
 /**
  * Schema for the `UsageMetricsModelMetric` type.
@@ -7608,26 +4116,6 @@ export interface UsageMetricsModelMetricTokenDetail {
   tokenCount: number;
 }
 /**
- * Schema for the `WorkspacesCheckpoints` type.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "WorkspacesCheckpoints".
- */
-export interface WorkspacesCheckpoints {
-  /**
-   * Checkpoint number assigned by the workspace manager
-   */
-  number: number;
-  /**
-   * Human-readable checkpoint title
-   */
-  title: string;
-  /**
-   * Filename of the checkpoint within the workspace checkpoints directory
-   */
-  filename: string;
-}
-/**
  * Relative path and UTF-8 content for the workspace file to create or overwrite.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -7644,7 +4132,7 @@ export interface WorkspacesCreateFileRequest {
   content: string;
 }
 /**
- * Current workspace metadata for the session, including its absolute filesystem path when available.
+ * Current workspace metadata for the session, or null when not available.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "WorkspacesGetWorkspaceResult".
@@ -7671,22 +4159,6 @@ export interface WorkspacesGetWorkspaceResult {
     mc_last_event_id?: string;
     chronicle_sync_dismissed?: boolean;
   } | null;
-  /**
-   * Absolute filesystem path to the workspace directory. Omitted when the session has no workspace (e.g. remote sessions).
-   */
-  path?: string;
-}
-/**
- * Workspace checkpoints in chronological order; empty when the workspace is not enabled.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "WorkspacesListCheckpointsResult".
- */
-export interface WorkspacesListCheckpointsResult {
-  /**
-   * Workspace checkpoints in chronological order. Empty when workspace is not enabled.
-   */
-  checkpoints: WorkspacesCheckpoints[];
 }
 /**
  * Relative paths of files stored in the session workspace files directory.
@@ -7699,30 +4171,6 @@ export interface WorkspacesListFilesResult {
    * Relative file paths in the workspace files directory
    */
   files: string[];
-}
-/**
- * Checkpoint number to read.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "WorkspacesReadCheckpointRequest".
- */
-export interface WorkspacesReadCheckpointRequest {
-  /**
-   * Checkpoint number to read
-   */
-  number: number;
-}
-/**
- * Checkpoint content as a UTF-8 string, or null when the checkpoint or workspace is missing.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "WorkspacesReadCheckpointResult".
- */
-export interface WorkspacesReadCheckpointResult {
-  /**
-   * Checkpoint content as a UTF-8 string, or null when the checkpoint or workspace is missing
-   */
-  content: string | null;
 }
 /**
  * Relative path of the workspace file to read.
@@ -7749,43 +4197,6 @@ export interface WorkspacesReadFileResult {
   content: string;
 }
 /**
- * Pasted content to save as a UTF-8 file in the session workspace.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "WorkspacesSaveLargePasteRequest".
- */
-export interface WorkspacesSaveLargePasteRequest {
-  /**
-   * Pasted content to save as a UTF-8 file
-   */
-  content: string;
-}
-/**
- * Descriptor for the saved paste file, or null when the workspace is unavailable.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "WorkspacesSaveLargePasteResult".
- */
-export interface WorkspacesSaveLargePasteResult {
-  /**
-   * Saved-paste descriptor, or null when the workspace is unavailable (e.g. CCA runtime, non-infinite sessions, remote sessions)
-   */
-  saved: {
-    /**
-     * Absolute filesystem path to the saved paste file
-     */
-    filePath: string;
-    /**
-     * Filename within the workspace files directory
-     */
-    filename: string;
-    /**
-     * Size of the saved file in bytes
-     */
-    sizeBytes: number;
-  } | null;
-}
-/**
  * Identifies the target session.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -7806,10 +4217,14 @@ export function createServerRpc(connection: MessageConnection) {
          *
          * @param params Optional message to echo back to the caller.
          *
-         * @returns Server liveness response, including the echoed message, current server timestamp, and protocol version.
+         * @returns Server liveness response, including the echoed message, current timestamp, and protocol version.
          */
-        ping: async (params: PingRequest): Promise<PingResult> =>
-            connection.sendRequest("ping", params),
+        ping: async (params: PingRequest): Promise<PingResult> => {
+            if (params == null) {
+                throw new TypeError("params is required");
+            }
+            return connection.sendRequest("ping", params);
+        },
         models: {
             /**
              * Lists Copilot models available to the authenticated user.
@@ -7818,8 +4233,12 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns List of Copilot models available to the resolved user, including capabilities and billing metadata.
              */
-            list: async (params: ModelsListRequest): Promise<ModelList> =>
-                connection.sendRequest("models.list", params),
+            list: async (params: ModelsListRequest): Promise<ModelList> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("models.list", params);
+            },
         },
         tools: {
             /**
@@ -7829,8 +4248,12 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Built-in tools available for the requested model, with their parameters and instructions.
              */
-            list: async (params: ToolsListRequest): Promise<ToolList> =>
-                connection.sendRequest("tools.list", params),
+            list: async (params: ToolsListRequest): Promise<ToolList> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("tools.list", params);
+            },
         },
         account: {
             /**
@@ -7840,8 +4263,12 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Quota usage snapshots for the resolved user, keyed by quota type.
              */
-            getQuota: async (params: AccountGetQuotaRequest): Promise<AccountGetQuotaResult> =>
-                connection.sendRequest("account.getQuota", params),
+            getQuota: async (params: AccountGetQuotaRequest): Promise<AccountGetQuotaResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("account.getQuota", params);
+            },
         },
         mcp: {
             config: {
@@ -7850,43 +4277,64 @@ export function createServerRpc(connection: MessageConnection) {
                  *
                  * @returns User-configured MCP servers, keyed by server name.
                  */
-                list: async (): Promise<McpConfigList> =>
-                    connection.sendRequest("mcp.config.list", {}),
+                list: async (): Promise<McpConfigList> => {
+                    return connection.sendRequest("mcp.config.list", {});
+                },
                 /**
                  * Adds an MCP server to user configuration.
                  *
                  * @param params MCP server name and configuration to add to user configuration.
                  */
-                add: async (params: McpConfigAddRequest): Promise<void> =>
-                    connection.sendRequest("mcp.config.add", params),
+                add: async (params: McpConfigAddRequest): Promise<void> => {
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("mcp.config.add", params);
+                },
                 /**
                  * Updates an MCP server in user configuration.
                  *
                  * @param params MCP server name and replacement configuration to write to user configuration.
                  */
-                update: async (params: McpConfigUpdateRequest): Promise<void> =>
-                    connection.sendRequest("mcp.config.update", params),
+                update: async (params: McpConfigUpdateRequest): Promise<void> => {
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("mcp.config.update", params);
+                },
                 /**
                  * Removes an MCP server from user configuration.
                  *
                  * @param params MCP server name to remove from user configuration.
                  */
-                remove: async (params: McpConfigRemoveRequest): Promise<void> =>
-                    connection.sendRequest("mcp.config.remove", params),
+                remove: async (params: McpConfigRemoveRequest): Promise<void> => {
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("mcp.config.remove", params);
+                },
                 /**
                  * Enables MCP servers in user configuration for new sessions.
                  *
                  * @param params MCP server names to enable for new sessions.
                  */
-                enable: async (params: McpConfigEnableRequest): Promise<void> =>
-                    connection.sendRequest("mcp.config.enable", params),
+                enable: async (params: McpConfigEnableRequest): Promise<void> => {
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("mcp.config.enable", params);
+                },
                 /**
                  * Disables MCP servers in user configuration for new sessions.
                  *
                  * @param params MCP server names to disable for new sessions.
                  */
-                disable: async (params: McpConfigDisableRequest): Promise<void> =>
-                    connection.sendRequest("mcp.config.disable", params),
+                disable: async (params: McpConfigDisableRequest): Promise<void> => {
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("mcp.config.disable", params);
+                },
             },
             /**
              * Discovers MCP servers from user, workspace, plugin, and builtin sources.
@@ -7895,8 +4343,12 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns MCP servers discovered from user, workspace, plugin, and built-in sources.
              */
-            discover: async (params: McpDiscoverRequest): Promise<McpDiscoverResult> =>
-                connection.sendRequest("mcp.discover", params),
+            discover: async (params: McpDiscoverRequest): Promise<McpDiscoverResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("mcp.discover", params);
+            },
         },
         skills: {
             config: {
@@ -7905,8 +4357,12 @@ export function createServerRpc(connection: MessageConnection) {
                  *
                  * @param params Skill names to mark as disabled in global configuration, replacing any previous list.
                  */
-                setDisabledSkills: async (params: SkillsConfigSetDisabledSkillsRequest): Promise<void> =>
-                    connection.sendRequest("skills.config.setDisabledSkills", params),
+                setDisabledSkills: async (params: SkillsConfigSetDisabledSkillsRequest): Promise<void> => {
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("skills.config.setDisabledSkills", params);
+                },
             },
             /**
              * Discovers skills across global and project sources.
@@ -7915,8 +4371,12 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Skills discovered across global and project sources.
              */
-            discover: async (params: SkillsDiscoverRequest): Promise<ServerSkillList> =>
-                connection.sendRequest("skills.discover", params),
+            discover: async (params: SkillsDiscoverRequest): Promise<ServerSkillList> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("skills.discover", params);
+            },
         },
         sessionFs: {
             /**
@@ -7926,8 +4386,12 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Indicates whether the calling client was registered as the session filesystem provider.
              */
-            setProvider: async (params: SessionFsSetProviderRequest): Promise<SessionFsSetProviderResult> =>
-                connection.sendRequest("sessionFs.setProvider", params),
+            setProvider: async (params: SessionFsSetProviderRequest): Promise<SessionFsSetProviderResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("sessionFs.setProvider", params);
+            },
         },
         /** @experimental */
         sessions: {
@@ -7938,8 +4402,12 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Identifier and optional friendly name assigned to the newly forked session.
              */
-            fork: async (params: SessionsForkRequest): Promise<SessionsForkResult> =>
-                connection.sendRequest("sessions.fork", params),
+            fork: async (params: SessionsForkRequest): Promise<SessionsForkResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("sessions.fork", params);
+            },
             /**
              * Connects to an existing remote session and exposes it as an SDK session.
              *
@@ -7947,159 +4415,12 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Remote session connection result.
              */
-            connect: async (params: ConnectRemoteSessionParams): Promise<RemoteSessionConnectionResult> =>
-                connection.sendRequest("sessions.connect", params),
-            /**
-             * Lists persisted sessions, optionally filtered by working-directory context.
-             *
-             * @param params Optional metadata-load limit and context filter applied to the returned sessions.
-             *
-             * @returns Persisted sessions matching the filter, ordered most-recently-modified first.
-             */
-            list: async (params: SessionsListRequest): Promise<SessionList> =>
-                connection.sendRequest("sessions.list", params),
-            /**
-             * Finds the local session bound to a GitHub task ID, if any.
-             *
-             * @param params GitHub task ID to look up.
-             *
-             * @returns ID of the local session bound to the given GitHub task, or omitted when none.
-             */
-            findByTaskId: async (params: SessionsFindByTaskIDRequest): Promise<SessionsFindByTaskIDResult> =>
-                connection.sendRequest("sessions.findByTaskId", params),
-            /**
-             * Resolves a UUID prefix to a unique session ID, if exactly one session matches.
-             *
-             * @param params UUID prefix to resolve to a unique session ID.
-             *
-             * @returns Session ID matching the prefix, omitted when no unique match exists.
-             */
-            findByPrefix: async (params: SessionsFindByPrefixRequest): Promise<SessionsFindByPrefixResult> =>
-                connection.sendRequest("sessions.findByPrefix", params),
-            /**
-             * Returns the most-relevant prior session for a given working-directory context.
-             *
-             * @param params Optional working-directory context used to score session relevance.
-             *
-             * @returns Most-relevant session ID for the supplied context, or omitted when no sessions exist.
-             */
-            getLastForContext: async (params: SessionsGetLastForContextRequest): Promise<SessionsGetLastForContextResult> =>
-                connection.sendRequest("sessions.getLastForContext", params),
-            /**
-             * Computes the absolute path to a session's persisted events.jsonl file.
-             *
-             * @param params Session ID whose event-log file path to compute.
-             *
-             * @returns Absolute path to the session's events.jsonl file on disk.
-             */
-            getEventFilePath: async (params: SessionsGetEventFilePathRequest): Promise<SessionsGetEventFilePathResult> =>
-                connection.sendRequest("sessions.getEventFilePath", params),
-            /**
-             * Returns the on-disk byte size of each session's workspace directory.
-             *
-             * @returns Map of sessionId -> on-disk size in bytes for each session's workspace directory.
-             */
-            getSizes: async (): Promise<SessionSizes> =>
-                connection.sendRequest("sessions.getSizes", {}),
-            /**
-             * Returns the subset of the supplied session IDs that are currently held by another running process.
-             *
-             * @param params Session IDs to test for live in-use locks.
-             *
-             * @returns Session IDs from the input set that are currently in use by another process.
-             */
-            checkInUse: async (params: SessionsCheckInUseRequest): Promise<SessionsCheckInUseResult> =>
-                connection.sendRequest("sessions.checkInUse", params),
-            /**
-             * Returns a session's persisted remote-steerable flag, if any has been recorded.
-             *
-             * @param params Session ID to look up the persisted remote-steerable flag for.
-             *
-             * @returns The session's persisted remote-steerable flag, or omitted when no value has been persisted.
-             */
-            getPersistedRemoteSteerable: async (params: SessionsGetPersistedRemoteSteerableRequest): Promise<SessionsGetPersistedRemoteSteerableResult> =>
-                connection.sendRequest("sessions.getPersistedRemoteSteerable", params),
-            /**
-             * Closes a session: emits shutdown, flushes pending events, releases the in-use lock, and disposes the active session.
-             *
-             * @param params Session ID to close.
-             *
-             * @returns Closes a session: emits shutdown, flushes pending events to disk, releases the in-use lock, disposes the active session. Idempotent: succeeds even if the session is not currently active.
-             */
-            close: async (params: SessionsCloseRequest): Promise<SessionsCloseResult> =>
-                connection.sendRequest("sessions.close", params),
-            /**
-             * Closes, deactivates, and deletes a set of sessions, returning the bytes freed per session.
-             *
-             * @param params Session IDs to close, deactivate, and delete from disk.
-             *
-             * @returns Map of sessionId -> bytes freed by removing the session's workspace directory.
-             */
-            bulkDelete: async (params: SessionsBulkDeleteRequest): Promise<SessionBulkDeleteResult> =>
-                connection.sendRequest("sessions.bulkDelete", params),
-            /**
-             * Deletes sessions older than the given threshold, with optional dry-run and exclusion list.
-             *
-             * @param params Age threshold and optional flags controlling which old sessions are pruned (or simulated when dryRun is true).
-             *
-             * @returns Outcome of the prune operation: deleted IDs, dry-run candidates, skipped IDs, total bytes freed, and the dry-run flag.
-             */
-            pruneOld: async (params: SessionsPruneOldRequest): Promise<SessionPruneResult> =>
-                connection.sendRequest("sessions.pruneOld", params),
-            /**
-             * Flushes a session's pending events to disk.
-             *
-             * @param params Session ID whose pending events should be flushed to disk.
-             *
-             * @returns Flush a session's pending events to disk. No-op when no writer exists for the session (e.g., already closed).
-             */
-            save: async (params: SessionsSaveRequest): Promise<SessionsSaveResult> =>
-                connection.sendRequest("sessions.save", params),
-            /**
-             * Releases the in-use lock held by this process for a session.
-             *
-             * @param params Session ID whose in-use lock should be released.
-             *
-             * @returns Release the in-use lock held by this process for the given session. No-op when this process does not currently hold a lock for the session.
-             */
-            releaseLock: async (params: SessionsReleaseLockRequest): Promise<SessionsReleaseLockResult> =>
-                connection.sendRequest("sessions.releaseLock", params),
-            /**
-             * Backfills missing summary and context fields on the supplied session metadata records.
-             *
-             * @param params Session metadata records to enrich with summary and context information.
-             *
-             * @returns The same metadata records, with summary and context fields backfilled where available.
-             */
-            enrichMetadata: async (params: SessionsEnrichMetadataRequest): Promise<SessionEnrichMetadataResult> =>
-                connection.sendRequest("sessions.enrichMetadata", params),
-            /**
-             * Reloads user, plugin, and (optionally) repo hooks on the active session.
-             *
-             * @param params Active session ID and an optional flag for deferring repo-level hooks until folder trust.
-             *
-             * @returns Reload all hooks (user, plugin, optionally repo) and apply them to the active session. Call after installing or removing plugins so their hooks take effect immediately. No-op when no active session matches the given sessionId.
-             */
-            reloadPluginHooks: async (params: SessionsReloadPluginHooksRequest): Promise<SessionsReloadPluginHooksResult> =>
-                connection.sendRequest("sessions.reloadPluginHooks", params),
-            /**
-             * Loads previously-deferred repo-level hooks on the active session, returning queued startup prompts.
-             *
-             * @param params Active session ID whose deferred repo-level hooks should be loaded.
-             *
-             * @returns Queued repo-level startup prompts and the total hook command count after loading.
-             */
-            loadDeferredRepoHooks: async (params: SessionsLoadDeferredRepoHooksRequest): Promise<SessionLoadDeferredRepoHooksResult> =>
-                connection.sendRequest("sessions.loadDeferredRepoHooks", params),
-            /**
-             * Replaces the manager-wide additional plugins registered with the session manager.
-             *
-             * @param params Manager-wide additional plugins to register; replaces any previously-configured set.
-             *
-             * @returns Replace the manager-wide additional plugins. New session creations and subsequent hook reloads see the new set; already-running sessions keep their existing hook installation until the next reload.
-             */
-            setAdditionalPlugins: async (params: SessionsSetAdditionalPluginsRequest): Promise<SessionsSetAdditionalPluginsResult> =>
-                connection.sendRequest("sessions.setAdditionalPlugins", params),
+            connect: async (params: ConnectRemoteSessionParams): Promise<RemoteSessionConnectionResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("sessions.connect", params);
+            },
         },
     };
 }
@@ -8118,70 +4439,46 @@ export function createInternalServerRpc(connection: MessageConnection) {
          *
          * @returns Handshake result reporting the server's protocol version and package version on success.
          */
-        connect: async (params: ConnectRequest): Promise<ConnectResult> =>
-            connection.sendRequest("connect", params),
+        connect: async (params: ConnectRequest): Promise<ConnectResult> => {
+            if (params == null) {
+                throw new TypeError("params is required");
+            }
+            return connection.sendRequest("connect", params);
+        },
     };
 }
 
 /** Create typed session-scoped RPC methods. */
-export function createSessionRpc(connection: MessageConnection, sessionId: string) {
+export function createSessionRpc(connection: MessageConnection, sessionId: string, assertActive?: () => void) {
     return {
         /**
          * Suspends the session while preserving persisted state for later resume.
          */
-        suspend: async (): Promise<void> =>
-            connection.sendRequest("session.suspend", { sessionId }),
-        /**
-         * Sends a user message to the session and returns its message ID.
-         *
-         * @param params Parameters for sending a user message to the session
-         *
-         * @returns Result of sending a user message
-         */
-        send: async (params: SendRequest): Promise<SendResult> =>
-            connection.sendRequest("session.send", { sessionId, ...params }),
-        /**
-         * Aborts the current agent turn.
-         *
-         * @param params Parameters for aborting the current turn
-         *
-         * @returns Result of aborting the current turn
-         */
-        abort: async (params: AbortRequest): Promise<AbortResult> =>
-            connection.sendRequest("session.abort", { sessionId, ...params }),
-        /**
-         * Shuts down the session and persists its final state. Awaits any deferred sessionEnd hooks before resolving so user-supplied hook scripts complete before the runtime tears down.
-         *
-         * @param params Parameters for shutting down the session
-         */
-        shutdown: async (params: ShutdownRequest): Promise<void> =>
-            connection.sendRequest("session.shutdown", { sessionId, ...params }),
+        suspend: async (): Promise<void> => {
+            assertActive?.();
+            return connection.sendRequest("session.suspend", { sessionId });
+        },
         auth: {
             /**
              * Gets authentication status and account metadata for the session.
              *
              * @returns Authentication status and account metadata for the session.
              */
-            getStatus: async (): Promise<SessionAuthStatus> =>
-                connection.sendRequest("session.auth.getStatus", { sessionId }),
-            /**
-             * Updates the session's auth credentials used for outbound model and API requests.
-             *
-             * @param params New auth credentials to install on the session. Omit to leave credentials unchanged.
-             *
-             * @returns Indicates whether the credential update succeeded.
-             */
-            setCredentials: async (params: SessionSetCredentialsParams): Promise<SessionSetCredentialsResult> =>
-                connection.sendRequest("session.auth.setCredentials", { sessionId, ...params }),
+            getStatus: async (): Promise<SessionAuthStatus> => {
+                assertActive?.();
+                return connection.sendRequest("session.auth.getStatus", { sessionId });
+            },
         },
         model: {
             /**
              * Gets the currently selected model for the session.
              *
-             * @returns The currently selected model and reasoning effort for the session.
+             * @returns The currently selected model for the session.
              */
-            getCurrent: async (): Promise<CurrentModel> =>
-                connection.sendRequest("session.model.getCurrent", { sessionId }),
+            getCurrent: async (): Promise<CurrentModel> => {
+                assertActive?.();
+                return connection.sendRequest("session.model.getCurrent", { sessionId });
+            },
             /**
              * Switches the session to a model and optional reasoning configuration.
              *
@@ -8189,17 +4486,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns The model identifier active on the session after the switch.
              */
-            switchTo: async (params: ModelSwitchToRequest): Promise<ModelSwitchToResult> =>
-                connection.sendRequest("session.model.switchTo", { sessionId, ...params }),
-            /**
-             * Updates the session's reasoning effort without changing the selected model.
-             *
-             * @param params Reasoning effort level to apply to the currently selected model.
-             *
-             * @returns Update the session's reasoning effort without changing the selected model. Use `switchTo` instead when you also need to change the model. The runtime stores the effort on the session and applies it to subsequent turns.
-             */
-            setReasoningEffort: async (params: ModelSetReasoningEffortRequest): Promise<ModelSetReasoningEffortResult> =>
-                connection.sendRequest("session.model.setReasoningEffort", { sessionId, ...params }),
+            switchTo: async (params: ModelSwitchToRequest): Promise<ModelSwitchToResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.model.switchTo", { sessionId, ...params });
+            },
         },
         mode: {
             /**
@@ -8207,15 +4500,22 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns The session mode the agent is operating in
              */
-            get: async (): Promise<SessionMode> =>
-                connection.sendRequest("session.mode.get", { sessionId }),
+            get: async (): Promise<SessionMode> => {
+                assertActive?.();
+                return connection.sendRequest("session.mode.get", { sessionId });
+            },
             /**
              * Sets the current agent interaction mode.
              *
              * @param params Agent interaction mode to apply to the session.
              */
-            set: async (params: ModeSetRequest): Promise<void> =>
-                connection.sendRequest("session.mode.set", { sessionId, ...params }),
+            set: async (params: ModeSetRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.mode.set", { sessionId, ...params });
+            },
         },
         name: {
             /**
@@ -8223,24 +4523,22 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns The session's friendly name, or null when not yet set.
              */
-            get: async (): Promise<NameGetResult> =>
-                connection.sendRequest("session.name.get", { sessionId }),
+            get: async (): Promise<NameGetResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.name.get", { sessionId });
+            },
             /**
              * Sets the session's friendly name.
              *
              * @param params New friendly name to apply to the session.
              */
-            set: async (params: NameSetRequest): Promise<void> =>
-                connection.sendRequest("session.name.set", { sessionId, ...params }),
-            /**
-             * Persists an auto-generated session summary as the session's name when no user-set name exists.
-             *
-             * @param params Auto-generated session summary to apply as the session's name when no user-set name exists.
-             *
-             * @returns Indicates whether the auto-generated summary was applied as the session's name.
-             */
-            setAuto: async (params: NameSetAutoRequest): Promise<NameSetAutoResult> =>
-                connection.sendRequest("session.name.setAuto", { sessionId, ...params }),
+            set: async (params: NameSetRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.name.set", { sessionId, ...params });
+            },
         },
         plan: {
             /**
@@ -8248,36 +4546,49 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Existence, contents, and resolved path of the session plan file.
              */
-            read: async (): Promise<PlanReadResult> =>
-                connection.sendRequest("session.plan.read", { sessionId }),
+            read: async (): Promise<PlanReadResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.plan.read", { sessionId });
+            },
             /**
              * Writes new content to the session plan file.
              *
              * @param params Replacement contents to write to the session plan file.
              */
-            update: async (params: PlanUpdateRequest): Promise<void> =>
-                connection.sendRequest("session.plan.update", { sessionId, ...params }),
+            update: async (params: PlanUpdateRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.plan.update", { sessionId, ...params });
+            },
             /**
              * Deletes the session plan file from the workspace.
              */
-            delete: async (): Promise<void> =>
-                connection.sendRequest("session.plan.delete", { sessionId }),
+            delete: async (): Promise<void> => {
+                assertActive?.();
+                return connection.sendRequest("session.plan.delete", { sessionId });
+            },
         },
         workspaces: {
             /**
              * Gets current workspace metadata for the session.
              *
-             * @returns Current workspace metadata for the session, including its absolute filesystem path when available.
+             * @returns Current workspace metadata for the session, or null when not available.
              */
-            getWorkspace: async (): Promise<WorkspacesGetWorkspaceResult> =>
-                connection.sendRequest("session.workspaces.getWorkspace", { sessionId }),
+            getWorkspace: async (): Promise<WorkspacesGetWorkspaceResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.workspaces.getWorkspace", { sessionId });
+            },
             /**
              * Lists files stored in the session workspace files directory.
              *
              * @returns Relative paths of files stored in the session workspace files directory.
              */
-            listFiles: async (): Promise<WorkspacesListFilesResult> =>
-                connection.sendRequest("session.workspaces.listFiles", { sessionId }),
+            listFiles: async (): Promise<WorkspacesListFilesResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.workspaces.listFiles", { sessionId });
+            },
             /**
              * Reads a file from the session workspace files directory.
              *
@@ -8285,40 +4596,25 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Contents of the requested workspace file as a UTF-8 string.
              */
-            readFile: async (params: WorkspacesReadFileRequest): Promise<WorkspacesReadFileResult> =>
-                connection.sendRequest("session.workspaces.readFile", { sessionId, ...params }),
+            readFile: async (params: WorkspacesReadFileRequest): Promise<WorkspacesReadFileResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.workspaces.readFile", { sessionId, ...params });
+            },
             /**
              * Creates or overwrites a file in the session workspace files directory.
              *
              * @param params Relative path and UTF-8 content for the workspace file to create or overwrite.
              */
-            createFile: async (params: WorkspacesCreateFileRequest): Promise<void> =>
-                connection.sendRequest("session.workspaces.createFile", { sessionId, ...params }),
-            /**
-             * Lists workspace checkpoints in chronological order.
-             *
-             * @returns Workspace checkpoints in chronological order; empty when the workspace is not enabled.
-             */
-            listCheckpoints: async (): Promise<WorkspacesListCheckpointsResult> =>
-                connection.sendRequest("session.workspaces.listCheckpoints", { sessionId }),
-            /**
-             * Reads the content of a workspace checkpoint by number.
-             *
-             * @param params Checkpoint number to read.
-             *
-             * @returns Checkpoint content as a UTF-8 string, or null when the checkpoint or workspace is missing.
-             */
-            readCheckpoint: async (params: WorkspacesReadCheckpointRequest): Promise<WorkspacesReadCheckpointResult> =>
-                connection.sendRequest("session.workspaces.readCheckpoint", { sessionId, ...params }),
-            /**
-             * Saves pasted content as a UTF-8 file in the session workspace.
-             *
-             * @param params Pasted content to save as a UTF-8 file in the session workspace.
-             *
-             * @returns Descriptor for the saved paste file, or null when the workspace is unavailable.
-             */
-            saveLargePaste: async (params: WorkspacesSaveLargePasteRequest): Promise<WorkspacesSaveLargePasteResult> =>
-                connection.sendRequest("session.workspaces.saveLargePaste", { sessionId, ...params }),
+            createFile: async (params: WorkspacesCreateFileRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.workspaces.createFile", { sessionId, ...params });
+            },
         },
         instructions: {
             /**
@@ -8326,8 +4622,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Instruction sources loaded for the session, in merge order.
              */
-            getSources: async (): Promise<InstructionsGetSourcesResult> =>
-                connection.sendRequest("session.instructions.getSources", { sessionId }),
+            getSources: async (): Promise<InstructionsGetSourcesResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.instructions.getSources", { sessionId });
+            },
         },
         /** @experimental */
         fleet: {
@@ -8338,8 +4636,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether fleet mode was successfully activated.
              */
-            start: async (params: FleetStartRequest): Promise<FleetStartResult> =>
-                connection.sendRequest("session.fleet.start", { sessionId, ...params }),
+            start: async (params: FleetStartRequest): Promise<FleetStartResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.fleet.start", { sessionId, ...params });
+            },
         },
         /** @experimental */
         agent: {
@@ -8348,15 +4651,19 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Custom agents available to the session.
              */
-            list: async (): Promise<AgentList> =>
-                connection.sendRequest("session.agent.list", { sessionId }),
+            list: async (): Promise<AgentList> => {
+                assertActive?.();
+                return connection.sendRequest("session.agent.list", { sessionId });
+            },
             /**
              * Gets the currently selected custom agent for the session.
              *
              * @returns The currently selected custom agent, or null when using the default agent.
              */
-            getCurrent: async (): Promise<AgentGetCurrentResult> =>
-                connection.sendRequest("session.agent.getCurrent", { sessionId }),
+            getCurrent: async (): Promise<AgentGetCurrentResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.agent.getCurrent", { sessionId });
+            },
             /**
              * Selects a custom agent for subsequent turns in the session.
              *
@@ -8364,20 +4671,29 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns The newly selected custom agent.
              */
-            select: async (params: AgentSelectRequest): Promise<AgentSelectResult> =>
-                connection.sendRequest("session.agent.select", { sessionId, ...params }),
+            select: async (params: AgentSelectRequest): Promise<AgentSelectResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.agent.select", { sessionId, ...params });
+            },
             /**
              * Clears the selected custom agent and returns the session to the default agent.
              */
-            deselect: async (): Promise<void> =>
-                connection.sendRequest("session.agent.deselect", { sessionId }),
+            deselect: async (): Promise<void> => {
+                assertActive?.();
+                return connection.sendRequest("session.agent.deselect", { sessionId });
+            },
             /**
              * Reloads custom agent definitions and returns the refreshed list.
              *
              * @returns Custom agents available to the session after reloading definitions from disk.
              */
-            reload: async (): Promise<AgentReloadResult> =>
-                connection.sendRequest("session.agent.reload", { sessionId }),
+            reload: async (): Promise<AgentReloadResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.agent.reload", { sessionId });
+            },
         },
         /** @experimental */
         tasks: {
@@ -8388,45 +4704,22 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Identifier assigned to the newly started background agent task.
              */
-            startAgent: async (params: TasksStartAgentRequest): Promise<TasksStartAgentResult> =>
-                connection.sendRequest("session.tasks.startAgent", { sessionId, ...params }),
+            startAgent: async (params: TasksStartAgentRequest): Promise<TasksStartAgentResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.tasks.startAgent", { sessionId, ...params });
+            },
             /**
              * Lists background tasks tracked by the session.
              *
              * @returns Background tasks currently tracked by the session.
              */
-            list: async (): Promise<TaskList> =>
-                connection.sendRequest("session.tasks.list", { sessionId }),
-            /**
-             * Refreshes metadata for any detached background shells the runtime knows about.
-             *
-             * @returns Refresh metadata for any detached background shells the runtime knows about. Use after a long pause to pick up exit/output state for shells running outside the agent loop.
-             */
-            refresh: async (): Promise<TasksRefreshResult> =>
-                connection.sendRequest("session.tasks.refresh", { sessionId }),
-            /**
-             * Waits for all in-flight background tasks and any follow-up turns to settle.
-             *
-             * @returns Wait until all in-flight background tasks (agents + shells) and any follow-up turns scheduled by their completions have settled. Returns when the runtime is fully drained or after an internal timeout (default 10 minutes; configurable via COPILOT_TASK_WAIT_TIMEOUT_SECONDS).
-             */
-            waitForPending: async (): Promise<TasksWaitForPendingResult> =>
-                connection.sendRequest("session.tasks.waitForPending", { sessionId }),
-            /**
-             * Returns progress information for a background task by ID.
-             *
-             * @param params Identifier of the background task to fetch progress for.
-             *
-             * @returns Progress information for the task, or null when no task with that ID is tracked.
-             */
-            getProgress: async (params: TasksGetProgressRequest): Promise<TasksGetProgressResult> =>
-                connection.sendRequest("session.tasks.getProgress", { sessionId, ...params }),
-            /**
-             * Returns the first sync-waiting task that can currently be promoted to background mode.
-             *
-             * @returns The first sync-waiting task that can currently be promoted to background mode.
-             */
-            getCurrentPromotable: async (): Promise<TasksGetCurrentPromotableResult> =>
-                connection.sendRequest("session.tasks.getCurrentPromotable", { sessionId }),
+            list: async (): Promise<TaskList> => {
+                assertActive?.();
+                return connection.sendRequest("session.tasks.list", { sessionId });
+            },
             /**
              * Promotes an eligible synchronously-waited task so it continues running in the background.
              *
@@ -8434,15 +4727,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the task was successfully promoted to background mode.
              */
-            promoteToBackground: async (params: TasksPromoteToBackgroundRequest): Promise<TasksPromoteToBackgroundResult> =>
-                connection.sendRequest("session.tasks.promoteToBackground", { sessionId, ...params }),
-            /**
-             * Atomically promotes the first promotable sync-waiting task to background mode and returns it.
-             *
-             * @returns The promoted task as it now exists in background mode, omitted if no promotable task was waiting.
-             */
-            promoteCurrentToBackground: async (): Promise<TasksPromoteCurrentToBackgroundResult> =>
-                connection.sendRequest("session.tasks.promoteCurrentToBackground", { sessionId }),
+            promoteToBackground: async (params: TasksPromoteToBackgroundRequest): Promise<TasksPromoteToBackgroundResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.tasks.promoteToBackground", { sessionId, ...params });
+            },
             /**
              * Cancels a background task.
              *
@@ -8450,8 +4741,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the background task was successfully cancelled.
              */
-            cancel: async (params: TasksCancelRequest): Promise<TasksCancelResult> =>
-                connection.sendRequest("session.tasks.cancel", { sessionId, ...params }),
+            cancel: async (params: TasksCancelRequest): Promise<TasksCancelResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.tasks.cancel", { sessionId, ...params });
+            },
             /**
              * Removes a completed or cancelled background task from tracking.
              *
@@ -8459,8 +4755,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the task was removed. False when the task does not exist or is still running/idle.
              */
-            remove: async (params: TasksRemoveRequest): Promise<TasksRemoveResult> =>
-                connection.sendRequest("session.tasks.remove", { sessionId, ...params }),
+            remove: async (params: TasksRemoveRequest): Promise<TasksRemoveResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.tasks.remove", { sessionId, ...params });
+            },
             /**
              * Sends a message to a background agent task.
              *
@@ -8468,8 +4769,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the message was delivered, with an error message when delivery failed.
              */
-            sendMessage: async (params: TasksSendMessageRequest): Promise<TasksSendMessageResult> =>
-                connection.sendRequest("session.tasks.sendMessage", { sessionId, ...params }),
+            sendMessage: async (params: TasksSendMessageRequest): Promise<TasksSendMessageResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.tasks.sendMessage", { sessionId, ...params });
+            },
         },
         /** @experimental */
         skills: {
@@ -8478,41 +4784,43 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Skills available to the session, with their enabled state.
              */
-            list: async (): Promise<SkillList> =>
-                connection.sendRequest("session.skills.list", { sessionId }),
-            /**
-             * Returns the skills that have been invoked during this session.
-             *
-             * @returns Skills invoked during this session, ordered by invocation time (most recent last).
-             */
-            getInvoked: async (): Promise<SkillsGetInvokedResult> =>
-                connection.sendRequest("session.skills.getInvoked", { sessionId }),
+            list: async (): Promise<SkillList> => {
+                assertActive?.();
+                return connection.sendRequest("session.skills.list", { sessionId });
+            },
             /**
              * Enables a skill for the session.
              *
              * @param params Name of the skill to enable for the session.
              */
-            enable: async (params: SkillsEnableRequest): Promise<void> =>
-                connection.sendRequest("session.skills.enable", { sessionId, ...params }),
+            enable: async (params: SkillsEnableRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.skills.enable", { sessionId, ...params });
+            },
             /**
              * Disables a skill for the session.
              *
              * @param params Name of the skill to disable for the session.
              */
-            disable: async (params: SkillsDisableRequest): Promise<void> =>
-                connection.sendRequest("session.skills.disable", { sessionId, ...params }),
+            disable: async (params: SkillsDisableRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.skills.disable", { sessionId, ...params });
+            },
             /**
              * Reloads skill definitions for the session.
              *
              * @returns Diagnostics from reloading skill definitions, with warnings and errors as separate lists.
              */
-            reload: async (): Promise<SkillsLoadDiagnostics> =>
-                connection.sendRequest("session.skills.reload", { sessionId }),
-            /**
-             * Ensures the session's skill definitions have been loaded from disk.
-             */
-            ensureLoaded: async (): Promise<void> =>
-                connection.sendRequest("session.skills.ensureLoaded", { sessionId }),
+            reload: async (): Promise<SkillsLoadDiagnostics> => {
+                assertActive?.();
+                return connection.sendRequest("session.skills.reload", { sessionId });
+            },
         },
         /** @experimental */
         mcp: {
@@ -8521,61 +4829,41 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns MCP servers configured for the session, with their connection status.
              */
-            list: async (): Promise<McpServerList> =>
-                connection.sendRequest("session.mcp.list", { sessionId }),
+            list: async (): Promise<McpServerList> => {
+                assertActive?.();
+                return connection.sendRequest("session.mcp.list", { sessionId });
+            },
             /**
              * Enables an MCP server for the session.
              *
              * @param params Name of the MCP server to enable for the session.
              */
-            enable: async (params: McpEnableRequest): Promise<void> =>
-                connection.sendRequest("session.mcp.enable", { sessionId, ...params }),
+            enable: async (params: McpEnableRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.mcp.enable", { sessionId, ...params });
+            },
             /**
              * Disables an MCP server for the session.
              *
              * @param params Name of the MCP server to disable for the session.
              */
-            disable: async (params: McpDisableRequest): Promise<void> =>
-                connection.sendRequest("session.mcp.disable", { sessionId, ...params }),
+            disable: async (params: McpDisableRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.mcp.disable", { sessionId, ...params });
+            },
             /**
              * Reloads MCP server connections for the session.
              */
-            reload: async (): Promise<void> =>
-                connection.sendRequest("session.mcp.reload", { sessionId }),
-            /**
-             * Runs an MCP sampling inference on behalf of an MCP server.
-             *
-             * @param params Identifiers and raw MCP CreateMessageRequest params used to run a sampling inference.
-             *
-             * @returns Outcome of an MCP sampling execution: success result, failure error, or cancellation.
-             */
-            executeSampling: async (params: McpExecuteSamplingParams): Promise<McpSamplingExecutionResult> =>
-                connection.sendRequest("session.mcp.executeSampling", { sessionId, ...params }),
-            /**
-             * Cancels an in-flight MCP sampling execution by request ID.
-             *
-             * @param params The requestId previously passed to executeSampling that should be cancelled.
-             *
-             * @returns Indicates whether an in-flight sampling execution with the given requestId was found and cancelled.
-             */
-            cancelSamplingExecution: async (params: McpCancelSamplingExecutionParams): Promise<McpCancelSamplingExecutionResult> =>
-                connection.sendRequest("session.mcp.cancelSamplingExecution", { sessionId, ...params }),
-            /**
-             * Sets how environment-variable values supplied to MCP servers are resolved (direct or indirect).
-             *
-             * @param params Mode controlling how MCP server env values are resolved (`direct` or `indirect`).
-             *
-             * @returns Env-value mode recorded on the session after the update.
-             */
-            setEnvValueMode: async (params: McpSetEnvValueModeParams): Promise<McpSetEnvValueModeResult> =>
-                connection.sendRequest("session.mcp.setEnvValueMode", { sessionId, ...params }),
-            /**
-             * Removes the auto-managed `github` MCP server when present.
-             *
-             * @returns Indicates whether the auto-managed `github` MCP server was removed (false when nothing to remove).
-             */
-            removeGitHub: async (): Promise<McpRemoveGitHubResult> =>
-                connection.sendRequest("session.mcp.removeGitHub", { sessionId }),
+            reload: async (): Promise<void> => {
+                assertActive?.();
+                return connection.sendRequest("session.mcp.reload", { sessionId });
+            },
             /** @experimental */
             oauth: {
                 /**
@@ -8585,8 +4873,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                  *
                  * @returns OAuth authorization URL the caller should open, or empty when cached tokens already authenticated the server.
                  */
-                login: async (params: McpOauthLoginRequest): Promise<McpOauthLoginResult> =>
-                    connection.sendRequest("session.mcp.oauth.login", { sessionId, ...params }),
+                login: async (params: McpOauthLoginRequest): Promise<McpOauthLoginResult> => {
+                    assertActive?.();
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("session.mcp.oauth.login", { sessionId, ...params });
+                },
             },
         },
         /** @experimental */
@@ -8596,30 +4889,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Plugins installed for the session, with their enabled state and version metadata.
              */
-            list: async (): Promise<PluginList> =>
-                connection.sendRequest("session.plugins.list", { sessionId }),
-        },
-        /** @experimental */
-        options: {
-            /**
-             * Patches the genuinely-mutable subset of session options.
-             *
-             * @param params Patch of mutable session options to apply to the running session.
-             *
-             * @returns Indicates whether the session options patch was applied successfully.
-             */
-            update: async (params: SessionUpdateOptionsParams): Promise<SessionUpdateOptionsResult> =>
-                connection.sendRequest("session.options.update", { sessionId, ...params }),
-        },
-        /** @experimental */
-        lsp: {
-            /**
-             * Loads the merged LSP configuration set for the session's working directory.
-             *
-             * @param params Parameters for (re)loading the merged LSP configuration set.
-             */
-            initialize: async (params: LspInitializeRequest): Promise<void> =>
-                connection.sendRequest("session.lsp.initialize", { sessionId, ...params }),
+            list: async (): Promise<PluginList> => {
+                assertActive?.();
+                return connection.sendRequest("session.plugins.list", { sessionId });
+            },
         },
         /** @experimental */
         extensions: {
@@ -8628,27 +4901,41 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Extensions discovered for the session, with their current status.
              */
-            list: async (): Promise<ExtensionList> =>
-                connection.sendRequest("session.extensions.list", { sessionId }),
+            list: async (): Promise<ExtensionList> => {
+                assertActive?.();
+                return connection.sendRequest("session.extensions.list", { sessionId });
+            },
             /**
              * Enables an extension for the session.
              *
              * @param params Source-qualified extension identifier to enable for the session.
              */
-            enable: async (params: ExtensionsEnableRequest): Promise<void> =>
-                connection.sendRequest("session.extensions.enable", { sessionId, ...params }),
+            enable: async (params: ExtensionsEnableRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.extensions.enable", { sessionId, ...params });
+            },
             /**
              * Disables an extension for the session.
              *
              * @param params Source-qualified extension identifier to disable for the session.
              */
-            disable: async (params: ExtensionsDisableRequest): Promise<void> =>
-                connection.sendRequest("session.extensions.disable", { sessionId, ...params }),
+            disable: async (params: ExtensionsDisableRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.extensions.disable", { sessionId, ...params });
+            },
             /**
              * Reloads extension definitions and processes for the session.
              */
-            reload: async (): Promise<void> =>
-                connection.sendRequest("session.extensions.reload", { sessionId }),
+            reload: async (): Promise<void> => {
+                assertActive?.();
+                return connection.sendRequest("session.extensions.reload", { sessionId });
+            },
         },
         tools: {
             /**
@@ -8658,15 +4945,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the external tool call result was handled successfully.
              */
-            handlePendingToolCall: async (params: HandlePendingToolCallRequest): Promise<HandlePendingToolCallResult> =>
-                connection.sendRequest("session.tools.handlePendingToolCall", { sessionId, ...params }),
-            /**
-             * Resolves, builds, and validates the runtime tool list for the session.
-             *
-             * @returns Resolve, build, and validate the runtime tool list for this session. Subagent sessions and consumer flows that need an initialized tool set before `send` invoke this. Default base-class implementation is a no-op for sessions that don't support tool validation.
-             */
-            initializeAndValidate: async (): Promise<ToolsInitializeAndValidateResult> =>
-                connection.sendRequest("session.tools.initializeAndValidate", { sessionId }),
+            handlePendingToolCall: async (params: HandlePendingToolCallRequest): Promise<HandlePendingToolCallResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.tools.handlePendingToolCall", { sessionId, ...params });
+            },
         },
         commands: {
             /**
@@ -8676,8 +4961,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Slash commands available in the session, after applying any include/exclude filters.
              */
-            list: async (params?: CommandsListRequest): Promise<CommandList> =>
-                connection.sendRequest("session.commands.list", { sessionId, ...params }),
+            list: async (params?: CommandsListRequest): Promise<CommandList> => {
+                assertActive?.();
+                return connection.sendRequest("session.commands.list", { sessionId, ...params });
+            },
             /**
              * Invokes a slash command in the session.
              *
@@ -8685,8 +4972,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Result of invoking the slash command (text output, prompt to send to the agent, or completion).
              */
-            invoke: async (params: CommandsInvokeRequest): Promise<SlashCommandInvocationResult> =>
-                connection.sendRequest("session.commands.invoke", { sessionId, ...params }),
+            invoke: async (params: CommandsInvokeRequest): Promise<SlashCommandInvocationResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.commands.invoke", { sessionId, ...params });
+            },
             /**
              * Reports completion of a pending client-handled slash command.
              *
@@ -8694,45 +4986,27 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the pending client-handled command was completed successfully.
              */
-            handlePendingCommand: async (params: CommandsHandlePendingCommandRequest): Promise<CommandsHandlePendingCommandResult> =>
-                connection.sendRequest("session.commands.handlePendingCommand", { sessionId, ...params }),
+            handlePendingCommand: async (params: CommandsHandlePendingCommandRequest): Promise<CommandsHandlePendingCommandResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.commands.handlePendingCommand", { sessionId, ...params });
+            },
             /**
-             * Executes a slash command synchronously and returns any error.
+             * Responds to a queued command request from the session.
              *
-             * @param params Slash command name and argument string to execute synchronously.
+             * @param params Queued command request ID and the result indicating whether the client handled it.
              *
-             * @returns Error message produced while executing the command, if any.
+             * @returns Indicates whether the queued-command response was accepted by the session.
              */
-            execute: async (params: ExecuteCommandParams): Promise<ExecuteCommandResult> =>
-                connection.sendRequest("session.commands.execute", { sessionId, ...params }),
-            /**
-             * Enqueues a slash command for FIFO processing on the local session.
-             *
-             * @param params Slash-prefixed command string to enqueue for FIFO processing.
-             *
-             * @returns Indicates whether the command was accepted into the local execution queue.
-             */
-            enqueue: async (params: EnqueueCommandParams): Promise<EnqueueCommandResult> =>
-                connection.sendRequest("session.commands.enqueue", { sessionId, ...params }),
-            /**
-             * Reports whether the host actually executed a queued command and whether to continue processing.
-             *
-             * @param params Queued-command request ID and the result indicating whether the host executed it (and whether to stop processing further queued commands).
-             *
-             * @returns Indicates whether the queued-command response was matched to a pending request.
-             */
-            respondToQueuedCommand: async (params: CommandsRespondToQueuedCommandRequest): Promise<CommandsRespondToQueuedCommandResult> =>
-                connection.sendRequest("session.commands.respondToQueuedCommand", { sessionId, ...params }),
-        },
-        /** @experimental */
-        telemetry: {
-            /**
-             * Sets feature override key/value pairs to attach to subsequent telemetry events for the session.
-             *
-             * @param params Feature override key/value pairs to attach to subsequent telemetry events from this session.
-             */
-            setFeatureOverrides: async (params: TelemetrySetFeatureOverridesRequest): Promise<void> =>
-                connection.sendRequest("session.telemetry.setFeatureOverrides", { sessionId, ...params }),
+            respondToQueuedCommand: async (params: CommandsRespondToQueuedCommandRequest): Promise<CommandsRespondToQueuedCommandResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.commands.respondToQueuedCommand", { sessionId, ...params });
+            },
         },
         ui: {
             /**
@@ -8742,8 +5016,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns The elicitation response (accept with form values, decline, or cancel)
              */
-            elicitation: async (params: UIElicitationRequest): Promise<UIElicitationResponse> =>
-                connection.sendRequest("session.ui.elicitation", { sessionId, ...params }),
+            elicitation: async (params: UIElicitationRequest): Promise<UIElicitationResponse> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.ui.elicitation", { sessionId, ...params });
+            },
             /**
              * Provides the user response for a pending elicitation request.
              *
@@ -8751,71 +5030,15 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the elicitation response was accepted; false if it was already resolved by another client.
              */
-            handlePendingElicitation: async (params: UIHandlePendingElicitationRequest): Promise<UIElicitationResult> =>
-                connection.sendRequest("session.ui.handlePendingElicitation", { sessionId, ...params }),
-            /**
-             * Resolves a pending `user_input.requested` event with the user's response.
-             *
-             * @param params Request ID of a pending `user_input.requested` event and the user's response.
-             *
-             * @returns Indicates whether the pending UI request was resolved by this call.
-             */
-            handlePendingUserInput: async (params: UIHandlePendingUserInputRequest): Promise<UIHandlePendingResult> =>
-                connection.sendRequest("session.ui.handlePendingUserInput", { sessionId, ...params }),
-            /**
-             * Resolves a pending `sampling.requested` event with a sampling result, or rejects it.
-             *
-             * @param params Request ID of a pending `sampling.requested` event and an optional sampling result payload (omit to reject).
-             *
-             * @returns Indicates whether the pending UI request was resolved by this call.
-             */
-            handlePendingSampling: async (params: UIHandlePendingSamplingRequest): Promise<UIHandlePendingResult> =>
-                connection.sendRequest("session.ui.handlePendingSampling", { sessionId, ...params }),
-            /**
-             * Resolves a pending `auto_mode_switch.requested` event with the user's accept/decline decision.
-             *
-             * @param params Request ID of a pending `auto_mode_switch.requested` event and the user's response.
-             *
-             * @returns Indicates whether the pending UI request was resolved by this call.
-             */
-            handlePendingAutoModeSwitch: async (params: UIHandlePendingAutoModeSwitchRequest): Promise<UIHandlePendingResult> =>
-                connection.sendRequest("session.ui.handlePendingAutoModeSwitch", { sessionId, ...params }),
-            /**
-             * Resolves a pending `exit_plan_mode.requested` event with the user's response.
-             *
-             * @param params Request ID of a pending `exit_plan_mode.requested` event and the user's response.
-             *
-             * @returns Indicates whether the pending UI request was resolved by this call.
-             */
-            handlePendingExitPlanMode: async (params: UIHandlePendingExitPlanModeRequest): Promise<UIHandlePendingResult> =>
-                connection.sendRequest("session.ui.handlePendingExitPlanMode", { sessionId, ...params }),
-            /**
-             * Registers an in-process handler for auto-mode-switch requests so the server bridge skips dispatch.
-             *
-             * @returns Register an in-process handler for `auto_mode_switch.requested` events. The caller still attaches the actual listener via the standard event-subscription mechanism; this registration solely tells the server bridge to skip its own dispatch (so a remote client doesn't race the in-process handler for the same requestId).
-             */
-            registerDirectAutoModeSwitchHandler: async (): Promise<UIRegisterDirectAutoModeSwitchHandlerResult> =>
-                connection.sendRequest("session.ui.registerDirectAutoModeSwitchHandler", { sessionId }),
-            /**
-             * Unregisters a previously-registered in-process auto-mode-switch handler by its opaque handle.
-             *
-             * @param params Opaque handle previously returned by `registerDirectAutoModeSwitchHandler` to release.
-             *
-             * @returns Indicates whether the handle was active and the registration count was decremented.
-             */
-            unregisterDirectAutoModeSwitchHandler: async (params: UIUnregisterDirectAutoModeSwitchHandlerRequest): Promise<UIUnregisterDirectAutoModeSwitchHandlerResult> =>
-                connection.sendRequest("session.ui.unregisterDirectAutoModeSwitchHandler", { sessionId, ...params }),
+            handlePendingElicitation: async (params: UIHandlePendingElicitationRequest): Promise<UIElicitationResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.ui.handlePendingElicitation", { sessionId, ...params });
+            },
         },
         permissions: {
-            /**
-             * Replaces selected permission policy fields (rules, paths, URLs, exclusions, allow-all flags) on the session.
-             *
-             * @param params Patch of permission policy fields to apply (omit a field to leave it unchanged).
-             *
-             * @returns Indicates whether the operation succeeded.
-             */
-            configure: async (params: PermissionsConfigureParams): Promise<PermissionsConfigureResult> =>
-                connection.sendRequest("session.permissions.configure", { sessionId, ...params }),
             /**
              * Provides a decision for a pending tool permission request.
              *
@@ -8823,176 +5046,50 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the permission decision was applied; false when the request was already resolved.
              */
-            handlePendingPermissionRequest: async (params: PermissionDecisionRequest): Promise<PermissionRequestResult> =>
-                connection.sendRequest("session.permissions.handlePendingPermissionRequest", { sessionId, ...params }),
-            /**
-             * Reconstructs the set of pending tool permission requests from the session's event history.
-             *
-             * @returns List of pending permission requests reconstructed from event history.
-             */
-            pendingRequests: async (): Promise<PendingPermissionRequestList> =>
-                connection.sendRequest("session.permissions.pendingRequests", { sessionId }),
+            handlePendingPermissionRequest: async (params: PermissionDecisionRequest): Promise<PermissionRequestResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.permissions.handlePendingPermissionRequest", { sessionId, ...params });
+            },
             /**
              * Enables or disables automatic approval of tool permission requests for the session.
              *
-             * @param params Allow-all toggle for tool permission requests, with an optional telemetry source.
+             * @param params Whether to auto-approve all tool permission requests for the rest of the session.
              *
              * @returns Indicates whether the operation succeeded.
              */
-            setApproveAll: async (params: PermissionsSetApproveAllRequest): Promise<PermissionsSetApproveAllResult> =>
-                connection.sendRequest("session.permissions.setApproveAll", { sessionId, ...params }),
-            /**
-             * Adds or removes session-scoped or location-scoped permission rules.
-             *
-             * @param params Scope and add/remove instructions for modifying session- or location-scoped permission rules.
-             *
-             * @returns Indicates whether the operation succeeded.
-             */
-            modifyRules: async (params: PermissionsModifyRulesParams): Promise<PermissionsModifyRulesResult> =>
-                connection.sendRequest("session.permissions.modifyRules", { sessionId, ...params }),
-            /**
-             * Sets whether the client wants permission prompts bridged into session events.
-             *
-             * @param params Toggles whether permission prompts should be bridged into session events for this client.
-             *
-             * @returns Indicates whether the operation succeeded.
-             */
-            setRequired: async (params: PermissionsSetRequiredRequest): Promise<PermissionsSetRequiredResult> =>
-                connection.sendRequest("session.permissions.setRequired", { sessionId, ...params }),
+            setApproveAll: async (params: PermissionsSetApproveAllRequest): Promise<PermissionsSetApproveAllResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.permissions.setApproveAll", { sessionId, ...params });
+            },
             /**
              * Clears session-scoped tool permission approvals.
              *
              * @returns Indicates whether the operation succeeded.
              */
-            resetSessionApprovals: async (): Promise<PermissionsResetSessionApprovalsResult> =>
-                connection.sendRequest("session.permissions.resetSessionApprovals", { sessionId }),
-            /**
-             * Notifies the runtime that a permission prompt UI has been shown to the user.
-             *
-             * @param params Notification payload describing the permission prompt that the client just rendered.
-             *
-             * @returns Indicates whether the operation succeeded.
-             */
-            notifyPromptShown: async (params: PermissionPromptShownNotification): Promise<PermissionsNotifyPromptShownResult> =>
-                connection.sendRequest("session.permissions.notifyPromptShown", { sessionId, ...params }),
-            paths: {
-                /**
-                 * Returns the session's allowed directories and primary working directory.
-                 *
-                 * @returns Snapshot of the session's allow-listed directories and primary working directory.
-                 */
-                list: async (): Promise<PermissionPathsList> =>
-                    connection.sendRequest("session.permissions.paths.list", { sessionId }),
-                /**
-                 * Adds a directory to the session's allow-list.
-                 *
-                 * @param params Directory path to add to the session's allowed directories.
-                 *
-                 * @returns Indicates whether the operation succeeded.
-                 */
-                add: async (params: PermissionPathsAddParams): Promise<PermissionsPathsAddResult> =>
-                    connection.sendRequest("session.permissions.paths.add", { sessionId, ...params }),
-                /**
-                 * Updates the session's primary working directory used by the permission policy.
-                 *
-                 * @param params Directory path to set as the session's new primary working directory.
-                 *
-                 * @returns Indicates whether the operation succeeded.
-                 */
-                updatePrimary: async (params: PermissionPathsUpdatePrimaryParams): Promise<PermissionsPathsUpdatePrimaryResult> =>
-                    connection.sendRequest("session.permissions.paths.updatePrimary", { sessionId, ...params }),
-                /**
-                 * Reports whether a path falls within any of the session's allowed directories.
-                 *
-                 * @param params Path to evaluate against the session's allowed directories.
-                 *
-                 * @returns Indicates whether the supplied path is within the session's allowed directories.
-                 */
-                isPathWithinAllowedDirectories: async (params: PermissionPathsAllowedCheckParams): Promise<PermissionPathsAllowedCheckResult> =>
-                    connection.sendRequest("session.permissions.paths.isPathWithinAllowedDirectories", { sessionId, ...params }),
-                /**
-                 * Reports whether a path falls within the session's workspace (primary) directory.
-                 *
-                 * @param params Path to evaluate against the session's workspace (primary) directory.
-                 *
-                 * @returns Indicates whether the supplied path is within the session's workspace directory.
-                 */
-                isPathWithinWorkspace: async (params: PermissionPathsWorkspaceCheckParams): Promise<PermissionPathsWorkspaceCheckResult> =>
-                    connection.sendRequest("session.permissions.paths.isPathWithinWorkspace", { sessionId, ...params }),
-            },
-            urls: {
-                /**
-                 * Toggles the runtime's URL-permission policy between unrestricted and restricted modes.
-                 *
-                 * @param params Whether the URL-permission policy should run in unrestricted mode.
-                 *
-                 * @returns Indicates whether the operation succeeded.
-                 */
-                setUnrestrictedMode: async (params: PermissionUrlsSetUnrestrictedModeParams): Promise<PermissionsUrlsSetUnrestrictedModeResult> =>
-                    connection.sendRequest("session.permissions.urls.setUnrestrictedMode", { sessionId, ...params }),
+            resetSessionApprovals: async (): Promise<PermissionsResetSessionApprovalsResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.permissions.resetSessionApprovals", { sessionId });
             },
         },
         /**
          * Emits a user-visible session log event.
          *
-         * @param params Message text, optional severity level, persistence flag, optional follow-up URL, and optional tip.
+         * @param params Message text, optional severity level, persistence flag, and optional follow-up URL.
          *
          * @returns Identifier of the session event that was emitted for the log message.
          */
-        log: async (params: LogRequest): Promise<LogResult> =>
-            connection.sendRequest("session.log", { sessionId, ...params }),
-        /** @experimental */
-        metadata: {
-            /**
-             * Returns a snapshot of the session's identifying metadata, mode, agent, and remote info.
-             *
-             * @returns Point-in-time snapshot of slow-changing session identifier and state fields
-             */
-            snapshot: async (): Promise<SessionMetadataSnapshot> =>
-                connection.sendRequest("session.metadata.snapshot", { sessionId }),
-            /**
-             * Reports whether the local session is currently processing user/agent messages.
-             *
-             * @returns Indicates whether the local session is currently processing a turn or background continuation.
-             */
-            isProcessing: async (): Promise<MetadataIsProcessingResult> =>
-                connection.sendRequest("session.metadata.isProcessing", { sessionId }),
-            /**
-             * Returns the token breakdown for the session's current context window for a given model.
-             *
-             * @param params Model identifier and token limits used to compute the context-info breakdown.
-             *
-             * @returns Token breakdown for the session's current context window, or null if uninitialized.
-             */
-            contextInfo: async (params: MetadataContextInfoRequest): Promise<MetadataContextInfoResult> =>
-                connection.sendRequest("session.metadata.contextInfo", { sessionId, ...params }),
-            /**
-             * Records a working-directory/git context change and emits a `session.context_changed` event.
-             *
-             * @param params Updated working-directory/git context to record on the session.
-             *
-             * @returns Notify the session that its working directory context has changed. Emits a `session.context_changed` event so consumers (telemetry, OTel tracker, ACP, the timeline UI) can react. Use this when the host has detected a cwd/branch/repo change outside the session's normal lifecycle (e.g., after a shell command in interactive mode).
-             */
-            recordContextChange: async (params: MetadataRecordContextChangeRequest): Promise<MetadataRecordContextChangeResult> =>
-                connection.sendRequest("session.metadata.recordContextChange", { sessionId, ...params }),
-            /**
-             * Updates the session's recorded working directory.
-             *
-             * @param params Absolute path to set as the session's new working directory.
-             *
-             * @returns Update the session's working directory. Used by the host when the user explicitly changes cwd (e.g., the `/cd` slash command). The host is responsible for `process.chdir` and any related side-effects (file index, etc.); this method only updates the session's own recorded path.
-             */
-            setWorkingDirectory: async (params: MetadataSetWorkingDirectoryRequest): Promise<MetadataSetWorkingDirectoryResult> =>
-                connection.sendRequest("session.metadata.setWorkingDirectory", { sessionId, ...params }),
-            /**
-             * Re-tokenizes the session's existing messages against a model and returns aggregate token totals.
-             *
-             * @param params Model identifier to use when re-tokenizing the session's existing messages.
-             *
-             * @returns Re-tokenize the session's existing messages against `modelId` and return the token totals. Useful for hosts that want an initial estimate of context usage on session resume, before the next agent turn fires `session.context_info_changed` events. Returns zeros for an empty session.
-             */
-            recomputeContextTokens: async (params: MetadataRecomputeContextTokensRequest): Promise<MetadataRecomputeContextTokensResult> =>
-                connection.sendRequest("session.metadata.recomputeContextTokens", { sessionId, ...params }),
+        log: async (params: LogRequest): Promise<LogResult> => {
+            assertActive?.();
+            if (params == null) {
+                throw new TypeError("params is required");
+            }
+            return connection.sendRequest("session.log", { sessionId, ...params });
         },
         shell: {
             /**
@@ -9002,8 +5099,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Identifier of the spawned process, used to correlate streamed output and exit notifications.
              */
-            exec: async (params: ShellExecRequest): Promise<ShellExecResult> =>
-                connection.sendRequest("session.shell.exec", { sessionId, ...params }),
+            exec: async (params: ShellExecRequest): Promise<ShellExecResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.shell.exec", { sessionId, ...params });
+            },
             /**
              * Sends a signal to a shell process previously started via "shell.exec".
              *
@@ -9011,18 +5113,25 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether the signal was delivered; false if the process was unknown or already exited.
              */
-            kill: async (params: ShellKillRequest): Promise<ShellKillResult> =>
-                connection.sendRequest("session.shell.kill", { sessionId, ...params }),
+            kill: async (params: ShellKillRequest): Promise<ShellKillResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.shell.kill", { sessionId, ...params });
+            },
         },
         /** @experimental */
         history: {
             /**
              * Compacts the session history to reduce context usage.
              *
-             * @returns Compaction outcome with the number of tokens and messages removed, summary text, and the resulting context window breakdown.
+             * @returns Compaction outcome with the number of tokens and messages removed and the resulting context window breakdown.
              */
-            compact: async (): Promise<HistoryCompactResult> =>
-                connection.sendRequest("session.history.compact", { sessionId }),
+            compact: async (): Promise<HistoryCompactResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.history.compact", { sessionId });
+            },
             /**
              * Truncates persisted session history to a specific event.
              *
@@ -9030,88 +5139,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Number of events that were removed by the truncation.
              */
-            truncate: async (params: HistoryTruncateRequest): Promise<HistoryTruncateResult> =>
-                connection.sendRequest("session.history.truncate", { sessionId, ...params }),
-            /**
-             * Cancels any in-progress background compaction on a local session.
-             *
-             * @returns Indicates whether an in-progress background compaction was cancelled.
-             */
-            cancelBackgroundCompaction: async (): Promise<HistoryCancelBackgroundCompactionResult> =>
-                connection.sendRequest("session.history.cancelBackgroundCompaction", { sessionId }),
-            /**
-             * Aborts any in-progress manual compaction on a local session.
-             *
-             * @returns Indicates whether an in-progress manual compaction was aborted.
-             */
-            abortManualCompaction: async (): Promise<HistoryAbortManualCompactionResult> =>
-                connection.sendRequest("session.history.abortManualCompaction", { sessionId }),
-            /**
-             * Produces a markdown summary of the session's conversation context for hand-off scenarios.
-             *
-             * @returns Markdown summary of the conversation context (empty when not available).
-             */
-            summarizeForHandoff: async (): Promise<HistorySummarizeForHandoffResult> =>
-                connection.sendRequest("session.history.summarizeForHandoff", { sessionId }),
-        },
-        /** @experimental */
-        queue: {
-            /**
-             * Returns the local session's pending user-facing queued items and steering messages.
-             *
-             * @returns Snapshot of the session's pending queued items and immediate-steering messages.
-             */
-            pendingItems: async (): Promise<QueuePendingItemsResult> =>
-                connection.sendRequest("session.queue.pendingItems", { sessionId }),
-            /**
-             * Removes the most recently queued user-facing item (LIFO).
-             *
-             * @returns Indicates whether a user-facing pending item was removed.
-             */
-            removeMostRecent: async (): Promise<QueueRemoveMostRecentResult> =>
-                connection.sendRequest("session.queue.removeMostRecent", { sessionId }),
-            /**
-             * Clears all pending queued items on the local session.
-             */
-            clear: async (): Promise<void> =>
-                connection.sendRequest("session.queue.clear", { sessionId }),
-        },
-        /** @experimental */
-        eventLog: {
-            /**
-             * Reads a batch of session events from a cursor, optionally waiting for new events.
-             *
-             * @param params Cursor, batch size, and optional long-poll/filter parameters for reading session events.
-             *
-             * @returns Batch of session events returned by a read, with cursor and continuation metadata.
-             */
-            read: async (params: EventLogReadRequest): Promise<EventsReadResult> =>
-                connection.sendRequest("session.eventLog.read", { sessionId, ...params }),
-            /**
-             * Returns a snapshot of the current tail cursor without consuming events.
-             *
-             * @returns Snapshot of the current tail cursor without returning any events. Use this when a consumer wants to subscribe to live events going forward without first paginating through the entire persisted history (which would happen if `read` were called without a cursor on a long-lived session).
-             */
-            tail: async (): Promise<EventLogTailResult> =>
-                connection.sendRequest("session.eventLog.tail", { sessionId }),
-            /**
-             * Registers consumer interest in an event type for runtime gating purposes.
-             *
-             * @param params Event type to register consumer interest for, used by runtime gating logic.
-             *
-             * @returns Opaque handle representing an event-type interest registration.
-             */
-            registerInterest: async (params: RegisterEventInterestParams): Promise<RegisterEventInterestResult> =>
-                connection.sendRequest("session.eventLog.registerInterest", { sessionId, ...params }),
-            /**
-             * Releases a consumer's previously-registered interest in an event type.
-             *
-             * @param params Opaque handle previously returned by `registerInterest` to release.
-             *
-             * @returns Indicates whether the operation succeeded.
-             */
-            releaseInterest: async (params: ReleaseEventInterestParams): Promise<EventLogReleaseInterestResult> =>
-                connection.sendRequest("session.eventLog.releaseInterest", { sessionId, ...params }),
+            truncate: async (params: HistoryTruncateRequest): Promise<HistoryTruncateResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.history.truncate", { sessionId, ...params });
+            },
         },
         /** @experimental */
         usage: {
@@ -9120,8 +5154,10 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Accumulated session usage metrics, including premium request cost, token counts, model breakdown, and code-change totals.
              */
-            getMetrics: async (): Promise<UsageGetMetricsResult> =>
-                connection.sendRequest("session.usage.getMetrics", { sessionId }),
+            getMetrics: async (): Promise<UsageGetMetricsResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.usage.getMetrics", { sessionId });
+            },
         },
         /** @experimental */
         remote: {
@@ -9132,41 +5168,20 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns GitHub URL for the session and a flag indicating whether remote steering is enabled.
              */
-            enable: async (params: RemoteEnableRequest): Promise<RemoteEnableResult> =>
-                connection.sendRequest("session.remote.enable", { sessionId, ...params }),
+            enable: async (params: RemoteEnableRequest): Promise<RemoteEnableResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.remote.enable", { sessionId, ...params });
+            },
             /**
              * Disables remote session export and steering.
              */
-            disable: async (): Promise<void> =>
-                connection.sendRequest("session.remote.disable", { sessionId }),
-            /**
-             * Persists a remote-steerability change emitted by the host as a session event.
-             *
-             * @param params New remote-steerability state to persist as a `session.remote_steerable_changed` event.
-             *
-             * @returns Persist a steerability change as a `session.remote_steerable_changed` event. Used by the host (CLI / SDK consumer) when it has just finished enabling or disabling steering on a remote exporter that the runtime does not directly own.
-             */
-            notifySteerableChanged: async (params: RemoteNotifySteerableChangedRequest): Promise<RemoteNotifySteerableChangedResult> =>
-                connection.sendRequest("session.remote.notifySteerableChanged", { sessionId, ...params }),
-        },
-        /** @experimental */
-        schedule: {
-            /**
-             * Lists the session's currently active scheduled prompts.
-             *
-             * @returns Snapshot of the currently active recurring prompts for this session.
-             */
-            list: async (): Promise<ScheduleList> =>
-                connection.sendRequest("session.schedule.list", { sessionId }),
-            /**
-             * Removes a scheduled prompt by id.
-             *
-             * @param params Identifier of the scheduled prompt to remove.
-             *
-             * @returns Remove a scheduled prompt by id. The result entry is omitted if the id was unknown.
-             */
-            stop: async (params: ScheduleStopRequest): Promise<ScheduleStopResult> =>
-                connection.sendRequest("session.schedule.stop", { sessionId, ...params }),
+            disable: async (): Promise<void> => {
+                assertActive?.();
+                return connection.sendRequest("session.remote.disable", { sessionId });
+            },
         },
     };
 }

--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -4219,11 +4219,8 @@ export function createServerRpc(connection: MessageConnection) {
          *
          * @returns Server liveness response, including the echoed message, current timestamp, and protocol version.
          */
-        ping: async (params: PingRequest): Promise<PingResult> => {
-            if (params == null) {
-                throw new TypeError("params is required");
-            }
-            return connection.sendRequest("ping", params);
+        ping: async (params?: PingRequest): Promise<PingResult> => {
+            return connection.sendRequest("ping", (params ?? {}));
         },
         models: {
             /**
@@ -4233,11 +4230,8 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns List of Copilot models available to the resolved user, including capabilities and billing metadata.
              */
-            list: async (params: ModelsListRequest): Promise<ModelList> => {
-                if (params == null) {
-                    throw new TypeError("params is required");
-                }
-                return connection.sendRequest("models.list", params);
+            list: async (params?: ModelsListRequest): Promise<ModelList> => {
+                return connection.sendRequest("models.list", (params ?? {}));
             },
         },
         tools: {
@@ -4248,11 +4242,8 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Built-in tools available for the requested model, with their parameters and instructions.
              */
-            list: async (params: ToolsListRequest): Promise<ToolList> => {
-                if (params == null) {
-                    throw new TypeError("params is required");
-                }
-                return connection.sendRequest("tools.list", params);
+            list: async (params?: ToolsListRequest): Promise<ToolList> => {
+                return connection.sendRequest("tools.list", (params ?? {}));
             },
         },
         account: {
@@ -4263,11 +4254,8 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Quota usage snapshots for the resolved user, keyed by quota type.
              */
-            getQuota: async (params: AccountGetQuotaRequest): Promise<AccountGetQuotaResult> => {
-                if (params == null) {
-                    throw new TypeError("params is required");
-                }
-                return connection.sendRequest("account.getQuota", params);
+            getQuota: async (params?: AccountGetQuotaRequest): Promise<AccountGetQuotaResult> => {
+                return connection.sendRequest("account.getQuota", (params ?? {}));
             },
         },
         mcp: {
@@ -4343,11 +4331,8 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns MCP servers discovered from user, workspace, plugin, and built-in sources.
              */
-            discover: async (params: McpDiscoverRequest): Promise<McpDiscoverResult> => {
-                if (params == null) {
-                    throw new TypeError("params is required");
-                }
-                return connection.sendRequest("mcp.discover", params);
+            discover: async (params?: McpDiscoverRequest): Promise<McpDiscoverResult> => {
+                return connection.sendRequest("mcp.discover", (params ?? {}));
             },
         },
         skills: {
@@ -4371,11 +4356,8 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Skills discovered across global and project sources.
              */
-            discover: async (params: SkillsDiscoverRequest): Promise<ServerSkillList> => {
-                if (params == null) {
-                    throw new TypeError("params is required");
-                }
-                return connection.sendRequest("skills.discover", params);
+            discover: async (params?: SkillsDiscoverRequest): Promise<ServerSkillList> => {
+                return connection.sendRequest("skills.discover", (params ?? {}));
             },
         },
         sessionFs: {
@@ -4402,11 +4384,8 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Identifier and optional friendly name assigned to the newly forked session.
              */
-            fork: async (params: SessionsForkRequest): Promise<SessionsForkResult> => {
-                if (params == null) {
-                    throw new TypeError("params is required");
-                }
-                return connection.sendRequest("sessions.fork", params);
+            fork: async (params?: SessionsForkRequest): Promise<SessionsForkResult> => {
+                return connection.sendRequest("sessions.fork", (params ?? {}));
             },
             /**
              * Connects to an existing remote session and exposes it as an SDK session.
@@ -4415,11 +4394,8 @@ export function createServerRpc(connection: MessageConnection) {
              *
              * @returns Remote session connection result.
              */
-            connect: async (params: ConnectRemoteSessionParams): Promise<RemoteSessionConnectionResult> => {
-                if (params == null) {
-                    throw new TypeError("params is required");
-                }
-                return connection.sendRequest("sessions.connect", params);
+            connect: async (params?: ConnectRemoteSessionParams): Promise<RemoteSessionConnectionResult> => {
+                return connection.sendRequest("sessions.connect", (params ?? {}));
             },
         },
     };
@@ -4439,11 +4415,8 @@ export function createInternalServerRpc(connection: MessageConnection) {
          *
          * @returns Handshake result reporting the server's protocol version and package version on success.
          */
-        connect: async (params: ConnectRequest): Promise<ConnectResult> => {
-            if (params == null) {
-                throw new TypeError("params is required");
-            }
-            return connection.sendRequest("connect", params);
+        connect: async (params?: ConnectRequest): Promise<ConnectResult> => {
+            return connection.sendRequest("connect", (params ?? {}));
         },
     };
 }
@@ -4636,11 +4609,8 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns Indicates whether fleet mode was successfully activated.
              */
-            start: async (params: FleetStartRequest): Promise<FleetStartResult> => {
+            start: async (params?: FleetStartRequest): Promise<FleetStartResult> => {
                 assertActive?.();
-                if (params == null) {
-                    throw new TypeError("params is required");
-                }
                 return connection.sendRequest("session.fleet.start", { sessionId, ...params });
             },
         },
@@ -5168,11 +5138,8 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              *
              * @returns GitHub URL for the session and a flag indicating whether remote steering is enabled.
              */
-            enable: async (params: RemoteEnableRequest): Promise<RemoteEnableResult> => {
+            enable: async (params?: RemoteEnableRequest): Promise<RemoteEnableResult> => {
                 assertActive?.();
-                if (params == null) {
-                    throw new TypeError("params is required");
-                }
                 return connection.sendRequest("session.remote.enable", { sessionId, ...params });
             },
             /**

--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -5,8 +5,30 @@
 
 import type { MessageConnection } from "vscode-jsonrpc/node.js";
 
-import type { EmbeddedBlobResourceContents, EmbeddedTextResourceContents, McpServerSource, McpServerStatus, ReasoningSummary, SessionMode, SkillSource } from "./session-events.js";
+import type { AbortReason, EmbeddedBlobResourceContents, EmbeddedTextResourceContents, McpServerSource, McpServerStatus, PermissionPromptRequest, PermissionRule, ReasoningSummary, SessionEvent, SessionMode, ShutdownType, SkillSource, UserToolSessionApproval } from "./session-events.js";
 
+/**
+ * Where the agent definition was loaded from
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "AgentInfoSource".
+ */
+/** @experimental */
+export type AgentInfoSource = "user" | "project" | "inherited" | "remote" | "plugin" | "builtin";
+/**
+ * The new auth credentials to install on the session. When omitted or `undefined`, the call is a no-op and the session's existing credentials are preserved. The runtime stores the value verbatim and uses it for outbound model/API requests; it does NOT re-validate or re-fetch the associated Copilot user response. Several variants carry secret material; treat this method's params as containing secrets at rest and in transit.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "AuthInfo".
+ */
+export type AuthInfo =
+  | HMACAuthInfo
+  | EnvAuthInfo
+  | TokenAuthInfo
+  | CopilotApiTokenAuthInfo
+  | UserAuthInfo
+  | GhCliAuthInfo
+  | ApiKeyAuthInfo;
 /**
  * Authentication type
  *
@@ -29,7 +51,7 @@ export type SlashCommandKind = "builtin" | "skill" | "client";
  */
 export type SlashCommandInputCompletion = "directory";
 /**
- * Result of the queued command execution
+ * Result of the queued command execution.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "QueuedCommandResult".
@@ -57,6 +79,30 @@ export type ContentFilterMode = "none" | "markdown" | "hidden_characters";
  * via the `definition` "DiscoveredMcpServerType".
  */
 export type DiscoveredMcpServerType = "stdio" | "http" | "sse" | "memory";
+/**
+ * Either '*' to receive all event types, or a non-empty list of event types to receive
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "EventLogTypes".
+ */
+/** @experimental */
+export type EventLogTypes = "*" | [string, ...string[]];
+/**
+ * Agent-scope filter: 'primary' returns only main-agent events plus events whose type starts with 'subagent.' (matching the typed-subscription default behavior); 'all' returns events from all agents (matching wildcard-subscription behavior). Default is 'all' to preserve wildcard semantics for catch-up callers.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "EventsAgentScope".
+ */
+/** @experimental */
+export type EventsAgentScope = "primary" | "all";
+/**
+ * Cursor status: 'ok' means the cursor was applied successfully; 'expired' means the cursor referred to an event that no longer exists in history (e.g. truncated or compacted away) and the read started from the beginning of the remaining history.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "EventsCursorStatus".
+ */
+/** @experimental */
+export type EventsCursorStatus = "ok" | "expired";
 /**
  * Discovery source: project (.github/extensions/) or user (~/.copilot/extensions/)
  *
@@ -128,19 +174,38 @@ export type FilterMapping =
     }
   | ContentFilterMode;
 /**
+ * Source for direct repo installs (when marketplace is empty)
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "InstalledPluginSource".
+ */
+/** @experimental */
+export type InstalledPluginSource =
+  | string
+  | InstalledPluginSourceGithub
+  | InstalledPluginSourceUrl
+  | InstalledPluginSourceLocal;
+/**
  * Category of instruction source — used for merge logic
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "InstructionsSourcesType".
  */
-export type InstructionsSourcesType = "home" | "repo" | "model" | "vscode" | "nested-agents" | "child-instructions";
+export type InstructionsSourcesType =
+  | "home"
+  | "repo"
+  | "model"
+  | "vscode"
+  | "nested-agents"
+  | "child-instructions"
+  | "plugin";
 /**
  * Where this source lives — used for UI grouping
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "InstructionsSourcesLocation".
  */
-export type InstructionsSourcesLocation = "user" | "repository" | "working-directory";
+export type InstructionsSourcesLocation = "user" | "repository" | "working-directory" | "plugin";
 /**
  * Log severity level. Determines how the message is displayed in the timeline. Defaults to "info".
  *
@@ -170,6 +235,91 @@ export type McpServerConfigHttpType = "http" | "sse";
  */
 export type McpServerConfigHttpOauthGrantType = "authorization_code" | "client_credentials";
 /**
+ * Outcome of the sampling inference. 'success' produced a response; 'failure' encountered an error (including agent-side rejection by content filter or criteria); 'cancelled' the caller cancelled this execution via cancelSamplingExecution.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "McpSamplingExecutionAction".
+ */
+/** @experimental */
+export type McpSamplingExecutionAction = "success" | "failure" | "cancelled";
+/**
+ * How environment-variable values supplied to MCP servers are resolved. "direct" passes literal string values; "indirect" treats values as references (e.g. names of environment variables on the host) that the runtime resolves before launch. Defaults to the runtime's startup mode; clients that intentionally launch MCP servers with literal values (e.g. CLI prompt mode and ACP) set this to "direct".
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "McpSetEnvValueModeDetails".
+ */
+/** @experimental */
+export type McpSetEnvValueModeDetails = "direct" | "indirect";
+/**
+ * Token breakdown for the current context window, or null if the session has not yet been initialized (no system prompt or tool metadata cached).
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionContextInfo".
+ */
+/** @experimental */
+export type SessionContextInfo = {
+  /**
+   * The model used for token counting
+   */
+  modelName: string;
+  /**
+   * Tokens consumed by the system prompt
+   */
+  systemTokens: number;
+  /**
+   * Tokens consumed by user/assistant/tool messages
+   */
+  conversationTokens: number;
+  /**
+   * Tokens consumed by tool definitions sent to the model (excludes deferred tools)
+   */
+  toolDefinitionsTokens: number;
+  /**
+   * Sum of system, conversation and tool-definition tokens
+   */
+  totalTokens: number;
+  /**
+   * Maximum prompt tokens allowed by the model (or DEFAULT_TOKEN_LIMIT if unspecified)
+   */
+  promptTokenLimit: number;
+  /**
+   * Token count at which background compaction starts (configurable percentage of promptTokenLimit)
+   */
+  compactionThreshold: number;
+  /**
+   * Total context limit for /context display. promptTokenLimit + min(32k or 64k, outputTokenLimit) depending on model.
+   */
+  limit: number;
+  /**
+   * Output reserve plus tokens after the buffer-exhaustion blocking threshold (default 95%)
+   */
+  bufferTokens: number;
+} | null;
+/**
+ * Hosting platform type of the repository
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionWorkingDirectoryContextHostType".
+ */
+/** @experimental */
+export type SessionWorkingDirectoryContextHostType = "github" | "ado";
+/**
+ * The current agent mode for this session (e.g., 'interactive', 'plan', 'autopilot')
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "MetadataSnapshotCurrentMode".
+ */
+/** @experimental */
+export type MetadataSnapshotCurrentMode = "interactive" | "plan" | "autopilot";
+/**
+ * Whether the remote task originated from Copilot Coding Agent (cca) or a CLI `--remote` invocation.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "MetadataSnapshotRemoteMetadataTaskType".
+ */
+/** @experimental */
+export type MetadataSnapshotRemoteMetadataTaskType = "cca" | "cli";
+/**
  * Current policy state for this model
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -191,7 +341,15 @@ export type ModelPickerCategory = "lightweight" | "versatile" | "powerful";
  */
 export type ModelPickerPriceCategory = "low" | "medium" | "high" | "very_high";
 /**
- * Decision to apply to a pending permission request.
+ * How env values are passed to MCP servers (`direct` inlines literal values; `indirect` resolves at launch).
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "OptionsUpdateEnvValueMode".
+ */
+/** @experimental */
+export type OptionsUpdateEnvValueMode = "direct" | "indirect";
+/**
+ * The client's response to the pending permission prompt
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "PermissionDecision".
@@ -202,9 +360,18 @@ export type PermissionDecision =
   | PermissionDecisionApproveForLocation
   | PermissionDecisionApprovePermanently
   | PermissionDecisionReject
-  | PermissionDecisionUserNotAvailable;
+  | PermissionDecisionUserNotAvailable
+  | PermissionDecisionApproved
+  | PermissionDecisionApprovedForSession
+  | PermissionDecisionApprovedForLocation
+  | PermissionDecisionCancelled
+  | PermissionDecisionDeniedByRules
+  | PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser
+  | PermissionDecisionDeniedInteractivelyByUser
+  | PermissionDecisionDeniedByContentExclusionPolicy
+  | PermissionDecisionDeniedByPermissionRequestHook;
 /**
- * The approval to add as a session-scoped rule
+ * Session-scoped approval to remember (tool prompts only; omitted for path/url prompts)
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "PermissionDecisionApproveForSessionApproval".
@@ -220,7 +387,7 @@ export type PermissionDecisionApproveForSessionApproval =
   | PermissionDecisionApproveForSessionApprovalExtensionManagement
   | PermissionDecisionApproveForSessionApprovalExtensionPermissionAccess;
 /**
- * The approval to persist for this location
+ * Approval to persist for this location
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "PermissionDecisionApproveForLocationApproval".
@@ -236,6 +403,35 @@ export type PermissionDecisionApproveForLocationApproval =
   | PermissionDecisionApproveForLocationApprovalExtensionManagement
   | PermissionDecisionApproveForLocationApprovalExtensionPermissionAccess;
 /**
+ * Allowed values for the `PermissionsConfigureAdditionalContentExclusionPolicyScope` enumeration.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionsConfigureAdditionalContentExclusionPolicyScope".
+ */
+export type PermissionsConfigureAdditionalContentExclusionPolicyScope = "repo" | "all";
+/**
+ * Whether the change applies to ephemeral session-scoped rules (cleared at session end) or to location-scoped rules persisted via the location-permissions config file.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionsModifyRulesScope".
+ */
+export type PermissionsModifyRulesScope = "session" | "location";
+/**
+ * Optional source for allow-all telemetry. Defaults to `rpc` when omitted for SDK callers.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionsSetApproveAllSource".
+ */
+export type PermissionsSetApproveAllSource = "cli_flag" | "slash_command" | "autopilot_confirmation" | "rpc";
+/**
+ * Whether this item is a queued user message or a queued slash command / model change
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "QueuePendingItemsKind".
+ */
+/** @experimental */
+export type QueuePendingItemsKind = "message" | "command";
+/**
  * Per-session remote mode. "off" disables remote, "export" exports session events to GitHub without enabling remote steering, "on" enables both export and remote steering.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -243,6 +439,47 @@ export type PermissionDecisionApproveForLocationApproval =
  */
 /** @experimental */
 export type RemoteSessionMode = "off" | "export" | "on";
+/**
+ * The UI mode the agent was in when this message was sent. Defaults to the session's current mode.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SendAgentMode".
+ */
+export type SendAgentMode = "interactive" | "plan" | "autopilot" | "shell";
+/**
+ * A user message attachment — a file, directory, code selection, blob, or GitHub reference
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SendAttachment".
+ */
+export type SendAttachment =
+  | SendAttachmentFile
+  | SendAttachmentDirectory
+  | SendAttachmentSelection
+  | SendAttachmentGithubReference
+  | SendAttachmentBlob;
+/**
+ * Type of GitHub reference
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SendAttachmentGithubReferenceType".
+ */
+export type SendAttachmentGithubReferenceType = "issue" | "pr" | "discussion";
+/**
+ * How to deliver the message. `enqueue` (default) appends to the message queue. `immediate` interjects during an in-progress turn.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SendMode".
+ */
+export type SendMode = "enqueue" | "immediate";
+/**
+ * Repository host type
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionContextHostType".
+ */
+/** @experimental */
+export type SessionContextHostType = "github" | "ado";
 /**
  * Error classification
  *
@@ -271,6 +508,63 @@ export type SessionFsSetProviderConventions = "windows" | "posix";
  * via the `definition` "SessionFsSqliteQueryType".
  */
 export type SessionFsSqliteQueryType = "exec" | "query" | "run";
+/**
+ * Source descriptor for direct repo installs (when marketplace is empty)
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionInstalledPluginSource".
+ */
+/** @experimental */
+export type SessionInstalledPluginSource =
+  | string
+  | SessionInstalledPluginSourceGithub
+  | SessionInstalledPluginSourceUrl
+  | SessionInstalledPluginSourceLocal;
+/**
+ * Public-facing workspace metadata for this session, or null if the session has no associated workspace. Excludes runtime-internal fields (GitHub IDs, summary count, internal flags).
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "WorkspaceSummary".
+ */
+/** @experimental */
+export type WorkspaceSummary = {
+  /**
+   * Workspace identifier (1:1 with sessionId)
+   */
+  id: string;
+  /**
+   * Current working directory at session start
+   */
+  cwd?: string;
+  /**
+   * Resolved git root for cwd, if any
+   */
+  git_root?: string;
+  /**
+   * Repository identifier in 'owner/repo' or 'org/project/repo' format, if any
+   */
+  repository?: string;
+  /**
+   * Repository host type, if known
+   */
+  host_type?: "github" | "ado";
+  /**
+   * Branch checked out at session start, if any
+   */
+  branch?: string;
+  /**
+   * Display name for the session, if set
+   */
+  name?: string;
+  /**
+   * ISO 8601 timestamp when the workspace was created
+   */
+  created_at?: string;
+  /**
+   * ISO 8601 timestamp when the workspace was last updated
+   */
+  updated_at?: string;
+} | null;
 /**
  * Signal to send (default: SIGTERM)
  *
@@ -305,6 +599,51 @@ export type TaskStatus = "running" | "idle" | "completed" | "failed" | "cancelle
 /** @experimental */
 export type TaskExecutionMode = "sync" | "background";
 /**
+ * Schema for the `TaskAgentProgress` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "TaskAgentProgress".
+ */
+/** @experimental */
+export type TaskAgentProgress =
+  | {
+      /**
+       * Progress kind
+       */
+      type: "agent";
+      /**
+       * Recent tool execution events converted to display lines
+       */
+      recentActivity: {
+        /**
+         * Display message, e.g., "▸ bash", "✓ edit src/foo.ts"
+         */
+        message: string;
+        /**
+         * ISO 8601 timestamp when this event occurred
+         */
+        timestamp: string;
+      }[];
+      /**
+       * The most recent intent reported by the agent
+       */
+      latestIntent?: string;
+    }
+  | {
+      /**
+       * Progress kind
+       */
+      type: "shell";
+      /**
+       * Recent stdout/stderr lines from the running shell command
+       */
+      recentOutput: string;
+      /**
+       * Process ID when available
+       */
+      pid?: number;
+    };
+/**
  * Schema for the `TaskInfo` type.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -320,6 +659,29 @@ export type TaskInfo = TaskAgentInfo | TaskShellInfo;
  */
 /** @experimental */
 export type TaskShellInfoAttachmentMode = "attached" | "detached";
+/**
+ * Progress information for the task, discriminated by type. Returns null when no task with this ID is currently tracked.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "TaskProgress".
+ */
+/** @experimental */
+export type TaskProgress = TaskAgentProgress | TaskShellProgress;
+/**
+ * Schema for the `TaskShellProgress` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "TaskShellProgress".
+ */
+/** @experimental */
+export type TaskShellProgress = null;
+/**
+ * User's choice for auto-mode switching: yes (allow this turn), yes_always (allow + persist as setting), or no (decline).
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "UIAutoModeSwitchResponse".
+ */
+export type UIAutoModeSwitchResponse = "yes" | "yes_always" | "no";
 /**
  * Schema for the `UIElicitationFieldValue` type.
  *
@@ -365,6 +727,39 @@ export type UIElicitationSchemaPropertyNumberType = "number" | "integer";
  * via the `definition` "UIElicitationResponseAction".
  */
 export type UIElicitationResponseAction = "accept" | "decline" | "cancel";
+/**
+ * The action the user selected. Defaults to 'autopilot' when autoApproveEdits is true, otherwise 'interactive'.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "UIExitPlanModeAction".
+ */
+export type UIExitPlanModeAction = "exit_only" | "interactive" | "autopilot" | "autopilot_fleet";
+
+/**
+ * Parameters for aborting the current turn
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "AbortRequest".
+ */
+export interface AbortRequest {
+  reason?: AbortReason;
+}
+/**
+ * Result of aborting the current turn
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "AbortResult".
+ */
+export interface AbortResult {
+  /**
+   * Whether the abort completed successfully
+   */
+  success: boolean;
+  /**
+   * Error message if the abort failed
+   */
+  error?: string;
+}
 
 export interface AccountGetQuotaRequest {
   /**
@@ -463,6 +858,33 @@ export interface AgentInfo {
    * Absolute local file path of the agent definition. Only set for file-based agents loaded from disk; remote agents do not have a path.
    */
   path?: string;
+  /**
+   * Stable identifier for selection. For most agents this is the same as `name`; for plugin/builtin agents it may differ. Always populated; defaults to `name` when no distinct id was assigned.
+   */
+  id: string;
+  source?: AgentInfoSource;
+  /**
+   * Whether the agent can be selected directly by the user. Agents marked `false` are subagent-only.
+   */
+  userInvocable?: boolean;
+  /**
+   * Allowed tool names for this agent. Empty array means none; omitted means inherit defaults.
+   */
+  tools?: string[];
+  /**
+   * Preferred model id for this agent. When omitted, inherits the outer agent's model.
+   */
+  model?: string;
+  /**
+   * MCP server configurations attached to this agent, keyed by server name. Server config shape mirrors the MCP `mcpServers` schema.
+   */
+  mcpServers?: {
+    [k: string]: unknown | undefined;
+  };
+  /**
+   * Skill names preloaded into this agent's context. Omitted means none.
+   */
+  skills?: string[];
 }
 /**
  * Custom agents available to the session.
@@ -512,6 +934,333 @@ export interface AgentSelectRequest {
 /** @experimental */
 export interface AgentSelectResult {
   agent: AgentInfo;
+}
+/**
+ * Schema for the `ApiKeyAuthInfo` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ApiKeyAuthInfo".
+ */
+export interface ApiKeyAuthInfo {
+  /**
+   * API-key authentication for non-GitHub LLM providers (e.g. when running BYOM-style).
+   */
+  type: "api-key";
+  /**
+   * The API key. Treat as a secret.
+   */
+  apiKey: string;
+  /**
+   * Authentication host.
+   */
+  host: string;
+  copilotUser?: CopilotUserResponse;
+}
+/**
+ * Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this verbatim and does not re-fetch when set.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "CopilotUserResponse".
+ */
+export interface CopilotUserResponse {
+  login?: string;
+  access_type_sku?: string;
+  analytics_tracking_id?: string;
+  assigned_date?:
+    | (
+        | {
+            [k: string]: unknown | undefined;
+          }
+        | string
+      )
+    | null;
+  can_signup_for_limited?: boolean;
+  chat_enabled?: boolean;
+  copilot_plan?: string;
+  copilotignore_enabled?: boolean;
+  endpoints?: CopilotUserResponseEndpoints;
+  organization_login_list?: string[];
+  organization_list?:
+    | (
+        | {
+            [k: string]: unknown | undefined;
+          }
+        | ({
+            login?:
+              | (
+                  | {
+                      [k: string]: unknown | undefined;
+                    }
+                  | string
+                )
+              | null;
+            name?:
+              | (
+                  | {
+                      [k: string]: unknown | undefined;
+                    }
+                  | string
+                )
+              | null;
+          } | null)[]
+      )
+    | null;
+  codex_agent_enabled?: boolean;
+  is_mcp_enabled?:
+    | (
+        | {
+            [k: string]: unknown | undefined;
+          }
+        | boolean
+      )
+    | null;
+  quota_reset_date?: string;
+  quota_snapshots?: CopilotUserResponseQuotaSnapshots;
+  restricted_telemetry?: boolean;
+  token_based_billing?: boolean;
+  quota_reset_date_utc?: string;
+  limited_user_quotas?: {
+    [k: string]: number | undefined;
+  };
+  limited_user_reset_date?: string;
+  monthly_quotas?: {
+    [k: string]: number | undefined;
+  };
+  cloud_session_storage_enabled?: boolean;
+  cli_remote_control_enabled?: boolean;
+}
+/**
+ * Schema for the `CopilotUserResponseEndpoints` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "CopilotUserResponseEndpoints".
+ */
+export interface CopilotUserResponseEndpoints {
+  api?: string;
+  "origin-tracker"?: string;
+  proxy?: string;
+  telemetry?: string;
+}
+/**
+ * Schema for the `CopilotUserResponseQuotaSnapshots` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "CopilotUserResponseQuotaSnapshots".
+ */
+export interface CopilotUserResponseQuotaSnapshots {
+  chat?: CopilotUserResponseQuotaSnapshotsChat;
+  completions?: CopilotUserResponseQuotaSnapshotsCompletions;
+  premium_interactions?: CopilotUserResponseQuotaSnapshotsPremiumInteractions;
+  [k: string]:
+    | ({
+        entitlement?: number;
+        overage_count?: number;
+        overage_permitted?: boolean;
+        percent_remaining?: number;
+        quota_id?: string;
+        quota_remaining?: number;
+        remaining?: number;
+        unlimited?: boolean;
+        timestamp_utc?: string;
+        has_quota?: boolean;
+        quota_reset_at?: number;
+        token_based_billing?: boolean;
+      } | null)
+    | undefined;
+}
+/**
+ * Schema for the `CopilotUserResponseQuotaSnapshotsChat` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "CopilotUserResponseQuotaSnapshotsChat".
+ */
+export interface CopilotUserResponseQuotaSnapshotsChat {
+  entitlement?: number;
+  overage_count?: number;
+  overage_permitted?: boolean;
+  percent_remaining?: number;
+  quota_id?: string;
+  quota_remaining?: number;
+  remaining?: number;
+  unlimited?: boolean;
+  timestamp_utc?: string;
+  has_quota?: boolean;
+  quota_reset_at?: number;
+  token_based_billing?: boolean;
+}
+/**
+ * Schema for the `CopilotUserResponseQuotaSnapshotsCompletions` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "CopilotUserResponseQuotaSnapshotsCompletions".
+ */
+export interface CopilotUserResponseQuotaSnapshotsCompletions {
+  entitlement?: number;
+  overage_count?: number;
+  overage_permitted?: boolean;
+  percent_remaining?: number;
+  quota_id?: string;
+  quota_remaining?: number;
+  remaining?: number;
+  unlimited?: boolean;
+  timestamp_utc?: string;
+  has_quota?: boolean;
+  quota_reset_at?: number;
+  token_based_billing?: boolean;
+}
+/**
+ * Schema for the `CopilotUserResponseQuotaSnapshotsPremiumInteractions` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "CopilotUserResponseQuotaSnapshotsPremiumInteractions".
+ */
+export interface CopilotUserResponseQuotaSnapshotsPremiumInteractions {
+  entitlement?: number;
+  overage_count?: number;
+  overage_permitted?: boolean;
+  percent_remaining?: number;
+  quota_id?: string;
+  quota_remaining?: number;
+  remaining?: number;
+  unlimited?: boolean;
+  timestamp_utc?: string;
+  has_quota?: boolean;
+  quota_reset_at?: number;
+  token_based_billing?: boolean;
+}
+/**
+ * Schema for the `HMACAuthInfo` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "HMACAuthInfo".
+ */
+export interface HMACAuthInfo {
+  /**
+   * HMAC-based authentication used by GitHub-internal services.
+   */
+  type: "hmac";
+  /**
+   * Authentication host. HMAC auth always targets the public GitHub host.
+   */
+  host: "https://github.com";
+  /**
+   * HMAC secret used to sign requests.
+   */
+  hmac: string;
+  copilotUser?: CopilotUserResponse;
+}
+/**
+ * Schema for the `EnvAuthInfo` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "EnvAuthInfo".
+ */
+export interface EnvAuthInfo {
+  /**
+   * Personal access token (PAT) or server-to-server token sourced from an environment variable.
+   */
+  type: "env";
+  /**
+   * Authentication host (e.g. https://github.com or a GHES host).
+   */
+  host: string;
+  /**
+   * User login associated with the token. Undefined for server-to-server tokens (those starting with `ghs_`).
+   */
+  login?: string;
+  /**
+   * The token value itself. Treat as a secret.
+   */
+  token: string;
+  /**
+   * Name of the environment variable the token was sourced from.
+   */
+  envVar: string;
+  copilotUser?: CopilotUserResponse;
+}
+/**
+ * Schema for the `TokenAuthInfo` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "TokenAuthInfo".
+ */
+export interface TokenAuthInfo {
+  /**
+   * SDK-side token authentication; the host configured the token directly via the SDK.
+   */
+  type: "token";
+  /**
+   * Authentication host.
+   */
+  host: string;
+  /**
+   * The token value itself. Treat as a secret.
+   */
+  token: string;
+  copilotUser?: CopilotUserResponse;
+}
+/**
+ * Schema for the `CopilotApiTokenAuthInfo` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "CopilotApiTokenAuthInfo".
+ */
+export interface CopilotApiTokenAuthInfo {
+  /**
+   * Direct Copilot API authentication via the `GITHUB_COPILOT_API_TOKEN` + `COPILOT_API_URL` environment-variable pair. The token itself is read from the environment by the runtime, not carried in this struct.
+   */
+  type: "copilot-api-token";
+  /**
+   * Authentication host (always the public GitHub host).
+   */
+  host: "https://github.com";
+  copilotUser?: CopilotUserResponse;
+}
+/**
+ * Schema for the `UserAuthInfo` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "UserAuthInfo".
+ */
+export interface UserAuthInfo {
+  /**
+   * OAuth user authentication. The token itself is held in the runtime's secret token store (keyed by host+login) and is NOT carried in this struct.
+   */
+  type: "user";
+  /**
+   * Authentication host.
+   */
+  host: string;
+  /**
+   * OAuth user login.
+   */
+  login: string;
+  copilotUser?: CopilotUserResponse;
+}
+/**
+ * Schema for the `GhCliAuthInfo` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "GhCliAuthInfo".
+ */
+export interface GhCliAuthInfo {
+  /**
+   * Authentication via the `gh` CLI's saved credentials.
+   */
+  type: "gh-cli";
+  /**
+   * Authentication host.
+   */
+  host: string;
+  /**
+   * User login as reported by `gh auth status`.
+   */
+  login: string;
+  /**
+   * The token returned by `gh auth token`. Treat as a secret.
+   */
+  token: string;
+  copilotUser?: CopilotUserResponse;
 }
 /**
  * Slash commands available in the session, after applying any include/exclude filters.
@@ -641,14 +1390,14 @@ export interface CommandsListRequest {
   includeClientCommands?: boolean;
 }
 /**
- * Queued command request ID and the result indicating whether the client handled it.
+ * Queued-command request ID and the result indicating whether the host executed it (and whether to stop processing further queued commands).
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "CommandsRespondToQueuedCommandRequest".
  */
 export interface CommandsRespondToQueuedCommandRequest {
   /**
-   * Request ID from the queued command event
+   * Request ID from the `command.queued` event the host is responding to.
    */
   requestId: string;
   result: QueuedCommandResult;
@@ -661,11 +1410,11 @@ export interface CommandsRespondToQueuedCommandRequest {
  */
 export interface QueuedCommandHandled {
   /**
-   * The command was handled
+   * The host actually executed the queued command.
    */
   handled: true;
   /**
-   * If true, stop processing remaining queued items
+   * When true, the runtime will not process subsequent queued commands until a new request comes in.
    */
   stopProcessingQueue?: boolean;
 }
@@ -677,19 +1426,19 @@ export interface QueuedCommandHandled {
  */
 export interface QueuedCommandNotHandled {
   /**
-   * The command was not handled
+   * The host did not execute the queued command. Unblocks the queue without claiming the command was processed (e.g. when the handler threw before completing).
    */
   handled: false;
 }
 /**
- * Indicates whether the queued-command response was accepted by the session.
+ * Indicates whether the queued-command response was matched to a pending request.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "CommandsRespondToQueuedCommandResult".
  */
 export interface CommandsRespondToQueuedCommandResult {
   /**
-   * Whether the response was accepted (false if the requestId was not found or already resolved)
+   * Whether a pending queued command with the given request ID was found and resolved. False when the request was already resolved, cancelled, or unknown.
    */
   success: boolean;
 }
@@ -809,7 +1558,7 @@ export interface ConnectResult {
   version: string;
 }
 /**
- * The currently selected model for the session.
+ * The currently selected model and reasoning effort for the session.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "CurrentModel".
@@ -819,6 +1568,10 @@ export interface CurrentModel {
    * Currently active model identifier
    */
   modelId?: string;
+  /**
+   * Reasoning effort level currently applied to the active model, when one is set. Reads `Session.getReasoningEffort()` synchronously after `getSelectedModel()` resolves so the two values are reported as a snapshot.
+   */
+  reasoningEffort?: string;
 }
 /**
  * Schema for the `DiscoveredMcpServer` type.
@@ -837,6 +1590,129 @@ export interface DiscoveredMcpServer {
    * Whether the server is enabled (not in the disabled list)
    */
   enabled: boolean;
+}
+/**
+ * Slash-prefixed command string to enqueue for FIFO processing.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "EnqueueCommandParams".
+ */
+export interface EnqueueCommandParams {
+  /**
+   * Slash-prefixed command string to enqueue, e.g. '/compact' or '/model gpt-4'. Queued FIFO with any in-flight items; if the session is idle, processing kicks off immediately.
+   */
+  command: string;
+}
+/**
+ * Indicates whether the command was accepted into the local execution queue.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "EnqueueCommandResult".
+ */
+export interface EnqueueCommandResult {
+  /**
+   * True when the command was accepted into the local execution queue. False when the call targets a session that does not support local command queueing (e.g. remote sessions).
+   */
+  queued: boolean;
+}
+/**
+ * Cursor, batch size, and optional long-poll/filter parameters for reading session events.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "EventLogReadRequest".
+ */
+/** @experimental */
+export interface EventLogReadRequest {
+  /**
+   * Opaque cursor returned by a previous read. Omit on the first call to start from the beginning of the session's persisted history.
+   */
+  cursor?: string;
+  /**
+   * Maximum number of events to return in this batch (1–1000, default 200).
+   */
+  max?: number;
+  /**
+   * Milliseconds to wait for new events when the cursor is at the tail of history. 0 (default) returns immediately even if no events are available. Capped at 30000ms. Ephemeral events that arrive during the wait are delivered in this batch but are NOT replayable on a subsequent read (use a non-zero waitMs in your next call to capture future ephemerals as they happen).
+   */
+  waitMs?: number;
+  types?: EventLogTypes;
+  agentScope?: EventsAgentScope;
+}
+/**
+ * Indicates whether the operation succeeded.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "EventLogReleaseInterestResult".
+ */
+/** @experimental */
+export interface EventLogReleaseInterestResult {
+  /**
+   * Whether the operation succeeded
+   */
+  success: boolean;
+}
+/**
+ * Snapshot of the current tail cursor without returning any events. Use this when a consumer wants to subscribe to live events going forward without first paginating through the entire persisted history (which would happen if `read` were called without a cursor on a long-lived session).
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "EventLogTailResult".
+ */
+/** @experimental */
+export interface EventLogTailResult {
+  /**
+   * Opaque cursor pointing at the current tail of the session's persisted-events history. Pass back to `read` to receive only events that arrive AFTER this snapshot. When the session has no events, this returns the same sentinel as an unset cursor (i.e. equivalent to omitting the cursor on a first read).
+   */
+  cursor: string;
+}
+/**
+ * Batch of session events returned by a read, with cursor and continuation metadata.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "EventsReadResult".
+ */
+/** @experimental */
+export interface EventsReadResult {
+  /**
+   * Events are delivered in two batches per read: persisted events first (in append order), then ephemeral events (in seq order). When `waitMs > 0` and the catch-up batches were empty, post-wait events follow the same two-batch ordering. Persisted and ephemeral events do not interleave within a single read.
+   */
+  events: SessionEvent[];
+  /**
+   * Opaque cursor for the next read. Pass back unchanged in the next read.cursor to continue from where this read left off. Always present, even when no events were returned.
+   */
+  cursor: string;
+  /**
+   * True when the read returned `max` events and more events are available immediately. When false, the next read with a non-zero `waitMs` will block until a new event arrives or the wait expires.
+   */
+  hasMore: boolean;
+  cursorStatus: EventsCursorStatus;
+}
+/**
+ * Slash command name and argument string to execute synchronously.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExecuteCommandParams".
+ */
+export interface ExecuteCommandParams {
+  /**
+   * Name of the slash command to invoke (without the leading '/').
+   */
+  commandName: string;
+  /**
+   * Argument string to pass to the command (empty string if none).
+   */
+  args: string;
+}
+/**
+ * Error message produced while executing the command, if any.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExecuteCommandResult".
+ */
+export interface ExecuteCommandResult {
+  /**
+   * Error message produced while executing the command, if any. Omitted when the handler succeeded.
+   */
+  error?: string;
 }
 /**
  * Schema for the `Extension` type.
@@ -1170,6 +2046,32 @@ export interface HandlePendingToolCallResult {
   success: boolean;
 }
 /**
+ * Indicates whether an in-progress manual compaction was aborted.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "HistoryAbortManualCompactionResult".
+ */
+/** @experimental */
+export interface HistoryAbortManualCompactionResult {
+  /**
+   * Whether an in-progress manual compaction was aborted. False when no manual compaction was running, when its abort controller was already aborted, or when the session is remote.
+   */
+  aborted: boolean;
+}
+/**
+ * Indicates whether an in-progress background compaction was cancelled.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "HistoryCancelBackgroundCompactionResult".
+ */
+/** @experimental */
+export interface HistoryCancelBackgroundCompactionResult {
+  /**
+   * Whether an in-progress background compaction was cancelled. False when no compaction was running, when the session is remote, or when the underlying processor was unavailable.
+   */
+  cancelled: boolean;
+}
+/**
  * Post-compaction context window usage breakdown
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -1203,7 +2105,7 @@ export interface HistoryCompactContextWindow {
   toolDefinitionsTokens?: number;
 }
 /**
- * Compaction outcome with the number of tokens and messages removed and the resulting context window breakdown.
+ * Compaction outcome with the number of tokens and messages removed, summary text, and the resulting context window breakdown.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "HistoryCompactResult".
@@ -1222,7 +2124,24 @@ export interface HistoryCompactResult {
    * Number of messages removed during compaction
    */
   messagesRemoved: number;
+  /**
+   * Summary text produced by compaction. Omitted when compaction did not produce a summary (e.g. failure path).
+   */
+  summaryContent?: string;
   contextWindow?: HistoryCompactContextWindow;
+}
+/**
+ * Markdown summary of the conversation context (empty when not available).
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "HistorySummarizeForHandoffResult".
+ */
+/** @experimental */
+export interface HistorySummarizeForHandoffResult {
+  /**
+   * Markdown summary of the conversation context produced by an LLM. Empty string when there are no messages or when the session does not support local summarization.
+   */
+  summary: string;
 }
 /**
  * Identifier of the event to truncate to; this event and all later events are removed.
@@ -1249,6 +2168,86 @@ export interface HistoryTruncateResult {
    * Number of events that were removed
    */
   eventsRemoved: number;
+}
+/**
+ * Schema for the `InstalledPlugin` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "InstalledPlugin".
+ */
+/** @experimental */
+export interface InstalledPlugin {
+  /**
+   * Plugin name
+   */
+  name: string;
+  /**
+   * Marketplace the plugin came from (empty string for direct repo installs)
+   */
+  marketplace: string;
+  /**
+   * Version installed (if available)
+   */
+  version?: string;
+  /**
+   * Installation timestamp
+   */
+  installed_at: string;
+  /**
+   * Whether the plugin is currently enabled
+   */
+  enabled: boolean;
+  /**
+   * Path where the plugin is cached locally
+   */
+  cache_path?: string;
+  source?: InstalledPluginSource;
+}
+/**
+ * Schema for the `InstalledPluginSourceGithub` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "InstalledPluginSourceGithub".
+ */
+/** @experimental */
+export interface InstalledPluginSourceGithub {
+  /**
+   * Constant value. Always "github".
+   */
+  source: "github";
+  repo: string;
+  ref?: string;
+  path?: string;
+}
+/**
+ * Schema for the `InstalledPluginSourceUrl` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "InstalledPluginSourceUrl".
+ */
+/** @experimental */
+export interface InstalledPluginSourceUrl {
+  /**
+   * Constant value. Always "url".
+   */
+  source: "url";
+  url: string;
+  ref?: string;
+  path?: string;
+}
+/**
+ * Schema for the `InstalledPluginSourceLocal` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "InstalledPluginSourceLocal".
+ */
+/** @experimental */
+export interface InstalledPluginSourceLocal {
+  /**
+   * Constant value. Always "local".
+   */
+  source: "local";
+  path: string;
 }
 /**
  * Instruction sources loaded for the session, in merge order.
@@ -1288,16 +2287,20 @@ export interface InstructionsSources {
   type: InstructionsSourcesType;
   location: InstructionsSourcesLocation;
   /**
-   * Glob pattern from frontmatter — when set, this instruction applies only to matching files
+   * Glob pattern(s) from frontmatter — when set, this instruction applies only to matching files
    */
-  applyTo?: string;
+  applyTo?: string[];
   /**
    * Short description (body after frontmatter) for use in instruction tables
    */
   description?: string;
+  /**
+   * When true, this source starts disabled and must be toggled on by the user
+   */
+  defaultDisabled?: boolean;
 }
 /**
- * Message text, optional severity level, persistence flag, and optional follow-up URL.
+ * Message text, optional severity level, persistence flag, optional follow-up URL, and optional tip.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "LogRequest".
@@ -1309,6 +2312,10 @@ export interface LogRequest {
   message: string;
   level?: SessionLogLevel;
   /**
+   * Domain category for this log entry (e.g., "mcp", "subscription", "policy", "model"). Maps to `infoType`/`warningType`/`errorType` on the emitted event. Defaults to "notification".
+   */
+  type?: string;
+  /**
    * When true, the message is transient and not persisted to the session event log on disk
    */
   ephemeral?: boolean;
@@ -1316,6 +2323,10 @@ export interface LogRequest {
    * Optional URL the user can open in their browser for more details
    */
   url?: string;
+  /**
+   * Optional actionable tip displayed alongside the message. Only honored on `level: "info"`.
+   */
+  tip?: string;
 }
 /**
  * Identifier of the session event that was emitted for the log message.
@@ -1328,6 +2339,53 @@ export interface LogResult {
    * The unique identifier of the emitted session event
    */
   eventId: string;
+}
+/**
+ * Parameters for (re)loading the merged LSP configuration set.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "LspInitializeRequest".
+ */
+/** @experimental */
+export interface LspInitializeRequest {
+  /**
+   * Working directory used to load project-level LSP configs. Defaults to the session working directory when omitted.
+   */
+  workingDirectory?: string;
+  /**
+   * Git root used as the boundary when traversing for project-level LSP configs (supports monorepos).
+   */
+  gitRoot?: string;
+  /**
+   * Force re-initialization even when LSP configs were already loaded for the working directory.
+   */
+  force?: boolean;
+}
+/**
+ * The requestId previously passed to executeSampling that should be cancelled.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "McpCancelSamplingExecutionParams".
+ */
+/** @experimental */
+export interface McpCancelSamplingExecutionParams {
+  /**
+   * The requestId previously passed to executeSampling that should be cancelled
+   */
+  requestId: string;
+}
+/**
+ * Indicates whether an in-flight sampling execution with the given requestId was found and cancelled.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "McpCancelSamplingExecutionResult".
+ */
+/** @experimental */
+export interface McpCancelSamplingExecutionResult {
+  /**
+   * True if an in-flight execution with the given requestId was found and signalled to cancel. False when no such execution is in flight (already completed, never started, or cancelled by another caller).
+   */
+  cancelled: boolean;
 }
 /**
  * MCP server name and configuration to add to user configuration.
@@ -1549,6 +2607,48 @@ export interface McpEnableRequest {
   serverName: string;
 }
 /**
+ * Identifiers and raw MCP CreateMessageRequest params used to run a sampling inference.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "McpExecuteSamplingParams".
+ */
+/** @experimental */
+export interface McpExecuteSamplingParams {
+  /**
+   * Caller-provided unique identifier for this sampling execution. Use this same ID with cancelSamplingExecution to cancel the in-flight call. Must be unique within the session for the lifetime of the call.
+   */
+  requestId: string;
+  /**
+   * Name of the MCP server that initiated the sampling request
+   */
+  serverName: string;
+  /**
+   * The original MCP JSON-RPC request ID (string or number). Used by the runtime to correlate the inference with the originating MCP request for telemetry; this is distinct from `requestId` (which is the schema-level cancellation handle).
+   */
+  mcpRequestId: string | number;
+  request: McpExecuteSamplingRequest;
+}
+/**
+ * Raw MCP CreateMessageRequest params, as received in the `sampling.requested` event. Treated as opaque at the schema layer; the runtime converts the embedded MCP messages into the OpenAI chat-completion shape internally.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "McpExecuteSamplingRequest".
+ */
+/** @experimental */
+export interface McpExecuteSamplingRequest {
+  [k: string]: unknown | undefined;
+}
+/**
+ * MCP CreateMessageResult payload (with optional 'tools' extension), present when action='success'. Treated as opaque at the schema layer; consumers should construct/consume it per the MCP CreateMessageResult shape.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "McpExecuteSamplingResult".
+ */
+/** @experimental */
+export interface McpExecuteSamplingResult {
+  [k: string]: unknown | undefined;
+}
+/**
  * Remote MCP server name and optional overrides controlling reauthentication, OAuth client display name, and the callback success-page copy.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -1587,6 +2687,34 @@ export interface McpOauthLoginResult {
   authorizationUrl?: string;
 }
 /**
+ * Indicates whether the auto-managed `github` MCP server was removed (false when nothing to remove).
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "McpRemoveGitHubResult".
+ */
+/** @experimental */
+export interface McpRemoveGitHubResult {
+  /**
+   * True when the auto-managed `github` MCP server was removed; false when no removal happened (e.g. user has explicitly configured a `github` server, or the server was not registered).
+   */
+  removed: boolean;
+}
+/**
+ * Outcome of an MCP sampling execution: success result, failure error, or cancellation.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "McpSamplingExecutionResult".
+ */
+/** @experimental */
+export interface McpSamplingExecutionResult {
+  action: McpSamplingExecutionAction;
+  result?: McpExecuteSamplingResult;
+  /**
+   * Error description, present when action='failure'.
+   */
+  error?: string;
+}
+/**
  * Schema for the `McpServer` type.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -1617,6 +2745,229 @@ export interface McpServerList {
    * Configured MCP servers
    */
   servers: McpServer[];
+}
+/**
+ * Mode controlling how MCP server env values are resolved (`direct` or `indirect`).
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "McpSetEnvValueModeParams".
+ */
+/** @experimental */
+export interface McpSetEnvValueModeParams {
+  mode: McpSetEnvValueModeDetails;
+}
+/**
+ * Env-value mode recorded on the session after the update.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "McpSetEnvValueModeResult".
+ */
+/** @experimental */
+export interface McpSetEnvValueModeResult {
+  mode: McpSetEnvValueModeDetails;
+}
+/**
+ * Model identifier and token limits used to compute the context-info breakdown.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "MetadataContextInfoRequest".
+ */
+/** @experimental */
+export interface MetadataContextInfoRequest {
+  /**
+   * Maximum prompt tokens allowed by the target model. Pass 0 to use the runtime default.
+   */
+  promptTokenLimit: number;
+  /**
+   * Maximum output tokens allowed by the target model. Pass 0 if unknown.
+   */
+  outputTokenLimit: number;
+  /**
+   * Model identifier used for tokenization. Omit to use the session default. Used both for token counting and to compute display values.
+   */
+  selectedModel?: string;
+}
+/**
+ * Token breakdown for the session's current context window, or null if uninitialized.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "MetadataContextInfoResult".
+ */
+/** @experimental */
+export interface MetadataContextInfoResult {
+  /**
+   * Token breakdown for the current context window, or null if the session has not yet been initialized (no system prompt or tool metadata cached).
+   */
+  contextInfo?: SessionContextInfo | null;
+}
+/**
+ * Indicates whether the local session is currently processing a turn or background continuation.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "MetadataIsProcessingResult".
+ */
+/** @experimental */
+export interface MetadataIsProcessingResult {
+  /**
+   * Whether the session is currently processing user/agent messages. False for non-local sessions (which don't run a local agentic loop). Reflects an in-flight turn or background continuation.
+   */
+  processing: boolean;
+}
+/**
+ * Model identifier to use when re-tokenizing the session's existing messages.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "MetadataRecomputeContextTokensRequest".
+ */
+/** @experimental */
+export interface MetadataRecomputeContextTokensRequest {
+  /**
+   * Model identifier used for tokenization. The runtime token-counts both chat-context and system-context messages against this model.
+   */
+  modelId: string;
+}
+/**
+ * Re-tokenize the session's existing messages against `modelId` and return the token totals. Useful for hosts that want an initial estimate of context usage on session resume, before the next agent turn fires `session.context_info_changed` events. Returns zeros for an empty session.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "MetadataRecomputeContextTokensResult".
+ */
+/** @experimental */
+export interface MetadataRecomputeContextTokensResult {
+  /**
+   * Sum of tokens across chat-context and system-context messages currently held by the session.
+   */
+  totalTokens: number;
+  /**
+   * Tokens contributed by user/assistant/tool messages (excludes system/developer prompts).
+   */
+  messagesTokenCount: number;
+  /**
+   * Tokens contributed by system/developer prompt snapshots.
+   */
+  systemTokenCount: number;
+}
+/**
+ * Updated working-directory/git context to record on the session.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "MetadataRecordContextChangeRequest".
+ */
+/** @experimental */
+export interface MetadataRecordContextChangeRequest {
+  context: SessionWorkingDirectoryContext;
+}
+/**
+ * Updated working directory and git context. Emitted as the new payload of `session.context_changed`.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionWorkingDirectoryContext".
+ */
+/** @experimental */
+export interface SessionWorkingDirectoryContext {
+  /**
+   * Current working directory path
+   */
+  cwd: string;
+  /**
+   * Root directory of the git repository, resolved via git rev-parse
+   */
+  gitRoot?: string;
+  /**
+   * Repository identifier derived from the git remote URL ("owner/name" for GitHub, "org/project/repo" for Azure DevOps)
+   */
+  repository?: string;
+  hostType?: SessionWorkingDirectoryContextHostType;
+  /**
+   * Raw host string from the git remote URL (e.g. "github.com", "dev.azure.com")
+   */
+  repositoryHost?: string;
+  /**
+   * Current git branch name
+   */
+  branch?: string;
+  /**
+   * Head commit of the current git branch
+   */
+  headCommit?: string;
+  /**
+   * Merge-base commit SHA (fork point from the remote default branch)
+   */
+  baseCommit?: string;
+}
+/**
+ * Notify the session that its working directory context has changed. Emits a `session.context_changed` event so consumers (telemetry, OTel tracker, ACP, the timeline UI) can react. Use this when the host has detected a cwd/branch/repo change outside the session's normal lifecycle (e.g., after a shell command in interactive mode).
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "MetadataRecordContextChangeResult".
+ */
+/** @experimental */
+export interface MetadataRecordContextChangeResult {}
+/**
+ * Absolute path to set as the session's new working directory.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "MetadataSetWorkingDirectoryRequest".
+ */
+/** @experimental */
+export interface MetadataSetWorkingDirectoryRequest {
+  /**
+   * Absolute path to set as the session's working directory. The runtime updates the session's recorded cwd so subsequent operations (shell tools, file lookups, telemetry) anchor to it.
+   */
+  workingDirectory: string;
+}
+/**
+ * Update the session's working directory. Used by the host when the user explicitly changes cwd (e.g., the `/cd` slash command). The host is responsible for `process.chdir` and any related side-effects (file index, etc.); this method only updates the session's own recorded path.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "MetadataSetWorkingDirectoryResult".
+ */
+/** @experimental */
+export interface MetadataSetWorkingDirectoryResult {
+  /**
+   * Working directory after the update
+   */
+  workingDirectory: string;
+}
+/**
+ * Remote-session-specific metadata. Populated only when `isRemote` is true. Fields are immutable for the lifetime of the session.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "MetadataSnapshotRemoteMetadata".
+ */
+/** @experimental */
+export interface MetadataSnapshotRemoteMetadata {
+  /**
+   * The original resource identifier (task ID or PR node ID), preserved across event-replay reconstructions. Falls back to `sessionId` when absent.
+   */
+  resourceId?: string;
+  repository: MetadataSnapshotRemoteMetadataRepository;
+  /**
+   * The pull request number the remote session is associated with, if any.
+   */
+  pullRequestNumber?: number;
+  taskType?: MetadataSnapshotRemoteMetadataTaskType;
+}
+/**
+ * The repository the remote session targets.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "MetadataSnapshotRemoteMetadataRepository".
+ */
+/** @experimental */
+export interface MetadataSnapshotRemoteMetadataRepository {
+  /**
+   * The GitHub owner (user or organization) of the target repository.
+   */
+  owner: string;
+  /**
+   * The GitHub repository name (without owner).
+   */
+  name: string;
+  /**
+   * The branch the remote session is operating on.
+   */
+  branch: string;
 }
 /**
  * Schema for the `Model` type.
@@ -1843,6 +3194,30 @@ export interface ModelList {
    */
   models: Model[];
 }
+/**
+ * Reasoning effort level to apply to the currently selected model.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ModelSetReasoningEffortRequest".
+ */
+export interface ModelSetReasoningEffortRequest {
+  /**
+   * Reasoning effort level to apply to the currently selected model. The host is responsible for validating the value against the model's supported levels before calling.
+   */
+  reasoningEffort: string;
+}
+/**
+ * Update the session's reasoning effort without changing the selected model. Use `switchTo` instead when you also need to change the model. The runtime stores the effort on the session and applies it to subsequent turns.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ModelSetReasoningEffortResult".
+ */
+export interface ModelSetReasoningEffortResult {
+  /**
+   * Reasoning effort level recorded on the session after the update
+   */
+  reasoningEffort: string;
+}
 
 export interface ModelsListRequest {
   /**
@@ -1902,6 +3277,30 @@ export interface NameGetResult {
   name: string | null;
 }
 /**
+ * Auto-generated session summary to apply as the session's name when no user-set name exists.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "NameSetAutoRequest".
+ */
+export interface NameSetAutoRequest {
+  /**
+   * Auto-generated session summary. Empty/whitespace-only values are ignored; values are trimmed before persisting.
+   */
+  summary: string;
+}
+/**
+ * Indicates whether the auto-generated summary was applied as the session's name.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "NameSetAutoResult".
+ */
+export interface NameSetAutoResult {
+  /**
+   * Whether the auto-generated summary was persisted. False if the session already has a user-set name, the summary normalized to empty, or the session does not have a workspace.
+   */
+  applied: boolean;
+}
+/**
  * New friendly name to apply to the session.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -1914,6 +3313,31 @@ export interface NameSetRequest {
   name: string;
 }
 /**
+ * Schema for the `PendingPermissionRequest` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PendingPermissionRequest".
+ */
+export interface PendingPermissionRequest {
+  /**
+   * Unique identifier for the pending permission request
+   */
+  requestId: string;
+  request: PermissionPromptRequest;
+}
+/**
+ * List of pending permission requests reconstructed from event history.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PendingPermissionRequestList".
+ */
+export interface PendingPermissionRequestList {
+  /**
+   * Pending permission prompts reconstructed from the session's event history. Equivalent to the set of `permission.requested` events that have not yet been followed by a matching `permission.completed` event. Used by clients (e.g. the CLI) to hydrate UI for prompts that were emitted before the client attached to the session.
+   */
+  items: PendingPermissionRequest[];
+}
+/**
  * Schema for the `PermissionDecisionApproveOnce` type.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -1921,7 +3345,7 @@ export interface NameSetRequest {
  */
 export interface PermissionDecisionApproveOnce {
   /**
-   * The permission request was approved for this one instance
+   * Approve this single request only
    */
   kind: "approve-once";
 }
@@ -1933,12 +3357,12 @@ export interface PermissionDecisionApproveOnce {
  */
 export interface PermissionDecisionApproveForSession {
   /**
-   * Approved and remembered for the rest of the session
+   * Approve and remember for the rest of the session
    */
   kind: "approve-for-session";
   approval?: PermissionDecisionApproveForSessionApproval;
   /**
-   * The URL domain to approve for this session
+   * URL domain to approve for the rest of the session (URL prompts only)
    */
   domain?: string;
 }
@@ -2086,12 +3510,12 @@ export interface PermissionDecisionApproveForSessionApprovalExtensionPermissionA
  */
 export interface PermissionDecisionApproveForLocation {
   /**
-   * Approved and persisted for this project location
+   * Approve and persist for this project location
    */
   kind: "approve-for-location";
   approval: PermissionDecisionApproveForLocationApproval;
   /**
-   * The location key (git root or cwd) to persist the approval to
+   * Location key (git root or cwd) to persist the approval to
    */
   locationKey: string;
 }
@@ -2239,11 +3663,11 @@ export interface PermissionDecisionApproveForLocationApprovalExtensionPermission
  */
 export interface PermissionDecisionApprovePermanently {
   /**
-   * Approved and persisted across sessions
+   * Approve and persist across sessions (URL prompts only)
    */
   kind: "approve-permanently";
   /**
-   * The URL domain to approve permanently
+   * URL domain to approve permanently
    */
   domain: string;
 }
@@ -2255,11 +3679,11 @@ export interface PermissionDecisionApprovePermanently {
  */
 export interface PermissionDecisionReject {
   /**
-   * Denied by the user during an interactive prompt
+   * Reject the request
    */
   kind: "reject";
   /**
-   * Optional feedback from the user explaining the denial
+   * Optional feedback explaining the rejection
    */
   feedback?: string;
 }
@@ -2271,9 +3695,155 @@ export interface PermissionDecisionReject {
  */
 export interface PermissionDecisionUserNotAvailable {
   /**
-   * Denied because user confirmation was unavailable
+   * No user is available to confirm the request
    */
   kind: "user-not-available";
+}
+/**
+ * Schema for the `PermissionDecisionApproved` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionDecisionApproved".
+ */
+export interface PermissionDecisionApproved {
+  /**
+   * The permission request was approved
+   */
+  kind: "approved";
+}
+/**
+ * Schema for the `PermissionDecisionApprovedForSession` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionDecisionApprovedForSession".
+ */
+export interface PermissionDecisionApprovedForSession {
+  /**
+   * Approved and remembered for the rest of the session
+   */
+  kind: "approved-for-session";
+  approval: UserToolSessionApproval;
+}
+/**
+ * Schema for the `PermissionDecisionApprovedForLocation` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionDecisionApprovedForLocation".
+ */
+export interface PermissionDecisionApprovedForLocation {
+  /**
+   * Approved and persisted for this project location
+   */
+  kind: "approved-for-location";
+  approval: UserToolSessionApproval;
+  /**
+   * The location key (git root or cwd) to persist the approval to
+   */
+  locationKey: string;
+}
+/**
+ * Schema for the `PermissionDecisionCancelled` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionDecisionCancelled".
+ */
+export interface PermissionDecisionCancelled {
+  /**
+   * The permission request was cancelled before a response was used
+   */
+  kind: "cancelled";
+  /**
+   * Optional explanation of why the request was cancelled
+   */
+  reason?: string;
+}
+/**
+ * Schema for the `PermissionDecisionDeniedByRules` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionDecisionDeniedByRules".
+ */
+export interface PermissionDecisionDeniedByRules {
+  /**
+   * Denied because approval rules explicitly blocked it
+   */
+  kind: "denied-by-rules";
+  /**
+   * Rules that denied the request
+   */
+  rules: PermissionRule[];
+}
+/**
+ * Schema for the `PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser".
+ */
+export interface PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser {
+  /**
+   * Denied because no approval rule matched and user confirmation was unavailable
+   */
+  kind: "denied-no-approval-rule-and-could-not-request-from-user";
+}
+/**
+ * Schema for the `PermissionDecisionDeniedInteractivelyByUser` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionDecisionDeniedInteractivelyByUser".
+ */
+export interface PermissionDecisionDeniedInteractivelyByUser {
+  /**
+   * Denied by the user during an interactive prompt
+   */
+  kind: "denied-interactively-by-user";
+  /**
+   * Optional feedback from the user explaining the denial
+   */
+  feedback?: string;
+  /**
+   * Whether to force-reject the current agent turn
+   */
+  forceReject?: boolean;
+}
+/**
+ * Schema for the `PermissionDecisionDeniedByContentExclusionPolicy` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionDecisionDeniedByContentExclusionPolicy".
+ */
+export interface PermissionDecisionDeniedByContentExclusionPolicy {
+  /**
+   * Denied by the organization's content exclusion policy
+   */
+  kind: "denied-by-content-exclusion-policy";
+  /**
+   * File path that triggered the exclusion
+   */
+  path: string;
+  /**
+   * Human-readable explanation of why the path was excluded
+   */
+  message: string;
+}
+/**
+ * Schema for the `PermissionDecisionDeniedByPermissionRequestHook` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionDecisionDeniedByPermissionRequestHook".
+ */
+export interface PermissionDecisionDeniedByPermissionRequestHook {
+  /**
+   * Denied by a permission request hook registered by an extension or plugin
+   */
+  kind: "denied-by-permission-request-hook";
+  /**
+   * Optional message from the hook explaining the denial
+   */
+  message?: string;
+  /**
+   * Whether to interrupt the current agent turn
+   */
+  interrupt?: boolean;
 }
 /**
  * Pending permission request ID and the decision to apply (approve/reject and scope).
@@ -2289,6 +3859,130 @@ export interface PermissionDecisionRequest {
   result: PermissionDecision;
 }
 /**
+ * Directory path to add to the session's allowed directories.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionPathsAddParams".
+ */
+export interface PermissionPathsAddParams {
+  /**
+   * Directory to add to the allow-list. The runtime resolves and validates the path before adding.
+   */
+  path: string;
+}
+/**
+ * Path to evaluate against the session's allowed directories.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionPathsAllowedCheckParams".
+ */
+export interface PermissionPathsAllowedCheckParams {
+  /**
+   * Path to check against the session's allowed directories
+   */
+  path: string;
+}
+/**
+ * Indicates whether the supplied path is within the session's allowed directories.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionPathsAllowedCheckResult".
+ */
+export interface PermissionPathsAllowedCheckResult {
+  /**
+   * Whether the path is within the session's allowed directories
+   */
+  allowed: boolean;
+}
+/**
+ * If specified, replaces the session's path-permission policy. The runtime constructs the appropriate PathManager based on these inputs (rooted at the session's working directory). Omit to leave the current path policy unchanged.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionPathsConfig".
+ */
+export interface PermissionPathsConfig {
+  /**
+   * If true, the runtime allows access to all paths without prompting. Equivalent to constructing an UnrestrictedPathManager.
+   */
+  unrestricted?: boolean;
+  /**
+   * Additional directories to allow tool access to (in addition to the session's working directory). When `unrestricted` is true, these are still pre-populated on the UnrestrictedPathManager so they remain visible via getDirectories() (e.g. for @-mention completion).
+   */
+  additionalDirectories?: string[];
+  /**
+   * Whether to include the system temp directory in the allowed list (defaults to true). Ignored when `unrestricted` is true.
+   */
+  includeTempDirectory?: boolean;
+  /**
+   * Workspace root path (special-cased to be allowed even before the directory exists). Ignored when `unrestricted` is true.
+   */
+  workspacePath?: string;
+}
+/**
+ * Snapshot of the session's allow-listed directories and primary working directory.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionPathsList".
+ */
+export interface PermissionPathsList {
+  /**
+   * All directories currently allowed for tool access on this session.
+   */
+  directories: string[];
+  /**
+   * The primary working directory for this session.
+   */
+  primary: string;
+}
+/**
+ * Directory path to set as the session's new primary working directory.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionPathsUpdatePrimaryParams".
+ */
+export interface PermissionPathsUpdatePrimaryParams {
+  /**
+   * Directory to set as the new primary working directory for the session's permission policy.
+   */
+  path: string;
+}
+/**
+ * Path to evaluate against the session's workspace (primary) directory.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionPathsWorkspaceCheckParams".
+ */
+export interface PermissionPathsWorkspaceCheckParams {
+  /**
+   * Path to check against the session workspace directory
+   */
+  path: string;
+}
+/**
+ * Indicates whether the supplied path is within the session's workspace directory.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionPathsWorkspaceCheckResult".
+ */
+export interface PermissionPathsWorkspaceCheckResult {
+  /**
+   * Whether the path is within the session workspace directory
+   */
+  allowed: boolean;
+}
+/**
+ * Notification payload describing the permission prompt that the client just rendered.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionPromptShownNotification".
+ */
+export interface PermissionPromptShownNotification {
+  /**
+   * Human-readable description of the prompt the user is being asked to approve. Used by the runtime to fire the registered `permission_prompt` notification hook (e.g. terminal bell, desktop notification).
+   */
+  message: string;
+}
+/**
  * Indicates whether the permission decision was applied; false when the request was already resolved.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -2300,6 +3994,191 @@ export interface PermissionRequestResult {
    */
   success: boolean;
 }
+/**
+ * If specified, replaces the session's approved/denied permission rules. Omit to leave the current rules unchanged.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionRulesSet".
+ */
+export interface PermissionRulesSet {
+  /**
+   * Rules that auto-approve matching requests
+   */
+  approved: PermissionRule[];
+  /**
+   * Rules that auto-deny matching requests
+   */
+  denied: PermissionRule[];
+}
+/**
+ * Schema for the `PermissionsConfigureAdditionalContentExclusionPolicy` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionsConfigureAdditionalContentExclusionPolicy".
+ */
+export interface PermissionsConfigureAdditionalContentExclusionPolicy {
+  rules: PermissionsConfigureAdditionalContentExclusionPolicyRule[];
+  last_updated_at: string | number;
+  scope: PermissionsConfigureAdditionalContentExclusionPolicyScope;
+  [k: string]: unknown | undefined;
+}
+/**
+ * Schema for the `PermissionsConfigureAdditionalContentExclusionPolicyRule` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionsConfigureAdditionalContentExclusionPolicyRule".
+ */
+export interface PermissionsConfigureAdditionalContentExclusionPolicyRule {
+  paths: string[];
+  ifAnyMatch?: string[];
+  ifNoneMatch?: string[];
+  source: PermissionsConfigureAdditionalContentExclusionPolicyRuleSource;
+  [k: string]: unknown | undefined;
+}
+/**
+ * Schema for the `PermissionsConfigureAdditionalContentExclusionPolicyRuleSource` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionsConfigureAdditionalContentExclusionPolicyRuleSource".
+ */
+export interface PermissionsConfigureAdditionalContentExclusionPolicyRuleSource {
+  name: string;
+  type: string;
+}
+/**
+ * Patch of permission policy fields to apply (omit a field to leave it unchanged).
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionsConfigureParams".
+ */
+export interface PermissionsConfigureParams {
+  /**
+   * If specified, sets whether tool permission requests are auto-approved without prompting. Omit to leave the current value unchanged.
+   */
+  approveAllToolPermissionRequests?: boolean;
+  /**
+   * If specified, sets whether path/URL read permission requests are auto-approved. Omit to leave the current value unchanged.
+   */
+  approveAllReadPermissionRequests?: boolean;
+  rules?: PermissionRulesSet;
+  paths?: PermissionPathsConfig;
+  urls?: PermissionUrlsConfig;
+  /**
+   * If specified, replaces the host-supplied GitHub Content Exclusion policies on the session (combined with natively-discovered policies when evaluating tool/file access). Omit to leave the current policies unchanged.
+   */
+  additionalContentExclusionPolicies?: PermissionsConfigureAdditionalContentExclusionPolicy[];
+}
+/**
+ * If specified, replaces the session's URL-permission policy. The runtime constructs a fresh DefaultUrlManager based on these inputs. Omit to leave the current URL policy unchanged.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionUrlsConfig".
+ */
+export interface PermissionUrlsConfig {
+  /**
+   * If true, the runtime allows access to all URLs without prompting. Initial allow-list is ignored when this is true.
+   */
+  unrestricted?: boolean;
+  /**
+   * Initial list of allowed URL/domain patterns. Patterns may include path components. Ignored when `unrestricted` is true.
+   */
+  initialAllowed?: string[];
+}
+/**
+ * Indicates whether the operation succeeded.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionsConfigureResult".
+ */
+export interface PermissionsConfigureResult {
+  /**
+   * Whether the operation succeeded
+   */
+  success: boolean;
+}
+/**
+ * Scope and add/remove instructions for modifying session- or location-scoped permission rules.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionsModifyRulesParams".
+ */
+export interface PermissionsModifyRulesParams {
+  scope: PermissionsModifyRulesScope;
+  /**
+   * Rules to add to the scope. Applied before `remove`/`removeAll`.
+   */
+  add?: PermissionRule[];
+  /**
+   * Specific rules to remove from the scope. Ignored when `removeAll` is true.
+   */
+  remove?: PermissionRule[];
+  /**
+   * When true, removes every rule currently in the scope (after any `add` is applied). Useful for clearing the location scope wholesale.
+   */
+  removeAll?: boolean;
+}
+/**
+ * Indicates whether the operation succeeded.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionsModifyRulesResult".
+ */
+export interface PermissionsModifyRulesResult {
+  /**
+   * Whether the operation succeeded
+   */
+  success: boolean;
+}
+/**
+ * Indicates whether the operation succeeded.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionsNotifyPromptShownResult".
+ */
+export interface PermissionsNotifyPromptShownResult {
+  /**
+   * Whether the operation succeeded
+   */
+  success: boolean;
+}
+/**
+ * Indicates whether the operation succeeded.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionsPathsAddResult".
+ */
+export interface PermissionsPathsAddResult {
+  /**
+   * Whether the operation succeeded
+   */
+  success: boolean;
+}
+/**
+ * No parameters; returns the session's allow-listed directories.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionsPathsListRequest".
+ */
+export interface PermissionsPathsListRequest {}
+/**
+ * Indicates whether the operation succeeded.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionsPathsUpdatePrimaryResult".
+ */
+export interface PermissionsPathsUpdatePrimaryResult {
+  /**
+   * Whether the operation succeeded
+   */
+  success: boolean;
+}
+/**
+ * No parameters; returns currently-pending permission requests for the session.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionsPendingRequestsRequest".
+ */
+export interface PermissionsPendingRequestsRequest {}
 /**
  * No parameters; clears all session-scoped tool permission approvals.
  *
@@ -2320,7 +4199,7 @@ export interface PermissionsResetSessionApprovalsResult {
   success: boolean;
 }
 /**
- * Whether to auto-approve all tool permission requests for the rest of the session.
+ * Allow-all toggle for tool permission requests, with an optional telemetry source.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "PermissionsSetApproveAllRequest".
@@ -2330,6 +4209,7 @@ export interface PermissionsSetApproveAllRequest {
    * Whether to auto-approve all tool permission requests
    */
   enabled: boolean;
+  source?: PermissionsSetApproveAllSource;
 }
 /**
  * Indicates whether the operation succeeded.
@@ -2344,6 +4224,54 @@ export interface PermissionsSetApproveAllResult {
   success: boolean;
 }
 /**
+ * Toggles whether permission prompts should be bridged into session events for this client.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionsSetRequiredRequest".
+ */
+export interface PermissionsSetRequiredRequest {
+  /**
+   * Whether the client wants `permission.requested` events bridged from the session-owned permission service. CLI clients that render prompt UI set this to `true` for as long as their listener is mounted; headless callers leave it unset (the default is `false`).
+   */
+  required: boolean;
+}
+/**
+ * Indicates whether the operation succeeded.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionsSetRequiredResult".
+ */
+export interface PermissionsSetRequiredResult {
+  /**
+   * Whether the operation succeeded
+   */
+  success: boolean;
+}
+/**
+ * Indicates whether the operation succeeded.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionsUrlsSetUnrestrictedModeResult".
+ */
+export interface PermissionsUrlsSetUnrestrictedModeResult {
+  /**
+   * Whether the operation succeeded
+   */
+  success: boolean;
+}
+/**
+ * Whether the URL-permission policy should run in unrestricted mode.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "PermissionUrlsSetUnrestrictedModeParams".
+ */
+export interface PermissionUrlsSetUnrestrictedModeParams {
+  /**
+   * Whether to allow access to all URLs without prompting. Toggles the runtime's URL-permission policy in place.
+   */
+  enabled: boolean;
+}
+/**
  * Optional message to echo back to the caller.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -2356,7 +4284,7 @@ export interface PingRequest {
   message?: string;
 }
 /**
- * Server liveness response, including the echoed message, current timestamp, and protocol version.
+ * Server liveness response, including the echoed message, current server timestamp, and protocol version.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "PingResult".
@@ -2367,9 +4295,9 @@ export interface PingResult {
    */
   message: string;
   /**
-   * Server timestamp in milliseconds
+   * ISO 8601 timestamp when the server handled the ping
    */
-  timestamp: number;
+  timestamp: string;
   /**
    * Server protocol version number
    */
@@ -2446,6 +4374,89 @@ export interface PluginList {
   plugins: Plugin[];
 }
 /**
+ * Schema for the `QueuePendingItems` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "QueuePendingItems".
+ */
+/** @experimental */
+export interface QueuePendingItems {
+  kind: QueuePendingItemsKind;
+  /**
+   * Human-readable text to display for this queue entry in the UI
+   */
+  displayText: string;
+}
+/**
+ * Snapshot of the session's pending queued items and immediate-steering messages.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "QueuePendingItemsResult".
+ */
+/** @experimental */
+export interface QueuePendingItemsResult {
+  /**
+   * Pending queued items in submission order. Includes user messages, queued slash commands, and queued model changes; omits internal system items.
+   */
+  items: QueuePendingItems[];
+  /**
+   * Display text for messages currently in the immediate steering queue (interjections sent during a running turn).
+   */
+  steeringMessages: string[];
+}
+/**
+ * Indicates whether a user-facing pending item was removed.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "QueueRemoveMostRecentResult".
+ */
+/** @experimental */
+export interface QueueRemoveMostRecentResult {
+  /**
+   * True if a user-facing pending item was removed (LIFO across both queues); false when no removable items remained.
+   */
+  removed: boolean;
+}
+/**
+ * Event type to register consumer interest for, used by runtime gating logic.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "RegisterEventInterestParams".
+ */
+/** @experimental */
+export interface RegisterEventInterestParams {
+  /**
+   * The event type the consumer wants the runtime to treat as 'observed' for behavior-switching gating. Some runtime code paths inspect whether any consumer is interested in a specific event type and choose a different implementation accordingly (e.g. `mcp.oauth_required`: when interest is registered the runtime delegates the full interactive OAuth flow to the consumer; when no interest is registered the runtime installs a browserless fallback that silently reuses cached tokens). SDK clients that long-poll events do NOT automatically appear as listeners to these gating checks — they must explicitly call `registerInterest` for each event type they want the runtime to count as having a consumer. Multiple registrations for the same event type from the same or different consumers are tracked independently and must each be released. See: `mcp.oauth_required`, `sampling.requested`, `auto_mode_switch.requested`, `user_input.requested`, `elicitation.requested`, `command.queued`, `exit_plan_mode.requested`.
+   */
+  eventType: string;
+}
+/**
+ * Opaque handle representing an event-type interest registration.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "RegisterEventInterestResult".
+ */
+/** @experimental */
+export interface RegisterEventInterestResult {
+  /**
+   * Opaque handle for this registration. Pass to releaseInterest to release. Each call to registerInterest produces a fresh handle, even when the same eventType is registered multiple times.
+   */
+  handle: string;
+}
+/**
+ * Opaque handle previously returned by `registerInterest` to release.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ReleaseEventInterestParams".
+ */
+/** @experimental */
+export interface ReleaseEventInterestParams {
+  /**
+   * Handle returned by a previous `registerInterest` call. Idempotent: releasing an unknown or already-released handle is a no-op (returns success). When the last outstanding handle for an event type is released, the runtime reverts to its 'no consumer' code path for that event type.
+   */
+  handle: string;
+}
+/**
  * Optional remote session mode ("off", "export", or "on"); defaults to enabling both export and remote steering.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -2473,6 +4484,27 @@ export interface RemoteEnableResult {
   remoteSteerable: boolean;
 }
 /**
+ * New remote-steerability state to persist as a `session.remote_steerable_changed` event.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "RemoteNotifySteerableChangedRequest".
+ */
+/** @experimental */
+export interface RemoteNotifySteerableChangedRequest {
+  /**
+   * Whether the session now supports remote steering via GitHub. The runtime persists this as a `session.remote_steerable_changed` event so resume/replay sees the up-to-date capability.
+   */
+  remoteSteerable: boolean;
+}
+/**
+ * Persist a steerability change as a `session.remote_steerable_changed` event. Used by the host (CLI / SDK consumer) when it has just finished enabling or disabling steering on a remote exporter that the runtime does not directly own.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "RemoteNotifySteerableChangedResult".
+ */
+/** @experimental */
+export interface RemoteNotifySteerableChangedResult {}
+/**
  * Remote session connection result.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -2485,6 +4517,322 @@ export interface RemoteSessionConnectionResult {
    */
   sessionId: string;
   metadata: ConnectedRemoteSessionMetadata;
+}
+/**
+ * Schema for the `ScheduleEntry` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ScheduleEntry".
+ */
+/** @experimental */
+export interface ScheduleEntry {
+  /**
+   * Sequential id assigned by the runtime within the session. Stable across resumes (rebuilt from the event log).
+   */
+  id: number;
+  /**
+   * Interval between scheduled ticks, in milliseconds.
+   */
+  intervalMs: number;
+  /**
+   * Prompt text that gets enqueued on every tick.
+   */
+  prompt: string;
+  /**
+   * Whether the schedule re-arms after each tick (`/every`) or fires once (`/after`).
+   */
+  recurring: boolean;
+  /**
+   * Display-only label for the prompt as shown in the UI (e.g. `/skill-name` for a skill-invocation schedule). The actual enqueued prompt is `prompt`.
+   */
+  displayPrompt?: string;
+  /**
+   * ISO 8601 timestamp when the next tick is scheduled to fire.
+   */
+  nextRunAt: string;
+}
+/**
+ * Snapshot of the currently active recurring prompts for this session.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ScheduleList".
+ */
+/** @experimental */
+export interface ScheduleList {
+  /**
+   * Active scheduled prompts, ordered by id.
+   */
+  entries: ScheduleEntry[];
+}
+/**
+ * Identifier of the scheduled prompt to remove.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ScheduleStopRequest".
+ */
+/** @experimental */
+export interface ScheduleStopRequest {
+  /**
+   * Id of the scheduled prompt to remove.
+   */
+  id: number;
+}
+/**
+ * Remove a scheduled prompt by id. The result entry is omitted if the id was unknown.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ScheduleStopResult".
+ */
+/** @experimental */
+export interface ScheduleStopResult {
+  entry?: ScheduleEntry;
+}
+/**
+ * File attachment
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SendAttachmentFile".
+ */
+export interface SendAttachmentFile {
+  /**
+   * Attachment type discriminator
+   */
+  type: "file";
+  /**
+   * Absolute file path
+   */
+  path: string;
+  /**
+   * User-facing display name for the attachment
+   */
+  displayName: string;
+  lineRange?: SendAttachmentFileLineRange;
+}
+/**
+ * Optional line range to scope the attachment to a specific section of the file
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SendAttachmentFileLineRange".
+ */
+export interface SendAttachmentFileLineRange {
+  /**
+   * Start line number (1-based)
+   */
+  start: number;
+  /**
+   * End line number (1-based, inclusive)
+   */
+  end: number;
+}
+/**
+ * Directory attachment
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SendAttachmentDirectory".
+ */
+export interface SendAttachmentDirectory {
+  /**
+   * Attachment type discriminator
+   */
+  type: "directory";
+  /**
+   * Absolute directory path
+   */
+  path: string;
+  /**
+   * User-facing display name for the attachment
+   */
+  displayName: string;
+}
+/**
+ * Code selection attachment from an editor
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SendAttachmentSelection".
+ */
+export interface SendAttachmentSelection {
+  /**
+   * Attachment type discriminator
+   */
+  type: "selection";
+  /**
+   * Absolute path to the file containing the selection
+   */
+  filePath: string;
+  /**
+   * User-facing display name for the selection
+   */
+  displayName: string;
+  /**
+   * The selected text content
+   */
+  text: string;
+  selection: SendAttachmentSelectionDetails;
+}
+/**
+ * Position range of the selection within the file
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SendAttachmentSelectionDetails".
+ */
+export interface SendAttachmentSelectionDetails {
+  start: SendAttachmentSelectionDetailsStart;
+  end: SendAttachmentSelectionDetailsEnd;
+}
+/**
+ * Start position of the selection
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SendAttachmentSelectionDetailsStart".
+ */
+export interface SendAttachmentSelectionDetailsStart {
+  /**
+   * Start line number (0-based)
+   */
+  line: number;
+  /**
+   * Start character offset within the line (0-based)
+   */
+  character: number;
+}
+/**
+ * End position of the selection
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SendAttachmentSelectionDetailsEnd".
+ */
+export interface SendAttachmentSelectionDetailsEnd {
+  /**
+   * End line number (0-based)
+   */
+  line: number;
+  /**
+   * End character offset within the line (0-based)
+   */
+  character: number;
+}
+/**
+ * GitHub issue, pull request, or discussion reference
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SendAttachmentGithubReference".
+ */
+export interface SendAttachmentGithubReference {
+  /**
+   * Attachment type discriminator
+   */
+  type: "github_reference";
+  /**
+   * Issue, pull request, or discussion number
+   */
+  number: number;
+  /**
+   * Title of the referenced item
+   */
+  title: string;
+  referenceType: SendAttachmentGithubReferenceType;
+  /**
+   * Current state of the referenced item (e.g., open, closed, merged)
+   */
+  state: string;
+  /**
+   * URL to the referenced item on GitHub
+   */
+  url: string;
+}
+/**
+ * Blob attachment with inline base64-encoded data
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SendAttachmentBlob".
+ */
+export interface SendAttachmentBlob {
+  /**
+   * Attachment type discriminator
+   */
+  type: "blob";
+  /**
+   * Base64-encoded content
+   */
+  data: string;
+  /**
+   * MIME type of the inline data
+   */
+  mimeType: string;
+  /**
+   * User-facing display name for the attachment
+   */
+  displayName?: string;
+}
+/**
+ * Parameters for sending a user message to the session
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SendRequest".
+ */
+export interface SendRequest {
+  /**
+   * The user message text
+   */
+  prompt: string;
+  /**
+   * If provided, this is shown in the timeline instead of `prompt`
+   */
+  displayPrompt?: string;
+  /**
+   * Optional attachments (files, directories, selections, blobs, GitHub references) to include with the message
+   */
+  attachments?: SendAttachment[];
+  mode?: SendMode;
+  /**
+   * If true, adds the message to the front of the queue instead of the end
+   */
+  prepend?: boolean;
+  /**
+   * If false, this message will not trigger a Premium Request Unit charge. User messages default to billable.
+   */
+  billable?: boolean;
+  /**
+   * If set, the request will fail if the named tool is not available when this message is among the user messages at the start of the current exchange
+   */
+  requiredTool?: string;
+  /**
+   * Optional provenance tag copied to the resulting user.message event. Supported values are `system`, `command-*`, and `schedule-*`.
+   */
+  source?: {
+    [k: string]: unknown | undefined;
+  };
+  agentMode?: SendAgentMode;
+  /**
+   * Custom HTTP headers to include in outbound model requests for this turn. Merged with session-level provider headers; per-turn headers augment and overwrite session-level headers with the same key.
+   */
+  requestHeaders?: {
+    [k: string]: string | undefined;
+  };
+  /**
+   * W3C Trace Context traceparent header for distributed tracing of this agent turn
+   */
+  traceparent?: string;
+  /**
+   * W3C Trace Context tracestate header for distributed tracing
+   */
+  tracestate?: string;
+  /**
+   * If true, await completion of the agentic loop for this message before returning. Defaults to false (fire-and-forget). When true, the result still contains the same `messageId`; the caller can rely on the agent having processed the message before the call resolves.
+   */
+  wait?: boolean;
+}
+/**
+ * Result of sending a user message
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SendResult".
+ */
+export interface SendResult {
+  /**
+   * Unique identifier assigned to the message
+   */
+  messageId: string;
 }
 /**
  * Schema for the `ServerSkill` type.
@@ -2559,6 +4907,98 @@ export interface SessionAuthStatus {
    * Copilot plan tier (e.g., individual_pro, business)
    */
   copilotPlan?: string;
+}
+/**
+ * Map of sessionId -> bytes freed by removing the session's workspace directory.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionBulkDeleteResult".
+ */
+/** @experimental */
+export interface SessionBulkDeleteResult {
+  /**
+   * Map of sessionId -> bytes freed by removing the session's workspace directory. Sessions whose deletion failed are omitted from this map (failures are logged on the server but not surfaced per-id; check the map for absent IDs to detect them).
+   */
+  freedBytes: {
+    [k: string]: number | undefined;
+  };
+}
+/**
+ * Schema for the `SessionContext` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionContext".
+ */
+/** @experimental */
+export interface SessionContext {
+  /**
+   * Most recent working directory for this session
+   */
+  cwd: string;
+  /**
+   * Git repository root, if the cwd was inside a git repo
+   */
+  gitRoot?: string;
+  /**
+   * Repository slug in `owner/name` form, when known
+   */
+  repository?: string;
+  hostType?: SessionContextHostType;
+  /**
+   * Active git branch
+   */
+  branch?: string;
+}
+/**
+ * The same metadata records, with summary and context fields backfilled where available.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionEnrichMetadataResult".
+ */
+/** @experimental */
+export interface SessionEnrichMetadataResult {
+  /**
+   * Same records, with summary and context backfilled
+   */
+  sessions: SessionMetadata[];
+}
+/**
+ * Schema for the `SessionMetadata` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionMetadata".
+ */
+/** @experimental */
+export interface SessionMetadata {
+  /**
+   * Stable session identifier
+   */
+  sessionId: string;
+  /**
+   * Session creation time as an ISO 8601 timestamp
+   */
+  startTime: string;
+  /**
+   * Last-modified time of the session's persisted state, as ISO 8601
+   */
+  modifiedTime: string;
+  /**
+   * Short summary of the session, when one has been derived
+   */
+  summary?: string;
+  /**
+   * Optional human-friendly name set via /rename
+   */
+  name?: string;
+  /**
+   * True for remote (GitHub) sessions; false for local
+   */
+  isRemote: boolean;
+  context?: SessionContext;
+  /**
+   * GitHub task ID, when this local session is bound to one. Only present for local sessions exported to remote control.
+   */
+  mcTaskId?: string;
 }
 /**
  * File path, content to append, and optional mode for the client-provided session filesystem.
@@ -2892,7 +5332,7 @@ export interface SessionFsSqliteQueryResult {
    */
   rowsAffected: number;
   /**
-   * Last inserted row ID (for INSERT)
+   * SQLite last_insert_rowid() value for INSERT.
    */
   lastInsertRowid?: number;
   error?: SessionFsError;
@@ -2967,6 +5407,346 @@ export interface SessionFsWriteFileRequest {
   mode?: number;
 }
 /**
+ * Schema for the `SessionInstalledPlugin` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionInstalledPlugin".
+ */
+/** @experimental */
+export interface SessionInstalledPlugin {
+  /**
+   * Plugin name
+   */
+  name: string;
+  /**
+   * Marketplace the plugin came from (empty string for direct repo installs)
+   */
+  marketplace: string;
+  /**
+   * Installed version, if known
+   */
+  version?: string;
+  /**
+   * Installation timestamp (ISO-8601)
+   */
+  installed_at: string;
+  /**
+   * Whether the plugin is currently enabled
+   */
+  enabled: boolean;
+  /**
+   * Path where the plugin is cached locally
+   */
+  cache_path?: string;
+  source?: SessionInstalledPluginSource;
+}
+/**
+ * Schema for the `SessionInstalledPluginSourceGithub` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionInstalledPluginSourceGithub".
+ */
+/** @experimental */
+export interface SessionInstalledPluginSourceGithub {
+  /**
+   * Constant value. Always "github".
+   */
+  source: "github";
+  repo: string;
+  ref?: string;
+  path?: string;
+}
+/**
+ * Schema for the `SessionInstalledPluginSourceUrl` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionInstalledPluginSourceUrl".
+ */
+/** @experimental */
+export interface SessionInstalledPluginSourceUrl {
+  /**
+   * Constant value. Always "url".
+   */
+  source: "url";
+  url: string;
+  ref?: string;
+  path?: string;
+}
+/**
+ * Schema for the `SessionInstalledPluginSourceLocal` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionInstalledPluginSourceLocal".
+ */
+/** @experimental */
+export interface SessionInstalledPluginSourceLocal {
+  /**
+   * Constant value. Always "local".
+   */
+  source: "local";
+  path: string;
+}
+/**
+ * Persisted sessions matching the filter, ordered most-recently-modified first.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionList".
+ */
+/** @experimental */
+export interface SessionList {
+  /**
+   * Sessions ordered most-recently-modified first
+   */
+  sessions: SessionMetadata[];
+}
+/**
+ * Queued repo-level startup prompts and the total hook command count after loading.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionLoadDeferredRepoHooksResult".
+ */
+/** @experimental */
+export interface SessionLoadDeferredRepoHooksResult {
+  /**
+   * Repo-level startup prompts queued from repo hook configs. Empty on resume, when no repo configs were pending, or when disableAllHooks is set.
+   */
+  startupPrompts: string[];
+  /**
+   * Total hook command count (user + plugin + repo) loaded for the session by this call. Captured atomically with startupPrompts so callers don't need to read a separate counter.
+   */
+  hookCount: number;
+}
+/**
+ * Point-in-time snapshot of slow-changing session identifier and state fields
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionMetadataSnapshot".
+ */
+/** @experimental */
+export interface SessionMetadataSnapshot {
+  /**
+   * The unique identifier of the session
+   */
+  sessionId: string;
+  /**
+   * ISO 8601 timestamp of when the session started
+   */
+  startTime: string;
+  /**
+   * ISO 8601 timestamp of when the session's persisted state was last modified on disk. For new sessions, equals startTime. For resumed sessions, reflects the previous modification time at construction.
+   */
+  modifiedTime: string;
+  /**
+   * Whether this is a remote session (i.e., one whose runtime executes elsewhere and is steered through this process)
+   */
+  isRemote: boolean;
+  /**
+   * True when the session was detected to be in use by another process at construction time. Local consumers may surface a confirmation prompt before fully attaching. Always false for new sessions.
+   */
+  alreadyInUse: boolean;
+  /**
+   * Absolute path to the session's workspace directory on disk, or null if the session has no associated workspace
+   */
+  workspacePath: string | null;
+  /**
+   * User-provided name supplied at session construction (via `--name`), if any. Immutable after construction.
+   */
+  initialName?: string;
+  remoteMetadata?: MetadataSnapshotRemoteMetadata;
+  /**
+   * Short human-readable summary of the session, if known. Omitted when no summary has been generated.
+   */
+  summary?: string;
+  /**
+   * Absolute path to the session's current working directory
+   */
+  workingDirectory: string;
+  currentMode: MetadataSnapshotCurrentMode;
+  /**
+   * Currently selected model identifier, if any
+   */
+  selectedModel?: string;
+  /**
+   * Public-facing workspace metadata for this session, or null if the session has no associated workspace. Excludes runtime-internal fields (GitHub IDs, summary count, internal flags).
+   */
+  workspace?: WorkspaceSummary | null;
+}
+/**
+ * Outcome of the prune operation: deleted IDs, dry-run candidates, skipped IDs, total bytes freed, and the dry-run flag.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionPruneResult".
+ */
+/** @experimental */
+export interface SessionPruneResult {
+  /**
+   * Session IDs that were deleted (always empty in dry-run mode)
+   */
+  deleted: string[];
+  /**
+   * Session IDs that would be deleted in dry-run mode (always empty otherwise)
+   */
+  candidates: string[];
+  /**
+   * Session IDs that were skipped (e.g., named sessions)
+   */
+  skipped: string[];
+  /**
+   * Total bytes freed (actual when not dry-run, projected when dry-run)
+   */
+  freedBytes: number;
+  /**
+   * True when no deletions were actually performed
+   */
+  dryRun: boolean;
+}
+/**
+ * Session IDs to close, deactivate, and delete from disk.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsBulkDeleteRequest".
+ */
+/** @experimental */
+export interface SessionsBulkDeleteRequest {
+  /**
+   * Session IDs to close, deactivate, and delete from disk
+   */
+  sessionIds: string[];
+}
+/**
+ * Session IDs to test for live in-use locks.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsCheckInUseRequest".
+ */
+/** @experimental */
+export interface SessionsCheckInUseRequest {
+  /**
+   * Session IDs to test for live in-use locks
+   */
+  sessionIds: string[];
+}
+/**
+ * Session IDs from the input set that are currently in use by another process.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsCheckInUseResult".
+ */
+/** @experimental */
+export interface SessionsCheckInUseResult {
+  /**
+   * Session IDs from the input set that are currently held by another running process via an alive lock file
+   */
+  inUse: string[];
+}
+/**
+ * Session ID to close.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsCloseRequest".
+ */
+/** @experimental */
+export interface SessionsCloseRequest {
+  /**
+   * Session ID to close
+   */
+  sessionId: string;
+}
+/**
+ * Closes a session: emits shutdown, flushes pending events to disk, releases the in-use lock, disposes the active session. Idempotent: succeeds even if the session is not currently active.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsCloseResult".
+ */
+/** @experimental */
+export interface SessionsCloseResult {}
+/**
+ * Session metadata records to enrich with summary and context information.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsEnrichMetadataRequest".
+ */
+/** @experimental */
+export interface SessionsEnrichMetadataRequest {
+  /**
+   * Session metadata records to enrich. Records that already have summary and context are returned unchanged.
+   */
+  sessions: SessionMetadata[];
+}
+/**
+ * New auth credentials to install on the session. Omit to leave credentials unchanged.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionSetCredentialsParams".
+ */
+export interface SessionSetCredentialsParams {
+  credentials?: AuthInfo;
+}
+/**
+ * Indicates whether the credential update succeeded.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionSetCredentialsResult".
+ */
+export interface SessionSetCredentialsResult {
+  /**
+   * Whether the operation succeeded
+   */
+  success: boolean;
+}
+/**
+ * UUID prefix to resolve to a unique session ID.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsFindByPrefixRequest".
+ */
+/** @experimental */
+export interface SessionsFindByPrefixRequest {
+  /**
+   * UUID prefix (>=7 hex chars, <36 chars). Returns the unique session ID, or undefined when there is no match or the prefix matches multiple sessions.
+   */
+  prefix: string;
+}
+/**
+ * Session ID matching the prefix, omitted when no unique match exists.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsFindByPrefixResult".
+ */
+/** @experimental */
+export interface SessionsFindByPrefixResult {
+  /**
+   * Omitted when no unique session matches the prefix (no match or ambiguous)
+   */
+  sessionId?: string;
+}
+/**
+ * GitHub task ID to look up.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsFindByTaskIDRequest".
+ */
+/** @experimental */
+export interface SessionsFindByTaskIDRequest {
+  /**
+   * GitHub task ID to look up
+   */
+  taskId: string;
+}
+/**
+ * ID of the local session bound to the given GitHub task, or omitted when none.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsFindByTaskIDResult".
+ */
+/** @experimental */
+export interface SessionsFindByTaskIDResult {
+  /**
+   * Omitted when no local session is bound to that GitHub task
+   */
+  sessionId?: string;
+}
+/**
  * Source session identifier to fork from, optional event-ID boundary, and optional friendly name for the new session.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -3003,6 +5783,425 @@ export interface SessionsForkResult {
    * Friendly name assigned to the forked session, if any.
    */
   name?: string;
+}
+/**
+ * Session ID whose event-log file path to compute.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsGetEventFilePathRequest".
+ */
+/** @experimental */
+export interface SessionsGetEventFilePathRequest {
+  /**
+   * Session ID whose event-log file path to compute
+   */
+  sessionId: string;
+}
+/**
+ * Absolute path to the session's events.jsonl file on disk.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsGetEventFilePathResult".
+ */
+/** @experimental */
+export interface SessionsGetEventFilePathResult {
+  /**
+   * Absolute path to the session's events.jsonl file
+   */
+  filePath: string;
+}
+/**
+ * Optional working-directory context used to score session relevance.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsGetLastForContextRequest".
+ */
+/** @experimental */
+export interface SessionsGetLastForContextRequest {
+  context?: SessionContext;
+}
+/**
+ * Most-relevant session ID for the supplied context, or omitted when no sessions exist.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsGetLastForContextResult".
+ */
+/** @experimental */
+export interface SessionsGetLastForContextResult {
+  /**
+   * Most-relevant session ID for the supplied context, or omitted when no sessions exist
+   */
+  sessionId?: string;
+}
+/**
+ * Session ID to look up the persisted remote-steerable flag for.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsGetPersistedRemoteSteerableRequest".
+ */
+/** @experimental */
+export interface SessionsGetPersistedRemoteSteerableRequest {
+  /**
+   * Session ID to look up the persisted remote-steerable flag for
+   */
+  sessionId: string;
+}
+/**
+ * The session's persisted remote-steerable flag, or omitted when no value has been persisted.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsGetPersistedRemoteSteerableResult".
+ */
+/** @experimental */
+export interface SessionsGetPersistedRemoteSteerableResult {
+  /**
+   * The session's persisted remote-steerable flag if recorded; omitted when no value has been persisted
+   */
+  remoteSteerable?: boolean;
+}
+/**
+ * Map of sessionId -> on-disk size in bytes for each session's workspace directory.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionSizes".
+ */
+/** @experimental */
+export interface SessionSizes {
+  /**
+   * Map of sessionId -> on-disk size in bytes for the session's workspace directory
+   */
+  sizes: {
+    [k: string]: number | undefined;
+  };
+}
+/**
+ * Optional metadata-load limit and context filter applied to the returned sessions.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsListRequest".
+ */
+/** @experimental */
+export interface SessionsListRequest {
+  /**
+   * When provided, only the first N sessions (sorted by modification time, newest first) load full metadata; remaining sessions return basic info only. Use 0 to return only basic info for every session.
+   */
+  metadataLimit?: number;
+  /**
+   * Optional filter applied to the returned sessions
+   */
+  filter?: {
+    /**
+     * Match sessions whose context.cwd equals this value
+     */
+    cwd?: string;
+    /**
+     * Match sessions whose context.gitRoot equals this value
+     */
+    gitRoot?: string;
+    /**
+     * Match sessions whose context.repository equals this value
+     */
+    repository?: string;
+    /**
+     * Match sessions whose context.branch equals this value
+     */
+    branch?: string;
+  };
+}
+/**
+ * Active session ID whose deferred repo-level hooks should be loaded.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsLoadDeferredRepoHooksRequest".
+ */
+/** @experimental */
+export interface SessionsLoadDeferredRepoHooksRequest {
+  /**
+   * Active session ID whose deferred repo-level hooks should be loaded
+   */
+  sessionId: string;
+}
+/**
+ * Age threshold and optional flags controlling which old sessions are pruned (or simulated when dryRun is true).
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsPruneOldRequest".
+ */
+/** @experimental */
+export interface SessionsPruneOldRequest {
+  /**
+   * Delete sessions whose modifiedTime is at least this many days old
+   */
+  olderThanDays: number;
+  /**
+   * When true, only report what would be deleted without performing any deletion
+   */
+  dryRun?: boolean;
+  /**
+   * When true, named sessions (set via /rename) are also eligible for pruning
+   */
+  includeNamed?: boolean;
+  /**
+   * Session IDs that should never be considered for pruning
+   */
+  excludeSessionIds?: string[];
+}
+/**
+ * Session ID whose in-use lock should be released.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsReleaseLockRequest".
+ */
+/** @experimental */
+export interface SessionsReleaseLockRequest {
+  /**
+   * Session ID whose in-use lock should be released
+   */
+  sessionId: string;
+}
+/**
+ * Release the in-use lock held by this process for the given session. No-op when this process does not currently hold a lock for the session.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsReleaseLockResult".
+ */
+/** @experimental */
+export interface SessionsReleaseLockResult {}
+/**
+ * Active session ID and an optional flag for deferring repo-level hooks until folder trust.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsReloadPluginHooksRequest".
+ */
+/** @experimental */
+export interface SessionsReloadPluginHooksRequest {
+  /**
+   * Active session ID to reload hooks for
+   */
+  sessionId: string;
+  /**
+   * When true, skip repo-level hooks. Use before folder trust is confirmed; loadDeferredRepoHooks loads them post-trust.
+   */
+  deferRepoHooks?: boolean;
+}
+/**
+ * Reload all hooks (user, plugin, optionally repo) and apply them to the active session. Call after installing or removing plugins so their hooks take effect immediately. No-op when no active session matches the given sessionId.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsReloadPluginHooksResult".
+ */
+/** @experimental */
+export interface SessionsReloadPluginHooksResult {}
+/**
+ * Session ID whose pending events should be flushed to disk.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsSaveRequest".
+ */
+/** @experimental */
+export interface SessionsSaveRequest {
+  /**
+   * Session ID whose pending events should be flushed to disk
+   */
+  sessionId: string;
+}
+/**
+ * Flush a session's pending events to disk. No-op when no writer exists for the session (e.g., already closed).
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsSaveResult".
+ */
+/** @experimental */
+export interface SessionsSaveResult {}
+/**
+ * Manager-wide additional plugins to register; replaces any previously-configured set.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsSetAdditionalPluginsRequest".
+ */
+/** @experimental */
+export interface SessionsSetAdditionalPluginsRequest {
+  /**
+   * Manager-wide additional plugins to register. Replaces any previously-configured set. Pass an empty array to clear.
+   */
+  plugins: InstalledPlugin[];
+}
+/**
+ * Replace the manager-wide additional plugins. New session creations and subsequent hook reloads see the new set; already-running sessions keep their existing hook installation until the next reload.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsSetAdditionalPluginsResult".
+ */
+/** @experimental */
+export interface SessionsSetAdditionalPluginsResult {}
+/**
+ * Patch of mutable session options to apply to the running session.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionUpdateOptionsParams".
+ */
+/** @experimental */
+export interface SessionUpdateOptionsParams {
+  /**
+   * The model ID to use for assistant turns.
+   */
+  model?: string;
+  /**
+   * Reasoning effort for the selected model (model-defined enum).
+   */
+  reasoningEffort?: string;
+  /**
+   * Identifier of the client driving the session.
+   */
+  clientName?: string;
+  /**
+   * Identifier sent to LSP-style integrations.
+   */
+  lspClientName?: string;
+  /**
+   * Stable integration identifier used for analytics and rate-limit attribution.
+   */
+  integrationId?: string;
+  /**
+   * Map of feature-flag IDs to their boolean enabled state.
+   */
+  featureFlags?: {
+    [k: string]: boolean | undefined;
+  };
+  /**
+   * Whether experimental capabilities are enabled.
+   */
+  isExperimentalMode?: boolean;
+  /**
+   * Custom model-provider configuration (BYOK). Opaque shape; see `ProviderConfig` in the runtime.
+   */
+  provider?: {
+    [k: string]: unknown | undefined;
+  };
+  /**
+   * Absolute working-directory path for shell tools.
+   */
+  workingDirectory?: string;
+  /**
+   * Allowlist of tool names available to this session.
+   */
+  availableTools?: string[];
+  /**
+   * Denylist of tool names for this session.
+   */
+  excludedTools?: string[];
+  /**
+   * Whether shell-script safety heuristics are enabled.
+   */
+  enableScriptSafety?: boolean;
+  /**
+   * Shell init profile (`None` or `NonInteractive`).
+   */
+  shellInitProfile?: string;
+  /**
+   * Per-shell process flags (e.g., `pwsh` arguments).
+   */
+  shellProcessFlags?: string[];
+  /**
+   * Sandbox configuration shape; opaque to SDK consumers. See `SandboxConfig` in the runtime.
+   */
+  sandboxConfig?: {
+    [k: string]: unknown | undefined;
+  };
+  /**
+   * Whether interactive shell sessions are logged.
+   */
+  logInteractiveShells?: boolean;
+  envValueMode?: OptionsUpdateEnvValueMode;
+  /**
+   * Additional directories to search for skills.
+   */
+  skillDirectories?: string[];
+  /**
+   * Skill IDs that should be excluded from this session.
+   */
+  disabledSkills?: string[];
+  /**
+   * Whether to discover custom instructions on demand after successful file views (AGENTS.md / CLAUDE.md / .github/copilot-instructions.md surfacing). Combined with `skipCustomInstructions` and the runtime-side `ON_DEMAND_INSTRUCTIONS` feature flag.
+   */
+  enableOnDemandInstructionDiscovery?: boolean;
+  /**
+   * Full set of installed plugins for the session. Replaces the existing list; the runtime invalidates the skills cache only when the list materially changes.
+   */
+  installedPlugins?: SessionInstalledPlugin[];
+  /**
+   * Whether to default custom agents to local-only execution.
+   */
+  customAgentsLocalOnly?: boolean;
+  /**
+   * Whether to skip loading custom instruction sources.
+   */
+  skipCustomInstructions?: boolean;
+  /**
+   * Instruction source IDs to exclude from the system prompt.
+   */
+  disabledInstructionSources?: string[];
+  /**
+   * Whether to include the `Co-authored-by` trailer in commit messages.
+   */
+  coauthorEnabled?: boolean;
+  /**
+   * Optional path for trajectory output.
+   */
+  trajectoryFile?: string;
+  /**
+   * Whether to stream model responses.
+   */
+  enableStreaming?: boolean;
+  /**
+   * Override URL for the Copilot API endpoint.
+   */
+  copilotUrl?: string;
+  /**
+   * Whether to disable the `ask_user` tool (encourages autonomous behavior).
+   */
+  askUserDisabled?: boolean;
+  /**
+   * Whether to allow auto-mode continuation across turns.
+   */
+  continueOnAutoMode?: boolean;
+  /**
+   * Whether the session is running in an interactive UI.
+   */
+  runningInInteractiveMode?: boolean;
+  /**
+   * Whether to surface reasoning-summary events from the model.
+   */
+  enableReasoningSummaries?: boolean;
+  /**
+   * Runtime context discriminator (e.g., `cli`, `actions`).
+   */
+  agentContext?: string;
+  /**
+   * Override directory for the session-events log. When unset, the runtime's default events log directory is used.
+   */
+  eventsLogDirectory?: string;
+  /**
+   * Additional content-exclusion policies to merge into the session's policy set. Opaque shape; see `ContentExclusionApiResponse` in the runtime.
+   */
+  additionalContentExclusionPolicies?: unknown[];
+  /**
+   * Whether to expose the `manage_schedule` tool to the agent. The runtime always owns the per-session schedule registry; this flag only controls tool exposure (typically gated to staff users).
+   */
+  manageScheduleEnabled?: boolean;
+}
+/**
+ * Indicates whether the session options patch was applied successfully.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionUpdateOptionsResult".
+ */
+/** @experimental */
+export interface SessionUpdateOptionsResult {
+  /**
+   * Whether the operation succeeded
+   */
+  success: boolean;
 }
 /**
  * Shell command to run, with optional working directory and timeout in milliseconds.
@@ -3062,6 +6261,19 @@ export interface ShellKillResult {
   killed: boolean;
 }
 /**
+ * Parameters for shutting down the session
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ShutdownRequest".
+ */
+export interface ShutdownRequest {
+  type?: ShutdownType;
+  /**
+   * Optional human-readable reason. Typically the message of the error that triggered shutdown when type is 'error'.
+   */
+  reason?: string;
+}
+/**
  * Schema for the `Skill` type.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -3090,6 +6302,10 @@ export interface Skill {
    * Absolute path to the skill file
    */
   path?: string;
+  /**
+   * Name of the plugin that provides the skill, when source is 'plugin'
+   */
+  pluginName?: string;
 }
 /**
  * Skills available to the session, with their enabled state.
@@ -3157,6 +6373,48 @@ export interface SkillsEnableRequest {
    * Name of the skill to enable
    */
   name: string;
+}
+/**
+ * Skills invoked during this session, ordered by invocation time (most recent last).
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SkillsGetInvokedResult".
+ */
+/** @experimental */
+export interface SkillsGetInvokedResult {
+  /**
+   * Skills invoked during this session, ordered by invocation time (most recent last)
+   */
+  skills: SkillsInvokedSkill[];
+}
+/**
+ * Schema for the `SkillsInvokedSkill` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SkillsInvokedSkill".
+ */
+/** @experimental */
+export interface SkillsInvokedSkill {
+  /**
+   * Unique identifier for the skill
+   */
+  name: string;
+  /**
+   * Path to the SKILL.md file
+   */
+  path: string;
+  /**
+   * Full content of the skill file
+   */
+  content: string;
+  /**
+   * Tools that should be auto-approved when this skill is active, captured at invocation time
+   */
+  allowedTools?: string[];
+  /**
+   * Turn number when the skill was invoked
+   */
+  invokedAtTurn: number;
 }
 /**
  * Diagnostics from reloading skill definitions, with warnings and errors as separate lists.
@@ -3411,6 +6669,52 @@ export interface TasksCancelResult {
   cancelled: boolean;
 }
 /**
+ * The first sync-waiting task that can currently be promoted to background mode.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "TasksGetCurrentPromotableResult".
+ */
+/** @experimental */
+export interface TasksGetCurrentPromotableResult {
+  task?: TaskInfo;
+}
+/**
+ * Identifier of the background task to fetch progress for.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "TasksGetProgressRequest".
+ */
+/** @experimental */
+export interface TasksGetProgressRequest {
+  /**
+   * Task identifier (agent ID or shell ID)
+   */
+  id: string;
+}
+/**
+ * Progress information for the task, or null when no task with that ID is tracked.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "TasksGetProgressResult".
+ */
+/** @experimental */
+export interface TasksGetProgressResult {
+  /**
+   * Progress information for the task, discriminated by type. Returns null when no task with this ID is currently tracked.
+   */
+  progress?: TaskProgress | null;
+}
+/**
+ * The promoted task as it now exists in background mode, omitted if no promotable task was waiting.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "TasksPromoteCurrentToBackgroundResult".
+ */
+/** @experimental */
+export interface TasksPromoteCurrentToBackgroundResult {
+  task?: TaskInfo;
+}
+/**
  * Identifier of the task to promote to background mode.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -3436,6 +6740,14 @@ export interface TasksPromoteToBackgroundResult {
    */
   promoted: boolean;
 }
+/**
+ * Refresh metadata for any detached background shells the runtime knows about. Use after a long pause to pick up exit/output state for shells running outside the agent loop.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "TasksRefreshResult".
+ */
+/** @experimental */
+export interface TasksRefreshResult {}
 /**
  * Identifier of the completed or cancelled task to remove from tracking.
  *
@@ -3543,6 +6855,29 @@ export interface TasksStartAgentResult {
   agentId: string;
 }
 /**
+ * Wait until all in-flight background tasks (agents + shells) and any follow-up turns scheduled by their completions have settled. Returns when the runtime is fully drained or after an internal timeout (default 10 minutes; configurable via COPILOT_TASK_WAIT_TIMEOUT_SECONDS).
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "TasksWaitForPendingResult".
+ */
+/** @experimental */
+export interface TasksWaitForPendingResult {}
+/**
+ * Feature override key/value pairs to attach to subsequent telemetry events from this session.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "TelemetrySetFeatureOverridesRequest".
+ */
+/** @experimental */
+export interface TelemetrySetFeatureOverridesRequest {
+  /**
+   * Override key/value pairs to attach to subsequent telemetry events from this session. Replaces any previously-set overrides.
+   */
+  features: {
+    [k: string]: string | undefined;
+  };
+}
+/**
  * Schema for the `Tool` type.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -3584,6 +6919,13 @@ export interface ToolList {
    */
   tools: Tool[];
 }
+/**
+ * Resolve, build, and validate the runtime tool list for this session. Subagent sessions and consumer flows that need an initialized tool set before `send` invoke this. Default base-class implementation is a no-op for sessions that don't support tool validation.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ToolsInitializeAndValidateResult".
+ */
+export interface ToolsInitializeAndValidateResult {}
 /**
  * Optional model identifier whose tool overrides should be applied to the listing.
  *
@@ -3935,6 +7277,40 @@ export interface UIElicitationResult {
   success: boolean;
 }
 /**
+ * Schema for the `UIExitPlanModeResponse` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "UIExitPlanModeResponse".
+ */
+export interface UIExitPlanModeResponse {
+  /**
+   * Whether the plan was approved.
+   */
+  approved: boolean;
+  selectedAction?: UIExitPlanModeAction;
+  /**
+   * Whether subsequent edits should be auto-approved without confirmation.
+   */
+  autoApproveEdits?: boolean;
+  /**
+   * Feedback from the user when they declined the plan or requested changes.
+   */
+  feedback?: string;
+}
+/**
+ * Request ID of a pending `auto_mode_switch.requested` event and the user's response.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "UIHandlePendingAutoModeSwitchRequest".
+ */
+export interface UIHandlePendingAutoModeSwitchRequest {
+  /**
+   * The unique request ID from the auto_mode_switch.requested event
+   */
+  requestId: string;
+  response: UIAutoModeSwitchResponse;
+}
+/**
  * Pending elicitation request ID and the user's response (accept/decline/cancel + form values).
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -3946,6 +7322,118 @@ export interface UIHandlePendingElicitationRequest {
    */
   requestId: string;
   result: UIElicitationResponse;
+}
+/**
+ * Request ID of a pending `exit_plan_mode.requested` event and the user's response.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "UIHandlePendingExitPlanModeRequest".
+ */
+export interface UIHandlePendingExitPlanModeRequest {
+  /**
+   * The unique request ID from the exit_plan_mode.requested event
+   */
+  requestId: string;
+  response: UIExitPlanModeResponse;
+}
+/**
+ * Indicates whether the pending UI request was resolved by this call.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "UIHandlePendingResult".
+ */
+export interface UIHandlePendingResult {
+  /**
+   * True if the request was still pending and was resolved by this call. False if the request ID was unknown, already resolved by another client (e.g. GitHub), expired, or otherwise no longer pending.
+   */
+  success: boolean;
+}
+/**
+ * Request ID of a pending `sampling.requested` event and an optional sampling result payload (omit to reject).
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "UIHandlePendingSamplingRequest".
+ */
+export interface UIHandlePendingSamplingRequest {
+  /**
+   * The unique request ID from the sampling.requested event
+   */
+  requestId: string;
+  response?: UIHandlePendingSamplingResponse;
+}
+/**
+ * Optional sampling result payload. Omit to reject/cancel the sampling request without providing a result.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "UIHandlePendingSamplingResponse".
+ */
+export interface UIHandlePendingSamplingResponse {
+  [k: string]: unknown | undefined;
+}
+/**
+ * Request ID of a pending `user_input.requested` event and the user's response.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "UIHandlePendingUserInputRequest".
+ */
+export interface UIHandlePendingUserInputRequest {
+  /**
+   * The unique request ID from the user_input.requested event
+   */
+  requestId: string;
+  response: UIUserInputResponse;
+}
+/**
+ * Schema for the `UIUserInputResponse` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "UIUserInputResponse".
+ */
+export interface UIUserInputResponse {
+  /**
+   * The user's answer text
+   */
+  answer: string;
+  /**
+   * True if the user typed a freeform response, false if they selected a presented choice. Used by telemetry to differentiate between free text input and choice selection.
+   */
+  wasFreeform: boolean;
+}
+/**
+ * Register an in-process handler for `auto_mode_switch.requested` events. The caller still attaches the actual listener via the standard event-subscription mechanism; this registration solely tells the server bridge to skip its own dispatch (so a remote client doesn't race the in-process handler for the same requestId).
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "UIRegisterDirectAutoModeSwitchHandlerResult".
+ */
+export interface UIRegisterDirectAutoModeSwitchHandlerResult {
+  /**
+   * Opaque handle representing the registration. Pass this same handle to `unregisterDirectAutoModeSwitchHandler` when the in-process handler is no longer active. Multiple registrations are reference-counted; the server bridge will only dispatch auto-mode-switch requests when no handles are active.
+   */
+  handle: string;
+}
+/**
+ * Opaque handle previously returned by `registerDirectAutoModeSwitchHandler` to release.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "UIUnregisterDirectAutoModeSwitchHandlerRequest".
+ */
+export interface UIUnregisterDirectAutoModeSwitchHandlerRequest {
+  /**
+   * Handle previously returned by `registerDirectAutoModeSwitchHandler`
+   */
+  handle: string;
+}
+/**
+ * Indicates whether the handle was active and the registration count was decremented.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "UIUnregisterDirectAutoModeSwitchHandlerResult".
+ */
+export interface UIUnregisterDirectAutoModeSwitchHandlerResult {
+  /**
+   * True if the handle was active and decremented the counter; false if the handle was unknown.
+   */
+  unregistered: boolean;
 }
 /**
  * Accumulated session usage metrics, including premium request cost, token counts, model breakdown, and code-change totals.
@@ -3978,9 +7466,9 @@ export interface UsageGetMetricsResult {
    */
   totalApiDurationMs: number;
   /**
-   * Session start timestamp (epoch milliseconds)
+   * ISO 8601 timestamp when the session started
    */
-  sessionStartTime: number;
+  sessionStartTime: string;
   codeChanges: UsageMetricsCodeChanges;
   /**
    * Per-model token and request metrics, keyed by model identifier
@@ -4034,6 +7522,10 @@ export interface UsageMetricsCodeChanges {
    * Number of distinct files modified
    */
   filesModifiedCount: number;
+  /**
+   * Distinct file paths modified during the session
+   */
+  filesModified: string[];
 }
 /**
  * Schema for the `UsageMetricsModelMetric` type.
@@ -4116,6 +7608,26 @@ export interface UsageMetricsModelMetricTokenDetail {
   tokenCount: number;
 }
 /**
+ * Schema for the `WorkspacesCheckpoints` type.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "WorkspacesCheckpoints".
+ */
+export interface WorkspacesCheckpoints {
+  /**
+   * Checkpoint number assigned by the workspace manager
+   */
+  number: number;
+  /**
+   * Human-readable checkpoint title
+   */
+  title: string;
+  /**
+   * Filename of the checkpoint within the workspace checkpoints directory
+   */
+  filename: string;
+}
+/**
  * Relative path and UTF-8 content for the workspace file to create or overwrite.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -4132,7 +7644,7 @@ export interface WorkspacesCreateFileRequest {
   content: string;
 }
 /**
- * Current workspace metadata for the session, or null when not available.
+ * Current workspace metadata for the session, including its absolute filesystem path when available.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "WorkspacesGetWorkspaceResult".
@@ -4159,6 +7671,22 @@ export interface WorkspacesGetWorkspaceResult {
     mc_last_event_id?: string;
     chronicle_sync_dismissed?: boolean;
   } | null;
+  /**
+   * Absolute filesystem path to the workspace directory. Omitted when the session has no workspace (e.g. remote sessions).
+   */
+  path?: string;
+}
+/**
+ * Workspace checkpoints in chronological order; empty when the workspace is not enabled.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "WorkspacesListCheckpointsResult".
+ */
+export interface WorkspacesListCheckpointsResult {
+  /**
+   * Workspace checkpoints in chronological order. Empty when workspace is not enabled.
+   */
+  checkpoints: WorkspacesCheckpoints[];
 }
 /**
  * Relative paths of files stored in the session workspace files directory.
@@ -4171,6 +7699,30 @@ export interface WorkspacesListFilesResult {
    * Relative file paths in the workspace files directory
    */
   files: string[];
+}
+/**
+ * Checkpoint number to read.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "WorkspacesReadCheckpointRequest".
+ */
+export interface WorkspacesReadCheckpointRequest {
+  /**
+   * Checkpoint number to read
+   */
+  number: number;
+}
+/**
+ * Checkpoint content as a UTF-8 string, or null when the checkpoint or workspace is missing.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "WorkspacesReadCheckpointResult".
+ */
+export interface WorkspacesReadCheckpointResult {
+  /**
+   * Checkpoint content as a UTF-8 string, or null when the checkpoint or workspace is missing
+   */
+  content: string | null;
 }
 /**
  * Relative path of the workspace file to read.
@@ -4197,6 +7749,43 @@ export interface WorkspacesReadFileResult {
   content: string;
 }
 /**
+ * Pasted content to save as a UTF-8 file in the session workspace.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "WorkspacesSaveLargePasteRequest".
+ */
+export interface WorkspacesSaveLargePasteRequest {
+  /**
+   * Pasted content to save as a UTF-8 file
+   */
+  content: string;
+}
+/**
+ * Descriptor for the saved paste file, or null when the workspace is unavailable.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "WorkspacesSaveLargePasteResult".
+ */
+export interface WorkspacesSaveLargePasteResult {
+  /**
+   * Saved-paste descriptor, or null when the workspace is unavailable (e.g. CCA runtime, non-infinite sessions, remote sessions)
+   */
+  saved: {
+    /**
+     * Absolute filesystem path to the saved paste file
+     */
+    filePath: string;
+    /**
+     * Filename within the workspace files directory
+     */
+    filename: string;
+    /**
+     * Size of the saved file in bytes
+     */
+    sizeBytes: number;
+  } | null;
+}
+/**
  * Identifies the target session.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -4217,7 +7806,7 @@ export function createServerRpc(connection: MessageConnection) {
          *
          * @param params Optional message to echo back to the caller.
          *
-         * @returns Server liveness response, including the echoed message, current timestamp, and protocol version.
+         * @returns Server liveness response, including the echoed message, current server timestamp, and protocol version.
          */
         ping: async (params?: PingRequest): Promise<PingResult> => {
             return connection.sendRequest("ping", (params ?? {}));
@@ -4397,6 +7986,195 @@ export function createServerRpc(connection: MessageConnection) {
             connect: async (params?: ConnectRemoteSessionParams): Promise<RemoteSessionConnectionResult> => {
                 return connection.sendRequest("sessions.connect", (params ?? {}));
             },
+            /**
+             * Lists persisted sessions, optionally filtered by working-directory context.
+             *
+             * @param params Optional metadata-load limit and context filter applied to the returned sessions.
+             *
+             * @returns Persisted sessions matching the filter, ordered most-recently-modified first.
+             */
+            list: async (params?: SessionsListRequest): Promise<SessionList> => {
+                return connection.sendRequest("sessions.list", (params ?? {}));
+            },
+            /**
+             * Finds the local session bound to a GitHub task ID, if any.
+             *
+             * @param params GitHub task ID to look up.
+             *
+             * @returns ID of the local session bound to the given GitHub task, or omitted when none.
+             */
+            findByTaskId: async (params: SessionsFindByTaskIDRequest): Promise<SessionsFindByTaskIDResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("sessions.findByTaskId", params);
+            },
+            /**
+             * Resolves a UUID prefix to a unique session ID, if exactly one session matches.
+             *
+             * @param params UUID prefix to resolve to a unique session ID.
+             *
+             * @returns Session ID matching the prefix, omitted when no unique match exists.
+             */
+            findByPrefix: async (params: SessionsFindByPrefixRequest): Promise<SessionsFindByPrefixResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("sessions.findByPrefix", params);
+            },
+            /**
+             * Returns the most-relevant prior session for a given working-directory context.
+             *
+             * @param params Optional working-directory context used to score session relevance.
+             *
+             * @returns Most-relevant session ID for the supplied context, or omitted when no sessions exist.
+             */
+            getLastForContext: async (params?: SessionsGetLastForContextRequest): Promise<SessionsGetLastForContextResult> => {
+                return connection.sendRequest("sessions.getLastForContext", (params ?? {}));
+            },
+            /**
+             * Computes the absolute path to a session's persisted events.jsonl file.
+             *
+             * @param params Session ID whose event-log file path to compute.
+             *
+             * @returns Absolute path to the session's events.jsonl file on disk.
+             */
+            getEventFilePath: async (params?: SessionsGetEventFilePathRequest): Promise<SessionsGetEventFilePathResult> => {
+                return connection.sendRequest("sessions.getEventFilePath", (params ?? {}));
+            },
+            /**
+             * Returns the on-disk byte size of each session's workspace directory.
+             *
+             * @returns Map of sessionId -> on-disk size in bytes for each session's workspace directory.
+             */
+            getSizes: async (): Promise<SessionSizes> => {
+                return connection.sendRequest("sessions.getSizes", {});
+            },
+            /**
+             * Returns the subset of the supplied session IDs that are currently held by another running process.
+             *
+             * @param params Session IDs to test for live in-use locks.
+             *
+             * @returns Session IDs from the input set that are currently in use by another process.
+             */
+            checkInUse: async (params: SessionsCheckInUseRequest): Promise<SessionsCheckInUseResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("sessions.checkInUse", params);
+            },
+            /**
+             * Returns a session's persisted remote-steerable flag, if any has been recorded.
+             *
+             * @param params Session ID to look up the persisted remote-steerable flag for.
+             *
+             * @returns The session's persisted remote-steerable flag, or omitted when no value has been persisted.
+             */
+            getPersistedRemoteSteerable: async (params?: SessionsGetPersistedRemoteSteerableRequest): Promise<SessionsGetPersistedRemoteSteerableResult> => {
+                return connection.sendRequest("sessions.getPersistedRemoteSteerable", (params ?? {}));
+            },
+            /**
+             * Closes a session: emits shutdown, flushes pending events, releases the in-use lock, and disposes the active session.
+             *
+             * @param params Session ID to close.
+             *
+             * @returns Closes a session: emits shutdown, flushes pending events to disk, releases the in-use lock, disposes the active session. Idempotent: succeeds even if the session is not currently active.
+             */
+            close: async (params?: SessionsCloseRequest): Promise<SessionsCloseResult> => {
+                return connection.sendRequest("sessions.close", (params ?? {}));
+            },
+            /**
+             * Closes, deactivates, and deletes a set of sessions, returning the bytes freed per session.
+             *
+             * @param params Session IDs to close, deactivate, and delete from disk.
+             *
+             * @returns Map of sessionId -> bytes freed by removing the session's workspace directory.
+             */
+            bulkDelete: async (params: SessionsBulkDeleteRequest): Promise<SessionBulkDeleteResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("sessions.bulkDelete", params);
+            },
+            /**
+             * Deletes sessions older than the given threshold, with optional dry-run and exclusion list.
+             *
+             * @param params Age threshold and optional flags controlling which old sessions are pruned (or simulated when dryRun is true).
+             *
+             * @returns Outcome of the prune operation: deleted IDs, dry-run candidates, skipped IDs, total bytes freed, and the dry-run flag.
+             */
+            pruneOld: async (params: SessionsPruneOldRequest): Promise<SessionPruneResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("sessions.pruneOld", params);
+            },
+            /**
+             * Flushes a session's pending events to disk.
+             *
+             * @param params Session ID whose pending events should be flushed to disk.
+             *
+             * @returns Flush a session's pending events to disk. No-op when no writer exists for the session (e.g., already closed).
+             */
+            save: async (params?: SessionsSaveRequest): Promise<SessionsSaveResult> => {
+                return connection.sendRequest("sessions.save", (params ?? {}));
+            },
+            /**
+             * Releases the in-use lock held by this process for a session.
+             *
+             * @param params Session ID whose in-use lock should be released.
+             *
+             * @returns Release the in-use lock held by this process for the given session. No-op when this process does not currently hold a lock for the session.
+             */
+            releaseLock: async (params?: SessionsReleaseLockRequest): Promise<SessionsReleaseLockResult> => {
+                return connection.sendRequest("sessions.releaseLock", (params ?? {}));
+            },
+            /**
+             * Backfills missing summary and context fields on the supplied session metadata records.
+             *
+             * @param params Session metadata records to enrich with summary and context information.
+             *
+             * @returns The same metadata records, with summary and context fields backfilled where available.
+             */
+            enrichMetadata: async (params: SessionsEnrichMetadataRequest): Promise<SessionEnrichMetadataResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("sessions.enrichMetadata", params);
+            },
+            /**
+             * Reloads user, plugin, and (optionally) repo hooks on the active session.
+             *
+             * @param params Active session ID and an optional flag for deferring repo-level hooks until folder trust.
+             *
+             * @returns Reload all hooks (user, plugin, optionally repo) and apply them to the active session. Call after installing or removing plugins so their hooks take effect immediately. No-op when no active session matches the given sessionId.
+             */
+            reloadPluginHooks: async (params?: SessionsReloadPluginHooksRequest): Promise<SessionsReloadPluginHooksResult> => {
+                return connection.sendRequest("sessions.reloadPluginHooks", (params ?? {}));
+            },
+            /**
+             * Loads previously-deferred repo-level hooks on the active session, returning queued startup prompts.
+             *
+             * @param params Active session ID whose deferred repo-level hooks should be loaded.
+             *
+             * @returns Queued repo-level startup prompts and the total hook command count after loading.
+             */
+            loadDeferredRepoHooks: async (params?: SessionsLoadDeferredRepoHooksRequest): Promise<SessionLoadDeferredRepoHooksResult> => {
+                return connection.sendRequest("sessions.loadDeferredRepoHooks", (params ?? {}));
+            },
+            /**
+             * Replaces the manager-wide additional plugins registered with the session manager.
+             *
+             * @param params Manager-wide additional plugins to register; replaces any previously-configured set.
+             *
+             * @returns Replace the manager-wide additional plugins. New session creations and subsequent hook reloads see the new set; already-running sessions keep their existing hook installation until the next reload.
+             */
+            setAdditionalPlugins: async (params: SessionsSetAdditionalPluginsRequest): Promise<SessionsSetAdditionalPluginsResult> => {
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("sessions.setAdditionalPlugins", params);
+            },
         },
     };
 }
@@ -4431,6 +8209,40 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
             assertActive?.();
             return connection.sendRequest("session.suspend", { sessionId });
         },
+        /**
+         * Sends a user message to the session and returns its message ID.
+         *
+         * @param params Parameters for sending a user message to the session
+         *
+         * @returns Result of sending a user message
+         */
+        send: async (params: SendRequest): Promise<SendResult> => {
+            assertActive?.();
+            if (params == null) {
+                throw new TypeError("params is required");
+            }
+            return connection.sendRequest("session.send", { sessionId, ...params });
+        },
+        /**
+         * Aborts the current agent turn.
+         *
+         * @param params Parameters for aborting the current turn
+         *
+         * @returns Result of aborting the current turn
+         */
+        abort: async (params?: AbortRequest): Promise<AbortResult> => {
+            assertActive?.();
+            return connection.sendRequest("session.abort", { sessionId, ...params });
+        },
+        /**
+         * Shuts down the session and persists its final state. Awaits any deferred sessionEnd hooks before resolving so user-supplied hook scripts complete before the runtime tears down.
+         *
+         * @param params Parameters for shutting down the session
+         */
+        shutdown: async (params?: ShutdownRequest): Promise<void> => {
+            assertActive?.();
+            return connection.sendRequest("session.shutdown", { sessionId, ...params });
+        },
         auth: {
             /**
              * Gets authentication status and account metadata for the session.
@@ -4441,12 +8253,23 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                 assertActive?.();
                 return connection.sendRequest("session.auth.getStatus", { sessionId });
             },
+            /**
+             * Updates the session's auth credentials used for outbound model and API requests.
+             *
+             * @param params New auth credentials to install on the session. Omit to leave credentials unchanged.
+             *
+             * @returns Indicates whether the credential update succeeded.
+             */
+            setCredentials: async (params?: SessionSetCredentialsParams): Promise<SessionSetCredentialsResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.auth.setCredentials", { sessionId, ...params });
+            },
         },
         model: {
             /**
              * Gets the currently selected model for the session.
              *
-             * @returns The currently selected model for the session.
+             * @returns The currently selected model and reasoning effort for the session.
              */
             getCurrent: async (): Promise<CurrentModel> => {
                 assertActive?.();
@@ -4465,6 +8288,20 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                     throw new TypeError("params is required");
                 }
                 return connection.sendRequest("session.model.switchTo", { sessionId, ...params });
+            },
+            /**
+             * Updates the session's reasoning effort without changing the selected model.
+             *
+             * @param params Reasoning effort level to apply to the currently selected model.
+             *
+             * @returns Update the session's reasoning effort without changing the selected model. Use `switchTo` instead when you also need to change the model. The runtime stores the effort on the session and applies it to subsequent turns.
+             */
+            setReasoningEffort: async (params: ModelSetReasoningEffortRequest): Promise<ModelSetReasoningEffortResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.model.setReasoningEffort", { sessionId, ...params });
             },
         },
         mode: {
@@ -4512,6 +8349,20 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                 }
                 return connection.sendRequest("session.name.set", { sessionId, ...params });
             },
+            /**
+             * Persists an auto-generated session summary as the session's name when no user-set name exists.
+             *
+             * @param params Auto-generated session summary to apply as the session's name when no user-set name exists.
+             *
+             * @returns Indicates whether the auto-generated summary was applied as the session's name.
+             */
+            setAuto: async (params: NameSetAutoRequest): Promise<NameSetAutoResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.name.setAuto", { sessionId, ...params });
+            },
         },
         plan: {
             /**
@@ -4547,7 +8398,7 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
             /**
              * Gets current workspace metadata for the session.
              *
-             * @returns Current workspace metadata for the session, or null when not available.
+             * @returns Current workspace metadata for the session, including its absolute filesystem path when available.
              */
             getWorkspace: async (): Promise<WorkspacesGetWorkspaceResult> => {
                 assertActive?.();
@@ -4587,6 +8438,43 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                     throw new TypeError("params is required");
                 }
                 return connection.sendRequest("session.workspaces.createFile", { sessionId, ...params });
+            },
+            /**
+             * Lists workspace checkpoints in chronological order.
+             *
+             * @returns Workspace checkpoints in chronological order; empty when the workspace is not enabled.
+             */
+            listCheckpoints: async (): Promise<WorkspacesListCheckpointsResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.workspaces.listCheckpoints", { sessionId });
+            },
+            /**
+             * Reads the content of a workspace checkpoint by number.
+             *
+             * @param params Checkpoint number to read.
+             *
+             * @returns Checkpoint content as a UTF-8 string, or null when the checkpoint or workspace is missing.
+             */
+            readCheckpoint: async (params: WorkspacesReadCheckpointRequest): Promise<WorkspacesReadCheckpointResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.workspaces.readCheckpoint", { sessionId, ...params });
+            },
+            /**
+             * Saves pasted content as a UTF-8 file in the session workspace.
+             *
+             * @param params Pasted content to save as a UTF-8 file in the session workspace.
+             *
+             * @returns Descriptor for the saved paste file, or null when the workspace is unavailable.
+             */
+            saveLargePaste: async (params: WorkspacesSaveLargePasteRequest): Promise<WorkspacesSaveLargePasteResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.workspaces.saveLargePaste", { sessionId, ...params });
             },
         },
         instructions: {
@@ -4691,6 +8579,47 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                 return connection.sendRequest("session.tasks.list", { sessionId });
             },
             /**
+             * Refreshes metadata for any detached background shells the runtime knows about.
+             *
+             * @returns Refresh metadata for any detached background shells the runtime knows about. Use after a long pause to pick up exit/output state for shells running outside the agent loop.
+             */
+            refresh: async (): Promise<TasksRefreshResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.tasks.refresh", { sessionId });
+            },
+            /**
+             * Waits for all in-flight background tasks and any follow-up turns to settle.
+             *
+             * @returns Wait until all in-flight background tasks (agents + shells) and any follow-up turns scheduled by their completions have settled. Returns when the runtime is fully drained or after an internal timeout (default 10 minutes; configurable via COPILOT_TASK_WAIT_TIMEOUT_SECONDS).
+             */
+            waitForPending: async (): Promise<TasksWaitForPendingResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.tasks.waitForPending", { sessionId });
+            },
+            /**
+             * Returns progress information for a background task by ID.
+             *
+             * @param params Identifier of the background task to fetch progress for.
+             *
+             * @returns Progress information for the task, or null when no task with that ID is tracked.
+             */
+            getProgress: async (params: TasksGetProgressRequest): Promise<TasksGetProgressResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.tasks.getProgress", { sessionId, ...params });
+            },
+            /**
+             * Returns the first sync-waiting task that can currently be promoted to background mode.
+             *
+             * @returns The first sync-waiting task that can currently be promoted to background mode.
+             */
+            getCurrentPromotable: async (): Promise<TasksGetCurrentPromotableResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.tasks.getCurrentPromotable", { sessionId });
+            },
+            /**
              * Promotes an eligible synchronously-waited task so it continues running in the background.
              *
              * @param params Identifier of the task to promote to background mode.
@@ -4703,6 +8632,15 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                     throw new TypeError("params is required");
                 }
                 return connection.sendRequest("session.tasks.promoteToBackground", { sessionId, ...params });
+            },
+            /**
+             * Atomically promotes the first promotable sync-waiting task to background mode and returns it.
+             *
+             * @returns The promoted task as it now exists in background mode, omitted if no promotable task was waiting.
+             */
+            promoteCurrentToBackground: async (): Promise<TasksPromoteCurrentToBackgroundResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.tasks.promoteCurrentToBackground", { sessionId });
             },
             /**
              * Cancels a background task.
@@ -4759,6 +8697,15 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                 return connection.sendRequest("session.skills.list", { sessionId });
             },
             /**
+             * Returns the skills that have been invoked during this session.
+             *
+             * @returns Skills invoked during this session, ordered by invocation time (most recent last).
+             */
+            getInvoked: async (): Promise<SkillsGetInvokedResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.skills.getInvoked", { sessionId });
+            },
+            /**
              * Enables a skill for the session.
              *
              * @param params Name of the skill to enable for the session.
@@ -4790,6 +8737,13 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
             reload: async (): Promise<SkillsLoadDiagnostics> => {
                 assertActive?.();
                 return connection.sendRequest("session.skills.reload", { sessionId });
+            },
+            /**
+             * Ensures the session's skill definitions have been loaded from disk.
+             */
+            ensureLoaded: async (): Promise<void> => {
+                assertActive?.();
+                return connection.sendRequest("session.skills.ensureLoaded", { sessionId });
             },
         },
         /** @experimental */
@@ -4834,6 +8788,57 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                 assertActive?.();
                 return connection.sendRequest("session.mcp.reload", { sessionId });
             },
+            /**
+             * Runs an MCP sampling inference on behalf of an MCP server.
+             *
+             * @param params Identifiers and raw MCP CreateMessageRequest params used to run a sampling inference.
+             *
+             * @returns Outcome of an MCP sampling execution: success result, failure error, or cancellation.
+             */
+            executeSampling: async (params: McpExecuteSamplingParams): Promise<McpSamplingExecutionResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.mcp.executeSampling", { sessionId, ...params });
+            },
+            /**
+             * Cancels an in-flight MCP sampling execution by request ID.
+             *
+             * @param params The requestId previously passed to executeSampling that should be cancelled.
+             *
+             * @returns Indicates whether an in-flight sampling execution with the given requestId was found and cancelled.
+             */
+            cancelSamplingExecution: async (params: McpCancelSamplingExecutionParams): Promise<McpCancelSamplingExecutionResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.mcp.cancelSamplingExecution", { sessionId, ...params });
+            },
+            /**
+             * Sets how environment-variable values supplied to MCP servers are resolved (direct or indirect).
+             *
+             * @param params Mode controlling how MCP server env values are resolved (`direct` or `indirect`).
+             *
+             * @returns Env-value mode recorded on the session after the update.
+             */
+            setEnvValueMode: async (params: McpSetEnvValueModeParams): Promise<McpSetEnvValueModeResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.mcp.setEnvValueMode", { sessionId, ...params });
+            },
+            /**
+             * Removes the auto-managed `github` MCP server when present.
+             *
+             * @returns Indicates whether the auto-managed `github` MCP server was removed (false when nothing to remove).
+             */
+            removeGitHub: async (): Promise<McpRemoveGitHubResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.mcp.removeGitHub", { sessionId });
+            },
             /** @experimental */
             oauth: {
                 /**
@@ -4862,6 +8867,32 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
             list: async (): Promise<PluginList> => {
                 assertActive?.();
                 return connection.sendRequest("session.plugins.list", { sessionId });
+            },
+        },
+        /** @experimental */
+        options: {
+            /**
+             * Patches the genuinely-mutable subset of session options.
+             *
+             * @param params Patch of mutable session options to apply to the running session.
+             *
+             * @returns Indicates whether the session options patch was applied successfully.
+             */
+            update: async (params?: SessionUpdateOptionsParams): Promise<SessionUpdateOptionsResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.options.update", { sessionId, ...params });
+            },
+        },
+        /** @experimental */
+        lsp: {
+            /**
+             * Loads the merged LSP configuration set for the session's working directory.
+             *
+             * @param params Parameters for (re)loading the merged LSP configuration set.
+             */
+            initialize: async (params?: LspInitializeRequest): Promise<void> => {
+                assertActive?.();
+                return connection.sendRequest("session.lsp.initialize", { sessionId, ...params });
             },
         },
         /** @experimental */
@@ -4922,6 +8953,15 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                 }
                 return connection.sendRequest("session.tools.handlePendingToolCall", { sessionId, ...params });
             },
+            /**
+             * Resolves, builds, and validates the runtime tool list for the session.
+             *
+             * @returns Resolve, build, and validate the runtime tool list for this session. Subagent sessions and consumer flows that need an initialized tool set before `send` invoke this. Default base-class implementation is a no-op for sessions that don't support tool validation.
+             */
+            initializeAndValidate: async (): Promise<ToolsInitializeAndValidateResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.tools.initializeAndValidate", { sessionId });
+            },
         },
         commands: {
             /**
@@ -4964,11 +9004,39 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                 return connection.sendRequest("session.commands.handlePendingCommand", { sessionId, ...params });
             },
             /**
-             * Responds to a queued command request from the session.
+             * Executes a slash command synchronously and returns any error.
              *
-             * @param params Queued command request ID and the result indicating whether the client handled it.
+             * @param params Slash command name and argument string to execute synchronously.
              *
-             * @returns Indicates whether the queued-command response was accepted by the session.
+             * @returns Error message produced while executing the command, if any.
+             */
+            execute: async (params: ExecuteCommandParams): Promise<ExecuteCommandResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.commands.execute", { sessionId, ...params });
+            },
+            /**
+             * Enqueues a slash command for FIFO processing on the local session.
+             *
+             * @param params Slash-prefixed command string to enqueue for FIFO processing.
+             *
+             * @returns Indicates whether the command was accepted into the local execution queue.
+             */
+            enqueue: async (params: EnqueueCommandParams): Promise<EnqueueCommandResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.commands.enqueue", { sessionId, ...params });
+            },
+            /**
+             * Reports whether the host actually executed a queued command and whether to continue processing.
+             *
+             * @param params Queued-command request ID and the result indicating whether the host executed it (and whether to stop processing further queued commands).
+             *
+             * @returns Indicates whether the queued-command response was matched to a pending request.
              */
             respondToQueuedCommand: async (params: CommandsRespondToQueuedCommandRequest): Promise<CommandsRespondToQueuedCommandResult> => {
                 assertActive?.();
@@ -4976,6 +9044,21 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                     throw new TypeError("params is required");
                 }
                 return connection.sendRequest("session.commands.respondToQueuedCommand", { sessionId, ...params });
+            },
+        },
+        /** @experimental */
+        telemetry: {
+            /**
+             * Sets feature override key/value pairs to attach to subsequent telemetry events for the session.
+             *
+             * @param params Feature override key/value pairs to attach to subsequent telemetry events from this session.
+             */
+            setFeatureOverrides: async (params: TelemetrySetFeatureOverridesRequest): Promise<void> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.telemetry.setFeatureOverrides", { sessionId, ...params });
             },
         },
         ui: {
@@ -5007,8 +9090,98 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                 }
                 return connection.sendRequest("session.ui.handlePendingElicitation", { sessionId, ...params });
             },
+            /**
+             * Resolves a pending `user_input.requested` event with the user's response.
+             *
+             * @param params Request ID of a pending `user_input.requested` event and the user's response.
+             *
+             * @returns Indicates whether the pending UI request was resolved by this call.
+             */
+            handlePendingUserInput: async (params: UIHandlePendingUserInputRequest): Promise<UIHandlePendingResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.ui.handlePendingUserInput", { sessionId, ...params });
+            },
+            /**
+             * Resolves a pending `sampling.requested` event with a sampling result, or rejects it.
+             *
+             * @param params Request ID of a pending `sampling.requested` event and an optional sampling result payload (omit to reject).
+             *
+             * @returns Indicates whether the pending UI request was resolved by this call.
+             */
+            handlePendingSampling: async (params: UIHandlePendingSamplingRequest): Promise<UIHandlePendingResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.ui.handlePendingSampling", { sessionId, ...params });
+            },
+            /**
+             * Resolves a pending `auto_mode_switch.requested` event with the user's accept/decline decision.
+             *
+             * @param params Request ID of a pending `auto_mode_switch.requested` event and the user's response.
+             *
+             * @returns Indicates whether the pending UI request was resolved by this call.
+             */
+            handlePendingAutoModeSwitch: async (params: UIHandlePendingAutoModeSwitchRequest): Promise<UIHandlePendingResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.ui.handlePendingAutoModeSwitch", { sessionId, ...params });
+            },
+            /**
+             * Resolves a pending `exit_plan_mode.requested` event with the user's response.
+             *
+             * @param params Request ID of a pending `exit_plan_mode.requested` event and the user's response.
+             *
+             * @returns Indicates whether the pending UI request was resolved by this call.
+             */
+            handlePendingExitPlanMode: async (params: UIHandlePendingExitPlanModeRequest): Promise<UIHandlePendingResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.ui.handlePendingExitPlanMode", { sessionId, ...params });
+            },
+            /**
+             * Registers an in-process handler for auto-mode-switch requests so the server bridge skips dispatch.
+             *
+             * @returns Register an in-process handler for `auto_mode_switch.requested` events. The caller still attaches the actual listener via the standard event-subscription mechanism; this registration solely tells the server bridge to skip its own dispatch (so a remote client doesn't race the in-process handler for the same requestId).
+             */
+            registerDirectAutoModeSwitchHandler: async (): Promise<UIRegisterDirectAutoModeSwitchHandlerResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.ui.registerDirectAutoModeSwitchHandler", { sessionId });
+            },
+            /**
+             * Unregisters a previously-registered in-process auto-mode-switch handler by its opaque handle.
+             *
+             * @param params Opaque handle previously returned by `registerDirectAutoModeSwitchHandler` to release.
+             *
+             * @returns Indicates whether the handle was active and the registration count was decremented.
+             */
+            unregisterDirectAutoModeSwitchHandler: async (params: UIUnregisterDirectAutoModeSwitchHandlerRequest): Promise<UIUnregisterDirectAutoModeSwitchHandlerResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.ui.unregisterDirectAutoModeSwitchHandler", { sessionId, ...params });
+            },
         },
         permissions: {
+            /**
+             * Replaces selected permission policy fields (rules, paths, URLs, exclusions, allow-all flags) on the session.
+             *
+             * @param params Patch of permission policy fields to apply (omit a field to leave it unchanged).
+             *
+             * @returns Indicates whether the operation succeeded.
+             */
+            configure: async (params?: PermissionsConfigureParams): Promise<PermissionsConfigureResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.permissions.configure", { sessionId, ...params });
+            },
             /**
              * Provides a decision for a pending tool permission request.
              *
@@ -5024,9 +9197,18 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                 return connection.sendRequest("session.permissions.handlePendingPermissionRequest", { sessionId, ...params });
             },
             /**
+             * Reconstructs the set of pending tool permission requests from the session's event history.
+             *
+             * @returns List of pending permission requests reconstructed from event history.
+             */
+            pendingRequests: async (): Promise<PendingPermissionRequestList> => {
+                assertActive?.();
+                return connection.sendRequest("session.permissions.pendingRequests", { sessionId });
+            },
+            /**
              * Enables or disables automatic approval of tool permission requests for the session.
              *
-             * @param params Whether to auto-approve all tool permission requests for the rest of the session.
+             * @param params Allow-all toggle for tool permission requests, with an optional telemetry source.
              *
              * @returns Indicates whether the operation succeeded.
              */
@@ -5038,6 +9220,34 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                 return connection.sendRequest("session.permissions.setApproveAll", { sessionId, ...params });
             },
             /**
+             * Adds or removes session-scoped or location-scoped permission rules.
+             *
+             * @param params Scope and add/remove instructions for modifying session- or location-scoped permission rules.
+             *
+             * @returns Indicates whether the operation succeeded.
+             */
+            modifyRules: async (params: PermissionsModifyRulesParams): Promise<PermissionsModifyRulesResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.permissions.modifyRules", { sessionId, ...params });
+            },
+            /**
+             * Sets whether the client wants permission prompts bridged into session events.
+             *
+             * @param params Toggles whether permission prompts should be bridged into session events for this client.
+             *
+             * @returns Indicates whether the operation succeeded.
+             */
+            setRequired: async (params: PermissionsSetRequiredRequest): Promise<PermissionsSetRequiredResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.permissions.setRequired", { sessionId, ...params });
+            },
+            /**
              * Clears session-scoped tool permission approvals.
              *
              * @returns Indicates whether the operation succeeded.
@@ -5046,11 +9256,108 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                 assertActive?.();
                 return connection.sendRequest("session.permissions.resetSessionApprovals", { sessionId });
             },
+            /**
+             * Notifies the runtime that a permission prompt UI has been shown to the user.
+             *
+             * @param params Notification payload describing the permission prompt that the client just rendered.
+             *
+             * @returns Indicates whether the operation succeeded.
+             */
+            notifyPromptShown: async (params: PermissionPromptShownNotification): Promise<PermissionsNotifyPromptShownResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.permissions.notifyPromptShown", { sessionId, ...params });
+            },
+            paths: {
+                /**
+                 * Returns the session's allowed directories and primary working directory.
+                 *
+                 * @returns Snapshot of the session's allow-listed directories and primary working directory.
+                 */
+                list: async (): Promise<PermissionPathsList> => {
+                    assertActive?.();
+                    return connection.sendRequest("session.permissions.paths.list", { sessionId });
+                },
+                /**
+                 * Adds a directory to the session's allow-list.
+                 *
+                 * @param params Directory path to add to the session's allowed directories.
+                 *
+                 * @returns Indicates whether the operation succeeded.
+                 */
+                add: async (params: PermissionPathsAddParams): Promise<PermissionsPathsAddResult> => {
+                    assertActive?.();
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("session.permissions.paths.add", { sessionId, ...params });
+                },
+                /**
+                 * Updates the session's primary working directory used by the permission policy.
+                 *
+                 * @param params Directory path to set as the session's new primary working directory.
+                 *
+                 * @returns Indicates whether the operation succeeded.
+                 */
+                updatePrimary: async (params: PermissionPathsUpdatePrimaryParams): Promise<PermissionsPathsUpdatePrimaryResult> => {
+                    assertActive?.();
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("session.permissions.paths.updatePrimary", { sessionId, ...params });
+                },
+                /**
+                 * Reports whether a path falls within any of the session's allowed directories.
+                 *
+                 * @param params Path to evaluate against the session's allowed directories.
+                 *
+                 * @returns Indicates whether the supplied path is within the session's allowed directories.
+                 */
+                isPathWithinAllowedDirectories: async (params: PermissionPathsAllowedCheckParams): Promise<PermissionPathsAllowedCheckResult> => {
+                    assertActive?.();
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("session.permissions.paths.isPathWithinAllowedDirectories", { sessionId, ...params });
+                },
+                /**
+                 * Reports whether a path falls within the session's workspace (primary) directory.
+                 *
+                 * @param params Path to evaluate against the session's workspace (primary) directory.
+                 *
+                 * @returns Indicates whether the supplied path is within the session's workspace directory.
+                 */
+                isPathWithinWorkspace: async (params: PermissionPathsWorkspaceCheckParams): Promise<PermissionPathsWorkspaceCheckResult> => {
+                    assertActive?.();
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("session.permissions.paths.isPathWithinWorkspace", { sessionId, ...params });
+                },
+            },
+            urls: {
+                /**
+                 * Toggles the runtime's URL-permission policy between unrestricted and restricted modes.
+                 *
+                 * @param params Whether the URL-permission policy should run in unrestricted mode.
+                 *
+                 * @returns Indicates whether the operation succeeded.
+                 */
+                setUnrestrictedMode: async (params: PermissionUrlsSetUnrestrictedModeParams): Promise<PermissionsUrlsSetUnrestrictedModeResult> => {
+                    assertActive?.();
+                    if (params == null) {
+                        throw new TypeError("params is required");
+                    }
+                    return connection.sendRequest("session.permissions.urls.setUnrestrictedMode", { sessionId, ...params });
+                },
+            },
         },
         /**
          * Emits a user-visible session log event.
          *
-         * @param params Message text, optional severity level, persistence flag, and optional follow-up URL.
+         * @param params Message text, optional severity level, persistence flag, optional follow-up URL, and optional tip.
          *
          * @returns Identifier of the session event that was emitted for the log message.
          */
@@ -5060,6 +9367,83 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                 throw new TypeError("params is required");
             }
             return connection.sendRequest("session.log", { sessionId, ...params });
+        },
+        /** @experimental */
+        metadata: {
+            /**
+             * Returns a snapshot of the session's identifying metadata, mode, agent, and remote info.
+             *
+             * @returns Point-in-time snapshot of slow-changing session identifier and state fields
+             */
+            snapshot: async (): Promise<SessionMetadataSnapshot> => {
+                assertActive?.();
+                return connection.sendRequest("session.metadata.snapshot", { sessionId });
+            },
+            /**
+             * Reports whether the local session is currently processing user/agent messages.
+             *
+             * @returns Indicates whether the local session is currently processing a turn or background continuation.
+             */
+            isProcessing: async (): Promise<MetadataIsProcessingResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.metadata.isProcessing", { sessionId });
+            },
+            /**
+             * Returns the token breakdown for the session's current context window for a given model.
+             *
+             * @param params Model identifier and token limits used to compute the context-info breakdown.
+             *
+             * @returns Token breakdown for the session's current context window, or null if uninitialized.
+             */
+            contextInfo: async (params: MetadataContextInfoRequest): Promise<MetadataContextInfoResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.metadata.contextInfo", { sessionId, ...params });
+            },
+            /**
+             * Records a working-directory/git context change and emits a `session.context_changed` event.
+             *
+             * @param params Updated working-directory/git context to record on the session.
+             *
+             * @returns Notify the session that its working directory context has changed. Emits a `session.context_changed` event so consumers (telemetry, OTel tracker, ACP, the timeline UI) can react. Use this when the host has detected a cwd/branch/repo change outside the session's normal lifecycle (e.g., after a shell command in interactive mode).
+             */
+            recordContextChange: async (params: MetadataRecordContextChangeRequest): Promise<MetadataRecordContextChangeResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.metadata.recordContextChange", { sessionId, ...params });
+            },
+            /**
+             * Updates the session's recorded working directory.
+             *
+             * @param params Absolute path to set as the session's new working directory.
+             *
+             * @returns Update the session's working directory. Used by the host when the user explicitly changes cwd (e.g., the `/cd` slash command). The host is responsible for `process.chdir` and any related side-effects (file index, etc.); this method only updates the session's own recorded path.
+             */
+            setWorkingDirectory: async (params: MetadataSetWorkingDirectoryRequest): Promise<MetadataSetWorkingDirectoryResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.metadata.setWorkingDirectory", { sessionId, ...params });
+            },
+            /**
+             * Re-tokenizes the session's existing messages against a model and returns aggregate token totals.
+             *
+             * @param params Model identifier to use when re-tokenizing the session's existing messages.
+             *
+             * @returns Re-tokenize the session's existing messages against `modelId` and return the token totals. Useful for hosts that want an initial estimate of context usage on session resume, before the next agent turn fires `session.context_info_changed` events. Returns zeros for an empty session.
+             */
+            recomputeContextTokens: async (params: MetadataRecomputeContextTokensRequest): Promise<MetadataRecomputeContextTokensResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.metadata.recomputeContextTokens", { sessionId, ...params });
+            },
         },
         shell: {
             /**
@@ -5096,7 +9480,7 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
             /**
              * Compacts the session history to reduce context usage.
              *
-             * @returns Compaction outcome with the number of tokens and messages removed and the resulting context window breakdown.
+             * @returns Compaction outcome with the number of tokens and messages removed, summary text, and the resulting context window breakdown.
              */
             compact: async (): Promise<HistoryCompactResult> => {
                 assertActive?.();
@@ -5115,6 +9499,112 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                     throw new TypeError("params is required");
                 }
                 return connection.sendRequest("session.history.truncate", { sessionId, ...params });
+            },
+            /**
+             * Cancels any in-progress background compaction on a local session.
+             *
+             * @returns Indicates whether an in-progress background compaction was cancelled.
+             */
+            cancelBackgroundCompaction: async (): Promise<HistoryCancelBackgroundCompactionResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.history.cancelBackgroundCompaction", { sessionId });
+            },
+            /**
+             * Aborts any in-progress manual compaction on a local session.
+             *
+             * @returns Indicates whether an in-progress manual compaction was aborted.
+             */
+            abortManualCompaction: async (): Promise<HistoryAbortManualCompactionResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.history.abortManualCompaction", { sessionId });
+            },
+            /**
+             * Produces a markdown summary of the session's conversation context for hand-off scenarios.
+             *
+             * @returns Markdown summary of the conversation context (empty when not available).
+             */
+            summarizeForHandoff: async (): Promise<HistorySummarizeForHandoffResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.history.summarizeForHandoff", { sessionId });
+            },
+        },
+        /** @experimental */
+        queue: {
+            /**
+             * Returns the local session's pending user-facing queued items and steering messages.
+             *
+             * @returns Snapshot of the session's pending queued items and immediate-steering messages.
+             */
+            pendingItems: async (): Promise<QueuePendingItemsResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.queue.pendingItems", { sessionId });
+            },
+            /**
+             * Removes the most recently queued user-facing item (LIFO).
+             *
+             * @returns Indicates whether a user-facing pending item was removed.
+             */
+            removeMostRecent: async (): Promise<QueueRemoveMostRecentResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.queue.removeMostRecent", { sessionId });
+            },
+            /**
+             * Clears all pending queued items on the local session.
+             */
+            clear: async (): Promise<void> => {
+                assertActive?.();
+                return connection.sendRequest("session.queue.clear", { sessionId });
+            },
+        },
+        /** @experimental */
+        eventLog: {
+            /**
+             * Reads a batch of session events from a cursor, optionally waiting for new events.
+             *
+             * @param params Cursor, batch size, and optional long-poll/filter parameters for reading session events.
+             *
+             * @returns Batch of session events returned by a read, with cursor and continuation metadata.
+             */
+            read: async (params?: EventLogReadRequest): Promise<EventsReadResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.eventLog.read", { sessionId, ...params });
+            },
+            /**
+             * Returns a snapshot of the current tail cursor without consuming events.
+             *
+             * @returns Snapshot of the current tail cursor without returning any events. Use this when a consumer wants to subscribe to live events going forward without first paginating through the entire persisted history (which would happen if `read` were called without a cursor on a long-lived session).
+             */
+            tail: async (): Promise<EventLogTailResult> => {
+                assertActive?.();
+                return connection.sendRequest("session.eventLog.tail", { sessionId });
+            },
+            /**
+             * Registers consumer interest in an event type for runtime gating purposes.
+             *
+             * @param params Event type to register consumer interest for, used by runtime gating logic.
+             *
+             * @returns Opaque handle representing an event-type interest registration.
+             */
+            registerInterest: async (params: RegisterEventInterestParams): Promise<RegisterEventInterestResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.eventLog.registerInterest", { sessionId, ...params });
+            },
+            /**
+             * Releases a consumer's previously-registered interest in an event type.
+             *
+             * @param params Opaque handle previously returned by `registerInterest` to release.
+             *
+             * @returns Indicates whether the operation succeeded.
+             */
+            releaseInterest: async (params: ReleaseEventInterestParams): Promise<EventLogReleaseInterestResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.eventLog.releaseInterest", { sessionId, ...params });
             },
         },
         /** @experimental */
@@ -5148,6 +9638,46 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
             disable: async (): Promise<void> => {
                 assertActive?.();
                 return connection.sendRequest("session.remote.disable", { sessionId });
+            },
+            /**
+             * Persists a remote-steerability change emitted by the host as a session event.
+             *
+             * @param params New remote-steerability state to persist as a `session.remote_steerable_changed` event.
+             *
+             * @returns Persist a steerability change as a `session.remote_steerable_changed` event. Used by the host (CLI / SDK consumer) when it has just finished enabling or disabling steering on a remote exporter that the runtime does not directly own.
+             */
+            notifySteerableChanged: async (params: RemoteNotifySteerableChangedRequest): Promise<RemoteNotifySteerableChangedResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.remote.notifySteerableChanged", { sessionId, ...params });
+            },
+        },
+        /** @experimental */
+        schedule: {
+            /**
+             * Lists the session's currently active scheduled prompts.
+             *
+             * @returns Snapshot of the currently active recurring prompts for this session.
+             */
+            list: async (): Promise<ScheduleList> => {
+                assertActive?.();
+                return connection.sendRequest("session.schedule.list", { sessionId });
+            },
+            /**
+             * Removes a scheduled prompt by id.
+             *
+             * @param params Identifier of the scheduled prompt to remove.
+             *
+             * @returns Remove a scheduled prompt by id. The result entry is omitted if the id was unknown.
+             */
+            stop: async (params: ScheduleStopRequest): Promise<ScheduleStopResult> => {
+                assertActive?.();
+                if (params == null) {
+                    throw new TypeError("params is required");
+                }
+                return connection.sendRequest("session.schedule.stop", { sessionId, ...params });
             },
         },
     };

--- a/nodejs/src/generated/session-events.ts
+++ b/nodejs/src/generated/session-events.ts
@@ -1791,7 +1791,7 @@ export interface UserMessageData {
    */
   isAutopilotContinuation?: boolean;
   /**
-   * Path-backed native document attachments that stayed on the tagged_files path flow because native upload would exceed the request size limit
+   * Path-backed native document attachments that stayed on the tagged_files path flow because native upload could not read them or would exceed the request size limit
    */
   nativeDocumentPathFallbackPaths?: string[];
   /**
@@ -2623,7 +2623,7 @@ export interface AssistantUsageQuotaSnapshot {
    */
   overageAllowedWithExhaustedQuota: boolean;
   /**
-   * Percentage of quota remaining (0.0 to 1.0)
+   * Percentage of quota remaining (0 to 100)
    */
   remainingPercentage: number;
   /**
@@ -4721,7 +4721,7 @@ export interface PermissionDeniedByRules {
  */
 export interface PermissionRule {
   /**
-   * Optional rule argument matched against the request
+   * Argument value matched against the request, or null when the rule kind has no argument (e.g. 'read', 'write', 'memory').
    */
   argument: string | null;
   /**

--- a/nodejs/src/generated/session-events.ts
+++ b/nodejs/src/generated/session-events.ts
@@ -1791,7 +1791,7 @@ export interface UserMessageData {
    */
   isAutopilotContinuation?: boolean;
   /**
-   * Path-backed native document attachments that stayed on the tagged_files path flow because native upload could not read them or would exceed the request size limit
+   * Path-backed native document attachments that stayed on the tagged_files path flow because native upload would exceed the request size limit
    */
   nativeDocumentPathFallbackPaths?: string[];
   /**
@@ -2623,7 +2623,7 @@ export interface AssistantUsageQuotaSnapshot {
    */
   overageAllowedWithExhaustedQuota: boolean;
   /**
-   * Percentage of quota remaining (0 to 100)
+   * Percentage of quota remaining (0.0 to 1.0)
    */
   remainingPercentage: number;
   /**
@@ -4721,7 +4721,7 @@ export interface PermissionDeniedByRules {
  */
 export interface PermissionRule {
   /**
-   * Argument value matched against the request, or null when the rule kind has no argument (e.g. 'read', 'write', 'memory').
+   * Optional rule argument matched against the request
    */
   argument: string | null;
   /**

--- a/nodejs/src/session.ts
+++ b/nodejs/src/session.ts
@@ -97,6 +97,9 @@ export class CopilotSession {
     private _rpc: ReturnType<typeof createSessionRpc> | null = null;
     private traceContextProvider?: TraceContextProvider;
     private _capabilities: SessionCapabilities = {};
+    private disconnected = false;
+    private disconnectPromise?: Promise<void>;
+    private readonly onDisconnected?: (session: CopilotSession) => void;
 
     /** @internal Client session API handlers, populated by CopilotClient during create/resume. */
     clientSessionApis: ClientSessionApiHandlers = {};
@@ -114,17 +117,22 @@ export class CopilotSession {
         public readonly sessionId: string,
         private connection: MessageConnection,
         private _workspacePath?: string,
-        traceContextProvider?: TraceContextProvider
+        traceContextProvider?: TraceContextProvider,
+        onDisconnected?: (session: CopilotSession) => void
     ) {
         this.traceContextProvider = traceContextProvider;
+        this.onDisconnected = onDisconnected;
     }
 
     /**
      * Typed session-scoped RPC methods.
      */
     get rpc(): ReturnType<typeof createSessionRpc> {
+        this.assertActive();
         if (!this._rpc) {
-            this._rpc = createSessionRpc(this.connection, this.sessionId);
+            this._rpc = createSessionRpc(this.connection, this.sessionId, () =>
+                this.assertActive()
+            );
         }
         return this._rpc;
     }
@@ -159,6 +167,7 @@ export class CopilotSession {
      * ```
      */
     get ui(): SessionUiApi {
+        this.assertActive();
         return {
             elicitation: (params: ElicitationParams) => this._elicitation(params),
             confirm: (message: string) => this._confirm(message),
@@ -186,6 +195,7 @@ export class CopilotSession {
      * ```
      */
     async send(options: MessageOptions): Promise<string> {
+        this.assertActive();
         const response = await this.connection.sendRequest("session.send", {
             ...(await getTraceContext(this.traceContextProvider)),
             sessionId: this.sessionId,
@@ -225,6 +235,7 @@ export class CopilotSession {
         options: MessageOptions,
         timeout?: number
     ): Promise<AssistantMessageEvent | undefined> {
+        this.assertActive();
         const effectiveTimeout = timeout ?? 60_000;
 
         let resolveIdle: () => void;
@@ -328,6 +339,7 @@ export class CopilotSession {
         eventTypeOrHandler: K | SessionEventHandler,
         handler?: TypedSessionEventHandler<K>
     ): () => void {
+        this.assertActive();
         // Overload 1: on(eventType, handler) - typed event subscription
         if (typeof eventTypeOrHandler === "string" && handler) {
             const eventType = eventTypeOrHandler;
@@ -720,7 +732,14 @@ export class CopilotSession {
         this._capabilities = capabilities ?? {};
     }
 
+    private assertActive(): void {
+        if (this.disconnected) {
+            throw new Error("Session has been disconnected.");
+        }
+    }
+
     private assertElicitation(): void {
+        this.assertActive();
         if (!this._capabilities.ui?.elicitation) {
             throw new Error(
                 "Elicitation is not supported by the host. " +
@@ -992,6 +1011,7 @@ export class CopilotSession {
      * ```
      */
     async getMessages(): Promise<SessionEvent[]> {
+        this.assertActive();
         const response = await this.connection.sendRequest("session.getMessages", {
             sessionId: this.sessionId,
         });
@@ -1021,17 +1041,48 @@ export class CopilotSession {
      * ```
      */
     async disconnect(): Promise<void> {
-        await this.connection.sendRequest("session.destroy", {
-            sessionId: this.sessionId,
-        });
+        if (this.disconnected) {
+            return;
+        }
+        if (!this.disconnectPromise) {
+            this.disconnectPromise = this.disconnectCore();
+        }
+        await this.disconnectPromise;
+    }
+
+    private async disconnectCore(): Promise<void> {
+        try {
+            await this.connection.sendRequest("session.destroy", {
+                sessionId: this.sessionId,
+            });
+        } finally {
+            this.markDisconnected();
+        }
+    }
+
+    /** @internal Marks the session unusable after client-side forced cleanup. */
+    _markDisconnected(): void {
+        this.markDisconnected();
+    }
+
+    private markDisconnected(): void {
+        if (this.disconnected) {
+            return;
+        }
+        this.disconnected = true;
+        this._rpc = null;
         this.eventHandlers.clear();
         this.typedEventHandlers.clear();
         this.toolHandlers.clear();
+        this.commandHandlers.clear();
         this.permissionHandler = undefined;
         this.userInputHandler = undefined;
         this.elicitationHandler = undefined;
         this.exitPlanModeHandler = undefined;
         this.autoModeSwitchHandler = undefined;
+        this.hooks = undefined;
+        this.transformCallbacks = undefined;
+        this.onDisconnected?.(this);
     }
 
     /**
@@ -1073,6 +1124,7 @@ export class CopilotSession {
      * ```
      */
     async abort(): Promise<void> {
+        this.assertActive();
         await this.connection.sendRequest("session.abort", {
             sessionId: this.sessionId,
         });
@@ -1098,6 +1150,7 @@ export class CopilotSession {
             modelCapabilities?: ModelCapabilitiesOverride;
         }
     ): Promise<void> {
+        this.assertActive();
         await this.rpc.model.switchTo({ modelId: model, ...options });
     }
 
@@ -1121,6 +1174,7 @@ export class CopilotSession {
         message: string,
         options?: { level?: "info" | "warning" | "error"; ephemeral?: boolean }
     ): Promise<void> {
+        this.assertActive();
         await this.rpc.log({ message, ...options });
     }
 }

--- a/nodejs/src/session.ts
+++ b/nodejs/src/session.ts
@@ -502,8 +502,14 @@ export class CopilotSession {
             } else {
                 result = JSON.stringify(rawResult);
             }
+            if (this.disconnected) {
+                return;
+            }
             await this.rpc.tools.handlePendingToolCall({ requestId, result });
         } catch (error) {
+            if (this.disconnected) {
+                return;
+            }
             const message = error instanceof Error ? error.message : String(error);
             try {
                 await this.rpc.tools.handlePendingToolCall({ requestId, error: message });
@@ -531,8 +537,14 @@ export class CopilotSession {
             if (result.kind === "no-result") {
                 return;
             }
+            if (this.disconnected) {
+                return;
+            }
             await this.rpc.permissions.handlePendingPermissionRequest({ requestId, result });
         } catch (_error) {
+            if (this.disconnected) {
+                return;
+            }
             try {
                 await this.rpc.permissions.handlePendingPermissionRequest({
                     requestId,
@@ -576,8 +588,14 @@ export class CopilotSession {
 
         try {
             await handler({ sessionId: this.sessionId, command, commandName, args });
+            if (this.disconnected) {
+                return;
+            }
             await this.rpc.commands.handlePendingCommand({ requestId });
         } catch (error) {
+            if (this.disconnected) {
+                return;
+            }
             const message = error instanceof Error ? error.message : String(error);
             try {
                 await this.rpc.commands.handlePendingCommand({ requestId, error: message });

--- a/nodejs/test/client.test.ts
+++ b/nodejs/test/client.test.ts
@@ -5,6 +5,9 @@ import { CopilotSession } from "../src/session.js";
 import { defaultJoinSessionPermissionHandler } from "../src/types.js";
 
 // This file is for unit tests. Where relevant, prefer to add e2e tests in e2e/*.test.ts instead
+function markInactiveForResume(session: CopilotSession): void {
+    session._markDisconnected();
+}
 
 describe("CopilotClient", () => {
     it("allows createSession without onPermissionRequest", async () => {
@@ -82,6 +85,95 @@ describe("CopilotClient", () => {
         );
     });
 
+    it("keeps a directly disconnected session registered until session.destroy completes", async () => {
+        const client = new CopilotClient({ autoStart: false });
+        let session: CopilotSession;
+        const connection = {
+            sendRequest: vi.fn(async (method: string) => {
+                if (method === "session.destroy") {
+                    expect((client as any).sessions.get("session-1")).toBe(session);
+                }
+                return {};
+            }),
+        } as any;
+        session = new CopilotSession("session-1", connection, undefined, undefined, (s) =>
+            (client as any).unregisterSession(s)
+        );
+        (client as any).registerSession(session);
+
+        await session.disconnect();
+
+        expect(connection.sendRequest).toHaveBeenCalledWith("session.destroy", {
+            sessionId: "session-1",
+        });
+        expect((client as any).sessions.has("session-1")).toBe(false);
+        await expect(session.send({ prompt: "hello" })).rejects.toThrow(/disconnected/);
+        expect(() => session.rpc).toThrow(/disconnected/);
+    });
+
+    it("reports stop errors when session.destroy fails", async () => {
+        const client = new CopilotClient({ autoStart: false });
+        const connection = {
+            dispose: vi.fn(),
+            sendRequest: vi.fn(async (method: string) => {
+                if (method === "session.destroy") {
+                    throw new Error("destroy failed");
+                }
+                return {};
+            }),
+        } as any;
+        (client as any).connection = connection;
+        const session = new CopilotSession("session-1", connection, undefined, undefined, (s) =>
+            (client as any).unregisterSession(s)
+        );
+        (client as any).registerSession(session);
+
+        const errors = await client.stop();
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toBe("Failed to disconnect session session-1: destroy failed");
+        expect(connection.sendRequest).toHaveBeenCalledTimes(1);
+        expect((client as any).sessions.size).toBe(0);
+        await expect(session.send({ prompt: "hello" })).rejects.toThrow(/disconnected/);
+    });
+
+    it("does not unregister a replacement session when a stale session disconnects", () => {
+        const client = new CopilotClient({ autoStart: false });
+        const connection = { sendRequest: vi.fn() } as any;
+        const stale = new CopilotSession("session-1", connection, undefined, undefined, (s) =>
+            (client as any).unregisterSession(s)
+        );
+        const replacement = new CopilotSession("session-1", connection, undefined, undefined, (s) =>
+            (client as any).unregisterSession(s)
+        );
+
+        (client as any).sessions.set("session-1", replacement);
+        stale._markDisconnected();
+
+        expect((client as any).sessions.get("session-1")).toBe(replacement);
+        replacement._markDisconnected();
+    });
+
+    it("rejects duplicate active session registrations", () => {
+        const client = new CopilotClient({ autoStart: false });
+        const connection = { sendRequest: vi.fn() } as any;
+        const first = new CopilotSession("session-1", connection);
+        const second = new CopilotSession("session-1", connection);
+
+        (client as any).registerSession(first);
+
+        expect(() => (client as any).registerSession(second)).toThrow(/already active/);
+        first._markDisconnected();
+    });
+
+    it("validates required generated RPC params before sending requests", async () => {
+        const connection = { sendRequest: vi.fn() } as any;
+        const session = new CopilotSession("session-1", connection);
+
+        await expect((session.rpc.commands.invoke as any)()).rejects.toThrow("params is required");
+        expect(connection.sendRequest).not.toHaveBeenCalled();
+    });
+
     it("forwards clientName in session.resume request", async () => {
         const client = new CopilotClient();
         await client.start();
@@ -95,6 +187,7 @@ describe("CopilotClient", () => {
                 if (method === "session.resume") return { sessionId: params.sessionId };
                 throw new Error(`Unexpected method: ${method}`);
             });
+        markInactiveForResume(session);
         await client.resumeSession(session.sessionId, {
             clientName: "my-app",
             onPermissionRequest: approveAll,
@@ -136,6 +229,7 @@ describe("CopilotClient", () => {
                 if (method === "session.resume") return { sessionId: params.sessionId };
                 throw new Error(`Unexpected method: ${method}`);
             });
+        markInactiveForResume(session);
         await client.resumeSession(session.sessionId, {
             enableSessionTelemetry: false,
             onPermissionRequest: approveAll,
@@ -187,6 +281,7 @@ describe("CopilotClient", () => {
                 if (method === "session.resume") return { sessionId: params.sessionId };
                 throw new Error(`Unexpected method: ${method}`);
             });
+        markInactiveForResume(session);
         await client.resumeSession(session.sessionId, { onPermissionRequest: approveAll });
 
         const payload = spy.mock.calls.find((c) => c[0] === "session.resume")![1] as any;
@@ -206,6 +301,7 @@ describe("CopilotClient", () => {
                 if (method === "session.resume") return { sessionId: params.sessionId };
                 throw new Error(`Unexpected method: ${method}`);
             });
+        markInactiveForResume(session);
         await client.resumeSession(session.sessionId, {
             onPermissionRequest: approveAll,
             includeSubAgentStreamingEvents: false,
@@ -228,6 +324,7 @@ describe("CopilotClient", () => {
                 if (method === "session.resume") return { sessionId: params.sessionId };
                 throw new Error(`Unexpected method: ${method}`);
             });
+        markInactiveForResume(session);
         await client.resumeSession(session.sessionId, {
             onPermissionRequest: approveAll,
             continuePendingWork: true,
@@ -250,6 +347,7 @@ describe("CopilotClient", () => {
                 if (method === "session.resume") return { sessionId: params.sessionId };
                 throw new Error(`Unexpected method: ${method}`);
             });
+        markInactiveForResume(session);
         await client.resumeSession(session.sessionId, { onPermissionRequest: approveAll });
 
         const payload = spy.mock.calls.find((c) => c[0] === "session.resume")![1] as any;
@@ -308,6 +406,7 @@ describe("CopilotClient", () => {
                 throw new Error(`Unexpected method: ${method}`);
             });
 
+        markInactiveForResume(session);
         await client.resumeSession(session.sessionId, {
             onPermissionRequest: approveAll,
             provider: {
@@ -360,6 +459,7 @@ describe("CopilotClient", () => {
 
         const session = await client.createSession({ onPermissionRequest: approveAll });
         const spy = vi.spyOn((client as any).connection!, "sendRequest");
+        markInactiveForResume(session);
         await client.resumeSession(session.sessionId, {
             defaultAgent: { excludedTools: ["heavy-tool"] },
             onPermissionRequest: approveAll,
@@ -404,6 +504,7 @@ describe("CopilotClient", () => {
                 if (method === "session.resume") return { sessionId: params.sessionId };
                 throw new Error(`Unexpected method: ${method}`);
             });
+        markInactiveForResume(session);
         await client.resumeSession(session.sessionId, {
             instructionDirectories,
             onPermissionRequest: approveAll,
@@ -432,6 +533,7 @@ describe("CopilotClient", () => {
                 throw new Error(`Unexpected method: ${method}`);
             });
 
+        markInactiveForResume(session);
         await client.resumeSession(session.sessionId, {
             onPermissionRequest: defaultJoinSessionPermissionHandler,
         });
@@ -459,6 +561,7 @@ describe("CopilotClient", () => {
                 throw new Error(`Unexpected method: ${method}`);
             });
 
+        markInactiveForResume(session);
         await client.resumeSession(session.sessionId, {
             onPermissionRequest: approveAll,
         });
@@ -486,6 +589,7 @@ describe("CopilotClient", () => {
                 throw new Error(`Unexpected method: ${method}`);
             });
 
+        markInactiveForResume(session);
         await client.resumeSession(session.sessionId, {
             onPermissionRequest: approveAll,
             onExitPlanMode: () => ({ approved: true }),
@@ -834,6 +938,7 @@ describe("CopilotClient", () => {
                     if (method === "session.resume") return { sessionId: params.sessionId };
                     throw new Error(`Unexpected method: ${method}`);
                 });
+            markInactiveForResume(session);
             await client.resumeSession(session.sessionId, {
                 onPermissionRequest: approveAll,
                 tools: [
@@ -912,6 +1017,7 @@ describe("CopilotClient", () => {
                     if (method === "session.resume") return { sessionId: params.sessionId };
                     throw new Error(`Unexpected method: ${method}`);
                 });
+            markInactiveForResume(session);
             await client.resumeSession(session.sessionId, {
                 onPermissionRequest: approveAll,
                 customAgents: [
@@ -1075,6 +1181,7 @@ describe("CopilotClient", () => {
                     if (method === "session.resume") return { sessionId: params.sessionId };
                     throw new Error(`Unexpected method: ${method}`);
                 });
+            markInactiveForResume(session);
             await client.resumeSession(session.sessionId, { onPermissionRequest: approveAll });
 
             expect(spy).toHaveBeenCalledWith(
@@ -1186,6 +1293,7 @@ describe("CopilotClient", () => {
                     if (method === "session.resume") return { sessionId: params.sessionId };
                     throw new Error(`Unexpected method: ${method}`);
                 });
+            markInactiveForResume(session);
             await client.resumeSession(session.sessionId, {
                 onPermissionRequest: approveAll,
                 commands: [{ name: "deploy", description: "Deploy", handler: async () => {} }],

--- a/nodejs/test/client.test.ts
+++ b/nodejs/test/client.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { approveAll, CopilotClient, type ModelInfo } from "../src/index.js";
+import { createServerRpc } from "../src/generated/rpc.js";
 import { CopilotSession } from "../src/session.js";
 import { defaultJoinSessionPermissionHandler } from "../src/types.js";
 
@@ -172,6 +173,21 @@ describe("CopilotClient", () => {
 
         await expect((session.rpc.commands.invoke as any)()).rejects.toThrow("params is required");
         expect(connection.sendRequest).not.toHaveBeenCalled();
+    });
+
+    it("allows generated RPC params with only optional fields to be omitted", async () => {
+        const connection = {
+            sendRequest: vi.fn(async (method: string) =>
+                method === "models.list" ? { models: [] } : { tools: [] }
+            ),
+        } as any;
+        const rpc = createServerRpc(connection);
+
+        await rpc.models.list();
+        await rpc.tools.list();
+
+        expect(connection.sendRequest).toHaveBeenCalledWith("models.list", {});
+        expect(connection.sendRequest).toHaveBeenCalledWith("tools.list", {});
     });
 
     it("forwards clientName in session.resume request", async () => {

--- a/nodejs/test/e2e/commands.e2e.test.ts
+++ b/nodejs/test/e2e/commands.e2e.test.ts
@@ -6,6 +6,7 @@ import { afterAll, describe, expect, it } from "vitest";
 import { CopilotClient, approveAll } from "../../src/index.js";
 import type { SessionEvent } from "../../src/index.js";
 import { createSdkTestContext } from "./harness/sdkTestContext.js";
+import { markInactiveForResume } from "./harness/sdkTestHelper.js";
 
 describe("Commands", async () => {
     // Use TCP mode so a second client can connect to the same CLI process
@@ -83,7 +84,7 @@ describe("Commands", async () => {
     it("session with commands resumes successfully", async () => {
         const session1 = await client1.createSession({ onPermissionRequest: approveAll });
         const sessionId = session1.sessionId;
-        await session1.disconnect();
+        markInactiveForResume(session1);
 
         const session2 = await client1.resumeSession(sessionId, {
             onPermissionRequest: approveAll,

--- a/nodejs/test/e2e/commands.e2e.test.ts
+++ b/nodejs/test/e2e/commands.e2e.test.ts
@@ -83,6 +83,7 @@ describe("Commands", async () => {
     it("session with commands resumes successfully", async () => {
         const session1 = await client1.createSession({ onPermissionRequest: approveAll });
         const sessionId = session1.sessionId;
+        await session1.disconnect();
 
         const session2 = await client1.resumeSession(sessionId, {
             onPermissionRequest: approveAll,

--- a/nodejs/test/e2e/harness/sdkTestHelper.ts
+++ b/nodejs/test/e2e/harness/sdkTestHelper.ts
@@ -130,3 +130,7 @@ export function getNextEventOfType(
         });
     });
 }
+
+export function markInactiveForResume(session: CopilotSession): void {
+    session._markDisconnected();
+}

--- a/nodejs/test/e2e/mcp_and_agents.e2e.test.ts
+++ b/nodejs/test/e2e/mcp_and_agents.e2e.test.ts
@@ -49,6 +49,7 @@ describe("MCP Servers and Custom Agents", async () => {
             const session1 = await client.createSession({ onPermissionRequest: approveAll });
             const sessionId = session1.sessionId;
             await session1.sendAndWait({ prompt: "What is 1+1?" });
+            await session1.disconnect();
 
             // Resume with MCP servers
             const mcpServers: Record<string, MCPServerConfig> = {
@@ -160,6 +161,7 @@ describe("MCP Servers and Custom Agents", async () => {
             const session1 = await client.createSession({ onPermissionRequest: approveAll });
             const sessionId = session1.sessionId;
             await session1.sendAndWait({ prompt: "What is 1+1?" });
+            await session1.disconnect();
 
             // Resume with custom agents
             const customAgents: CustomAgentConfig[] = [
@@ -338,6 +340,7 @@ describe("MCP Servers and Custom Agents", async () => {
             const session1 = await client.createSession({ onPermissionRequest: approveAll });
             const sessionId = session1.sessionId;
             await session1.sendAndWait({ prompt: "What is 3+3?" });
+            await session1.disconnect();
 
             const secretTool = defineTool("secret_tool", {
                 description: "A secret tool hidden from the default agent",

--- a/nodejs/test/e2e/permissions.e2e.test.ts
+++ b/nodejs/test/e2e/permissions.e2e.test.ts
@@ -118,6 +118,7 @@ describe("Permission callbacks", async () => {
         const session1 = await client.createSession({ onPermissionRequest: approveAll });
         const sessionId = session1.sessionId;
         await session1.sendAndWait({ prompt: "What is 1+1?" });
+        await session1.disconnect();
 
         const session2 = await client.resumeSession(sessionId, {
             onPermissionRequest: () => ({
@@ -182,6 +183,7 @@ describe("Permission callbacks", async () => {
         const session1 = await client.createSession({ onPermissionRequest: approveAll });
         const sessionId = session1.sessionId;
         await session1.sendAndWait({ prompt: "What is 1+1?" });
+        await session1.disconnect();
 
         // Resume with permission handler
         const session2 = await client.resumeSession(sessionId, {

--- a/nodejs/test/e2e/session.e2e.test.ts
+++ b/nodejs/test/e2e/session.e2e.test.ts
@@ -31,7 +31,7 @@ describe("Sessions", async () => {
         ]);
 
         await session.disconnect();
-        await expect(() => session.getMessages()).rejects.toThrow(/Session not found/);
+        await expect(() => session.getMessages()).rejects.toThrow(/Session has been disconnected/);
     });
 
     // TODO: Re-enable once test harness CAPI proxy supports this test's session lifecycle
@@ -253,7 +253,7 @@ describe("Sessions", async () => {
         // All can be disconnected
         await Promise.all([s1.disconnect(), s2.disconnect(), s3.disconnect()]);
         for (const s of [s1, s2, s3]) {
-            await expect(() => s.getMessages()).rejects.toThrow(/Session not found/);
+            await expect(() => s.getMessages()).rejects.toThrow(/Session has been disconnected/);
         }
     });
 
@@ -263,6 +263,7 @@ describe("Sessions", async () => {
         const sessionId = session1.sessionId;
         const answer = await session1.sendAndWait({ prompt: "What is 1+1?" });
         expect(answer?.data.content).toContain("2");
+        await session1.disconnect();
 
         // Resume using the same client
         const session2 = await client.resumeSession(sessionId, { onPermissionRequest: approveAll });
@@ -353,6 +354,7 @@ describe("Sessions", async () => {
     it("should resume session with a custom provider", async () => {
         const session = await client.createSession({ onPermissionRequest: approveAll });
         const sessionId = session.sessionId;
+        await session.disconnect();
 
         // Resume the session with a provider
         const session2 = await client.resumeSession(sessionId, {

--- a/nodejs/test/e2e/session.e2e.test.ts
+++ b/nodejs/test/e2e/session.e2e.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { ParsedHttpExchange } from "../../../test/harness/replayingCapiProxy.js";
 import { CopilotClient, approveAll, defineTool } from "../../src/index.js";
 import { createSdkTestContext, isCI } from "./harness/sdkTestContext.js";
-import { getFinalAssistantMessage, getNextEventOfType } from "./harness/sdkTestHelper.js";
+import {
+    getFinalAssistantMessage,
+    getNextEventOfType,
+    markInactiveForResume,
+} from "./harness/sdkTestHelper.js";
 
 describe("Sessions", async () => {
     const {
@@ -354,7 +358,7 @@ describe("Sessions", async () => {
     it("should resume session with a custom provider", async () => {
         const session = await client.createSession({ onPermissionRequest: approveAll });
         const sessionId = session.sessionId;
-        await session.disconnect();
+        markInactiveForResume(session);
 
         // Resume the session with a provider
         const session2 = await client.resumeSession(sessionId, {

--- a/nodejs/test/e2e/session_config.e2e.test.ts
+++ b/nodejs/test/e2e/session_config.e2e.test.ts
@@ -3,6 +3,7 @@ import { writeFile, mkdir } from "fs/promises";
 import { join } from "path";
 import { approveAll } from "../../src/index.js";
 import { createSdkTestContext } from "./harness/sdkTestContext.js";
+import { markInactiveForResume } from "./harness/sdkTestHelper.js";
 
 describe("Session Configuration", async () => {
     const { copilotClient: client, workDir, openAiEndpoint } = await createSdkTestContext();
@@ -247,7 +248,7 @@ describe("Session Configuration", async () => {
             onPermissionRequest: approveAll,
             workingDirectory: projectDir,
         });
-        await session1.disconnect();
+        markInactiveForResume(session1);
         const session2 = await client.resumeSession(session1.sessionId, {
             onPermissionRequest: approveAll,
             workingDirectory: projectDir,
@@ -305,7 +306,7 @@ describe("Session Configuration", async () => {
     it("should forward custom provider headers on resume", async () => {
         const session1 = await client.createSession({ onPermissionRequest: approveAll });
         const sessionId = session1.sessionId;
-        await session1.disconnect();
+        markInactiveForResume(session1);
 
         const session2 = await client.resumeSession(sessionId, {
             onPermissionRequest: approveAll,
@@ -386,7 +387,7 @@ describe("Session Configuration", async () => {
 
         const session1 = await client.createSession({ onPermissionRequest: approveAll });
         const sessionId = session1.sessionId;
-        await session1.disconnect();
+        markInactiveForResume(session1);
 
         const session2 = await client.resumeSession(sessionId, {
             onPermissionRequest: approveAll,
@@ -404,7 +405,7 @@ describe("Session Configuration", async () => {
     it("should apply systemMessage on session resume", async () => {
         const session1 = await client.createSession({ onPermissionRequest: approveAll });
         const sessionId = session1.sessionId;
-        await session1.disconnect();
+        markInactiveForResume(session1);
 
         const resumeInstruction = "End the response with RESUME_SYSTEM_MESSAGE_SENTINEL.";
         const session2 = await client.resumeSession(sessionId, {
@@ -426,7 +427,7 @@ describe("Session Configuration", async () => {
     it("should apply availableTools on session resume", async () => {
         const session1 = await client.createSession({ onPermissionRequest: approveAll });
         const sessionId = session1.sessionId;
-        await session1.disconnect();
+        markInactiveForResume(session1);
 
         const session2 = await client.resumeSession(sessionId, {
             onPermissionRequest: approveAll,

--- a/nodejs/test/e2e/session_config.e2e.test.ts
+++ b/nodejs/test/e2e/session_config.e2e.test.ts
@@ -247,6 +247,7 @@ describe("Session Configuration", async () => {
             onPermissionRequest: approveAll,
             workingDirectory: projectDir,
         });
+        await session1.disconnect();
         const session2 = await client.resumeSession(session1.sessionId, {
             onPermissionRequest: approveAll,
             workingDirectory: projectDir,
@@ -304,6 +305,7 @@ describe("Session Configuration", async () => {
     it("should forward custom provider headers on resume", async () => {
         const session1 = await client.createSession({ onPermissionRequest: approveAll });
         const sessionId = session1.sessionId;
+        await session1.disconnect();
 
         const session2 = await client.resumeSession(sessionId, {
             onPermissionRequest: approveAll,
@@ -384,6 +386,7 @@ describe("Session Configuration", async () => {
 
         const session1 = await client.createSession({ onPermissionRequest: approveAll });
         const sessionId = session1.sessionId;
+        await session1.disconnect();
 
         const session2 = await client.resumeSession(sessionId, {
             onPermissionRequest: approveAll,
@@ -401,6 +404,7 @@ describe("Session Configuration", async () => {
     it("should apply systemMessage on session resume", async () => {
         const session1 = await client.createSession({ onPermissionRequest: approveAll });
         const sessionId = session1.sessionId;
+        await session1.disconnect();
 
         const resumeInstruction = "End the response with RESUME_SYSTEM_MESSAGE_SENTINEL.";
         const session2 = await client.resumeSession(sessionId, {
@@ -422,6 +426,7 @@ describe("Session Configuration", async () => {
     it("should apply availableTools on session resume", async () => {
         const session1 = await client.createSession({ onPermissionRequest: approveAll });
         const sessionId = session1.sessionId;
+        await session1.disconnect();
 
         const session2 = await client.resumeSession(sessionId, {
             onPermissionRequest: approveAll,

--- a/nodejs/test/e2e/skills.e2e.test.ts
+++ b/nodejs/test/e2e/skills.e2e.test.ts
@@ -162,6 +162,7 @@ IMPORTANT: You MUST include the exact text "${SKILL_MARKER}" somewhere in EVERY 
             // First message without skill - marker should not appear
             const message1 = await session1.sendAndWait({ prompt: "Say hi." });
             expect(message1?.data.content).not.toContain(SKILL_MARKER);
+            await session1.disconnect();
 
             // Resume with skillDirectories - skill should now be active
             const session2 = await client.resumeSession(sessionId, {

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -1022,6 +1022,18 @@ class CopilotClient:
             raise RuntimeError("Client is not connected. Call start() first.")
         return self._rpc
 
+    def _register_session(self, session: CopilotSession) -> None:
+        with self._sessions_lock:
+            existing = self._sessions.get(session.session_id)
+            if existing is not None and existing is not session:
+                raise RuntimeError(f"Session {session.session_id} is already active.")
+            self._sessions[session.session_id] = session
+
+    def _unregister_session(self, session: CopilotSession) -> None:
+        with self._sessions_lock:
+            if self._sessions.get(session.session_id) is session:
+                del self._sessions[session.session_id]
+
     @property
     def actual_port(self) -> int | None:
         """The actual TCP port the CLI server is listening on, if using TCP transport.
@@ -1229,11 +1241,8 @@ class CopilotClient:
         """
         errors: list[StopError] = []
 
-        # Atomically take ownership of all sessions and clear the dict
-        # so no other thread can access them
         with self._sessions_lock:
             sessions_to_destroy = list(self._sessions.values())
-            self._sessions.clear()
 
         for session in sessions_to_destroy:
             try:
@@ -1247,6 +1256,12 @@ class CopilotClient:
                 errors.append(
                     StopError(message=f"Failed to disconnect session {session.session_id}: {e}")
                 )
+
+        with self._sessions_lock:
+            remaining_sessions = list(self._sessions.values())
+            self._sessions.clear()
+        for session in remaining_sessions:
+            session._mark_disconnected()
 
         # Close client
         if self._client:
@@ -1290,9 +1305,11 @@ class CopilotClient:
             ... except asyncio.TimeoutError:
             ...     await client.force_stop()
         """
-        # Clear sessions immediately without trying to destroy them
         with self._sessions_lock:
+            sessions_to_destroy = list(self._sessions.values())
             self._sessions.clear()
+        for session in sessions_to_destroy:
+            session._mark_disconnected()
 
         # Close the transport first to signal the server immediately.
         # For external servers (TCP), this closes the socket.
@@ -1621,24 +1638,33 @@ class CopilotClient:
         # Create and register the session before issuing the RPC so that
         # events emitted by the CLI (e.g. session.start) are not dropped.
         setup_start = time.perf_counter()
-        session = CopilotSession(actual_session_id, self._client, workspace_path=None)
-        if self._session_fs_config:
-            if create_session_fs_handler is None:
-                raise ValueError(
-                    "create_session_fs_handler is required in session config when "
-                    "session_fs is enabled in client options."
-                )
-            fs_provider: SessionFsProvider = create_session_fs_handler(session)
-            caps = self._session_fs_config.get("capabilities")
-            if caps and caps.get("sqlite"):
-                from .session_fs_provider import SessionFsSqliteProvider
-
-                if not isinstance(fs_provider, SessionFsSqliteProvider):
+        session = CopilotSession(
+            actual_session_id,
+            self._client,
+            workspace_path=None,
+            on_disconnected=self._unregister_session,
+        )
+        try:
+            if self._session_fs_config:
+                if create_session_fs_handler is None:
                     raise ValueError(
-                        "SessionFs capabilities declare SQLite support but the provider "
-                        "does not implement SessionFsSqliteProvider"
+                        "create_session_fs_handler is required in session config when "
+                        "session_fs is enabled in client options."
                     )
-            session._client_session_apis.session_fs = create_session_fs_adapter(fs_provider)
+                fs_provider: SessionFsProvider = create_session_fs_handler(session)
+                caps = self._session_fs_config.get("capabilities")
+                if caps and caps.get("sqlite"):
+                    from .session_fs_provider import SessionFsSqliteProvider
+
+                    if not isinstance(fs_provider, SessionFsSqliteProvider):
+                        raise ValueError(
+                            "SessionFs capabilities declare SQLite support but the provider "
+                            "does not implement SessionFsSqliteProvider"
+                        )
+                session._client_session_apis.session_fs = create_session_fs_adapter(fs_provider)
+        except BaseException:
+            session._mark_disconnected()
+            raise
         session._register_tools(tools)
         session._register_commands(commands)
         session._register_permission_handler(on_permission_request)
@@ -1656,8 +1682,11 @@ class CopilotClient:
             session._register_transform_callbacks(transform_callbacks)
         if on_event:
             session.on(on_event)
-        with self._sessions_lock:
-            self._sessions[actual_session_id] = session
+        try:
+            self._register_session(session)
+        except BaseException:
+            session._mark_disconnected()
+            raise
         log_timing(
             logger,
             logging.DEBUG,
@@ -1683,8 +1712,8 @@ class CopilotClient:
             capabilities = response.get("capabilities")
             session._set_capabilities(capabilities)
         except BaseException as exc:
-            with self._sessions_lock:
-                self._sessions.pop(actual_session_id, None)
+            self._unregister_session(session)
+            session._mark_disconnected()
             if not isinstance(exc, asyncio.CancelledError):
                 log_timing(
                     logger,
@@ -1974,24 +2003,33 @@ class CopilotClient:
         # Create and register the session before issuing the RPC so that
         # events emitted by the CLI (e.g. session.start) are not dropped.
         setup_start = time.perf_counter()
-        session = CopilotSession(session_id, self._client, workspace_path=None)
-        if self._session_fs_config:
-            if create_session_fs_handler is None:
-                raise ValueError(
-                    "create_session_fs_handler is required in session config when "
-                    "session_fs is enabled in client options."
-                )
-            fs_provider: SessionFsProvider = create_session_fs_handler(session)
-            caps = self._session_fs_config.get("capabilities")
-            if caps and caps.get("sqlite"):
-                from .session_fs_provider import SessionFsSqliteProvider
-
-                if not isinstance(fs_provider, SessionFsSqliteProvider):
+        session = CopilotSession(
+            session_id,
+            self._client,
+            workspace_path=None,
+            on_disconnected=self._unregister_session,
+        )
+        try:
+            if self._session_fs_config:
+                if create_session_fs_handler is None:
                     raise ValueError(
-                        "SessionFs capabilities declare SQLite support but the provider "
-                        "does not implement SessionFsSqliteProvider"
+                        "create_session_fs_handler is required in session config when "
+                        "session_fs is enabled in client options."
                     )
-            session._client_session_apis.session_fs = create_session_fs_adapter(fs_provider)
+                fs_provider: SessionFsProvider = create_session_fs_handler(session)
+                caps = self._session_fs_config.get("capabilities")
+                if caps and caps.get("sqlite"):
+                    from .session_fs_provider import SessionFsSqliteProvider
+
+                    if not isinstance(fs_provider, SessionFsSqliteProvider):
+                        raise ValueError(
+                            "SessionFs capabilities declare SQLite support but the provider "
+                            "does not implement SessionFsSqliteProvider"
+                        )
+                session._client_session_apis.session_fs = create_session_fs_adapter(fs_provider)
+        except BaseException:
+            session._mark_disconnected()
+            raise
         session._register_tools(tools)
         session._register_commands(commands)
         session._register_permission_handler(on_permission_request)
@@ -2009,8 +2047,11 @@ class CopilotClient:
             session._register_transform_callbacks(transform_callbacks)
         if on_event:
             session.on(on_event)
-        with self._sessions_lock:
-            self._sessions[session_id] = session
+        try:
+            self._register_session(session)
+        except BaseException:
+            session._mark_disconnected()
+            raise
         log_timing(
             logger,
             logging.DEBUG,
@@ -2036,8 +2077,8 @@ class CopilotClient:
             capabilities = response.get("capabilities")
             session._set_capabilities(capabilities)
         except BaseException as exc:
-            with self._sessions_lock:
-                self._sessions.pop(session_id, None)
+            self._unregister_session(session)
+            session._mark_disconnected()
             if not isinstance(exc, asyncio.CancelledError):
                 log_timing(
                     logger,
@@ -2281,8 +2322,9 @@ class CopilotClient:
 
         # Remove from local sessions map if present
         with self._sessions_lock:
-            if session_id in self._sessions:
-                del self._sessions[session_id]
+            session = self._sessions.get(session_id)
+        if session is not None:
+            session._mark_disconnected()
 
     async def get_last_session_id(self) -> str | None:
         """

--- a/python/copilot/generated/rpc.py
+++ b/python/copilot/generated/rpc.py
@@ -8325,12 +8325,9 @@ class ServerModelsApi:
     def __init__(self, client: "JsonRpcClient"):
         self._client = client
 
-    async def list(self, params: ModelsListRequest, *, timeout: float | None = None) -> ModelList:
+    async def list(self, params: ModelsListRequest | None = None, *, timeout: float | None = None) -> ModelList:
         "Lists Copilot models available to the authenticated user.\n\nArgs:\n    params: Optional GitHub token used to list models for a specific user instead of the global auth context.\n\nReturns:\n    List of Copilot models available to the resolved user, including capabilities and billing metadata."
-        if params is None:
-            raise TypeError("params is required")
-
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return ModelList.from_dict(_patch_model_capabilities(await self._client.request("models.list", params_dict, **_timeout_kwargs(timeout))))
 
 
@@ -8338,12 +8335,9 @@ class ServerToolsApi:
     def __init__(self, client: "JsonRpcClient"):
         self._client = client
 
-    async def list(self, params: ToolsListRequest, *, timeout: float | None = None) -> ToolList:
+    async def list(self, params: ToolsListRequest | None = None, *, timeout: float | None = None) -> ToolList:
         "Lists built-in tools available for a model.\n\nArgs:\n    params: Optional model identifier whose tool overrides should be applied to the listing.\n\nReturns:\n    Built-in tools available for the requested model, with their parameters and instructions."
-        if params is None:
-            raise TypeError("params is required")
-
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return ToolList.from_dict(await self._client.request("tools.list", params_dict, **_timeout_kwargs(timeout)))
 
 
@@ -8351,12 +8345,9 @@ class ServerAccountApi:
     def __init__(self, client: "JsonRpcClient"):
         self._client = client
 
-    async def get_quota(self, params: AccountGetQuotaRequest, *, timeout: float | None = None) -> AccountGetQuotaResult:
+    async def get_quota(self, params: AccountGetQuotaRequest | None = None, *, timeout: float | None = None) -> AccountGetQuotaResult:
         "Gets Copilot quota usage for the authenticated user or supplied GitHub token.\n\nArgs:\n    params: Optional GitHub token used to look up quota for a specific user instead of the global auth context.\n\nReturns:\n    Quota usage snapshots for the resolved user, keyed by quota type."
-        if params is None:
-            raise TypeError("params is required")
-
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return AccountGetQuotaResult.from_dict(await self._client.request("account.getQuota", params_dict, **_timeout_kwargs(timeout)))
 
 
@@ -8414,12 +8405,9 @@ class ServerMcpApi:
         self._client = client
         self.config = ServerMcpConfigApi(client)
 
-    async def discover(self, params: MCPDiscoverRequest, *, timeout: float | None = None) -> MCPDiscoverResult:
+    async def discover(self, params: MCPDiscoverRequest | None = None, *, timeout: float | None = None) -> MCPDiscoverResult:
         "Discovers MCP servers from user, workspace, plugin, and builtin sources.\n\nArgs:\n    params: Optional working directory used as context for MCP server discovery.\n\nReturns:\n    MCP servers discovered from user, workspace, plugin, and built-in sources."
-        if params is None:
-            raise TypeError("params is required")
-
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return MCPDiscoverResult.from_dict(await self._client.request("mcp.discover", params_dict, **_timeout_kwargs(timeout)))
 
 
@@ -8441,12 +8429,9 @@ class ServerSkillsApi:
         self._client = client
         self.config = ServerSkillsConfigApi(client)
 
-    async def discover(self, params: SkillsDiscoverRequest, *, timeout: float | None = None) -> ServerSkillList:
+    async def discover(self, params: SkillsDiscoverRequest | None = None, *, timeout: float | None = None) -> ServerSkillList:
         "Discovers skills across global and project sources.\n\nArgs:\n    params: Optional project paths and additional skill directories to include in discovery.\n\nReturns:\n    Skills discovered across global and project sources."
-        if params is None:
-            raise TypeError("params is required")
-
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return ServerSkillList.from_dict(await self._client.request("skills.discover", params_dict, **_timeout_kwargs(timeout)))
 
 
@@ -8468,20 +8453,14 @@ class ServerSessionsApi:
     def __init__(self, client: "JsonRpcClient"):
         self._client = client
 
-    async def fork(self, params: SessionsForkRequest, *, timeout: float | None = None) -> SessionsForkResult:
+    async def fork(self, params: SessionsForkRequest | None = None, *, timeout: float | None = None) -> SessionsForkResult:
         "Creates a new session by forking persisted history from an existing session.\n\nArgs:\n    params: Source session identifier to fork from, optional event-ID boundary, and optional friendly name for the new session.\n\nReturns:\n    Identifier and optional friendly name assigned to the newly forked session."
-        if params is None:
-            raise TypeError("params is required")
-
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return SessionsForkResult.from_dict(await self._client.request("sessions.fork", params_dict, **_timeout_kwargs(timeout)))
 
-    async def connect(self, params: ConnectRemoteSessionParams, *, timeout: float | None = None) -> RemoteSessionConnectionResult:
+    async def connect(self, params: ConnectRemoteSessionParams | None = None, *, timeout: float | None = None) -> RemoteSessionConnectionResult:
         "Connects to an existing remote session and exposes it as an SDK session.\n\nArgs:\n    params: Remote session connection parameters.\n\nReturns:\n    Remote session connection result."
-        if params is None:
-            raise TypeError("params is required")
-
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return RemoteSessionConnectionResult.from_dict(await self._client.request("sessions.connect", params_dict, **_timeout_kwargs(timeout)))
 
 
@@ -8497,12 +8476,9 @@ class ServerRpc:
         self.session_fs = ServerSessionFsApi(client)
         self.sessions = ServerSessionsApi(client)
 
-    async def ping(self, params: PingRequest, *, timeout: float | None = None) -> PingResult:
+    async def ping(self, params: PingRequest | None = None, *, timeout: float | None = None) -> PingResult:
         "Checks server responsiveness and returns protocol information.\n\nArgs:\n    params: Optional message to echo back to the caller.\n\nReturns:\n    Server liveness response, including the echoed message, current timestamp, and protocol version."
-        if params is None:
-            raise TypeError("params is required")
-
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return PingResult.from_dict(await self._client.request("ping", params_dict, **_timeout_kwargs(timeout)))
 
 
@@ -8511,12 +8487,9 @@ class _InternalServerRpc:
     def __init__(self, client: "JsonRpcClient"):
         self._client = client
 
-    async def connect(self, params: ConnectRequest, *, timeout: float | None = None) -> ConnectResult:
+    async def connect(self, params: ConnectRequest | None = None, *, timeout: float | None = None) -> ConnectResult:
         "Performs the SDK server connection handshake and validates the optional connection token.\n\nArgs:\n    params: Optional connection token presented by the SDK client during the handshake.\n\nReturns:\n    Handshake result reporting the server's protocol version and package version on success.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
-        if params is None:
-            raise TypeError("params is required")
-
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return ConnectResult.from_dict(await self._client.request("connect", params_dict, **_timeout_kwargs(timeout)))
 
 
@@ -8705,14 +8678,12 @@ class FleetApi:
         self._session_id = session_id
         self._assert_active = assert_active
 
-    async def start(self, params: FleetStartRequest, *, timeout: float | None = None) -> FleetStartResult:
+    async def start(self, params: FleetStartRequest | None = None, *, timeout: float | None = None) -> FleetStartResult:
         "Starts fleet mode by submitting the fleet orchestration prompt to the session.\n\nArgs:\n    params: Optional user prompt to combine with the fleet orchestration instructions.\n\nReturns:\n    Indicates whether fleet mode was successfully activated."
         if self._assert_active is not None:
             self._assert_active()
-        if params is None:
-            raise TypeError("params is required")
 
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         params_dict["sessionId"] = self._session_id
         return FleetStartResult.from_dict(await self._client.request("session.fleet.start", params_dict, **_timeout_kwargs(timeout)))
 
@@ -9210,14 +9181,12 @@ class RemoteApi:
         self._session_id = session_id
         self._assert_active = assert_active
 
-    async def enable(self, params: RemoteEnableRequest, *, timeout: float | None = None) -> RemoteEnableResult:
+    async def enable(self, params: RemoteEnableRequest | None = None, *, timeout: float | None = None) -> RemoteEnableResult:
         "Enables remote session export or steering.\n\nArgs:\n    params: Optional remote session mode (\"off\", \"export\", or \"on\"); defaults to enabling both export and remote steering.\n\nReturns:\n    GitHub URL for the session and a flag indicating whether remote steering is enabled."
         if self._assert_active is not None:
             self._assert_active()
-        if params is None:
-            raise TypeError("params is required")
 
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         params_dict["sessionId"] = self._session_id
         return RemoteEnableResult.from_dict(await self._client.request("session.remote.enable", params_dict, **_timeout_kwargs(timeout)))
 

--- a/python/copilot/generated/rpc.py
+++ b/python/copilot/generated/rpc.py
@@ -16499,9 +16499,9 @@ class ServerModelsApi:
     def __init__(self, client: "JsonRpcClient"):
         self._client = client
 
-    async def list(self, params: ModelsListRequest, *, timeout: float | None = None) -> ModelList:
+    async def list(self, params: ModelsListRequest | None = None, *, timeout: float | None = None) -> ModelList:
         "Lists Copilot models available to the authenticated user.\n\nArgs:\n    params: Optional GitHub token used to list models for a specific user instead of the global auth context.\n\nReturns:\n    List of Copilot models available to the resolved user, including capabilities and billing metadata."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return ModelList.from_dict(_patch_model_capabilities(await self._client.request("models.list", params_dict, **_timeout_kwargs(timeout))))
 
 
@@ -16509,9 +16509,9 @@ class ServerToolsApi:
     def __init__(self, client: "JsonRpcClient"):
         self._client = client
 
-    async def list(self, params: ToolsListRequest, *, timeout: float | None = None) -> ToolList:
+    async def list(self, params: ToolsListRequest | None = None, *, timeout: float | None = None) -> ToolList:
         "Lists built-in tools available for a model.\n\nArgs:\n    params: Optional model identifier whose tool overrides should be applied to the listing.\n\nReturns:\n    Built-in tools available for the requested model, with their parameters and instructions."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return ToolList.from_dict(await self._client.request("tools.list", params_dict, **_timeout_kwargs(timeout)))
 
 
@@ -16519,9 +16519,9 @@ class ServerAccountApi:
     def __init__(self, client: "JsonRpcClient"):
         self._client = client
 
-    async def get_quota(self, params: AccountGetQuotaRequest, *, timeout: float | None = None) -> AccountGetQuotaResult:
+    async def get_quota(self, params: AccountGetQuotaRequest | None = None, *, timeout: float | None = None) -> AccountGetQuotaResult:
         "Gets Copilot quota usage for the authenticated user or supplied GitHub token.\n\nArgs:\n    params: Optional GitHub token used to look up quota for a specific user instead of the global auth context.\n\nReturns:\n    Quota usage snapshots for the resolved user, keyed by quota type."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return AccountGetQuotaResult.from_dict(await self._client.request("account.getQuota", params_dict, **_timeout_kwargs(timeout)))
 
 
@@ -16535,26 +16535,41 @@ class ServerMcpConfigApi:
 
     async def add(self, params: MCPConfigAddRequest, *, timeout: float | None = None) -> None:
         "Adds an MCP server to user configuration.\n\nArgs:\n    params: MCP server name and configuration to add to user configuration."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         await self._client.request("mcp.config.add", params_dict, **_timeout_kwargs(timeout))
 
     async def update(self, params: MCPConfigUpdateRequest, *, timeout: float | None = None) -> None:
         "Updates an MCP server in user configuration.\n\nArgs:\n    params: MCP server name and replacement configuration to write to user configuration."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         await self._client.request("mcp.config.update", params_dict, **_timeout_kwargs(timeout))
 
     async def remove(self, params: MCPConfigRemoveRequest, *, timeout: float | None = None) -> None:
         "Removes an MCP server from user configuration.\n\nArgs:\n    params: MCP server name to remove from user configuration."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         await self._client.request("mcp.config.remove", params_dict, **_timeout_kwargs(timeout))
 
     async def enable(self, params: MCPConfigEnableRequest, *, timeout: float | None = None) -> None:
         "Enables MCP servers in user configuration for new sessions.\n\nArgs:\n    params: MCP server names to enable for new sessions."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         await self._client.request("mcp.config.enable", params_dict, **_timeout_kwargs(timeout))
 
     async def disable(self, params: MCPConfigDisableRequest, *, timeout: float | None = None) -> None:
         "Disables MCP servers in user configuration for new sessions.\n\nArgs:\n    params: MCP server names to disable for new sessions."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         await self._client.request("mcp.config.disable", params_dict, **_timeout_kwargs(timeout))
 
@@ -16564,9 +16579,9 @@ class ServerMcpApi:
         self._client = client
         self.config = ServerMcpConfigApi(client)
 
-    async def discover(self, params: MCPDiscoverRequest, *, timeout: float | None = None) -> MCPDiscoverResult:
+    async def discover(self, params: MCPDiscoverRequest | None = None, *, timeout: float | None = None) -> MCPDiscoverResult:
         "Discovers MCP servers from user, workspace, plugin, and builtin sources.\n\nArgs:\n    params: Optional working directory used as context for MCP server discovery.\n\nReturns:\n    MCP servers discovered from user, workspace, plugin, and built-in sources."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return MCPDiscoverResult.from_dict(await self._client.request("mcp.discover", params_dict, **_timeout_kwargs(timeout)))
 
 
@@ -16576,6 +16591,9 @@ class ServerSkillsConfigApi:
 
     async def set_disabled_skills(self, params: SkillsConfigSetDisabledSkillsRequest, *, timeout: float | None = None) -> None:
         "Replaces the global list of disabled skills.\n\nArgs:\n    params: Skill names to mark as disabled in global configuration, replacing any previous list."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         await self._client.request("skills.config.setDisabledSkills", params_dict, **_timeout_kwargs(timeout))
 
@@ -16585,9 +16603,9 @@ class ServerSkillsApi:
         self._client = client
         self.config = ServerSkillsConfigApi(client)
 
-    async def discover(self, params: SkillsDiscoverRequest, *, timeout: float | None = None) -> ServerSkillList:
+    async def discover(self, params: SkillsDiscoverRequest | None = None, *, timeout: float | None = None) -> ServerSkillList:
         "Discovers skills across global and project sources.\n\nArgs:\n    params: Optional project paths and additional skill directories to include in discovery.\n\nReturns:\n    Skills discovered across global and project sources."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return ServerSkillList.from_dict(await self._client.request("skills.discover", params_dict, **_timeout_kwargs(timeout)))
 
 
@@ -16597,6 +16615,9 @@ class ServerSessionFsApi:
 
     async def set_provider(self, params: SessionFSSetProviderRequest, *, timeout: float | None = None) -> SessionFSSetProviderResult:
         "Registers an SDK client as the session filesystem provider.\n\nArgs:\n    params: Initial working directory, session-state path layout, and path conventions used to register the calling SDK client as the session filesystem provider.\n\nReturns:\n    Indicates whether the calling client was registered as the session filesystem provider."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return SessionFSSetProviderResult.from_dict(await self._client.request("sessionFs.setProvider", params_dict, **_timeout_kwargs(timeout)))
 
@@ -16606,39 +16627,45 @@ class ServerSessionsApi:
     def __init__(self, client: "JsonRpcClient"):
         self._client = client
 
-    async def fork(self, params: SessionsForkRequest, *, timeout: float | None = None) -> SessionsForkResult:
+    async def fork(self, params: SessionsForkRequest | None = None, *, timeout: float | None = None) -> SessionsForkResult:
         "Creates a new session by forking persisted history from an existing session.\n\nArgs:\n    params: Source session identifier to fork from, optional event-ID boundary, and optional friendly name for the new session.\n\nReturns:\n    Identifier and optional friendly name assigned to the newly forked session."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return SessionsForkResult.from_dict(await self._client.request("sessions.fork", params_dict, **_timeout_kwargs(timeout)))
 
-    async def connect(self, params: ConnectRemoteSessionParams, *, timeout: float | None = None) -> RemoteSessionConnectionResult:
+    async def connect(self, params: ConnectRemoteSessionParams | None = None, *, timeout: float | None = None) -> RemoteSessionConnectionResult:
         "Connects to an existing remote session and exposes it as an SDK session.\n\nArgs:\n    params: Remote session connection parameters.\n\nReturns:\n    Remote session connection result."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return RemoteSessionConnectionResult.from_dict(await self._client.request("sessions.connect", params_dict, **_timeout_kwargs(timeout)))
 
-    async def list(self, params: SessionsListRequest, *, timeout: float | None = None) -> SessionList:
+    async def list(self, params: SessionsListRequest | None = None, *, timeout: float | None = None) -> SessionList:
         "Lists persisted sessions, optionally filtered by working-directory context.\n\nArgs:\n    params: Optional metadata-load limit and context filter applied to the returned sessions.\n\nReturns:\n    Persisted sessions matching the filter, ordered most-recently-modified first."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return SessionList.from_dict(await self._client.request("sessions.list", params_dict, **_timeout_kwargs(timeout)))
 
     async def find_by_task_id(self, params: SessionsFindByTaskIDRequest, *, timeout: float | None = None) -> SessionsFindByTaskIDResult:
         "Finds the local session bound to a GitHub task ID, if any.\n\nArgs:\n    params: GitHub task ID to look up.\n\nReturns:\n    ID of the local session bound to the given GitHub task, or omitted when none."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return SessionsFindByTaskIDResult.from_dict(await self._client.request("sessions.findByTaskId", params_dict, **_timeout_kwargs(timeout)))
 
     async def find_by_prefix(self, params: SessionsFindByPrefixRequest, *, timeout: float | None = None) -> SessionsFindByPrefixResult:
         "Resolves a UUID prefix to a unique session ID, if exactly one session matches.\n\nArgs:\n    params: UUID prefix to resolve to a unique session ID.\n\nReturns:\n    Session ID matching the prefix, omitted when no unique match exists."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return SessionsFindByPrefixResult.from_dict(await self._client.request("sessions.findByPrefix", params_dict, **_timeout_kwargs(timeout)))
 
-    async def get_last_for_context(self, params: SessionsGetLastForContextRequest, *, timeout: float | None = None) -> SessionsGetLastForContextResult:
+    async def get_last_for_context(self, params: SessionsGetLastForContextRequest | None = None, *, timeout: float | None = None) -> SessionsGetLastForContextResult:
         "Returns the most-relevant prior session for a given working-directory context.\n\nArgs:\n    params: Optional working-directory context used to score session relevance.\n\nReturns:\n    Most-relevant session ID for the supplied context, or omitted when no sessions exist."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return SessionsGetLastForContextResult.from_dict(await self._client.request("sessions.getLastForContext", params_dict, **_timeout_kwargs(timeout)))
 
-    async def get_event_file_path(self, params: SessionsGetEventFilePathRequest, *, timeout: float | None = None) -> SessionsGetEventFilePathResult:
+    async def get_event_file_path(self, params: SessionsGetEventFilePathRequest | None = None, *, timeout: float | None = None) -> SessionsGetEventFilePathResult:
         "Computes the absolute path to a session's persisted events.jsonl file.\n\nArgs:\n    params: Session ID whose event-log file path to compute.\n\nReturns:\n    Absolute path to the session's events.jsonl file on disk."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return SessionsGetEventFilePathResult.from_dict(await self._client.request("sessions.getEventFilePath", params_dict, **_timeout_kwargs(timeout)))
 
     async def get_sizes(self, *, timeout: float | None = None) -> SessionSizes:
@@ -16647,56 +16674,71 @@ class ServerSessionsApi:
 
     async def check_in_use(self, params: SessionsCheckInUseRequest, *, timeout: float | None = None) -> SessionsCheckInUseResult:
         "Returns the subset of the supplied session IDs that are currently held by another running process.\n\nArgs:\n    params: Session IDs to test for live in-use locks.\n\nReturns:\n    Session IDs from the input set that are currently in use by another process."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return SessionsCheckInUseResult.from_dict(await self._client.request("sessions.checkInUse", params_dict, **_timeout_kwargs(timeout)))
 
-    async def get_persisted_remote_steerable(self, params: SessionsGetPersistedRemoteSteerableRequest, *, timeout: float | None = None) -> SessionsGetPersistedRemoteSteerableResult:
+    async def get_persisted_remote_steerable(self, params: SessionsGetPersistedRemoteSteerableRequest | None = None, *, timeout: float | None = None) -> SessionsGetPersistedRemoteSteerableResult:
         "Returns a session's persisted remote-steerable flag, if any has been recorded.\n\nArgs:\n    params: Session ID to look up the persisted remote-steerable flag for.\n\nReturns:\n    The session's persisted remote-steerable flag, or omitted when no value has been persisted."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return SessionsGetPersistedRemoteSteerableResult.from_dict(await self._client.request("sessions.getPersistedRemoteSteerable", params_dict, **_timeout_kwargs(timeout)))
 
-    async def close(self, params: SessionsCloseRequest, *, timeout: float | None = None) -> SessionsCloseResult:
+    async def close(self, params: SessionsCloseRequest | None = None, *, timeout: float | None = None) -> SessionsCloseResult:
         "Closes a session: emits shutdown, flushes pending events, releases the in-use lock, and disposes the active session.\n\nArgs:\n    params: Session ID to close.\n\nReturns:\n    Closes a session: emits shutdown, flushes pending events to disk, releases the in-use lock, disposes the active session. Idempotent: succeeds even if the session is not currently active."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return SessionsCloseResult.from_dict(await self._client.request("sessions.close", params_dict, **_timeout_kwargs(timeout)))
 
     async def bulk_delete(self, params: SessionsBulkDeleteRequest, *, timeout: float | None = None) -> SessionBulkDeleteResult:
         "Closes, deactivates, and deletes a set of sessions, returning the bytes freed per session.\n\nArgs:\n    params: Session IDs to close, deactivate, and delete from disk.\n\nReturns:\n    Map of sessionId -> bytes freed by removing the session's workspace directory."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return SessionBulkDeleteResult.from_dict(await self._client.request("sessions.bulkDelete", params_dict, **_timeout_kwargs(timeout)))
 
     async def prune_old(self, params: SessionsPruneOldRequest, *, timeout: float | None = None) -> SessionPruneResult:
         "Deletes sessions older than the given threshold, with optional dry-run and exclusion list.\n\nArgs:\n    params: Age threshold and optional flags controlling which old sessions are pruned (or simulated when dryRun is true).\n\nReturns:\n    Outcome of the prune operation: deleted IDs, dry-run candidates, skipped IDs, total bytes freed, and the dry-run flag."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return SessionPruneResult.from_dict(await self._client.request("sessions.pruneOld", params_dict, **_timeout_kwargs(timeout)))
 
-    async def save(self, params: SessionsSaveRequest, *, timeout: float | None = None) -> SessionsSaveResult:
+    async def save(self, params: SessionsSaveRequest | None = None, *, timeout: float | None = None) -> SessionsSaveResult:
         "Flushes a session's pending events to disk.\n\nArgs:\n    params: Session ID whose pending events should be flushed to disk.\n\nReturns:\n    Flush a session's pending events to disk. No-op when no writer exists for the session (e.g., already closed)."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return SessionsSaveResult.from_dict(await self._client.request("sessions.save", params_dict, **_timeout_kwargs(timeout)))
 
-    async def release_lock(self, params: SessionsReleaseLockRequest, *, timeout: float | None = None) -> SessionsReleaseLockResult:
+    async def release_lock(self, params: SessionsReleaseLockRequest | None = None, *, timeout: float | None = None) -> SessionsReleaseLockResult:
         "Releases the in-use lock held by this process for a session.\n\nArgs:\n    params: Session ID whose in-use lock should be released.\n\nReturns:\n    Release the in-use lock held by this process for the given session. No-op when this process does not currently hold a lock for the session."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return SessionsReleaseLockResult.from_dict(await self._client.request("sessions.releaseLock", params_dict, **_timeout_kwargs(timeout)))
 
     async def enrich_metadata(self, params: SessionsEnrichMetadataRequest, *, timeout: float | None = None) -> SessionEnrichMetadataResult:
         "Backfills missing summary and context fields on the supplied session metadata records.\n\nArgs:\n    params: Session metadata records to enrich with summary and context information.\n\nReturns:\n    The same metadata records, with summary and context fields backfilled where available."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return SessionEnrichMetadataResult.from_dict(await self._client.request("sessions.enrichMetadata", params_dict, **_timeout_kwargs(timeout)))
 
-    async def reload_plugin_hooks(self, params: SessionsReloadPluginHooksRequest, *, timeout: float | None = None) -> SessionsReloadPluginHooksResult:
+    async def reload_plugin_hooks(self, params: SessionsReloadPluginHooksRequest | None = None, *, timeout: float | None = None) -> SessionsReloadPluginHooksResult:
         "Reloads user, plugin, and (optionally) repo hooks on the active session.\n\nArgs:\n    params: Active session ID and an optional flag for deferring repo-level hooks until folder trust.\n\nReturns:\n    Reload all hooks (user, plugin, optionally repo) and apply them to the active session. Call after installing or removing plugins so their hooks take effect immediately. No-op when no active session matches the given sessionId."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return SessionsReloadPluginHooksResult.from_dict(await self._client.request("sessions.reloadPluginHooks", params_dict, **_timeout_kwargs(timeout)))
 
-    async def load_deferred_repo_hooks(self, params: SessionsLoadDeferredRepoHooksRequest, *, timeout: float | None = None) -> SessionLoadDeferredRepoHooksResult:
+    async def load_deferred_repo_hooks(self, params: SessionsLoadDeferredRepoHooksRequest | None = None, *, timeout: float | None = None) -> SessionLoadDeferredRepoHooksResult:
         "Loads previously-deferred repo-level hooks on the active session, returning queued startup prompts.\n\nArgs:\n    params: Active session ID whose deferred repo-level hooks should be loaded.\n\nReturns:\n    Queued repo-level startup prompts and the total hook command count after loading."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return SessionLoadDeferredRepoHooksResult.from_dict(await self._client.request("sessions.loadDeferredRepoHooks", params_dict, **_timeout_kwargs(timeout)))
 
     async def set_additional_plugins(self, params: SessionsSetAdditionalPluginsRequest, *, timeout: float | None = None) -> SessionsSetAdditionalPluginsResult:
         "Replaces the manager-wide additional plugins registered with the session manager.\n\nArgs:\n    params: Manager-wide additional plugins to register; replaces any previously-configured set.\n\nReturns:\n    Replace the manager-wide additional plugins. New session creations and subsequent hook reloads see the new set; already-running sessions keep their existing hook installation until the next reload."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return SessionsSetAdditionalPluginsResult.from_dict(await self._client.request("sessions.setAdditionalPlugins", params_dict, **_timeout_kwargs(timeout)))
 
@@ -16713,9 +16755,9 @@ class ServerRpc:
         self.session_fs = ServerSessionFsApi(client)
         self.sessions = ServerSessionsApi(client)
 
-    async def ping(self, params: PingRequest, *, timeout: float | None = None) -> PingResult:
+    async def ping(self, params: PingRequest | None = None, *, timeout: float | None = None) -> PingResult:
         "Checks server responsiveness and returns protocol information.\n\nArgs:\n    params: Optional message to echo back to the caller.\n\nReturns:\n    Server liveness response, including the echoed message, current server timestamp, and protocol version."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return PingResult.from_dict(await self._client.request("ping", params_dict, **_timeout_kwargs(timeout)))
 
 
@@ -16724,47 +16766,68 @@ class _InternalServerRpc:
     def __init__(self, client: "JsonRpcClient"):
         self._client = client
 
-    async def connect(self, params: ConnectRequest, *, timeout: float | None = None) -> ConnectResult:
+    async def connect(self, params: ConnectRequest | None = None, *, timeout: float | None = None) -> ConnectResult:
         "Performs the SDK server connection handshake and validates the optional connection token.\n\nArgs:\n    params: Optional connection token presented by the SDK client during the handshake.\n\nReturns:\n    Handshake result reporting the server's protocol version and package version on success.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return ConnectResult.from_dict(await self._client.request("connect", params_dict, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class AuthApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def get_status(self, *, timeout: float | None = None) -> SessionAuthStatus:
         "Gets authentication status and account metadata for the session.\n\nReturns:\n    Authentication status and account metadata for the session."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return SessionAuthStatus.from_dict(await self._client.request("session.auth.getStatus", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
-    async def set_credentials(self, params: SessionSetCredentialsParams, *, timeout: float | None = None) -> SessionSetCredentialsResult:
+    async def set_credentials(self, params: SessionSetCredentialsParams | None = None, *, timeout: float | None = None) -> SessionSetCredentialsResult:
         "Updates the session's auth credentials used for outbound model and API requests.\n\nArgs:\n    params: New auth credentials to install on the session. Omit to leave credentials unchanged.\n\nReturns:\n    Indicates whether the credential update succeeded."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        if self._assert_active is not None:
+            self._assert_active()
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         params_dict["sessionId"] = self._session_id
         return SessionSetCredentialsResult.from_dict(await self._client.request("session.auth.setCredentials", params_dict, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class ModelApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def get_current(self, *, timeout: float | None = None) -> CurrentModel:
         "Gets the currently selected model for the session.\n\nReturns:\n    The currently selected model and reasoning effort for the session."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return CurrentModel.from_dict(await self._client.request("session.model.getCurrent", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def switch_to(self, params: ModelSwitchToRequest, *, timeout: float | None = None) -> ModelSwitchToResult:
         "Switches the session to a model and optional reasoning configuration.\n\nArgs:\n    params: Target model identifier and optional reasoning effort, summary, and capability overrides.\n\nReturns:\n    The model identifier active on the session after the switch."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return ModelSwitchToResult.from_dict(await self._client.request("session.model.switchTo", params_dict, **_timeout_kwargs(timeout)))
 
     async def set_reasoning_effort(self, params: ModelSetReasoningEffortRequest, *, timeout: float | None = None) -> ModelSetReasoningEffortResult:
         "Updates the session's reasoning effort without changing the selected model.\n\nArgs:\n    params: Reasoning effort level to apply to the currently selected model.\n\nReturns:\n    Update the session's reasoning effort without changing the selected model. Use `switchTo` instead when you also need to change the model. The runtime stores the effort on the session and applies it to subsequent turns."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return ModelSetReasoningEffortResult.from_dict(await self._client.request("session.model.setReasoningEffort", params_dict, **_timeout_kwargs(timeout)))
@@ -16772,16 +16835,25 @@ class ModelApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class ModeApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def get(self, *, timeout: float | None = None) -> SessionMode:
         "Gets the current agent interaction mode.\n\nReturns:\n    The session mode the agent is operating in"
+        if self._assert_active is not None:
+            self._assert_active()
+
         return SessionMode(await self._client.request("session.mode.get", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def set(self, params: ModeSetRequest, *, timeout: float | None = None) -> None:
         "Sets the current agent interaction mode.\n\nArgs:\n    params: Agent interaction mode to apply to the session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.mode.set", params_dict, **_timeout_kwargs(timeout))
@@ -16789,22 +16861,36 @@ class ModeApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class NameApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def get(self, *, timeout: float | None = None) -> NameGetResult:
         "Gets the session's friendly name.\n\nReturns:\n    The session's friendly name, or null when not yet set."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return NameGetResult.from_dict(await self._client.request("session.name.get", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def set(self, params: NameSetRequest, *, timeout: float | None = None) -> None:
         "Sets the session's friendly name.\n\nArgs:\n    params: New friendly name to apply to the session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.name.set", params_dict, **_timeout_kwargs(timeout))
 
     async def set_auto(self, params: NameSetAutoRequest, *, timeout: float | None = None) -> NameSetAutoResult:
         "Persists an auto-generated session summary as the session's name when no user-set name exists.\n\nArgs:\n    params: Auto-generated session summary to apply as the session's name when no user-set name exists.\n\nReturns:\n    Indicates whether the auto-generated summary was applied as the session's name."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return NameSetAutoResult.from_dict(await self._client.request("session.name.setAuto", params_dict, **_timeout_kwargs(timeout)))
@@ -16812,63 +16898,105 @@ class NameApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class PlanApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def read(self, *, timeout: float | None = None) -> PlanReadResult:
         "Reads the session plan file from the workspace.\n\nReturns:\n    Existence, contents, and resolved path of the session plan file."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return PlanReadResult.from_dict(await self._client.request("session.plan.read", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def update(self, params: PlanUpdateRequest, *, timeout: float | None = None) -> None:
         "Writes new content to the session plan file.\n\nArgs:\n    params: Replacement contents to write to the session plan file."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.plan.update", params_dict, **_timeout_kwargs(timeout))
 
     async def delete(self, *, timeout: float | None = None) -> None:
         "Deletes the session plan file from the workspace."
+        if self._assert_active is not None:
+            self._assert_active()
+
         await self._client.request("session.plan.delete", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class WorkspacesApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def get_workspace(self, *, timeout: float | None = None) -> WorkspacesGetWorkspaceResult:
         "Gets current workspace metadata for the session.\n\nReturns:\n    Current workspace metadata for the session, including its absolute filesystem path when available."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return WorkspacesGetWorkspaceResult.from_dict(await self._client.request("session.workspaces.getWorkspace", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def list_files(self, *, timeout: float | None = None) -> WorkspacesListFilesResult:
         "Lists files stored in the session workspace files directory.\n\nReturns:\n    Relative paths of files stored in the session workspace files directory."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return WorkspacesListFilesResult.from_dict(await self._client.request("session.workspaces.listFiles", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def read_file(self, params: WorkspacesReadFileRequest, *, timeout: float | None = None) -> WorkspacesReadFileResult:
         "Reads a file from the session workspace files directory.\n\nArgs:\n    params: Relative path of the workspace file to read.\n\nReturns:\n    Contents of the requested workspace file as a UTF-8 string."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return WorkspacesReadFileResult.from_dict(await self._client.request("session.workspaces.readFile", params_dict, **_timeout_kwargs(timeout)))
 
     async def create_file(self, params: WorkspacesCreateFileRequest, *, timeout: float | None = None) -> None:
         "Creates or overwrites a file in the session workspace files directory.\n\nArgs:\n    params: Relative path and UTF-8 content for the workspace file to create or overwrite."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.workspaces.createFile", params_dict, **_timeout_kwargs(timeout))
 
     async def list_checkpoints(self, *, timeout: float | None = None) -> WorkspacesListCheckpointsResult:
         "Lists workspace checkpoints in chronological order.\n\nReturns:\n    Workspace checkpoints in chronological order; empty when the workspace is not enabled."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return WorkspacesListCheckpointsResult.from_dict(await self._client.request("session.workspaces.listCheckpoints", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def read_checkpoint(self, params: WorkspacesReadCheckpointRequest, *, timeout: float | None = None) -> WorkspacesReadCheckpointResult:
         "Reads the content of a workspace checkpoint by number.\n\nArgs:\n    params: Checkpoint number to read.\n\nReturns:\n    Checkpoint content as a UTF-8 string, or null when the checkpoint or workspace is missing."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return WorkspacesReadCheckpointResult.from_dict(await self._client.request("session.workspaces.readCheckpoint", params_dict, **_timeout_kwargs(timeout)))
 
     async def save_large_paste(self, params: WorkspacesSaveLargePasteRequest, *, timeout: float | None = None) -> WorkspacesSaveLargePasteResult:
         "Saves pasted content as a UTF-8 file in the session workspace.\n\nArgs:\n    params: Pasted content to save as a UTF-8 file in the session workspace.\n\nReturns:\n    Descriptor for the saved paste file, or null when the workspace is unavailable."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return WorkspacesSaveLargePasteResult.from_dict(await self._client.request("session.workspaces.saveLargePaste", params_dict, **_timeout_kwargs(timeout)))
@@ -16876,115 +17004,187 @@ class WorkspacesApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class InstructionsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def get_sources(self, *, timeout: float | None = None) -> InstructionsGetSourcesResult:
         "Gets instruction sources loaded for the session.\n\nReturns:\n    Instruction sources loaded for the session, in merge order."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return InstructionsGetSourcesResult.from_dict(await self._client.request("session.instructions.getSources", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class FleetApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
-    async def start(self, params: FleetStartRequest, *, timeout: float | None = None) -> FleetStartResult:
+    async def start(self, params: FleetStartRequest | None = None, *, timeout: float | None = None) -> FleetStartResult:
         "Starts fleet mode by submitting the fleet orchestration prompt to the session.\n\nArgs:\n    params: Optional user prompt to combine with the fleet orchestration instructions.\n\nReturns:\n    Indicates whether fleet mode was successfully activated."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        if self._assert_active is not None:
+            self._assert_active()
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         params_dict["sessionId"] = self._session_id
         return FleetStartResult.from_dict(await self._client.request("session.fleet.start", params_dict, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class AgentApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def list(self, *, timeout: float | None = None) -> AgentList:
         "Lists custom agents available to the session.\n\nReturns:\n    Custom agents available to the session."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return AgentList.from_dict(await self._client.request("session.agent.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def get_current(self, *, timeout: float | None = None) -> AgentGetCurrentResult:
         "Gets the currently selected custom agent for the session.\n\nReturns:\n    The currently selected custom agent, or null when using the default agent."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return AgentGetCurrentResult.from_dict(await self._client.request("session.agent.getCurrent", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def select(self, params: AgentSelectRequest, *, timeout: float | None = None) -> AgentSelectResult:
         "Selects a custom agent for subsequent turns in the session.\n\nArgs:\n    params: Name of the custom agent to select for subsequent turns.\n\nReturns:\n    The newly selected custom agent."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return AgentSelectResult.from_dict(await self._client.request("session.agent.select", params_dict, **_timeout_kwargs(timeout)))
 
     async def deselect(self, *, timeout: float | None = None) -> None:
         "Clears the selected custom agent and returns the session to the default agent."
+        if self._assert_active is not None:
+            self._assert_active()
+
         await self._client.request("session.agent.deselect", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
     async def reload(self, *, timeout: float | None = None) -> AgentReloadResult:
         "Reloads custom agent definitions and returns the refreshed list.\n\nReturns:\n    Custom agents available to the session after reloading definitions from disk."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return AgentReloadResult.from_dict(await self._client.request("session.agent.reload", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class TasksApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def start_agent(self, params: TasksStartAgentRequest, *, timeout: float | None = None) -> TasksStartAgentResult:
         "Starts a background agent task in the session.\n\nArgs:\n    params: Agent type, prompt, name, and optional description and model override for the new task.\n\nReturns:\n    Identifier assigned to the newly started background agent task."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return TasksStartAgentResult.from_dict(await self._client.request("session.tasks.startAgent", params_dict, **_timeout_kwargs(timeout)))
 
     async def list(self, *, timeout: float | None = None) -> TaskList:
         "Lists background tasks tracked by the session.\n\nReturns:\n    Background tasks currently tracked by the session."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return TaskList.from_dict(await self._client.request("session.tasks.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def refresh(self, *, timeout: float | None = None) -> TasksRefreshResult:
         "Refreshes metadata for any detached background shells the runtime knows about.\n\nReturns:\n    Refresh metadata for any detached background shells the runtime knows about. Use after a long pause to pick up exit/output state for shells running outside the agent loop."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return TasksRefreshResult.from_dict(await self._client.request("session.tasks.refresh", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def wait_for_pending(self, *, timeout: float | None = None) -> TasksWaitForPendingResult:
         "Waits for all in-flight background tasks and any follow-up turns to settle.\n\nReturns:\n    Wait until all in-flight background tasks (agents + shells) and any follow-up turns scheduled by their completions have settled. Returns when the runtime is fully drained or after an internal timeout (default 10 minutes; configurable via COPILOT_TASK_WAIT_TIMEOUT_SECONDS)."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return TasksWaitForPendingResult.from_dict(await self._client.request("session.tasks.waitForPending", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def get_progress(self, params: TasksGetProgressRequest, *, timeout: float | None = None) -> TasksGetProgressResult:
         "Returns progress information for a background task by ID.\n\nArgs:\n    params: Identifier of the background task to fetch progress for.\n\nReturns:\n    Progress information for the task, or null when no task with that ID is tracked."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return TasksGetProgressResult.from_dict(await self._client.request("session.tasks.getProgress", params_dict, **_timeout_kwargs(timeout)))
 
     async def get_current_promotable(self, *, timeout: float | None = None) -> TasksGetCurrentPromotableResult:
         "Returns the first sync-waiting task that can currently be promoted to background mode.\n\nReturns:\n    The first sync-waiting task that can currently be promoted to background mode."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return TasksGetCurrentPromotableResult.from_dict(await self._client.request("session.tasks.getCurrentPromotable", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def promote_to_background(self, params: TasksPromoteToBackgroundRequest, *, timeout: float | None = None) -> TasksPromoteToBackgroundResult:
         "Promotes an eligible synchronously-waited task so it continues running in the background.\n\nArgs:\n    params: Identifier of the task to promote to background mode.\n\nReturns:\n    Indicates whether the task was successfully promoted to background mode."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return TasksPromoteToBackgroundResult.from_dict(await self._client.request("session.tasks.promoteToBackground", params_dict, **_timeout_kwargs(timeout)))
 
     async def promote_current_to_background(self, *, timeout: float | None = None) -> TasksPromoteCurrentToBackgroundResult:
         "Atomically promotes the first promotable sync-waiting task to background mode and returns it.\n\nReturns:\n    The promoted task as it now exists in background mode, omitted if no promotable task was waiting."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return TasksPromoteCurrentToBackgroundResult.from_dict(await self._client.request("session.tasks.promoteCurrentToBackground", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def cancel(self, params: TasksCancelRequest, *, timeout: float | None = None) -> TasksCancelResult:
         "Cancels a background task.\n\nArgs:\n    params: Identifier of the background task to cancel.\n\nReturns:\n    Indicates whether the background task was successfully cancelled."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return TasksCancelResult.from_dict(await self._client.request("session.tasks.cancel", params_dict, **_timeout_kwargs(timeout)))
 
     async def remove(self, params: TasksRemoveRequest, *, timeout: float | None = None) -> TasksRemoveResult:
         "Removes a completed or cancelled background task from tracking.\n\nArgs:\n    params: Identifier of the completed or cancelled task to remove from tracking.\n\nReturns:\n    Indicates whether the task was removed. False when the task does not exist or is still running/idle."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return TasksRemoveResult.from_dict(await self._client.request("session.tasks.remove", params_dict, **_timeout_kwargs(timeout)))
 
     async def send_message(self, params: TasksSendMessageRequest, *, timeout: float | None = None) -> TasksSendMessageResult:
         "Sends a message to a background agent task.\n\nArgs:\n    params: Identifier of the target agent task, message content, and optional sender agent ID.\n\nReturns:\n    Indicates whether the message was delivered, with an error message when delivery failed."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return TasksSendMessageResult.from_dict(await self._client.request("session.tasks.sendMessage", params_dict, **_timeout_kwargs(timeout)))
@@ -16992,47 +17192,76 @@ class TasksApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class SkillsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def list(self, *, timeout: float | None = None) -> SkillList:
         "Lists skills available to the session.\n\nReturns:\n    Skills available to the session, with their enabled state."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return SkillList.from_dict(await self._client.request("session.skills.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def get_invoked(self, *, timeout: float | None = None) -> SkillsGetInvokedResult:
         "Returns the skills that have been invoked during this session.\n\nReturns:\n    Skills invoked during this session, ordered by invocation time (most recent last)."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return SkillsGetInvokedResult.from_dict(await self._client.request("session.skills.getInvoked", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def enable(self, params: SkillsEnableRequest, *, timeout: float | None = None) -> None:
         "Enables a skill for the session.\n\nArgs:\n    params: Name of the skill to enable for the session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.skills.enable", params_dict, **_timeout_kwargs(timeout))
 
     async def disable(self, params: SkillsDisableRequest, *, timeout: float | None = None) -> None:
         "Disables a skill for the session.\n\nArgs:\n    params: Name of the skill to disable for the session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.skills.disable", params_dict, **_timeout_kwargs(timeout))
 
     async def reload(self, *, timeout: float | None = None) -> SkillsLoadDiagnostics:
         "Reloads skill definitions for the session.\n\nReturns:\n    Diagnostics from reloading skill definitions, with warnings and errors as separate lists."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return SkillsLoadDiagnostics.from_dict(await self._client.request("session.skills.reload", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def ensure_loaded(self, *, timeout: float | None = None) -> None:
         "Ensures the session's skill definitions have been loaded from disk."
+        if self._assert_active is not None:
+            self._assert_active()
+
         await self._client.request("session.skills.ensureLoaded", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class McpOauthApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def login(self, params: MCPOauthLoginRequest, *, timeout: float | None = None) -> MCPOauthLoginResult:
         "Starts OAuth authentication for a remote MCP server.\n\nArgs:\n    params: Remote MCP server name and optional overrides controlling reauthentication, OAuth client display name, and the callback success-page copy.\n\nReturns:\n    OAuth authorization URL the caller should open, or empty when cached tokens already authenticated the server."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return MCPOauthLoginResult.from_dict(await self._client.request("session.mcp.oauth.login", params_dict, **_timeout_kwargs(timeout)))
@@ -17040,173 +17269,275 @@ class McpOauthApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class McpApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
-        self.oauth = McpOauthApi(client, session_id)
+        self._assert_active = assert_active
+        self.oauth = McpOauthApi(client, session_id, assert_active)
 
     async def list(self, *, timeout: float | None = None) -> MCPServerList:
         "Lists MCP servers configured for the session and their connection status.\n\nReturns:\n    MCP servers configured for the session, with their connection status."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return MCPServerList.from_dict(await self._client.request("session.mcp.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def enable(self, params: MCPEnableRequest, *, timeout: float | None = None) -> None:
         "Enables an MCP server for the session.\n\nArgs:\n    params: Name of the MCP server to enable for the session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.mcp.enable", params_dict, **_timeout_kwargs(timeout))
 
     async def disable(self, params: MCPDisableRequest, *, timeout: float | None = None) -> None:
         "Disables an MCP server for the session.\n\nArgs:\n    params: Name of the MCP server to disable for the session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.mcp.disable", params_dict, **_timeout_kwargs(timeout))
 
     async def reload(self, *, timeout: float | None = None) -> None:
         "Reloads MCP server connections for the session."
+        if self._assert_active is not None:
+            self._assert_active()
+
         await self._client.request("session.mcp.reload", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
     async def execute_sampling(self, params: MCPExecuteSamplingParams, *, timeout: float | None = None) -> MCPSamplingExecutionResult:
         "Runs an MCP sampling inference on behalf of an MCP server.\n\nArgs:\n    params: Identifiers and raw MCP CreateMessageRequest params used to run a sampling inference.\n\nReturns:\n    Outcome of an MCP sampling execution: success result, failure error, or cancellation."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return MCPSamplingExecutionResult.from_dict(await self._client.request("session.mcp.executeSampling", params_dict, **_timeout_kwargs(timeout)))
 
     async def cancel_sampling_execution(self, params: MCPCancelSamplingExecutionParams, *, timeout: float | None = None) -> MCPCancelSamplingExecutionResult:
         "Cancels an in-flight MCP sampling execution by request ID.\n\nArgs:\n    params: The requestId previously passed to executeSampling that should be cancelled.\n\nReturns:\n    Indicates whether an in-flight sampling execution with the given requestId was found and cancelled."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return MCPCancelSamplingExecutionResult.from_dict(await self._client.request("session.mcp.cancelSamplingExecution", params_dict, **_timeout_kwargs(timeout)))
 
     async def set_env_value_mode(self, params: MCPSetEnvValueModeParams, *, timeout: float | None = None) -> MCPSetEnvValueModeResult:
         "Sets how environment-variable values supplied to MCP servers are resolved (direct or indirect).\n\nArgs:\n    params: Mode controlling how MCP server env values are resolved (`direct` or `indirect`).\n\nReturns:\n    Env-value mode recorded on the session after the update."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return MCPSetEnvValueModeResult.from_dict(await self._client.request("session.mcp.setEnvValueMode", params_dict, **_timeout_kwargs(timeout)))
 
     async def remove_git_hub(self, *, timeout: float | None = None) -> MCPRemoveGitHubResult:
         "Removes the auto-managed `github` MCP server when present.\n\nReturns:\n    Indicates whether the auto-managed `github` MCP server was removed (false when nothing to remove)."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return MCPRemoveGitHubResult.from_dict(await self._client.request("session.mcp.removeGitHub", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class PluginsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def list(self, *, timeout: float | None = None) -> PluginList:
         "Lists plugins installed for the session.\n\nReturns:\n    Plugins installed for the session, with their enabled state and version metadata."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return PluginList.from_dict(await self._client.request("session.plugins.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class OptionsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
-    async def update(self, params: SessionUpdateOptionsParams, *, timeout: float | None = None) -> SessionUpdateOptionsResult:
+    async def update(self, params: SessionUpdateOptionsParams | None = None, *, timeout: float | None = None) -> SessionUpdateOptionsResult:
         "Patches the genuinely-mutable subset of session options.\n\nArgs:\n    params: Patch of mutable session options to apply to the running session.\n\nReturns:\n    Indicates whether the session options patch was applied successfully."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        if self._assert_active is not None:
+            self._assert_active()
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         params_dict["sessionId"] = self._session_id
         return SessionUpdateOptionsResult.from_dict(await self._client.request("session.options.update", params_dict, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class LspApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
-    async def initialize(self, params: LspInitializeRequest, *, timeout: float | None = None) -> None:
+    async def initialize(self, params: LspInitializeRequest | None = None, *, timeout: float | None = None) -> None:
         "Loads the merged LSP configuration set for the session's working directory.\n\nArgs:\n    params: Parameters for (re)loading the merged LSP configuration set."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        if self._assert_active is not None:
+            self._assert_active()
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.lsp.initialize", params_dict, **_timeout_kwargs(timeout))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class ExtensionsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def list(self, *, timeout: float | None = None) -> ExtensionList:
         "Lists extensions discovered for the session and their current status.\n\nReturns:\n    Extensions discovered for the session, with their current status."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return ExtensionList.from_dict(await self._client.request("session.extensions.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def enable(self, params: ExtensionsEnableRequest, *, timeout: float | None = None) -> None:
         "Enables an extension for the session.\n\nArgs:\n    params: Source-qualified extension identifier to enable for the session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.extensions.enable", params_dict, **_timeout_kwargs(timeout))
 
     async def disable(self, params: ExtensionsDisableRequest, *, timeout: float | None = None) -> None:
         "Disables an extension for the session.\n\nArgs:\n    params: Source-qualified extension identifier to disable for the session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.extensions.disable", params_dict, **_timeout_kwargs(timeout))
 
     async def reload(self, *, timeout: float | None = None) -> None:
         "Reloads extension definitions and processes for the session."
+        if self._assert_active is not None:
+            self._assert_active()
+
         await self._client.request("session.extensions.reload", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class ToolsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def handle_pending_tool_call(self, params: HandlePendingToolCallRequest, *, timeout: float | None = None) -> HandlePendingToolCallResult:
         "Provides the result for a pending external tool call.\n\nArgs:\n    params: Pending external tool call request ID, with the tool result or an error describing why it failed.\n\nReturns:\n    Indicates whether the external tool call result was handled successfully."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return HandlePendingToolCallResult.from_dict(await self._client.request("session.tools.handlePendingToolCall", params_dict, **_timeout_kwargs(timeout)))
 
     async def initialize_and_validate(self, *, timeout: float | None = None) -> ToolsInitializeAndValidateResult:
         "Resolves, builds, and validates the runtime tool list for the session.\n\nReturns:\n    Resolve, build, and validate the runtime tool list for this session. Subagent sessions and consumer flows that need an initialized tool set before `send` invoke this. Default base-class implementation is a no-op for sessions that don't support tool validation."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return ToolsInitializeAndValidateResult.from_dict(await self._client.request("session.tools.initializeAndValidate", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class CommandsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def list(self, params: CommandsListRequest | None = None, *, timeout: float | None = None) -> CommandList:
         "Lists slash commands available in the session.\n\nArgs:\n    params: Optional filters controlling which command sources to include in the listing.\n\nReturns:\n    Slash commands available in the session, after applying any include/exclude filters."
+        if self._assert_active is not None:
+            self._assert_active()
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         params_dict["sessionId"] = self._session_id
         return CommandList.from_dict(await self._client.request("session.commands.list", params_dict, **_timeout_kwargs(timeout)))
 
     async def invoke(self, params: CommandsInvokeRequest, *, timeout: float | None = None) -> SlashCommandInvocationResult:
         "Invokes a slash command in the session.\n\nArgs:\n    params: Slash command name and optional raw input string to invoke.\n\nReturns:\n    Result of invoking the slash command (text output, prompt to send to the agent, or completion)."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return SlashCommandInvocationResult.from_dict(await self._client.request("session.commands.invoke", params_dict, **_timeout_kwargs(timeout)))
 
     async def handle_pending_command(self, params: CommandsHandlePendingCommandRequest, *, timeout: float | None = None) -> CommandsHandlePendingCommandResult:
         "Reports completion of a pending client-handled slash command.\n\nArgs:\n    params: Pending command request ID and an optional error if the client handler failed.\n\nReturns:\n    Indicates whether the pending client-handled command was completed successfully."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return CommandsHandlePendingCommandResult.from_dict(await self._client.request("session.commands.handlePendingCommand", params_dict, **_timeout_kwargs(timeout)))
 
     async def execute(self, params: ExecuteCommandParams, *, timeout: float | None = None) -> ExecuteCommandResult:
         "Executes a slash command synchronously and returns any error.\n\nArgs:\n    params: Slash command name and argument string to execute synchronously.\n\nReturns:\n    Error message produced while executing the command, if any."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return ExecuteCommandResult.from_dict(await self._client.request("session.commands.execute", params_dict, **_timeout_kwargs(timeout)))
 
     async def enqueue(self, params: EnqueueCommandParams, *, timeout: float | None = None) -> EnqueueCommandResult:
         "Enqueues a slash command for FIFO processing on the local session.\n\nArgs:\n    params: Slash-prefixed command string to enqueue for FIFO processing.\n\nReturns:\n    Indicates whether the command was accepted into the local execution queue."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return EnqueueCommandResult.from_dict(await self._client.request("session.commands.enqueue", params_dict, **_timeout_kwargs(timeout)))
 
     async def respond_to_queued_command(self, params: CommandsRespondToQueuedCommandRequest, *, timeout: float | None = None) -> CommandsRespondToQueuedCommandResult:
         "Reports whether the host actually executed a queued command and whether to continue processing.\n\nArgs:\n    params: Queued-command request ID and the result indicating whether the host executed it (and whether to stop processing further queued commands).\n\nReturns:\n    Indicates whether the queued-command response was matched to a pending request."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return CommandsRespondToQueuedCommandResult.from_dict(await self._client.request("session.commands.respondToQueuedCommand", params_dict, **_timeout_kwargs(timeout)))
@@ -17214,12 +17545,18 @@ class CommandsApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class TelemetryApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def set_feature_overrides(self, params: TelemetrySetFeatureOverridesRequest, *, timeout: float | None = None) -> None:
         "Sets feature override key/value pairs to attach to subsequent telemetry events for the session.\n\nArgs:\n    params: Feature override key/value pairs to attach to subsequent telemetry events from this session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.telemetry.setFeatureOverrides", params_dict, **_timeout_kwargs(timeout))
@@ -17227,52 +17564,91 @@ class TelemetryApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class UiApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def elicitation(self, params: UIElicitationRequest, *, timeout: float | None = None) -> UIElicitationResponse:
         "Requests structured input from a UI-capable client.\n\nArgs:\n    params: Prompt message and JSON schema describing the form fields to elicit from the user.\n\nReturns:\n    The elicitation response (accept with form values, decline, or cancel)"
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return UIElicitationResponse.from_dict(await self._client.request("session.ui.elicitation", params_dict, **_timeout_kwargs(timeout)))
 
     async def handle_pending_elicitation(self, params: UIHandlePendingElicitationRequest, *, timeout: float | None = None) -> UIElicitationResult:
         "Provides the user response for a pending elicitation request.\n\nArgs:\n    params: Pending elicitation request ID and the user's response (accept/decline/cancel + form values).\n\nReturns:\n    Indicates whether the elicitation response was accepted; false if it was already resolved by another client."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return UIElicitationResult.from_dict(await self._client.request("session.ui.handlePendingElicitation", params_dict, **_timeout_kwargs(timeout)))
 
     async def handle_pending_user_input(self, params: UIHandlePendingUserInputRequest, *, timeout: float | None = None) -> UIHandlePendingResult:
         "Resolves a pending `user_input.requested` event with the user's response.\n\nArgs:\n    params: Request ID of a pending `user_input.requested` event and the user's response.\n\nReturns:\n    Indicates whether the pending UI request was resolved by this call."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return UIHandlePendingResult.from_dict(await self._client.request("session.ui.handlePendingUserInput", params_dict, **_timeout_kwargs(timeout)))
 
     async def handle_pending_sampling(self, params: UIHandlePendingSamplingRequest, *, timeout: float | None = None) -> UIHandlePendingResult:
         "Resolves a pending `sampling.requested` event with a sampling result, or rejects it.\n\nArgs:\n    params: Request ID of a pending `sampling.requested` event and an optional sampling result payload (omit to reject).\n\nReturns:\n    Indicates whether the pending UI request was resolved by this call."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return UIHandlePendingResult.from_dict(await self._client.request("session.ui.handlePendingSampling", params_dict, **_timeout_kwargs(timeout)))
 
     async def handle_pending_auto_mode_switch(self, params: UIHandlePendingAutoModeSwitchRequest, *, timeout: float | None = None) -> UIHandlePendingResult:
         "Resolves a pending `auto_mode_switch.requested` event with the user's accept/decline decision.\n\nArgs:\n    params: Request ID of a pending `auto_mode_switch.requested` event and the user's response.\n\nReturns:\n    Indicates whether the pending UI request was resolved by this call."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return UIHandlePendingResult.from_dict(await self._client.request("session.ui.handlePendingAutoModeSwitch", params_dict, **_timeout_kwargs(timeout)))
 
     async def handle_pending_exit_plan_mode(self, params: UIHandlePendingExitPlanModeRequest, *, timeout: float | None = None) -> UIHandlePendingResult:
         "Resolves a pending `exit_plan_mode.requested` event with the user's response.\n\nArgs:\n    params: Request ID of a pending `exit_plan_mode.requested` event and the user's response.\n\nReturns:\n    Indicates whether the pending UI request was resolved by this call."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return UIHandlePendingResult.from_dict(await self._client.request("session.ui.handlePendingExitPlanMode", params_dict, **_timeout_kwargs(timeout)))
 
     async def register_direct_auto_mode_switch_handler(self, *, timeout: float | None = None) -> UIRegisterDirectAutoModeSwitchHandlerResult:
         "Registers an in-process handler for auto-mode-switch requests so the server bridge skips dispatch.\n\nReturns:\n    Register an in-process handler for `auto_mode_switch.requested` events. The caller still attaches the actual listener via the standard event-subscription mechanism; this registration solely tells the server bridge to skip its own dispatch (so a remote client doesn't race the in-process handler for the same requestId)."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return UIRegisterDirectAutoModeSwitchHandlerResult.from_dict(await self._client.request("session.ui.registerDirectAutoModeSwitchHandler", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def unregister_direct_auto_mode_switch_handler(self, params: UIUnregisterDirectAutoModeSwitchHandlerRequest, *, timeout: float | None = None) -> UIUnregisterDirectAutoModeSwitchHandlerResult:
         "Unregisters a previously-registered in-process auto-mode-switch handler by its opaque handle.\n\nArgs:\n    params: Opaque handle previously returned by `registerDirectAutoModeSwitchHandler` to release.\n\nReturns:\n    Indicates whether the handle was active and the registration count was decremented."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return UIUnregisterDirectAutoModeSwitchHandlerResult.from_dict(await self._client.request("session.ui.unregisterDirectAutoModeSwitchHandler", params_dict, **_timeout_kwargs(timeout)))
@@ -17280,34 +17656,58 @@ class UiApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class PermissionsPathsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def list(self, *, timeout: float | None = None) -> PermissionPathsList:
         "Returns the session's allowed directories and primary working directory.\n\nReturns:\n    Snapshot of the session's allow-listed directories and primary working directory."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return PermissionPathsList.from_dict(await self._client.request("session.permissions.paths.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def add(self, params: PermissionPathsAddParams, *, timeout: float | None = None) -> PermissionsPathsAddResult:
         "Adds a directory to the session's allow-list.\n\nArgs:\n    params: Directory path to add to the session's allowed directories.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return PermissionsPathsAddResult.from_dict(await self._client.request("session.permissions.paths.add", params_dict, **_timeout_kwargs(timeout)))
 
     async def update_primary(self, params: PermissionPathsUpdatePrimaryParams, *, timeout: float | None = None) -> PermissionsPathsUpdatePrimaryResult:
         "Updates the session's primary working directory used by the permission policy.\n\nArgs:\n    params: Directory path to set as the session's new primary working directory.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return PermissionsPathsUpdatePrimaryResult.from_dict(await self._client.request("session.permissions.paths.updatePrimary", params_dict, **_timeout_kwargs(timeout)))
 
     async def is_path_within_allowed_directories(self, params: PermissionPathsAllowedCheckParams, *, timeout: float | None = None) -> PermissionPathsAllowedCheckResult:
         "Reports whether a path falls within any of the session's allowed directories.\n\nArgs:\n    params: Path to evaluate against the session's allowed directories.\n\nReturns:\n    Indicates whether the supplied path is within the session's allowed directories."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return PermissionPathsAllowedCheckResult.from_dict(await self._client.request("session.permissions.paths.isPathWithinAllowedDirectories", params_dict, **_timeout_kwargs(timeout)))
 
     async def is_path_within_workspace(self, params: PermissionPathsWorkspaceCheckParams, *, timeout: float | None = None) -> PermissionPathsWorkspaceCheckResult:
         "Reports whether a path falls within the session's workspace (primary) directory.\n\nArgs:\n    params: Path to evaluate against the session's workspace (primary) directory.\n\nReturns:\n    Indicates whether the supplied path is within the session's workspace directory."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return PermissionPathsWorkspaceCheckResult.from_dict(await self._client.request("session.permissions.paths.isPathWithinWorkspace", params_dict, **_timeout_kwargs(timeout)))
@@ -17315,24 +17715,40 @@ class PermissionsPathsApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class PermissionsLocationsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def resolve(self, params: PermissionLocationResolveParams, *, timeout: float | None = None) -> PermissionLocationResolveResult:
         "Resolves the permission location key and type for a working directory.\n\nArgs:\n    params: Working directory to resolve into a location-permissions key.\n\nReturns:\n    Resolved location-permissions key and type."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return PermissionLocationResolveResult.from_dict(await self._client.request("session.permissions.locations.resolve", params_dict, **_timeout_kwargs(timeout)))
 
     async def apply(self, params: PermissionLocationApplyParams, *, timeout: float | None = None) -> PermissionLocationApplyResult:
         "Applies persisted location-scoped tool approvals and allowed directories for a working directory to this session's permission service.\n\nArgs:\n    params: Working directory to load persisted location permissions for.\n\nReturns:\n    Summary of persisted location permissions applied to the session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return PermissionLocationApplyResult.from_dict(await self._client.request("session.permissions.locations.apply", params_dict, **_timeout_kwargs(timeout)))
 
     async def add_tool_approval(self, params: PermissionLocationAddToolApprovalParams, *, timeout: float | None = None) -> PermissionsLocationsAddToolApprovalResult:
         "Persists a tool approval for a permission location and applies its rules to this session's live permission service.\n\nArgs:\n    params: Location-scoped tool approval to persist.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return PermissionsLocationsAddToolApprovalResult.from_dict(await self._client.request("session.permissions.locations.addToolApproval", params_dict, **_timeout_kwargs(timeout)))
@@ -17340,18 +17756,29 @@ class PermissionsLocationsApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class PermissionsFolderTrustApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def is_trusted(self, params: FolderTrustCheckParams, *, timeout: float | None = None) -> FolderTrustCheckResult:
         "Reports whether a folder is trusted according to the user's folder trust state.\n\nArgs:\n    params: Folder path to check for trust.\n\nReturns:\n    Folder trust check result."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return FolderTrustCheckResult.from_dict(await self._client.request("session.permissions.folderTrust.isTrusted", params_dict, **_timeout_kwargs(timeout)))
 
     async def add_trusted(self, params: FolderTrustAddParams, *, timeout: float | None = None) -> PermissionsFolderTrustAddTrustedResult:
         "Adds a folder to the user's trusted folders list.\n\nArgs:\n    params: Folder path to add to trusted folders.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return PermissionsFolderTrustAddTrustedResult.from_dict(await self._client.request("session.permissions.folderTrust.addTrusted", params_dict, **_timeout_kwargs(timeout)))
@@ -17359,12 +17786,18 @@ class PermissionsFolderTrustApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class PermissionsUrlsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def set_unrestricted_mode(self, params: PermissionUrlsSetUnrestrictedModeParams, *, timeout: float | None = None) -> PermissionsUrlsSetUnrestrictedModeResult:
         "Toggles the runtime's URL-permission policy between unrestricted and restricted modes.\n\nArgs:\n    params: Whether the URL-permission policy should run in unrestricted mode.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return PermissionsUrlsSetUnrestrictedModeResult.from_dict(await self._client.request("session.permissions.urls.setUnrestrictedMode", params_dict, **_timeout_kwargs(timeout)))
@@ -17372,54 +17805,89 @@ class PermissionsUrlsApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class PermissionsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
-        self.paths = PermissionsPathsApi(client, session_id)
-        self.locations = PermissionsLocationsApi(client, session_id)
-        self.folder_trust = PermissionsFolderTrustApi(client, session_id)
-        self.urls = PermissionsUrlsApi(client, session_id)
+        self._assert_active = assert_active
+        self.paths = PermissionsPathsApi(client, session_id, assert_active)
+        self.locations = PermissionsLocationsApi(client, session_id, assert_active)
+        self.folder_trust = PermissionsFolderTrustApi(client, session_id, assert_active)
+        self.urls = PermissionsUrlsApi(client, session_id, assert_active)
 
-    async def configure(self, params: PermissionsConfigureParams, *, timeout: float | None = None) -> PermissionsConfigureResult:
+    async def configure(self, params: PermissionsConfigureParams | None = None, *, timeout: float | None = None) -> PermissionsConfigureResult:
         "Replaces selected permission policy fields (rules, paths, URLs, exclusions, allow-all flags) on the session.\n\nArgs:\n    params: Patch of permission policy fields to apply (omit a field to leave it unchanged).\n\nReturns:\n    Indicates whether the operation succeeded."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        if self._assert_active is not None:
+            self._assert_active()
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         params_dict["sessionId"] = self._session_id
         return PermissionsConfigureResult.from_dict(await self._client.request("session.permissions.configure", params_dict, **_timeout_kwargs(timeout)))
 
     async def handle_pending_permission_request(self, params: PermissionDecisionRequest, *, timeout: float | None = None) -> PermissionRequestResult:
         "Provides a decision for a pending tool permission request.\n\nArgs:\n    params: Pending permission request ID and the decision to apply (approve/reject and scope).\n\nReturns:\n    Indicates whether the permission decision was applied; false when the request was already resolved."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return PermissionRequestResult.from_dict(await self._client.request("session.permissions.handlePendingPermissionRequest", params_dict, **_timeout_kwargs(timeout)))
 
     async def pending_requests(self, *, timeout: float | None = None) -> PendingPermissionRequestList:
         "Reconstructs the set of pending tool permission requests from the session's event history.\n\nReturns:\n    List of pending permission requests reconstructed from event history."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return PendingPermissionRequestList.from_dict(await self._client.request("session.permissions.pendingRequests", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def set_approve_all(self, params: PermissionsSetApproveAllRequest, *, timeout: float | None = None) -> PermissionsSetApproveAllResult:
         "Enables or disables automatic approval of tool permission requests for the session.\n\nArgs:\n    params: Allow-all toggle for tool permission requests, with an optional telemetry source.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return PermissionsSetApproveAllResult.from_dict(await self._client.request("session.permissions.setApproveAll", params_dict, **_timeout_kwargs(timeout)))
 
     async def modify_rules(self, params: PermissionsModifyRulesParams, *, timeout: float | None = None) -> PermissionsModifyRulesResult:
         "Adds or removes session-scoped or location-scoped permission rules.\n\nArgs:\n    params: Scope and add/remove instructions for modifying session- or location-scoped permission rules.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return PermissionsModifyRulesResult.from_dict(await self._client.request("session.permissions.modifyRules", params_dict, **_timeout_kwargs(timeout)))
 
     async def set_required(self, params: PermissionsSetRequiredRequest, *, timeout: float | None = None) -> PermissionsSetRequiredResult:
         "Sets whether the client wants permission prompts bridged into session events.\n\nArgs:\n    params: Toggles whether permission prompts should be bridged into session events for this client.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return PermissionsSetRequiredResult.from_dict(await self._client.request("session.permissions.setRequired", params_dict, **_timeout_kwargs(timeout)))
 
     async def reset_session_approvals(self, *, timeout: float | None = None) -> PermissionsResetSessionApprovalsResult:
         "Clears session-scoped tool permission approvals.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return PermissionsResetSessionApprovalsResult.from_dict(await self._client.request("session.permissions.resetSessionApprovals", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def notify_prompt_shown(self, params: PermissionPromptShownNotification, *, timeout: float | None = None) -> PermissionsNotifyPromptShownResult:
         "Notifies the runtime that a permission prompt UI has been shown to the user.\n\nArgs:\n    params: Notification payload describing the permission prompt that the client just rendered.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return PermissionsNotifyPromptShownResult.from_dict(await self._client.request("session.permissions.notifyPromptShown", params_dict, **_timeout_kwargs(timeout)))
@@ -17427,38 +17895,65 @@ class PermissionsApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class MetadataApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def snapshot(self, *, timeout: float | None = None) -> SessionMetadataSnapshot:
         "Returns a snapshot of the session's identifying metadata, mode, agent, and remote info.\n\nReturns:\n    Point-in-time snapshot of slow-changing session identifier and state fields"
+        if self._assert_active is not None:
+            self._assert_active()
+
         return SessionMetadataSnapshot.from_dict(await self._client.request("session.metadata.snapshot", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def is_processing(self, *, timeout: float | None = None) -> MetadataIsProcessingResult:
         "Reports whether the local session is currently processing user/agent messages.\n\nReturns:\n    Indicates whether the local session is currently processing a turn or background continuation."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return MetadataIsProcessingResult.from_dict(await self._client.request("session.metadata.isProcessing", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def context_info(self, params: MetadataContextInfoRequest, *, timeout: float | None = None) -> MetadataContextInfoResult:
         "Returns the token breakdown for the session's current context window for a given model.\n\nArgs:\n    params: Model identifier and token limits used to compute the context-info breakdown.\n\nReturns:\n    Token breakdown for the session's current context window, or null if uninitialized."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return MetadataContextInfoResult.from_dict(await self._client.request("session.metadata.contextInfo", params_dict, **_timeout_kwargs(timeout)))
 
     async def record_context_change(self, params: MetadataRecordContextChangeRequest, *, timeout: float | None = None) -> MetadataRecordContextChangeResult:
         "Records a working-directory/git context change and emits a `session.context_changed` event.\n\nArgs:\n    params: Updated working-directory/git context to record on the session.\n\nReturns:\n    Notify the session that its working directory context has changed. Emits a `session.context_changed` event so consumers (telemetry, OTel tracker, ACP, the timeline UI) can react. Use this when the host has detected a cwd/branch/repo change outside the session's normal lifecycle (e.g., after a shell command in interactive mode)."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return MetadataRecordContextChangeResult.from_dict(await self._client.request("session.metadata.recordContextChange", params_dict, **_timeout_kwargs(timeout)))
 
     async def set_working_directory(self, params: MetadataSetWorkingDirectoryRequest, *, timeout: float | None = None) -> MetadataSetWorkingDirectoryResult:
         "Updates the session's recorded working directory.\n\nArgs:\n    params: Absolute path to set as the session's new working directory.\n\nReturns:\n    Update the session's working directory. Used by the host when the user explicitly changes cwd (e.g., the `/cd` slash command). The host is responsible for `process.chdir` and any related side-effects (file index, etc.); this method only updates the session's own recorded path."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return MetadataSetWorkingDirectoryResult.from_dict(await self._client.request("session.metadata.setWorkingDirectory", params_dict, **_timeout_kwargs(timeout)))
 
     async def recompute_context_tokens(self, params: MetadataRecomputeContextTokensRequest, *, timeout: float | None = None) -> MetadataRecomputeContextTokensResult:
         "Re-tokenizes the session's existing messages against a model and returns aggregate token totals.\n\nArgs:\n    params: Model identifier to use when re-tokenizing the session's existing messages.\n\nReturns:\n    Re-tokenize the session's existing messages against `modelId` and return the token totals. Useful for hosts that want an initial estimate of context usage on session resume, before the next agent turn fires `session.context_info_changed` events. Returns zeros for an empty session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return MetadataRecomputeContextTokensResult.from_dict(await self._client.request("session.metadata.recomputeContextTokens", params_dict, **_timeout_kwargs(timeout)))
@@ -17466,18 +17961,29 @@ class MetadataApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class ShellApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def exec(self, params: ShellExecRequest, *, timeout: float | None = None) -> ShellExecResult:
         "Starts a shell command and streams output through session notifications.\n\nArgs:\n    params: Shell command to run, with optional working directory and timeout in milliseconds.\n\nReturns:\n    Identifier of the spawned process, used to correlate streamed output and exit notifications."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return ShellExecResult.from_dict(await self._client.request("session.shell.exec", params_dict, **_timeout_kwargs(timeout)))
 
     async def kill(self, params: ShellKillRequest, *, timeout: float | None = None) -> ShellKillResult:
         "Sends a signal to a shell process previously started via \"shell.exec\".\n\nArgs:\n    params: Identifier of a process previously returned by \"shell.exec\" and the signal to send.\n\nReturns:\n    Indicates whether the signal was delivered; false if the process was unknown or already exited."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return ShellKillResult.from_dict(await self._client.request("session.shell.kill", params_dict, **_timeout_kwargs(timeout)))
@@ -17485,76 +17991,121 @@ class ShellApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class HistoryApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def compact(self, *, timeout: float | None = None) -> HistoryCompactResult:
         "Compacts the session history to reduce context usage.\n\nReturns:\n    Compaction outcome with the number of tokens and messages removed, summary text, and the resulting context window breakdown."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return HistoryCompactResult.from_dict(await self._client.request("session.history.compact", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def truncate(self, params: HistoryTruncateRequest, *, timeout: float | None = None) -> HistoryTruncateResult:
         "Truncates persisted session history to a specific event.\n\nArgs:\n    params: Identifier of the event to truncate to; this event and all later events are removed.\n\nReturns:\n    Number of events that were removed by the truncation."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return HistoryTruncateResult.from_dict(await self._client.request("session.history.truncate", params_dict, **_timeout_kwargs(timeout)))
 
     async def cancel_background_compaction(self, *, timeout: float | None = None) -> HistoryCancelBackgroundCompactionResult:
         "Cancels any in-progress background compaction on a local session.\n\nReturns:\n    Indicates whether an in-progress background compaction was cancelled."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return HistoryCancelBackgroundCompactionResult.from_dict(await self._client.request("session.history.cancelBackgroundCompaction", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def abort_manual_compaction(self, *, timeout: float | None = None) -> HistoryAbortManualCompactionResult:
         "Aborts any in-progress manual compaction on a local session.\n\nReturns:\n    Indicates whether an in-progress manual compaction was aborted."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return HistoryAbortManualCompactionResult.from_dict(await self._client.request("session.history.abortManualCompaction", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def summarize_for_handoff(self, *, timeout: float | None = None) -> HistorySummarizeForHandoffResult:
         "Produces a markdown summary of the session's conversation context for hand-off scenarios.\n\nReturns:\n    Markdown summary of the conversation context (empty when not available)."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return HistorySummarizeForHandoffResult.from_dict(await self._client.request("session.history.summarizeForHandoff", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class QueueApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def pending_items(self, *, timeout: float | None = None) -> QueuePendingItemsResult:
         "Returns the local session's pending user-facing queued items and steering messages.\n\nReturns:\n    Snapshot of the session's pending queued items and immediate-steering messages."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return QueuePendingItemsResult.from_dict(await self._client.request("session.queue.pendingItems", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def remove_most_recent(self, *, timeout: float | None = None) -> QueueRemoveMostRecentResult:
         "Removes the most recently queued user-facing item (LIFO).\n\nReturns:\n    Indicates whether a user-facing pending item was removed."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return QueueRemoveMostRecentResult.from_dict(await self._client.request("session.queue.removeMostRecent", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def clear(self, *, timeout: float | None = None) -> None:
         "Clears all pending queued items on the local session."
+        if self._assert_active is not None:
+            self._assert_active()
+
         await self._client.request("session.queue.clear", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class EventLogApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
-    async def read(self, params: EventLogReadRequest, *, timeout: float | None = None) -> EventsReadResult:
+    async def read(self, params: EventLogReadRequest | None = None, *, timeout: float | None = None) -> EventsReadResult:
         "Reads a batch of session events from a cursor, optionally waiting for new events.\n\nArgs:\n    params: Cursor, batch size, and optional long-poll/filter parameters for reading session events.\n\nReturns:\n    Batch of session events returned by a read, with cursor and continuation metadata."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        if self._assert_active is not None:
+            self._assert_active()
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         params_dict["sessionId"] = self._session_id
         return EventsReadResult.from_dict(await self._client.request("session.eventLog.read", params_dict, **_timeout_kwargs(timeout)))
 
     async def tail(self, *, timeout: float | None = None) -> EventLogTailResult:
         "Returns a snapshot of the current tail cursor without consuming events.\n\nReturns:\n    Snapshot of the current tail cursor without returning any events. Use this when a consumer wants to subscribe to live events going forward without first paginating through the entire persisted history (which would happen if `read` were called without a cursor on a long-lived session)."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return EventLogTailResult.from_dict(await self._client.request("session.eventLog.tail", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def register_interest(self, params: RegisterEventInterestParams, *, timeout: float | None = None) -> RegisterEventInterestResult:
         "Registers consumer interest in an event type for runtime gating purposes.\n\nArgs:\n    params: Event type to register consumer interest for, used by runtime gating logic.\n\nReturns:\n    Opaque handle representing an event-type interest registration."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return RegisterEventInterestResult.from_dict(await self._client.request("session.eventLog.registerInterest", params_dict, **_timeout_kwargs(timeout)))
 
     async def release_interest(self, params: ReleaseEventInterestParams, *, timeout: float | None = None) -> EventLogReleaseInterestResult:
         "Releases a consumer's previously-registered interest in an event type.\n\nArgs:\n    params: Opaque handle previously returned by `registerInterest` to release.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return EventLogReleaseInterestResult.from_dict(await self._client.request("session.eventLog.releaseInterest", params_dict, **_timeout_kwargs(timeout)))
@@ -17562,33 +18113,49 @@ class EventLogApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class UsageApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def get_metrics(self, *, timeout: float | None = None) -> UsageGetMetricsResult:
         "Gets accumulated usage metrics for the session.\n\nReturns:\n    Accumulated session usage metrics, including premium request cost, token counts, model breakdown, and code-change totals."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return UsageGetMetricsResult.from_dict(await self._client.request("session.usage.getMetrics", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class RemoteApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
-    async def enable(self, params: RemoteEnableRequest, *, timeout: float | None = None) -> RemoteEnableResult:
+    async def enable(self, params: RemoteEnableRequest | None = None, *, timeout: float | None = None) -> RemoteEnableResult:
         "Enables remote session export or steering.\n\nArgs:\n    params: Optional remote session mode (\"off\", \"export\", or \"on\"); defaults to enabling both export and remote steering.\n\nReturns:\n    GitHub URL for the session and a flag indicating whether remote steering is enabled."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        if self._assert_active is not None:
+            self._assert_active()
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         params_dict["sessionId"] = self._session_id
         return RemoteEnableResult.from_dict(await self._client.request("session.remote.enable", params_dict, **_timeout_kwargs(timeout)))
 
     async def disable(self, *, timeout: float | None = None) -> None:
         "Disables remote session export and steering."
+        if self._assert_active is not None:
+            self._assert_active()
+
         await self._client.request("session.remote.disable", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
     async def notify_steerable_changed(self, params: RemoteNotifySteerableChangedRequest, *, timeout: float | None = None) -> RemoteNotifySteerableChangedResult:
         "Persists a remote-steerability change emitted by the host as a session event.\n\nArgs:\n    params: New remote-steerability state to persist as a `session.remote_steerable_changed` event.\n\nReturns:\n    Persist a steerability change as a `session.remote_steerable_changed` event. Used by the host (CLI / SDK consumer) when it has just finished enabling or disabling steering on a remote exporter that the runtime does not directly own."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return RemoteNotifySteerableChangedResult.from_dict(await self._client.request("session.remote.notifySteerableChanged", params_dict, **_timeout_kwargs(timeout)))
@@ -17596,16 +18163,25 @@ class RemoteApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class ScheduleApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def list(self, *, timeout: float | None = None) -> ScheduleList:
         "Lists the session's currently active scheduled prompts.\n\nReturns:\n    Snapshot of the currently active recurring prompts for this session."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return ScheduleList.from_dict(await self._client.request("session.schedule.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def stop(self, params: ScheduleStopRequest, *, timeout: float | None = None) -> ScheduleStopResult:
         "Removes a scheduled prompt by id.\n\nArgs:\n    params: Identifier of the scheduled prompt to remove.\n\nReturns:\n    Remove a scheduled prompt by id. The result entry is omitted if the id was unknown."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return ScheduleStopResult.from_dict(await self._client.request("session.schedule.stop", params_dict, **_timeout_kwargs(timeout)))
@@ -17613,63 +18189,83 @@ class ScheduleApi:
 
 class SessionRpc:
     """Typed session-scoped RPC methods."""
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
-        self.auth = AuthApi(client, session_id)
-        self.model = ModelApi(client, session_id)
-        self.mode = ModeApi(client, session_id)
-        self.name = NameApi(client, session_id)
-        self.plan = PlanApi(client, session_id)
-        self.workspaces = WorkspacesApi(client, session_id)
-        self.instructions = InstructionsApi(client, session_id)
-        self.fleet = FleetApi(client, session_id)
-        self.agent = AgentApi(client, session_id)
-        self.tasks = TasksApi(client, session_id)
-        self.skills = SkillsApi(client, session_id)
-        self.mcp = McpApi(client, session_id)
-        self.plugins = PluginsApi(client, session_id)
-        self.options = OptionsApi(client, session_id)
-        self.lsp = LspApi(client, session_id)
-        self.extensions = ExtensionsApi(client, session_id)
-        self.tools = ToolsApi(client, session_id)
-        self.commands = CommandsApi(client, session_id)
-        self.telemetry = TelemetryApi(client, session_id)
-        self.ui = UiApi(client, session_id)
-        self.permissions = PermissionsApi(client, session_id)
-        self.metadata = MetadataApi(client, session_id)
-        self.shell = ShellApi(client, session_id)
-        self.history = HistoryApi(client, session_id)
-        self.queue = QueueApi(client, session_id)
-        self.event_log = EventLogApi(client, session_id)
-        self.usage = UsageApi(client, session_id)
-        self.remote = RemoteApi(client, session_id)
-        self.schedule = ScheduleApi(client, session_id)
+        self._assert_active = assert_active
+        self.auth = AuthApi(client, session_id, assert_active)
+        self.model = ModelApi(client, session_id, assert_active)
+        self.mode = ModeApi(client, session_id, assert_active)
+        self.name = NameApi(client, session_id, assert_active)
+        self.plan = PlanApi(client, session_id, assert_active)
+        self.workspaces = WorkspacesApi(client, session_id, assert_active)
+        self.instructions = InstructionsApi(client, session_id, assert_active)
+        self.fleet = FleetApi(client, session_id, assert_active)
+        self.agent = AgentApi(client, session_id, assert_active)
+        self.tasks = TasksApi(client, session_id, assert_active)
+        self.skills = SkillsApi(client, session_id, assert_active)
+        self.mcp = McpApi(client, session_id, assert_active)
+        self.plugins = PluginsApi(client, session_id, assert_active)
+        self.options = OptionsApi(client, session_id, assert_active)
+        self.lsp = LspApi(client, session_id, assert_active)
+        self.extensions = ExtensionsApi(client, session_id, assert_active)
+        self.tools = ToolsApi(client, session_id, assert_active)
+        self.commands = CommandsApi(client, session_id, assert_active)
+        self.telemetry = TelemetryApi(client, session_id, assert_active)
+        self.ui = UiApi(client, session_id, assert_active)
+        self.permissions = PermissionsApi(client, session_id, assert_active)
+        self.metadata = MetadataApi(client, session_id, assert_active)
+        self.shell = ShellApi(client, session_id, assert_active)
+        self.history = HistoryApi(client, session_id, assert_active)
+        self.queue = QueueApi(client, session_id, assert_active)
+        self.event_log = EventLogApi(client, session_id, assert_active)
+        self.usage = UsageApi(client, session_id, assert_active)
+        self.remote = RemoteApi(client, session_id, assert_active)
+        self.schedule = ScheduleApi(client, session_id, assert_active)
 
     async def suspend(self, *, timeout: float | None = None) -> None:
         "Suspends the session while preserving persisted state for later resume.\n\n.. warning:: This API is experimental and may change or be removed in future versions."
+        if self._assert_active is not None:
+            self._assert_active()
+
         await self._client.request("session.suspend", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
     async def send(self, params: SendRequest, *, timeout: float | None = None) -> SendResult:
         "Sends a user message to the session and returns its message ID.\n\nArgs:\n    params: Parameters for sending a user message to the session\n\nReturns:\n    Result of sending a user message\n\n.. warning:: This API is experimental and may change or be removed in future versions."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return SendResult.from_dict(await self._client.request("session.send", params_dict, **_timeout_kwargs(timeout)))
 
-    async def abort(self, params: AbortRequest, *, timeout: float | None = None) -> AbortResult:
+    async def abort(self, params: AbortRequest | None = None, *, timeout: float | None = None) -> AbortResult:
         "Aborts the current agent turn.\n\nArgs:\n    params: Parameters for aborting the current turn\n\nReturns:\n    Result of aborting the current turn\n\n.. warning:: This API is experimental and may change or be removed in future versions."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        if self._assert_active is not None:
+            self._assert_active()
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         params_dict["sessionId"] = self._session_id
         return AbortResult.from_dict(await self._client.request("session.abort", params_dict, **_timeout_kwargs(timeout)))
 
-    async def shutdown(self, params: ShutdownRequest, *, timeout: float | None = None) -> None:
+    async def shutdown(self, params: ShutdownRequest | None = None, *, timeout: float | None = None) -> None:
         "Shuts down the session and persists its final state. Awaits any deferred sessionEnd hooks before resolving so user-supplied hook scripts complete before the runtime tears down.\n\nArgs:\n    params: Parameters for shutting down the session\n\n.. warning:: This API is experimental and may change or be removed in future versions."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        if self._assert_active is not None:
+            self._assert_active()
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.shutdown", params_dict, **_timeout_kwargs(timeout))
 
     async def log(self, params: LogRequest, *, timeout: float | None = None) -> LogResult:
         "Emits a user-visible session log event.\n\nArgs:\n    params: Message text, optional severity level, persistence flag, optional follow-up URL, and optional tip.\n\nReturns:\n    Identifier of the session event that was emitted for the log message.\n\n.. warning:: This API is experimental and may change or be removed in future versions."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return LogResult.from_dict(await self._client.request("session.log", params_dict, **_timeout_kwargs(timeout)))

--- a/python/copilot/generated/rpc.py
+++ b/python/copilot/generated/rpc.py
@@ -5,7 +5,7 @@ Generated from: api.schema.json
 
 from typing import TYPE_CHECKING
 
-from .session_events import AbortReason, EmbeddedBlobResourceContents, EmbeddedTextResourceContents, McpServerSource, McpServerStatus, PermissionPromptRequest, PermissionRule, ReasoningSummary, SessionEvent, SessionMode, ShutdownType, SkillSource, UserToolSessionApproval
+from .session_events import EmbeddedBlobResourceContents, EmbeddedTextResourceContents, McpServerSource, McpServerStatus, ReasoningSummary, SessionMode, SkillSource
 
 if TYPE_CHECKING:
     from .._jsonrpc import JsonRpcClient
@@ -39,16 +39,12 @@ def from_union(fs, x):
             pass
     assert False
 
-def to_class(c: type[T], x: Any) -> dict:
-    assert isinstance(x, c)
-    return cast(Any, x).to_dict()
+def from_int(x: Any) -> int:
+    assert isinstance(x, int) and not isinstance(x, bool)
+    return x
 
 def from_bool(x: Any) -> bool:
     assert isinstance(x, bool)
-    return x
-
-def from_int(x: Any) -> int:
-    assert isinstance(x, int) and not isinstance(x, bool)
     return x
 
 def from_float(x: Any) -> float:
@@ -63,6 +59,10 @@ def from_dict(f: Callable[[Any], T], x: Any) -> dict[str, T]:
     assert isinstance(x, dict)
     return { k: f(v) for (k, v) in x.items() }
 
+def to_class(c: type[T], x: Any) -> dict:
+    assert isinstance(x, c)
+    return cast(Any, x).to_dict()
+
 def from_list(f: Callable[[Any], T], x: Any) -> list[T]:
     assert isinstance(x, list)
     return [f(y) for y in x]
@@ -73,49 +73,6 @@ def to_enum(c: type[EnumT], x: Any) -> EnumT:
 
 def from_datetime(x: Any) -> datetime:
     return dateutil.parser.parse(x)
-
-@dataclass
-class AbortRequest:
-    """Parameters for aborting the current turn"""
-
-    reason: AbortReason | None = None
-    """Finite reason code describing why the current turn was aborted"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'AbortRequest':
-        assert isinstance(obj, dict)
-        reason = from_union([AbortReason, from_none], obj.get("reason"))
-        return AbortRequest(reason)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.reason is not None:
-            result["reason"] = from_union([lambda x: to_enum(AbortReason, x), from_none], self.reason)
-        return result
-
-@dataclass
-class AbortResult:
-    """Result of aborting the current turn"""
-
-    success: bool
-    """Whether the abort completed successfully"""
-
-    error: str | None = None
-    """Error message if the abort failed"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'AbortResult':
-        assert isinstance(obj, dict)
-        success = from_bool(obj.get("success"))
-        error = from_union([from_str, from_none], obj.get("error"))
-        return AbortResult(success, error)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["success"] = from_bool(self.success)
-        if self.error is not None:
-            result["error"] = from_union([from_str, from_none], self.error)
-        return result
 
 @dataclass
 class AccountGetQuotaRequest:
@@ -191,15 +148,43 @@ class AccountQuotaSnapshot:
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
-class AgentInfoSource(Enum):
-    """Where the agent definition was loaded from"""
+@dataclass
+class AgentInfo:
+    """Schema for the `AgentInfo` type.
 
-    BUILTIN = "builtin"
-    INHERITED = "inherited"
-    PLUGIN = "plugin"
-    PROJECT = "project"
-    REMOTE = "remote"
-    USER = "user"
+    The newly selected custom agent
+    """
+    description: str
+    """Description of the agent's purpose"""
+
+    display_name: str
+    """Human-readable display name"""
+
+    name: str
+    """Unique identifier of the custom agent"""
+
+    path: str | None = None
+    """Absolute local file path of the agent definition. Only set for file-based agents loaded
+    from disk; remote agents do not have a path.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'AgentInfo':
+        assert isinstance(obj, dict)
+        description = from_str(obj.get("description"))
+        display_name = from_str(obj.get("displayName"))
+        name = from_str(obj.get("name"))
+        path = from_union([from_str, from_none], obj.get("path"))
+        return AgentInfo(description, display_name, name, path)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["description"] = from_str(self.description)
+        result["displayName"] = from_str(self.display_name)
+        result["name"] = from_str(self.name)
+        if self.path is not None:
+            result["path"] = from_union([from_str, from_none], self.path)
+        return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
@@ -219,39 +204,6 @@ class AgentSelectRequest:
         result: dict = {}
         result["name"] = from_str(self.name)
         return result
-
-@dataclass
-class CopilotUserResponseEndpoints:
-    """Schema for the `CopilotUserResponseEndpoints` type."""
-
-    api: str | None = None
-    origin_tracker: str | None = None
-    proxy: str | None = None
-    telemetry: str | None = None
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'CopilotUserResponseEndpoints':
-        assert isinstance(obj, dict)
-        api = from_union([from_str, from_none], obj.get("api"))
-        origin_tracker = from_union([from_str, from_none], obj.get("origin-tracker"))
-        proxy = from_union([from_str, from_none], obj.get("proxy"))
-        telemetry = from_union([from_str, from_none], obj.get("telemetry"))
-        return CopilotUserResponseEndpoints(api, origin_tracker, proxy, telemetry)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.api is not None:
-            result["api"] = from_union([from_str, from_none], self.api)
-        if self.origin_tracker is not None:
-            result["origin-tracker"] = from_union([from_str, from_none], self.origin_tracker)
-        if self.proxy is not None:
-            result["proxy"] = from_union([from_str, from_none], self.proxy)
-        if self.telemetry is not None:
-            result["telemetry"] = from_union([from_str, from_none], self.telemetry)
-        return result
-
-class APIKeyAuthInfoType(Enum):
-    API_KEY = "api-key"
 
 class AuthInfoType(Enum):
     """Authentication type"""
@@ -376,11 +328,11 @@ class CommandsListRequest:
 
 @dataclass
 class CommandsRespondToQueuedCommandResult:
-    """Indicates whether the queued-command response was matched to a pending request."""
+    """Indicates whether the queued-command response was accepted by the session."""
 
     success: bool
-    """Whether a pending queued command with the given request ID was found and resolved. False
-    when the request was already resolved, cancelled, or unknown.
+    """Whether the response was accepted (false if the requestId was not found or already
+    resolved)
     """
 
     @staticmethod
@@ -507,224 +459,23 @@ class ContentFilterMode(Enum):
     MARKDOWN = "markdown"
     NONE = "none"
 
-class Host(Enum):
-    HTTPS_GITHUB_COM = "https://github.com"
-
-class CopilotAPITokenAuthInfoType(Enum):
-    COPILOT_API_TOKEN = "copilot-api-token"
-
-@dataclass
-class CopilotUserResponseQuotaSnapshotsChat:
-    """Schema for the `CopilotUserResponseQuotaSnapshotsChat` type."""
-
-    entitlement: float | None = None
-    has_quota: bool | None = None
-    overage_count: float | None = None
-    overage_permitted: bool | None = None
-    percent_remaining: float | None = None
-    quota_id: str | None = None
-    quota_remaining: float | None = None
-    quota_reset_at: float | None = None
-    remaining: float | None = None
-    timestamp_utc: str | None = None
-    token_based_billing: bool | None = None
-    unlimited: bool | None = None
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'CopilotUserResponseQuotaSnapshotsChat':
-        assert isinstance(obj, dict)
-        entitlement = from_union([from_float, from_none], obj.get("entitlement"))
-        has_quota = from_union([from_bool, from_none], obj.get("has_quota"))
-        overage_count = from_union([from_float, from_none], obj.get("overage_count"))
-        overage_permitted = from_union([from_bool, from_none], obj.get("overage_permitted"))
-        percent_remaining = from_union([from_float, from_none], obj.get("percent_remaining"))
-        quota_id = from_union([from_str, from_none], obj.get("quota_id"))
-        quota_remaining = from_union([from_float, from_none], obj.get("quota_remaining"))
-        quota_reset_at = from_union([from_float, from_none], obj.get("quota_reset_at"))
-        remaining = from_union([from_float, from_none], obj.get("remaining"))
-        timestamp_utc = from_union([from_str, from_none], obj.get("timestamp_utc"))
-        token_based_billing = from_union([from_bool, from_none], obj.get("token_based_billing"))
-        unlimited = from_union([from_bool, from_none], obj.get("unlimited"))
-        return CopilotUserResponseQuotaSnapshotsChat(entitlement, has_quota, overage_count, overage_permitted, percent_remaining, quota_id, quota_remaining, quota_reset_at, remaining, timestamp_utc, token_based_billing, unlimited)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.entitlement is not None:
-            result["entitlement"] = from_union([to_float, from_none], self.entitlement)
-        if self.has_quota is not None:
-            result["has_quota"] = from_union([from_bool, from_none], self.has_quota)
-        if self.overage_count is not None:
-            result["overage_count"] = from_union([to_float, from_none], self.overage_count)
-        if self.overage_permitted is not None:
-            result["overage_permitted"] = from_union([from_bool, from_none], self.overage_permitted)
-        if self.percent_remaining is not None:
-            result["percent_remaining"] = from_union([to_float, from_none], self.percent_remaining)
-        if self.quota_id is not None:
-            result["quota_id"] = from_union([from_str, from_none], self.quota_id)
-        if self.quota_remaining is not None:
-            result["quota_remaining"] = from_union([to_float, from_none], self.quota_remaining)
-        if self.quota_reset_at is not None:
-            result["quota_reset_at"] = from_union([to_float, from_none], self.quota_reset_at)
-        if self.remaining is not None:
-            result["remaining"] = from_union([to_float, from_none], self.remaining)
-        if self.timestamp_utc is not None:
-            result["timestamp_utc"] = from_union([from_str, from_none], self.timestamp_utc)
-        if self.token_based_billing is not None:
-            result["token_based_billing"] = from_union([from_bool, from_none], self.token_based_billing)
-        if self.unlimited is not None:
-            result["unlimited"] = from_union([from_bool, from_none], self.unlimited)
-        return result
-
-@dataclass
-class CopilotUserResponseQuotaSnapshotsCompletions:
-    """Schema for the `CopilotUserResponseQuotaSnapshotsCompletions` type."""
-
-    entitlement: float | None = None
-    has_quota: bool | None = None
-    overage_count: float | None = None
-    overage_permitted: bool | None = None
-    percent_remaining: float | None = None
-    quota_id: str | None = None
-    quota_remaining: float | None = None
-    quota_reset_at: float | None = None
-    remaining: float | None = None
-    timestamp_utc: str | None = None
-    token_based_billing: bool | None = None
-    unlimited: bool | None = None
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'CopilotUserResponseQuotaSnapshotsCompletions':
-        assert isinstance(obj, dict)
-        entitlement = from_union([from_float, from_none], obj.get("entitlement"))
-        has_quota = from_union([from_bool, from_none], obj.get("has_quota"))
-        overage_count = from_union([from_float, from_none], obj.get("overage_count"))
-        overage_permitted = from_union([from_bool, from_none], obj.get("overage_permitted"))
-        percent_remaining = from_union([from_float, from_none], obj.get("percent_remaining"))
-        quota_id = from_union([from_str, from_none], obj.get("quota_id"))
-        quota_remaining = from_union([from_float, from_none], obj.get("quota_remaining"))
-        quota_reset_at = from_union([from_float, from_none], obj.get("quota_reset_at"))
-        remaining = from_union([from_float, from_none], obj.get("remaining"))
-        timestamp_utc = from_union([from_str, from_none], obj.get("timestamp_utc"))
-        token_based_billing = from_union([from_bool, from_none], obj.get("token_based_billing"))
-        unlimited = from_union([from_bool, from_none], obj.get("unlimited"))
-        return CopilotUserResponseQuotaSnapshotsCompletions(entitlement, has_quota, overage_count, overage_permitted, percent_remaining, quota_id, quota_remaining, quota_reset_at, remaining, timestamp_utc, token_based_billing, unlimited)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.entitlement is not None:
-            result["entitlement"] = from_union([to_float, from_none], self.entitlement)
-        if self.has_quota is not None:
-            result["has_quota"] = from_union([from_bool, from_none], self.has_quota)
-        if self.overage_count is not None:
-            result["overage_count"] = from_union([to_float, from_none], self.overage_count)
-        if self.overage_permitted is not None:
-            result["overage_permitted"] = from_union([from_bool, from_none], self.overage_permitted)
-        if self.percent_remaining is not None:
-            result["percent_remaining"] = from_union([to_float, from_none], self.percent_remaining)
-        if self.quota_id is not None:
-            result["quota_id"] = from_union([from_str, from_none], self.quota_id)
-        if self.quota_remaining is not None:
-            result["quota_remaining"] = from_union([to_float, from_none], self.quota_remaining)
-        if self.quota_reset_at is not None:
-            result["quota_reset_at"] = from_union([to_float, from_none], self.quota_reset_at)
-        if self.remaining is not None:
-            result["remaining"] = from_union([to_float, from_none], self.remaining)
-        if self.timestamp_utc is not None:
-            result["timestamp_utc"] = from_union([from_str, from_none], self.timestamp_utc)
-        if self.token_based_billing is not None:
-            result["token_based_billing"] = from_union([from_bool, from_none], self.token_based_billing)
-        if self.unlimited is not None:
-            result["unlimited"] = from_union([from_bool, from_none], self.unlimited)
-        return result
-
-@dataclass
-class CopilotUserResponseQuotaSnapshotsPremiumInteractions:
-    """Schema for the `CopilotUserResponseQuotaSnapshotsPremiumInteractions` type."""
-
-    entitlement: float | None = None
-    has_quota: bool | None = None
-    overage_count: float | None = None
-    overage_permitted: bool | None = None
-    percent_remaining: float | None = None
-    quota_id: str | None = None
-    quota_remaining: float | None = None
-    quota_reset_at: float | None = None
-    remaining: float | None = None
-    timestamp_utc: str | None = None
-    token_based_billing: bool | None = None
-    unlimited: bool | None = None
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'CopilotUserResponseQuotaSnapshotsPremiumInteractions':
-        assert isinstance(obj, dict)
-        entitlement = from_union([from_float, from_none], obj.get("entitlement"))
-        has_quota = from_union([from_bool, from_none], obj.get("has_quota"))
-        overage_count = from_union([from_float, from_none], obj.get("overage_count"))
-        overage_permitted = from_union([from_bool, from_none], obj.get("overage_permitted"))
-        percent_remaining = from_union([from_float, from_none], obj.get("percent_remaining"))
-        quota_id = from_union([from_str, from_none], obj.get("quota_id"))
-        quota_remaining = from_union([from_float, from_none], obj.get("quota_remaining"))
-        quota_reset_at = from_union([from_float, from_none], obj.get("quota_reset_at"))
-        remaining = from_union([from_float, from_none], obj.get("remaining"))
-        timestamp_utc = from_union([from_str, from_none], obj.get("timestamp_utc"))
-        token_based_billing = from_union([from_bool, from_none], obj.get("token_based_billing"))
-        unlimited = from_union([from_bool, from_none], obj.get("unlimited"))
-        return CopilotUserResponseQuotaSnapshotsPremiumInteractions(entitlement, has_quota, overage_count, overage_permitted, percent_remaining, quota_id, quota_remaining, quota_reset_at, remaining, timestamp_utc, token_based_billing, unlimited)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.entitlement is not None:
-            result["entitlement"] = from_union([to_float, from_none], self.entitlement)
-        if self.has_quota is not None:
-            result["has_quota"] = from_union([from_bool, from_none], self.has_quota)
-        if self.overage_count is not None:
-            result["overage_count"] = from_union([to_float, from_none], self.overage_count)
-        if self.overage_permitted is not None:
-            result["overage_permitted"] = from_union([from_bool, from_none], self.overage_permitted)
-        if self.percent_remaining is not None:
-            result["percent_remaining"] = from_union([to_float, from_none], self.percent_remaining)
-        if self.quota_id is not None:
-            result["quota_id"] = from_union([from_str, from_none], self.quota_id)
-        if self.quota_remaining is not None:
-            result["quota_remaining"] = from_union([to_float, from_none], self.quota_remaining)
-        if self.quota_reset_at is not None:
-            result["quota_reset_at"] = from_union([to_float, from_none], self.quota_reset_at)
-        if self.remaining is not None:
-            result["remaining"] = from_union([to_float, from_none], self.remaining)
-        if self.timestamp_utc is not None:
-            result["timestamp_utc"] = from_union([from_str, from_none], self.timestamp_utc)
-        if self.token_based_billing is not None:
-            result["token_based_billing"] = from_union([from_bool, from_none], self.token_based_billing)
-        if self.unlimited is not None:
-            result["unlimited"] = from_union([from_bool, from_none], self.unlimited)
-        return result
-
 @dataclass
 class CurrentModel:
-    """The currently selected model and reasoning effort for the session."""
+    """The currently selected model for the session."""
 
     model_id: str | None = None
     """Currently active model identifier"""
-
-    reasoning_effort: str | None = None
-    """Reasoning effort level currently applied to the active model, when one is set. Reads
-    `Session.getReasoningEffort()` synchronously after `getSelectedModel()` resolves so the
-    two values are reported as a snapshot.
-    """
 
     @staticmethod
     def from_dict(obj: Any) -> 'CurrentModel':
         assert isinstance(obj, dict)
         model_id = from_union([from_str, from_none], obj.get("modelId"))
-        reasoning_effort = from_union([from_str, from_none], obj.get("reasoningEffort"))
-        return CurrentModel(model_id, reasoning_effort)
+        return CurrentModel(model_id)
 
     def to_dict(self) -> dict:
         result: dict = {}
         if self.model_id is not None:
             result["modelId"] = from_union([from_str, from_none], self.model_id)
-        if self.reasoning_effort is not None:
-            result["reasoningEffort"] = from_union([from_str, from_none], self.reasoning_effort)
         return result
 
 class DiscoveredMCPServerType(Enum):
@@ -734,161 +485,6 @@ class DiscoveredMCPServerType(Enum):
     MEMORY = "memory"
     SSE = "sse"
     STDIO = "stdio"
-
-@dataclass
-class EnqueueCommandParams:
-    """Slash-prefixed command string to enqueue for FIFO processing."""
-
-    command: str
-    """Slash-prefixed command string to enqueue, e.g. '/compact' or '/model gpt-4'. Queued FIFO
-    with any in-flight items; if the session is idle, processing kicks off immediately.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'EnqueueCommandParams':
-        assert isinstance(obj, dict)
-        command = from_str(obj.get("command"))
-        return EnqueueCommandParams(command)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["command"] = from_str(self.command)
-        return result
-
-@dataclass
-class EnqueueCommandResult:
-    """Indicates whether the command was accepted into the local execution queue."""
-
-    queued: bool
-    """True when the command was accepted into the local execution queue. False when the call
-    targets a session that does not support local command queueing (e.g. remote sessions).
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'EnqueueCommandResult':
-        assert isinstance(obj, dict)
-        queued = from_bool(obj.get("queued"))
-        return EnqueueCommandResult(queued)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["queued"] = from_bool(self.queued)
-        return result
-
-class EnvAuthInfoType(Enum):
-    ENV = "env"
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-class EventsAgentScope(Enum):
-    """Agent-scope filter: 'primary' returns only main-agent events plus events whose type
-    starts with 'subagent.' (matching the typed-subscription default behavior); 'all' returns
-    events from all agents (matching wildcard-subscription behavior). Default is 'all' to
-    preserve wildcard semantics for catch-up callers.
-    """
-    ALL = "all"
-    PRIMARY = "primary"
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-class EventLogTypes(Enum):
-    EMPTY = "*"
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class EventLogReleaseInterestResult:
-    """Indicates whether the operation succeeded."""
-
-    success: bool
-    """Whether the operation succeeded"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'EventLogReleaseInterestResult':
-        assert isinstance(obj, dict)
-        success = from_bool(obj.get("success"))
-        return EventLogReleaseInterestResult(success)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["success"] = from_bool(self.success)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class EventLogTailResult:
-    """Snapshot of the current tail cursor without returning any events. Use this when a
-    consumer wants to subscribe to live events going forward without first paginating through
-    the entire persisted history (which would happen if `read` were called without a cursor
-    on a long-lived session).
-    """
-    cursor: str
-    """Opaque cursor pointing at the current tail of the session's persisted-events history.
-    Pass back to `read` to receive only events that arrive AFTER this snapshot. When the
-    session has no events, this returns the same sentinel as an unset cursor (i.e. equivalent
-    to omitting the cursor on a first read).
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'EventLogTailResult':
-        assert isinstance(obj, dict)
-        cursor = from_str(obj.get("cursor"))
-        return EventLogTailResult(cursor)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["cursor"] = from_str(self.cursor)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-class EventsCursorStatus(Enum):
-    """Cursor status: 'ok' means the cursor was applied successfully; 'expired' means the cursor
-    referred to an event that no longer exists in history (e.g. truncated or compacted away)
-    and the read started from the beginning of the remaining history.
-    """
-    EXPIRED = "expired"
-    OK = "ok"
-
-@dataclass
-class ExecuteCommandParams:
-    """Slash command name and argument string to execute synchronously."""
-
-    args: str
-    """Argument string to pass to the command (empty string if none)."""
-
-    command_name: str
-    """Name of the slash command to invoke (without the leading '/')."""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'ExecuteCommandParams':
-        assert isinstance(obj, dict)
-        args = from_str(obj.get("args"))
-        command_name = from_str(obj.get("commandName"))
-        return ExecuteCommandParams(args, command_name)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["args"] = from_str(self.args)
-        result["commandName"] = from_str(self.command_name)
-        return result
-
-@dataclass
-class ExecuteCommandResult:
-    """Error message produced while executing the command, if any."""
-
-    error: str | None = None
-    """Error message produced while executing the command, if any. Omitted when the handler
-    succeeded.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'ExecuteCommandResult':
-        assert isinstance(obj, dict)
-        error = from_union([from_str, from_none], obj.get("error"))
-        return ExecuteCommandResult(error)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.error is not None:
-            result["error"] = from_union([from_str, from_none], self.error)
-        return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 class ExtensionSource(Enum):
@@ -1022,9 +618,6 @@ class FleetStartResult:
         result["started"] = from_bool(self.started)
         return result
 
-class GhCLIAuthInfoType(Enum):
-    GH_CLI = "gh-cli"
-
 @dataclass
 class HandlePendingToolCallResult:
     """Indicates whether the external tool call result was handled successfully."""
@@ -1041,48 +634,6 @@ class HandlePendingToolCallResult:
     def to_dict(self) -> dict:
         result: dict = {}
         result["success"] = from_bool(self.success)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class HistoryAbortManualCompactionResult:
-    """Indicates whether an in-progress manual compaction was aborted."""
-
-    aborted: bool
-    """Whether an in-progress manual compaction was aborted. False when no manual compaction was
-    running, when its abort controller was already aborted, or when the session is remote.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'HistoryAbortManualCompactionResult':
-        assert isinstance(obj, dict)
-        aborted = from_bool(obj.get("aborted"))
-        return HistoryAbortManualCompactionResult(aborted)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["aborted"] = from_bool(self.aborted)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class HistoryCancelBackgroundCompactionResult:
-    """Indicates whether an in-progress background compaction was cancelled."""
-
-    cancelled: bool
-    """Whether an in-progress background compaction was cancelled. False when no compaction was
-    running, when the session is remote, or when the underlying processor was unavailable.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'HistoryCancelBackgroundCompactionResult':
-        assert isinstance(obj, dict)
-        cancelled = from_bool(obj.get("cancelled"))
-        return HistoryCancelBackgroundCompactionResult(cancelled)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["cancelled"] = from_bool(self.cancelled)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -1134,27 +685,6 @@ class HistoryCompactContextWindow:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
-class HistorySummarizeForHandoffResult:
-    """Markdown summary of the conversation context (empty when not available)."""
-
-    summary: str
-    """Markdown summary of the conversation context produced by an LLM. Empty string when there
-    are no messages or when the session does not support local summarization.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'HistorySummarizeForHandoffResult':
-        assert isinstance(obj, dict)
-        summary = from_str(obj.get("summary"))
-        return HistorySummarizeForHandoffResult(summary)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["summary"] = from_str(self.summary)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
 class HistoryTruncateRequest:
     """Identifier of the event to truncate to; this event and all later events are removed."""
 
@@ -1191,27 +721,9 @@ class HistoryTruncateResult:
         result["eventsRemoved"] = from_int(self.events_removed)
         return result
 
-class HMACAuthInfoType(Enum):
-    HMAC = "hmac"
-
-class PurpleSource(Enum):
-    GITHUB = "github"
-    LOCAL = "local"
-    URL = "url"
-
-class FluffySource(Enum):
-    GITHUB = "github"
-
-class TentacledSource(Enum):
-    LOCAL = "local"
-
-class StickySource(Enum):
-    URL = "url"
-
 class InstructionsSourcesLocation(Enum):
     """Where this source lives — used for UI grouping"""
 
-    PLUGIN = "plugin"
     REPOSITORY = "repository"
     USER = "user"
     WORKING_DIRECTORY = "working-directory"
@@ -1223,7 +735,6 @@ class InstructionsSourcesType(Enum):
     HOME = "home"
     MODEL = "model"
     NESTED_AGENTS = "nested-agents"
-    PLUGIN = "plugin"
     REPO = "repo"
     VSCODE = "vscode"
 
@@ -1251,84 +762,6 @@ class LogResult:
     def to_dict(self) -> dict:
         result: dict = {}
         result["eventId"] = str(self.event_id)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class LspInitializeRequest:
-    """Parameters for (re)loading the merged LSP configuration set."""
-
-    force: bool | None = None
-    """Force re-initialization even when LSP configs were already loaded for the working
-    directory.
-    """
-    git_root: str | None = None
-    """Git root used as the boundary when traversing for project-level LSP configs (supports
-    monorepos).
-    """
-    working_directory: str | None = None
-    """Working directory used to load project-level LSP configs. Defaults to the session working
-    directory when omitted.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'LspInitializeRequest':
-        assert isinstance(obj, dict)
-        force = from_union([from_bool, from_none], obj.get("force"))
-        git_root = from_union([from_str, from_none], obj.get("gitRoot"))
-        working_directory = from_union([from_str, from_none], obj.get("workingDirectory"))
-        return LspInitializeRequest(force, git_root, working_directory)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.force is not None:
-            result["force"] = from_union([from_bool, from_none], self.force)
-        if self.git_root is not None:
-            result["gitRoot"] = from_union([from_str, from_none], self.git_root)
-        if self.working_directory is not None:
-            result["workingDirectory"] = from_union([from_str, from_none], self.working_directory)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class MCPCancelSamplingExecutionParams:
-    """The requestId previously passed to executeSampling that should be cancelled."""
-
-    request_id: str
-    """The requestId previously passed to executeSampling that should be cancelled"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'MCPCancelSamplingExecutionParams':
-        assert isinstance(obj, dict)
-        request_id = from_str(obj.get("requestId"))
-        return MCPCancelSamplingExecutionParams(request_id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["requestId"] = from_str(self.request_id)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class MCPCancelSamplingExecutionResult:
-    """Indicates whether an in-flight sampling execution with the given requestId was found and
-    cancelled.
-    """
-    cancelled: bool
-    """True if an in-flight execution with the given requestId was found and signalled to
-    cancel. False when no such execution is in flight (already completed, never started, or
-    cancelled by another caller).
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'MCPCancelSamplingExecutionResult':
-        assert isinstance(obj, dict)
-        cancelled = from_bool(obj.get("cancelled"))
-        return MCPCancelSamplingExecutionResult(cancelled)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["cancelled"] = from_bool(self.cancelled)
         return result
 
 @dataclass
@@ -1553,39 +986,6 @@ class MCPOauthLoginResult:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
-class MCPRemoveGitHubResult:
-    """Indicates whether the auto-managed `github` MCP server was removed (false when nothing to
-    remove).
-    """
-    removed: bool
-    """True when the auto-managed `github` MCP server was removed; false when no removal
-    happened (e.g. user has explicitly configured a `github` server, or the server was not
-    registered).
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'MCPRemoveGitHubResult':
-        assert isinstance(obj, dict)
-        removed = from_bool(obj.get("removed"))
-        return MCPRemoveGitHubResult(removed)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["removed"] = from_bool(self.removed)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-class MCPSamplingExecutionAction(Enum):
-    """Outcome of the sampling inference. 'success' produced a response; 'failure' encountered
-    an error (including agent-side rejection by content filter or criteria); 'cancelled' the
-    caller cancelled this execution via cancelSamplingExecution.
-    """
-    CANCELLED = "cancelled"
-    FAILURE = "failure"
-    SUCCESS = "success"
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
 class MCPServer:
     """Schema for the `McpServer` type."""
 
@@ -1619,257 +1019,6 @@ class MCPServer:
         if self.source is not None:
             result["source"] = from_union([lambda x: to_enum(McpServerSource, x), from_none], self.source)
         return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-class MCPSetEnvValueModeDetails(Enum):
-    """How environment-variable values supplied to MCP servers are resolved. "direct" passes
-    literal string values; "indirect" treats values as references (e.g. names of environment
-    variables on the host) that the runtime resolves before launch. Defaults to the runtime's
-    startup mode; clients that intentionally launch MCP servers with literal values (e.g. CLI
-    prompt mode and ACP) set this to "direct".
-
-    Mode recorded on the session after the update
-
-    How env values are passed to MCP servers (`direct` inlines literal values; `indirect`
-    resolves at launch).
-    """
-    DIRECT = "direct"
-    INDIRECT = "indirect"
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionContextInfo:
-    """Token-usage breakdown for the session's current context window"""
-
-    buffer_tokens: int
-    """Output reserve plus tokens after the buffer-exhaustion blocking threshold (default 95%)"""
-
-    compaction_threshold: int
-    """Token count at which background compaction starts (configurable percentage of
-    promptTokenLimit)
-    """
-    conversation_tokens: int
-    """Tokens consumed by user/assistant/tool messages"""
-
-    limit: int
-    """Total context limit for /context display. promptTokenLimit + min(32k or 64k,
-    outputTokenLimit) depending on model.
-    """
-    model_name: str
-    """The model used for token counting"""
-
-    prompt_token_limit: int
-    """Maximum prompt tokens allowed by the model (or DEFAULT_TOKEN_LIMIT if unspecified)"""
-
-    system_tokens: int
-    """Tokens consumed by the system prompt"""
-
-    tool_definitions_tokens: int
-    """Tokens consumed by tool definitions sent to the model (excludes deferred tools)"""
-
-    total_tokens: int
-    """Sum of system, conversation and tool-definition tokens"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionContextInfo':
-        assert isinstance(obj, dict)
-        buffer_tokens = from_int(obj.get("bufferTokens"))
-        compaction_threshold = from_int(obj.get("compactionThreshold"))
-        conversation_tokens = from_int(obj.get("conversationTokens"))
-        limit = from_int(obj.get("limit"))
-        model_name = from_str(obj.get("modelName"))
-        prompt_token_limit = from_int(obj.get("promptTokenLimit"))
-        system_tokens = from_int(obj.get("systemTokens"))
-        tool_definitions_tokens = from_int(obj.get("toolDefinitionsTokens"))
-        total_tokens = from_int(obj.get("totalTokens"))
-        return SessionContextInfo(buffer_tokens, compaction_threshold, conversation_tokens, limit, model_name, prompt_token_limit, system_tokens, tool_definitions_tokens, total_tokens)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["bufferTokens"] = from_int(self.buffer_tokens)
-        result["compactionThreshold"] = from_int(self.compaction_threshold)
-        result["conversationTokens"] = from_int(self.conversation_tokens)
-        result["limit"] = from_int(self.limit)
-        result["modelName"] = from_str(self.model_name)
-        result["promptTokenLimit"] = from_int(self.prompt_token_limit)
-        result["systemTokens"] = from_int(self.system_tokens)
-        result["toolDefinitionsTokens"] = from_int(self.tool_definitions_tokens)
-        result["totalTokens"] = from_int(self.total_tokens)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class MetadataIsProcessingResult:
-    """Indicates whether the local session is currently processing a turn or background
-    continuation.
-    """
-    processing: bool
-    """Whether the session is currently processing user/agent messages. False for non-local
-    sessions (which don't run a local agentic loop). Reflects an in-flight turn or background
-    continuation.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'MetadataIsProcessingResult':
-        assert isinstance(obj, dict)
-        processing = from_bool(obj.get("processing"))
-        return MetadataIsProcessingResult(processing)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["processing"] = from_bool(self.processing)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class MetadataRecomputeContextTokensResult:
-    """Re-tokenize the session's existing messages against `modelId` and return the token
-    totals. Useful for hosts that want an initial estimate of context usage on session
-    resume, before the next agent turn fires `session.context_info_changed` events. Returns
-    zeros for an empty session.
-    """
-    messages_token_count: int
-    """Tokens contributed by user/assistant/tool messages (excludes system/developer prompts)."""
-
-    system_token_count: int
-    """Tokens contributed by system/developer prompt snapshots."""
-
-    total_tokens: int
-    """Sum of tokens across chat-context and system-context messages currently held by the
-    session.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'MetadataRecomputeContextTokensResult':
-        assert isinstance(obj, dict)
-        messages_token_count = from_int(obj.get("messagesTokenCount"))
-        system_token_count = from_int(obj.get("systemTokenCount"))
-        total_tokens = from_int(obj.get("totalTokens"))
-        return MetadataRecomputeContextTokensResult(messages_token_count, system_token_count, total_tokens)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["messagesTokenCount"] = from_int(self.messages_token_count)
-        result["systemTokenCount"] = from_int(self.system_token_count)
-        result["totalTokens"] = from_int(self.total_tokens)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-class SessionContextHostType(Enum):
-    """Hosting platform type of the repository
-
-    Repository host type
-
-    Repository host type, if known
-    """
-    ADO = "ado"
-    GITHUB = "github"
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class MetadataRecordContextChangeResult:
-    """Notify the session that its working directory context has changed. Emits a
-    `session.context_changed` event so consumers (telemetry, OTel tracker, ACP, the timeline
-    UI) can react. Use this when the host has detected a cwd/branch/repo change outside the
-    session's normal lifecycle (e.g., after a shell command in interactive mode).
-    """
-    @staticmethod
-    def from_dict(obj: Any) -> 'MetadataRecordContextChangeResult':
-        assert isinstance(obj, dict)
-        return MetadataRecordContextChangeResult()
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class MetadataSetWorkingDirectoryRequest:
-    """Absolute path to set as the session's new working directory."""
-
-    working_directory: str
-    """Absolute path to set as the session's working directory. The runtime updates the
-    session's recorded cwd so subsequent operations (shell tools, file lookups, telemetry)
-    anchor to it.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'MetadataSetWorkingDirectoryRequest':
-        assert isinstance(obj, dict)
-        working_directory = from_str(obj.get("workingDirectory"))
-        return MetadataSetWorkingDirectoryRequest(working_directory)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["workingDirectory"] = from_str(self.working_directory)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class MetadataSetWorkingDirectoryResult:
-    """Update the session's working directory. Used by the host when the user explicitly changes
-    cwd (e.g., the `/cd` slash command). The host is responsible for `process.chdir` and any
-    related side-effects (file index, etc.); this method only updates the session's own
-    recorded path.
-    """
-    working_directory: str
-    """Working directory after the update"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'MetadataSetWorkingDirectoryResult':
-        assert isinstance(obj, dict)
-        working_directory = from_str(obj.get("workingDirectory"))
-        return MetadataSetWorkingDirectoryResult(working_directory)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["workingDirectory"] = from_str(self.working_directory)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-class MetadataSnapshotCurrentMode(Enum):
-    """The current agent mode for this session (e.g., 'interactive', 'plan', 'autopilot')"""
-
-    AUTOPILOT = "autopilot"
-    INTERACTIVE = "interactive"
-    PLAN = "plan"
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class MetadataSnapshotRemoteMetadataRepository:
-    """The repository the remote session targets."""
-
-    branch: str
-    """The branch the remote session is operating on."""
-
-    name: str
-    """The GitHub repository name (without owner)."""
-
-    owner: str
-    """The GitHub owner (user or organization) of the target repository."""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'MetadataSnapshotRemoteMetadataRepository':
-        assert isinstance(obj, dict)
-        branch = from_str(obj.get("branch"))
-        name = from_str(obj.get("name"))
-        owner = from_str(obj.get("owner"))
-        return MetadataSnapshotRemoteMetadataRepository(branch, name, owner)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["branch"] = from_str(self.branch)
-        result["name"] = from_str(self.name)
-        result["owner"] = from_str(self.owner)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-class MetadataSnapshotRemoteMetadataTaskType(Enum):
-    """Whether the remote task originated from Copilot Coding Agent (cca) or a CLI `--remote`
-    invocation.
-    """
-    CCA = "cca"
-    CLI = "cli"
 
 @dataclass
 class ModeSetRequest:
@@ -2055,46 +1204,6 @@ class ModelCapabilitiesOverrideSupports:
         return result
 
 @dataclass
-class ModelSetReasoningEffortRequest:
-    """Reasoning effort level to apply to the currently selected model."""
-
-    reasoning_effort: str
-    """Reasoning effort level to apply to the currently selected model. The host is responsible
-    for validating the value against the model's supported levels before calling.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'ModelSetReasoningEffortRequest':
-        assert isinstance(obj, dict)
-        reasoning_effort = from_str(obj.get("reasoningEffort"))
-        return ModelSetReasoningEffortRequest(reasoning_effort)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["reasoningEffort"] = from_str(self.reasoning_effort)
-        return result
-
-@dataclass
-class ModelSetReasoningEffortResult:
-    """Update the session's reasoning effort without changing the selected model. Use `switchTo`
-    instead when you also need to change the model. The runtime stores the effort on the
-    session and applies it to subsequent turns.
-    """
-    reasoning_effort: str
-    """Reasoning effort level recorded on the session after the update"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'ModelSetReasoningEffortResult':
-        assert isinstance(obj, dict)
-        reasoning_effort = from_str(obj.get("reasoningEffort"))
-        return ModelSetReasoningEffortResult(reasoning_effort)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["reasoningEffort"] = from_str(self.reasoning_effort)
-        return result
-
-@dataclass
 class ModelSwitchToResult:
     """The model identifier active on the session after the switch."""
 
@@ -2151,47 +1260,6 @@ class NameGetResult:
         return result
 
 @dataclass
-class NameSetAutoRequest:
-    """Auto-generated session summary to apply as the session's name when no user-set name
-    exists.
-    """
-    summary: str
-    """Auto-generated session summary. Empty/whitespace-only values are ignored; values are
-    trimmed before persisting.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'NameSetAutoRequest':
-        assert isinstance(obj, dict)
-        summary = from_str(obj.get("summary"))
-        return NameSetAutoRequest(summary)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["summary"] = from_str(self.summary)
-        return result
-
-@dataclass
-class NameSetAutoResult:
-    """Indicates whether the auto-generated summary was applied as the session's name."""
-
-    applied: bool
-    """Whether the auto-generated summary was persisted. False if the session already has a
-    user-set name, the summary normalized to empty, or the session does not have a workspace.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'NameSetAutoResult':
-        assert isinstance(obj, dict)
-        applied = from_bool(obj.get("applied"))
-        return NameSetAutoResult(applied)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["applied"] = from_bool(self.applied)
-        return result
-
-@dataclass
 class NameSetRequest:
     """New friendly name to apply to the session."""
 
@@ -2209,30 +1277,6 @@ class NameSetRequest:
         result["name"] = from_str(self.name)
         return result
 
-@dataclass
-class PendingPermissionRequest:
-    """Schema for the `PendingPermissionRequest` type."""
-
-    request: PermissionPromptRequest
-    """The user-facing permission prompt details (commands, write, read, mcp, url, memory,
-    custom-tool, path, hook)
-    """
-    request_id: str
-    """Unique identifier for the pending permission request"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PendingPermissionRequest':
-        assert isinstance(obj, dict)
-        request = PermissionPromptRequest.from_dict(obj.get("request"))
-        request_id = from_str(obj.get("requestId"))
-        return PendingPermissionRequest(request, request_id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["request"] = to_class(PermissionPromptRequest, self.request)
-        result["requestId"] = from_str(self.request_id)
-        return result
-
 class ApprovalKind(Enum):
     COMMANDS = "commands"
     CUSTOM_TOOL = "custom-tool"
@@ -2245,19 +1289,10 @@ class ApprovalKind(Enum):
     WRITE = "write"
 
 class PermissionDecisionKind(Enum):
-    APPROVED = "approved"
-    APPROVED_FOR_LOCATION = "approved-for-location"
-    APPROVED_FOR_SESSION = "approved-for-session"
     APPROVE_FOR_LOCATION = "approve-for-location"
     APPROVE_FOR_SESSION = "approve-for-session"
     APPROVE_ONCE = "approve-once"
     APPROVE_PERMANENTLY = "approve-permanently"
-    CANCELLED = "cancelled"
-    DENIED_BY_CONTENT_EXCLUSION_POLICY = "denied-by-content-exclusion-policy"
-    DENIED_BY_PERMISSION_REQUEST_HOOK = "denied-by-permission-request-hook"
-    DENIED_BY_RULES = "denied-by-rules"
-    DENIED_INTERACTIVELY_BY_USER = "denied-interactively-by-user"
-    DENIED_NO_APPROVAL_RULE_AND_COULD_NOT_REQUEST_FROM_USER = "denied-no-approval-rule-and-could-not-request-from-user"
     REJECT = "reject"
     USER_NOT_AVAILABLE = "user-not-available"
 
@@ -2300,192 +1335,11 @@ class PermissionDecisionApproveOnceKind(Enum):
 class PermissionDecisionApprovePermanentlyKind(Enum):
     APPROVE_PERMANENTLY = "approve-permanently"
 
-class PermissionDecisionApprovedKind(Enum):
-    APPROVED = "approved"
-
-class PermissionDecisionApprovedForLocationKind(Enum):
-    APPROVED_FOR_LOCATION = "approved-for-location"
-
-class PermissionDecisionApprovedForSessionKind(Enum):
-    APPROVED_FOR_SESSION = "approved-for-session"
-
-class PermissionDecisionCancelledKind(Enum):
-    CANCELLED = "cancelled"
-
-class PermissionDecisionDeniedByContentExclusionPolicyKind(Enum):
-    DENIED_BY_CONTENT_EXCLUSION_POLICY = "denied-by-content-exclusion-policy"
-
-class PermissionDecisionDeniedByPermissionRequestHookKind(Enum):
-    DENIED_BY_PERMISSION_REQUEST_HOOK = "denied-by-permission-request-hook"
-
-class PermissionDecisionDeniedByRulesKind(Enum):
-    DENIED_BY_RULES = "denied-by-rules"
-
-class PermissionDecisionDeniedInteractivelyByUserKind(Enum):
-    DENIED_INTERACTIVELY_BY_USER = "denied-interactively-by-user"
-
-class PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUserKind(Enum):
-    DENIED_NO_APPROVAL_RULE_AND_COULD_NOT_REQUEST_FROM_USER = "denied-no-approval-rule-and-could-not-request-from-user"
-
 class PermissionDecisionRejectKind(Enum):
     REJECT = "reject"
 
 class PermissionDecisionUserNotAvailableKind(Enum):
     USER_NOT_AVAILABLE = "user-not-available"
-
-@dataclass
-class PermissionPathsAddParams:
-    """Directory path to add to the session's allowed directories."""
-
-    path: str
-    """Directory to add to the allow-list. The runtime resolves and validates the path before
-    adding.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionPathsAddParams':
-        assert isinstance(obj, dict)
-        path = from_str(obj.get("path"))
-        return PermissionPathsAddParams(path)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["path"] = from_str(self.path)
-        return result
-
-@dataclass
-class PermissionPathsAllowedCheckParams:
-    """Path to evaluate against the session's allowed directories."""
-
-    path: str
-    """Path to check against the session's allowed directories"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionPathsAllowedCheckParams':
-        assert isinstance(obj, dict)
-        path = from_str(obj.get("path"))
-        return PermissionPathsAllowedCheckParams(path)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["path"] = from_str(self.path)
-        return result
-
-@dataclass
-class PermissionPathsAllowedCheckResult:
-    """Indicates whether the supplied path is within the session's allowed directories."""
-
-    allowed: bool
-    """Whether the path is within the session's allowed directories"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionPathsAllowedCheckResult':
-        assert isinstance(obj, dict)
-        allowed = from_bool(obj.get("allowed"))
-        return PermissionPathsAllowedCheckResult(allowed)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["allowed"] = from_bool(self.allowed)
-        return result
-
-@dataclass
-class PermissionPathsList:
-    """Snapshot of the session's allow-listed directories and primary working directory."""
-
-    directories: list[str]
-    """All directories currently allowed for tool access on this session."""
-
-    primary: str
-    """The primary working directory for this session."""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionPathsList':
-        assert isinstance(obj, dict)
-        directories = from_list(from_str, obj.get("directories"))
-        primary = from_str(obj.get("primary"))
-        return PermissionPathsList(directories, primary)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["directories"] = from_list(from_str, self.directories)
-        result["primary"] = from_str(self.primary)
-        return result
-
-@dataclass
-class PermissionPathsUpdatePrimaryParams:
-    """Directory path to set as the session's new primary working directory."""
-
-    path: str
-    """Directory to set as the new primary working directory for the session's permission policy."""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionPathsUpdatePrimaryParams':
-        assert isinstance(obj, dict)
-        path = from_str(obj.get("path"))
-        return PermissionPathsUpdatePrimaryParams(path)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["path"] = from_str(self.path)
-        return result
-
-@dataclass
-class PermissionPathsWorkspaceCheckParams:
-    """Path to evaluate against the session's workspace (primary) directory."""
-
-    path: str
-    """Path to check against the session workspace directory"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionPathsWorkspaceCheckParams':
-        assert isinstance(obj, dict)
-        path = from_str(obj.get("path"))
-        return PermissionPathsWorkspaceCheckParams(path)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["path"] = from_str(self.path)
-        return result
-
-@dataclass
-class PermissionPathsWorkspaceCheckResult:
-    """Indicates whether the supplied path is within the session's workspace directory."""
-
-    allowed: bool
-    """Whether the path is within the session workspace directory"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionPathsWorkspaceCheckResult':
-        assert isinstance(obj, dict)
-        allowed = from_bool(obj.get("allowed"))
-        return PermissionPathsWorkspaceCheckResult(allowed)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["allowed"] = from_bool(self.allowed)
-        return result
-
-@dataclass
-class PermissionPromptShownNotification:
-    """Notification payload describing the permission prompt that the client just rendered."""
-
-    message: str
-    """Human-readable description of the prompt the user is being asked to approve. Used by the
-    runtime to fire the registered `permission_prompt` notification hook (e.g. terminal bell,
-    desktop notification).
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionPromptShownNotification':
-        assert isinstance(obj, dict)
-        message = from_str(obj.get("message"))
-        return PermissionPromptShownNotification(message)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["message"] = from_str(self.message)
-        return result
 
 @dataclass
 class PermissionRequestResult:
@@ -2504,228 +1358,6 @@ class PermissionRequestResult:
     def to_dict(self) -> dict:
         result: dict = {}
         result["success"] = from_bool(self.success)
-        return result
-
-@dataclass
-class PermissionRulesSet:
-    """If specified, replaces the session's approved/denied permission rules. Omit to leave the
-    current rules unchanged.
-    """
-    approved: list[PermissionRule]
-    """Rules that auto-approve matching requests"""
-
-    denied: list[PermissionRule]
-    """Rules that auto-deny matching requests"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionRulesSet':
-        assert isinstance(obj, dict)
-        approved = from_list(PermissionRule.from_dict, obj.get("approved"))
-        denied = from_list(PermissionRule.from_dict, obj.get("denied"))
-        return PermissionRulesSet(approved, denied)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["approved"] = from_list(lambda x: to_class(PermissionRule, x), self.approved)
-        result["denied"] = from_list(lambda x: to_class(PermissionRule, x), self.denied)
-        return result
-
-@dataclass
-class PermissionUrlsConfig:
-    """If specified, replaces the session's URL-permission policy. The runtime constructs a
-    fresh DefaultUrlManager based on these inputs. Omit to leave the current URL policy
-    unchanged.
-    """
-    initial_allowed: list[str] | None = None
-    """Initial list of allowed URL/domain patterns. Patterns may include path components.
-    Ignored when `unrestricted` is true.
-    """
-    unrestricted: bool | None = None
-    """If true, the runtime allows access to all URLs without prompting. Initial allow-list is
-    ignored when this is true.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionUrlsConfig':
-        assert isinstance(obj, dict)
-        initial_allowed = from_union([lambda x: from_list(from_str, x), from_none], obj.get("initialAllowed"))
-        unrestricted = from_union([from_bool, from_none], obj.get("unrestricted"))
-        return PermissionUrlsConfig(initial_allowed, unrestricted)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.initial_allowed is not None:
-            result["initialAllowed"] = from_union([lambda x: from_list(from_str, x), from_none], self.initial_allowed)
-        if self.unrestricted is not None:
-            result["unrestricted"] = from_union([from_bool, from_none], self.unrestricted)
-        return result
-
-@dataclass
-class PermissionUrlsSetUnrestrictedModeParams:
-    """Whether the URL-permission policy should run in unrestricted mode."""
-
-    enabled: bool
-    """Whether to allow access to all URLs without prompting. Toggles the runtime's
-    URL-permission policy in place.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionUrlsSetUnrestrictedModeParams':
-        assert isinstance(obj, dict)
-        enabled = from_bool(obj.get("enabled"))
-        return PermissionUrlsSetUnrestrictedModeParams(enabled)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["enabled"] = from_bool(self.enabled)
-        return result
-
-@dataclass
-class PermissionsConfigureAdditionalContentExclusionPolicyRuleSource:
-    """Schema for the `PermissionsConfigureAdditionalContentExclusionPolicyRuleSource` type."""
-
-    name: str
-    type: str
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionsConfigureAdditionalContentExclusionPolicyRuleSource':
-        assert isinstance(obj, dict)
-        name = from_str(obj.get("name"))
-        type = from_str(obj.get("type"))
-        return PermissionsConfigureAdditionalContentExclusionPolicyRuleSource(name, type)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["name"] = from_str(self.name)
-        result["type"] = from_str(self.type)
-        return result
-
-class PermissionsConfigureAdditionalContentExclusionPolicyScope(Enum):
-    """Allowed values for the `PermissionsConfigureAdditionalContentExclusionPolicyScope`
-    enumeration.
-    """
-    ALL = "all"
-    REPO = "repo"
-
-@dataclass
-class PermissionsConfigureResult:
-    """Indicates whether the operation succeeded."""
-
-    success: bool
-    """Whether the operation succeeded"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionsConfigureResult':
-        assert isinstance(obj, dict)
-        success = from_bool(obj.get("success"))
-        return PermissionsConfigureResult(success)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["success"] = from_bool(self.success)
-        return result
-
-class PermissionsModifyRulesScope(Enum):
-    """Whether the change applies to ephemeral session-scoped rules (cleared at session end) or
-    to location-scoped rules persisted via the location-permissions config file.
-    """
-    LOCATION = "location"
-    SESSION = "session"
-
-@dataclass
-class PermissionsModifyRulesResult:
-    """Indicates whether the operation succeeded."""
-
-    success: bool
-    """Whether the operation succeeded"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionsModifyRulesResult':
-        assert isinstance(obj, dict)
-        success = from_bool(obj.get("success"))
-        return PermissionsModifyRulesResult(success)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["success"] = from_bool(self.success)
-        return result
-
-@dataclass
-class PermissionsNotifyPromptShownResult:
-    """Indicates whether the operation succeeded."""
-
-    success: bool
-    """Whether the operation succeeded"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionsNotifyPromptShownResult':
-        assert isinstance(obj, dict)
-        success = from_bool(obj.get("success"))
-        return PermissionsNotifyPromptShownResult(success)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["success"] = from_bool(self.success)
-        return result
-
-@dataclass
-class PermissionsPathsAddResult:
-    """Indicates whether the operation succeeded."""
-
-    success: bool
-    """Whether the operation succeeded"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionsPathsAddResult':
-        assert isinstance(obj, dict)
-        success = from_bool(obj.get("success"))
-        return PermissionsPathsAddResult(success)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["success"] = from_bool(self.success)
-        return result
-
-@dataclass
-class PermissionsPathsListRequest:
-    """No parameters; returns the session's allow-listed directories."""
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionsPathsListRequest':
-        assert isinstance(obj, dict)
-        return PermissionsPathsListRequest()
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        return result
-
-@dataclass
-class PermissionsPathsUpdatePrimaryResult:
-    """Indicates whether the operation succeeded."""
-
-    success: bool
-    """Whether the operation succeeded"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionsPathsUpdatePrimaryResult':
-        assert isinstance(obj, dict)
-        success = from_bool(obj.get("success"))
-        return PermissionsPathsUpdatePrimaryResult(success)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["success"] = from_bool(self.success)
-        return result
-
-@dataclass
-class PermissionsPendingRequestsRequest:
-    """No parameters; returns currently-pending permission requests for the session."""
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionsPendingRequestsRequest':
-        assert isinstance(obj, dict)
-        return PermissionsPendingRequestsRequest()
-
-    def to_dict(self) -> dict:
-        result: dict = {}
         return result
 
 @dataclass
@@ -2759,6 +1391,24 @@ class PermissionsResetSessionApprovalsResult:
         return result
 
 @dataclass
+class PermissionsSetApproveAllRequest:
+    """Whether to auto-approve all tool permission requests for the rest of the session."""
+
+    enabled: bool
+    """Whether to auto-approve all tool permission requests"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsSetApproveAllRequest':
+        assert isinstance(obj, dict)
+        enabled = from_bool(obj.get("enabled"))
+        return PermissionsSetApproveAllRequest(enabled)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["enabled"] = from_bool(self.enabled)
+        return result
+
+@dataclass
 class PermissionsSetApproveAllResult:
     """Indicates whether the operation succeeded."""
 
@@ -2770,63 +1420,6 @@ class PermissionsSetApproveAllResult:
         assert isinstance(obj, dict)
         success = from_bool(obj.get("success"))
         return PermissionsSetApproveAllResult(success)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["success"] = from_bool(self.success)
-        return result
-
-@dataclass
-class PermissionsSetRequiredRequest:
-    """Toggles whether permission prompts should be bridged into session events for this client."""
-
-    required: bool
-    """Whether the client wants `permission.requested` events bridged from the session-owned
-    permission service. CLI clients that render prompt UI set this to `true` for as long as
-    their listener is mounted; headless callers leave it unset (the default is `false`).
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionsSetRequiredRequest':
-        assert isinstance(obj, dict)
-        required = from_bool(obj.get("required"))
-        return PermissionsSetRequiredRequest(required)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["required"] = from_bool(self.required)
-        return result
-
-@dataclass
-class PermissionsSetRequiredResult:
-    """Indicates whether the operation succeeded."""
-
-    success: bool
-    """Whether the operation succeeded"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionsSetRequiredResult':
-        assert isinstance(obj, dict)
-        success = from_bool(obj.get("success"))
-        return PermissionsSetRequiredResult(success)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["success"] = from_bool(self.success)
-        return result
-
-@dataclass
-class PermissionsUrlsSetUnrestrictedModeResult:
-    """Indicates whether the operation succeeded."""
-
-    success: bool
-    """Whether the operation succeeded"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionsUrlsSetUnrestrictedModeResult':
-        assert isinstance(obj, dict)
-        success = from_bool(obj.get("success"))
-        return PermissionsUrlsSetUnrestrictedModeResult(success)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -2854,8 +1447,8 @@ class PingRequest:
 
 @dataclass
 class PingResult:
-    """Server liveness response, including the echoed message, current server timestamp, and
-    protocol version.
+    """Server liveness response, including the echoed message, current timestamp, and protocol
+    version.
     """
     message: str
     """Echoed message (or default greeting)"""
@@ -2863,22 +1456,22 @@ class PingResult:
     protocol_version: int
     """Server protocol version number"""
 
-    timestamp: datetime
-    """ISO 8601 timestamp when the server handled the ping"""
+    timestamp: int
+    """Server timestamp in milliseconds"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PingResult':
         assert isinstance(obj, dict)
         message = from_str(obj.get("message"))
         protocol_version = from_int(obj.get("protocolVersion"))
-        timestamp = from_datetime(obj.get("timestamp"))
+        timestamp = from_int(obj.get("timestamp"))
         return PingResult(message, protocol_version, timestamp)
 
     def to_dict(self) -> dict:
         result: dict = {}
         result["message"] = from_str(self.message)
         result["protocolVersion"] = from_int(self.protocol_version)
-        result["timestamp"] = self.timestamp.isoformat()
+        result["timestamp"] = from_int(self.timestamp)
         return result
 
 @dataclass
@@ -2962,45 +1555,15 @@ class Plugin:
             result["version"] = from_union([from_str, from_none], self.version)
         return result
 
-# Experimental: this type is part of an experimental API and may change or be removed.
-class QueuePendingItemsKind(Enum):
-    """Whether this item is a queued user message or a queued slash command / model change"""
-
-    COMMAND = "command"
-    MESSAGE = "message"
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class QueueRemoveMostRecentResult:
-    """Indicates whether a user-facing pending item was removed."""
-
-    removed: bool
-    """True if a user-facing pending item was removed (LIFO across both queues); false when no
-    removable items remained.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'QueueRemoveMostRecentResult':
-        assert isinstance(obj, dict)
-        removed = from_bool(obj.get("removed"))
-        return QueueRemoveMostRecentResult(removed)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["removed"] = from_bool(self.removed)
-        return result
-
 @dataclass
 class QueuedCommandHandled:
     """Schema for the `QueuedCommandHandled` type."""
 
     handled: bool
-    """The host actually executed the queued command."""
+    """The command was handled"""
 
     stop_processing_queue: bool | None = None
-    """When true, the runtime will not process subsequent queued commands until a new request
-    comes in.
-    """
+    """If true, stop processing remaining queued items"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'QueuedCommandHandled':
@@ -3021,9 +1584,7 @@ class QueuedCommandNotHandled:
     """Schema for the `QueuedCommandNotHandled` type."""
 
     handled: bool
-    """The host did not execute the queued command. Unblocks the queue without claiming the
-    command was processed (e.g. when the handler threw before completing).
-    """
+    """The command was not handled"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'QueuedCommandNotHandled':
@@ -3034,83 +1595,6 @@ class QueuedCommandNotHandled:
     def to_dict(self) -> dict:
         result: dict = {}
         result["handled"] = from_bool(self.handled)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class RegisterEventInterestParams:
-    """Event type to register consumer interest for, used by runtime gating logic."""
-
-    event_type: str
-    """The event type the consumer wants the runtime to treat as 'observed' for
-    behavior-switching gating. Some runtime code paths inspect whether any consumer is
-    interested in a specific event type and choose a different implementation accordingly
-    (e.g. `mcp.oauth_required`: when interest is registered the runtime delegates the full
-    interactive OAuth flow to the consumer; when no interest is registered the runtime
-    installs a browserless fallback that silently reuses cached tokens). SDK clients that
-    long-poll events do NOT automatically appear as listeners to these gating checks — they
-    must explicitly call `registerInterest` for each event type they want the runtime to
-    count as having a consumer. Multiple registrations for the same event type from the same
-    or different consumers are tracked independently and must each be released. See:
-    `mcp.oauth_required`, `sampling.requested`, `auto_mode_switch.requested`,
-    `user_input.requested`, `elicitation.requested`, `command.queued`,
-    `exit_plan_mode.requested`.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'RegisterEventInterestParams':
-        assert isinstance(obj, dict)
-        event_type = from_str(obj.get("eventType"))
-        return RegisterEventInterestParams(event_type)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["eventType"] = from_str(self.event_type)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class RegisterEventInterestResult:
-    """Opaque handle representing an event-type interest registration."""
-
-    handle: str
-    """Opaque handle for this registration. Pass to releaseInterest to release. Each call to
-    registerInterest produces a fresh handle, even when the same eventType is registered
-    multiple times.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'RegisterEventInterestResult':
-        assert isinstance(obj, dict)
-        handle = from_str(obj.get("handle"))
-        return RegisterEventInterestResult(handle)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["handle"] = from_str(self.handle)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class ReleaseEventInterestParams:
-    """Opaque handle previously returned by `registerInterest` to release."""
-
-    handle: str
-    """Handle returned by a previous `registerInterest` call. Idempotent: releasing an unknown
-    or already-released handle is a no-op (returns success). When the last outstanding handle
-    for an event type is released, the runtime reverts to its 'no consumer' code path for
-    that event type.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'ReleaseEventInterestParams':
-        assert isinstance(obj, dict)
-        handle = from_str(obj.get("handle"))
-        return ReleaseEventInterestParams(handle)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["handle"] = from_str(self.handle)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -3145,242 +1629,6 @@ class RemoteEnableResult:
         result["remoteSteerable"] = from_bool(self.remote_steerable)
         if self.url is not None:
             result["url"] = from_union([from_str, from_none], self.url)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class RemoteNotifySteerableChangedRequest:
-    """New remote-steerability state to persist as a `session.remote_steerable_changed` event."""
-
-    remote_steerable: bool
-    """Whether the session now supports remote steering via GitHub. The runtime persists this as
-    a `session.remote_steerable_changed` event so resume/replay sees the up-to-date
-    capability.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'RemoteNotifySteerableChangedRequest':
-        assert isinstance(obj, dict)
-        remote_steerable = from_bool(obj.get("remoteSteerable"))
-        return RemoteNotifySteerableChangedRequest(remote_steerable)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["remoteSteerable"] = from_bool(self.remote_steerable)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class RemoteNotifySteerableChangedResult:
-    """Persist a steerability change as a `session.remote_steerable_changed` event. Used by the
-    host (CLI / SDK consumer) when it has just finished enabling or disabling steering on a
-    remote exporter that the runtime does not directly own.
-    """
-    @staticmethod
-    def from_dict(obj: Any) -> 'RemoteNotifySteerableChangedResult':
-        assert isinstance(obj, dict)
-        return RemoteNotifySteerableChangedResult()
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class ScheduleEntry:
-    """Schema for the `ScheduleEntry` type.
-
-    The removed entry, or omitted if no entry matched.
-    """
-    id: int
-    """Sequential id assigned by the runtime within the session. Stable across resumes (rebuilt
-    from the event log).
-    """
-    interval_ms: int
-    """Interval between scheduled ticks, in milliseconds."""
-
-    next_run_at: datetime
-    """ISO 8601 timestamp when the next tick is scheduled to fire."""
-
-    prompt: str
-    """Prompt text that gets enqueued on every tick."""
-
-    recurring: bool
-    """Whether the schedule re-arms after each tick (`/every`) or fires once (`/after`)."""
-
-    display_prompt: str | None = None
-    """Display-only label for the prompt as shown in the UI (e.g. `/skill-name` for a
-    skill-invocation schedule). The actual enqueued prompt is `prompt`.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'ScheduleEntry':
-        assert isinstance(obj, dict)
-        id = from_int(obj.get("id"))
-        interval_ms = from_int(obj.get("intervalMs"))
-        next_run_at = from_datetime(obj.get("nextRunAt"))
-        prompt = from_str(obj.get("prompt"))
-        recurring = from_bool(obj.get("recurring"))
-        display_prompt = from_union([from_str, from_none], obj.get("displayPrompt"))
-        return ScheduleEntry(id, interval_ms, next_run_at, prompt, recurring, display_prompt)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["id"] = from_int(self.id)
-        result["intervalMs"] = from_int(self.interval_ms)
-        result["nextRunAt"] = self.next_run_at.isoformat()
-        result["prompt"] = from_str(self.prompt)
-        result["recurring"] = from_bool(self.recurring)
-        if self.display_prompt is not None:
-            result["displayPrompt"] = from_union([from_str, from_none], self.display_prompt)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class ScheduleStopRequest:
-    """Identifier of the scheduled prompt to remove."""
-
-    id: int
-    """Id of the scheduled prompt to remove."""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'ScheduleStopRequest':
-        assert isinstance(obj, dict)
-        id = from_int(obj.get("id"))
-        return ScheduleStopRequest(id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["id"] = from_int(self.id)
-        return result
-
-class SendAgentMode(Enum):
-    """The UI mode the agent was in when this message was sent. Defaults to the session's
-    current mode.
-    """
-    AUTOPILOT = "autopilot"
-    INTERACTIVE = "interactive"
-    PLAN = "plan"
-    SHELL = "shell"
-
-@dataclass
-class SendAttachmentFileLineRange:
-    """Optional line range to scope the attachment to a specific section of the file"""
-
-    end: int
-    """End line number (1-based, inclusive)"""
-
-    start: int
-    """Start line number (1-based)"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SendAttachmentFileLineRange':
-        assert isinstance(obj, dict)
-        end = from_int(obj.get("end"))
-        start = from_int(obj.get("start"))
-        return SendAttachmentFileLineRange(end, start)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["end"] = from_int(self.end)
-        result["start"] = from_int(self.start)
-        return result
-
-class SendAttachmentGithubReferenceTypeEnum(Enum):
-    """Type of GitHub reference"""
-
-    DISCUSSION = "discussion"
-    ISSUE = "issue"
-    PR = "pr"
-
-@dataclass
-class SendAttachmentSelectionDetailsEnd:
-    """End position of the selection"""
-
-    character: int
-    """End character offset within the line (0-based)"""
-
-    line: int
-    """End line number (0-based)"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SendAttachmentSelectionDetailsEnd':
-        assert isinstance(obj, dict)
-        character = from_int(obj.get("character"))
-        line = from_int(obj.get("line"))
-        return SendAttachmentSelectionDetailsEnd(character, line)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["character"] = from_int(self.character)
-        result["line"] = from_int(self.line)
-        return result
-
-@dataclass
-class SendAttachmentSelectionDetailsStart:
-    """Start position of the selection"""
-
-    character: int
-    """Start character offset within the line (0-based)"""
-
-    line: int
-    """Start line number (0-based)"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SendAttachmentSelectionDetailsStart':
-        assert isinstance(obj, dict)
-        character = from_int(obj.get("character"))
-        line = from_int(obj.get("line"))
-        return SendAttachmentSelectionDetailsStart(character, line)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["character"] = from_int(self.character)
-        result["line"] = from_int(self.line)
-        return result
-
-class SendAttachmentType(Enum):
-    BLOB = "blob"
-    DIRECTORY = "directory"
-    FILE = "file"
-    GITHUB_REFERENCE = "github_reference"
-    SELECTION = "selection"
-
-class SendAttachmentBlobType(Enum):
-    BLOB = "blob"
-
-class SendAttachmentFileType(Enum):
-    FILE = "file"
-
-class SendAttachmentGithubReferenceType(Enum):
-    GITHUB_REFERENCE = "github_reference"
-
-class SendAttachmentSelectionType(Enum):
-    SELECTION = "selection"
-
-class SendMode(Enum):
-    """How to deliver the message. `enqueue` (default) appends to the message queue. `immediate`
-    interjects during an in-progress turn.
-    """
-    ENQUEUE = "enqueue"
-    IMMEDIATE = "immediate"
-
-@dataclass
-class SendResult:
-    """Result of sending a user message"""
-
-    message_id: str
-    """Unique identifier assigned to the message"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SendResult':
-        assert isinstance(obj, dict)
-        message_id = from_str(obj.get("messageId"))
-        return SendResult(message_id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["messageId"] = from_str(self.message_id)
         return result
 
 @dataclass
@@ -3431,28 +1679,6 @@ class ServerSkill:
             result["path"] = from_union([from_str, from_none], self.path)
         if self.project_path is not None:
             result["projectPath"] = from_union([from_str, from_none], self.project_path)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionBulkDeleteResult:
-    """Map of sessionId -> bytes freed by removing the session's workspace directory."""
-
-    freed_bytes: dict[str, int]
-    """Map of sessionId -> bytes freed by removing the session's workspace directory. Sessions
-    whose deletion failed are omitted from this map (failures are logged on the server but
-    not surfaced per-id; check the map for absent IDs to detect them).
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionBulkDeleteResult':
-        assert isinstance(obj, dict)
-        freed_bytes = from_dict(from_int, obj.get("freedBytes"))
-        return SessionBulkDeleteResult(freed_bytes)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["freedBytes"] = from_dict(from_int, self.freed_bytes)
         return result
 
 @dataclass
@@ -3860,303 +2086,6 @@ class SessionFSWriteFileRequest:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
-class SessionLoadDeferredRepoHooksResult:
-    """Queued repo-level startup prompts and the total hook command count after loading."""
-
-    hook_count: int
-    """Total hook command count (user + plugin + repo) loaded for the session by this call.
-    Captured atomically with startupPrompts so callers don't need to read a separate counter.
-    """
-    startup_prompts: list[str]
-    """Repo-level startup prompts queued from repo hook configs. Empty on resume, when no repo
-    configs were pending, or when disableAllHooks is set.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionLoadDeferredRepoHooksResult':
-        assert isinstance(obj, dict)
-        hook_count = from_int(obj.get("hookCount"))
-        startup_prompts = from_list(from_str, obj.get("startupPrompts"))
-        return SessionLoadDeferredRepoHooksResult(hook_count, startup_prompts)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["hookCount"] = from_int(self.hook_count)
-        result["startupPrompts"] = from_list(from_str, self.startup_prompts)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionPruneResult:
-    """Outcome of the prune operation: deleted IDs, dry-run candidates, skipped IDs, total bytes
-    freed, and the dry-run flag.
-    """
-    candidates: list[str]
-    """Session IDs that would be deleted in dry-run mode (always empty otherwise)"""
-
-    deleted: list[str]
-    """Session IDs that were deleted (always empty in dry-run mode)"""
-
-    dry_run: bool
-    """True when no deletions were actually performed"""
-
-    freed_bytes: int
-    """Total bytes freed (actual when not dry-run, projected when dry-run)"""
-
-    skipped: list[str]
-    """Session IDs that were skipped (e.g., named sessions)"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionPruneResult':
-        assert isinstance(obj, dict)
-        candidates = from_list(from_str, obj.get("candidates"))
-        deleted = from_list(from_str, obj.get("deleted"))
-        dry_run = from_bool(obj.get("dryRun"))
-        freed_bytes = from_int(obj.get("freedBytes"))
-        skipped = from_list(from_str, obj.get("skipped"))
-        return SessionPruneResult(candidates, deleted, dry_run, freed_bytes, skipped)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["candidates"] = from_list(from_str, self.candidates)
-        result["deleted"] = from_list(from_str, self.deleted)
-        result["dryRun"] = from_bool(self.dry_run)
-        result["freedBytes"] = from_int(self.freed_bytes)
-        result["skipped"] = from_list(from_str, self.skipped)
-        return result
-
-@dataclass
-class SessionSetCredentialsResult:
-    """Indicates whether the credential update succeeded."""
-
-    success: bool
-    """Whether the operation succeeded"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionSetCredentialsResult':
-        assert isinstance(obj, dict)
-        success = from_bool(obj.get("success"))
-        return SessionSetCredentialsResult(success)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["success"] = from_bool(self.success)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionSizes:
-    """Map of sessionId -> on-disk size in bytes for each session's workspace directory."""
-
-    sizes: dict[str, int]
-    """Map of sessionId -> on-disk size in bytes for the session's workspace directory"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionSizes':
-        assert isinstance(obj, dict)
-        sizes = from_dict(from_int, obj.get("sizes"))
-        return SessionSizes(sizes)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["sizes"] = from_dict(from_int, self.sizes)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionUpdateOptionsResult:
-    """Indicates whether the session options patch was applied successfully."""
-
-    success: bool
-    """Whether the operation succeeded"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionUpdateOptionsResult':
-        assert isinstance(obj, dict)
-        success = from_bool(obj.get("success"))
-        return SessionUpdateOptionsResult(success)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["success"] = from_bool(self.success)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsBulkDeleteRequest:
-    """Session IDs to close, deactivate, and delete from disk."""
-
-    session_ids: list[str]
-    """Session IDs to close, deactivate, and delete from disk"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsBulkDeleteRequest':
-        assert isinstance(obj, dict)
-        session_ids = from_list(from_str, obj.get("sessionIds"))
-        return SessionsBulkDeleteRequest(session_ids)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["sessionIds"] = from_list(from_str, self.session_ids)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsCheckInUseRequest:
-    """Session IDs to test for live in-use locks."""
-
-    session_ids: list[str]
-    """Session IDs to test for live in-use locks"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsCheckInUseRequest':
-        assert isinstance(obj, dict)
-        session_ids = from_list(from_str, obj.get("sessionIds"))
-        return SessionsCheckInUseRequest(session_ids)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["sessionIds"] = from_list(from_str, self.session_ids)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsCheckInUseResult:
-    """Session IDs from the input set that are currently in use by another process."""
-
-    in_use: list[str]
-    """Session IDs from the input set that are currently held by another running process via an
-    alive lock file
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsCheckInUseResult':
-        assert isinstance(obj, dict)
-        in_use = from_list(from_str, obj.get("inUse"))
-        return SessionsCheckInUseResult(in_use)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["inUse"] = from_list(from_str, self.in_use)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsCloseRequest:
-    """Session ID to close."""
-
-    session_id: str
-    """Session ID to close"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsCloseRequest':
-        assert isinstance(obj, dict)
-        session_id = from_str(obj.get("sessionId"))
-        return SessionsCloseRequest(session_id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["sessionId"] = from_str(self.session_id)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsCloseResult:
-    """Closes a session: emits shutdown, flushes pending events to disk, releases the in-use
-    lock, disposes the active session. Idempotent: succeeds even if the session is not
-    currently active.
-    """
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsCloseResult':
-        assert isinstance(obj, dict)
-        return SessionsCloseResult()
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsFindByPrefixRequest:
-    """UUID prefix to resolve to a unique session ID."""
-
-    prefix: str
-    """UUID prefix (>=7 hex chars, <36 chars). Returns the unique session ID, or undefined when
-    there is no match or the prefix matches multiple sessions.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsFindByPrefixRequest':
-        assert isinstance(obj, dict)
-        prefix = from_str(obj.get("prefix"))
-        return SessionsFindByPrefixRequest(prefix)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["prefix"] = from_str(self.prefix)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsFindByPrefixResult:
-    """Session ID matching the prefix, omitted when no unique match exists."""
-
-    session_id: str | None = None
-    """Omitted when no unique session matches the prefix (no match or ambiguous)"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsFindByPrefixResult':
-        assert isinstance(obj, dict)
-        session_id = from_union([from_str, from_none], obj.get("sessionId"))
-        return SessionsFindByPrefixResult(session_id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.session_id is not None:
-            result["sessionId"] = from_union([from_str, from_none], self.session_id)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsFindByTaskIDRequest:
-    """GitHub task ID to look up."""
-
-    task_id: str
-    """GitHub task ID to look up"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsFindByTaskIDRequest':
-        assert isinstance(obj, dict)
-        task_id = from_str(obj.get("taskId"))
-        return SessionsFindByTaskIDRequest(task_id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["taskId"] = from_str(self.task_id)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsFindByTaskIDResult:
-    """ID of the local session bound to the given GitHub task, or omitted when none."""
-
-    session_id: str | None = None
-    """Omitted when no local session is bound to that GitHub task"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsFindByTaskIDResult':
-        assert isinstance(obj, dict)
-        session_id = from_union([from_str, from_none], obj.get("sessionId"))
-        return SessionsFindByTaskIDResult(session_id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.session_id is not None:
-            result["sessionId"] = from_union([from_str, from_none], self.session_id)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
 class SessionsForkRequest:
     """Source session identifier to fork from, optional event-ID boundary, and optional friendly
     name for the new session.
@@ -4212,327 +2141,6 @@ class SessionsForkResult:
         result["sessionId"] = from_str(self.session_id)
         if self.name is not None:
             result["name"] = from_union([from_str, from_none], self.name)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsGetEventFilePathRequest:
-    """Session ID whose event-log file path to compute."""
-
-    session_id: str
-    """Session ID whose event-log file path to compute"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsGetEventFilePathRequest':
-        assert isinstance(obj, dict)
-        session_id = from_str(obj.get("sessionId"))
-        return SessionsGetEventFilePathRequest(session_id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["sessionId"] = from_str(self.session_id)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsGetEventFilePathResult:
-    """Absolute path to the session's events.jsonl file on disk."""
-
-    file_path: str
-    """Absolute path to the session's events.jsonl file"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsGetEventFilePathResult':
-        assert isinstance(obj, dict)
-        file_path = from_str(obj.get("filePath"))
-        return SessionsGetEventFilePathResult(file_path)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["filePath"] = from_str(self.file_path)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsGetLastForContextResult:
-    """Most-relevant session ID for the supplied context, or omitted when no sessions exist."""
-
-    session_id: str | None = None
-    """Most-relevant session ID for the supplied context, or omitted when no sessions exist"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsGetLastForContextResult':
-        assert isinstance(obj, dict)
-        session_id = from_union([from_str, from_none], obj.get("sessionId"))
-        return SessionsGetLastForContextResult(session_id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.session_id is not None:
-            result["sessionId"] = from_union([from_str, from_none], self.session_id)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsGetPersistedRemoteSteerableRequest:
-    """Session ID to look up the persisted remote-steerable flag for."""
-
-    session_id: str
-    """Session ID to look up the persisted remote-steerable flag for"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsGetPersistedRemoteSteerableRequest':
-        assert isinstance(obj, dict)
-        session_id = from_str(obj.get("sessionId"))
-        return SessionsGetPersistedRemoteSteerableRequest(session_id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["sessionId"] = from_str(self.session_id)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsGetPersistedRemoteSteerableResult:
-    """The session's persisted remote-steerable flag, or omitted when no value has been
-    persisted.
-    """
-    remote_steerable: bool | None = None
-    """The session's persisted remote-steerable flag if recorded; omitted when no value has been
-    persisted
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsGetPersistedRemoteSteerableResult':
-        assert isinstance(obj, dict)
-        remote_steerable = from_union([from_bool, from_none], obj.get("remoteSteerable"))
-        return SessionsGetPersistedRemoteSteerableResult(remote_steerable)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.remote_steerable is not None:
-            result["remoteSteerable"] = from_union([from_bool, from_none], self.remote_steerable)
-        return result
-
-@dataclass
-class Filter:
-    """Optional filter applied to the returned sessions"""
-
-    branch: str | None = None
-    """Match sessions whose context.branch equals this value"""
-
-    cwd: str | None = None
-    """Match sessions whose context.cwd equals this value"""
-
-    git_root: str | None = None
-    """Match sessions whose context.gitRoot equals this value"""
-
-    repository: str | None = None
-    """Match sessions whose context.repository equals this value"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'Filter':
-        assert isinstance(obj, dict)
-        branch = from_union([from_str, from_none], obj.get("branch"))
-        cwd = from_union([from_str, from_none], obj.get("cwd"))
-        git_root = from_union([from_str, from_none], obj.get("gitRoot"))
-        repository = from_union([from_str, from_none], obj.get("repository"))
-        return Filter(branch, cwd, git_root, repository)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.branch is not None:
-            result["branch"] = from_union([from_str, from_none], self.branch)
-        if self.cwd is not None:
-            result["cwd"] = from_union([from_str, from_none], self.cwd)
-        if self.git_root is not None:
-            result["gitRoot"] = from_union([from_str, from_none], self.git_root)
-        if self.repository is not None:
-            result["repository"] = from_union([from_str, from_none], self.repository)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsLoadDeferredRepoHooksRequest:
-    """Active session ID whose deferred repo-level hooks should be loaded."""
-
-    session_id: str
-    """Active session ID whose deferred repo-level hooks should be loaded"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsLoadDeferredRepoHooksRequest':
-        assert isinstance(obj, dict)
-        session_id = from_str(obj.get("sessionId"))
-        return SessionsLoadDeferredRepoHooksRequest(session_id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["sessionId"] = from_str(self.session_id)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsPruneOldRequest:
-    """Age threshold and optional flags controlling which old sessions are pruned (or simulated
-    when dryRun is true).
-    """
-    older_than_days: int
-    """Delete sessions whose modifiedTime is at least this many days old"""
-
-    dry_run: bool | None = None
-    """When true, only report what would be deleted without performing any deletion"""
-
-    exclude_session_ids: list[str] | None = None
-    """Session IDs that should never be considered for pruning"""
-
-    include_named: bool | None = None
-    """When true, named sessions (set via /rename) are also eligible for pruning"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsPruneOldRequest':
-        assert isinstance(obj, dict)
-        older_than_days = from_int(obj.get("olderThanDays"))
-        dry_run = from_union([from_bool, from_none], obj.get("dryRun"))
-        exclude_session_ids = from_union([lambda x: from_list(from_str, x), from_none], obj.get("excludeSessionIds"))
-        include_named = from_union([from_bool, from_none], obj.get("includeNamed"))
-        return SessionsPruneOldRequest(older_than_days, dry_run, exclude_session_ids, include_named)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["olderThanDays"] = from_int(self.older_than_days)
-        if self.dry_run is not None:
-            result["dryRun"] = from_union([from_bool, from_none], self.dry_run)
-        if self.exclude_session_ids is not None:
-            result["excludeSessionIds"] = from_union([lambda x: from_list(from_str, x), from_none], self.exclude_session_ids)
-        if self.include_named is not None:
-            result["includeNamed"] = from_union([from_bool, from_none], self.include_named)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsReleaseLockRequest:
-    """Session ID whose in-use lock should be released."""
-
-    session_id: str
-    """Session ID whose in-use lock should be released"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsReleaseLockRequest':
-        assert isinstance(obj, dict)
-        session_id = from_str(obj.get("sessionId"))
-        return SessionsReleaseLockRequest(session_id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["sessionId"] = from_str(self.session_id)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsReleaseLockResult:
-    """Release the in-use lock held by this process for the given session. No-op when this
-    process does not currently hold a lock for the session.
-    """
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsReleaseLockResult':
-        assert isinstance(obj, dict)
-        return SessionsReleaseLockResult()
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsReloadPluginHooksRequest:
-    """Active session ID and an optional flag for deferring repo-level hooks until folder trust."""
-
-    session_id: str
-    """Active session ID to reload hooks for"""
-
-    defer_repo_hooks: bool | None = None
-    """When true, skip repo-level hooks. Use before folder trust is confirmed;
-    loadDeferredRepoHooks loads them post-trust.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsReloadPluginHooksRequest':
-        assert isinstance(obj, dict)
-        session_id = from_str(obj.get("sessionId"))
-        defer_repo_hooks = from_union([from_bool, from_none], obj.get("deferRepoHooks"))
-        return SessionsReloadPluginHooksRequest(session_id, defer_repo_hooks)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["sessionId"] = from_str(self.session_id)
-        if self.defer_repo_hooks is not None:
-            result["deferRepoHooks"] = from_union([from_bool, from_none], self.defer_repo_hooks)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsReloadPluginHooksResult:
-    """Reload all hooks (user, plugin, optionally repo) and apply them to the active session.
-    Call after installing or removing plugins so their hooks take effect immediately. No-op
-    when no active session matches the given sessionId.
-    """
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsReloadPluginHooksResult':
-        assert isinstance(obj, dict)
-        return SessionsReloadPluginHooksResult()
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsSaveRequest:
-    """Session ID whose pending events should be flushed to disk."""
-
-    session_id: str
-    """Session ID whose pending events should be flushed to disk"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsSaveRequest':
-        assert isinstance(obj, dict)
-        session_id = from_str(obj.get("sessionId"))
-        return SessionsSaveRequest(session_id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["sessionId"] = from_str(self.session_id)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsSaveResult:
-    """Flush a session's pending events to disk. No-op when no writer exists for the session
-    (e.g., already closed).
-    """
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsSaveResult':
-        assert isinstance(obj, dict)
-        return SessionsSaveResult()
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsSetAdditionalPluginsResult:
-    """Replace the manager-wide additional plugins. New session creations and subsequent hook
-    reloads see the new set; already-running sessions keep their existing hook installation
-    until the next reload.
-    """
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsSetAdditionalPluginsResult':
-        assert isinstance(obj, dict)
-        return SessionsSetAdditionalPluginsResult()
-
-    def to_dict(self) -> dict:
-        result: dict = {}
         return result
 
 @dataclass
@@ -4610,32 +2218,6 @@ class ShellKillResult:
         result["killed"] = from_bool(self.killed)
         return result
 
-@dataclass
-class ShutdownRequest:
-    """Parameters for shutting down the session"""
-
-    reason: str | None = None
-    """Optional human-readable reason. Typically the message of the error that triggered
-    shutdown when type is 'error'.
-    """
-    type: ShutdownType | None = None
-    """Why the session is being shut down. Defaults to "routine" when omitted."""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'ShutdownRequest':
-        assert isinstance(obj, dict)
-        reason = from_union([from_str, from_none], obj.get("reason"))
-        type = from_union([ShutdownType, from_none], obj.get("type"))
-        return ShutdownRequest(reason, type)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.reason is not None:
-            result["reason"] = from_union([from_str, from_none], self.reason)
-        if self.type is not None:
-            result["type"] = from_union([lambda x: to_enum(ShutdownType, x), from_none], self.type)
-        return result
-
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
 class Skill:
@@ -4659,9 +2241,6 @@ class Skill:
     path: str | None = None
     """Absolute path to the skill file"""
 
-    plugin_name: str | None = None
-    """Name of the plugin that provides the skill, when source is 'plugin'"""
-
     @staticmethod
     def from_dict(obj: Any) -> 'Skill':
         assert isinstance(obj, dict)
@@ -4671,8 +2250,7 @@ class Skill:
         source = SkillSource(obj.get("source"))
         user_invocable = from_bool(obj.get("userInvocable"))
         path = from_union([from_str, from_none], obj.get("path"))
-        plugin_name = from_union([from_str, from_none], obj.get("pluginName"))
-        return Skill(description, enabled, name, source, user_invocable, path, plugin_name)
+        return Skill(description, enabled, name, source, user_invocable, path)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -4683,8 +2261,6 @@ class Skill:
         result["userInvocable"] = from_bool(self.user_invocable)
         if self.path is not None:
             result["path"] = from_union([from_str, from_none], self.path)
-        if self.plugin_name is not None:
-            result["pluginName"] = from_union([from_str, from_none], self.plugin_name)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -4752,46 +2328,6 @@ class SkillsEnableRequest:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
-class SkillsInvokedSkill:
-    """Schema for the `SkillsInvokedSkill` type."""
-
-    content: str
-    """Full content of the skill file"""
-
-    invoked_at_turn: int
-    """Turn number when the skill was invoked"""
-
-    name: str
-    """Unique identifier for the skill"""
-
-    path: str
-    """Path to the SKILL.md file"""
-
-    allowed_tools: list[str] | None = None
-    """Tools that should be auto-approved when this skill is active, captured at invocation time"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SkillsInvokedSkill':
-        assert isinstance(obj, dict)
-        content = from_str(obj.get("content"))
-        invoked_at_turn = from_int(obj.get("invokedAtTurn"))
-        name = from_str(obj.get("name"))
-        path = from_str(obj.get("path"))
-        allowed_tools = from_union([lambda x: from_list(from_str, x), from_none], obj.get("allowedTools"))
-        return SkillsInvokedSkill(content, invoked_at_turn, name, path, allowed_tools)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["content"] = from_str(self.content)
-        result["invokedAtTurn"] = from_int(self.invoked_at_turn)
-        result["name"] = from_str(self.name)
-        result["path"] = from_str(self.path)
-        if self.allowed_tools is not None:
-            result["allowedTools"] = from_union([lambda x: from_list(from_str, x), from_none], self.allowed_tools)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
 class SkillsLoadDiagnostics:
     """Diagnostics from reloading skill definitions, with warnings and errors as separate lists."""
 
@@ -4845,31 +2381,6 @@ class TaskStatus(Enum):
 class TaskAgentInfoType(Enum):
     AGENT = "agent"
 
-@dataclass
-class RecentActivity:
-    message: str
-    """Display message, e.g., "▸ bash", "✓ edit src/foo.ts\""""
-
-    timestamp: datetime
-    """ISO 8601 timestamp when this event occurred"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'RecentActivity':
-        assert isinstance(obj, dict)
-        message = from_str(obj.get("message"))
-        timestamp = from_datetime(obj.get("timestamp"))
-        return RecentActivity(message, timestamp)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["message"] = from_str(self.message)
-        result["timestamp"] = self.timestamp.isoformat()
-        return result
-
-class TaskAgentProgressType(Enum):
-    AGENT = "agent"
-    SHELL = "shell"
-
 # Experimental: this type is part of an experimental API and may change or be removed.
 class TaskShellInfoAttachmentMode(Enum):
     """Whether the shell runs inside a managed PTY session or as an independent background
@@ -4877,6 +2388,10 @@ class TaskShellInfoAttachmentMode(Enum):
     """
     ATTACHED = "attached"
     DETACHED = "detached"
+
+class TaskInfoType(Enum):
+    AGENT = "agent"
+    SHELL = "shell"
 
 class TaskShellInfoType(Enum):
     SHELL = "shell"
@@ -4921,25 +2436,6 @@ class TasksCancelResult:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
-class TasksGetProgressRequest:
-    """Identifier of the background task to fetch progress for."""
-
-    id: str
-    """Task identifier (agent ID or shell ID)"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'TasksGetProgressRequest':
-        assert isinstance(obj, dict)
-        id = from_str(obj.get("id"))
-        return TasksGetProgressRequest(id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["id"] = from_str(self.id)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
 class TasksPromoteToBackgroundRequest:
     """Identifier of the task to promote to background mode."""
 
@@ -4974,21 +2470,6 @@ class TasksPromoteToBackgroundResult:
     def to_dict(self) -> dict:
         result: dict = {}
         result["promoted"] = from_bool(self.promoted)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class TasksRefreshResult:
-    """Refresh metadata for any detached background shells the runtime knows about. Use after a
-    long pause to pick up exit/output state for shells running outside the agent loop.
-    """
-    @staticmethod
-    def from_dict(obj: Any) -> 'TasksRefreshResult':
-        assert isinstance(obj, dict)
-        return TasksRefreshResult()
-
-    def to_dict(self) -> dict:
-        result: dict = {}
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -5147,48 +2628,6 @@ class TasksStartAgentResult:
         result["agentId"] = from_str(self.agent_id)
         return result
 
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class TasksWaitForPendingResult:
-    """Wait until all in-flight background tasks (agents + shells) and any follow-up turns
-    scheduled by their completions have settled. Returns when the runtime is fully drained or
-    after an internal timeout (default 10 minutes; configurable via
-    COPILOT_TASK_WAIT_TIMEOUT_SECONDS).
-    """
-    @staticmethod
-    def from_dict(obj: Any) -> 'TasksWaitForPendingResult':
-        assert isinstance(obj, dict)
-        return TasksWaitForPendingResult()
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class TelemetrySetFeatureOverridesRequest:
-    """Feature override key/value pairs to attach to subsequent telemetry events from this
-    session.
-    """
-    features: dict[str, str]
-    """Override key/value pairs to attach to subsequent telemetry events from this session.
-    Replaces any previously-set overrides.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'TelemetrySetFeatureOverridesRequest':
-        assert isinstance(obj, dict)
-        features = from_dict(from_str, obj.get("features"))
-        return TelemetrySetFeatureOverridesRequest(features)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["features"] = from_dict(from_str, self.features)
-        return result
-
-class TokenAuthInfoType(Enum):
-    TOKEN = "token"
-
 @dataclass
 class Tool:
     """Schema for the `Tool` type."""
@@ -5232,21 +2671,6 @@ class Tool:
         return result
 
 @dataclass
-class ToolsInitializeAndValidateResult:
-    """Resolve, build, and validate the runtime tool list for this session. Subagent sessions
-    and consumer flows that need an initialized tool set before `send` invoke this. Default
-    base-class implementation is a no-op for sessions that don't support tool validation.
-    """
-    @staticmethod
-    def from_dict(obj: Any) -> 'ToolsInitializeAndValidateResult':
-        assert isinstance(obj, dict)
-        return ToolsInitializeAndValidateResult()
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        return result
-
-@dataclass
 class ToolsListRequest:
     """Optional model identifier whose tool overrides should be applied to the listing."""
 
@@ -5266,14 +2690,6 @@ class ToolsListRequest:
         if self.model is not None:
             result["model"] = from_union([from_str, from_none], self.model)
         return result
-
-class UIAutoModeSwitchResponse(Enum):
-    """User's choice for auto-mode switching: yes (allow this turn), yes_always (allow + persist
-    as setting), or no (decline).
-    """
-    NO = "no"
-    YES = "yes"
-    YES_ALWAYS = "yes_always"
 
 @dataclass
 class UIElicitationArrayAnyOfFieldItemsAnyOf:
@@ -5384,158 +2800,10 @@ class UIElicitationSchemaPropertyNumberType(Enum):
     INTEGER = "integer"
     NUMBER = "number"
 
-class UIExitPlanModeAction(Enum):
-    """The action the user selected. Defaults to 'autopilot' when autoApproveEdits is true,
-    otherwise 'interactive'.
-    """
-    AUTOPILOT = "autopilot"
-    AUTOPILOT_FLEET = "autopilot_fleet"
-    EXIT_ONLY = "exit_only"
-    INTERACTIVE = "interactive"
-
-@dataclass
-class UIHandlePendingResult:
-    """Indicates whether the pending UI request was resolved by this call."""
-
-    success: bool
-    """True if the request was still pending and was resolved by this call. False if the request
-    ID was unknown, already resolved by another client (e.g. GitHub), expired, or otherwise
-    no longer pending.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'UIHandlePendingResult':
-        assert isinstance(obj, dict)
-        success = from_bool(obj.get("success"))
-        return UIHandlePendingResult(success)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["success"] = from_bool(self.success)
-        return result
-
-@dataclass
-class UIHandlePendingSamplingRequest:
-    """Request ID of a pending `sampling.requested` event and an optional sampling result
-    payload (omit to reject).
-    """
-    request_id: str
-    """The unique request ID from the sampling.requested event"""
-
-    response: dict[str, Any] | None = None
-    """Optional sampling result payload. Omit to reject/cancel the sampling request without
-    providing a result.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'UIHandlePendingSamplingRequest':
-        assert isinstance(obj, dict)
-        request_id = from_str(obj.get("requestId"))
-        response = from_union([lambda x: from_dict(lambda x: x, x), from_none], obj.get("response"))
-        return UIHandlePendingSamplingRequest(request_id, response)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["requestId"] = from_str(self.request_id)
-        if self.response is not None:
-            result["response"] = from_union([lambda x: from_dict(lambda x: x, x), from_none], self.response)
-        return result
-
-@dataclass
-class UIUserInputResponse:
-    """Schema for the `UIUserInputResponse` type."""
-
-    answer: str
-    """The user's answer text"""
-
-    was_freeform: bool
-    """True if the user typed a freeform response, false if they selected a presented choice.
-    Used by telemetry to differentiate between free text input and choice selection.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'UIUserInputResponse':
-        assert isinstance(obj, dict)
-        answer = from_str(obj.get("answer"))
-        was_freeform = from_bool(obj.get("wasFreeform"))
-        return UIUserInputResponse(answer, was_freeform)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["answer"] = from_str(self.answer)
-        result["wasFreeform"] = from_bool(self.was_freeform)
-        return result
-
-@dataclass
-class UIRegisterDirectAutoModeSwitchHandlerResult:
-    """Register an in-process handler for `auto_mode_switch.requested` events. The caller still
-    attaches the actual listener via the standard event-subscription mechanism; this
-    registration solely tells the server bridge to skip its own dispatch (so a remote client
-    doesn't race the in-process handler for the same requestId).
-    """
-    handle: str
-    """Opaque handle representing the registration. Pass this same handle to
-    `unregisterDirectAutoModeSwitchHandler` when the in-process handler is no longer active.
-    Multiple registrations are reference-counted; the server bridge will only dispatch
-    auto-mode-switch requests when no handles are active.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'UIRegisterDirectAutoModeSwitchHandlerResult':
-        assert isinstance(obj, dict)
-        handle = from_str(obj.get("handle"))
-        return UIRegisterDirectAutoModeSwitchHandlerResult(handle)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["handle"] = from_str(self.handle)
-        return result
-
-@dataclass
-class UIUnregisterDirectAutoModeSwitchHandlerRequest:
-    """Opaque handle previously returned by `registerDirectAutoModeSwitchHandler` to release."""
-
-    handle: str
-    """Handle previously returned by `registerDirectAutoModeSwitchHandler`"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'UIUnregisterDirectAutoModeSwitchHandlerRequest':
-        assert isinstance(obj, dict)
-        handle = from_str(obj.get("handle"))
-        return UIUnregisterDirectAutoModeSwitchHandlerRequest(handle)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["handle"] = from_str(self.handle)
-        return result
-
-@dataclass
-class UIUnregisterDirectAutoModeSwitchHandlerResult:
-    """Indicates whether the handle was active and the registration count was decremented."""
-
-    unregistered: bool
-    """True if the handle was active and decremented the counter; false if the handle was
-    unknown.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'UIUnregisterDirectAutoModeSwitchHandlerResult':
-        assert isinstance(obj, dict)
-        unregistered = from_bool(obj.get("unregistered"))
-        return UIUnregisterDirectAutoModeSwitchHandlerResult(unregistered)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["unregistered"] = from_bool(self.unregistered)
-        return result
-
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
 class UsageMetricsCodeChanges:
     """Aggregated code change metrics"""
-
-    files_modified: list[str]
-    """Distinct file paths modified during the session"""
 
     files_modified_count: int
     """Number of distinct files modified"""
@@ -5549,15 +2817,13 @@ class UsageMetricsCodeChanges:
     @staticmethod
     def from_dict(obj: Any) -> 'UsageMetricsCodeChanges':
         assert isinstance(obj, dict)
-        files_modified = from_list(from_str, obj.get("filesModified"))
         files_modified_count = from_int(obj.get("filesModifiedCount"))
         lines_added = from_int(obj.get("linesAdded"))
         lines_removed = from_int(obj.get("linesRemoved"))
-        return UsageMetricsCodeChanges(files_modified, files_modified_count, lines_added, lines_removed)
+        return UsageMetricsCodeChanges(files_modified_count, lines_added, lines_removed)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["filesModified"] = from_list(from_str, self.files_modified)
         result["filesModifiedCount"] = from_int(self.files_modified_count)
         result["linesAdded"] = from_int(self.lines_added)
         result["linesRemoved"] = from_int(self.lines_removed)
@@ -5665,37 +2931,6 @@ class UsageMetricsTokenDetail:
         result["tokenCount"] = from_int(self.token_count)
         return result
 
-class UserAuthInfoType(Enum):
-    USER = "user"
-
-@dataclass
-class WorkspacesCheckpoints:
-    """Schema for the `WorkspacesCheckpoints` type."""
-
-    filename: str
-    """Filename of the checkpoint within the workspace checkpoints directory"""
-
-    number: int
-    """Checkpoint number assigned by the workspace manager"""
-
-    title: str
-    """Human-readable checkpoint title"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'WorkspacesCheckpoints':
-        assert isinstance(obj, dict)
-        filename = from_str(obj.get("filename"))
-        number = from_int(obj.get("number"))
-        title = from_str(obj.get("title"))
-        return WorkspacesCheckpoints(filename, number, title)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["filename"] = from_str(self.filename)
-        result["number"] = from_int(self.number)
-        result["title"] = from_str(self.title)
-        return result
-
 @dataclass
 class WorkspacesCreateFileRequest:
     """Relative path and UTF-8 content for the workspace file to create or overwrite."""
@@ -5719,6 +2954,10 @@ class WorkspacesCreateFileRequest:
         result["path"] = from_str(self.path)
         return result
 
+class HostType(Enum):
+    ADO = "ado"
+    GITHUB = "github"
+
 @dataclass
 class WorkspacesListFilesResult:
     """Relative paths of files stored in the session workspace files directory."""
@@ -5735,42 +2974,6 @@ class WorkspacesListFilesResult:
     def to_dict(self) -> dict:
         result: dict = {}
         result["files"] = from_list(from_str, self.files)
-        return result
-
-@dataclass
-class WorkspacesReadCheckpointRequest:
-    """Checkpoint number to read."""
-
-    number: int
-    """Checkpoint number to read"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'WorkspacesReadCheckpointRequest':
-        assert isinstance(obj, dict)
-        number = from_int(obj.get("number"))
-        return WorkspacesReadCheckpointRequest(number)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["number"] = from_int(self.number)
-        return result
-
-@dataclass
-class WorkspacesReadCheckpointResult:
-    """Checkpoint content as a UTF-8 string, or null when the checkpoint or workspace is missing."""
-
-    content: str | None = None
-    """Checkpoint content as a UTF-8 string, or null when the checkpoint or workspace is missing"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'WorkspacesReadCheckpointResult':
-        assert isinstance(obj, dict)
-        content = from_union([from_none, from_str], obj.get("content"))
-        return WorkspacesReadCheckpointResult(content)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["content"] = from_union([from_none, from_str], self.content)
         return result
 
 @dataclass
@@ -5810,50 +3013,6 @@ class WorkspacesReadFileResult:
         return result
 
 @dataclass
-class WorkspacesSaveLargePasteRequest:
-    """Pasted content to save as a UTF-8 file in the session workspace."""
-
-    content: str
-    """Pasted content to save as a UTF-8 file"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'WorkspacesSaveLargePasteRequest':
-        assert isinstance(obj, dict)
-        content = from_str(obj.get("content"))
-        return WorkspacesSaveLargePasteRequest(content)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["content"] = from_str(self.content)
-        return result
-
-@dataclass
-class Saved:
-    filename: str
-    """Filename within the workspace files directory"""
-
-    file_path: str
-    """Absolute filesystem path to the saved paste file"""
-
-    size_bytes: int
-    """Size of the saved file in bytes"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'Saved':
-        assert isinstance(obj, dict)
-        filename = from_str(obj.get("filename"))
-        file_path = from_str(obj.get("filePath"))
-        size_bytes = from_int(obj.get("sizeBytes"))
-        return Saved(filename, file_path, size_bytes)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["filename"] = from_str(self.filename)
-        result["filePath"] = from_str(self.file_path)
-        result["sizeBytes"] = from_int(self.size_bytes)
-        return result
-
-@dataclass
 class AccountGetQuotaResult:
     """Quota usage snapshots for the resolved user, keyed by quota type."""
 
@@ -5869,6 +3028,83 @@ class AccountGetQuotaResult:
     def to_dict(self) -> dict:
         result: dict = {}
         result["quotaSnapshots"] = from_dict(lambda x: to_class(AccountQuotaSnapshot, x), self.quota_snapshots)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class AgentGetCurrentResult:
+    """The currently selected custom agent, or null when using the default agent."""
+
+    agent: AgentInfo | None = None
+    """Currently selected custom agent, or null if using the default agent"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'AgentGetCurrentResult':
+        assert isinstance(obj, dict)
+        agent = from_union([AgentInfo.from_dict, from_none], obj.get("agent"))
+        return AgentGetCurrentResult(agent)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.agent is not None:
+            result["agent"] = from_union([lambda x: to_class(AgentInfo, x), from_none], self.agent)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class AgentList:
+    """Custom agents available to the session."""
+
+    agents: list[AgentInfo]
+    """Available custom agents"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'AgentList':
+        assert isinstance(obj, dict)
+        agents = from_list(AgentInfo.from_dict, obj.get("agents"))
+        return AgentList(agents)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["agents"] = from_list(lambda x: to_class(AgentInfo, x), self.agents)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class AgentReloadResult:
+    """Custom agents available to the session after reloading definitions from disk."""
+
+    agents: list[AgentInfo]
+    """Reloaded custom agents"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'AgentReloadResult':
+        assert isinstance(obj, dict)
+        agents = from_list(AgentInfo.from_dict, obj.get("agents"))
+        return AgentReloadResult(agents)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["agents"] = from_list(lambda x: to_class(AgentInfo, x), self.agents)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class AgentSelectResult:
+    """The newly selected custom agent."""
+
+    agent: AgentInfo
+    """The newly selected custom agent"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'AgentSelectResult':
+        assert isinstance(obj, dict)
+        agent = AgentInfo.from_dict(obj.get("agent"))
+        return AgentSelectResult(agent)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["agent"] = to_class(AgentInfo, self.agent)
         return result
 
 @dataclass
@@ -5956,34 +3192,6 @@ class SlashCommandInput:
             result["preserveMultilineInput"] = from_union([from_bool, from_none], self.preserve_multiline_input)
         if self.required is not None:
             result["required"] = from_union([from_bool, from_none], self.required)
-        return result
-
-@dataclass
-class SendAttachmentDirectory:
-    """Directory attachment"""
-
-    display_name: str
-    """User-facing display name for the attachment"""
-
-    path: str
-    """Absolute directory path"""
-
-    type: SlashCommandInputCompletion
-    """Attachment type discriminator"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SendAttachmentDirectory':
-        assert isinstance(obj, dict)
-        display_name = from_str(obj.get("displayName"))
-        path = from_str(obj.get("path"))
-        type = SlashCommandInputCompletion(obj.get("type"))
-        return SendAttachmentDirectory(display_name, path, type)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["displayName"] = from_str(self.display_name)
-        result["path"] = from_str(self.path)
-        result["type"] = to_enum(SlashCommandInputCompletion, self.type)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -6124,72 +3332,6 @@ class MCPServerConfigStdio:
         return result
 
 @dataclass
-class CopilotUserResponseQuotaSnapshots:
-    """Schema for the `CopilotUserResponseQuotaSnapshotsChat` type.
-
-    Schema for the `CopilotUserResponseQuotaSnapshotsCompletions` type.
-
-    Schema for the `CopilotUserResponseQuotaSnapshotsPremiumInteractions` type.
-    """
-    entitlement: float | None = None
-    has_quota: bool | None = None
-    overage_count: float | None = None
-    overage_permitted: bool | None = None
-    percent_remaining: float | None = None
-    quota_id: str | None = None
-    quota_remaining: float | None = None
-    quota_reset_at: float | None = None
-    remaining: float | None = None
-    timestamp_utc: str | None = None
-    token_based_billing: bool | None = None
-    unlimited: bool | None = None
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'CopilotUserResponseQuotaSnapshots':
-        assert isinstance(obj, dict)
-        entitlement = from_union([from_float, from_none], obj.get("entitlement"))
-        has_quota = from_union([from_bool, from_none], obj.get("has_quota"))
-        overage_count = from_union([from_float, from_none], obj.get("overage_count"))
-        overage_permitted = from_union([from_bool, from_none], obj.get("overage_permitted"))
-        percent_remaining = from_union([from_float, from_none], obj.get("percent_remaining"))
-        quota_id = from_union([from_str, from_none], obj.get("quota_id"))
-        quota_remaining = from_union([from_float, from_none], obj.get("quota_remaining"))
-        quota_reset_at = from_union([from_float, from_none], obj.get("quota_reset_at"))
-        remaining = from_union([from_float, from_none], obj.get("remaining"))
-        timestamp_utc = from_union([from_str, from_none], obj.get("timestamp_utc"))
-        token_based_billing = from_union([from_bool, from_none], obj.get("token_based_billing"))
-        unlimited = from_union([from_bool, from_none], obj.get("unlimited"))
-        return CopilotUserResponseQuotaSnapshots(entitlement, has_quota, overage_count, overage_permitted, percent_remaining, quota_id, quota_remaining, quota_reset_at, remaining, timestamp_utc, token_based_billing, unlimited)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.entitlement is not None:
-            result["entitlement"] = from_union([to_float, from_none], self.entitlement)
-        if self.has_quota is not None:
-            result["has_quota"] = from_union([from_bool, from_none], self.has_quota)
-        if self.overage_count is not None:
-            result["overage_count"] = from_union([to_float, from_none], self.overage_count)
-        if self.overage_permitted is not None:
-            result["overage_permitted"] = from_union([from_bool, from_none], self.overage_permitted)
-        if self.percent_remaining is not None:
-            result["percent_remaining"] = from_union([to_float, from_none], self.percent_remaining)
-        if self.quota_id is not None:
-            result["quota_id"] = from_union([from_str, from_none], self.quota_id)
-        if self.quota_remaining is not None:
-            result["quota_remaining"] = from_union([to_float, from_none], self.quota_remaining)
-        if self.quota_reset_at is not None:
-            result["quota_reset_at"] = from_union([to_float, from_none], self.quota_reset_at)
-        if self.remaining is not None:
-            result["remaining"] = from_union([to_float, from_none], self.remaining)
-        if self.timestamp_utc is not None:
-            result["timestamp_utc"] = from_union([from_str, from_none], self.timestamp_utc)
-        if self.token_based_billing is not None:
-            result["token_based_billing"] = from_union([from_bool, from_none], self.token_based_billing)
-        if self.unlimited is not None:
-            result["unlimited"] = from_union([from_bool, from_none], self.unlimited)
-        return result
-
-@dataclass
 class DiscoveredMCPServer:
     """Schema for the `DiscoveredMcpServer` type."""
 
@@ -6221,102 +3363,6 @@ class DiscoveredMCPServer:
         result["source"] = to_enum(McpServerSource, self.source)
         if self.type is not None:
             result["type"] = from_union([lambda x: to_enum(DiscoveredMCPServerType, x), from_none], self.type)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class EventLogReadRequest:
-    """Cursor, batch size, and optional long-poll/filter parameters for reading session events."""
-
-    agent_scope: EventsAgentScope | None = None
-    """Agent-scope filter: 'primary' returns only main-agent events plus events whose type
-    starts with 'subagent.' (matching the typed-subscription default behavior); 'all' returns
-    events from all agents (matching wildcard-subscription behavior). Default is 'all' to
-    preserve wildcard semantics for catch-up callers.
-    """
-    cursor: str | None = None
-    """Opaque cursor returned by a previous read. Omit on the first call to start from the
-    beginning of the session's persisted history.
-    """
-    max: int | None = None
-    """Maximum number of events to return in this batch (1–1000, default 200)."""
-
-    types: list[str] | EventLogTypes | None = None
-    """Either '*' to receive all event types, or a non-empty list of event types to receive"""
-
-    wait_ms: int | None = None
-    """Milliseconds to wait for new events when the cursor is at the tail of history. 0
-    (default) returns immediately even if no events are available. Capped at 30000ms.
-    Ephemeral events that arrive during the wait are delivered in this batch but are NOT
-    replayable on a subsequent read (use a non-zero waitMs in your next call to capture
-    future ephemerals as they happen).
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'EventLogReadRequest':
-        assert isinstance(obj, dict)
-        agent_scope = from_union([EventsAgentScope, from_none], obj.get("agentScope"))
-        cursor = from_union([from_str, from_none], obj.get("cursor"))
-        max = from_union([from_int, from_none], obj.get("max"))
-        types = from_union([lambda x: from_list(from_str, x), EventLogTypes, from_none], obj.get("types"))
-        wait_ms = from_union([from_int, from_none], obj.get("waitMs"))
-        return EventLogReadRequest(agent_scope, cursor, max, types, wait_ms)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.agent_scope is not None:
-            result["agentScope"] = from_union([lambda x: to_enum(EventsAgentScope, x), from_none], self.agent_scope)
-        if self.cursor is not None:
-            result["cursor"] = from_union([from_str, from_none], self.cursor)
-        if self.max is not None:
-            result["max"] = from_union([from_int, from_none], self.max)
-        if self.types is not None:
-            result["types"] = from_union([lambda x: from_list(from_str, x), lambda x: to_enum(EventLogTypes, x), from_none], self.types)
-        if self.wait_ms is not None:
-            result["waitMs"] = from_union([from_int, from_none], self.wait_ms)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class EventsReadResult:
-    """Batch of session events returned by a read, with cursor and continuation metadata."""
-
-    cursor: str
-    """Opaque cursor for the next read. Pass back unchanged in the next read.cursor to continue
-    from where this read left off. Always present, even when no events were returned.
-    """
-    cursor_status: EventsCursorStatus
-    """Cursor status: 'ok' means the cursor was applied successfully; 'expired' means the cursor
-    referred to an event that no longer exists in history (e.g. truncated or compacted away)
-    and the read started from the beginning of the remaining history.
-    """
-    events: list[SessionEvent]
-    """Events are delivered in two batches per read: persisted events first (in append order),
-    then ephemeral events (in seq order). When `waitMs > 0` and the catch-up batches were
-    empty, post-wait events follow the same two-batch ordering. Persisted and ephemeral
-    events do not interleave within a single read.
-    """
-    has_more: bool
-    """True when the read returned `max` events and more events are available immediately. When
-    false, the next read with a non-zero `waitMs` will block until a new event arrives or the
-    wait expires.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'EventsReadResult':
-        assert isinstance(obj, dict)
-        cursor = from_str(obj.get("cursor"))
-        cursor_status = EventsCursorStatus(obj.get("cursorStatus"))
-        events = from_list(SessionEvent.from_dict, obj.get("events"))
-        has_more = from_bool(obj.get("hasMore"))
-        return EventsReadResult(cursor, cursor_status, events, has_more)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["cursor"] = from_str(self.cursor)
-        result["cursorStatus"] = to_enum(EventsCursorStatus, self.cursor_status)
-        result["events"] = from_list(lambda x: to_class(SessionEvent, x), self.events)
-        result["hasMore"] = from_bool(self.has_more)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -6524,7 +3570,7 @@ class ExternalToolTextResultForLlmContentTerminal:
     cwd: str | None = None
     """Working directory where the command was executed"""
 
-    exit_code: int | None = None
+    exit_code: float | None = None
     """Process exit code, if the command has completed"""
 
     @staticmethod
@@ -6533,7 +3579,7 @@ class ExternalToolTextResultForLlmContentTerminal:
         text = from_str(obj.get("text"))
         type = ExternalToolTextResultForLlmContentTerminalType(obj.get("type"))
         cwd = from_union([from_str, from_none], obj.get("cwd"))
-        exit_code = from_union([from_int, from_none], obj.get("exitCode"))
+        exit_code = from_union([from_float, from_none], obj.get("exitCode"))
         return ExternalToolTextResultForLlmContentTerminal(text, type, cwd, exit_code)
 
     def to_dict(self) -> dict:
@@ -6543,7 +3589,7 @@ class ExternalToolTextResultForLlmContentTerminal:
         if self.cwd is not None:
             result["cwd"] = from_union([from_str, from_none], self.cwd)
         if self.exit_code is not None:
-            result["exitCode"] = from_union([from_int, from_none], self.exit_code)
+            result["exitCode"] = from_union([to_float, from_none], self.exit_code)
         return result
 
 @dataclass
@@ -6615,8 +3661,8 @@ class SlashCommandTextResult:
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
 class HistoryCompactResult:
-    """Compaction outcome with the number of tokens and messages removed, summary text, and the
-    resulting context window breakdown.
+    """Compaction outcome with the number of tokens and messages removed and the resulting
+    context window breakdown.
     """
     messages_removed: int
     """Number of messages removed during compaction"""
@@ -6630,11 +3676,6 @@ class HistoryCompactResult:
     context_window: HistoryCompactContextWindow | None = None
     """Post-compaction context window usage breakdown"""
 
-    summary_content: str | None = None
-    """Summary text produced by compaction. Omitted when compaction did not produce a summary
-    (e.g. failure path).
-    """
-
     @staticmethod
     def from_dict(obj: Any) -> 'HistoryCompactResult':
         assert isinstance(obj, dict)
@@ -6642,8 +3683,7 @@ class HistoryCompactResult:
         success = from_bool(obj.get("success"))
         tokens_removed = from_int(obj.get("tokensRemoved"))
         context_window = from_union([HistoryCompactContextWindow.from_dict, from_none], obj.get("contextWindow"))
-        summary_content = from_union([from_str, from_none], obj.get("summaryContent"))
-        return HistoryCompactResult(messages_removed, success, tokens_removed, context_window, summary_content)
+        return HistoryCompactResult(messages_removed, success, tokens_removed, context_window)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -6652,176 +3692,6 @@ class HistoryCompactResult:
         result["tokensRemoved"] = from_int(self.tokens_removed)
         if self.context_window is not None:
             result["contextWindow"] = from_union([lambda x: to_class(HistoryCompactContextWindow, x), from_none], self.context_window)
-        if self.summary_content is not None:
-            result["summaryContent"] = from_union([from_str, from_none], self.summary_content)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class InstalledPluginSourceGithub:
-    """Schema for the `InstalledPluginSourceGithub` type."""
-
-    repo: str
-    source: FluffySource
-    """Constant value. Always "github"."""
-
-    path: str | None = None
-    ref: str | None = None
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'InstalledPluginSourceGithub':
-        assert isinstance(obj, dict)
-        repo = from_str(obj.get("repo"))
-        source = FluffySource(obj.get("source"))
-        path = from_union([from_str, from_none], obj.get("path"))
-        ref = from_union([from_str, from_none], obj.get("ref"))
-        return InstalledPluginSourceGithub(repo, source, path, ref)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["repo"] = from_str(self.repo)
-        result["source"] = to_enum(FluffySource, self.source)
-        if self.path is not None:
-            result["path"] = from_union([from_str, from_none], self.path)
-        if self.ref is not None:
-            result["ref"] = from_union([from_str, from_none], self.ref)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionInstalledPluginSourceGithub:
-    """Schema for the `SessionInstalledPluginSourceGithub` type."""
-
-    repo: str
-    source: FluffySource
-    """Constant value. Always "github"."""
-
-    path: str | None = None
-    ref: str | None = None
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionInstalledPluginSourceGithub':
-        assert isinstance(obj, dict)
-        repo = from_str(obj.get("repo"))
-        source = FluffySource(obj.get("source"))
-        path = from_union([from_str, from_none], obj.get("path"))
-        ref = from_union([from_str, from_none], obj.get("ref"))
-        return SessionInstalledPluginSourceGithub(repo, source, path, ref)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["repo"] = from_str(self.repo)
-        result["source"] = to_enum(FluffySource, self.source)
-        if self.path is not None:
-            result["path"] = from_union([from_str, from_none], self.path)
-        if self.ref is not None:
-            result["ref"] = from_union([from_str, from_none], self.ref)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class InstalledPluginSourceLocal:
-    """Schema for the `InstalledPluginSourceLocal` type."""
-
-    path: str
-    source: TentacledSource
-    """Constant value. Always "local"."""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'InstalledPluginSourceLocal':
-        assert isinstance(obj, dict)
-        path = from_str(obj.get("path"))
-        source = TentacledSource(obj.get("source"))
-        return InstalledPluginSourceLocal(path, source)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["path"] = from_str(self.path)
-        result["source"] = to_enum(TentacledSource, self.source)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionInstalledPluginSourceLocal:
-    """Schema for the `SessionInstalledPluginSourceLocal` type."""
-
-    path: str
-    source: TentacledSource
-    """Constant value. Always "local"."""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionInstalledPluginSourceLocal':
-        assert isinstance(obj, dict)
-        path = from_str(obj.get("path"))
-        source = TentacledSource(obj.get("source"))
-        return SessionInstalledPluginSourceLocal(path, source)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["path"] = from_str(self.path)
-        result["source"] = to_enum(TentacledSource, self.source)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class InstalledPluginSourceURL:
-    """Schema for the `InstalledPluginSourceUrl` type."""
-
-    source: StickySource
-    """Constant value. Always "url"."""
-
-    url: str
-    path: str | None = None
-    ref: str | None = None
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'InstalledPluginSourceURL':
-        assert isinstance(obj, dict)
-        source = StickySource(obj.get("source"))
-        url = from_str(obj.get("url"))
-        path = from_union([from_str, from_none], obj.get("path"))
-        ref = from_union([from_str, from_none], obj.get("ref"))
-        return InstalledPluginSourceURL(source, url, path, ref)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["source"] = to_enum(StickySource, self.source)
-        result["url"] = from_str(self.url)
-        if self.path is not None:
-            result["path"] = from_union([from_str, from_none], self.path)
-        if self.ref is not None:
-            result["ref"] = from_union([from_str, from_none], self.ref)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionInstalledPluginSourceURL:
-    """Schema for the `SessionInstalledPluginSourceUrl` type."""
-
-    source: StickySource
-    """Constant value. Always "url"."""
-
-    url: str
-    path: str | None = None
-    ref: str | None = None
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionInstalledPluginSourceURL':
-        assert isinstance(obj, dict)
-        source = StickySource(obj.get("source"))
-        url = from_str(obj.get("url"))
-        path = from_union([from_str, from_none], obj.get("path"))
-        ref = from_union([from_str, from_none], obj.get("ref"))
-        return SessionInstalledPluginSourceURL(source, url, path, ref)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["source"] = to_enum(StickySource, self.source)
-        result["url"] = from_str(self.url)
-        if self.path is not None:
-            result["path"] = from_union([from_str, from_none], self.path)
-        if self.ref is not None:
-            result["ref"] = from_union([from_str, from_none], self.ref)
         return result
 
 @dataclass
@@ -6846,12 +3716,8 @@ class InstructionsSources:
     type: InstructionsSourcesType
     """Category of instruction source — used for merge logic"""
 
-    apply_to: list[str] | None = None
-    """Glob pattern(s) from frontmatter — when set, this instruction applies only to matching
-    files
-    """
-    default_disabled: bool | None = None
-    """When true, this source starts disabled and must be toggled on by the user"""
+    apply_to: str | None = None
+    """Glob pattern from frontmatter — when set, this instruction applies only to matching files"""
 
     description: str | None = None
     """Short description (body after frontmatter) for use in instruction tables"""
@@ -6865,10 +3731,9 @@ class InstructionsSources:
         location = InstructionsSourcesLocation(obj.get("location"))
         source_path = from_str(obj.get("sourcePath"))
         type = InstructionsSourcesType(obj.get("type"))
-        apply_to = from_union([lambda x: from_list(from_str, x), from_none], obj.get("applyTo"))
-        default_disabled = from_union([from_bool, from_none], obj.get("defaultDisabled"))
+        apply_to = from_union([from_str, from_none], obj.get("applyTo"))
         description = from_union([from_str, from_none], obj.get("description"))
-        return InstructionsSources(content, id, label, location, source_path, type, apply_to, default_disabled, description)
+        return InstructionsSources(content, id, label, location, source_path, type, apply_to, description)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -6879,18 +3744,15 @@ class InstructionsSources:
         result["sourcePath"] = from_str(self.source_path)
         result["type"] = to_enum(InstructionsSourcesType, self.type)
         if self.apply_to is not None:
-            result["applyTo"] = from_union([lambda x: from_list(from_str, x), from_none], self.apply_to)
-        if self.default_disabled is not None:
-            result["defaultDisabled"] = from_union([from_bool, from_none], self.default_disabled)
+            result["applyTo"] = from_union([from_str, from_none], self.apply_to)
         if self.description is not None:
             result["description"] = from_union([from_str, from_none], self.description)
         return result
 
 @dataclass
 class LogRequest:
-    """Message text, optional severity level, persistence flag, optional follow-up URL, and
-    optional tip.
-    """
+    """Message text, optional severity level, persistence flag, and optional follow-up URL."""
+
     message: str
     """Human-readable message"""
 
@@ -6901,13 +3763,6 @@ class LogRequest:
     """Log severity level. Determines how the message is displayed in the timeline. Defaults to
     "info".
     """
-    tip: str | None = None
-    """Optional actionable tip displayed alongside the message. Only honored on `level: "info"`."""
-
-    type: str | None = None
-    """Domain category for this log entry (e.g., "mcp", "subscription", "policy", "model"). Maps
-    to `infoType`/`warningType`/`errorType` on the emitted event. Defaults to "notification".
-    """
     url: str | None = None
     """Optional URL the user can open in their browser for more details"""
 
@@ -6917,10 +3772,8 @@ class LogRequest:
         message = from_str(obj.get("message"))
         ephemeral = from_union([from_bool, from_none], obj.get("ephemeral"))
         level = from_union([SessionLogLevel, from_none], obj.get("level"))
-        tip = from_union([from_str, from_none], obj.get("tip"))
-        type = from_union([from_str, from_none], obj.get("type"))
         url = from_union([from_str, from_none], obj.get("url"))
-        return LogRequest(message, ephemeral, level, tip, type, url)
+        return LogRequest(message, ephemeral, level, url)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -6929,10 +3782,6 @@ class LogRequest:
             result["ephemeral"] = from_union([from_bool, from_none], self.ephemeral)
         if self.level is not None:
             result["level"] = from_union([lambda x: to_enum(SessionLogLevel, x), from_none], self.level)
-        if self.tip is not None:
-            result["tip"] = from_union([from_str, from_none], self.tip)
-        if self.type is not None:
-            result["type"] = from_union([from_str, from_none], self.type)
         if self.url is not None:
             result["url"] = from_union([from_str, from_none], self.url)
         return result
@@ -7128,42 +3977,6 @@ class MCPServerConfigHTTP:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
-class MCPSamplingExecutionResult:
-    """Outcome of an MCP sampling execution: success result, failure error, or cancellation."""
-
-    action: MCPSamplingExecutionAction
-    """Outcome of the sampling inference. 'success' produced a response; 'failure' encountered
-    an error (including agent-side rejection by content filter or criteria); 'cancelled' the
-    caller cancelled this execution via cancelSamplingExecution.
-    """
-    error: str | None = None
-    """Error description, present when action='failure'."""
-
-    result: dict[str, Any] | None = None
-    """MCP CreateMessageResult payload (with optional 'tools' extension), present when
-    action='success'. Treated as opaque at the schema layer; consumers should
-    construct/consume it per the MCP CreateMessageResult shape.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'MCPSamplingExecutionResult':
-        assert isinstance(obj, dict)
-        action = MCPSamplingExecutionAction(obj.get("action"))
-        error = from_union([from_str, from_none], obj.get("error"))
-        result = from_union([lambda x: from_dict(lambda x: x, x), from_none], obj.get("result"))
-        return MCPSamplingExecutionResult(action, error, result)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["action"] = to_enum(MCPSamplingExecutionAction, self.action)
-        if self.error is not None:
-            result["error"] = from_union([from_str, from_none], self.error)
-        if self.result is not None:
-            result["result"] = from_union([lambda x: from_dict(lambda x: x, x), from_none], self.result)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
 class MCPServerList:
     """MCP servers configured for the session, with their connection status."""
 
@@ -7179,296 +3992,6 @@ class MCPServerList:
     def to_dict(self) -> dict:
         result: dict = {}
         result["servers"] = from_list(lambda x: to_class(MCPServer, x), self.servers)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class MCPSetEnvValueModeParams:
-    """Mode controlling how MCP server env values are resolved (`direct` or `indirect`)."""
-
-    mode: MCPSetEnvValueModeDetails
-    """How environment-variable values supplied to MCP servers are resolved. "direct" passes
-    literal string values; "indirect" treats values as references (e.g. names of environment
-    variables on the host) that the runtime resolves before launch. Defaults to the runtime's
-    startup mode; clients that intentionally launch MCP servers with literal values (e.g. CLI
-    prompt mode and ACP) set this to "direct".
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'MCPSetEnvValueModeParams':
-        assert isinstance(obj, dict)
-        mode = MCPSetEnvValueModeDetails(obj.get("mode"))
-        return MCPSetEnvValueModeParams(mode)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["mode"] = to_enum(MCPSetEnvValueModeDetails, self.mode)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class MCPSetEnvValueModeResult:
-    """Env-value mode recorded on the session after the update."""
-
-    mode: MCPSetEnvValueModeDetails
-    """Mode recorded on the session after the update"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'MCPSetEnvValueModeResult':
-        assert isinstance(obj, dict)
-        mode = MCPSetEnvValueModeDetails(obj.get("mode"))
-        return MCPSetEnvValueModeResult(mode)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["mode"] = to_enum(MCPSetEnvValueModeDetails, self.mode)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class MetadataContextInfoResult:
-    """Token breakdown for the session's current context window, or null if uninitialized."""
-
-    context_info: SessionContextInfo | None = None
-    """Token breakdown for the current context window, or null if the session has not yet been
-    initialized (no system prompt or tool metadata cached).
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'MetadataContextInfoResult':
-        assert isinstance(obj, dict)
-        context_info = from_union([SessionContextInfo.from_dict, from_none], obj.get("contextInfo"))
-        return MetadataContextInfoResult(context_info)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.context_info is not None:
-            result["contextInfo"] = from_union([lambda x: to_class(SessionContextInfo, x), from_none], self.context_info)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionWorkingDirectoryContext:
-    """Updated working directory and git context. Emitted as the new payload of
-    `session.context_changed`.
-    """
-    cwd: str
-    """Current working directory path"""
-
-    base_commit: str | None = None
-    """Merge-base commit SHA (fork point from the remote default branch)"""
-
-    branch: str | None = None
-    """Current git branch name"""
-
-    git_root: str | None = None
-    """Root directory of the git repository, resolved via git rev-parse"""
-
-    head_commit: str | None = None
-    """Head commit of the current git branch"""
-
-    host_type: SessionContextHostType | None = None
-    """Hosting platform type of the repository"""
-
-    repository: str | None = None
-    """Repository identifier derived from the git remote URL ("owner/name" for GitHub,
-    "org/project/repo" for Azure DevOps)
-    """
-    repository_host: str | None = None
-    """Raw host string from the git remote URL (e.g. "github.com", "dev.azure.com")"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionWorkingDirectoryContext':
-        assert isinstance(obj, dict)
-        cwd = from_str(obj.get("cwd"))
-        base_commit = from_union([from_str, from_none], obj.get("baseCommit"))
-        branch = from_union([from_str, from_none], obj.get("branch"))
-        git_root = from_union([from_str, from_none], obj.get("gitRoot"))
-        head_commit = from_union([from_str, from_none], obj.get("headCommit"))
-        host_type = from_union([SessionContextHostType, from_none], obj.get("hostType"))
-        repository = from_union([from_str, from_none], obj.get("repository"))
-        repository_host = from_union([from_str, from_none], obj.get("repositoryHost"))
-        return SessionWorkingDirectoryContext(cwd, base_commit, branch, git_root, head_commit, host_type, repository, repository_host)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["cwd"] = from_str(self.cwd)
-        if self.base_commit is not None:
-            result["baseCommit"] = from_union([from_str, from_none], self.base_commit)
-        if self.branch is not None:
-            result["branch"] = from_union([from_str, from_none], self.branch)
-        if self.git_root is not None:
-            result["gitRoot"] = from_union([from_str, from_none], self.git_root)
-        if self.head_commit is not None:
-            result["headCommit"] = from_union([from_str, from_none], self.head_commit)
-        if self.host_type is not None:
-            result["hostType"] = from_union([lambda x: to_enum(SessionContextHostType, x), from_none], self.host_type)
-        if self.repository is not None:
-            result["repository"] = from_union([from_str, from_none], self.repository)
-        if self.repository_host is not None:
-            result["repositoryHost"] = from_union([from_str, from_none], self.repository_host)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionContext:
-    """Schema for the `SessionContext` type.
-
-    Optional working-directory context used to score session relevance. When omitted the
-    most-recently-modified session wins.
-    """
-    cwd: str
-    """Most recent working directory for this session"""
-
-    branch: str | None = None
-    """Active git branch"""
-
-    git_root: str | None = None
-    """Git repository root, if the cwd was inside a git repo"""
-
-    host_type: SessionContextHostType | None = None
-    """Repository host type"""
-
-    repository: str | None = None
-    """Repository slug in `owner/name` form, when known"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionContext':
-        assert isinstance(obj, dict)
-        cwd = from_str(obj.get("cwd"))
-        branch = from_union([from_str, from_none], obj.get("branch"))
-        git_root = from_union([from_str, from_none], obj.get("gitRoot"))
-        host_type = from_union([SessionContextHostType, from_none], obj.get("hostType"))
-        repository = from_union([from_str, from_none], obj.get("repository"))
-        return SessionContext(cwd, branch, git_root, host_type, repository)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["cwd"] = from_str(self.cwd)
-        if self.branch is not None:
-            result["branch"] = from_union([from_str, from_none], self.branch)
-        if self.git_root is not None:
-            result["gitRoot"] = from_union([from_str, from_none], self.git_root)
-        if self.host_type is not None:
-            result["hostType"] = from_union([lambda x: to_enum(SessionContextHostType, x), from_none], self.host_type)
-        if self.repository is not None:
-            result["repository"] = from_union([from_str, from_none], self.repository)
-        return result
-
-@dataclass
-class Workspace:
-    id: UUID
-    branch: str | None = None
-    chronicle_sync_dismissed: bool | None = None
-    created_at: datetime | None = None
-    cwd: str | None = None
-    git_root: str | None = None
-    host_type: SessionContextHostType | None = None
-    mc_last_event_id: str | None = None
-    mc_session_id: str | None = None
-    mc_task_id: str | None = None
-    name: str | None = None
-    remote_steerable: bool | None = None
-    repository: str | None = None
-    summary_count: int | None = None
-    updated_at: datetime | None = None
-    user_named: bool | None = None
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'Workspace':
-        assert isinstance(obj, dict)
-        id = UUID(obj.get("id"))
-        branch = from_union([from_str, from_none], obj.get("branch"))
-        chronicle_sync_dismissed = from_union([from_bool, from_none], obj.get("chronicle_sync_dismissed"))
-        created_at = from_union([from_datetime, from_none], obj.get("created_at"))
-        cwd = from_union([from_str, from_none], obj.get("cwd"))
-        git_root = from_union([from_str, from_none], obj.get("git_root"))
-        host_type = from_union([SessionContextHostType, from_none], obj.get("host_type"))
-        mc_last_event_id = from_union([from_str, from_none], obj.get("mc_last_event_id"))
-        mc_session_id = from_union([from_str, from_none], obj.get("mc_session_id"))
-        mc_task_id = from_union([from_str, from_none], obj.get("mc_task_id"))
-        name = from_union([from_str, from_none], obj.get("name"))
-        remote_steerable = from_union([from_bool, from_none], obj.get("remote_steerable"))
-        repository = from_union([from_str, from_none], obj.get("repository"))
-        summary_count = from_union([from_int, from_none], obj.get("summary_count"))
-        updated_at = from_union([from_datetime, from_none], obj.get("updated_at"))
-        user_named = from_union([from_bool, from_none], obj.get("user_named"))
-        return Workspace(id, branch, chronicle_sync_dismissed, created_at, cwd, git_root, host_type, mc_last_event_id, mc_session_id, mc_task_id, name, remote_steerable, repository, summary_count, updated_at, user_named)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["id"] = str(self.id)
-        if self.branch is not None:
-            result["branch"] = from_union([from_str, from_none], self.branch)
-        if self.chronicle_sync_dismissed is not None:
-            result["chronicle_sync_dismissed"] = from_union([from_bool, from_none], self.chronicle_sync_dismissed)
-        if self.created_at is not None:
-            result["created_at"] = from_union([lambda x: x.isoformat(), from_none], self.created_at)
-        if self.cwd is not None:
-            result["cwd"] = from_union([from_str, from_none], self.cwd)
-        if self.git_root is not None:
-            result["git_root"] = from_union([from_str, from_none], self.git_root)
-        if self.host_type is not None:
-            result["host_type"] = from_union([lambda x: to_enum(SessionContextHostType, x), from_none], self.host_type)
-        if self.mc_last_event_id is not None:
-            result["mc_last_event_id"] = from_union([from_str, from_none], self.mc_last_event_id)
-        if self.mc_session_id is not None:
-            result["mc_session_id"] = from_union([from_str, from_none], self.mc_session_id)
-        if self.mc_task_id is not None:
-            result["mc_task_id"] = from_union([from_str, from_none], self.mc_task_id)
-        if self.name is not None:
-            result["name"] = from_union([from_str, from_none], self.name)
-        if self.remote_steerable is not None:
-            result["remote_steerable"] = from_union([from_bool, from_none], self.remote_steerable)
-        if self.repository is not None:
-            result["repository"] = from_union([from_str, from_none], self.repository)
-        if self.summary_count is not None:
-            result["summary_count"] = from_union([from_int, from_none], self.summary_count)
-        if self.updated_at is not None:
-            result["updated_at"] = from_union([lambda x: x.isoformat(), from_none], self.updated_at)
-        if self.user_named is not None:
-            result["user_named"] = from_union([from_bool, from_none], self.user_named)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class MetadataSnapshotRemoteMetadata:
-    """Remote-session-specific metadata. Populated only when `isRemote` is true. Fields are
-    immutable for the lifetime of the session.
-    """
-    repository: MetadataSnapshotRemoteMetadataRepository
-    """The repository the remote session targets."""
-
-    pull_request_number: int | None = None
-    """The pull request number the remote session is associated with, if any."""
-
-    resource_id: str | None = None
-    """The original resource identifier (task ID or PR node ID), preserved across event-replay
-    reconstructions. Falls back to `sessionId` when absent.
-    """
-    task_type: MetadataSnapshotRemoteMetadataTaskType | None = None
-    """Whether the remote task originated from Copilot Coding Agent (cca) or a CLI `--remote`
-    invocation.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'MetadataSnapshotRemoteMetadata':
-        assert isinstance(obj, dict)
-        repository = MetadataSnapshotRemoteMetadataRepository.from_dict(obj.get("repository"))
-        pull_request_number = from_union([from_int, from_none], obj.get("pullRequestNumber"))
-        resource_id = from_union([from_str, from_none], obj.get("resourceId"))
-        task_type = from_union([MetadataSnapshotRemoteMetadataTaskType, from_none], obj.get("taskType"))
-        return MetadataSnapshotRemoteMetadata(repository, pull_request_number, resource_id, task_type)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["repository"] = to_class(MetadataSnapshotRemoteMetadataRepository, self.repository)
-        if self.pull_request_number is not None:
-            result["pullRequestNumber"] = from_union([from_int, from_none], self.pull_request_number)
-        if self.resource_id is not None:
-            result["resourceId"] = from_union([from_str, from_none], self.resource_id)
-        if self.task_type is not None:
-            result["taskType"] = from_union([lambda x: to_enum(MetadataSnapshotRemoteMetadataTaskType, x), from_none], self.task_type)
         return result
 
 @dataclass
@@ -7595,28 +4118,6 @@ class ModelCapabilitiesOverrideLimits:
         return result
 
 @dataclass
-class PendingPermissionRequestList:
-    """List of pending permission requests reconstructed from event history."""
-
-    items: list[PendingPermissionRequest]
-    """Pending permission prompts reconstructed from the session's event history. Equivalent to
-    the set of `permission.requested` events that have not yet been followed by a matching
-    `permission.completed` event. Used by clients (e.g. the CLI) to hydrate UI for prompts
-    that were emitted before the client attached to the session.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PendingPermissionRequestList':
-        assert isinstance(obj, dict)
-        items = from_list(PendingPermissionRequest.from_dict, obj.get("items"))
-        return PendingPermissionRequestList(items)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["items"] = from_list(lambda x: to_class(PendingPermissionRequest, x), self.items)
-        return result
-
-@dataclass
 class PermissionDecisionApproveForLocationApprovalCommands:
     """Schema for the `PermissionDecisionApproveForLocationApprovalCommands` type."""
 
@@ -7663,29 +4164,6 @@ class PermissionDecisionApproveForSessionApprovalCommands:
         return result
 
 @dataclass
-class UserToolSessionApprovalCommands:
-    """Schema for the `UserToolSessionApprovalCommands` type."""
-
-    command_identifiers: list[str]
-    """Command identifiers approved by the user"""
-
-    kind: PermissionDecisionApproveForLocationApprovalCommandsKind
-    """Command approval kind"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'UserToolSessionApprovalCommands':
-        assert isinstance(obj, dict)
-        command_identifiers = from_list(from_str, obj.get("commandIdentifiers"))
-        kind = PermissionDecisionApproveForLocationApprovalCommandsKind(obj.get("kind"))
-        return UserToolSessionApprovalCommands(command_identifiers, kind)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["commandIdentifiers"] = from_list(from_str, self.command_identifiers)
-        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalCommandsKind, self.kind)
-        return result
-
-@dataclass
 class PermissionDecisionApproveForLocationApprovalCustomTool:
     """Schema for the `PermissionDecisionApproveForLocationApprovalCustomTool` type."""
 
@@ -7724,29 +4202,6 @@ class PermissionDecisionApproveForSessionApprovalCustomTool:
         kind = PermissionDecisionApproveForLocationApprovalCustomToolKind(obj.get("kind"))
         tool_name = from_str(obj.get("toolName"))
         return PermissionDecisionApproveForSessionApprovalCustomTool(kind, tool_name)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalCustomToolKind, self.kind)
-        result["toolName"] = from_str(self.tool_name)
-        return result
-
-@dataclass
-class UserToolSessionApprovalCustomTool:
-    """Schema for the `UserToolSessionApprovalCustomTool` type."""
-
-    kind: PermissionDecisionApproveForLocationApprovalCustomToolKind
-    """Custom tool approval kind"""
-
-    tool_name: str
-    """Custom tool name"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'UserToolSessionApprovalCustomTool':
-        assert isinstance(obj, dict)
-        kind = PermissionDecisionApproveForLocationApprovalCustomToolKind(obj.get("kind"))
-        tool_name = from_str(obj.get("toolName"))
-        return UserToolSessionApprovalCustomTool(kind, tool_name)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -7863,34 +4318,6 @@ class PermissionDecisionApproveForSessionApprovalMCP:
         return result
 
 @dataclass
-class UserToolSessionApprovalMCP:
-    """Schema for the `UserToolSessionApprovalMcp` type."""
-
-    kind: PermissionDecisionApproveForLocationApprovalMCPKind
-    """MCP tool approval kind"""
-
-    server_name: str
-    """MCP server name"""
-
-    tool_name: str | None = None
-    """Optional MCP tool name, or null for all tools on the server"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'UserToolSessionApprovalMCP':
-        assert isinstance(obj, dict)
-        kind = PermissionDecisionApproveForLocationApprovalMCPKind(obj.get("kind"))
-        server_name = from_str(obj.get("serverName"))
-        tool_name = from_union([from_none, from_str], obj.get("toolName"))
-        return UserToolSessionApprovalMCP(kind, server_name, tool_name)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalMCPKind, self.kind)
-        result["serverName"] = from_str(self.server_name)
-        result["toolName"] = from_union([from_none, from_str], self.tool_name)
-        return result
-
-@dataclass
 class PermissionDecisionApproveForLocationApprovalMCPSampling:
     """Schema for the `PermissionDecisionApproveForLocationApprovalMcpSampling` type."""
 
@@ -7973,24 +4400,6 @@ class PermissionDecisionApproveForSessionApprovalMemory:
         return result
 
 @dataclass
-class UserToolSessionApprovalMemory:
-    """Schema for the `UserToolSessionApprovalMemory` type."""
-
-    kind: PermissionDecisionApproveForLocationApprovalMemoryKind
-    """Memory approval kind"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'UserToolSessionApprovalMemory':
-        assert isinstance(obj, dict)
-        kind = PermissionDecisionApproveForLocationApprovalMemoryKind(obj.get("kind"))
-        return UserToolSessionApprovalMemory(kind)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalMemoryKind, self.kind)
-        return result
-
-@dataclass
 class PermissionDecisionApproveForLocationApprovalRead:
     """Schema for the `PermissionDecisionApproveForLocationApprovalRead` type."""
 
@@ -8020,24 +4429,6 @@ class PermissionDecisionApproveForSessionApprovalRead:
         assert isinstance(obj, dict)
         kind = PermissionDecisionApproveForLocationApprovalReadKind(obj.get("kind"))
         return PermissionDecisionApproveForSessionApprovalRead(kind)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalReadKind, self.kind)
-        return result
-
-@dataclass
-class UserToolSessionApprovalRead:
-    """Schema for the `UserToolSessionApprovalRead` type."""
-
-    kind: PermissionDecisionApproveForLocationApprovalReadKind
-    """Read approval kind"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'UserToolSessionApprovalRead':
-        assert isinstance(obj, dict)
-        kind = PermissionDecisionApproveForLocationApprovalReadKind(obj.get("kind"))
-        return UserToolSessionApprovalRead(kind)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -8081,29 +4472,11 @@ class PermissionDecisionApproveForSessionApprovalWrite:
         return result
 
 @dataclass
-class UserToolSessionApprovalWrite:
-    """Schema for the `UserToolSessionApprovalWrite` type."""
-
-    kind: PermissionDecisionApproveForLocationApprovalWriteKind
-    """Write approval kind"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'UserToolSessionApprovalWrite':
-        assert isinstance(obj, dict)
-        kind = PermissionDecisionApproveForLocationApprovalWriteKind(obj.get("kind"))
-        return UserToolSessionApprovalWrite(kind)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalWriteKind, self.kind)
-        return result
-
-@dataclass
 class PermissionDecisionApproveOnce:
     """Schema for the `PermissionDecisionApproveOnce` type."""
 
     kind: PermissionDecisionApproveOnceKind
-    """Approve this single request only"""
+    """The permission request was approved for this one instance"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecisionApproveOnce':
@@ -8121,10 +4494,10 @@ class PermissionDecisionApprovePermanently:
     """Schema for the `PermissionDecisionApprovePermanently` type."""
 
     domain: str
-    """URL domain to approve permanently"""
+    """The URL domain to approve permanently"""
 
     kind: PermissionDecisionApprovePermanentlyKind
-    """Approve and persist across sessions (URL prompts only)"""
+    """Approved and persisted across sessions"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecisionApprovePermanently':
@@ -8140,236 +4513,14 @@ class PermissionDecisionApprovePermanently:
         return result
 
 @dataclass
-class PermissionDecisionApproved:
-    """Schema for the `PermissionDecisionApproved` type."""
-
-    kind: PermissionDecisionApprovedKind
-    """The permission request was approved"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApproved':
-        assert isinstance(obj, dict)
-        kind = PermissionDecisionApprovedKind(obj.get("kind"))
-        return PermissionDecisionApproved(kind)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionApprovedKind, self.kind)
-        return result
-
-@dataclass
-class PermissionDecisionApprovedForLocation:
-    """Schema for the `PermissionDecisionApprovedForLocation` type."""
-
-    approval: UserToolSessionApproval
-    """The approval to persist for this location"""
-
-    kind: PermissionDecisionApprovedForLocationKind
-    """Approved and persisted for this project location"""
-
-    location_key: str
-    """The location key (git root or cwd) to persist the approval to"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForLocation':
-        assert isinstance(obj, dict)
-        approval = UserToolSessionApproval.from_dict(obj.get("approval"))
-        kind = PermissionDecisionApprovedForLocationKind(obj.get("kind"))
-        location_key = from_str(obj.get("locationKey"))
-        return PermissionDecisionApprovedForLocation(approval, kind, location_key)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["approval"] = to_class(UserToolSessionApproval, self.approval)
-        result["kind"] = to_enum(PermissionDecisionApprovedForLocationKind, self.kind)
-        result["locationKey"] = from_str(self.location_key)
-        return result
-
-@dataclass
-class PermissionDecisionApprovedForSession:
-    """Schema for the `PermissionDecisionApprovedForSession` type."""
-
-    approval: UserToolSessionApproval
-    """The approval to add as a session-scoped rule"""
-
-    kind: PermissionDecisionApprovedForSessionKind
-    """Approved and remembered for the rest of the session"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForSession':
-        assert isinstance(obj, dict)
-        approval = UserToolSessionApproval.from_dict(obj.get("approval"))
-        kind = PermissionDecisionApprovedForSessionKind(obj.get("kind"))
-        return PermissionDecisionApprovedForSession(approval, kind)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["approval"] = to_class(UserToolSessionApproval, self.approval)
-        result["kind"] = to_enum(PermissionDecisionApprovedForSessionKind, self.kind)
-        return result
-
-@dataclass
-class PermissionDecisionCancelled:
-    """Schema for the `PermissionDecisionCancelled` type."""
-
-    kind: PermissionDecisionCancelledKind
-    """The permission request was cancelled before a response was used"""
-
-    reason: str | None = None
-    """Optional explanation of why the request was cancelled"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionCancelled':
-        assert isinstance(obj, dict)
-        kind = PermissionDecisionCancelledKind(obj.get("kind"))
-        reason = from_union([from_str, from_none], obj.get("reason"))
-        return PermissionDecisionCancelled(kind, reason)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionCancelledKind, self.kind)
-        if self.reason is not None:
-            result["reason"] = from_union([from_str, from_none], self.reason)
-        return result
-
-@dataclass
-class PermissionDecisionDeniedByContentExclusionPolicy:
-    """Schema for the `PermissionDecisionDeniedByContentExclusionPolicy` type."""
-
-    kind: PermissionDecisionDeniedByContentExclusionPolicyKind
-    """Denied by the organization's content exclusion policy"""
-
-    message: str
-    """Human-readable explanation of why the path was excluded"""
-
-    path: str
-    """File path that triggered the exclusion"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionDeniedByContentExclusionPolicy':
-        assert isinstance(obj, dict)
-        kind = PermissionDecisionDeniedByContentExclusionPolicyKind(obj.get("kind"))
-        message = from_str(obj.get("message"))
-        path = from_str(obj.get("path"))
-        return PermissionDecisionDeniedByContentExclusionPolicy(kind, message, path)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionDeniedByContentExclusionPolicyKind, self.kind)
-        result["message"] = from_str(self.message)
-        result["path"] = from_str(self.path)
-        return result
-
-@dataclass
-class PermissionDecisionDeniedByPermissionRequestHook:
-    """Schema for the `PermissionDecisionDeniedByPermissionRequestHook` type."""
-
-    kind: PermissionDecisionDeniedByPermissionRequestHookKind
-    """Denied by a permission request hook registered by an extension or plugin"""
-
-    interrupt: bool | None = None
-    """Whether to interrupt the current agent turn"""
-
-    message: str | None = None
-    """Optional message from the hook explaining the denial"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionDeniedByPermissionRequestHook':
-        assert isinstance(obj, dict)
-        kind = PermissionDecisionDeniedByPermissionRequestHookKind(obj.get("kind"))
-        interrupt = from_union([from_bool, from_none], obj.get("interrupt"))
-        message = from_union([from_str, from_none], obj.get("message"))
-        return PermissionDecisionDeniedByPermissionRequestHook(kind, interrupt, message)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionDeniedByPermissionRequestHookKind, self.kind)
-        if self.interrupt is not None:
-            result["interrupt"] = from_union([from_bool, from_none], self.interrupt)
-        if self.message is not None:
-            result["message"] = from_union([from_str, from_none], self.message)
-        return result
-
-@dataclass
-class PermissionDecisionDeniedByRules:
-    """Schema for the `PermissionDecisionDeniedByRules` type."""
-
-    kind: PermissionDecisionDeniedByRulesKind
-    """Denied because approval rules explicitly blocked it"""
-
-    rules: list[PermissionRule]
-    """Rules that denied the request"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionDeniedByRules':
-        assert isinstance(obj, dict)
-        kind = PermissionDecisionDeniedByRulesKind(obj.get("kind"))
-        rules = from_list(PermissionRule.from_dict, obj.get("rules"))
-        return PermissionDecisionDeniedByRules(kind, rules)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionDeniedByRulesKind, self.kind)
-        result["rules"] = from_list(lambda x: to_class(PermissionRule, x), self.rules)
-        return result
-
-@dataclass
-class PermissionDecisionDeniedInteractivelyByUser:
-    """Schema for the `PermissionDecisionDeniedInteractivelyByUser` type."""
-
-    kind: PermissionDecisionDeniedInteractivelyByUserKind
-    """Denied by the user during an interactive prompt"""
-
-    feedback: str | None = None
-    """Optional feedback from the user explaining the denial"""
-
-    force_reject: bool | None = None
-    """Whether to force-reject the current agent turn"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionDeniedInteractivelyByUser':
-        assert isinstance(obj, dict)
-        kind = PermissionDecisionDeniedInteractivelyByUserKind(obj.get("kind"))
-        feedback = from_union([from_str, from_none], obj.get("feedback"))
-        force_reject = from_union([from_bool, from_none], obj.get("forceReject"))
-        return PermissionDecisionDeniedInteractivelyByUser(kind, feedback, force_reject)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionDeniedInteractivelyByUserKind, self.kind)
-        if self.feedback is not None:
-            result["feedback"] = from_union([from_str, from_none], self.feedback)
-        if self.force_reject is not None:
-            result["forceReject"] = from_union([from_bool, from_none], self.force_reject)
-        return result
-
-@dataclass
-class PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser:
-    """Schema for the `PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser` type."""
-
-    kind: PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUserKind
-    """Denied because no approval rule matched and user confirmation was unavailable"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser':
-        assert isinstance(obj, dict)
-        kind = PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUserKind(obj.get("kind"))
-        return PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser(kind)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUserKind, self.kind)
-        return result
-
-@dataclass
 class PermissionDecisionReject:
     """Schema for the `PermissionDecisionReject` type."""
 
     kind: PermissionDecisionRejectKind
-    """Reject the request"""
+    """Denied by the user during an interactive prompt"""
 
     feedback: str | None = None
-    """Optional feedback explaining the rejection"""
+    """Optional feedback from the user explaining the denial"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecisionReject':
@@ -8390,7 +4541,7 @@ class PermissionDecisionUserNotAvailable:
     """Schema for the `PermissionDecisionUserNotAvailable` type."""
 
     kind: PermissionDecisionUserNotAvailableKind
-    """No user is available to confirm the request"""
+    """Denied because user confirmation was unavailable"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecisionUserNotAvailable':
@@ -8401,76 +4552,6 @@ class PermissionDecisionUserNotAvailable:
     def to_dict(self) -> dict:
         result: dict = {}
         result["kind"] = to_enum(PermissionDecisionUserNotAvailableKind, self.kind)
-        return result
-
-@dataclass
-class PermissionsConfigureAdditionalContentExclusionPolicyRule:
-    """Schema for the `PermissionsConfigureAdditionalContentExclusionPolicyRule` type."""
-
-    paths: list[str]
-    source: PermissionsConfigureAdditionalContentExclusionPolicyRuleSource
-    """Schema for the `PermissionsConfigureAdditionalContentExclusionPolicyRuleSource` type."""
-
-    if_any_match: list[str] | None = None
-    if_none_match: list[str] | None = None
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionsConfigureAdditionalContentExclusionPolicyRule':
-        assert isinstance(obj, dict)
-        paths = from_list(from_str, obj.get("paths"))
-        source = PermissionsConfigureAdditionalContentExclusionPolicyRuleSource.from_dict(obj.get("source"))
-        if_any_match = from_union([lambda x: from_list(from_str, x), from_none], obj.get("ifAnyMatch"))
-        if_none_match = from_union([lambda x: from_list(from_str, x), from_none], obj.get("ifNoneMatch"))
-        return PermissionsConfigureAdditionalContentExclusionPolicyRule(paths, source, if_any_match, if_none_match)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["paths"] = from_list(from_str, self.paths)
-        result["source"] = to_class(PermissionsConfigureAdditionalContentExclusionPolicyRuleSource, self.source)
-        if self.if_any_match is not None:
-            result["ifAnyMatch"] = from_union([lambda x: from_list(from_str, x), from_none], self.if_any_match)
-        if self.if_none_match is not None:
-            result["ifNoneMatch"] = from_union([lambda x: from_list(from_str, x), from_none], self.if_none_match)
-        return result
-
-@dataclass
-class PermissionsModifyRulesParams:
-    """Scope and add/remove instructions for modifying session- or location-scoped permission
-    rules.
-    """
-    scope: PermissionsModifyRulesScope
-    """Whether the change applies to ephemeral session-scoped rules (cleared at session end) or
-    to location-scoped rules persisted via the location-permissions config file.
-    """
-    add: list[PermissionRule] | None = None
-    """Rules to add to the scope. Applied before `remove`/`removeAll`."""
-
-    remove: list[PermissionRule] | None = None
-    """Specific rules to remove from the scope. Ignored when `removeAll` is true."""
-
-    remove_all: bool | None = None
-    """When true, removes every rule currently in the scope (after any `add` is applied). Useful
-    for clearing the location scope wholesale.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionsModifyRulesParams':
-        assert isinstance(obj, dict)
-        scope = PermissionsModifyRulesScope(obj.get("scope"))
-        add = from_union([lambda x: from_list(PermissionRule.from_dict, x), from_none], obj.get("add"))
-        remove = from_union([lambda x: from_list(PermissionRule.from_dict, x), from_none], obj.get("remove"))
-        remove_all = from_union([from_bool, from_none], obj.get("removeAll"))
-        return PermissionsModifyRulesParams(scope, add, remove, remove_all)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["scope"] = to_enum(PermissionsModifyRulesScope, self.scope)
-        if self.add is not None:
-            result["add"] = from_union([lambda x: from_list(lambda x: to_class(PermissionRule, x), x), from_none], self.add)
-        if self.remove is not None:
-            result["remove"] = from_union([lambda x: from_list(lambda x: to_class(PermissionRule, x), x), from_none], self.remove)
-        if self.remove_all is not None:
-            result["removeAll"] = from_union([from_bool, from_none], self.remove_all)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -8492,48 +4573,21 @@ class PluginList:
         result["plugins"] = from_list(lambda x: to_class(Plugin, x), self.plugins)
         return result
 
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class QueuePendingItems:
-    """Schema for the `QueuePendingItems` type."""
-
-    display_text: str
-    """Human-readable text to display for this queue entry in the UI"""
-
-    kind: QueuePendingItemsKind
-    """Whether this item is a queued user message or a queued slash command / model change"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'QueuePendingItems':
-        assert isinstance(obj, dict)
-        display_text = from_str(obj.get("displayText"))
-        kind = QueuePendingItemsKind(obj.get("kind"))
-        return QueuePendingItems(display_text, kind)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["displayText"] = from_str(self.display_text)
-        result["kind"] = to_enum(QueuePendingItemsKind, self.kind)
-        return result
-
 @dataclass
 class QueuedCommandResult:
-    """Result of the queued command execution.
+    """Result of the queued command execution
 
     Schema for the `QueuedCommandHandled` type.
 
     Schema for the `QueuedCommandNotHandled` type.
     """
     handled: bool
-    """The host actually executed the queued command.
+    """The command was handled
 
-    The host did not execute the queued command. Unblocks the queue without claiming the
-    command was processed (e.g. when the handler threw before completing).
+    The command was not handled
     """
     stop_processing_queue: bool | None = None
-    """When true, the runtime will not process subsequent queued commands until a new request
-    comes in.
-    """
+    """If true, stop processing remaining queued items"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'QueuedCommandResult':
@@ -8570,179 +4624,6 @@ class RemoteEnableRequest:
         result: dict = {}
         if self.mode is not None:
             result["mode"] = from_union([lambda x: to_enum(RemoteSessionMode, x), from_none], self.mode)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class ScheduleList:
-    """Snapshot of the currently active recurring prompts for this session."""
-
-    entries: list[ScheduleEntry]
-    """Active scheduled prompts, ordered by id."""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'ScheduleList':
-        assert isinstance(obj, dict)
-        entries = from_list(ScheduleEntry.from_dict, obj.get("entries"))
-        return ScheduleList(entries)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["entries"] = from_list(lambda x: to_class(ScheduleEntry, x), self.entries)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class ScheduleStopResult:
-    """Remove a scheduled prompt by id. The result entry is omitted if the id was unknown."""
-
-    entry: ScheduleEntry | None = None
-    """The removed entry, or omitted if no entry matched."""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'ScheduleStopResult':
-        assert isinstance(obj, dict)
-        entry = from_union([ScheduleEntry.from_dict, from_none], obj.get("entry"))
-        return ScheduleStopResult(entry)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.entry is not None:
-            result["entry"] = from_union([lambda x: to_class(ScheduleEntry, x), from_none], self.entry)
-        return result
-
-@dataclass
-class SendAttachmentSelectionDetails:
-    """Position range of the selection within the file"""
-
-    end: SendAttachmentSelectionDetailsEnd
-    """End position of the selection"""
-
-    start: SendAttachmentSelectionDetailsStart
-    """Start position of the selection"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SendAttachmentSelectionDetails':
-        assert isinstance(obj, dict)
-        end = SendAttachmentSelectionDetailsEnd.from_dict(obj.get("end"))
-        start = SendAttachmentSelectionDetailsStart.from_dict(obj.get("start"))
-        return SendAttachmentSelectionDetails(end, start)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["end"] = to_class(SendAttachmentSelectionDetailsEnd, self.end)
-        result["start"] = to_class(SendAttachmentSelectionDetailsStart, self.start)
-        return result
-
-@dataclass
-class SendAttachmentBlob:
-    """Blob attachment with inline base64-encoded data"""
-
-    data: str
-    """Base64-encoded content"""
-
-    mime_type: str
-    """MIME type of the inline data"""
-
-    type: SendAttachmentBlobType
-    """Attachment type discriminator"""
-
-    display_name: str | None = None
-    """User-facing display name for the attachment"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SendAttachmentBlob':
-        assert isinstance(obj, dict)
-        data = from_str(obj.get("data"))
-        mime_type = from_str(obj.get("mimeType"))
-        type = SendAttachmentBlobType(obj.get("type"))
-        display_name = from_union([from_str, from_none], obj.get("displayName"))
-        return SendAttachmentBlob(data, mime_type, type, display_name)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["data"] = from_str(self.data)
-        result["mimeType"] = from_str(self.mime_type)
-        result["type"] = to_enum(SendAttachmentBlobType, self.type)
-        if self.display_name is not None:
-            result["displayName"] = from_union([from_str, from_none], self.display_name)
-        return result
-
-@dataclass
-class SendAttachmentFile:
-    """File attachment"""
-
-    display_name: str
-    """User-facing display name for the attachment"""
-
-    path: str
-    """Absolute file path"""
-
-    type: SendAttachmentFileType
-    """Attachment type discriminator"""
-
-    line_range: SendAttachmentFileLineRange | None = None
-    """Optional line range to scope the attachment to a specific section of the file"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SendAttachmentFile':
-        assert isinstance(obj, dict)
-        display_name = from_str(obj.get("displayName"))
-        path = from_str(obj.get("path"))
-        type = SendAttachmentFileType(obj.get("type"))
-        line_range = from_union([SendAttachmentFileLineRange.from_dict, from_none], obj.get("lineRange"))
-        return SendAttachmentFile(display_name, path, type, line_range)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["displayName"] = from_str(self.display_name)
-        result["path"] = from_str(self.path)
-        result["type"] = to_enum(SendAttachmentFileType, self.type)
-        if self.line_range is not None:
-            result["lineRange"] = from_union([lambda x: to_class(SendAttachmentFileLineRange, x), from_none], self.line_range)
-        return result
-
-@dataclass
-class SendAttachmentGithubReference:
-    """GitHub issue, pull request, or discussion reference"""
-
-    number: int
-    """Issue, pull request, or discussion number"""
-
-    reference_type: SendAttachmentGithubReferenceTypeEnum
-    """Type of GitHub reference"""
-
-    state: str
-    """Current state of the referenced item (e.g., open, closed, merged)"""
-
-    title: str
-    """Title of the referenced item"""
-
-    type: SendAttachmentGithubReferenceType
-    """Attachment type discriminator"""
-
-    url: str
-    """URL to the referenced item on GitHub"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SendAttachmentGithubReference':
-        assert isinstance(obj, dict)
-        number = from_int(obj.get("number"))
-        reference_type = SendAttachmentGithubReferenceTypeEnum(obj.get("referenceType"))
-        state = from_str(obj.get("state"))
-        title = from_str(obj.get("title"))
-        type = SendAttachmentGithubReferenceType(obj.get("type"))
-        url = from_str(obj.get("url"))
-        return SendAttachmentGithubReference(number, reference_type, state, title, type, url)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["number"] = from_int(self.number)
-        result["referenceType"] = to_enum(SendAttachmentGithubReferenceTypeEnum, self.reference_type)
-        result["state"] = from_str(self.state)
-        result["title"] = from_str(self.title)
-        result["type"] = to_enum(SendAttachmentGithubReferenceType, self.type)
-        result["url"] = from_str(self.url)
         return result
 
 @dataclass
@@ -8881,35 +4762,6 @@ class SessionFSSqliteQueryRequest:
             result["params"] = from_union([lambda x: from_dict(lambda x: from_union([from_none, to_float, from_str], x), x), from_none], self.params)
         return result
 
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsListRequest:
-    """Optional metadata-load limit and context filter applied to the returned sessions."""
-
-    filter: Filter | None = None
-    """Optional filter applied to the returned sessions"""
-
-    metadata_limit: int | None = None
-    """When provided, only the first N sessions (sorted by modification time, newest first) load
-    full metadata; remaining sessions return basic info only. Use 0 to return only basic info
-    for every session.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsListRequest':
-        assert isinstance(obj, dict)
-        filter = from_union([Filter.from_dict, from_none], obj.get("filter"))
-        metadata_limit = from_union([from_int, from_none], obj.get("metadataLimit"))
-        return SessionsListRequest(filter, metadata_limit)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.filter is not None:
-            result["filter"] = from_union([lambda x: to_class(Filter, x), from_none], self.filter)
-        if self.metadata_limit is not None:
-            result["metadataLimit"] = from_union([from_int, from_none], self.metadata_limit)
-        return result
-
 @dataclass
 class ShellKillRequest:
     """Identifier of a process previously returned by "shell.exec" and the signal to send."""
@@ -8932,90 +4784,6 @@ class ShellKillRequest:
         result["processId"] = from_str(self.process_id)
         if self.signal is not None:
             result["signal"] = from_union([lambda x: to_enum(ShellKillSignal, x), from_none], self.signal)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class AgentInfo:
-    """Schema for the `AgentInfo` type.
-
-    The newly selected custom agent
-    """
-    description: str
-    """Description of the agent's purpose"""
-
-    display_name: str
-    """Human-readable display name"""
-
-    id: str
-    """Stable identifier for selection. For most agents this is the same as `name`; for
-    plugin/builtin agents it may differ. Always populated; defaults to `name` when no
-    distinct id was assigned.
-    """
-    name: str
-    """Unique identifier of the custom agent"""
-
-    mcp_servers: dict[str, Any] | None = None
-    """MCP server configurations attached to this agent, keyed by server name. Server config
-    shape mirrors the MCP `mcpServers` schema.
-    """
-    model: str | None = None
-    """Preferred model id for this agent. When omitted, inherits the outer agent's model."""
-
-    path: str | None = None
-    """Absolute local file path of the agent definition. Only set for file-based agents loaded
-    from disk; remote agents do not have a path.
-    """
-    skills: list[str] | None = None
-    """Skill names preloaded into this agent's context. Omitted means none."""
-
-    source: AgentInfoSource | None = None
-    """Where the agent definition was loaded from"""
-
-    tools: list[str] | None = None
-    """Allowed tool names for this agent. Empty array means none; omitted means inherit defaults."""
-
-    user_invocable: bool | None = None
-    """Whether the agent can be selected directly by the user. Agents marked `false` are
-    subagent-only.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'AgentInfo':
-        assert isinstance(obj, dict)
-        description = from_str(obj.get("description"))
-        display_name = from_str(obj.get("displayName"))
-        id = from_str(obj.get("id"))
-        name = from_str(obj.get("name"))
-        mcp_servers = from_union([lambda x: from_dict(lambda x: x, x), from_none], obj.get("mcpServers"))
-        model = from_union([from_str, from_none], obj.get("model"))
-        path = from_union([from_str, from_none], obj.get("path"))
-        skills = from_union([lambda x: from_list(from_str, x), from_none], obj.get("skills"))
-        source = from_union([AgentInfoSource, from_none], obj.get("source"))
-        tools = from_union([lambda x: from_list(from_str, x), from_none], obj.get("tools"))
-        user_invocable = from_union([from_bool, from_none], obj.get("userInvocable"))
-        return AgentInfo(description, display_name, id, name, mcp_servers, model, path, skills, source, tools, user_invocable)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["description"] = from_str(self.description)
-        result["displayName"] = from_str(self.display_name)
-        result["id"] = from_str(self.id)
-        result["name"] = from_str(self.name)
-        if self.mcp_servers is not None:
-            result["mcpServers"] = from_union([lambda x: from_dict(lambda x: x, x), from_none], self.mcp_servers)
-        if self.model is not None:
-            result["model"] = from_union([from_str, from_none], self.model)
-        if self.path is not None:
-            result["path"] = from_union([from_str, from_none], self.path)
-        if self.skills is not None:
-            result["skills"] = from_union([lambda x: from_list(from_str, x), from_none], self.skills)
-        if self.source is not None:
-            result["source"] = from_union([lambda x: to_enum(AgentInfoSource, x), from_none], self.source)
-        if self.tools is not None:
-            result["tools"] = from_union([lambda x: from_list(from_str, x), from_none], self.tools)
-        if self.user_invocable is not None:
-            result["userInvocable"] = from_union([from_bool, from_none], self.user_invocable)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -9053,25 +4821,6 @@ class SkillsConfigSetDisabledSkillsRequest:
     def to_dict(self) -> dict:
         result: dict = {}
         result["disabledSkills"] = from_list(from_str, self.disabled_skills)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SkillsGetInvokedResult:
-    """Skills invoked during this session, ordered by invocation time (most recent last)."""
-
-    skills: list[SkillsInvokedSkill]
-    """Skills invoked during this session, ordered by invocation time (most recent last)"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SkillsGetInvokedResult':
-        assert isinstance(obj, dict)
-        skills = from_list(SkillsInvokedSkill.from_dict, obj.get("skills"))
-        return SkillsGetInvokedResult(skills)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["skills"] = from_list(lambda x: to_class(SkillsInvokedSkill, x), self.skills)
         return result
 
 @dataclass
@@ -9146,90 +4895,6 @@ class SlashCommandCompletedResult:
             result["message"] = from_union([from_str, from_none], self.message)
         if self.runtime_settings_changed is not None:
             result["runtimeSettingsChanged"] = from_union([from_bool, from_none], self.runtime_settings_changed)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class TaskAgentProgress:
-    """Schema for the `TaskAgentProgress` type."""
-
-    type: TaskAgentProgressType
-    """Progress kind"""
-
-    latest_intent: str | None = None
-    """The most recent intent reported by the agent"""
-
-    recent_activity: list[RecentActivity] | None = None
-    """Recent tool execution events converted to display lines"""
-
-    pid: int | None = None
-    """Process ID when available"""
-
-    recent_output: str | None = None
-    """Recent stdout/stderr lines from the running shell command"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'TaskAgentProgress':
-        assert isinstance(obj, dict)
-        type = TaskAgentProgressType(obj.get("type"))
-        latest_intent = from_union([from_str, from_none], obj.get("latestIntent"))
-        recent_activity = from_union([lambda x: from_list(RecentActivity.from_dict, x), from_none], obj.get("recentActivity"))
-        pid = from_union([from_int, from_none], obj.get("pid"))
-        recent_output = from_union([from_str, from_none], obj.get("recentOutput"))
-        return TaskAgentProgress(type, latest_intent, recent_activity, pid, recent_output)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["type"] = to_enum(TaskAgentProgressType, self.type)
-        if self.latest_intent is not None:
-            result["latestIntent"] = from_union([from_str, from_none], self.latest_intent)
-        if self.recent_activity is not None:
-            result["recentActivity"] = from_union([lambda x: from_list(lambda x: to_class(RecentActivity, x), x), from_none], self.recent_activity)
-        if self.pid is not None:
-            result["pid"] = from_union([from_int, from_none], self.pid)
-        if self.recent_output is not None:
-            result["recentOutput"] = from_union([from_str, from_none], self.recent_output)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class TaskProgressClass:
-    type: TaskAgentProgressType
-    """Progress kind"""
-
-    latest_intent: str | None = None
-    """The most recent intent reported by the agent"""
-
-    recent_activity: list[RecentActivity] | None = None
-    """Recent tool execution events converted to display lines"""
-
-    pid: int | None = None
-    """Process ID when available"""
-
-    recent_output: str | None = None
-    """Recent stdout/stderr lines from the running shell command"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'TaskProgressClass':
-        assert isinstance(obj, dict)
-        type = TaskAgentProgressType(obj.get("type"))
-        latest_intent = from_union([from_str, from_none], obj.get("latestIntent"))
-        recent_activity = from_union([lambda x: from_list(RecentActivity.from_dict, x), from_none], obj.get("recentActivity"))
-        pid = from_union([from_int, from_none], obj.get("pid"))
-        recent_output = from_union([from_str, from_none], obj.get("recentOutput"))
-        return TaskProgressClass(type, latest_intent, recent_activity, pid, recent_output)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["type"] = to_enum(TaskAgentProgressType, self.type)
-        if self.latest_intent is not None:
-            result["latestIntent"] = from_union([from_str, from_none], self.latest_intent)
-        if self.recent_activity is not None:
-            result["recentActivity"] = from_union([lambda x: from_list(lambda x: to_class(RecentActivity, x), x), from_none], self.recent_activity)
-        if self.pid is not None:
-            result["pid"] = from_union([from_int, from_none], self.pid)
-        if self.recent_output is not None:
-            result["recentOutput"] = from_union([from_str, from_none], self.recent_output)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -9328,31 +4993,6 @@ class ToolList:
     def to_dict(self) -> dict:
         result: dict = {}
         result["tools"] = from_list(lambda x: to_class(Tool, x), self.tools)
-        return result
-
-@dataclass
-class UIHandlePendingAutoModeSwitchRequest:
-    """Request ID of a pending `auto_mode_switch.requested` event and the user's response."""
-
-    request_id: str
-    """The unique request ID from the auto_mode_switch.requested event"""
-
-    response: UIAutoModeSwitchResponse
-    """User's choice for auto-mode switching: yes (allow this turn), yes_always (allow + persist
-    as setting), or no (decline).
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'UIHandlePendingAutoModeSwitchRequest':
-        assert isinstance(obj, dict)
-        request_id = from_str(obj.get("requestId"))
-        response = UIAutoModeSwitchResponse(obj.get("response"))
-        return UIHandlePendingAutoModeSwitchRequest(request_id, response)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["requestId"] = from_str(self.request_id)
-        result["response"] = to_enum(UIAutoModeSwitchResponse, self.response)
         return result
 
 @dataclass
@@ -9490,10 +5130,10 @@ class UIElicitationSchemaPropertyString:
     format: UIElicitationSchemaPropertyStringFormat | None = None
     """Optional format hint that constrains the accepted input."""
 
-    max_length: int | None = None
+    max_length: float | None = None
     """Maximum number of characters allowed."""
 
-    min_length: int | None = None
+    min_length: float | None = None
     """Minimum number of characters required."""
 
     title: str | None = None
@@ -9506,8 +5146,8 @@ class UIElicitationSchemaPropertyString:
         default = from_union([from_str, from_none], obj.get("default"))
         description = from_union([from_str, from_none], obj.get("description"))
         format = from_union([UIElicitationSchemaPropertyStringFormat, from_none], obj.get("format"))
-        max_length = from_union([from_int, from_none], obj.get("maxLength"))
-        min_length = from_union([from_int, from_none], obj.get("minLength"))
+        max_length = from_union([from_float, from_none], obj.get("maxLength"))
+        min_length = from_union([from_float, from_none], obj.get("minLength"))
         title = from_union([from_str, from_none], obj.get("title"))
         return UIElicitationSchemaPropertyString(type, default, description, format, max_length, min_length, title)
 
@@ -9521,9 +5161,9 @@ class UIElicitationSchemaPropertyString:
         if self.format is not None:
             result["format"] = from_union([lambda x: to_enum(UIElicitationSchemaPropertyStringFormat, x), from_none], self.format)
         if self.max_length is not None:
-            result["maxLength"] = from_union([from_int, from_none], self.max_length)
+            result["maxLength"] = from_union([to_float, from_none], self.max_length)
         if self.min_length is not None:
-            result["minLength"] = from_union([from_int, from_none], self.min_length)
+            result["minLength"] = from_union([to_float, from_none], self.min_length)
         if self.title is not None:
             result["title"] = from_union([from_str, from_none], self.title)
         return result
@@ -9677,67 +5317,6 @@ class UIElicitationSchemaPropertyNumber:
             result["title"] = from_union([from_str, from_none], self.title)
         return result
 
-@dataclass
-class UIExitPlanModeResponse:
-    """Schema for the `UIExitPlanModeResponse` type."""
-
-    approved: bool
-    """Whether the plan was approved."""
-
-    auto_approve_edits: bool | None = None
-    """Whether subsequent edits should be auto-approved without confirmation."""
-
-    feedback: str | None = None
-    """Feedback from the user when they declined the plan or requested changes."""
-
-    selected_action: UIExitPlanModeAction | None = None
-    """The action the user selected. Defaults to 'autopilot' when autoApproveEdits is true,
-    otherwise 'interactive'.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'UIExitPlanModeResponse':
-        assert isinstance(obj, dict)
-        approved = from_bool(obj.get("approved"))
-        auto_approve_edits = from_union([from_bool, from_none], obj.get("autoApproveEdits"))
-        feedback = from_union([from_str, from_none], obj.get("feedback"))
-        selected_action = from_union([UIExitPlanModeAction, from_none], obj.get("selectedAction"))
-        return UIExitPlanModeResponse(approved, auto_approve_edits, feedback, selected_action)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["approved"] = from_bool(self.approved)
-        if self.auto_approve_edits is not None:
-            result["autoApproveEdits"] = from_union([from_bool, from_none], self.auto_approve_edits)
-        if self.feedback is not None:
-            result["feedback"] = from_union([from_str, from_none], self.feedback)
-        if self.selected_action is not None:
-            result["selectedAction"] = from_union([lambda x: to_enum(UIExitPlanModeAction, x), from_none], self.selected_action)
-        return result
-
-@dataclass
-class UIHandlePendingUserInputRequest:
-    """Request ID of a pending `user_input.requested` event and the user's response."""
-
-    request_id: str
-    """The unique request ID from the user_input.requested event"""
-
-    response: UIUserInputResponse
-    """Schema for the `UIUserInputResponse` type."""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'UIHandlePendingUserInputRequest':
-        assert isinstance(obj, dict)
-        request_id = from_str(obj.get("requestId"))
-        response = UIUserInputResponse.from_dict(obj.get("response"))
-        return UIHandlePendingUserInputRequest(request_id, response)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["requestId"] = from_str(self.request_id)
-        result["response"] = to_class(UIUserInputResponse, self.response)
-        return result
-
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
 class UsageMetricsModelMetric:
@@ -9775,23 +5354,78 @@ class UsageMetricsModelMetric:
         return result
 
 @dataclass
-class WorkspacesSaveLargePasteResult:
-    """Descriptor for the saved paste file, or null when the workspace is unavailable."""
-
-    saved: Saved | None = None
-    """Saved-paste descriptor, or null when the workspace is unavailable (e.g. CCA runtime,
-    non-infinite sessions, remote sessions)
-    """
+class Workspace:
+    id: UUID
+    branch: str | None = None
+    chronicle_sync_dismissed: bool | None = None
+    created_at: datetime | None = None
+    cwd: str | None = None
+    git_root: str | None = None
+    host_type: HostType | None = None
+    mc_last_event_id: str | None = None
+    mc_session_id: str | None = None
+    mc_task_id: str | None = None
+    name: str | None = None
+    remote_steerable: bool | None = None
+    repository: str | None = None
+    summary_count: int | None = None
+    updated_at: datetime | None = None
+    user_named: bool | None = None
 
     @staticmethod
-    def from_dict(obj: Any) -> 'WorkspacesSaveLargePasteResult':
+    def from_dict(obj: Any) -> 'Workspace':
         assert isinstance(obj, dict)
-        saved = from_union([Saved.from_dict, from_none], obj.get("saved"))
-        return WorkspacesSaveLargePasteResult(saved)
+        id = UUID(obj.get("id"))
+        branch = from_union([from_str, from_none], obj.get("branch"))
+        chronicle_sync_dismissed = from_union([from_bool, from_none], obj.get("chronicle_sync_dismissed"))
+        created_at = from_union([from_datetime, from_none], obj.get("created_at"))
+        cwd = from_union([from_str, from_none], obj.get("cwd"))
+        git_root = from_union([from_str, from_none], obj.get("git_root"))
+        host_type = from_union([HostType, from_none], obj.get("host_type"))
+        mc_last_event_id = from_union([from_str, from_none], obj.get("mc_last_event_id"))
+        mc_session_id = from_union([from_str, from_none], obj.get("mc_session_id"))
+        mc_task_id = from_union([from_str, from_none], obj.get("mc_task_id"))
+        name = from_union([from_str, from_none], obj.get("name"))
+        remote_steerable = from_union([from_bool, from_none], obj.get("remote_steerable"))
+        repository = from_union([from_str, from_none], obj.get("repository"))
+        summary_count = from_union([from_int, from_none], obj.get("summary_count"))
+        updated_at = from_union([from_datetime, from_none], obj.get("updated_at"))
+        user_named = from_union([from_bool, from_none], obj.get("user_named"))
+        return Workspace(id, branch, chronicle_sync_dismissed, created_at, cwd, git_root, host_type, mc_last_event_id, mc_session_id, mc_task_id, name, remote_steerable, repository, summary_count, updated_at, user_named)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["saved"] = from_union([lambda x: to_class(Saved, x), from_none], self.saved)
+        result["id"] = str(self.id)
+        if self.branch is not None:
+            result["branch"] = from_union([from_str, from_none], self.branch)
+        if self.chronicle_sync_dismissed is not None:
+            result["chronicle_sync_dismissed"] = from_union([from_bool, from_none], self.chronicle_sync_dismissed)
+        if self.created_at is not None:
+            result["created_at"] = from_union([lambda x: x.isoformat(), from_none], self.created_at)
+        if self.cwd is not None:
+            result["cwd"] = from_union([from_str, from_none], self.cwd)
+        if self.git_root is not None:
+            result["git_root"] = from_union([from_str, from_none], self.git_root)
+        if self.host_type is not None:
+            result["host_type"] = from_union([lambda x: to_enum(HostType, x), from_none], self.host_type)
+        if self.mc_last_event_id is not None:
+            result["mc_last_event_id"] = from_union([from_str, from_none], self.mc_last_event_id)
+        if self.mc_session_id is not None:
+            result["mc_session_id"] = from_union([from_str, from_none], self.mc_session_id)
+        if self.mc_task_id is not None:
+            result["mc_task_id"] = from_union([from_str, from_none], self.mc_task_id)
+        if self.name is not None:
+            result["name"] = from_union([from_str, from_none], self.name)
+        if self.remote_steerable is not None:
+            result["remote_steerable"] = from_union([from_bool, from_none], self.remote_steerable)
+        if self.repository is not None:
+            result["repository"] = from_union([from_str, from_none], self.repository)
+        if self.summary_count is not None:
+            result["summary_count"] = from_union([from_int, from_none], self.summary_count)
+        if self.updated_at is not None:
+            result["updated_at"] = from_union([lambda x: x.isoformat(), from_none], self.updated_at)
+        if self.user_named is not None:
+            result["user_named"] = from_union([from_bool, from_none], self.user_named)
         return result
 
 @dataclass
@@ -9868,118 +5502,6 @@ class RemoteSessionConnectionResult:
         result: dict = {}
         result["metadata"] = to_class(ConnectedRemoteSessionMetadata, self.metadata)
         result["sessionId"] = from_str(self.session_id)
-        return result
-
-@dataclass
-class CopilotUserResponse:
-    """Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the
-    GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this
-    verbatim and does not re-fetch when set.
-    """
-    access_type_sku: str | None = None
-    analytics_tracking_id: str | None = None
-    assigned_date: Any = None
-    can_signup_for_limited: bool | None = None
-    chat_enabled: bool | None = None
-    cli_remote_control_enabled: bool | None = None
-    cloud_session_storage_enabled: bool | None = None
-    codex_agent_enabled: bool | None = None
-    copilot_plan: str | None = None
-    copilotignore_enabled: bool | None = None
-    endpoints: CopilotUserResponseEndpoints | None = None
-    """Schema for the `CopilotUserResponseEndpoints` type."""
-
-    is_mcp_enabled: Any = None
-    limited_user_quotas: dict[str, float] | None = None
-    limited_user_reset_date: str | None = None
-    login: str | None = None
-    monthly_quotas: dict[str, float] | None = None
-    organization_list: Any = None
-    organization_login_list: list[str] | None = None
-    quota_reset_date: str | None = None
-    quota_reset_date_utc: str | None = None
-    quota_snapshots: dict[str, CopilotUserResponseQuotaSnapshots | None] | None = None
-    """Schema for the `CopilotUserResponseQuotaSnapshots` type."""
-
-    restricted_telemetry: bool | None = None
-    token_based_billing: bool | None = None
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'CopilotUserResponse':
-        assert isinstance(obj, dict)
-        access_type_sku = from_union([from_str, from_none], obj.get("access_type_sku"))
-        analytics_tracking_id = from_union([from_str, from_none], obj.get("analytics_tracking_id"))
-        assigned_date = obj.get("assigned_date")
-        can_signup_for_limited = from_union([from_bool, from_none], obj.get("can_signup_for_limited"))
-        chat_enabled = from_union([from_bool, from_none], obj.get("chat_enabled"))
-        cli_remote_control_enabled = from_union([from_bool, from_none], obj.get("cli_remote_control_enabled"))
-        cloud_session_storage_enabled = from_union([from_bool, from_none], obj.get("cloud_session_storage_enabled"))
-        codex_agent_enabled = from_union([from_bool, from_none], obj.get("codex_agent_enabled"))
-        copilot_plan = from_union([from_str, from_none], obj.get("copilot_plan"))
-        copilotignore_enabled = from_union([from_bool, from_none], obj.get("copilotignore_enabled"))
-        endpoints = from_union([CopilotUserResponseEndpoints.from_dict, from_none], obj.get("endpoints"))
-        is_mcp_enabled = obj.get("is_mcp_enabled")
-        limited_user_quotas = from_union([lambda x: from_dict(from_float, x), from_none], obj.get("limited_user_quotas"))
-        limited_user_reset_date = from_union([from_str, from_none], obj.get("limited_user_reset_date"))
-        login = from_union([from_str, from_none], obj.get("login"))
-        monthly_quotas = from_union([lambda x: from_dict(from_float, x), from_none], obj.get("monthly_quotas"))
-        organization_list = obj.get("organization_list")
-        organization_login_list = from_union([lambda x: from_list(from_str, x), from_none], obj.get("organization_login_list"))
-        quota_reset_date = from_union([from_str, from_none], obj.get("quota_reset_date"))
-        quota_reset_date_utc = from_union([from_str, from_none], obj.get("quota_reset_date_utc"))
-        quota_snapshots = from_union([lambda x: from_dict(lambda x: from_union([CopilotUserResponseQuotaSnapshots.from_dict, from_none], x), x), from_none], obj.get("quota_snapshots"))
-        restricted_telemetry = from_union([from_bool, from_none], obj.get("restricted_telemetry"))
-        token_based_billing = from_union([from_bool, from_none], obj.get("token_based_billing"))
-        return CopilotUserResponse(access_type_sku, analytics_tracking_id, assigned_date, can_signup_for_limited, chat_enabled, cli_remote_control_enabled, cloud_session_storage_enabled, codex_agent_enabled, copilot_plan, copilotignore_enabled, endpoints, is_mcp_enabled, limited_user_quotas, limited_user_reset_date, login, monthly_quotas, organization_list, organization_login_list, quota_reset_date, quota_reset_date_utc, quota_snapshots, restricted_telemetry, token_based_billing)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.access_type_sku is not None:
-            result["access_type_sku"] = from_union([from_str, from_none], self.access_type_sku)
-        if self.analytics_tracking_id is not None:
-            result["analytics_tracking_id"] = from_union([from_str, from_none], self.analytics_tracking_id)
-        if self.assigned_date is not None:
-            result["assigned_date"] = self.assigned_date
-        if self.can_signup_for_limited is not None:
-            result["can_signup_for_limited"] = from_union([from_bool, from_none], self.can_signup_for_limited)
-        if self.chat_enabled is not None:
-            result["chat_enabled"] = from_union([from_bool, from_none], self.chat_enabled)
-        if self.cli_remote_control_enabled is not None:
-            result["cli_remote_control_enabled"] = from_union([from_bool, from_none], self.cli_remote_control_enabled)
-        if self.cloud_session_storage_enabled is not None:
-            result["cloud_session_storage_enabled"] = from_union([from_bool, from_none], self.cloud_session_storage_enabled)
-        if self.codex_agent_enabled is not None:
-            result["codex_agent_enabled"] = from_union([from_bool, from_none], self.codex_agent_enabled)
-        if self.copilot_plan is not None:
-            result["copilot_plan"] = from_union([from_str, from_none], self.copilot_plan)
-        if self.copilotignore_enabled is not None:
-            result["copilotignore_enabled"] = from_union([from_bool, from_none], self.copilotignore_enabled)
-        if self.endpoints is not None:
-            result["endpoints"] = from_union([lambda x: to_class(CopilotUserResponseEndpoints, x), from_none], self.endpoints)
-        if self.is_mcp_enabled is not None:
-            result["is_mcp_enabled"] = self.is_mcp_enabled
-        if self.limited_user_quotas is not None:
-            result["limited_user_quotas"] = from_union([lambda x: from_dict(to_float, x), from_none], self.limited_user_quotas)
-        if self.limited_user_reset_date is not None:
-            result["limited_user_reset_date"] = from_union([from_str, from_none], self.limited_user_reset_date)
-        if self.login is not None:
-            result["login"] = from_union([from_str, from_none], self.login)
-        if self.monthly_quotas is not None:
-            result["monthly_quotas"] = from_union([lambda x: from_dict(to_float, x), from_none], self.monthly_quotas)
-        if self.organization_list is not None:
-            result["organization_list"] = self.organization_list
-        if self.organization_login_list is not None:
-            result["organization_login_list"] = from_union([lambda x: from_list(from_str, x), from_none], self.organization_login_list)
-        if self.quota_reset_date is not None:
-            result["quota_reset_date"] = from_union([from_str, from_none], self.quota_reset_date)
-        if self.quota_reset_date_utc is not None:
-            result["quota_reset_date_utc"] = from_union([from_str, from_none], self.quota_reset_date_utc)
-        if self.quota_snapshots is not None:
-            result["quota_snapshots"] = from_union([lambda x: from_dict(lambda x: from_union([lambda x: to_class(CopilotUserResponseQuotaSnapshots, x), from_none], x), x), from_none], self.quota_snapshots)
-        if self.restricted_telemetry is not None:
-            result["restricted_telemetry"] = from_union([from_bool, from_none], self.restricted_telemetry)
-        if self.token_based_billing is not None:
-            result["token_based_billing"] = from_union([from_bool, from_none], self.token_based_billing)
         return result
 
 @dataclass
@@ -10068,53 +5590,6 @@ class PermissionDecisionApproveForSessionApprovalExtensionPermissionAccess:
         return result
 
 @dataclass
-class UserToolSessionApprovalExtensionManagement:
-    """Schema for the `UserToolSessionApprovalExtensionManagement` type."""
-
-    kind: PermissionDecisionApproveForLocationApprovalExtensionManagementKind
-    """Extension management approval kind"""
-
-    operation: str | None = None
-    """Optional operation identifier"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'UserToolSessionApprovalExtensionManagement':
-        assert isinstance(obj, dict)
-        kind = PermissionDecisionApproveForLocationApprovalExtensionManagementKind(obj.get("kind"))
-        operation = from_union([from_str, from_none], obj.get("operation"))
-        return UserToolSessionApprovalExtensionManagement(kind, operation)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalExtensionManagementKind, self.kind)
-        if self.operation is not None:
-            result["operation"] = from_union([from_str, from_none], self.operation)
-        return result
-
-@dataclass
-class UserToolSessionApprovalExtensionPermissionAccess:
-    """Schema for the `UserToolSessionApprovalExtensionPermissionAccess` type."""
-
-    extension_name: str
-    """Extension name"""
-
-    kind: PermissionDecisionApproveForLocationApprovalExtensionPermissionAccessKind
-    """Extension permission access approval kind"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'UserToolSessionApprovalExtensionPermissionAccess':
-        assert isinstance(obj, dict)
-        extension_name = from_str(obj.get("extensionName"))
-        kind = PermissionDecisionApproveForLocationApprovalExtensionPermissionAccessKind(obj.get("kind"))
-        return UserToolSessionApprovalExtensionPermissionAccess(extension_name, kind)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["extensionName"] = from_str(self.extension_name)
-        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalExtensionPermissionAccessKind, self.kind)
-        return result
-
-@dataclass
 class ExternalToolTextResultForLlmContent:
     """A content block within a tool result, which may be text, terminal output, image, audio,
     or a resource
@@ -10142,7 +5617,7 @@ class ExternalToolTextResultForLlmContent:
     cwd: str | None = None
     """Working directory where the command was executed"""
 
-    exit_code: int | None = None
+    exit_code: float | None = None
     """Process exit code, if the command has completed"""
 
     data: str | None = None
@@ -10166,7 +5641,7 @@ class ExternalToolTextResultForLlmContent:
     name: str | None = None
     """Resource name identifier"""
 
-    size: int | None = None
+    size: float | None = None
     """Size of the resource in bytes"""
 
     title: str | None = None
@@ -10184,13 +5659,13 @@ class ExternalToolTextResultForLlmContent:
         type = ExternalToolTextResultForLlmContentType(obj.get("type"))
         text = from_union([from_str, from_none], obj.get("text"))
         cwd = from_union([from_str, from_none], obj.get("cwd"))
-        exit_code = from_union([from_int, from_none], obj.get("exitCode"))
+        exit_code = from_union([from_float, from_none], obj.get("exitCode"))
         data = from_union([from_str, from_none], obj.get("data"))
         mime_type = from_union([from_str, from_none], obj.get("mimeType"))
         description = from_union([from_str, from_none], obj.get("description"))
         icons = from_union([lambda x: from_list(ExternalToolTextResultForLlmContentResourceLinkIcon.from_dict, x), from_none], obj.get("icons"))
         name = from_union([from_str, from_none], obj.get("name"))
-        size = from_union([from_int, from_none], obj.get("size"))
+        size = from_union([from_float, from_none], obj.get("size"))
         title = from_union([from_str, from_none], obj.get("title"))
         uri = from_union([from_str, from_none], obj.get("uri"))
         resource = from_union([(lambda x: from_union([EmbeddedTextResourceContents.from_dict, EmbeddedBlobResourceContents.from_dict], x)), from_none], obj.get("resource"))
@@ -10204,7 +5679,7 @@ class ExternalToolTextResultForLlmContent:
         if self.cwd is not None:
             result["cwd"] = from_union([from_str, from_none], self.cwd)
         if self.exit_code is not None:
-            result["exitCode"] = from_union([from_int, from_none], self.exit_code)
+            result["exitCode"] = from_union([to_float, from_none], self.exit_code)
         if self.data is not None:
             result["data"] = from_union([from_str, from_none], self.data)
         if self.mime_type is not None:
@@ -10216,7 +5691,7 @@ class ExternalToolTextResultForLlmContent:
         if self.name is not None:
             result["name"] = from_union([from_str, from_none], self.name)
         if self.size is not None:
-            result["size"] = from_union([from_int, from_none], self.size)
+            result["size"] = from_union([to_float, from_none], self.size)
         if self.title is not None:
             result["title"] = from_union([from_str, from_none], self.title)
         if self.uri is not None:
@@ -10247,7 +5722,7 @@ class ExternalToolTextResultForLlmContentResourceLink:
     mime_type: str | None = None
     """MIME type of the resource content"""
 
-    size: int | None = None
+    size: float | None = None
     """Size of the resource in bytes"""
 
     title: str | None = None
@@ -10262,7 +5737,7 @@ class ExternalToolTextResultForLlmContentResourceLink:
         description = from_union([from_str, from_none], obj.get("description"))
         icons = from_union([lambda x: from_list(ExternalToolTextResultForLlmContentResourceLinkIcon.from_dict, x), from_none], obj.get("icons"))
         mime_type = from_union([from_str, from_none], obj.get("mimeType"))
-        size = from_union([from_int, from_none], obj.get("size"))
+        size = from_union([from_float, from_none], obj.get("size"))
         title = from_union([from_str, from_none], obj.get("title"))
         return ExternalToolTextResultForLlmContentResourceLink(name, type, uri, description, icons, mime_type, size, title)
 
@@ -10278,97 +5753,9 @@ class ExternalToolTextResultForLlmContentResourceLink:
         if self.mime_type is not None:
             result["mimeType"] = from_union([from_str, from_none], self.mime_type)
         if self.size is not None:
-            result["size"] = from_union([from_int, from_none], self.size)
+            result["size"] = from_union([to_float, from_none], self.size)
         if self.title is not None:
             result["title"] = from_union([from_str, from_none], self.title)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class InstalledPluginSource:
-    """Schema for the `InstalledPluginSourceGithub` type.
-
-    Schema for the `InstalledPluginSourceUrl` type.
-
-    Schema for the `InstalledPluginSourceLocal` type.
-    """
-    source: PurpleSource
-    """Constant value. Always "github".
-
-    Constant value. Always "url".
-
-    Constant value. Always "local".
-    """
-    path: str | None = None
-    ref: str | None = None
-    repo: str | None = None
-    url: str | None = None
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'InstalledPluginSource':
-        assert isinstance(obj, dict)
-        source = PurpleSource(obj.get("source"))
-        path = from_union([from_str, from_none], obj.get("path"))
-        ref = from_union([from_str, from_none], obj.get("ref"))
-        repo = from_union([from_str, from_none], obj.get("repo"))
-        url = from_union([from_str, from_none], obj.get("url"))
-        return InstalledPluginSource(source, path, ref, repo, url)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["source"] = to_enum(PurpleSource, self.source)
-        if self.path is not None:
-            result["path"] = from_union([from_str, from_none], self.path)
-        if self.ref is not None:
-            result["ref"] = from_union([from_str, from_none], self.ref)
-        if self.repo is not None:
-            result["repo"] = from_union([from_str, from_none], self.repo)
-        if self.url is not None:
-            result["url"] = from_union([from_str, from_none], self.url)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionInstalledPluginSource:
-    """Schema for the `SessionInstalledPluginSourceGithub` type.
-
-    Schema for the `SessionInstalledPluginSourceUrl` type.
-
-    Schema for the `SessionInstalledPluginSourceLocal` type.
-    """
-    source: PurpleSource
-    """Constant value. Always "github".
-
-    Constant value. Always "url".
-
-    Constant value. Always "local".
-    """
-    path: str | None = None
-    ref: str | None = None
-    repo: str | None = None
-    url: str | None = None
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionInstalledPluginSource':
-        assert isinstance(obj, dict)
-        source = PurpleSource(obj.get("source"))
-        path = from_union([from_str, from_none], obj.get("path"))
-        ref = from_union([from_str, from_none], obj.get("ref"))
-        repo = from_union([from_str, from_none], obj.get("repo"))
-        url = from_union([from_str, from_none], obj.get("url"))
-        return SessionInstalledPluginSource(source, path, ref, repo, url)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["source"] = to_enum(PurpleSource, self.source)
-        if self.path is not None:
-            result["path"] = from_union([from_str, from_none], self.path)
-        if self.ref is not None:
-            result["ref"] = from_union([from_str, from_none], self.ref)
-        if self.repo is not None:
-            result["repo"] = from_union([from_str, from_none], self.repo)
-        if self.url is not None:
-            result["url"] = from_union([from_str, from_none], self.url)
         return result
 
 @dataclass
@@ -10453,265 +5840,6 @@ class MCPConfigUpdateRequest:
         result["name"] = from_str(self.name)
         return result
 
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class MetadataRecordContextChangeRequest:
-    """Updated working-directory/git context to record on the session."""
-
-    context: SessionWorkingDirectoryContext
-    """Updated working directory and git context. Emitted as the new payload of
-    `session.context_changed`.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'MetadataRecordContextChangeRequest':
-        assert isinstance(obj, dict)
-        context = SessionWorkingDirectoryContext.from_dict(obj.get("context"))
-        return MetadataRecordContextChangeRequest(context)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["context"] = to_class(SessionWorkingDirectoryContext, self.context)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionMetadata:
-    """Schema for the `SessionMetadata` type."""
-
-    is_remote: bool
-    """True for remote (GitHub) sessions; false for local"""
-
-    modified_time: str
-    """Last-modified time of the session's persisted state, as ISO 8601"""
-
-    session_id: str
-    """Stable session identifier"""
-
-    start_time: str
-    """Session creation time as an ISO 8601 timestamp"""
-
-    context: SessionContext | None = None
-    """Schema for the `SessionContext` type."""
-
-    mc_task_id: str | None = None
-    """GitHub task ID, when this local session is bound to one. Only present for local sessions
-    exported to remote control.
-    """
-    name: str | None = None
-    """Optional human-friendly name set via /rename"""
-
-    summary: str | None = None
-    """Short summary of the session, when one has been derived"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionMetadata':
-        assert isinstance(obj, dict)
-        is_remote = from_bool(obj.get("isRemote"))
-        modified_time = from_str(obj.get("modifiedTime"))
-        session_id = from_str(obj.get("sessionId"))
-        start_time = from_str(obj.get("startTime"))
-        context = from_union([SessionContext.from_dict, from_none], obj.get("context"))
-        mc_task_id = from_union([from_str, from_none], obj.get("mcTaskId"))
-        name = from_union([from_str, from_none], obj.get("name"))
-        summary = from_union([from_str, from_none], obj.get("summary"))
-        return SessionMetadata(is_remote, modified_time, session_id, start_time, context, mc_task_id, name, summary)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["isRemote"] = from_bool(self.is_remote)
-        result["modifiedTime"] = from_str(self.modified_time)
-        result["sessionId"] = from_str(self.session_id)
-        result["startTime"] = from_str(self.start_time)
-        if self.context is not None:
-            result["context"] = from_union([lambda x: to_class(SessionContext, x), from_none], self.context)
-        if self.mc_task_id is not None:
-            result["mcTaskId"] = from_union([from_str, from_none], self.mc_task_id)
-        if self.name is not None:
-            result["name"] = from_union([from_str, from_none], self.name)
-        if self.summary is not None:
-            result["summary"] = from_union([from_str, from_none], self.summary)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsGetLastForContextRequest:
-    """Optional working-directory context used to score session relevance."""
-
-    context: SessionContext | None = None
-    """Optional working-directory context used to score session relevance. When omitted the
-    most-recently-modified session wins.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsGetLastForContextRequest':
-        assert isinstance(obj, dict)
-        context = from_union([SessionContext.from_dict, from_none], obj.get("context"))
-        return SessionsGetLastForContextRequest(context)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.context is not None:
-            result["context"] = from_union([lambda x: to_class(SessionContext, x), from_none], self.context)
-        return result
-
-@dataclass
-class PermissionPathsConfig:
-    """If specified, replaces the session's path-permission policy. The runtime constructs the
-    appropriate PathManager based on these inputs (rooted at the session's working
-    directory). Omit to leave the current path policy unchanged.
-    """
-    additional_directories: list[str] | None = None
-    """Additional directories to allow tool access to (in addition to the session's working
-    directory). When `unrestricted` is true, these are still pre-populated on the
-    UnrestrictedPathManager so they remain visible via getDirectories() (e.g. for @-mention
-    completion).
-    """
-    include_temp_directory: bool | None = None
-    """Whether to include the system temp directory in the allowed list (defaults to true).
-    Ignored when `unrestricted` is true.
-    """
-    unrestricted: bool | None = None
-    """If true, the runtime allows access to all paths without prompting. Equivalent to
-    constructing an UnrestrictedPathManager.
-    """
-    workspace_path: str | None = None
-    """Workspace root path (special-cased to be allowed even before the directory exists).
-    Ignored when `unrestricted` is true.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionPathsConfig':
-        assert isinstance(obj, dict)
-        additional_directories = from_union([lambda x: from_list(from_str, x), from_none], obj.get("additionalDirectories"))
-        include_temp_directory = from_union([from_bool, from_none], obj.get("includeTempDirectory"))
-        unrestricted = from_union([from_bool, from_none], obj.get("unrestricted"))
-        workspace_path = from_union([from_str, from_none], obj.get("workspacePath"))
-        return PermissionPathsConfig(additional_directories, include_temp_directory, unrestricted, workspace_path)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.additional_directories is not None:
-            result["additionalDirectories"] = from_union([lambda x: from_list(from_str, x), from_none], self.additional_directories)
-        if self.include_temp_directory is not None:
-            result["includeTempDirectory"] = from_union([from_bool, from_none], self.include_temp_directory)
-        if self.unrestricted is not None:
-            result["unrestricted"] = from_union([from_bool, from_none], self.unrestricted)
-        if self.workspace_path is not None:
-            result["workspacePath"] = from_union([from_str, from_none], self.workspace_path)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class WorkspaceSummary:
-    """Public-facing projection of workspace metadata for SDK / TUI consumers"""
-
-    id: UUID
-    """Workspace identifier (1:1 with sessionId)"""
-
-    branch: str | None = None
-    """Branch checked out at session start, if any"""
-
-    created_at: datetime | None = None
-    """ISO 8601 timestamp when the workspace was created"""
-
-    cwd: str | None = None
-    """Current working directory at session start"""
-
-    git_root: str | None = None
-    """Resolved git root for cwd, if any"""
-
-    host_type: SessionContextHostType | None = None
-    """Repository host type, if known"""
-
-    name: str | None = None
-    """Display name for the session, if set"""
-
-    repository: str | None = None
-    """Repository identifier in 'owner/repo' or 'org/project/repo' format, if any"""
-
-    updated_at: datetime | None = None
-    """ISO 8601 timestamp when the workspace was last updated"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'WorkspaceSummary':
-        assert isinstance(obj, dict)
-        id = UUID(obj.get("id"))
-        branch = from_union([from_str, from_none], obj.get("branch"))
-        created_at = from_union([from_datetime, from_none], obj.get("created_at"))
-        cwd = from_union([from_str, from_none], obj.get("cwd"))
-        git_root = from_union([from_str, from_none], obj.get("git_root"))
-        host_type = from_union([SessionContextHostType, from_none], obj.get("host_type"))
-        name = from_union([from_str, from_none], obj.get("name"))
-        repository = from_union([from_str, from_none], obj.get("repository"))
-        updated_at = from_union([from_datetime, from_none], obj.get("updated_at"))
-        return WorkspaceSummary(id, branch, created_at, cwd, git_root, host_type, name, repository, updated_at)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["id"] = str(self.id)
-        if self.branch is not None:
-            result["branch"] = from_union([from_str, from_none], self.branch)
-        if self.created_at is not None:
-            result["created_at"] = from_union([lambda x: x.isoformat(), from_none], self.created_at)
-        if self.cwd is not None:
-            result["cwd"] = from_union([from_str, from_none], self.cwd)
-        if self.git_root is not None:
-            result["git_root"] = from_union([from_str, from_none], self.git_root)
-        if self.host_type is not None:
-            result["host_type"] = from_union([lambda x: to_enum(SessionContextHostType, x), from_none], self.host_type)
-        if self.name is not None:
-            result["name"] = from_union([from_str, from_none], self.name)
-        if self.repository is not None:
-            result["repository"] = from_union([from_str, from_none], self.repository)
-        if self.updated_at is not None:
-            result["updated_at"] = from_union([lambda x: x.isoformat(), from_none], self.updated_at)
-        return result
-
-@dataclass
-class WorkspacesGetWorkspaceResult:
-    """Current workspace metadata for the session, including its absolute filesystem path when
-    available.
-    """
-    path: str | None = None
-    """Absolute filesystem path to the workspace directory. Omitted when the session has no
-    workspace (e.g. remote sessions).
-    """
-    workspace: Workspace | None = None
-    """Current workspace metadata, or null if not available"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'WorkspacesGetWorkspaceResult':
-        assert isinstance(obj, dict)
-        path = from_union([from_str, from_none], obj.get("path"))
-        workspace = from_union([Workspace.from_dict, from_none], obj.get("workspace"))
-        return WorkspacesGetWorkspaceResult(path, workspace)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.path is not None:
-            result["path"] = from_union([from_str, from_none], self.path)
-        result["workspace"] = from_union([lambda x: to_class(Workspace, x), from_none], self.workspace)
-        return result
-
-@dataclass
-class WorkspacesListCheckpointsResult:
-    """Workspace checkpoints in chronological order; empty when the workspace is not enabled."""
-
-    checkpoints: list[WorkspacesCheckpoints]
-    """Workspace checkpoints in chronological order. Empty when workspace is not enabled."""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'WorkspacesListCheckpointsResult':
-        assert isinstance(obj, dict)
-        checkpoints = from_list(WorkspacesCheckpoints.from_dict, obj.get("checkpoints"))
-        return WorkspacesListCheckpointsResult(checkpoints)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["checkpoints"] = from_list(lambda x: to_class(WorkspacesCheckpoints, x), self.checkpoints)
-        return result
-
 @dataclass
 class ModelCapabilitiesOverride:
     """Override individual model capabilities resolved by the runtime"""
@@ -10738,68 +5866,14 @@ class ModelCapabilitiesOverride:
         return result
 
 @dataclass
-class PermissionsConfigureAdditionalContentExclusionPolicy:
-    """Schema for the `PermissionsConfigureAdditionalContentExclusionPolicy` type."""
-
-    last_updated_at: float | str
-    rules: list[PermissionsConfigureAdditionalContentExclusionPolicyRule]
-    scope: PermissionsConfigureAdditionalContentExclusionPolicyScope
-    """Allowed values for the `PermissionsConfigureAdditionalContentExclusionPolicyScope`
-    enumeration.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionsConfigureAdditionalContentExclusionPolicy':
-        assert isinstance(obj, dict)
-        last_updated_at = from_union([from_float, from_str], obj.get("last_updated_at"))
-        rules = from_list(PermissionsConfigureAdditionalContentExclusionPolicyRule.from_dict, obj.get("rules"))
-        scope = PermissionsConfigureAdditionalContentExclusionPolicyScope(obj.get("scope"))
-        return PermissionsConfigureAdditionalContentExclusionPolicy(last_updated_at, rules, scope)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["last_updated_at"] = from_union([to_float, from_str], self.last_updated_at)
-        result["rules"] = from_list(lambda x: to_class(PermissionsConfigureAdditionalContentExclusionPolicyRule, x), self.rules)
-        result["scope"] = to_enum(PermissionsConfigureAdditionalContentExclusionPolicyScope, self.scope)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class QueuePendingItemsResult:
-    """Snapshot of the session's pending queued items and immediate-steering messages."""
-
-    items: list[QueuePendingItems]
-    """Pending queued items in submission order. Includes user messages, queued slash commands,
-    and queued model changes; omits internal system items.
-    """
-    steering_messages: list[str]
-    """Display text for messages currently in the immediate steering queue (interjections sent
-    during a running turn).
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'QueuePendingItemsResult':
-        assert isinstance(obj, dict)
-        items = from_list(QueuePendingItems.from_dict, obj.get("items"))
-        steering_messages = from_list(from_str, obj.get("steeringMessages"))
-        return QueuePendingItemsResult(items, steering_messages)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["items"] = from_list(lambda x: to_class(QueuePendingItems, x), self.items)
-        result["steeringMessages"] = from_list(from_str, self.steering_messages)
-        return result
-
-@dataclass
 class CommandsRespondToQueuedCommandRequest:
-    """Queued-command request ID and the result indicating whether the host executed it (and
-    whether to stop processing further queued commands).
-    """
+    """Queued command request ID and the result indicating whether the client handled it."""
+
     request_id: str
-    """Request ID from the `command.queued` event the host is responding to."""
+    """Request ID from the queued command event"""
 
     result: QueuedCommandResult
-    """Result of the queued command execution."""
+    """Result of the queued command execution"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'CommandsRespondToQueuedCommandRequest':
@@ -10812,154 +5886,6 @@ class CommandsRespondToQueuedCommandRequest:
         result: dict = {}
         result["requestId"] = from_str(self.request_id)
         result["result"] = to_class(QueuedCommandResult, self.result)
-        return result
-
-@dataclass
-class SendAttachment:
-    """A user message attachment — a file, directory, code selection, blob, or GitHub reference
-
-    File attachment
-
-    Directory attachment
-
-    Code selection attachment from an editor
-
-    GitHub issue, pull request, or discussion reference
-
-    Blob attachment with inline base64-encoded data
-    """
-    type: SendAttachmentType
-    """Attachment type discriminator"""
-
-    display_name: str | None = None
-    """User-facing display name for the attachment
-
-    User-facing display name for the selection
-    """
-    line_range: SendAttachmentFileLineRange | None = None
-    """Optional line range to scope the attachment to a specific section of the file"""
-
-    path: str | None = None
-    """Absolute file path
-
-    Absolute directory path
-    """
-    file_path: str | None = None
-    """Absolute path to the file containing the selection"""
-
-    selection: SendAttachmentSelectionDetails | None = None
-    """Position range of the selection within the file"""
-
-    text: str | None = None
-    """The selected text content"""
-
-    number: int | None = None
-    """Issue, pull request, or discussion number"""
-
-    reference_type: SendAttachmentGithubReferenceTypeEnum | None = None
-    """Type of GitHub reference"""
-
-    state: str | None = None
-    """Current state of the referenced item (e.g., open, closed, merged)"""
-
-    title: str | None = None
-    """Title of the referenced item"""
-
-    url: str | None = None
-    """URL to the referenced item on GitHub"""
-
-    data: str | None = None
-    """Base64-encoded content"""
-
-    mime_type: str | None = None
-    """MIME type of the inline data"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SendAttachment':
-        assert isinstance(obj, dict)
-        type = SendAttachmentType(obj.get("type"))
-        display_name = from_union([from_str, from_none], obj.get("displayName"))
-        line_range = from_union([SendAttachmentFileLineRange.from_dict, from_none], obj.get("lineRange"))
-        path = from_union([from_str, from_none], obj.get("path"))
-        file_path = from_union([from_str, from_none], obj.get("filePath"))
-        selection = from_union([SendAttachmentSelectionDetails.from_dict, from_none], obj.get("selection"))
-        text = from_union([from_str, from_none], obj.get("text"))
-        number = from_union([from_int, from_none], obj.get("number"))
-        reference_type = from_union([SendAttachmentGithubReferenceTypeEnum, from_none], obj.get("referenceType"))
-        state = from_union([from_str, from_none], obj.get("state"))
-        title = from_union([from_str, from_none], obj.get("title"))
-        url = from_union([from_str, from_none], obj.get("url"))
-        data = from_union([from_str, from_none], obj.get("data"))
-        mime_type = from_union([from_str, from_none], obj.get("mimeType"))
-        return SendAttachment(type, display_name, line_range, path, file_path, selection, text, number, reference_type, state, title, url, data, mime_type)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["type"] = to_enum(SendAttachmentType, self.type)
-        if self.display_name is not None:
-            result["displayName"] = from_union([from_str, from_none], self.display_name)
-        if self.line_range is not None:
-            result["lineRange"] = from_union([lambda x: to_class(SendAttachmentFileLineRange, x), from_none], self.line_range)
-        if self.path is not None:
-            result["path"] = from_union([from_str, from_none], self.path)
-        if self.file_path is not None:
-            result["filePath"] = from_union([from_str, from_none], self.file_path)
-        if self.selection is not None:
-            result["selection"] = from_union([lambda x: to_class(SendAttachmentSelectionDetails, x), from_none], self.selection)
-        if self.text is not None:
-            result["text"] = from_union([from_str, from_none], self.text)
-        if self.number is not None:
-            result["number"] = from_union([from_int, from_none], self.number)
-        if self.reference_type is not None:
-            result["referenceType"] = from_union([lambda x: to_enum(SendAttachmentGithubReferenceTypeEnum, x), from_none], self.reference_type)
-        if self.state is not None:
-            result["state"] = from_union([from_str, from_none], self.state)
-        if self.title is not None:
-            result["title"] = from_union([from_str, from_none], self.title)
-        if self.url is not None:
-            result["url"] = from_union([from_str, from_none], self.url)
-        if self.data is not None:
-            result["data"] = from_union([from_str, from_none], self.data)
-        if self.mime_type is not None:
-            result["mimeType"] = from_union([from_str, from_none], self.mime_type)
-        return result
-
-@dataclass
-class SendAttachmentSelection:
-    """Code selection attachment from an editor"""
-
-    display_name: str
-    """User-facing display name for the selection"""
-
-    file_path: str
-    """Absolute path to the file containing the selection"""
-
-    selection: SendAttachmentSelectionDetails
-    """Position range of the selection within the file"""
-
-    text: str
-    """The selected text content"""
-
-    type: SendAttachmentSelectionType
-    """Attachment type discriminator"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SendAttachmentSelection':
-        assert isinstance(obj, dict)
-        display_name = from_str(obj.get("displayName"))
-        file_path = from_str(obj.get("filePath"))
-        selection = SendAttachmentSelectionDetails.from_dict(obj.get("selection"))
-        text = from_str(obj.get("text"))
-        type = SendAttachmentSelectionType(obj.get("type"))
-        return SendAttachmentSelection(display_name, file_path, selection, text, type)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["displayName"] = from_str(self.display_name)
-        result["filePath"] = from_str(self.file_path)
-        result["selection"] = to_class(SendAttachmentSelectionDetails, self.selection)
-        result["text"] = from_str(self.text)
-        result["type"] = to_enum(SendAttachmentSelectionType, self.type)
         return result
 
 @dataclass
@@ -11027,8 +5953,8 @@ class SessionFSSqliteQueryResult:
     error: SessionFSError | None = None
     """Describes a filesystem error."""
 
-    last_insert_rowid: int | None = None
-    """SQLite last_insert_rowid() value for INSERT."""
+    last_insert_rowid: float | None = None
+    """Last inserted row ID (for INSERT)"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'SessionFSSqliteQueryResult':
@@ -11037,7 +5963,7 @@ class SessionFSSqliteQueryResult:
         rows = from_list(lambda x: from_dict(lambda x: x, x), obj.get("rows"))
         rows_affected = from_int(obj.get("rowsAffected"))
         error = from_union([SessionFSError.from_dict, from_none], obj.get("error"))
-        last_insert_rowid = from_union([from_int, from_none], obj.get("lastInsertRowid"))
+        last_insert_rowid = from_union([from_float, from_none], obj.get("lastInsertRowid"))
         return SessionFSSqliteQueryResult(columns, rows, rows_affected, error, last_insert_rowid)
 
     def to_dict(self) -> dict:
@@ -11048,7 +5974,7 @@ class SessionFSSqliteQueryResult:
         if self.error is not None:
             result["error"] = from_union([lambda x: to_class(SessionFSError, x), from_none], self.error)
         if self.last_insert_rowid is not None:
-            result["lastInsertRowid"] = from_union([from_int, from_none], self.last_insert_rowid)
+            result["lastInsertRowid"] = from_union([to_float, from_none], self.last_insert_rowid)
         return result
 
 @dataclass
@@ -11118,83 +6044,6 @@ class SessionFSReaddirWithTypesResult:
         result["entries"] = from_list(lambda x: to_class(SessionFSReaddirWithTypesEntry, x), self.entries)
         if self.error is not None:
             result["error"] = from_union([lambda x: to_class(SessionFSError, x), from_none], self.error)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class AgentGetCurrentResult:
-    """The currently selected custom agent, or null when using the default agent."""
-
-    agent: AgentInfo | None = None
-    """Currently selected custom agent, or null if using the default agent"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'AgentGetCurrentResult':
-        assert isinstance(obj, dict)
-        agent = from_union([AgentInfo.from_dict, from_none], obj.get("agent"))
-        return AgentGetCurrentResult(agent)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.agent is not None:
-            result["agent"] = from_union([lambda x: to_class(AgentInfo, x), from_none], self.agent)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class AgentList:
-    """Custom agents available to the session."""
-
-    agents: list[AgentInfo]
-    """Available custom agents"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'AgentList':
-        assert isinstance(obj, dict)
-        agents = from_list(AgentInfo.from_dict, obj.get("agents"))
-        return AgentList(agents)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["agents"] = from_list(lambda x: to_class(AgentInfo, x), self.agents)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class AgentReloadResult:
-    """Custom agents available to the session after reloading definitions from disk."""
-
-    agents: list[AgentInfo]
-    """Reloaded custom agents"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'AgentReloadResult':
-        assert isinstance(obj, dict)
-        agents = from_list(AgentInfo.from_dict, obj.get("agents"))
-        return AgentReloadResult(agents)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["agents"] = from_list(lambda x: to_class(AgentInfo, x), self.agents)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class AgentSelectResult:
-    """The newly selected custom agent."""
-
-    agent: AgentInfo
-    """The newly selected custom agent"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'AgentSelectResult':
-        assert isinstance(obj, dict)
-        agent = AgentInfo.from_dict(obj.get("agent"))
-        return AgentSelectResult(agent)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["agent"] = to_class(AgentInfo, self.agent)
         return result
 
 @dataclass
@@ -11275,28 +6124,6 @@ class SlashCommandInvocationResult:
             result["message"] = from_union([from_str, from_none], self.message)
         return result
 
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class TasksGetProgressResult:
-    """Progress information for the task, or null when no task with that ID is tracked."""
-
-    progress: TaskProgressClass | None = None
-    """Progress information for the task, discriminated by type. Returns null when no task with
-    this ID is currently tracked.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'TasksGetProgressResult':
-        assert isinstance(obj, dict)
-        progress = from_union([TaskProgressClass.from_dict, from_none], obj.get("progress"))
-        return TasksGetProgressResult(progress)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.progress is not None:
-            result["progress"] = from_union([lambda x: to_class(TaskProgressClass, x), from_none], self.progress)
-        return result
-
 @dataclass
 class UIElicitationArrayAnyOfField:
     """Multi-select string field where each option pairs a value with a display label."""
@@ -11313,10 +6140,10 @@ class UIElicitationArrayAnyOfField:
     description: str | None = None
     """Help text describing the field."""
 
-    max_items: int | None = None
+    max_items: float | None = None
     """Maximum number of items the user may select."""
 
-    min_items: int | None = None
+    min_items: float | None = None
     """Minimum number of items the user must select."""
 
     title: str | None = None
@@ -11329,8 +6156,8 @@ class UIElicitationArrayAnyOfField:
         type = UIElicitationArrayAnyOfFieldType(obj.get("type"))
         default = from_union([lambda x: from_list(from_str, x), from_none], obj.get("default"))
         description = from_union([from_str, from_none], obj.get("description"))
-        max_items = from_union([from_int, from_none], obj.get("maxItems"))
-        min_items = from_union([from_int, from_none], obj.get("minItems"))
+        max_items = from_union([from_float, from_none], obj.get("maxItems"))
+        min_items = from_union([from_float, from_none], obj.get("minItems"))
         title = from_union([from_str, from_none], obj.get("title"))
         return UIElicitationArrayAnyOfField(items, type, default, description, max_items, min_items, title)
 
@@ -11343,9 +6170,9 @@ class UIElicitationArrayAnyOfField:
         if self.description is not None:
             result["description"] = from_union([from_str, from_none], self.description)
         if self.max_items is not None:
-            result["maxItems"] = from_union([from_int, from_none], self.max_items)
+            result["maxItems"] = from_union([to_float, from_none], self.max_items)
         if self.min_items is not None:
-            result["minItems"] = from_union([from_int, from_none], self.min_items)
+            result["minItems"] = from_union([to_float, from_none], self.min_items)
         if self.title is not None:
             result["title"] = from_union([from_str, from_none], self.title)
         return result
@@ -11366,10 +6193,10 @@ class UIElicitationArrayEnumField:
     description: str | None = None
     """Help text describing the field."""
 
-    max_items: int | None = None
+    max_items: float | None = None
     """Maximum number of items the user may select."""
 
-    min_items: int | None = None
+    min_items: float | None = None
     """Minimum number of items the user must select."""
 
     title: str | None = None
@@ -11382,8 +6209,8 @@ class UIElicitationArrayEnumField:
         type = UIElicitationArrayAnyOfFieldType(obj.get("type"))
         default = from_union([lambda x: from_list(from_str, x), from_none], obj.get("default"))
         description = from_union([from_str, from_none], obj.get("description"))
-        max_items = from_union([from_int, from_none], obj.get("maxItems"))
-        min_items = from_union([from_int, from_none], obj.get("minItems"))
+        max_items = from_union([from_float, from_none], obj.get("maxItems"))
+        min_items = from_union([from_float, from_none], obj.get("minItems"))
         title = from_union([from_str, from_none], obj.get("title"))
         return UIElicitationArrayEnumField(items, type, default, description, max_items, min_items, title)
 
@@ -11396,9 +6223,9 @@ class UIElicitationArrayEnumField:
         if self.description is not None:
             result["description"] = from_union([from_str, from_none], self.description)
         if self.max_items is not None:
-            result["maxItems"] = from_union([from_int, from_none], self.max_items)
+            result["maxItems"] = from_union([to_float, from_none], self.max_items)
         if self.min_items is not None:
-            result["minItems"] = from_union([from_int, from_none], self.min_items)
+            result["minItems"] = from_union([to_float, from_none], self.min_items)
         if self.title is not None:
             result["title"] = from_union([from_str, from_none], self.title)
         return result
@@ -11455,19 +6282,19 @@ class UIElicitationSchemaProperty:
     items: UIElicitationArrayFieldItems | None = None
     """Schema applied to each item in the array."""
 
-    max_items: int | None = None
+    max_items: float | None = None
     """Maximum number of items the user may select."""
 
-    min_items: int | None = None
+    min_items: float | None = None
     """Minimum number of items the user must select."""
 
     format: UIElicitationSchemaPropertyStringFormat | None = None
     """Optional format hint that constrains the accepted input."""
 
-    max_length: int | None = None
+    max_length: float | None = None
     """Maximum number of characters allowed."""
 
-    min_length: int | None = None
+    min_length: float | None = None
     """Minimum number of characters required."""
 
     maximum: float | None = None
@@ -11487,11 +6314,11 @@ class UIElicitationSchemaProperty:
         title = from_union([from_str, from_none], obj.get("title"))
         one_of = from_union([lambda x: from_list(UIElicitationStringOneOfFieldOneOf.from_dict, x), from_none], obj.get("oneOf"))
         items = from_union([UIElicitationArrayFieldItems.from_dict, from_none], obj.get("items"))
-        max_items = from_union([from_int, from_none], obj.get("maxItems"))
-        min_items = from_union([from_int, from_none], obj.get("minItems"))
+        max_items = from_union([from_float, from_none], obj.get("maxItems"))
+        min_items = from_union([from_float, from_none], obj.get("minItems"))
         format = from_union([UIElicitationSchemaPropertyStringFormat, from_none], obj.get("format"))
-        max_length = from_union([from_int, from_none], obj.get("maxLength"))
-        min_length = from_union([from_int, from_none], obj.get("minLength"))
+        max_length = from_union([from_float, from_none], obj.get("maxLength"))
+        min_length = from_union([from_float, from_none], obj.get("minLength"))
         maximum = from_union([from_float, from_none], obj.get("maximum"))
         minimum = from_union([from_float, from_none], obj.get("minimum"))
         return UIElicitationSchemaProperty(type, default, description, enum, enum_names, title, one_of, items, max_items, min_items, format, max_length, min_length, maximum, minimum)
@@ -11514,15 +6341,15 @@ class UIElicitationSchemaProperty:
         if self.items is not None:
             result["items"] = from_union([lambda x: to_class(UIElicitationArrayFieldItems, x), from_none], self.items)
         if self.max_items is not None:
-            result["maxItems"] = from_union([from_int, from_none], self.max_items)
+            result["maxItems"] = from_union([to_float, from_none], self.max_items)
         if self.min_items is not None:
-            result["minItems"] = from_union([from_int, from_none], self.min_items)
+            result["minItems"] = from_union([to_float, from_none], self.min_items)
         if self.format is not None:
             result["format"] = from_union([lambda x: to_enum(UIElicitationSchemaPropertyStringFormat, x), from_none], self.format)
         if self.max_length is not None:
-            result["maxLength"] = from_union([from_int, from_none], self.max_length)
+            result["maxLength"] = from_union([to_float, from_none], self.max_length)
         if self.min_length is not None:
-            result["minLength"] = from_union([from_int, from_none], self.min_length)
+            result["minLength"] = from_union([to_float, from_none], self.min_length)
         if self.maximum is not None:
             result["maximum"] = from_union([to_float, from_none], self.maximum)
         if self.minimum is not None:
@@ -11553,29 +6380,6 @@ class UIHandlePendingElicitationRequest:
         result["result"] = to_class(UIElicitationResponse, self.result)
         return result
 
-@dataclass
-class UIHandlePendingExitPlanModeRequest:
-    """Request ID of a pending `exit_plan_mode.requested` event and the user's response."""
-
-    request_id: str
-    """The unique request ID from the exit_plan_mode.requested event"""
-
-    response: UIExitPlanModeResponse
-    """Schema for the `UIExitPlanModeResponse` type."""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'UIHandlePendingExitPlanModeRequest':
-        assert isinstance(obj, dict)
-        request_id = from_str(obj.get("requestId"))
-        response = UIExitPlanModeResponse.from_dict(obj.get("response"))
-        return UIHandlePendingExitPlanModeRequest(request_id, response)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["requestId"] = from_str(self.request_id)
-        result["response"] = to_class(UIExitPlanModeResponse, self.response)
-        return result
-
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
 class UsageGetMetricsResult:
@@ -11594,10 +6398,10 @@ class UsageGetMetricsResult:
     model_metrics: dict[str, UsageMetricsModelMetric]
     """Per-model token and request metrics, keyed by model identifier"""
 
-    session_start_time: datetime
-    """ISO 8601 timestamp when the session started"""
+    session_start_time: int
+    """Session start timestamp (epoch milliseconds)"""
 
-    total_api_duration_ms: int
+    total_api_duration_ms: float
     """Total time spent in model API calls (milliseconds)"""
 
     total_premium_request_cost: float
@@ -11623,8 +6427,8 @@ class UsageGetMetricsResult:
         last_call_input_tokens = from_int(obj.get("lastCallInputTokens"))
         last_call_output_tokens = from_int(obj.get("lastCallOutputTokens"))
         model_metrics = from_dict(UsageMetricsModelMetric.from_dict, obj.get("modelMetrics"))
-        session_start_time = from_datetime(obj.get("sessionStartTime"))
-        total_api_duration_ms = from_int(obj.get("totalApiDurationMs"))
+        session_start_time = from_int(obj.get("sessionStartTime"))
+        total_api_duration_ms = from_float(obj.get("totalApiDurationMs"))
         total_premium_request_cost = from_float(obj.get("totalPremiumRequestCost"))
         total_user_requests = from_int(obj.get("totalUserRequests"))
         current_model = from_union([from_str, from_none], obj.get("currentModel"))
@@ -11638,8 +6442,8 @@ class UsageGetMetricsResult:
         result["lastCallInputTokens"] = from_int(self.last_call_input_tokens)
         result["lastCallOutputTokens"] = from_int(self.last_call_output_tokens)
         result["modelMetrics"] = from_dict(lambda x: to_class(UsageMetricsModelMetric, x), self.model_metrics)
-        result["sessionStartTime"] = self.session_start_time.isoformat()
-        result["totalApiDurationMs"] = from_int(self.total_api_duration_ms)
+        result["sessionStartTime"] = from_int(self.session_start_time)
+        result["totalApiDurationMs"] = to_float(self.total_api_duration_ms)
         result["totalPremiumRequestCost"] = to_float(self.total_premium_request_cost)
         result["totalUserRequests"] = from_int(self.total_user_requests)
         if self.current_model is not None:
@@ -11648,6 +6452,24 @@ class UsageGetMetricsResult:
             result["tokenDetails"] = from_union([lambda x: from_dict(lambda x: to_class(UsageMetricsTokenDetail, x), x), from_none], self.token_details)
         if self.total_nano_aiu is not None:
             result["totalNanoAiu"] = from_union([from_int, from_none], self.total_nano_aiu)
+        return result
+
+@dataclass
+class WorkspacesGetWorkspaceResult:
+    """Current workspace metadata for the session, or null when not available."""
+
+    workspace: Workspace | None = None
+    """Current workspace metadata, or null if not available"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'WorkspacesGetWorkspaceResult':
+        assert isinstance(obj, dict)
+        workspace = from_union([Workspace.from_dict, from_none], obj.get("workspace"))
+        return WorkspacesGetWorkspaceResult(workspace)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["workspace"] = from_union([lambda x: to_class(Workspace, x), from_none], self.workspace)
         return result
 
 @dataclass
@@ -11669,283 +6491,8 @@ class CommandList:
         return result
 
 @dataclass
-class APIKeyAuthInfo:
-    """Schema for the `ApiKeyAuthInfo` type."""
-
-    api_key: str
-    """The API key. Treat as a secret."""
-
-    host: str
-    """Authentication host."""
-
-    type: APIKeyAuthInfoType
-    """API-key authentication for non-GitHub LLM providers (e.g. when running BYOM-style)."""
-
-    copilot_user: CopilotUserResponse | None = None
-    """Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the
-    GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this
-    verbatim and does not re-fetch when set.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'APIKeyAuthInfo':
-        assert isinstance(obj, dict)
-        api_key = from_str(obj.get("apiKey"))
-        host = from_str(obj.get("host"))
-        type = APIKeyAuthInfoType(obj.get("type"))
-        copilot_user = from_union([CopilotUserResponse.from_dict, from_none], obj.get("copilotUser"))
-        return APIKeyAuthInfo(api_key, host, type, copilot_user)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["apiKey"] = from_str(self.api_key)
-        result["host"] = from_str(self.host)
-        result["type"] = to_enum(APIKeyAuthInfoType, self.type)
-        if self.copilot_user is not None:
-            result["copilotUser"] = from_union([lambda x: to_class(CopilotUserResponse, x), from_none], self.copilot_user)
-        return result
-
-@dataclass
-class CopilotAPITokenAuthInfo:
-    """Schema for the `CopilotApiTokenAuthInfo` type."""
-
-    host: Host
-    """Authentication host (always the public GitHub host)."""
-
-    type: CopilotAPITokenAuthInfoType
-    """Direct Copilot API authentication via the `GITHUB_COPILOT_API_TOKEN` + `COPILOT_API_URL`
-    environment-variable pair. The token itself is read from the environment by the runtime,
-    not carried in this struct.
-    """
-    copilot_user: CopilotUserResponse | None = None
-    """Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the
-    GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this
-    verbatim and does not re-fetch when set.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'CopilotAPITokenAuthInfo':
-        assert isinstance(obj, dict)
-        host = Host(obj.get("host"))
-        type = CopilotAPITokenAuthInfoType(obj.get("type"))
-        copilot_user = from_union([CopilotUserResponse.from_dict, from_none], obj.get("copilotUser"))
-        return CopilotAPITokenAuthInfo(host, type, copilot_user)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["host"] = to_enum(Host, self.host)
-        result["type"] = to_enum(CopilotAPITokenAuthInfoType, self.type)
-        if self.copilot_user is not None:
-            result["copilotUser"] = from_union([lambda x: to_class(CopilotUserResponse, x), from_none], self.copilot_user)
-        return result
-
-@dataclass
-class EnvAuthInfo:
-    """Schema for the `EnvAuthInfo` type."""
-
-    env_var: str
-    """Name of the environment variable the token was sourced from."""
-
-    host: str
-    """Authentication host (e.g. https://github.com or a GHES host)."""
-
-    token: str
-    """The token value itself. Treat as a secret."""
-
-    type: EnvAuthInfoType
-    """Personal access token (PAT) or server-to-server token sourced from an environment
-    variable.
-    """
-    copilot_user: CopilotUserResponse | None = None
-    """Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the
-    GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this
-    verbatim and does not re-fetch when set.
-    """
-    login: str | None = None
-    """User login associated with the token. Undefined for server-to-server tokens (those
-    starting with `ghs_`).
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'EnvAuthInfo':
-        assert isinstance(obj, dict)
-        env_var = from_str(obj.get("envVar"))
-        host = from_str(obj.get("host"))
-        token = from_str(obj.get("token"))
-        type = EnvAuthInfoType(obj.get("type"))
-        copilot_user = from_union([CopilotUserResponse.from_dict, from_none], obj.get("copilotUser"))
-        login = from_union([from_str, from_none], obj.get("login"))
-        return EnvAuthInfo(env_var, host, token, type, copilot_user, login)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["envVar"] = from_str(self.env_var)
-        result["host"] = from_str(self.host)
-        result["token"] = from_str(self.token)
-        result["type"] = to_enum(EnvAuthInfoType, self.type)
-        if self.copilot_user is not None:
-            result["copilotUser"] = from_union([lambda x: to_class(CopilotUserResponse, x), from_none], self.copilot_user)
-        if self.login is not None:
-            result["login"] = from_union([from_str, from_none], self.login)
-        return result
-
-@dataclass
-class GhCLIAuthInfo:
-    """Schema for the `GhCliAuthInfo` type."""
-
-    host: str
-    """Authentication host."""
-
-    login: str
-    """User login as reported by `gh auth status`."""
-
-    token: str
-    """The token returned by `gh auth token`. Treat as a secret."""
-
-    type: GhCLIAuthInfoType
-    """Authentication via the `gh` CLI's saved credentials."""
-
-    copilot_user: CopilotUserResponse | None = None
-    """Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the
-    GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this
-    verbatim and does not re-fetch when set.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'GhCLIAuthInfo':
-        assert isinstance(obj, dict)
-        host = from_str(obj.get("host"))
-        login = from_str(obj.get("login"))
-        token = from_str(obj.get("token"))
-        type = GhCLIAuthInfoType(obj.get("type"))
-        copilot_user = from_union([CopilotUserResponse.from_dict, from_none], obj.get("copilotUser"))
-        return GhCLIAuthInfo(host, login, token, type, copilot_user)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["host"] = from_str(self.host)
-        result["login"] = from_str(self.login)
-        result["token"] = from_str(self.token)
-        result["type"] = to_enum(GhCLIAuthInfoType, self.type)
-        if self.copilot_user is not None:
-            result["copilotUser"] = from_union([lambda x: to_class(CopilotUserResponse, x), from_none], self.copilot_user)
-        return result
-
-@dataclass
-class HMACAuthInfo:
-    """Schema for the `HMACAuthInfo` type."""
-
-    hmac: str
-    """HMAC secret used to sign requests."""
-
-    host: Host
-    """Authentication host. HMAC auth always targets the public GitHub host."""
-
-    type: HMACAuthInfoType
-    """HMAC-based authentication used by GitHub-internal services."""
-
-    copilot_user: CopilotUserResponse | None = None
-    """Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the
-    GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this
-    verbatim and does not re-fetch when set.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'HMACAuthInfo':
-        assert isinstance(obj, dict)
-        hmac = from_str(obj.get("hmac"))
-        host = Host(obj.get("host"))
-        type = HMACAuthInfoType(obj.get("type"))
-        copilot_user = from_union([CopilotUserResponse.from_dict, from_none], obj.get("copilotUser"))
-        return HMACAuthInfo(hmac, host, type, copilot_user)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["hmac"] = from_str(self.hmac)
-        result["host"] = to_enum(Host, self.host)
-        result["type"] = to_enum(HMACAuthInfoType, self.type)
-        if self.copilot_user is not None:
-            result["copilotUser"] = from_union([lambda x: to_class(CopilotUserResponse, x), from_none], self.copilot_user)
-        return result
-
-@dataclass
-class TokenAuthInfo:
-    """Schema for the `TokenAuthInfo` type."""
-
-    host: str
-    """Authentication host."""
-
-    token: str
-    """The token value itself. Treat as a secret."""
-
-    type: TokenAuthInfoType
-    """SDK-side token authentication; the host configured the token directly via the SDK."""
-
-    copilot_user: CopilotUserResponse | None = None
-    """Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the
-    GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this
-    verbatim and does not re-fetch when set.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'TokenAuthInfo':
-        assert isinstance(obj, dict)
-        host = from_str(obj.get("host"))
-        token = from_str(obj.get("token"))
-        type = TokenAuthInfoType(obj.get("type"))
-        copilot_user = from_union([CopilotUserResponse.from_dict, from_none], obj.get("copilotUser"))
-        return TokenAuthInfo(host, token, type, copilot_user)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["host"] = from_str(self.host)
-        result["token"] = from_str(self.token)
-        result["type"] = to_enum(TokenAuthInfoType, self.type)
-        if self.copilot_user is not None:
-            result["copilotUser"] = from_union([lambda x: to_class(CopilotUserResponse, x), from_none], self.copilot_user)
-        return result
-
-@dataclass
-class UserAuthInfo:
-    """Schema for the `UserAuthInfo` type."""
-
-    host: str
-    """Authentication host."""
-
-    login: str
-    """OAuth user login."""
-
-    type: UserAuthInfoType
-    """OAuth user authentication. The token itself is held in the runtime's secret token store
-    (keyed by host+login) and is NOT carried in this struct.
-    """
-    copilot_user: CopilotUserResponse | None = None
-    """Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the
-    GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this
-    verbatim and does not re-fetch when set.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'UserAuthInfo':
-        assert isinstance(obj, dict)
-        host = from_str(obj.get("host"))
-        login = from_str(obj.get("login"))
-        type = UserAuthInfoType(obj.get("type"))
-        copilot_user = from_union([CopilotUserResponse.from_dict, from_none], obj.get("copilotUser"))
-        return UserAuthInfo(host, login, type, copilot_user)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["host"] = from_str(self.host)
-        result["login"] = from_str(self.login)
-        result["type"] = to_enum(UserAuthInfoType, self.type)
-        if self.copilot_user is not None:
-            result["copilotUser"] = from_union([lambda x: to_class(CopilotUserResponse, x), from_none], self.copilot_user)
-        return result
-
-@dataclass
 class PermissionDecisionApproveForLocationApproval:
-    """Approval to persist for this location
+    """The approval to persist for this location
 
     Schema for the `PermissionDecisionApproveForLocationApprovalCommands` type.
 
@@ -12031,7 +6578,7 @@ class PermissionDecisionApproveForLocationApproval:
 
 @dataclass
 class PermissionDecisionApproveForIonApproval:
-    """Session-scoped approval to remember (tool prompts only; omitted for path/url prompts)
+    """The approval to add as a session-scoped rule
 
     Schema for the `PermissionDecisionApproveForSessionApprovalCommands` type.
 
@@ -12052,7 +6599,7 @@ class PermissionDecisionApproveForIonApproval:
     Schema for the `PermissionDecisionApproveForSessionApprovalExtensionPermissionAccess`
     type.
 
-    Approval to persist for this location
+    The approval to persist for this location
 
     Schema for the `PermissionDecisionApproveForLocationApprovalCommands` type.
 
@@ -12072,15 +6619,8 @@ class PermissionDecisionApproveForIonApproval:
 
     Schema for the `PermissionDecisionApproveForLocationApprovalExtensionPermissionAccess`
     type.
-
-    The approval to add as a session-scoped rule
-
-    The approval to persist for this location
     """
-    command_identifiers: list[str] | None = None
-    """Command identifiers covered by this approval."""
-
-    kind: ApprovalKind | None = None
+    kind: ApprovalKind
     """Approval scoped to specific command identifiers.
 
     Approval covering read-only filesystem operations.
@@ -12099,6 +6639,9 @@ class PermissionDecisionApproveForIonApproval:
 
     Approval covering an extension's request to access a permission-gated capability.
     """
+    command_identifiers: list[str] | None = None
+    """Command identifiers covered by this approval."""
+
     server_name: str | None = None
     """MCP server name."""
 
@@ -12114,26 +6657,22 @@ class PermissionDecisionApproveForIonApproval:
     extension_name: str | None = None
     """Extension name."""
 
-    external_ref_marker_external_ref_user_tool_session_approval: str | None = None
-
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecisionApproveForIonApproval':
         assert isinstance(obj, dict)
+        kind = ApprovalKind(obj.get("kind"))
         command_identifiers = from_union([lambda x: from_list(from_str, x), from_none], obj.get("commandIdentifiers"))
-        kind = from_union([ApprovalKind, from_none], obj.get("kind"))
         server_name = from_union([from_str, from_none], obj.get("serverName"))
         tool_name = from_union([from_none, from_str], obj.get("toolName"))
         operation = from_union([from_str, from_none], obj.get("operation"))
         extension_name = from_union([from_str, from_none], obj.get("extensionName"))
-        external_ref_marker_external_ref_user_tool_session_approval = from_union([from_str, from_none], obj.get("__externalRefMarker___ExternalRef_UserToolSessionApproval"))
-        return PermissionDecisionApproveForIonApproval(command_identifiers, kind, server_name, tool_name, operation, extension_name, external_ref_marker_external_ref_user_tool_session_approval)
+        return PermissionDecisionApproveForIonApproval(kind, command_identifiers, server_name, tool_name, operation, extension_name)
 
     def to_dict(self) -> dict:
         result: dict = {}
+        result["kind"] = to_enum(ApprovalKind, self.kind)
         if self.command_identifiers is not None:
             result["commandIdentifiers"] = from_union([lambda x: from_list(from_str, x), from_none], self.command_identifiers)
-        if self.kind is not None:
-            result["kind"] = from_union([lambda x: to_enum(ApprovalKind, x), from_none], self.kind)
         if self.server_name is not None:
             result["serverName"] = from_union([from_str, from_none], self.server_name)
         if self.tool_name is not None:
@@ -12142,13 +6681,11 @@ class PermissionDecisionApproveForIonApproval:
             result["operation"] = from_union([from_str, from_none], self.operation)
         if self.extension_name is not None:
             result["extensionName"] = from_union([from_str, from_none], self.extension_name)
-        if self.external_ref_marker_external_ref_user_tool_session_approval is not None:
-            result["__externalRefMarker___ExternalRef_UserToolSessionApproval"] = from_union([from_str, from_none], self.external_ref_marker_external_ref_user_tool_session_approval)
         return result
 
 @dataclass
 class PermissionDecisionApproveForSessionApproval:
-    """Session-scoped approval to remember (tool prompts only; omitted for path/url prompts)
+    """The approval to add as a session-scoped rule
 
     Schema for the `PermissionDecisionApproveForSessionApprovalCommands` type.
 
@@ -12287,425 +6824,6 @@ class ExternalToolTextResultForLlm:
             result["toolTelemetry"] = from_union([lambda x: from_dict(lambda x: x, x), from_none], self.tool_telemetry)
         return result
 
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class InstalledPlugin:
-    """Schema for the `InstalledPlugin` type."""
-
-    enabled: bool
-    """Whether the plugin is currently enabled"""
-
-    installed_at: str
-    """Installation timestamp"""
-
-    marketplace: str
-    """Marketplace the plugin came from (empty string for direct repo installs)"""
-
-    name: str
-    """Plugin name"""
-
-    cache_path: str | None = None
-    """Path where the plugin is cached locally"""
-
-    source: InstalledPluginSource | str | None = None
-    """Source for direct repo installs (when marketplace is empty)"""
-
-    version: str | None = None
-    """Version installed (if available)"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'InstalledPlugin':
-        assert isinstance(obj, dict)
-        enabled = from_bool(obj.get("enabled"))
-        installed_at = from_str(obj.get("installed_at"))
-        marketplace = from_str(obj.get("marketplace"))
-        name = from_str(obj.get("name"))
-        cache_path = from_union([from_str, from_none], obj.get("cache_path"))
-        source = from_union([InstalledPluginSource.from_dict, from_str, from_none], obj.get("source"))
-        version = from_union([from_str, from_none], obj.get("version"))
-        return InstalledPlugin(enabled, installed_at, marketplace, name, cache_path, source, version)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["enabled"] = from_bool(self.enabled)
-        result["installed_at"] = from_str(self.installed_at)
-        result["marketplace"] = from_str(self.marketplace)
-        result["name"] = from_str(self.name)
-        if self.cache_path is not None:
-            result["cache_path"] = from_union([from_str, from_none], self.cache_path)
-        if self.source is not None:
-            result["source"] = from_union([lambda x: to_class(InstalledPluginSource, x), from_str, from_none], self.source)
-        if self.version is not None:
-            result["version"] = from_union([from_str, from_none], self.version)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionInstalledPlugin:
-    """Schema for the `SessionInstalledPlugin` type."""
-
-    enabled: bool
-    """Whether the plugin is currently enabled"""
-
-    installed_at: str
-    """Installation timestamp (ISO-8601)"""
-
-    marketplace: str
-    """Marketplace the plugin came from (empty string for direct repo installs)"""
-
-    name: str
-    """Plugin name"""
-
-    cache_path: str | None = None
-    """Path where the plugin is cached locally"""
-
-    source: SessionInstalledPluginSource | str | None = None
-    """Source descriptor for direct repo installs (when marketplace is empty)"""
-
-    version: str | None = None
-    """Installed version, if known"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionInstalledPlugin':
-        assert isinstance(obj, dict)
-        enabled = from_bool(obj.get("enabled"))
-        installed_at = from_str(obj.get("installed_at"))
-        marketplace = from_str(obj.get("marketplace"))
-        name = from_str(obj.get("name"))
-        cache_path = from_union([from_str, from_none], obj.get("cache_path"))
-        source = from_union([SessionInstalledPluginSource.from_dict, from_str, from_none], obj.get("source"))
-        version = from_union([from_str, from_none], obj.get("version"))
-        return SessionInstalledPlugin(enabled, installed_at, marketplace, name, cache_path, source, version)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["enabled"] = from_bool(self.enabled)
-        result["installed_at"] = from_str(self.installed_at)
-        result["marketplace"] = from_str(self.marketplace)
-        result["name"] = from_str(self.name)
-        if self.cache_path is not None:
-            result["cache_path"] = from_union([from_str, from_none], self.cache_path)
-        if self.source is not None:
-            result["source"] = from_union([lambda x: to_class(SessionInstalledPluginSource, x), from_str, from_none], self.source)
-        if self.version is not None:
-            result["version"] = from_union([from_str, from_none], self.version)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionEnrichMetadataResult:
-    """The same metadata records, with summary and context fields backfilled where available."""
-
-    sessions: list[SessionMetadata]
-    """Same records, with summary and context backfilled"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionEnrichMetadataResult':
-        assert isinstance(obj, dict)
-        sessions = from_list(SessionMetadata.from_dict, obj.get("sessions"))
-        return SessionEnrichMetadataResult(sessions)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["sessions"] = from_list(lambda x: to_class(SessionMetadata, x), self.sessions)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionList:
-    """Persisted sessions matching the filter, ordered most-recently-modified first."""
-
-    sessions: list[SessionMetadata]
-    """Sessions ordered most-recently-modified first"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionList':
-        assert isinstance(obj, dict)
-        sessions = from_list(SessionMetadata.from_dict, obj.get("sessions"))
-        return SessionList(sessions)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["sessions"] = from_list(lambda x: to_class(SessionMetadata, x), self.sessions)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsEnrichMetadataRequest:
-    """Session metadata records to enrich with summary and context information."""
-
-    sessions: list[SessionMetadata]
-    """Session metadata records to enrich. Records that already have summary and context are
-    returned unchanged.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsEnrichMetadataRequest':
-        assert isinstance(obj, dict)
-        sessions = from_list(SessionMetadata.from_dict, obj.get("sessions"))
-        return SessionsEnrichMetadataRequest(sessions)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["sessions"] = from_list(lambda x: to_class(SessionMetadata, x), self.sessions)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionMetadataSnapshot:
-    """Point-in-time snapshot of slow-changing session identifier and state fields"""
-
-    already_in_use: bool
-    """True when the session was detected to be in use by another process at construction time.
-    Local consumers may surface a confirmation prompt before fully attaching. Always false
-    for new sessions.
-    """
-    current_mode: MetadataSnapshotCurrentMode
-    """The current agent mode for this session (e.g., 'interactive', 'plan', 'autopilot')"""
-
-    is_remote: bool
-    """Whether this is a remote session (i.e., one whose runtime executes elsewhere and is
-    steered through this process)
-    """
-    modified_time: datetime
-    """ISO 8601 timestamp of when the session's persisted state was last modified on disk. For
-    new sessions, equals startTime. For resumed sessions, reflects the previous modification
-    time at construction.
-    """
-    session_id: str
-    """The unique identifier of the session"""
-
-    start_time: datetime
-    """ISO 8601 timestamp of when the session started"""
-
-    working_directory: str
-    """Absolute path to the session's current working directory"""
-
-    initial_name: str | None = None
-    """User-provided name supplied at session construction (via `--name`), if any. Immutable
-    after construction.
-    """
-    remote_metadata: MetadataSnapshotRemoteMetadata | None = None
-    """Remote-session-specific metadata. Populated only when `isRemote` is true. Fields are
-    immutable for the lifetime of the session.
-    """
-    selected_model: str | None = None
-    """Currently selected model identifier, if any"""
-
-    summary: str | None = None
-    """Short human-readable summary of the session, if known. Omitted when no summary has been
-    generated.
-    """
-    workspace: WorkspaceSummary | None = None
-    """Public-facing workspace metadata for this session, or null if the session has no
-    associated workspace. Excludes runtime-internal fields (GitHub IDs, summary count,
-    internal flags).
-    """
-    workspace_path: str | None = None
-    """Absolute path to the session's workspace directory on disk, or null if the session has no
-    associated workspace
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionMetadataSnapshot':
-        assert isinstance(obj, dict)
-        already_in_use = from_bool(obj.get("alreadyInUse"))
-        current_mode = MetadataSnapshotCurrentMode(obj.get("currentMode"))
-        is_remote = from_bool(obj.get("isRemote"))
-        modified_time = from_datetime(obj.get("modifiedTime"))
-        session_id = from_str(obj.get("sessionId"))
-        start_time = from_datetime(obj.get("startTime"))
-        working_directory = from_str(obj.get("workingDirectory"))
-        initial_name = from_union([from_str, from_none], obj.get("initialName"))
-        remote_metadata = from_union([MetadataSnapshotRemoteMetadata.from_dict, from_none], obj.get("remoteMetadata"))
-        selected_model = from_union([from_str, from_none], obj.get("selectedModel"))
-        summary = from_union([from_str, from_none], obj.get("summary"))
-        workspace = from_union([WorkspaceSummary.from_dict, from_none], obj.get("workspace"))
-        workspace_path = from_union([from_none, from_str], obj.get("workspacePath"))
-        return SessionMetadataSnapshot(already_in_use, current_mode, is_remote, modified_time, session_id, start_time, working_directory, initial_name, remote_metadata, selected_model, summary, workspace, workspace_path)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["alreadyInUse"] = from_bool(self.already_in_use)
-        result["currentMode"] = to_enum(MetadataSnapshotCurrentMode, self.current_mode)
-        result["isRemote"] = from_bool(self.is_remote)
-        result["modifiedTime"] = self.modified_time.isoformat()
-        result["sessionId"] = from_str(self.session_id)
-        result["startTime"] = self.start_time.isoformat()
-        result["workingDirectory"] = from_str(self.working_directory)
-        if self.initial_name is not None:
-            result["initialName"] = from_union([from_str, from_none], self.initial_name)
-        if self.remote_metadata is not None:
-            result["remoteMetadata"] = from_union([lambda x: to_class(MetadataSnapshotRemoteMetadata, x), from_none], self.remote_metadata)
-        if self.selected_model is not None:
-            result["selectedModel"] = from_union([from_str, from_none], self.selected_model)
-        if self.summary is not None:
-            result["summary"] = from_union([from_str, from_none], self.summary)
-        if self.workspace is not None:
-            result["workspace"] = from_union([lambda x: to_class(WorkspaceSummary, x), from_none], self.workspace)
-        result["workspacePath"] = from_union([from_none, from_str], self.workspace_path)
-        return result
-
-@dataclass
-class PermissionsConfigureParams:
-    """Patch of permission policy fields to apply (omit a field to leave it unchanged)."""
-
-    additional_content_exclusion_policies: list[PermissionsConfigureAdditionalContentExclusionPolicy] | None = None
-    """If specified, replaces the host-supplied GitHub Content Exclusion policies on the session
-    (combined with natively-discovered policies when evaluating tool/file access). Omit to
-    leave the current policies unchanged.
-    """
-    approve_all_read_permission_requests: bool | None = None
-    """If specified, sets whether path/URL read permission requests are auto-approved. Omit to
-    leave the current value unchanged.
-    """
-    approve_all_tool_permission_requests: bool | None = None
-    """If specified, sets whether tool permission requests are auto-approved without prompting.
-    Omit to leave the current value unchanged.
-    """
-    paths: PermissionPathsConfig | None = None
-    """If specified, replaces the session's path-permission policy. The runtime constructs the
-    appropriate PathManager based on these inputs (rooted at the session's working
-    directory). Omit to leave the current path policy unchanged.
-    """
-    rules: PermissionRulesSet | None = None
-    """If specified, replaces the session's approved/denied permission rules. Omit to leave the
-    current rules unchanged.
-    """
-    urls: PermissionUrlsConfig | None = None
-    """If specified, replaces the session's URL-permission policy. The runtime constructs a
-    fresh DefaultUrlManager based on these inputs. Omit to leave the current URL policy
-    unchanged.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionsConfigureParams':
-        assert isinstance(obj, dict)
-        additional_content_exclusion_policies = from_union([lambda x: from_list(PermissionsConfigureAdditionalContentExclusionPolicy.from_dict, x), from_none], obj.get("additionalContentExclusionPolicies"))
-        approve_all_read_permission_requests = from_union([from_bool, from_none], obj.get("approveAllReadPermissionRequests"))
-        approve_all_tool_permission_requests = from_union([from_bool, from_none], obj.get("approveAllToolPermissionRequests"))
-        paths = from_union([PermissionPathsConfig.from_dict, from_none], obj.get("paths"))
-        rules = from_union([PermissionRulesSet.from_dict, from_none], obj.get("rules"))
-        urls = from_union([PermissionUrlsConfig.from_dict, from_none], obj.get("urls"))
-        return PermissionsConfigureParams(additional_content_exclusion_policies, approve_all_read_permission_requests, approve_all_tool_permission_requests, paths, rules, urls)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.additional_content_exclusion_policies is not None:
-            result["additionalContentExclusionPolicies"] = from_union([lambda x: from_list(lambda x: to_class(PermissionsConfigureAdditionalContentExclusionPolicy, x), x), from_none], self.additional_content_exclusion_policies)
-        if self.approve_all_read_permission_requests is not None:
-            result["approveAllReadPermissionRequests"] = from_union([from_bool, from_none], self.approve_all_read_permission_requests)
-        if self.approve_all_tool_permission_requests is not None:
-            result["approveAllToolPermissionRequests"] = from_union([from_bool, from_none], self.approve_all_tool_permission_requests)
-        if self.paths is not None:
-            result["paths"] = from_union([lambda x: to_class(PermissionPathsConfig, x), from_none], self.paths)
-        if self.rules is not None:
-            result["rules"] = from_union([lambda x: to_class(PermissionRulesSet, x), from_none], self.rules)
-        if self.urls is not None:
-            result["urls"] = from_union([lambda x: to_class(PermissionUrlsConfig, x), from_none], self.urls)
-        return result
-
-@dataclass
-class SendRequest:
-    """Parameters for sending a user message to the session"""
-
-    prompt: str
-    """The user message text"""
-
-    agent_mode: SendAgentMode | None = None
-    """The UI mode the agent was in when this message was sent. Defaults to the session's
-    current mode.
-    """
-    attachments: list[SendAttachment] | None = None
-    """Optional attachments (files, directories, selections, blobs, GitHub references) to
-    include with the message
-    """
-    billable: bool | None = None
-    """If false, this message will not trigger a Premium Request Unit charge. User messages
-    default to billable.
-    """
-    display_prompt: str | None = None
-    """If provided, this is shown in the timeline instead of `prompt`"""
-
-    mode: SendMode | None = None
-    """How to deliver the message. `enqueue` (default) appends to the message queue. `immediate`
-    interjects during an in-progress turn.
-    """
-    prepend: bool | None = None
-    """If true, adds the message to the front of the queue instead of the end"""
-
-    request_headers: dict[str, str] | None = None
-    """Custom HTTP headers to include in outbound model requests for this turn. Merged with
-    session-level provider headers; per-turn headers augment and overwrite session-level
-    headers with the same key.
-    """
-    required_tool: str | None = None
-    """If set, the request will fail if the named tool is not available when this message is
-    among the user messages at the start of the current exchange
-    """
-    source: Any = None
-    """Optional provenance tag copied to the resulting user.message event. Supported values are
-    `system`, `command-*`, and `schedule-*`.
-    """
-    traceparent: str | None = None
-    """W3C Trace Context traceparent header for distributed tracing of this agent turn"""
-
-    tracestate: str | None = None
-    """W3C Trace Context tracestate header for distributed tracing"""
-
-    wait: bool | None = None
-    """If true, await completion of the agentic loop for this message before returning. Defaults
-    to false (fire-and-forget). When true, the result still contains the same `messageId`;
-    the caller can rely on the agent having processed the message before the call resolves.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SendRequest':
-        assert isinstance(obj, dict)
-        prompt = from_str(obj.get("prompt"))
-        agent_mode = from_union([SendAgentMode, from_none], obj.get("agentMode"))
-        attachments = from_union([lambda x: from_list(SendAttachment.from_dict, x), from_none], obj.get("attachments"))
-        billable = from_union([from_bool, from_none], obj.get("billable"))
-        display_prompt = from_union([from_str, from_none], obj.get("displayPrompt"))
-        mode = from_union([SendMode, from_none], obj.get("mode"))
-        prepend = from_union([from_bool, from_none], obj.get("prepend"))
-        request_headers = from_union([lambda x: from_dict(from_str, x), from_none], obj.get("requestHeaders"))
-        required_tool = from_union([from_str, from_none], obj.get("requiredTool"))
-        source = obj.get("source")
-        traceparent = from_union([from_str, from_none], obj.get("traceparent"))
-        tracestate = from_union([from_str, from_none], obj.get("tracestate"))
-        wait = from_union([from_bool, from_none], obj.get("wait"))
-        return SendRequest(prompt, agent_mode, attachments, billable, display_prompt, mode, prepend, request_headers, required_tool, source, traceparent, tracestate, wait)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["prompt"] = from_str(self.prompt)
-        if self.agent_mode is not None:
-            result["agentMode"] = from_union([lambda x: to_enum(SendAgentMode, x), from_none], self.agent_mode)
-        if self.attachments is not None:
-            result["attachments"] = from_union([lambda x: from_list(lambda x: to_class(SendAttachment, x), x), from_none], self.attachments)
-        if self.billable is not None:
-            result["billable"] = from_union([from_bool, from_none], self.billable)
-        if self.display_prompt is not None:
-            result["displayPrompt"] = from_union([from_str, from_none], self.display_prompt)
-        if self.mode is not None:
-            result["mode"] = from_union([lambda x: to_enum(SendMode, x), from_none], self.mode)
-        if self.prepend is not None:
-            result["prepend"] = from_union([from_bool, from_none], self.prepend)
-        if self.request_headers is not None:
-            result["requestHeaders"] = from_union([lambda x: from_dict(from_str, x), from_none], self.request_headers)
-        if self.required_tool is not None:
-            result["requiredTool"] = from_union([from_str, from_none], self.required_tool)
-        if self.source is not None:
-            result["source"] = self.source
-        if self.traceparent is not None:
-            result["traceparent"] = from_union([from_str, from_none], self.traceparent)
-        if self.tracestate is not None:
-            result["tracestate"] = from_union([from_str, from_none], self.tracestate)
-        if self.wait is not None:
-            result["wait"] = from_union([from_bool, from_none], self.wait)
-        return result
-
 @dataclass
 class UIElicitationSchema:
     """JSON Schema describing the form fields to present to the user"""
@@ -12736,125 +6854,17 @@ class UIElicitationSchema:
         return result
 
 @dataclass
-class AuthInfo:
-    """The new auth credentials to install on the session. When omitted or `undefined`, the call
-    is a no-op and the session's existing credentials are preserved. The runtime stores the
-    value verbatim and uses it for outbound model/API requests; it does NOT re-validate or
-    re-fetch the associated Copilot user response. Several variants carry secret material;
-    treat this method's params as containing secrets at rest and in transit.
-
-    Schema for the `HMACAuthInfo` type.
-
-    Schema for the `EnvAuthInfo` type.
-
-    Schema for the `TokenAuthInfo` type.
-
-    Schema for the `CopilotApiTokenAuthInfo` type.
-
-    Schema for the `UserAuthInfo` type.
-
-    Schema for the `GhCliAuthInfo` type.
-
-    Schema for the `ApiKeyAuthInfo` type.
-    """
-    host: str
-    """Authentication host. HMAC auth always targets the public GitHub host.
-
-    Authentication host (e.g. https://github.com or a GHES host).
-
-    Authentication host.
-
-    Authentication host (always the public GitHub host).
-    """
-    type: AuthInfoType
-    """HMAC-based authentication used by GitHub-internal services.
-
-    Personal access token (PAT) or server-to-server token sourced from an environment
-    variable.
-
-    SDK-side token authentication; the host configured the token directly via the SDK.
-
-    Direct Copilot API authentication via the `GITHUB_COPILOT_API_TOKEN` + `COPILOT_API_URL`
-    environment-variable pair. The token itself is read from the environment by the runtime,
-    not carried in this struct.
-
-    OAuth user authentication. The token itself is held in the runtime's secret token store
-    (keyed by host+login) and is NOT carried in this struct.
-
-    Authentication via the `gh` CLI's saved credentials.
-
-    API-key authentication for non-GitHub LLM providers (e.g. when running BYOM-style).
-    """
-    copilot_user: CopilotUserResponse | None = None
-    """Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the
-    GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this
-    verbatim and does not re-fetch when set.
-    """
-    hmac: str | None = None
-    """HMAC secret used to sign requests."""
-
-    env_var: str | None = None
-    """Name of the environment variable the token was sourced from."""
-
-    login: str | None = None
-    """User login associated with the token. Undefined for server-to-server tokens (those
-    starting with `ghs_`).
-
-    OAuth user login.
-
-    User login as reported by `gh auth status`.
-    """
-    token: str | None = None
-    """The token value itself. Treat as a secret.
-
-    The token returned by `gh auth token`. Treat as a secret.
-    """
-    api_key: str | None = None
-    """The API key. Treat as a secret."""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'AuthInfo':
-        assert isinstance(obj, dict)
-        host = from_str(obj.get("host"))
-        type = AuthInfoType(obj.get("type"))
-        copilot_user = from_union([CopilotUserResponse.from_dict, from_none], obj.get("copilotUser"))
-        hmac = from_union([from_str, from_none], obj.get("hmac"))
-        env_var = from_union([from_str, from_none], obj.get("envVar"))
-        login = from_union([from_str, from_none], obj.get("login"))
-        token = from_union([from_str, from_none], obj.get("token"))
-        api_key = from_union([from_str, from_none], obj.get("apiKey"))
-        return AuthInfo(host, type, copilot_user, hmac, env_var, login, token, api_key)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["host"] = from_str(self.host)
-        result["type"] = to_enum(AuthInfoType, self.type)
-        if self.copilot_user is not None:
-            result["copilotUser"] = from_union([lambda x: to_class(CopilotUserResponse, x), from_none], self.copilot_user)
-        if self.hmac is not None:
-            result["hmac"] = from_union([from_str, from_none], self.hmac)
-        if self.env_var is not None:
-            result["envVar"] = from_union([from_str, from_none], self.env_var)
-        if self.login is not None:
-            result["login"] = from_union([from_str, from_none], self.login)
-        if self.token is not None:
-            result["token"] = from_union([from_str, from_none], self.token)
-        if self.api_key is not None:
-            result["apiKey"] = from_union([from_str, from_none], self.api_key)
-        return result
-
-@dataclass
 class PermissionDecisionApproveForLocation:
     """Schema for the `PermissionDecisionApproveForLocation` type."""
 
     approval: PermissionDecisionApproveForLocationApproval
-    """Approval to persist for this location"""
+    """The approval to persist for this location"""
 
     kind: PermissionDecisionApproveForLocationKind
-    """Approve and persist for this project location"""
+    """Approved and persisted for this project location"""
 
     location_key: str
-    """Location key (git root or cwd) to persist the approval to"""
+    """The location key (git root or cwd) to persist the approval to"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecisionApproveForLocation':
@@ -12876,13 +6886,13 @@ class PermissionDecisionApproveForSession:
     """Schema for the `PermissionDecisionApproveForSession` type."""
 
     kind: PermissionDecisionApproveForSessionKind
-    """Approve and remember for the rest of the session"""
+    """Approved and remembered for the rest of the session"""
 
     approval: PermissionDecisionApproveForSessionApproval | None = None
-    """Session-scoped approval to remember (tool prompts only; omitted for path/url prompts)"""
+    """The approval to add as a session-scoped rule"""
 
     domain: str | None = None
-    """URL domain to approve for the rest of the session (URL prompts only)"""
+    """The URL domain to approve for this session"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecisionApproveForSession':
@@ -12932,266 +6942,6 @@ class HandlePendingToolCallRequest:
             result["result"] = from_union([lambda x: to_class(ExternalToolTextResultForLlm, x), from_str, from_none], self.result)
         return result
 
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionsSetAdditionalPluginsRequest:
-    """Manager-wide additional plugins to register; replaces any previously-configured set."""
-
-    plugins: list[InstalledPlugin]
-    """Manager-wide additional plugins to register. Replaces any previously-configured set. Pass
-    an empty array to clear.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionsSetAdditionalPluginsRequest':
-        assert isinstance(obj, dict)
-        plugins = from_list(InstalledPlugin.from_dict, obj.get("plugins"))
-        return SessionsSetAdditionalPluginsRequest(plugins)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["plugins"] = from_list(lambda x: to_class(InstalledPlugin, x), self.plugins)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class SessionUpdateOptionsParams:
-    """Patch of mutable session options to apply to the running session."""
-
-    additional_content_exclusion_policies: list[Any] | None = None
-    """Additional content-exclusion policies to merge into the session's policy set. Opaque
-    shape; see `ContentExclusionApiResponse` in the runtime.
-    """
-    agent_context: str | None = None
-    """Runtime context discriminator (e.g., `cli`, `actions`)."""
-
-    ask_user_disabled: bool | None = None
-    """Whether to disable the `ask_user` tool (encourages autonomous behavior)."""
-
-    available_tools: list[str] | None = None
-    """Allowlist of tool names available to this session."""
-
-    client_name: str | None = None
-    """Identifier of the client driving the session."""
-
-    coauthor_enabled: bool | None = None
-    """Whether to include the `Co-authored-by` trailer in commit messages."""
-
-    continue_on_auto_mode: bool | None = None
-    """Whether to allow auto-mode continuation across turns."""
-
-    copilot_url: str | None = None
-    """Override URL for the Copilot API endpoint."""
-
-    custom_agents_local_only: bool | None = None
-    """Whether to default custom agents to local-only execution."""
-
-    disabled_instruction_sources: list[str] | None = None
-    """Instruction source IDs to exclude from the system prompt."""
-
-    disabled_skills: list[str] | None = None
-    """Skill IDs that should be excluded from this session."""
-
-    enable_on_demand_instruction_discovery: bool | None = None
-    """Whether to discover custom instructions on demand after successful file views (AGENTS.md
-    / CLAUDE.md / .github/copilot-instructions.md surfacing). Combined with
-    `skipCustomInstructions` and the runtime-side `ON_DEMAND_INSTRUCTIONS` feature flag.
-    """
-    enable_reasoning_summaries: bool | None = None
-    """Whether to surface reasoning-summary events from the model."""
-
-    enable_script_safety: bool | None = None
-    """Whether shell-script safety heuristics are enabled."""
-
-    enable_streaming: bool | None = None
-    """Whether to stream model responses."""
-
-    env_value_mode: MCPSetEnvValueModeDetails | None = None
-    """How env values are passed to MCP servers (`direct` inlines literal values; `indirect`
-    resolves at launch).
-    """
-    events_log_directory: str | None = None
-    """Override directory for the session-events log. When unset, the runtime's default events
-    log directory is used.
-    """
-    excluded_tools: list[str] | None = None
-    """Denylist of tool names for this session."""
-
-    feature_flags: dict[str, bool] | None = None
-    """Map of feature-flag IDs to their boolean enabled state."""
-
-    installed_plugins: list[SessionInstalledPlugin] | None = None
-    """Full set of installed plugins for the session. Replaces the existing list; the runtime
-    invalidates the skills cache only when the list materially changes.
-    """
-    integration_id: str | None = None
-    """Stable integration identifier used for analytics and rate-limit attribution."""
-
-    is_experimental_mode: bool | None = None
-    """Whether experimental capabilities are enabled."""
-
-    log_interactive_shells: bool | None = None
-    """Whether interactive shell sessions are logged."""
-
-    lsp_client_name: str | None = None
-    """Identifier sent to LSP-style integrations."""
-
-    manage_schedule_enabled: bool | None = None
-    """Whether to expose the `manage_schedule` tool to the agent. The runtime always owns the
-    per-session schedule registry; this flag only controls tool exposure (typically gated to
-    staff users).
-    """
-    model: str | None = None
-    """The model ID to use for assistant turns."""
-
-    provider: Any = None
-    """Custom model-provider configuration (BYOK). Opaque shape; see `ProviderConfig` in the
-    runtime.
-    """
-    reasoning_effort: str | None = None
-    """Reasoning effort for the selected model (model-defined enum)."""
-
-    running_in_interactive_mode: bool | None = None
-    """Whether the session is running in an interactive UI."""
-
-    sandbox_config: Any = None
-    """Sandbox configuration shape; opaque to SDK consumers. See `SandboxConfig` in the runtime."""
-
-    shell_init_profile: str | None = None
-    """Shell init profile (`None` or `NonInteractive`)."""
-
-    shell_process_flags: list[str] | None = None
-    """Per-shell process flags (e.g., `pwsh` arguments)."""
-
-    skill_directories: list[str] | None = None
-    """Additional directories to search for skills."""
-
-    skip_custom_instructions: bool | None = None
-    """Whether to skip loading custom instruction sources."""
-
-    trajectory_file: str | None = None
-    """Optional path for trajectory output."""
-
-    working_directory: str | None = None
-    """Absolute working-directory path for shell tools."""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionUpdateOptionsParams':
-        assert isinstance(obj, dict)
-        additional_content_exclusion_policies = from_union([lambda x: from_list(lambda x: x, x), from_none], obj.get("additionalContentExclusionPolicies"))
-        agent_context = from_union([from_str, from_none], obj.get("agentContext"))
-        ask_user_disabled = from_union([from_bool, from_none], obj.get("askUserDisabled"))
-        available_tools = from_union([lambda x: from_list(from_str, x), from_none], obj.get("availableTools"))
-        client_name = from_union([from_str, from_none], obj.get("clientName"))
-        coauthor_enabled = from_union([from_bool, from_none], obj.get("coauthorEnabled"))
-        continue_on_auto_mode = from_union([from_bool, from_none], obj.get("continueOnAutoMode"))
-        copilot_url = from_union([from_str, from_none], obj.get("copilotUrl"))
-        custom_agents_local_only = from_union([from_bool, from_none], obj.get("customAgentsLocalOnly"))
-        disabled_instruction_sources = from_union([lambda x: from_list(from_str, x), from_none], obj.get("disabledInstructionSources"))
-        disabled_skills = from_union([lambda x: from_list(from_str, x), from_none], obj.get("disabledSkills"))
-        enable_on_demand_instruction_discovery = from_union([from_bool, from_none], obj.get("enableOnDemandInstructionDiscovery"))
-        enable_reasoning_summaries = from_union([from_bool, from_none], obj.get("enableReasoningSummaries"))
-        enable_script_safety = from_union([from_bool, from_none], obj.get("enableScriptSafety"))
-        enable_streaming = from_union([from_bool, from_none], obj.get("enableStreaming"))
-        env_value_mode = from_union([MCPSetEnvValueModeDetails, from_none], obj.get("envValueMode"))
-        events_log_directory = from_union([from_str, from_none], obj.get("eventsLogDirectory"))
-        excluded_tools = from_union([lambda x: from_list(from_str, x), from_none], obj.get("excludedTools"))
-        feature_flags = from_union([lambda x: from_dict(from_bool, x), from_none], obj.get("featureFlags"))
-        installed_plugins = from_union([lambda x: from_list(SessionInstalledPlugin.from_dict, x), from_none], obj.get("installedPlugins"))
-        integration_id = from_union([from_str, from_none], obj.get("integrationId"))
-        is_experimental_mode = from_union([from_bool, from_none], obj.get("isExperimentalMode"))
-        log_interactive_shells = from_union([from_bool, from_none], obj.get("logInteractiveShells"))
-        lsp_client_name = from_union([from_str, from_none], obj.get("lspClientName"))
-        manage_schedule_enabled = from_union([from_bool, from_none], obj.get("manageScheduleEnabled"))
-        model = from_union([from_str, from_none], obj.get("model"))
-        provider = obj.get("provider")
-        reasoning_effort = from_union([from_str, from_none], obj.get("reasoningEffort"))
-        running_in_interactive_mode = from_union([from_bool, from_none], obj.get("runningInInteractiveMode"))
-        sandbox_config = obj.get("sandboxConfig")
-        shell_init_profile = from_union([from_str, from_none], obj.get("shellInitProfile"))
-        shell_process_flags = from_union([lambda x: from_list(from_str, x), from_none], obj.get("shellProcessFlags"))
-        skill_directories = from_union([lambda x: from_list(from_str, x), from_none], obj.get("skillDirectories"))
-        skip_custom_instructions = from_union([from_bool, from_none], obj.get("skipCustomInstructions"))
-        trajectory_file = from_union([from_str, from_none], obj.get("trajectoryFile"))
-        working_directory = from_union([from_str, from_none], obj.get("workingDirectory"))
-        return SessionUpdateOptionsParams(additional_content_exclusion_policies, agent_context, ask_user_disabled, available_tools, client_name, coauthor_enabled, continue_on_auto_mode, copilot_url, custom_agents_local_only, disabled_instruction_sources, disabled_skills, enable_on_demand_instruction_discovery, enable_reasoning_summaries, enable_script_safety, enable_streaming, env_value_mode, events_log_directory, excluded_tools, feature_flags, installed_plugins, integration_id, is_experimental_mode, log_interactive_shells, lsp_client_name, manage_schedule_enabled, model, provider, reasoning_effort, running_in_interactive_mode, sandbox_config, shell_init_profile, shell_process_flags, skill_directories, skip_custom_instructions, trajectory_file, working_directory)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.additional_content_exclusion_policies is not None:
-            result["additionalContentExclusionPolicies"] = from_union([lambda x: from_list(lambda x: x, x), from_none], self.additional_content_exclusion_policies)
-        if self.agent_context is not None:
-            result["agentContext"] = from_union([from_str, from_none], self.agent_context)
-        if self.ask_user_disabled is not None:
-            result["askUserDisabled"] = from_union([from_bool, from_none], self.ask_user_disabled)
-        if self.available_tools is not None:
-            result["availableTools"] = from_union([lambda x: from_list(from_str, x), from_none], self.available_tools)
-        if self.client_name is not None:
-            result["clientName"] = from_union([from_str, from_none], self.client_name)
-        if self.coauthor_enabled is not None:
-            result["coauthorEnabled"] = from_union([from_bool, from_none], self.coauthor_enabled)
-        if self.continue_on_auto_mode is not None:
-            result["continueOnAutoMode"] = from_union([from_bool, from_none], self.continue_on_auto_mode)
-        if self.copilot_url is not None:
-            result["copilotUrl"] = from_union([from_str, from_none], self.copilot_url)
-        if self.custom_agents_local_only is not None:
-            result["customAgentsLocalOnly"] = from_union([from_bool, from_none], self.custom_agents_local_only)
-        if self.disabled_instruction_sources is not None:
-            result["disabledInstructionSources"] = from_union([lambda x: from_list(from_str, x), from_none], self.disabled_instruction_sources)
-        if self.disabled_skills is not None:
-            result["disabledSkills"] = from_union([lambda x: from_list(from_str, x), from_none], self.disabled_skills)
-        if self.enable_on_demand_instruction_discovery is not None:
-            result["enableOnDemandInstructionDiscovery"] = from_union([from_bool, from_none], self.enable_on_demand_instruction_discovery)
-        if self.enable_reasoning_summaries is not None:
-            result["enableReasoningSummaries"] = from_union([from_bool, from_none], self.enable_reasoning_summaries)
-        if self.enable_script_safety is not None:
-            result["enableScriptSafety"] = from_union([from_bool, from_none], self.enable_script_safety)
-        if self.enable_streaming is not None:
-            result["enableStreaming"] = from_union([from_bool, from_none], self.enable_streaming)
-        if self.env_value_mode is not None:
-            result["envValueMode"] = from_union([lambda x: to_enum(MCPSetEnvValueModeDetails, x), from_none], self.env_value_mode)
-        if self.events_log_directory is not None:
-            result["eventsLogDirectory"] = from_union([from_str, from_none], self.events_log_directory)
-        if self.excluded_tools is not None:
-            result["excludedTools"] = from_union([lambda x: from_list(from_str, x), from_none], self.excluded_tools)
-        if self.feature_flags is not None:
-            result["featureFlags"] = from_union([lambda x: from_dict(from_bool, x), from_none], self.feature_flags)
-        if self.installed_plugins is not None:
-            result["installedPlugins"] = from_union([lambda x: from_list(lambda x: to_class(SessionInstalledPlugin, x), x), from_none], self.installed_plugins)
-        if self.integration_id is not None:
-            result["integrationId"] = from_union([from_str, from_none], self.integration_id)
-        if self.is_experimental_mode is not None:
-            result["isExperimentalMode"] = from_union([from_bool, from_none], self.is_experimental_mode)
-        if self.log_interactive_shells is not None:
-            result["logInteractiveShells"] = from_union([from_bool, from_none], self.log_interactive_shells)
-        if self.lsp_client_name is not None:
-            result["lspClientName"] = from_union([from_str, from_none], self.lsp_client_name)
-        if self.manage_schedule_enabled is not None:
-            result["manageScheduleEnabled"] = from_union([from_bool, from_none], self.manage_schedule_enabled)
-        if self.model is not None:
-            result["model"] = from_union([from_str, from_none], self.model)
-        if self.provider is not None:
-            result["provider"] = self.provider
-        if self.reasoning_effort is not None:
-            result["reasoningEffort"] = from_union([from_str, from_none], self.reasoning_effort)
-        if self.running_in_interactive_mode is not None:
-            result["runningInInteractiveMode"] = from_union([from_bool, from_none], self.running_in_interactive_mode)
-        if self.sandbox_config is not None:
-            result["sandboxConfig"] = self.sandbox_config
-        if self.shell_init_profile is not None:
-            result["shellInitProfile"] = from_union([from_str, from_none], self.shell_init_profile)
-        if self.shell_process_flags is not None:
-            result["shellProcessFlags"] = from_union([lambda x: from_list(from_str, x), from_none], self.shell_process_flags)
-        if self.skill_directories is not None:
-            result["skillDirectories"] = from_union([lambda x: from_list(from_str, x), from_none], self.skill_directories)
-        if self.skip_custom_instructions is not None:
-            result["skipCustomInstructions"] = from_union([from_bool, from_none], self.skip_custom_instructions)
-        if self.trajectory_file is not None:
-            result["trajectoryFile"] = from_union([from_str, from_none], self.trajectory_file)
-        if self.working_directory is not None:
-            result["workingDirectory"] = from_union([from_str, from_none], self.working_directory)
-        return result
-
 @dataclass
 class UIElicitationRequest:
     """Prompt message and JSON schema describing the form fields to elicit from the user."""
@@ -13216,32 +6966,8 @@ class UIElicitationRequest:
         return result
 
 @dataclass
-class SessionSetCredentialsParams:
-    """New auth credentials to install on the session. Omit to leave credentials unchanged."""
-
-    credentials: AuthInfo | None = None
-    """The new auth credentials to install on the session. When omitted or `undefined`, the call
-    is a no-op and the session's existing credentials are preserved. The runtime stores the
-    value verbatim and uses it for outbound model/API requests; it does NOT re-validate or
-    re-fetch the associated Copilot user response. Several variants carry secret material;
-    treat this method's params as containing secrets at rest and in transit.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'SessionSetCredentialsParams':
-        assert isinstance(obj, dict)
-        credentials = from_union([AuthInfo.from_dict, from_none], obj.get("credentials"))
-        return SessionSetCredentialsParams(credentials)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.credentials is not None:
-            result["credentials"] = from_union([lambda x: to_class(AuthInfo, x), from_none], self.credentials)
-        return result
-
-@dataclass
 class PermissionDecision:
-    """The client's response to the pending permission prompt
+    """Decision to apply to a pending permission request.
 
     Schema for the `PermissionDecisionApproveOnce` type.
 
@@ -13254,99 +6980,35 @@ class PermissionDecision:
     Schema for the `PermissionDecisionReject` type.
 
     Schema for the `PermissionDecisionUserNotAvailable` type.
-
-    Schema for the `PermissionDecisionApproved` type.
-
-    Schema for the `PermissionDecisionApprovedForSession` type.
-
-    Schema for the `PermissionDecisionApprovedForLocation` type.
-
-    Schema for the `PermissionDecisionCancelled` type.
-
-    Schema for the `PermissionDecisionDeniedByRules` type.
-
-    Schema for the `PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser` type.
-
-    Schema for the `PermissionDecisionDeniedInteractivelyByUser` type.
-
-    Schema for the `PermissionDecisionDeniedByContentExclusionPolicy` type.
-
-    Schema for the `PermissionDecisionDeniedByPermissionRequestHook` type.
     """
     kind: PermissionDecisionKind
-    """Approve this single request only
-
-    Approve and remember for the rest of the session
-
-    Approve and persist for this project location
-
-    Approve and persist across sessions (URL prompts only)
-
-    Reject the request
-
-    No user is available to confirm the request
-
-    The permission request was approved
+    """The permission request was approved for this one instance
 
     Approved and remembered for the rest of the session
 
     Approved and persisted for this project location
 
-    The permission request was cancelled before a response was used
-
-    Denied because approval rules explicitly blocked it
-
-    Denied because no approval rule matched and user confirmation was unavailable
+    Approved and persisted across sessions
 
     Denied by the user during an interactive prompt
 
-    Denied by the organization's content exclusion policy
-
-    Denied by a permission request hook registered by an extension or plugin
+    Denied because user confirmation was unavailable
     """
     approval: PermissionDecisionApproveForIonApproval | None = None
-    """Session-scoped approval to remember (tool prompts only; omitted for path/url prompts)
-
-    Approval to persist for this location
-
-    The approval to add as a session-scoped rule
+    """The approval to add as a session-scoped rule
 
     The approval to persist for this location
     """
     domain: str | None = None
-    """URL domain to approve for the rest of the session (URL prompts only)
+    """The URL domain to approve for this session
 
-    URL domain to approve permanently
+    The URL domain to approve permanently
     """
     location_key: str | None = None
-    """Location key (git root or cwd) to persist the approval to
+    """The location key (git root or cwd) to persist the approval to"""
 
-    The location key (git root or cwd) to persist the approval to
-    """
     feedback: str | None = None
-    """Optional feedback explaining the rejection
-
-    Optional feedback from the user explaining the denial
-    """
-    reason: str | None = None
-    """Optional explanation of why the request was cancelled"""
-
-    rules: list[PermissionRule] | None = None
-    """Rules that denied the request"""
-
-    force_reject: bool | None = None
-    """Whether to force-reject the current agent turn"""
-
-    message: str | None = None
-    """Human-readable explanation of why the path was excluded
-
-    Optional message from the hook explaining the denial
-    """
-    path: str | None = None
-    """File path that triggered the exclusion"""
-
-    interrupt: bool | None = None
-    """Whether to interrupt the current agent turn"""
+    """Optional feedback from the user explaining the denial"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecision':
@@ -13356,13 +7018,7 @@ class PermissionDecision:
         domain = from_union([from_str, from_none], obj.get("domain"))
         location_key = from_union([from_str, from_none], obj.get("locationKey"))
         feedback = from_union([from_str, from_none], obj.get("feedback"))
-        reason = from_union([from_str, from_none], obj.get("reason"))
-        rules = from_union([lambda x: from_list(PermissionRule.from_dict, x), from_none], obj.get("rules"))
-        force_reject = from_union([from_bool, from_none], obj.get("forceReject"))
-        message = from_union([from_str, from_none], obj.get("message"))
-        path = from_union([from_str, from_none], obj.get("path"))
-        interrupt = from_union([from_bool, from_none], obj.get("interrupt"))
-        return PermissionDecision(kind, approval, domain, location_key, feedback, reason, rules, force_reject, message, path, interrupt)
+        return PermissionDecision(kind, approval, domain, location_key, feedback)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -13375,18 +7031,6 @@ class PermissionDecision:
             result["locationKey"] = from_union([from_str, from_none], self.location_key)
         if self.feedback is not None:
             result["feedback"] = from_union([from_str, from_none], self.feedback)
-        if self.reason is not None:
-            result["reason"] = from_union([from_str, from_none], self.reason)
-        if self.rules is not None:
-            result["rules"] = from_union([lambda x: from_list(lambda x: to_class(PermissionRule, x), x), from_none], self.rules)
-        if self.force_reject is not None:
-            result["forceReject"] = from_union([from_bool, from_none], self.force_reject)
-        if self.message is not None:
-            result["message"] = from_union([from_str, from_none], self.message)
-        if self.path is not None:
-            result["path"] = from_union([from_str, from_none], self.path)
-        if self.interrupt is not None:
-            result["interrupt"] = from_union([from_bool, from_none], self.interrupt)
         return result
 
 @dataclass
@@ -13397,7 +7041,7 @@ class PermissionDecisionRequest:
     """Request ID of the pending permission request"""
 
     result: PermissionDecision
-    """The client's response to the pending permission prompt"""
+    """Decision to apply to a pending permission request."""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecisionRequest':
@@ -13410,99 +7054,6 @@ class PermissionDecisionRequest:
         result: dict = {}
         result["requestId"] = from_str(self.request_id)
         result["result"] = to_class(PermissionDecision, self.result)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class MCPExecuteSamplingParams:
-    """Identifiers and raw MCP CreateMessageRequest params used to run a sampling inference."""
-
-    mcp_request_id: float | str
-    """The original MCP JSON-RPC request ID (string or number). Used by the runtime to correlate
-    the inference with the originating MCP request for telemetry; this is distinct from
-    `requestId` (which is the schema-level cancellation handle).
-    """
-    request: dict[str, Any]
-    """Raw MCP CreateMessageRequest params, as received in the `sampling.requested` event.
-    Treated as opaque at the schema layer; the runtime converts the embedded MCP messages
-    into the OpenAI chat-completion shape internally.
-    """
-    request_id: str
-    """Caller-provided unique identifier for this sampling execution. Use this same ID with
-    cancelSamplingExecution to cancel the in-flight call. Must be unique within the session
-    for the lifetime of the call.
-    """
-    server_name: str
-    """Name of the MCP server that initiated the sampling request"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'MCPExecuteSamplingParams':
-        assert isinstance(obj, dict)
-        mcp_request_id = from_union([from_float, from_str], obj.get("mcpRequestId"))
-        request = from_dict(lambda x: x, obj.get("request"))
-        request_id = from_str(obj.get("requestId"))
-        server_name = from_str(obj.get("serverName"))
-        return MCPExecuteSamplingParams(mcp_request_id, request, request_id, server_name)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["mcpRequestId"] = from_union([to_float, from_str], self.mcp_request_id)
-        result["request"] = from_dict(lambda x: x, self.request)
-        result["requestId"] = from_str(self.request_id)
-        result["serverName"] = from_str(self.server_name)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class MetadataContextInfoRequest:
-    """Model identifier and token limits used to compute the context-info breakdown."""
-
-    output_token_limit: int
-    """Maximum output tokens allowed by the target model. Pass 0 if unknown."""
-
-    prompt_token_limit: int
-    """Maximum prompt tokens allowed by the target model. Pass 0 to use the runtime default."""
-
-    selected_model: str | None = None
-    """Model identifier used for tokenization. Omit to use the session default. Used both for
-    token counting and to compute display values.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'MetadataContextInfoRequest':
-        assert isinstance(obj, dict)
-        output_token_limit = from_int(obj.get("outputTokenLimit"))
-        prompt_token_limit = from_int(obj.get("promptTokenLimit"))
-        selected_model = from_union([from_str, from_none], obj.get("selectedModel"))
-        return MetadataContextInfoRequest(output_token_limit, prompt_token_limit, selected_model)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["outputTokenLimit"] = from_int(self.output_token_limit)
-        result["promptTokenLimit"] = from_int(self.prompt_token_limit)
-        if self.selected_model is not None:
-            result["selectedModel"] = from_union([from_str, from_none], self.selected_model)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class MetadataRecomputeContextTokensRequest:
-    """Model identifier to use when re-tokenizing the session's existing messages."""
-
-    model_id: str
-    """Model identifier used for tokenization. The runtime token-counts both chat-context and
-    system-context messages against this model.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'MetadataRecomputeContextTokensRequest':
-        assert isinstance(obj, dict)
-        model_id = from_str(obj.get("modelId"))
-        return MetadataRecomputeContextTokensRequest(model_id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["modelId"] = from_str(self.model_id)
         return result
 
 @dataclass
@@ -13656,38 +7207,6 @@ class ModelSwitchToRequest:
             result["reasoningSummary"] = from_union([lambda x: to_enum(ReasoningSummary, x), from_none], self.reasoning_summary)
         return result
 
-class PermissionsSetApproveAllSource(Enum):
-    """Optional source for allow-all telemetry. Defaults to `rpc` when omitted for SDK callers."""
-
-    AUTOPILOT_CONFIRMATION = "autopilot_confirmation"
-    CLI_FLAG = "cli_flag"
-    RPC = "rpc"
-    SLASH_COMMAND = "slash_command"
-
-@dataclass
-class PermissionsSetApproveAllRequest:
-    """Allow-all toggle for tool permission requests, with an optional telemetry source."""
-
-    enabled: bool
-    """Whether to auto-approve all tool permission requests"""
-
-    source: PermissionsSetApproveAllSource | None = None
-    """Optional source for allow-all telemetry. Defaults to `rpc` when omitted for SDK callers."""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionsSetApproveAllRequest':
-        assert isinstance(obj, dict)
-        enabled = from_bool(obj.get("enabled"))
-        source = from_union([PermissionsSetApproveAllSource, from_none], obj.get("source"))
-        return PermissionsSetApproveAllRequest(enabled, source)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["enabled"] = from_bool(self.enabled)
-        if self.source is not None:
-            result["source"] = from_union([lambda x: to_enum(PermissionsSetApproveAllSource, x), from_none], self.source)
-        return result
-
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
 class TaskAgentInfo:
@@ -13809,14 +7328,6 @@ class TaskAgentInfo:
 class TaskInfo:
     """Schema for the `TaskInfo` type.
 
-    The first sync-waiting task (agent first, then shell) that can currently be promoted to
-    background mode. Omitted if no such task exists. The returned task is guaranteed to have
-    executionMode='sync' and canPromoteToBackground=true at the time of the call.
-
-    The promoted task as it now exists in background mode, omitted if no promotable task was
-    waiting. Atomic operation: avoids the race window of getCurrentPromotable +
-    promoteToBackground.
-
     Schema for the `TaskAgentInfo` type.
 
     Schema for the `TaskShellInfo` type.
@@ -13833,7 +7344,7 @@ class TaskInfo:
     status: TaskStatus
     """Current lifecycle status of the task"""
 
-    type: TaskAgentProgressType
+    type: TaskInfoType
     """Task kind"""
 
     active_started_at: datetime | None = None
@@ -13899,7 +7410,7 @@ class TaskInfo:
         id = from_str(obj.get("id"))
         started_at = from_datetime(obj.get("startedAt"))
         status = TaskStatus(obj.get("status"))
-        type = TaskAgentProgressType(obj.get("type"))
+        type = TaskInfoType(obj.get("type"))
         active_started_at = from_union([from_datetime, from_none], obj.get("activeStartedAt"))
         active_time_ms = from_union([from_int, from_none], obj.get("activeTimeMs"))
         agent_type = from_union([from_str, from_none], obj.get("agentType"))
@@ -13925,7 +7436,7 @@ class TaskInfo:
         result["id"] = from_str(self.id)
         result["startedAt"] = self.started_at.isoformat()
         result["status"] = to_enum(TaskStatus, self.status)
-        result["type"] = to_enum(TaskAgentProgressType, self.type)
+        result["type"] = to_enum(TaskInfoType, self.type)
         if self.active_started_at is not None:
             result["activeStartedAt"] = from_union([lambda x: x.isoformat(), from_none], self.active_started_at)
         if self.active_time_ms is not None:
@@ -13981,69 +7492,17 @@ class TaskList:
         result["tasks"] = from_list(lambda x: to_class(TaskInfo, x), self.tasks)
         return result
 
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class TasksGetCurrentPromotableResult:
-    """The first sync-waiting task that can currently be promoted to background mode."""
-
-    task: TaskInfo | None = None
-    """The first sync-waiting task (agent first, then shell) that can currently be promoted to
-    background mode. Omitted if no such task exists. The returned task is guaranteed to have
-    executionMode='sync' and canPromoteToBackground=true at the time of the call.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'TasksGetCurrentPromotableResult':
-        assert isinstance(obj, dict)
-        task = from_union([TaskInfo.from_dict, from_none], obj.get("task"))
-        return TasksGetCurrentPromotableResult(task)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.task is not None:
-            result["task"] = from_union([lambda x: to_class(TaskInfo, x), from_none], self.task)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class TasksPromoteCurrentToBackgroundResult:
-    """The promoted task as it now exists in background mode, omitted if no promotable task was
-    waiting.
-    """
-    task: TaskInfo | None = None
-    """The promoted task as it now exists in background mode, omitted if no promotable task was
-    waiting. Atomic operation: avoids the race window of getCurrentPromotable +
-    promoteToBackground.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'TasksPromoteCurrentToBackgroundResult':
-        assert isinstance(obj, dict)
-        task = from_union([TaskInfo.from_dict, from_none], obj.get("task"))
-        return TasksPromoteCurrentToBackgroundResult(task)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.task is not None:
-            result["task"] = from_union([lambda x: to_class(TaskInfo, x), from_none], self.task)
-        return result
-
 @dataclass
 class RPC:
-    abort_request: AbortRequest
-    abort_result: AbortResult
     account_get_quota_request: AccountGetQuotaRequest
     account_get_quota_result: AccountGetQuotaResult
     account_quota_snapshot: AccountQuotaSnapshot
     agent_get_current_result: AgentGetCurrentResult
     agent_info: AgentInfo
-    agent_info_source: AgentInfoSource
     agent_list: AgentList
     agent_reload_result: AgentReloadResult
     agent_select_request: AgentSelectRequest
     agent_select_result: AgentSelectResult
-    api_key_auth_info: APIKeyAuthInfo
-    auth_info: AuthInfo
     auth_info_type: AuthInfoType
     command_list: CommandList
     commands_handle_pending_command_request: CommandsHandlePendingCommandRequest
@@ -14059,28 +7518,9 @@ class RPC:
     connect_request: ConnectRequest
     connect_result: ConnectResult
     content_filter_mode: ContentFilterMode
-    copilot_api_token_auth_info: CopilotAPITokenAuthInfo
-    copilot_user_response: CopilotUserResponse
-    copilot_user_response_endpoints: CopilotUserResponseEndpoints
-    copilot_user_response_quota_snapshots: dict[str, CopilotUserResponseQuotaSnapshots | None]
-    copilot_user_response_quota_snapshots_chat: CopilotUserResponseQuotaSnapshotsChat
-    copilot_user_response_quota_snapshots_completions: CopilotUserResponseQuotaSnapshotsCompletions
-    copilot_user_response_quota_snapshots_premium_interactions: CopilotUserResponseQuotaSnapshotsPremiumInteractions
     current_model: CurrentModel
     discovered_mcp_server: DiscoveredMCPServer
     discovered_mcp_server_type: DiscoveredMCPServerType
-    enqueue_command_params: EnqueueCommandParams
-    enqueue_command_result: EnqueueCommandResult
-    env_auth_info: EnvAuthInfo
-    event_log_read_request: EventLogReadRequest
-    event_log_release_interest_result: EventLogReleaseInterestResult
-    event_log_tail_result: EventLogTailResult
-    event_log_types: list[str] | EventLogTypes
-    events_agent_scope: EventsAgentScope
-    events_cursor_status: EventsCursorStatus
-    events_read_result: EventsReadResult
-    execute_command_params: ExecuteCommandParams
-    execute_command_result: ExecuteCommandResult
     extension: Extension
     extension_list: ExtensionList
     extensions_disable_request: ExtensionsDisableRequest
@@ -14104,31 +7544,18 @@ class RPC:
     filter_mapping: dict[str, ContentFilterMode] | ContentFilterMode
     fleet_start_request: FleetStartRequest
     fleet_start_result: FleetStartResult
-    gh_cli_auth_info: GhCLIAuthInfo
     handle_pending_tool_call_request: HandlePendingToolCallRequest
     handle_pending_tool_call_result: HandlePendingToolCallResult
-    history_abort_manual_compaction_result: HistoryAbortManualCompactionResult
-    history_cancel_background_compaction_result: HistoryCancelBackgroundCompactionResult
     history_compact_context_window: HistoryCompactContextWindow
     history_compact_result: HistoryCompactResult
-    history_summarize_for_handoff_result: HistorySummarizeForHandoffResult
     history_truncate_request: HistoryTruncateRequest
     history_truncate_result: HistoryTruncateResult
-    hmac_auth_info: HMACAuthInfo
-    installed_plugin: InstalledPlugin
-    installed_plugin_source: InstalledPluginSource | str
-    installed_plugin_source_github: InstalledPluginSourceGithub
-    installed_plugin_source_local: InstalledPluginSourceLocal
-    installed_plugin_source_url: InstalledPluginSourceURL
     instructions_get_sources_result: InstructionsGetSourcesResult
     instructions_sources: InstructionsSources
     instructions_sources_location: InstructionsSourcesLocation
     instructions_sources_type: InstructionsSourcesType
     log_request: LogRequest
     log_result: LogResult
-    lsp_initialize_request: LspInitializeRequest
-    mcp_cancel_sampling_execution_params: MCPCancelSamplingExecutionParams
-    mcp_cancel_sampling_execution_result: MCPCancelSamplingExecutionResult
     mcp_config_add_request: MCPConfigAddRequest
     mcp_config_disable_request: MCPConfigDisableRequest
     mcp_config_enable_request: MCPConfigEnableRequest
@@ -14139,14 +7566,8 @@ class RPC:
     mcp_discover_request: MCPDiscoverRequest
     mcp_discover_result: MCPDiscoverResult
     mcp_enable_request: MCPEnableRequest
-    mcp_execute_sampling_params: MCPExecuteSamplingParams
-    mcp_execute_sampling_request: dict[str, Any]
-    mcp_execute_sampling_result: dict[str, Any]
     mcp_oauth_login_request: MCPOauthLoginRequest
     mcp_oauth_login_result: MCPOauthLoginResult
-    mcp_remove_git_hub_result: MCPRemoveGitHubResult
-    mcp_sampling_execution_action: MCPSamplingExecutionAction
-    mcp_sampling_execution_result: MCPSamplingExecutionResult
     mcp_server: MCPServer
     mcp_server_config: MCPServerConfig
     mcp_server_config_http: MCPServerConfigHTTP
@@ -14155,22 +7576,6 @@ class RPC:
     mcp_server_config_http_type: MCPServerConfigHTTPType
     mcp_server_config_stdio: MCPServerConfigStdio
     mcp_server_list: MCPServerList
-    mcp_set_env_value_mode_details: MCPSetEnvValueModeDetails
-    mcp_set_env_value_mode_params: MCPSetEnvValueModeParams
-    mcp_set_env_value_mode_result: MCPSetEnvValueModeResult
-    metadata_context_info_request: MetadataContextInfoRequest
-    metadata_context_info_result: MetadataContextInfoResult
-    metadata_is_processing_result: MetadataIsProcessingResult
-    metadata_recompute_context_tokens_request: MetadataRecomputeContextTokensRequest
-    metadata_recompute_context_tokens_result: MetadataRecomputeContextTokensResult
-    metadata_record_context_change_request: MetadataRecordContextChangeRequest
-    metadata_record_context_change_result: MetadataRecordContextChangeResult
-    metadata_set_working_directory_request: MetadataSetWorkingDirectoryRequest
-    metadata_set_working_directory_result: MetadataSetWorkingDirectoryResult
-    metadata_snapshot_current_mode: MetadataSnapshotCurrentMode
-    metadata_snapshot_remote_metadata: MetadataSnapshotRemoteMetadata
-    metadata_snapshot_remote_metadata_repository: MetadataSnapshotRemoteMetadataRepository
-    metadata_snapshot_remote_metadata_task_type: MetadataSnapshotRemoteMetadataTaskType
     model: Model
     model_billing: ModelBilling
     model_billing_token_prices: ModelBillingTokenPrices
@@ -14187,23 +7592,13 @@ class RPC:
     model_picker_price_category: ModelPickerPriceCategory
     model_policy: ModelPolicy
     model_policy_state: ModelPolicyState
-    model_set_reasoning_effort_request: ModelSetReasoningEffortRequest
-    model_set_reasoning_effort_result: ModelSetReasoningEffortResult
     models_list_request: ModelsListRequest
     model_switch_to_request: ModelSwitchToRequest
     model_switch_to_result: ModelSwitchToResult
     mode_set_request: ModeSetRequest
     name_get_result: NameGetResult
-    name_set_auto_request: NameSetAutoRequest
-    name_set_auto_result: NameSetAutoResult
     name_set_request: NameSetRequest
-    options_update_env_value_mode: MCPSetEnvValueModeDetails
-    pending_permission_request: PendingPermissionRequest
-    pending_permission_request_list: PendingPermissionRequestList
     permission_decision: PermissionDecision
-    permission_decision_approved: PermissionDecisionApproved
-    permission_decision_approved_for_location: PermissionDecisionApprovedForLocation
-    permission_decision_approved_for_session: PermissionDecisionApprovedForSession
     permission_decision_approve_for_location: PermissionDecisionApproveForLocation
     permission_decision_approve_for_location_approval: PermissionDecisionApproveForLocationApproval
     permission_decision_approve_for_location_approval_commands: PermissionDecisionApproveForLocationApprovalCommands
@@ -14228,50 +7623,14 @@ class RPC:
     permission_decision_approve_for_session_approval_write: PermissionDecisionApproveForSessionApprovalWrite
     permission_decision_approve_once: PermissionDecisionApproveOnce
     permission_decision_approve_permanently: PermissionDecisionApprovePermanently
-    permission_decision_cancelled: PermissionDecisionCancelled
-    permission_decision_denied_by_content_exclusion_policy: PermissionDecisionDeniedByContentExclusionPolicy
-    permission_decision_denied_by_permission_request_hook: PermissionDecisionDeniedByPermissionRequestHook
-    permission_decision_denied_by_rules: PermissionDecisionDeniedByRules
-    permission_decision_denied_interactively_by_user: PermissionDecisionDeniedInteractivelyByUser
-    permission_decision_denied_no_approval_rule_and_could_not_request_from_user: PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser
     permission_decision_reject: PermissionDecisionReject
     permission_decision_request: PermissionDecisionRequest
     permission_decision_user_not_available: PermissionDecisionUserNotAvailable
-    permission_paths_add_params: PermissionPathsAddParams
-    permission_paths_allowed_check_params: PermissionPathsAllowedCheckParams
-    permission_paths_allowed_check_result: PermissionPathsAllowedCheckResult
-    permission_paths_config: PermissionPathsConfig
-    permission_paths_list: PermissionPathsList
-    permission_paths_update_primary_params: PermissionPathsUpdatePrimaryParams
-    permission_paths_workspace_check_params: PermissionPathsWorkspaceCheckParams
-    permission_paths_workspace_check_result: PermissionPathsWorkspaceCheckResult
-    permission_prompt_shown_notification: PermissionPromptShownNotification
     permission_request_result: PermissionRequestResult
-    permission_rules_set: PermissionRulesSet
-    permissions_configure_additional_content_exclusion_policy: PermissionsConfigureAdditionalContentExclusionPolicy
-    permissions_configure_additional_content_exclusion_policy_rule: PermissionsConfigureAdditionalContentExclusionPolicyRule
-    permissions_configure_additional_content_exclusion_policy_rule_source: PermissionsConfigureAdditionalContentExclusionPolicyRuleSource
-    permissions_configure_additional_content_exclusion_policy_scope: PermissionsConfigureAdditionalContentExclusionPolicyScope
-    permissions_configure_params: PermissionsConfigureParams
-    permissions_configure_result: PermissionsConfigureResult
-    permissions_modify_rules_params: PermissionsModifyRulesParams
-    permissions_modify_rules_result: PermissionsModifyRulesResult
-    permissions_modify_rules_scope: PermissionsModifyRulesScope
-    permissions_notify_prompt_shown_result: PermissionsNotifyPromptShownResult
-    permissions_paths_add_result: PermissionsPathsAddResult
-    permissions_paths_list_request: PermissionsPathsListRequest
-    permissions_paths_update_primary_result: PermissionsPathsUpdatePrimaryResult
-    permissions_pending_requests_request: PermissionsPendingRequestsRequest
     permissions_reset_session_approvals_request: PermissionsResetSessionApprovalsRequest
     permissions_reset_session_approvals_result: PermissionsResetSessionApprovalsResult
     permissions_set_approve_all_request: PermissionsSetApproveAllRequest
     permissions_set_approve_all_result: PermissionsSetApproveAllResult
-    permissions_set_approve_all_source: PermissionsSetApproveAllSource
-    permissions_set_required_request: PermissionsSetRequiredRequest
-    permissions_set_required_result: PermissionsSetRequiredResult
-    permissions_urls_set_unrestricted_mode_result: PermissionsUrlsSetUnrestrictedModeResult
-    permission_urls_config: PermissionUrlsConfig
-    permission_urls_set_unrestricted_mode_params: PermissionUrlsSetUnrestrictedModeParams
     ping_request: PingRequest
     ping_result: PingResult
     plan_read_result: PlanReadResult
@@ -14281,45 +7640,13 @@ class RPC:
     queued_command_handled: QueuedCommandHandled
     queued_command_not_handled: QueuedCommandNotHandled
     queued_command_result: QueuedCommandResult
-    queue_pending_items: QueuePendingItems
-    queue_pending_items_kind: QueuePendingItemsKind
-    queue_pending_items_result: QueuePendingItemsResult
-    queue_remove_most_recent_result: QueueRemoveMostRecentResult
-    register_event_interest_params: RegisterEventInterestParams
-    register_event_interest_result: RegisterEventInterestResult
-    release_event_interest_params: ReleaseEventInterestParams
     remote_enable_request: RemoteEnableRequest
     remote_enable_result: RemoteEnableResult
-    remote_notify_steerable_changed_request: RemoteNotifySteerableChangedRequest
-    remote_notify_steerable_changed_result: RemoteNotifySteerableChangedResult
     remote_session_connection_result: RemoteSessionConnectionResult
     remote_session_mode: RemoteSessionMode
-    schedule_entry: ScheduleEntry
-    schedule_list: ScheduleList
-    schedule_stop_request: ScheduleStopRequest
-    schedule_stop_result: ScheduleStopResult
-    send_agent_mode: SendAgentMode
-    send_attachment: SendAttachment
-    send_attachment_blob: SendAttachmentBlob
-    send_attachment_directory: SendAttachmentDirectory
-    send_attachment_file: SendAttachmentFile
-    send_attachment_file_line_range: SendAttachmentFileLineRange
-    send_attachment_github_reference: SendAttachmentGithubReference
-    send_attachment_github_reference_type: SendAttachmentGithubReferenceTypeEnum
-    send_attachment_selection: SendAttachmentSelection
-    send_attachment_selection_details: SendAttachmentSelectionDetails
-    send_attachment_selection_details_end: SendAttachmentSelectionDetailsEnd
-    send_attachment_selection_details_start: SendAttachmentSelectionDetailsStart
-    send_mode: SendMode
-    send_request: SendRequest
-    send_result: SendResult
     server_skill: ServerSkill
     server_skill_list: ServerSkillList
     session_auth_status: SessionAuthStatus
-    session_bulk_delete_result: SessionBulkDeleteResult
-    session_context: SessionContext
-    session_context_host_type: SessionContextHostType
-    session_enrich_metadata_result: SessionEnrichMetadataResult
     session_fs_append_file_request: SessionFSAppendFileRequest
     session_fs_error: SessionFSError
     session_fs_error_code: SessionFSErrorCode
@@ -14348,68 +7675,21 @@ class RPC:
     session_fs_stat_request: SessionFSStatRequest
     session_fs_stat_result: SessionFSStatResult
     session_fs_write_file_request: SessionFSWriteFileRequest
-    session_installed_plugin: SessionInstalledPlugin
-    session_installed_plugin_source: SessionInstalledPluginSource | str
-    session_installed_plugin_source_github: SessionInstalledPluginSourceGithub
-    session_installed_plugin_source_local: SessionInstalledPluginSourceLocal
-    session_installed_plugin_source_url: SessionInstalledPluginSourceURL
-    session_list: SessionList
-    session_load_deferred_repo_hooks_result: SessionLoadDeferredRepoHooksResult
     session_log_level: SessionLogLevel
-    session_metadata: SessionMetadata
-    session_metadata_snapshot: SessionMetadataSnapshot
     session_mode: SessionMode
-    session_prune_result: SessionPruneResult
-    sessions_bulk_delete_request: SessionsBulkDeleteRequest
-    sessions_check_in_use_request: SessionsCheckInUseRequest
-    sessions_check_in_use_result: SessionsCheckInUseResult
-    sessions_close_request: SessionsCloseRequest
-    sessions_close_result: SessionsCloseResult
-    sessions_enrich_metadata_request: SessionsEnrichMetadataRequest
-    session_set_credentials_params: SessionSetCredentialsParams
-    session_set_credentials_result: SessionSetCredentialsResult
-    sessions_find_by_prefix_request: SessionsFindByPrefixRequest
-    sessions_find_by_prefix_result: SessionsFindByPrefixResult
-    sessions_find_by_task_id_request: SessionsFindByTaskIDRequest
-    sessions_find_by_task_id_result: SessionsFindByTaskIDResult
     sessions_fork_request: SessionsForkRequest
     sessions_fork_result: SessionsForkResult
-    sessions_get_event_file_path_request: SessionsGetEventFilePathRequest
-    sessions_get_event_file_path_result: SessionsGetEventFilePathResult
-    sessions_get_last_for_context_request: SessionsGetLastForContextRequest
-    sessions_get_last_for_context_result: SessionsGetLastForContextResult
-    sessions_get_persisted_remote_steerable_request: SessionsGetPersistedRemoteSteerableRequest
-    sessions_get_persisted_remote_steerable_result: SessionsGetPersistedRemoteSteerableResult
-    session_sizes: SessionSizes
-    sessions_list_request: SessionsListRequest
-    sessions_load_deferred_repo_hooks_request: SessionsLoadDeferredRepoHooksRequest
-    sessions_prune_old_request: SessionsPruneOldRequest
-    sessions_release_lock_request: SessionsReleaseLockRequest
-    sessions_release_lock_result: SessionsReleaseLockResult
-    sessions_reload_plugin_hooks_request: SessionsReloadPluginHooksRequest
-    sessions_reload_plugin_hooks_result: SessionsReloadPluginHooksResult
-    sessions_save_request: SessionsSaveRequest
-    sessions_save_result: SessionsSaveResult
-    sessions_set_additional_plugins_request: SessionsSetAdditionalPluginsRequest
-    sessions_set_additional_plugins_result: SessionsSetAdditionalPluginsResult
-    session_update_options_params: SessionUpdateOptionsParams
-    session_update_options_result: SessionUpdateOptionsResult
-    session_working_directory_context: SessionWorkingDirectoryContext
-    session_working_directory_context_host_type: SessionContextHostType
     shell_exec_request: ShellExecRequest
     shell_exec_result: ShellExecResult
     shell_kill_request: ShellKillRequest
     shell_kill_result: ShellKillResult
     shell_kill_signal: ShellKillSignal
-    shutdown_request: ShutdownRequest
     skill: Skill
     skill_list: SkillList
     skills_config_set_disabled_skills_request: SkillsConfigSetDisabledSkillsRequest
     skills_disable_request: SkillsDisableRequest
     skills_discover_request: SkillsDiscoverRequest
     skills_enable_request: SkillsEnableRequest
-    skills_get_invoked_result: SkillsGetInvokedResult
-    skills_invoked_skill: SkillsInvokedSkill
     skills_load_diagnostics: SkillsLoadDiagnostics
     slash_command_agent_prompt_result: SlashCommandAgentPromptResult
     slash_command_completed_result: SlashCommandCompletedResult
@@ -14420,22 +7700,15 @@ class RPC:
     slash_command_kind: SlashCommandKind
     slash_command_text_result: SlashCommandTextResult
     task_agent_info: TaskAgentInfo
-    task_agent_progress: TaskAgentProgress
     task_execution_mode: TaskExecutionMode
     task_info: TaskInfo
     task_list: TaskList
     tasks_cancel_request: TasksCancelRequest
     tasks_cancel_result: TasksCancelResult
-    tasks_get_current_promotable_result: TasksGetCurrentPromotableResult
-    tasks_get_progress_request: TasksGetProgressRequest
-    tasks_get_progress_result: TasksGetProgressResult
     task_shell_info: TaskShellInfo
     task_shell_info_attachment_mode: TaskShellInfoAttachmentMode
-    task_shell_progress: None
-    tasks_promote_current_to_background_result: TasksPromoteCurrentToBackgroundResult
     tasks_promote_to_background_request: TasksPromoteToBackgroundRequest
     tasks_promote_to_background_result: TasksPromoteToBackgroundResult
-    tasks_refresh_result: TasksRefreshResult
     tasks_remove_request: TasksRemoveRequest
     tasks_remove_result: TasksRemoveResult
     tasks_send_message_request: TasksSendMessageRequest
@@ -14443,14 +7716,9 @@ class RPC:
     tasks_start_agent_request: TasksStartAgentRequest
     tasks_start_agent_result: TasksStartAgentResult
     task_status: TaskStatus
-    tasks_wait_for_pending_result: TasksWaitForPendingResult
-    telemetry_set_feature_overrides_request: TelemetrySetFeatureOverridesRequest
-    token_auth_info: TokenAuthInfo
     tool: Tool
     tool_list: ToolList
-    tools_initialize_and_validate_result: ToolsInitializeAndValidateResult
     tools_list_request: ToolsListRequest
-    ui_auto_mode_switch_response: UIAutoModeSwitchResponse
     ui_elicitation_array_any_of_field: UIElicitationArrayAnyOfField
     ui_elicitation_array_any_of_field_items: UIElicitationArrayAnyOfFieldItems
     ui_elicitation_array_any_of_field_items_any_of: UIElicitationArrayAnyOfFieldItemsAnyOf
@@ -14472,19 +7740,7 @@ class RPC:
     ui_elicitation_string_enum_field: UIElicitationStringEnumField
     ui_elicitation_string_one_of_field: UIElicitationStringOneOfField
     ui_elicitation_string_one_of_field_one_of: UIElicitationStringOneOfFieldOneOf
-    ui_exit_plan_mode_action: UIExitPlanModeAction
-    ui_exit_plan_mode_response: UIExitPlanModeResponse
-    ui_handle_pending_auto_mode_switch_request: UIHandlePendingAutoModeSwitchRequest
     ui_handle_pending_elicitation_request: UIHandlePendingElicitationRequest
-    ui_handle_pending_exit_plan_mode_request: UIHandlePendingExitPlanModeRequest
-    ui_handle_pending_result: UIHandlePendingResult
-    ui_handle_pending_sampling_request: UIHandlePendingSamplingRequest
-    ui_handle_pending_sampling_response: dict[str, Any]
-    ui_handle_pending_user_input_request: UIHandlePendingUserInputRequest
-    ui_register_direct_auto_mode_switch_handler_result: UIRegisterDirectAutoModeSwitchHandlerResult
-    ui_unregister_direct_auto_mode_switch_handler_request: UIUnregisterDirectAutoModeSwitchHandlerRequest
-    ui_unregister_direct_auto_mode_switch_handler_result: UIUnregisterDirectAutoModeSwitchHandlerResult
-    ui_user_input_response: UIUserInputResponse
     usage_get_metrics_result: UsageGetMetricsResult
     usage_metrics_code_changes: UsageMetricsCodeChanges
     usage_metrics_model_metric: UsageMetricsModelMetric
@@ -14492,47 +7748,24 @@ class RPC:
     usage_metrics_model_metric_token_detail: UsageMetricsModelMetricTokenDetail
     usage_metrics_model_metric_usage: UsageMetricsModelMetricUsage
     usage_metrics_token_detail: UsageMetricsTokenDetail
-    user_auth_info: UserAuthInfo
-    user_tool_session_approval_commands: UserToolSessionApprovalCommands
-    user_tool_session_approval_custom_tool: UserToolSessionApprovalCustomTool
-    user_tool_session_approval_extension_management: UserToolSessionApprovalExtensionManagement
-    user_tool_session_approval_extension_permission_access: UserToolSessionApprovalExtensionPermissionAccess
-    user_tool_session_approval_mcp: UserToolSessionApprovalMCP
-    user_tool_session_approval_memory: UserToolSessionApprovalMemory
-    user_tool_session_approval_read: UserToolSessionApprovalRead
-    user_tool_session_approval_write: UserToolSessionApprovalWrite
-    workspaces_checkpoints: WorkspacesCheckpoints
     workspaces_create_file_request: WorkspacesCreateFileRequest
     workspaces_get_workspace_result: WorkspacesGetWorkspaceResult
-    workspaces_list_checkpoints_result: WorkspacesListCheckpointsResult
     workspaces_list_files_result: WorkspacesListFilesResult
-    workspaces_read_checkpoint_request: WorkspacesReadCheckpointRequest
-    workspaces_read_checkpoint_result: WorkspacesReadCheckpointResult
     workspaces_read_file_request: WorkspacesReadFileRequest
     workspaces_read_file_result: WorkspacesReadFileResult
-    workspaces_save_large_paste_request: WorkspacesSaveLargePasteRequest
-    workspaces_save_large_paste_result: WorkspacesSaveLargePasteResult
-    session_context_info: SessionContextInfo | None = None
-    task_progress: TaskProgressClass | None = None
-    workspace_summary: WorkspaceSummary | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> 'RPC':
         assert isinstance(obj, dict)
-        abort_request = AbortRequest.from_dict(obj.get("AbortRequest"))
-        abort_result = AbortResult.from_dict(obj.get("AbortResult"))
         account_get_quota_request = AccountGetQuotaRequest.from_dict(obj.get("AccountGetQuotaRequest"))
         account_get_quota_result = AccountGetQuotaResult.from_dict(obj.get("AccountGetQuotaResult"))
         account_quota_snapshot = AccountQuotaSnapshot.from_dict(obj.get("AccountQuotaSnapshot"))
         agent_get_current_result = AgentGetCurrentResult.from_dict(obj.get("AgentGetCurrentResult"))
         agent_info = AgentInfo.from_dict(obj.get("AgentInfo"))
-        agent_info_source = AgentInfoSource(obj.get("AgentInfoSource"))
         agent_list = AgentList.from_dict(obj.get("AgentList"))
         agent_reload_result = AgentReloadResult.from_dict(obj.get("AgentReloadResult"))
         agent_select_request = AgentSelectRequest.from_dict(obj.get("AgentSelectRequest"))
         agent_select_result = AgentSelectResult.from_dict(obj.get("AgentSelectResult"))
-        api_key_auth_info = APIKeyAuthInfo.from_dict(obj.get("ApiKeyAuthInfo"))
-        auth_info = AuthInfo.from_dict(obj.get("AuthInfo"))
         auth_info_type = AuthInfoType(obj.get("AuthInfoType"))
         command_list = CommandList.from_dict(obj.get("CommandList"))
         commands_handle_pending_command_request = CommandsHandlePendingCommandRequest.from_dict(obj.get("CommandsHandlePendingCommandRequest"))
@@ -14548,28 +7781,9 @@ class RPC:
         connect_request = ConnectRequest.from_dict(obj.get("ConnectRequest"))
         connect_result = ConnectResult.from_dict(obj.get("ConnectResult"))
         content_filter_mode = ContentFilterMode(obj.get("ContentFilterMode"))
-        copilot_api_token_auth_info = CopilotAPITokenAuthInfo.from_dict(obj.get("CopilotApiTokenAuthInfo"))
-        copilot_user_response = CopilotUserResponse.from_dict(obj.get("CopilotUserResponse"))
-        copilot_user_response_endpoints = CopilotUserResponseEndpoints.from_dict(obj.get("CopilotUserResponseEndpoints"))
-        copilot_user_response_quota_snapshots = from_dict(lambda x: from_union([CopilotUserResponseQuotaSnapshots.from_dict, from_none], x), obj.get("CopilotUserResponseQuotaSnapshots"))
-        copilot_user_response_quota_snapshots_chat = CopilotUserResponseQuotaSnapshotsChat.from_dict(obj.get("CopilotUserResponseQuotaSnapshotsChat"))
-        copilot_user_response_quota_snapshots_completions = CopilotUserResponseQuotaSnapshotsCompletions.from_dict(obj.get("CopilotUserResponseQuotaSnapshotsCompletions"))
-        copilot_user_response_quota_snapshots_premium_interactions = CopilotUserResponseQuotaSnapshotsPremiumInteractions.from_dict(obj.get("CopilotUserResponseQuotaSnapshotsPremiumInteractions"))
         current_model = CurrentModel.from_dict(obj.get("CurrentModel"))
         discovered_mcp_server = DiscoveredMCPServer.from_dict(obj.get("DiscoveredMcpServer"))
         discovered_mcp_server_type = DiscoveredMCPServerType(obj.get("DiscoveredMcpServerType"))
-        enqueue_command_params = EnqueueCommandParams.from_dict(obj.get("EnqueueCommandParams"))
-        enqueue_command_result = EnqueueCommandResult.from_dict(obj.get("EnqueueCommandResult"))
-        env_auth_info = EnvAuthInfo.from_dict(obj.get("EnvAuthInfo"))
-        event_log_read_request = EventLogReadRequest.from_dict(obj.get("EventLogReadRequest"))
-        event_log_release_interest_result = EventLogReleaseInterestResult.from_dict(obj.get("EventLogReleaseInterestResult"))
-        event_log_tail_result = EventLogTailResult.from_dict(obj.get("EventLogTailResult"))
-        event_log_types = from_union([lambda x: from_list(from_str, x), EventLogTypes], obj.get("EventLogTypes"))
-        events_agent_scope = EventsAgentScope(obj.get("EventsAgentScope"))
-        events_cursor_status = EventsCursorStatus(obj.get("EventsCursorStatus"))
-        events_read_result = EventsReadResult.from_dict(obj.get("EventsReadResult"))
-        execute_command_params = ExecuteCommandParams.from_dict(obj.get("ExecuteCommandParams"))
-        execute_command_result = ExecuteCommandResult.from_dict(obj.get("ExecuteCommandResult"))
         extension = Extension.from_dict(obj.get("Extension"))
         extension_list = ExtensionList.from_dict(obj.get("ExtensionList"))
         extensions_disable_request = ExtensionsDisableRequest.from_dict(obj.get("ExtensionsDisableRequest"))
@@ -14593,31 +7807,18 @@ class RPC:
         filter_mapping = from_union([lambda x: from_dict(ContentFilterMode, x), ContentFilterMode], obj.get("FilterMapping"))
         fleet_start_request = FleetStartRequest.from_dict(obj.get("FleetStartRequest"))
         fleet_start_result = FleetStartResult.from_dict(obj.get("FleetStartResult"))
-        gh_cli_auth_info = GhCLIAuthInfo.from_dict(obj.get("GhCliAuthInfo"))
         handle_pending_tool_call_request = HandlePendingToolCallRequest.from_dict(obj.get("HandlePendingToolCallRequest"))
         handle_pending_tool_call_result = HandlePendingToolCallResult.from_dict(obj.get("HandlePendingToolCallResult"))
-        history_abort_manual_compaction_result = HistoryAbortManualCompactionResult.from_dict(obj.get("HistoryAbortManualCompactionResult"))
-        history_cancel_background_compaction_result = HistoryCancelBackgroundCompactionResult.from_dict(obj.get("HistoryCancelBackgroundCompactionResult"))
         history_compact_context_window = HistoryCompactContextWindow.from_dict(obj.get("HistoryCompactContextWindow"))
         history_compact_result = HistoryCompactResult.from_dict(obj.get("HistoryCompactResult"))
-        history_summarize_for_handoff_result = HistorySummarizeForHandoffResult.from_dict(obj.get("HistorySummarizeForHandoffResult"))
         history_truncate_request = HistoryTruncateRequest.from_dict(obj.get("HistoryTruncateRequest"))
         history_truncate_result = HistoryTruncateResult.from_dict(obj.get("HistoryTruncateResult"))
-        hmac_auth_info = HMACAuthInfo.from_dict(obj.get("HMACAuthInfo"))
-        installed_plugin = InstalledPlugin.from_dict(obj.get("InstalledPlugin"))
-        installed_plugin_source = from_union([InstalledPluginSource.from_dict, from_str], obj.get("InstalledPluginSource"))
-        installed_plugin_source_github = InstalledPluginSourceGithub.from_dict(obj.get("InstalledPluginSourceGithub"))
-        installed_plugin_source_local = InstalledPluginSourceLocal.from_dict(obj.get("InstalledPluginSourceLocal"))
-        installed_plugin_source_url = InstalledPluginSourceURL.from_dict(obj.get("InstalledPluginSourceUrl"))
         instructions_get_sources_result = InstructionsGetSourcesResult.from_dict(obj.get("InstructionsGetSourcesResult"))
         instructions_sources = InstructionsSources.from_dict(obj.get("InstructionsSources"))
         instructions_sources_location = InstructionsSourcesLocation(obj.get("InstructionsSourcesLocation"))
         instructions_sources_type = InstructionsSourcesType(obj.get("InstructionsSourcesType"))
         log_request = LogRequest.from_dict(obj.get("LogRequest"))
         log_result = LogResult.from_dict(obj.get("LogResult"))
-        lsp_initialize_request = LspInitializeRequest.from_dict(obj.get("LspInitializeRequest"))
-        mcp_cancel_sampling_execution_params = MCPCancelSamplingExecutionParams.from_dict(obj.get("McpCancelSamplingExecutionParams"))
-        mcp_cancel_sampling_execution_result = MCPCancelSamplingExecutionResult.from_dict(obj.get("McpCancelSamplingExecutionResult"))
         mcp_config_add_request = MCPConfigAddRequest.from_dict(obj.get("McpConfigAddRequest"))
         mcp_config_disable_request = MCPConfigDisableRequest.from_dict(obj.get("McpConfigDisableRequest"))
         mcp_config_enable_request = MCPConfigEnableRequest.from_dict(obj.get("McpConfigEnableRequest"))
@@ -14628,14 +7829,8 @@ class RPC:
         mcp_discover_request = MCPDiscoverRequest.from_dict(obj.get("McpDiscoverRequest"))
         mcp_discover_result = MCPDiscoverResult.from_dict(obj.get("McpDiscoverResult"))
         mcp_enable_request = MCPEnableRequest.from_dict(obj.get("McpEnableRequest"))
-        mcp_execute_sampling_params = MCPExecuteSamplingParams.from_dict(obj.get("McpExecuteSamplingParams"))
-        mcp_execute_sampling_request = from_dict(lambda x: x, obj.get("McpExecuteSamplingRequest"))
-        mcp_execute_sampling_result = from_dict(lambda x: x, obj.get("McpExecuteSamplingResult"))
         mcp_oauth_login_request = MCPOauthLoginRequest.from_dict(obj.get("McpOauthLoginRequest"))
         mcp_oauth_login_result = MCPOauthLoginResult.from_dict(obj.get("McpOauthLoginResult"))
-        mcp_remove_git_hub_result = MCPRemoveGitHubResult.from_dict(obj.get("McpRemoveGitHubResult"))
-        mcp_sampling_execution_action = MCPSamplingExecutionAction(obj.get("McpSamplingExecutionAction"))
-        mcp_sampling_execution_result = MCPSamplingExecutionResult.from_dict(obj.get("McpSamplingExecutionResult"))
         mcp_server = MCPServer.from_dict(obj.get("McpServer"))
         mcp_server_config = MCPServerConfig.from_dict(obj.get("McpServerConfig"))
         mcp_server_config_http = MCPServerConfigHTTP.from_dict(obj.get("McpServerConfigHttp"))
@@ -14644,22 +7839,6 @@ class RPC:
         mcp_server_config_http_type = MCPServerConfigHTTPType(obj.get("McpServerConfigHttpType"))
         mcp_server_config_stdio = MCPServerConfigStdio.from_dict(obj.get("McpServerConfigStdio"))
         mcp_server_list = MCPServerList.from_dict(obj.get("McpServerList"))
-        mcp_set_env_value_mode_details = MCPSetEnvValueModeDetails(obj.get("McpSetEnvValueModeDetails"))
-        mcp_set_env_value_mode_params = MCPSetEnvValueModeParams.from_dict(obj.get("McpSetEnvValueModeParams"))
-        mcp_set_env_value_mode_result = MCPSetEnvValueModeResult.from_dict(obj.get("McpSetEnvValueModeResult"))
-        metadata_context_info_request = MetadataContextInfoRequest.from_dict(obj.get("MetadataContextInfoRequest"))
-        metadata_context_info_result = MetadataContextInfoResult.from_dict(obj.get("MetadataContextInfoResult"))
-        metadata_is_processing_result = MetadataIsProcessingResult.from_dict(obj.get("MetadataIsProcessingResult"))
-        metadata_recompute_context_tokens_request = MetadataRecomputeContextTokensRequest.from_dict(obj.get("MetadataRecomputeContextTokensRequest"))
-        metadata_recompute_context_tokens_result = MetadataRecomputeContextTokensResult.from_dict(obj.get("MetadataRecomputeContextTokensResult"))
-        metadata_record_context_change_request = MetadataRecordContextChangeRequest.from_dict(obj.get("MetadataRecordContextChangeRequest"))
-        metadata_record_context_change_result = MetadataRecordContextChangeResult.from_dict(obj.get("MetadataRecordContextChangeResult"))
-        metadata_set_working_directory_request = MetadataSetWorkingDirectoryRequest.from_dict(obj.get("MetadataSetWorkingDirectoryRequest"))
-        metadata_set_working_directory_result = MetadataSetWorkingDirectoryResult.from_dict(obj.get("MetadataSetWorkingDirectoryResult"))
-        metadata_snapshot_current_mode = MetadataSnapshotCurrentMode(obj.get("MetadataSnapshotCurrentMode"))
-        metadata_snapshot_remote_metadata = MetadataSnapshotRemoteMetadata.from_dict(obj.get("MetadataSnapshotRemoteMetadata"))
-        metadata_snapshot_remote_metadata_repository = MetadataSnapshotRemoteMetadataRepository.from_dict(obj.get("MetadataSnapshotRemoteMetadataRepository"))
-        metadata_snapshot_remote_metadata_task_type = MetadataSnapshotRemoteMetadataTaskType(obj.get("MetadataSnapshotRemoteMetadataTaskType"))
         model = Model.from_dict(obj.get("Model"))
         model_billing = ModelBilling.from_dict(obj.get("ModelBilling"))
         model_billing_token_prices = ModelBillingTokenPrices.from_dict(obj.get("ModelBillingTokenPrices"))
@@ -14676,23 +7855,13 @@ class RPC:
         model_picker_price_category = ModelPickerPriceCategory(obj.get("ModelPickerPriceCategory"))
         model_policy = ModelPolicy.from_dict(obj.get("ModelPolicy"))
         model_policy_state = ModelPolicyState(obj.get("ModelPolicyState"))
-        model_set_reasoning_effort_request = ModelSetReasoningEffortRequest.from_dict(obj.get("ModelSetReasoningEffortRequest"))
-        model_set_reasoning_effort_result = ModelSetReasoningEffortResult.from_dict(obj.get("ModelSetReasoningEffortResult"))
         models_list_request = ModelsListRequest.from_dict(obj.get("ModelsListRequest"))
         model_switch_to_request = ModelSwitchToRequest.from_dict(obj.get("ModelSwitchToRequest"))
         model_switch_to_result = ModelSwitchToResult.from_dict(obj.get("ModelSwitchToResult"))
         mode_set_request = ModeSetRequest.from_dict(obj.get("ModeSetRequest"))
         name_get_result = NameGetResult.from_dict(obj.get("NameGetResult"))
-        name_set_auto_request = NameSetAutoRequest.from_dict(obj.get("NameSetAutoRequest"))
-        name_set_auto_result = NameSetAutoResult.from_dict(obj.get("NameSetAutoResult"))
         name_set_request = NameSetRequest.from_dict(obj.get("NameSetRequest"))
-        options_update_env_value_mode = MCPSetEnvValueModeDetails(obj.get("OptionsUpdateEnvValueMode"))
-        pending_permission_request = PendingPermissionRequest.from_dict(obj.get("PendingPermissionRequest"))
-        pending_permission_request_list = PendingPermissionRequestList.from_dict(obj.get("PendingPermissionRequestList"))
         permission_decision = PermissionDecision.from_dict(obj.get("PermissionDecision"))
-        permission_decision_approved = PermissionDecisionApproved.from_dict(obj.get("PermissionDecisionApproved"))
-        permission_decision_approved_for_location = PermissionDecisionApprovedForLocation.from_dict(obj.get("PermissionDecisionApprovedForLocation"))
-        permission_decision_approved_for_session = PermissionDecisionApprovedForSession.from_dict(obj.get("PermissionDecisionApprovedForSession"))
         permission_decision_approve_for_location = PermissionDecisionApproveForLocation.from_dict(obj.get("PermissionDecisionApproveForLocation"))
         permission_decision_approve_for_location_approval = PermissionDecisionApproveForLocationApproval.from_dict(obj.get("PermissionDecisionApproveForLocationApproval"))
         permission_decision_approve_for_location_approval_commands = PermissionDecisionApproveForLocationApprovalCommands.from_dict(obj.get("PermissionDecisionApproveForLocationApprovalCommands"))
@@ -14717,50 +7886,14 @@ class RPC:
         permission_decision_approve_for_session_approval_write = PermissionDecisionApproveForSessionApprovalWrite.from_dict(obj.get("PermissionDecisionApproveForSessionApprovalWrite"))
         permission_decision_approve_once = PermissionDecisionApproveOnce.from_dict(obj.get("PermissionDecisionApproveOnce"))
         permission_decision_approve_permanently = PermissionDecisionApprovePermanently.from_dict(obj.get("PermissionDecisionApprovePermanently"))
-        permission_decision_cancelled = PermissionDecisionCancelled.from_dict(obj.get("PermissionDecisionCancelled"))
-        permission_decision_denied_by_content_exclusion_policy = PermissionDecisionDeniedByContentExclusionPolicy.from_dict(obj.get("PermissionDecisionDeniedByContentExclusionPolicy"))
-        permission_decision_denied_by_permission_request_hook = PermissionDecisionDeniedByPermissionRequestHook.from_dict(obj.get("PermissionDecisionDeniedByPermissionRequestHook"))
-        permission_decision_denied_by_rules = PermissionDecisionDeniedByRules.from_dict(obj.get("PermissionDecisionDeniedByRules"))
-        permission_decision_denied_interactively_by_user = PermissionDecisionDeniedInteractivelyByUser.from_dict(obj.get("PermissionDecisionDeniedInteractivelyByUser"))
-        permission_decision_denied_no_approval_rule_and_could_not_request_from_user = PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser.from_dict(obj.get("PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser"))
         permission_decision_reject = PermissionDecisionReject.from_dict(obj.get("PermissionDecisionReject"))
         permission_decision_request = PermissionDecisionRequest.from_dict(obj.get("PermissionDecisionRequest"))
         permission_decision_user_not_available = PermissionDecisionUserNotAvailable.from_dict(obj.get("PermissionDecisionUserNotAvailable"))
-        permission_paths_add_params = PermissionPathsAddParams.from_dict(obj.get("PermissionPathsAddParams"))
-        permission_paths_allowed_check_params = PermissionPathsAllowedCheckParams.from_dict(obj.get("PermissionPathsAllowedCheckParams"))
-        permission_paths_allowed_check_result = PermissionPathsAllowedCheckResult.from_dict(obj.get("PermissionPathsAllowedCheckResult"))
-        permission_paths_config = PermissionPathsConfig.from_dict(obj.get("PermissionPathsConfig"))
-        permission_paths_list = PermissionPathsList.from_dict(obj.get("PermissionPathsList"))
-        permission_paths_update_primary_params = PermissionPathsUpdatePrimaryParams.from_dict(obj.get("PermissionPathsUpdatePrimaryParams"))
-        permission_paths_workspace_check_params = PermissionPathsWorkspaceCheckParams.from_dict(obj.get("PermissionPathsWorkspaceCheckParams"))
-        permission_paths_workspace_check_result = PermissionPathsWorkspaceCheckResult.from_dict(obj.get("PermissionPathsWorkspaceCheckResult"))
-        permission_prompt_shown_notification = PermissionPromptShownNotification.from_dict(obj.get("PermissionPromptShownNotification"))
         permission_request_result = PermissionRequestResult.from_dict(obj.get("PermissionRequestResult"))
-        permission_rules_set = PermissionRulesSet.from_dict(obj.get("PermissionRulesSet"))
-        permissions_configure_additional_content_exclusion_policy = PermissionsConfigureAdditionalContentExclusionPolicy.from_dict(obj.get("PermissionsConfigureAdditionalContentExclusionPolicy"))
-        permissions_configure_additional_content_exclusion_policy_rule = PermissionsConfigureAdditionalContentExclusionPolicyRule.from_dict(obj.get("PermissionsConfigureAdditionalContentExclusionPolicyRule"))
-        permissions_configure_additional_content_exclusion_policy_rule_source = PermissionsConfigureAdditionalContentExclusionPolicyRuleSource.from_dict(obj.get("PermissionsConfigureAdditionalContentExclusionPolicyRuleSource"))
-        permissions_configure_additional_content_exclusion_policy_scope = PermissionsConfigureAdditionalContentExclusionPolicyScope(obj.get("PermissionsConfigureAdditionalContentExclusionPolicyScope"))
-        permissions_configure_params = PermissionsConfigureParams.from_dict(obj.get("PermissionsConfigureParams"))
-        permissions_configure_result = PermissionsConfigureResult.from_dict(obj.get("PermissionsConfigureResult"))
-        permissions_modify_rules_params = PermissionsModifyRulesParams.from_dict(obj.get("PermissionsModifyRulesParams"))
-        permissions_modify_rules_result = PermissionsModifyRulesResult.from_dict(obj.get("PermissionsModifyRulesResult"))
-        permissions_modify_rules_scope = PermissionsModifyRulesScope(obj.get("PermissionsModifyRulesScope"))
-        permissions_notify_prompt_shown_result = PermissionsNotifyPromptShownResult.from_dict(obj.get("PermissionsNotifyPromptShownResult"))
-        permissions_paths_add_result = PermissionsPathsAddResult.from_dict(obj.get("PermissionsPathsAddResult"))
-        permissions_paths_list_request = PermissionsPathsListRequest.from_dict(obj.get("PermissionsPathsListRequest"))
-        permissions_paths_update_primary_result = PermissionsPathsUpdatePrimaryResult.from_dict(obj.get("PermissionsPathsUpdatePrimaryResult"))
-        permissions_pending_requests_request = PermissionsPendingRequestsRequest.from_dict(obj.get("PermissionsPendingRequestsRequest"))
         permissions_reset_session_approvals_request = PermissionsResetSessionApprovalsRequest.from_dict(obj.get("PermissionsResetSessionApprovalsRequest"))
         permissions_reset_session_approvals_result = PermissionsResetSessionApprovalsResult.from_dict(obj.get("PermissionsResetSessionApprovalsResult"))
         permissions_set_approve_all_request = PermissionsSetApproveAllRequest.from_dict(obj.get("PermissionsSetApproveAllRequest"))
         permissions_set_approve_all_result = PermissionsSetApproveAllResult.from_dict(obj.get("PermissionsSetApproveAllResult"))
-        permissions_set_approve_all_source = PermissionsSetApproveAllSource(obj.get("PermissionsSetApproveAllSource"))
-        permissions_set_required_request = PermissionsSetRequiredRequest.from_dict(obj.get("PermissionsSetRequiredRequest"))
-        permissions_set_required_result = PermissionsSetRequiredResult.from_dict(obj.get("PermissionsSetRequiredResult"))
-        permissions_urls_set_unrestricted_mode_result = PermissionsUrlsSetUnrestrictedModeResult.from_dict(obj.get("PermissionsUrlsSetUnrestrictedModeResult"))
-        permission_urls_config = PermissionUrlsConfig.from_dict(obj.get("PermissionUrlsConfig"))
-        permission_urls_set_unrestricted_mode_params = PermissionUrlsSetUnrestrictedModeParams.from_dict(obj.get("PermissionUrlsSetUnrestrictedModeParams"))
         ping_request = PingRequest.from_dict(obj.get("PingRequest"))
         ping_result = PingResult.from_dict(obj.get("PingResult"))
         plan_read_result = PlanReadResult.from_dict(obj.get("PlanReadResult"))
@@ -14770,45 +7903,13 @@ class RPC:
         queued_command_handled = QueuedCommandHandled.from_dict(obj.get("QueuedCommandHandled"))
         queued_command_not_handled = QueuedCommandNotHandled.from_dict(obj.get("QueuedCommandNotHandled"))
         queued_command_result = QueuedCommandResult.from_dict(obj.get("QueuedCommandResult"))
-        queue_pending_items = QueuePendingItems.from_dict(obj.get("QueuePendingItems"))
-        queue_pending_items_kind = QueuePendingItemsKind(obj.get("QueuePendingItemsKind"))
-        queue_pending_items_result = QueuePendingItemsResult.from_dict(obj.get("QueuePendingItemsResult"))
-        queue_remove_most_recent_result = QueueRemoveMostRecentResult.from_dict(obj.get("QueueRemoveMostRecentResult"))
-        register_event_interest_params = RegisterEventInterestParams.from_dict(obj.get("RegisterEventInterestParams"))
-        register_event_interest_result = RegisterEventInterestResult.from_dict(obj.get("RegisterEventInterestResult"))
-        release_event_interest_params = ReleaseEventInterestParams.from_dict(obj.get("ReleaseEventInterestParams"))
         remote_enable_request = RemoteEnableRequest.from_dict(obj.get("RemoteEnableRequest"))
         remote_enable_result = RemoteEnableResult.from_dict(obj.get("RemoteEnableResult"))
-        remote_notify_steerable_changed_request = RemoteNotifySteerableChangedRequest.from_dict(obj.get("RemoteNotifySteerableChangedRequest"))
-        remote_notify_steerable_changed_result = RemoteNotifySteerableChangedResult.from_dict(obj.get("RemoteNotifySteerableChangedResult"))
         remote_session_connection_result = RemoteSessionConnectionResult.from_dict(obj.get("RemoteSessionConnectionResult"))
         remote_session_mode = RemoteSessionMode(obj.get("RemoteSessionMode"))
-        schedule_entry = ScheduleEntry.from_dict(obj.get("ScheduleEntry"))
-        schedule_list = ScheduleList.from_dict(obj.get("ScheduleList"))
-        schedule_stop_request = ScheduleStopRequest.from_dict(obj.get("ScheduleStopRequest"))
-        schedule_stop_result = ScheduleStopResult.from_dict(obj.get("ScheduleStopResult"))
-        send_agent_mode = SendAgentMode(obj.get("SendAgentMode"))
-        send_attachment = SendAttachment.from_dict(obj.get("SendAttachment"))
-        send_attachment_blob = SendAttachmentBlob.from_dict(obj.get("SendAttachmentBlob"))
-        send_attachment_directory = SendAttachmentDirectory.from_dict(obj.get("SendAttachmentDirectory"))
-        send_attachment_file = SendAttachmentFile.from_dict(obj.get("SendAttachmentFile"))
-        send_attachment_file_line_range = SendAttachmentFileLineRange.from_dict(obj.get("SendAttachmentFileLineRange"))
-        send_attachment_github_reference = SendAttachmentGithubReference.from_dict(obj.get("SendAttachmentGithubReference"))
-        send_attachment_github_reference_type = SendAttachmentGithubReferenceTypeEnum(obj.get("SendAttachmentGithubReferenceType"))
-        send_attachment_selection = SendAttachmentSelection.from_dict(obj.get("SendAttachmentSelection"))
-        send_attachment_selection_details = SendAttachmentSelectionDetails.from_dict(obj.get("SendAttachmentSelectionDetails"))
-        send_attachment_selection_details_end = SendAttachmentSelectionDetailsEnd.from_dict(obj.get("SendAttachmentSelectionDetailsEnd"))
-        send_attachment_selection_details_start = SendAttachmentSelectionDetailsStart.from_dict(obj.get("SendAttachmentSelectionDetailsStart"))
-        send_mode = SendMode(obj.get("SendMode"))
-        send_request = SendRequest.from_dict(obj.get("SendRequest"))
-        send_result = SendResult.from_dict(obj.get("SendResult"))
         server_skill = ServerSkill.from_dict(obj.get("ServerSkill"))
         server_skill_list = ServerSkillList.from_dict(obj.get("ServerSkillList"))
         session_auth_status = SessionAuthStatus.from_dict(obj.get("SessionAuthStatus"))
-        session_bulk_delete_result = SessionBulkDeleteResult.from_dict(obj.get("SessionBulkDeleteResult"))
-        session_context = SessionContext.from_dict(obj.get("SessionContext"))
-        session_context_host_type = SessionContextHostType(obj.get("SessionContextHostType"))
-        session_enrich_metadata_result = SessionEnrichMetadataResult.from_dict(obj.get("SessionEnrichMetadataResult"))
         session_fs_append_file_request = SessionFSAppendFileRequest.from_dict(obj.get("SessionFsAppendFileRequest"))
         session_fs_error = SessionFSError.from_dict(obj.get("SessionFsError"))
         session_fs_error_code = SessionFSErrorCode(obj.get("SessionFsErrorCode"))
@@ -14837,68 +7938,21 @@ class RPC:
         session_fs_stat_request = SessionFSStatRequest.from_dict(obj.get("SessionFsStatRequest"))
         session_fs_stat_result = SessionFSStatResult.from_dict(obj.get("SessionFsStatResult"))
         session_fs_write_file_request = SessionFSWriteFileRequest.from_dict(obj.get("SessionFsWriteFileRequest"))
-        session_installed_plugin = SessionInstalledPlugin.from_dict(obj.get("SessionInstalledPlugin"))
-        session_installed_plugin_source = from_union([SessionInstalledPluginSource.from_dict, from_str], obj.get("SessionInstalledPluginSource"))
-        session_installed_plugin_source_github = SessionInstalledPluginSourceGithub.from_dict(obj.get("SessionInstalledPluginSourceGithub"))
-        session_installed_plugin_source_local = SessionInstalledPluginSourceLocal.from_dict(obj.get("SessionInstalledPluginSourceLocal"))
-        session_installed_plugin_source_url = SessionInstalledPluginSourceURL.from_dict(obj.get("SessionInstalledPluginSourceUrl"))
-        session_list = SessionList.from_dict(obj.get("SessionList"))
-        session_load_deferred_repo_hooks_result = SessionLoadDeferredRepoHooksResult.from_dict(obj.get("SessionLoadDeferredRepoHooksResult"))
         session_log_level = SessionLogLevel(obj.get("SessionLogLevel"))
-        session_metadata = SessionMetadata.from_dict(obj.get("SessionMetadata"))
-        session_metadata_snapshot = SessionMetadataSnapshot.from_dict(obj.get("SessionMetadataSnapshot"))
         session_mode = SessionMode(obj.get("SessionMode"))
-        session_prune_result = SessionPruneResult.from_dict(obj.get("SessionPruneResult"))
-        sessions_bulk_delete_request = SessionsBulkDeleteRequest.from_dict(obj.get("SessionsBulkDeleteRequest"))
-        sessions_check_in_use_request = SessionsCheckInUseRequest.from_dict(obj.get("SessionsCheckInUseRequest"))
-        sessions_check_in_use_result = SessionsCheckInUseResult.from_dict(obj.get("SessionsCheckInUseResult"))
-        sessions_close_request = SessionsCloseRequest.from_dict(obj.get("SessionsCloseRequest"))
-        sessions_close_result = SessionsCloseResult.from_dict(obj.get("SessionsCloseResult"))
-        sessions_enrich_metadata_request = SessionsEnrichMetadataRequest.from_dict(obj.get("SessionsEnrichMetadataRequest"))
-        session_set_credentials_params = SessionSetCredentialsParams.from_dict(obj.get("SessionSetCredentialsParams"))
-        session_set_credentials_result = SessionSetCredentialsResult.from_dict(obj.get("SessionSetCredentialsResult"))
-        sessions_find_by_prefix_request = SessionsFindByPrefixRequest.from_dict(obj.get("SessionsFindByPrefixRequest"))
-        sessions_find_by_prefix_result = SessionsFindByPrefixResult.from_dict(obj.get("SessionsFindByPrefixResult"))
-        sessions_find_by_task_id_request = SessionsFindByTaskIDRequest.from_dict(obj.get("SessionsFindByTaskIDRequest"))
-        sessions_find_by_task_id_result = SessionsFindByTaskIDResult.from_dict(obj.get("SessionsFindByTaskIDResult"))
         sessions_fork_request = SessionsForkRequest.from_dict(obj.get("SessionsForkRequest"))
         sessions_fork_result = SessionsForkResult.from_dict(obj.get("SessionsForkResult"))
-        sessions_get_event_file_path_request = SessionsGetEventFilePathRequest.from_dict(obj.get("SessionsGetEventFilePathRequest"))
-        sessions_get_event_file_path_result = SessionsGetEventFilePathResult.from_dict(obj.get("SessionsGetEventFilePathResult"))
-        sessions_get_last_for_context_request = SessionsGetLastForContextRequest.from_dict(obj.get("SessionsGetLastForContextRequest"))
-        sessions_get_last_for_context_result = SessionsGetLastForContextResult.from_dict(obj.get("SessionsGetLastForContextResult"))
-        sessions_get_persisted_remote_steerable_request = SessionsGetPersistedRemoteSteerableRequest.from_dict(obj.get("SessionsGetPersistedRemoteSteerableRequest"))
-        sessions_get_persisted_remote_steerable_result = SessionsGetPersistedRemoteSteerableResult.from_dict(obj.get("SessionsGetPersistedRemoteSteerableResult"))
-        session_sizes = SessionSizes.from_dict(obj.get("SessionSizes"))
-        sessions_list_request = SessionsListRequest.from_dict(obj.get("SessionsListRequest"))
-        sessions_load_deferred_repo_hooks_request = SessionsLoadDeferredRepoHooksRequest.from_dict(obj.get("SessionsLoadDeferredRepoHooksRequest"))
-        sessions_prune_old_request = SessionsPruneOldRequest.from_dict(obj.get("SessionsPruneOldRequest"))
-        sessions_release_lock_request = SessionsReleaseLockRequest.from_dict(obj.get("SessionsReleaseLockRequest"))
-        sessions_release_lock_result = SessionsReleaseLockResult.from_dict(obj.get("SessionsReleaseLockResult"))
-        sessions_reload_plugin_hooks_request = SessionsReloadPluginHooksRequest.from_dict(obj.get("SessionsReloadPluginHooksRequest"))
-        sessions_reload_plugin_hooks_result = SessionsReloadPluginHooksResult.from_dict(obj.get("SessionsReloadPluginHooksResult"))
-        sessions_save_request = SessionsSaveRequest.from_dict(obj.get("SessionsSaveRequest"))
-        sessions_save_result = SessionsSaveResult.from_dict(obj.get("SessionsSaveResult"))
-        sessions_set_additional_plugins_request = SessionsSetAdditionalPluginsRequest.from_dict(obj.get("SessionsSetAdditionalPluginsRequest"))
-        sessions_set_additional_plugins_result = SessionsSetAdditionalPluginsResult.from_dict(obj.get("SessionsSetAdditionalPluginsResult"))
-        session_update_options_params = SessionUpdateOptionsParams.from_dict(obj.get("SessionUpdateOptionsParams"))
-        session_update_options_result = SessionUpdateOptionsResult.from_dict(obj.get("SessionUpdateOptionsResult"))
-        session_working_directory_context = SessionWorkingDirectoryContext.from_dict(obj.get("SessionWorkingDirectoryContext"))
-        session_working_directory_context_host_type = SessionContextHostType(obj.get("SessionWorkingDirectoryContextHostType"))
         shell_exec_request = ShellExecRequest.from_dict(obj.get("ShellExecRequest"))
         shell_exec_result = ShellExecResult.from_dict(obj.get("ShellExecResult"))
         shell_kill_request = ShellKillRequest.from_dict(obj.get("ShellKillRequest"))
         shell_kill_result = ShellKillResult.from_dict(obj.get("ShellKillResult"))
         shell_kill_signal = ShellKillSignal(obj.get("ShellKillSignal"))
-        shutdown_request = ShutdownRequest.from_dict(obj.get("ShutdownRequest"))
         skill = Skill.from_dict(obj.get("Skill"))
         skill_list = SkillList.from_dict(obj.get("SkillList"))
         skills_config_set_disabled_skills_request = SkillsConfigSetDisabledSkillsRequest.from_dict(obj.get("SkillsConfigSetDisabledSkillsRequest"))
         skills_disable_request = SkillsDisableRequest.from_dict(obj.get("SkillsDisableRequest"))
         skills_discover_request = SkillsDiscoverRequest.from_dict(obj.get("SkillsDiscoverRequest"))
         skills_enable_request = SkillsEnableRequest.from_dict(obj.get("SkillsEnableRequest"))
-        skills_get_invoked_result = SkillsGetInvokedResult.from_dict(obj.get("SkillsGetInvokedResult"))
-        skills_invoked_skill = SkillsInvokedSkill.from_dict(obj.get("SkillsInvokedSkill"))
         skills_load_diagnostics = SkillsLoadDiagnostics.from_dict(obj.get("SkillsLoadDiagnostics"))
         slash_command_agent_prompt_result = SlashCommandAgentPromptResult.from_dict(obj.get("SlashCommandAgentPromptResult"))
         slash_command_completed_result = SlashCommandCompletedResult.from_dict(obj.get("SlashCommandCompletedResult"))
@@ -14909,22 +7963,15 @@ class RPC:
         slash_command_kind = SlashCommandKind(obj.get("SlashCommandKind"))
         slash_command_text_result = SlashCommandTextResult.from_dict(obj.get("SlashCommandTextResult"))
         task_agent_info = TaskAgentInfo.from_dict(obj.get("TaskAgentInfo"))
-        task_agent_progress = TaskAgentProgress.from_dict(obj.get("TaskAgentProgress"))
         task_execution_mode = TaskExecutionMode(obj.get("TaskExecutionMode"))
         task_info = TaskInfo.from_dict(obj.get("TaskInfo"))
         task_list = TaskList.from_dict(obj.get("TaskList"))
         tasks_cancel_request = TasksCancelRequest.from_dict(obj.get("TasksCancelRequest"))
         tasks_cancel_result = TasksCancelResult.from_dict(obj.get("TasksCancelResult"))
-        tasks_get_current_promotable_result = TasksGetCurrentPromotableResult.from_dict(obj.get("TasksGetCurrentPromotableResult"))
-        tasks_get_progress_request = TasksGetProgressRequest.from_dict(obj.get("TasksGetProgressRequest"))
-        tasks_get_progress_result = TasksGetProgressResult.from_dict(obj.get("TasksGetProgressResult"))
         task_shell_info = TaskShellInfo.from_dict(obj.get("TaskShellInfo"))
         task_shell_info_attachment_mode = TaskShellInfoAttachmentMode(obj.get("TaskShellInfoAttachmentMode"))
-        task_shell_progress = from_none(obj.get("TaskShellProgress"))
-        tasks_promote_current_to_background_result = TasksPromoteCurrentToBackgroundResult.from_dict(obj.get("TasksPromoteCurrentToBackgroundResult"))
         tasks_promote_to_background_request = TasksPromoteToBackgroundRequest.from_dict(obj.get("TasksPromoteToBackgroundRequest"))
         tasks_promote_to_background_result = TasksPromoteToBackgroundResult.from_dict(obj.get("TasksPromoteToBackgroundResult"))
-        tasks_refresh_result = TasksRefreshResult.from_dict(obj.get("TasksRefreshResult"))
         tasks_remove_request = TasksRemoveRequest.from_dict(obj.get("TasksRemoveRequest"))
         tasks_remove_result = TasksRemoveResult.from_dict(obj.get("TasksRemoveResult"))
         tasks_send_message_request = TasksSendMessageRequest.from_dict(obj.get("TasksSendMessageRequest"))
@@ -14932,14 +7979,9 @@ class RPC:
         tasks_start_agent_request = TasksStartAgentRequest.from_dict(obj.get("TasksStartAgentRequest"))
         tasks_start_agent_result = TasksStartAgentResult.from_dict(obj.get("TasksStartAgentResult"))
         task_status = TaskStatus(obj.get("TaskStatus"))
-        tasks_wait_for_pending_result = TasksWaitForPendingResult.from_dict(obj.get("TasksWaitForPendingResult"))
-        telemetry_set_feature_overrides_request = TelemetrySetFeatureOverridesRequest.from_dict(obj.get("TelemetrySetFeatureOverridesRequest"))
-        token_auth_info = TokenAuthInfo.from_dict(obj.get("TokenAuthInfo"))
         tool = Tool.from_dict(obj.get("Tool"))
         tool_list = ToolList.from_dict(obj.get("ToolList"))
-        tools_initialize_and_validate_result = ToolsInitializeAndValidateResult.from_dict(obj.get("ToolsInitializeAndValidateResult"))
         tools_list_request = ToolsListRequest.from_dict(obj.get("ToolsListRequest"))
-        ui_auto_mode_switch_response = UIAutoModeSwitchResponse(obj.get("UIAutoModeSwitchResponse"))
         ui_elicitation_array_any_of_field = UIElicitationArrayAnyOfField.from_dict(obj.get("UIElicitationArrayAnyOfField"))
         ui_elicitation_array_any_of_field_items = UIElicitationArrayAnyOfFieldItems.from_dict(obj.get("UIElicitationArrayAnyOfFieldItems"))
         ui_elicitation_array_any_of_field_items_any_of = UIElicitationArrayAnyOfFieldItemsAnyOf.from_dict(obj.get("UIElicitationArrayAnyOfFieldItemsAnyOf"))
@@ -14961,19 +8003,7 @@ class RPC:
         ui_elicitation_string_enum_field = UIElicitationStringEnumField.from_dict(obj.get("UIElicitationStringEnumField"))
         ui_elicitation_string_one_of_field = UIElicitationStringOneOfField.from_dict(obj.get("UIElicitationStringOneOfField"))
         ui_elicitation_string_one_of_field_one_of = UIElicitationStringOneOfFieldOneOf.from_dict(obj.get("UIElicitationStringOneOfFieldOneOf"))
-        ui_exit_plan_mode_action = UIExitPlanModeAction(obj.get("UIExitPlanModeAction"))
-        ui_exit_plan_mode_response = UIExitPlanModeResponse.from_dict(obj.get("UIExitPlanModeResponse"))
-        ui_handle_pending_auto_mode_switch_request = UIHandlePendingAutoModeSwitchRequest.from_dict(obj.get("UIHandlePendingAutoModeSwitchRequest"))
         ui_handle_pending_elicitation_request = UIHandlePendingElicitationRequest.from_dict(obj.get("UIHandlePendingElicitationRequest"))
-        ui_handle_pending_exit_plan_mode_request = UIHandlePendingExitPlanModeRequest.from_dict(obj.get("UIHandlePendingExitPlanModeRequest"))
-        ui_handle_pending_result = UIHandlePendingResult.from_dict(obj.get("UIHandlePendingResult"))
-        ui_handle_pending_sampling_request = UIHandlePendingSamplingRequest.from_dict(obj.get("UIHandlePendingSamplingRequest"))
-        ui_handle_pending_sampling_response = from_dict(lambda x: x, obj.get("UIHandlePendingSamplingResponse"))
-        ui_handle_pending_user_input_request = UIHandlePendingUserInputRequest.from_dict(obj.get("UIHandlePendingUserInputRequest"))
-        ui_register_direct_auto_mode_switch_handler_result = UIRegisterDirectAutoModeSwitchHandlerResult.from_dict(obj.get("UIRegisterDirectAutoModeSwitchHandlerResult"))
-        ui_unregister_direct_auto_mode_switch_handler_request = UIUnregisterDirectAutoModeSwitchHandlerRequest.from_dict(obj.get("UIUnregisterDirectAutoModeSwitchHandlerRequest"))
-        ui_unregister_direct_auto_mode_switch_handler_result = UIUnregisterDirectAutoModeSwitchHandlerResult.from_dict(obj.get("UIUnregisterDirectAutoModeSwitchHandlerResult"))
-        ui_user_input_response = UIUserInputResponse.from_dict(obj.get("UIUserInputResponse"))
         usage_get_metrics_result = UsageGetMetricsResult.from_dict(obj.get("UsageGetMetricsResult"))
         usage_metrics_code_changes = UsageMetricsCodeChanges.from_dict(obj.get("UsageMetricsCodeChanges"))
         usage_metrics_model_metric = UsageMetricsModelMetric.from_dict(obj.get("UsageMetricsModelMetric"))
@@ -14981,47 +8011,24 @@ class RPC:
         usage_metrics_model_metric_token_detail = UsageMetricsModelMetricTokenDetail.from_dict(obj.get("UsageMetricsModelMetricTokenDetail"))
         usage_metrics_model_metric_usage = UsageMetricsModelMetricUsage.from_dict(obj.get("UsageMetricsModelMetricUsage"))
         usage_metrics_token_detail = UsageMetricsTokenDetail.from_dict(obj.get("UsageMetricsTokenDetail"))
-        user_auth_info = UserAuthInfo.from_dict(obj.get("UserAuthInfo"))
-        user_tool_session_approval_commands = UserToolSessionApprovalCommands.from_dict(obj.get("UserToolSessionApprovalCommands"))
-        user_tool_session_approval_custom_tool = UserToolSessionApprovalCustomTool.from_dict(obj.get("UserToolSessionApprovalCustomTool"))
-        user_tool_session_approval_extension_management = UserToolSessionApprovalExtensionManagement.from_dict(obj.get("UserToolSessionApprovalExtensionManagement"))
-        user_tool_session_approval_extension_permission_access = UserToolSessionApprovalExtensionPermissionAccess.from_dict(obj.get("UserToolSessionApprovalExtensionPermissionAccess"))
-        user_tool_session_approval_mcp = UserToolSessionApprovalMCP.from_dict(obj.get("UserToolSessionApprovalMcp"))
-        user_tool_session_approval_memory = UserToolSessionApprovalMemory.from_dict(obj.get("UserToolSessionApprovalMemory"))
-        user_tool_session_approval_read = UserToolSessionApprovalRead.from_dict(obj.get("UserToolSessionApprovalRead"))
-        user_tool_session_approval_write = UserToolSessionApprovalWrite.from_dict(obj.get("UserToolSessionApprovalWrite"))
-        workspaces_checkpoints = WorkspacesCheckpoints.from_dict(obj.get("WorkspacesCheckpoints"))
         workspaces_create_file_request = WorkspacesCreateFileRequest.from_dict(obj.get("WorkspacesCreateFileRequest"))
         workspaces_get_workspace_result = WorkspacesGetWorkspaceResult.from_dict(obj.get("WorkspacesGetWorkspaceResult"))
-        workspaces_list_checkpoints_result = WorkspacesListCheckpointsResult.from_dict(obj.get("WorkspacesListCheckpointsResult"))
         workspaces_list_files_result = WorkspacesListFilesResult.from_dict(obj.get("WorkspacesListFilesResult"))
-        workspaces_read_checkpoint_request = WorkspacesReadCheckpointRequest.from_dict(obj.get("WorkspacesReadCheckpointRequest"))
-        workspaces_read_checkpoint_result = WorkspacesReadCheckpointResult.from_dict(obj.get("WorkspacesReadCheckpointResult"))
         workspaces_read_file_request = WorkspacesReadFileRequest.from_dict(obj.get("WorkspacesReadFileRequest"))
         workspaces_read_file_result = WorkspacesReadFileResult.from_dict(obj.get("WorkspacesReadFileResult"))
-        workspaces_save_large_paste_request = WorkspacesSaveLargePasteRequest.from_dict(obj.get("WorkspacesSaveLargePasteRequest"))
-        workspaces_save_large_paste_result = WorkspacesSaveLargePasteResult.from_dict(obj.get("WorkspacesSaveLargePasteResult"))
-        session_context_info = from_union([SessionContextInfo.from_dict, from_none], obj.get("SessionContextInfo"))
-        task_progress = from_union([TaskProgressClass.from_dict, from_none], obj.get("TaskProgress"))
-        workspace_summary = from_union([WorkspaceSummary.from_dict, from_none], obj.get("WorkspaceSummary"))
-        return RPC(abort_request, abort_result, account_get_quota_request, account_get_quota_result, account_quota_snapshot, agent_get_current_result, agent_info, agent_info_source, agent_list, agent_reload_result, agent_select_request, agent_select_result, api_key_auth_info, auth_info, auth_info_type, command_list, commands_handle_pending_command_request, commands_handle_pending_command_result, commands_invoke_request, commands_list_request, commands_respond_to_queued_command_request, commands_respond_to_queued_command_result, connected_remote_session_metadata, connected_remote_session_metadata_kind, connected_remote_session_metadata_repository, connect_remote_session_params, connect_request, connect_result, content_filter_mode, copilot_api_token_auth_info, copilot_user_response, copilot_user_response_endpoints, copilot_user_response_quota_snapshots, copilot_user_response_quota_snapshots_chat, copilot_user_response_quota_snapshots_completions, copilot_user_response_quota_snapshots_premium_interactions, current_model, discovered_mcp_server, discovered_mcp_server_type, enqueue_command_params, enqueue_command_result, env_auth_info, event_log_read_request, event_log_release_interest_result, event_log_tail_result, event_log_types, events_agent_scope, events_cursor_status, events_read_result, execute_command_params, execute_command_result, extension, extension_list, extensions_disable_request, extensions_enable_request, extension_source, extension_status, external_tool_result, external_tool_text_result_for_llm, external_tool_text_result_for_llm_binary_results_for_llm, external_tool_text_result_for_llm_binary_results_for_llm_type, external_tool_text_result_for_llm_content, external_tool_text_result_for_llm_content_audio, external_tool_text_result_for_llm_content_image, external_tool_text_result_for_llm_content_resource, external_tool_text_result_for_llm_content_resource_details, external_tool_text_result_for_llm_content_resource_link, external_tool_text_result_for_llm_content_resource_link_icon, external_tool_text_result_for_llm_content_resource_link_icon_theme, external_tool_text_result_for_llm_content_terminal, external_tool_text_result_for_llm_content_text, filter_mapping, fleet_start_request, fleet_start_result, gh_cli_auth_info, handle_pending_tool_call_request, handle_pending_tool_call_result, history_abort_manual_compaction_result, history_cancel_background_compaction_result, history_compact_context_window, history_compact_result, history_summarize_for_handoff_result, history_truncate_request, history_truncate_result, hmac_auth_info, installed_plugin, installed_plugin_source, installed_plugin_source_github, installed_plugin_source_local, installed_plugin_source_url, instructions_get_sources_result, instructions_sources, instructions_sources_location, instructions_sources_type, log_request, log_result, lsp_initialize_request, mcp_cancel_sampling_execution_params, mcp_cancel_sampling_execution_result, mcp_config_add_request, mcp_config_disable_request, mcp_config_enable_request, mcp_config_list, mcp_config_remove_request, mcp_config_update_request, mcp_disable_request, mcp_discover_request, mcp_discover_result, mcp_enable_request, mcp_execute_sampling_params, mcp_execute_sampling_request, mcp_execute_sampling_result, mcp_oauth_login_request, mcp_oauth_login_result, mcp_remove_git_hub_result, mcp_sampling_execution_action, mcp_sampling_execution_result, mcp_server, mcp_server_config, mcp_server_config_http, mcp_server_config_http_auth, mcp_server_config_http_oauth_grant_type, mcp_server_config_http_type, mcp_server_config_stdio, mcp_server_list, mcp_set_env_value_mode_details, mcp_set_env_value_mode_params, mcp_set_env_value_mode_result, metadata_context_info_request, metadata_context_info_result, metadata_is_processing_result, metadata_recompute_context_tokens_request, metadata_recompute_context_tokens_result, metadata_record_context_change_request, metadata_record_context_change_result, metadata_set_working_directory_request, metadata_set_working_directory_result, metadata_snapshot_current_mode, metadata_snapshot_remote_metadata, metadata_snapshot_remote_metadata_repository, metadata_snapshot_remote_metadata_task_type, model, model_billing, model_billing_token_prices, model_capabilities, model_capabilities_limits, model_capabilities_limits_vision, model_capabilities_override, model_capabilities_override_limits, model_capabilities_override_limits_vision, model_capabilities_override_supports, model_capabilities_supports, model_list, model_picker_category, model_picker_price_category, model_policy, model_policy_state, model_set_reasoning_effort_request, model_set_reasoning_effort_result, models_list_request, model_switch_to_request, model_switch_to_result, mode_set_request, name_get_result, name_set_auto_request, name_set_auto_result, name_set_request, options_update_env_value_mode, pending_permission_request, pending_permission_request_list, permission_decision, permission_decision_approved, permission_decision_approved_for_location, permission_decision_approved_for_session, permission_decision_approve_for_location, permission_decision_approve_for_location_approval, permission_decision_approve_for_location_approval_commands, permission_decision_approve_for_location_approval_custom_tool, permission_decision_approve_for_location_approval_extension_management, permission_decision_approve_for_location_approval_extension_permission_access, permission_decision_approve_for_location_approval_mcp, permission_decision_approve_for_location_approval_mcp_sampling, permission_decision_approve_for_location_approval_memory, permission_decision_approve_for_location_approval_read, permission_decision_approve_for_location_approval_write, permission_decision_approve_for_session, permission_decision_approve_for_session_approval, permission_decision_approve_for_session_approval_commands, permission_decision_approve_for_session_approval_custom_tool, permission_decision_approve_for_session_approval_extension_management, permission_decision_approve_for_session_approval_extension_permission_access, permission_decision_approve_for_session_approval_mcp, permission_decision_approve_for_session_approval_mcp_sampling, permission_decision_approve_for_session_approval_memory, permission_decision_approve_for_session_approval_read, permission_decision_approve_for_session_approval_write, permission_decision_approve_once, permission_decision_approve_permanently, permission_decision_cancelled, permission_decision_denied_by_content_exclusion_policy, permission_decision_denied_by_permission_request_hook, permission_decision_denied_by_rules, permission_decision_denied_interactively_by_user, permission_decision_denied_no_approval_rule_and_could_not_request_from_user, permission_decision_reject, permission_decision_request, permission_decision_user_not_available, permission_paths_add_params, permission_paths_allowed_check_params, permission_paths_allowed_check_result, permission_paths_config, permission_paths_list, permission_paths_update_primary_params, permission_paths_workspace_check_params, permission_paths_workspace_check_result, permission_prompt_shown_notification, permission_request_result, permission_rules_set, permissions_configure_additional_content_exclusion_policy, permissions_configure_additional_content_exclusion_policy_rule, permissions_configure_additional_content_exclusion_policy_rule_source, permissions_configure_additional_content_exclusion_policy_scope, permissions_configure_params, permissions_configure_result, permissions_modify_rules_params, permissions_modify_rules_result, permissions_modify_rules_scope, permissions_notify_prompt_shown_result, permissions_paths_add_result, permissions_paths_list_request, permissions_paths_update_primary_result, permissions_pending_requests_request, permissions_reset_session_approvals_request, permissions_reset_session_approvals_result, permissions_set_approve_all_request, permissions_set_approve_all_result, permissions_set_approve_all_source, permissions_set_required_request, permissions_set_required_result, permissions_urls_set_unrestricted_mode_result, permission_urls_config, permission_urls_set_unrestricted_mode_params, ping_request, ping_result, plan_read_result, plan_update_request, plugin, plugin_list, queued_command_handled, queued_command_not_handled, queued_command_result, queue_pending_items, queue_pending_items_kind, queue_pending_items_result, queue_remove_most_recent_result, register_event_interest_params, register_event_interest_result, release_event_interest_params, remote_enable_request, remote_enable_result, remote_notify_steerable_changed_request, remote_notify_steerable_changed_result, remote_session_connection_result, remote_session_mode, schedule_entry, schedule_list, schedule_stop_request, schedule_stop_result, send_agent_mode, send_attachment, send_attachment_blob, send_attachment_directory, send_attachment_file, send_attachment_file_line_range, send_attachment_github_reference, send_attachment_github_reference_type, send_attachment_selection, send_attachment_selection_details, send_attachment_selection_details_end, send_attachment_selection_details_start, send_mode, send_request, send_result, server_skill, server_skill_list, session_auth_status, session_bulk_delete_result, session_context, session_context_host_type, session_enrich_metadata_result, session_fs_append_file_request, session_fs_error, session_fs_error_code, session_fs_exists_request, session_fs_exists_result, session_fs_mkdir_request, session_fs_readdir_request, session_fs_readdir_result, session_fs_readdir_with_types_entry, session_fs_readdir_with_types_entry_type, session_fs_readdir_with_types_request, session_fs_readdir_with_types_result, session_fs_read_file_request, session_fs_read_file_result, session_fs_rename_request, session_fs_rm_request, session_fs_set_provider_capabilities, session_fs_set_provider_conventions, session_fs_set_provider_request, session_fs_set_provider_result, session_fs_sqlite_exists_request, session_fs_sqlite_exists_result, session_fs_sqlite_query_request, session_fs_sqlite_query_result, session_fs_sqlite_query_type, session_fs_stat_request, session_fs_stat_result, session_fs_write_file_request, session_installed_plugin, session_installed_plugin_source, session_installed_plugin_source_github, session_installed_plugin_source_local, session_installed_plugin_source_url, session_list, session_load_deferred_repo_hooks_result, session_log_level, session_metadata, session_metadata_snapshot, session_mode, session_prune_result, sessions_bulk_delete_request, sessions_check_in_use_request, sessions_check_in_use_result, sessions_close_request, sessions_close_result, sessions_enrich_metadata_request, session_set_credentials_params, session_set_credentials_result, sessions_find_by_prefix_request, sessions_find_by_prefix_result, sessions_find_by_task_id_request, sessions_find_by_task_id_result, sessions_fork_request, sessions_fork_result, sessions_get_event_file_path_request, sessions_get_event_file_path_result, sessions_get_last_for_context_request, sessions_get_last_for_context_result, sessions_get_persisted_remote_steerable_request, sessions_get_persisted_remote_steerable_result, session_sizes, sessions_list_request, sessions_load_deferred_repo_hooks_request, sessions_prune_old_request, sessions_release_lock_request, sessions_release_lock_result, sessions_reload_plugin_hooks_request, sessions_reload_plugin_hooks_result, sessions_save_request, sessions_save_result, sessions_set_additional_plugins_request, sessions_set_additional_plugins_result, session_update_options_params, session_update_options_result, session_working_directory_context, session_working_directory_context_host_type, shell_exec_request, shell_exec_result, shell_kill_request, shell_kill_result, shell_kill_signal, shutdown_request, skill, skill_list, skills_config_set_disabled_skills_request, skills_disable_request, skills_discover_request, skills_enable_request, skills_get_invoked_result, skills_invoked_skill, skills_load_diagnostics, slash_command_agent_prompt_result, slash_command_completed_result, slash_command_info, slash_command_input, slash_command_input_completion, slash_command_invocation_result, slash_command_kind, slash_command_text_result, task_agent_info, task_agent_progress, task_execution_mode, task_info, task_list, tasks_cancel_request, tasks_cancel_result, tasks_get_current_promotable_result, tasks_get_progress_request, tasks_get_progress_result, task_shell_info, task_shell_info_attachment_mode, task_shell_progress, tasks_promote_current_to_background_result, tasks_promote_to_background_request, tasks_promote_to_background_result, tasks_refresh_result, tasks_remove_request, tasks_remove_result, tasks_send_message_request, tasks_send_message_result, tasks_start_agent_request, tasks_start_agent_result, task_status, tasks_wait_for_pending_result, telemetry_set_feature_overrides_request, token_auth_info, tool, tool_list, tools_initialize_and_validate_result, tools_list_request, ui_auto_mode_switch_response, ui_elicitation_array_any_of_field, ui_elicitation_array_any_of_field_items, ui_elicitation_array_any_of_field_items_any_of, ui_elicitation_array_enum_field, ui_elicitation_array_enum_field_items, ui_elicitation_field_value, ui_elicitation_request, ui_elicitation_response, ui_elicitation_response_action, ui_elicitation_response_content, ui_elicitation_result, ui_elicitation_schema, ui_elicitation_schema_property, ui_elicitation_schema_property_boolean, ui_elicitation_schema_property_number, ui_elicitation_schema_property_number_type, ui_elicitation_schema_property_string, ui_elicitation_schema_property_string_format, ui_elicitation_string_enum_field, ui_elicitation_string_one_of_field, ui_elicitation_string_one_of_field_one_of, ui_exit_plan_mode_action, ui_exit_plan_mode_response, ui_handle_pending_auto_mode_switch_request, ui_handle_pending_elicitation_request, ui_handle_pending_exit_plan_mode_request, ui_handle_pending_result, ui_handle_pending_sampling_request, ui_handle_pending_sampling_response, ui_handle_pending_user_input_request, ui_register_direct_auto_mode_switch_handler_result, ui_unregister_direct_auto_mode_switch_handler_request, ui_unregister_direct_auto_mode_switch_handler_result, ui_user_input_response, usage_get_metrics_result, usage_metrics_code_changes, usage_metrics_model_metric, usage_metrics_model_metric_requests, usage_metrics_model_metric_token_detail, usage_metrics_model_metric_usage, usage_metrics_token_detail, user_auth_info, user_tool_session_approval_commands, user_tool_session_approval_custom_tool, user_tool_session_approval_extension_management, user_tool_session_approval_extension_permission_access, user_tool_session_approval_mcp, user_tool_session_approval_memory, user_tool_session_approval_read, user_tool_session_approval_write, workspaces_checkpoints, workspaces_create_file_request, workspaces_get_workspace_result, workspaces_list_checkpoints_result, workspaces_list_files_result, workspaces_read_checkpoint_request, workspaces_read_checkpoint_result, workspaces_read_file_request, workspaces_read_file_result, workspaces_save_large_paste_request, workspaces_save_large_paste_result, session_context_info, task_progress, workspace_summary)
+        return RPC(account_get_quota_request, account_get_quota_result, account_quota_snapshot, agent_get_current_result, agent_info, agent_list, agent_reload_result, agent_select_request, agent_select_result, auth_info_type, command_list, commands_handle_pending_command_request, commands_handle_pending_command_result, commands_invoke_request, commands_list_request, commands_respond_to_queued_command_request, commands_respond_to_queued_command_result, connected_remote_session_metadata, connected_remote_session_metadata_kind, connected_remote_session_metadata_repository, connect_remote_session_params, connect_request, connect_result, content_filter_mode, current_model, discovered_mcp_server, discovered_mcp_server_type, extension, extension_list, extensions_disable_request, extensions_enable_request, extension_source, extension_status, external_tool_result, external_tool_text_result_for_llm, external_tool_text_result_for_llm_binary_results_for_llm, external_tool_text_result_for_llm_binary_results_for_llm_type, external_tool_text_result_for_llm_content, external_tool_text_result_for_llm_content_audio, external_tool_text_result_for_llm_content_image, external_tool_text_result_for_llm_content_resource, external_tool_text_result_for_llm_content_resource_details, external_tool_text_result_for_llm_content_resource_link, external_tool_text_result_for_llm_content_resource_link_icon, external_tool_text_result_for_llm_content_resource_link_icon_theme, external_tool_text_result_for_llm_content_terminal, external_tool_text_result_for_llm_content_text, filter_mapping, fleet_start_request, fleet_start_result, handle_pending_tool_call_request, handle_pending_tool_call_result, history_compact_context_window, history_compact_result, history_truncate_request, history_truncate_result, instructions_get_sources_result, instructions_sources, instructions_sources_location, instructions_sources_type, log_request, log_result, mcp_config_add_request, mcp_config_disable_request, mcp_config_enable_request, mcp_config_list, mcp_config_remove_request, mcp_config_update_request, mcp_disable_request, mcp_discover_request, mcp_discover_result, mcp_enable_request, mcp_oauth_login_request, mcp_oauth_login_result, mcp_server, mcp_server_config, mcp_server_config_http, mcp_server_config_http_auth, mcp_server_config_http_oauth_grant_type, mcp_server_config_http_type, mcp_server_config_stdio, mcp_server_list, model, model_billing, model_billing_token_prices, model_capabilities, model_capabilities_limits, model_capabilities_limits_vision, model_capabilities_override, model_capabilities_override_limits, model_capabilities_override_limits_vision, model_capabilities_override_supports, model_capabilities_supports, model_list, model_picker_category, model_picker_price_category, model_policy, model_policy_state, models_list_request, model_switch_to_request, model_switch_to_result, mode_set_request, name_get_result, name_set_request, permission_decision, permission_decision_approve_for_location, permission_decision_approve_for_location_approval, permission_decision_approve_for_location_approval_commands, permission_decision_approve_for_location_approval_custom_tool, permission_decision_approve_for_location_approval_extension_management, permission_decision_approve_for_location_approval_extension_permission_access, permission_decision_approve_for_location_approval_mcp, permission_decision_approve_for_location_approval_mcp_sampling, permission_decision_approve_for_location_approval_memory, permission_decision_approve_for_location_approval_read, permission_decision_approve_for_location_approval_write, permission_decision_approve_for_session, permission_decision_approve_for_session_approval, permission_decision_approve_for_session_approval_commands, permission_decision_approve_for_session_approval_custom_tool, permission_decision_approve_for_session_approval_extension_management, permission_decision_approve_for_session_approval_extension_permission_access, permission_decision_approve_for_session_approval_mcp, permission_decision_approve_for_session_approval_mcp_sampling, permission_decision_approve_for_session_approval_memory, permission_decision_approve_for_session_approval_read, permission_decision_approve_for_session_approval_write, permission_decision_approve_once, permission_decision_approve_permanently, permission_decision_reject, permission_decision_request, permission_decision_user_not_available, permission_request_result, permissions_reset_session_approvals_request, permissions_reset_session_approvals_result, permissions_set_approve_all_request, permissions_set_approve_all_result, ping_request, ping_result, plan_read_result, plan_update_request, plugin, plugin_list, queued_command_handled, queued_command_not_handled, queued_command_result, remote_enable_request, remote_enable_result, remote_session_connection_result, remote_session_mode, server_skill, server_skill_list, session_auth_status, session_fs_append_file_request, session_fs_error, session_fs_error_code, session_fs_exists_request, session_fs_exists_result, session_fs_mkdir_request, session_fs_readdir_request, session_fs_readdir_result, session_fs_readdir_with_types_entry, session_fs_readdir_with_types_entry_type, session_fs_readdir_with_types_request, session_fs_readdir_with_types_result, session_fs_read_file_request, session_fs_read_file_result, session_fs_rename_request, session_fs_rm_request, session_fs_set_provider_capabilities, session_fs_set_provider_conventions, session_fs_set_provider_request, session_fs_set_provider_result, session_fs_sqlite_exists_request, session_fs_sqlite_exists_result, session_fs_sqlite_query_request, session_fs_sqlite_query_result, session_fs_sqlite_query_type, session_fs_stat_request, session_fs_stat_result, session_fs_write_file_request, session_log_level, session_mode, sessions_fork_request, sessions_fork_result, shell_exec_request, shell_exec_result, shell_kill_request, shell_kill_result, shell_kill_signal, skill, skill_list, skills_config_set_disabled_skills_request, skills_disable_request, skills_discover_request, skills_enable_request, skills_load_diagnostics, slash_command_agent_prompt_result, slash_command_completed_result, slash_command_info, slash_command_input, slash_command_input_completion, slash_command_invocation_result, slash_command_kind, slash_command_text_result, task_agent_info, task_execution_mode, task_info, task_list, tasks_cancel_request, tasks_cancel_result, task_shell_info, task_shell_info_attachment_mode, tasks_promote_to_background_request, tasks_promote_to_background_result, tasks_remove_request, tasks_remove_result, tasks_send_message_request, tasks_send_message_result, tasks_start_agent_request, tasks_start_agent_result, task_status, tool, tool_list, tools_list_request, ui_elicitation_array_any_of_field, ui_elicitation_array_any_of_field_items, ui_elicitation_array_any_of_field_items_any_of, ui_elicitation_array_enum_field, ui_elicitation_array_enum_field_items, ui_elicitation_field_value, ui_elicitation_request, ui_elicitation_response, ui_elicitation_response_action, ui_elicitation_response_content, ui_elicitation_result, ui_elicitation_schema, ui_elicitation_schema_property, ui_elicitation_schema_property_boolean, ui_elicitation_schema_property_number, ui_elicitation_schema_property_number_type, ui_elicitation_schema_property_string, ui_elicitation_schema_property_string_format, ui_elicitation_string_enum_field, ui_elicitation_string_one_of_field, ui_elicitation_string_one_of_field_one_of, ui_handle_pending_elicitation_request, usage_get_metrics_result, usage_metrics_code_changes, usage_metrics_model_metric, usage_metrics_model_metric_requests, usage_metrics_model_metric_token_detail, usage_metrics_model_metric_usage, usage_metrics_token_detail, workspaces_create_file_request, workspaces_get_workspace_result, workspaces_list_files_result, workspaces_read_file_request, workspaces_read_file_result)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["AbortRequest"] = to_class(AbortRequest, self.abort_request)
-        result["AbortResult"] = to_class(AbortResult, self.abort_result)
         result["AccountGetQuotaRequest"] = to_class(AccountGetQuotaRequest, self.account_get_quota_request)
         result["AccountGetQuotaResult"] = to_class(AccountGetQuotaResult, self.account_get_quota_result)
         result["AccountQuotaSnapshot"] = to_class(AccountQuotaSnapshot, self.account_quota_snapshot)
         result["AgentGetCurrentResult"] = to_class(AgentGetCurrentResult, self.agent_get_current_result)
         result["AgentInfo"] = to_class(AgentInfo, self.agent_info)
-        result["AgentInfoSource"] = to_enum(AgentInfoSource, self.agent_info_source)
         result["AgentList"] = to_class(AgentList, self.agent_list)
         result["AgentReloadResult"] = to_class(AgentReloadResult, self.agent_reload_result)
         result["AgentSelectRequest"] = to_class(AgentSelectRequest, self.agent_select_request)
         result["AgentSelectResult"] = to_class(AgentSelectResult, self.agent_select_result)
-        result["ApiKeyAuthInfo"] = to_class(APIKeyAuthInfo, self.api_key_auth_info)
-        result["AuthInfo"] = to_class(AuthInfo, self.auth_info)
         result["AuthInfoType"] = to_enum(AuthInfoType, self.auth_info_type)
         result["CommandList"] = to_class(CommandList, self.command_list)
         result["CommandsHandlePendingCommandRequest"] = to_class(CommandsHandlePendingCommandRequest, self.commands_handle_pending_command_request)
@@ -15037,28 +8044,9 @@ class RPC:
         result["ConnectRequest"] = to_class(ConnectRequest, self.connect_request)
         result["ConnectResult"] = to_class(ConnectResult, self.connect_result)
         result["ContentFilterMode"] = to_enum(ContentFilterMode, self.content_filter_mode)
-        result["CopilotApiTokenAuthInfo"] = to_class(CopilotAPITokenAuthInfo, self.copilot_api_token_auth_info)
-        result["CopilotUserResponse"] = to_class(CopilotUserResponse, self.copilot_user_response)
-        result["CopilotUserResponseEndpoints"] = to_class(CopilotUserResponseEndpoints, self.copilot_user_response_endpoints)
-        result["CopilotUserResponseQuotaSnapshots"] = from_dict(lambda x: from_union([lambda x: to_class(CopilotUserResponseQuotaSnapshots, x), from_none], x), self.copilot_user_response_quota_snapshots)
-        result["CopilotUserResponseQuotaSnapshotsChat"] = to_class(CopilotUserResponseQuotaSnapshotsChat, self.copilot_user_response_quota_snapshots_chat)
-        result["CopilotUserResponseQuotaSnapshotsCompletions"] = to_class(CopilotUserResponseQuotaSnapshotsCompletions, self.copilot_user_response_quota_snapshots_completions)
-        result["CopilotUserResponseQuotaSnapshotsPremiumInteractions"] = to_class(CopilotUserResponseQuotaSnapshotsPremiumInteractions, self.copilot_user_response_quota_snapshots_premium_interactions)
         result["CurrentModel"] = to_class(CurrentModel, self.current_model)
         result["DiscoveredMcpServer"] = to_class(DiscoveredMCPServer, self.discovered_mcp_server)
         result["DiscoveredMcpServerType"] = to_enum(DiscoveredMCPServerType, self.discovered_mcp_server_type)
-        result["EnqueueCommandParams"] = to_class(EnqueueCommandParams, self.enqueue_command_params)
-        result["EnqueueCommandResult"] = to_class(EnqueueCommandResult, self.enqueue_command_result)
-        result["EnvAuthInfo"] = to_class(EnvAuthInfo, self.env_auth_info)
-        result["EventLogReadRequest"] = to_class(EventLogReadRequest, self.event_log_read_request)
-        result["EventLogReleaseInterestResult"] = to_class(EventLogReleaseInterestResult, self.event_log_release_interest_result)
-        result["EventLogTailResult"] = to_class(EventLogTailResult, self.event_log_tail_result)
-        result["EventLogTypes"] = from_union([lambda x: from_list(from_str, x), lambda x: to_enum(EventLogTypes, x)], self.event_log_types)
-        result["EventsAgentScope"] = to_enum(EventsAgentScope, self.events_agent_scope)
-        result["EventsCursorStatus"] = to_enum(EventsCursorStatus, self.events_cursor_status)
-        result["EventsReadResult"] = to_class(EventsReadResult, self.events_read_result)
-        result["ExecuteCommandParams"] = to_class(ExecuteCommandParams, self.execute_command_params)
-        result["ExecuteCommandResult"] = to_class(ExecuteCommandResult, self.execute_command_result)
         result["Extension"] = to_class(Extension, self.extension)
         result["ExtensionList"] = to_class(ExtensionList, self.extension_list)
         result["ExtensionsDisableRequest"] = to_class(ExtensionsDisableRequest, self.extensions_disable_request)
@@ -15082,31 +8070,18 @@ class RPC:
         result["FilterMapping"] = from_union([lambda x: from_dict(lambda x: to_enum(ContentFilterMode, x), x), lambda x: to_enum(ContentFilterMode, x)], self.filter_mapping)
         result["FleetStartRequest"] = to_class(FleetStartRequest, self.fleet_start_request)
         result["FleetStartResult"] = to_class(FleetStartResult, self.fleet_start_result)
-        result["GhCliAuthInfo"] = to_class(GhCLIAuthInfo, self.gh_cli_auth_info)
         result["HandlePendingToolCallRequest"] = to_class(HandlePendingToolCallRequest, self.handle_pending_tool_call_request)
         result["HandlePendingToolCallResult"] = to_class(HandlePendingToolCallResult, self.handle_pending_tool_call_result)
-        result["HistoryAbortManualCompactionResult"] = to_class(HistoryAbortManualCompactionResult, self.history_abort_manual_compaction_result)
-        result["HistoryCancelBackgroundCompactionResult"] = to_class(HistoryCancelBackgroundCompactionResult, self.history_cancel_background_compaction_result)
         result["HistoryCompactContextWindow"] = to_class(HistoryCompactContextWindow, self.history_compact_context_window)
         result["HistoryCompactResult"] = to_class(HistoryCompactResult, self.history_compact_result)
-        result["HistorySummarizeForHandoffResult"] = to_class(HistorySummarizeForHandoffResult, self.history_summarize_for_handoff_result)
         result["HistoryTruncateRequest"] = to_class(HistoryTruncateRequest, self.history_truncate_request)
         result["HistoryTruncateResult"] = to_class(HistoryTruncateResult, self.history_truncate_result)
-        result["HMACAuthInfo"] = to_class(HMACAuthInfo, self.hmac_auth_info)
-        result["InstalledPlugin"] = to_class(InstalledPlugin, self.installed_plugin)
-        result["InstalledPluginSource"] = from_union([lambda x: to_class(InstalledPluginSource, x), from_str], self.installed_plugin_source)
-        result["InstalledPluginSourceGithub"] = to_class(InstalledPluginSourceGithub, self.installed_plugin_source_github)
-        result["InstalledPluginSourceLocal"] = to_class(InstalledPluginSourceLocal, self.installed_plugin_source_local)
-        result["InstalledPluginSourceUrl"] = to_class(InstalledPluginSourceURL, self.installed_plugin_source_url)
         result["InstructionsGetSourcesResult"] = to_class(InstructionsGetSourcesResult, self.instructions_get_sources_result)
         result["InstructionsSources"] = to_class(InstructionsSources, self.instructions_sources)
         result["InstructionsSourcesLocation"] = to_enum(InstructionsSourcesLocation, self.instructions_sources_location)
         result["InstructionsSourcesType"] = to_enum(InstructionsSourcesType, self.instructions_sources_type)
         result["LogRequest"] = to_class(LogRequest, self.log_request)
         result["LogResult"] = to_class(LogResult, self.log_result)
-        result["LspInitializeRequest"] = to_class(LspInitializeRequest, self.lsp_initialize_request)
-        result["McpCancelSamplingExecutionParams"] = to_class(MCPCancelSamplingExecutionParams, self.mcp_cancel_sampling_execution_params)
-        result["McpCancelSamplingExecutionResult"] = to_class(MCPCancelSamplingExecutionResult, self.mcp_cancel_sampling_execution_result)
         result["McpConfigAddRequest"] = to_class(MCPConfigAddRequest, self.mcp_config_add_request)
         result["McpConfigDisableRequest"] = to_class(MCPConfigDisableRequest, self.mcp_config_disable_request)
         result["McpConfigEnableRequest"] = to_class(MCPConfigEnableRequest, self.mcp_config_enable_request)
@@ -15117,14 +8092,8 @@ class RPC:
         result["McpDiscoverRequest"] = to_class(MCPDiscoverRequest, self.mcp_discover_request)
         result["McpDiscoverResult"] = to_class(MCPDiscoverResult, self.mcp_discover_result)
         result["McpEnableRequest"] = to_class(MCPEnableRequest, self.mcp_enable_request)
-        result["McpExecuteSamplingParams"] = to_class(MCPExecuteSamplingParams, self.mcp_execute_sampling_params)
-        result["McpExecuteSamplingRequest"] = from_dict(lambda x: x, self.mcp_execute_sampling_request)
-        result["McpExecuteSamplingResult"] = from_dict(lambda x: x, self.mcp_execute_sampling_result)
         result["McpOauthLoginRequest"] = to_class(MCPOauthLoginRequest, self.mcp_oauth_login_request)
         result["McpOauthLoginResult"] = to_class(MCPOauthLoginResult, self.mcp_oauth_login_result)
-        result["McpRemoveGitHubResult"] = to_class(MCPRemoveGitHubResult, self.mcp_remove_git_hub_result)
-        result["McpSamplingExecutionAction"] = to_enum(MCPSamplingExecutionAction, self.mcp_sampling_execution_action)
-        result["McpSamplingExecutionResult"] = to_class(MCPSamplingExecutionResult, self.mcp_sampling_execution_result)
         result["McpServer"] = to_class(MCPServer, self.mcp_server)
         result["McpServerConfig"] = to_class(MCPServerConfig, self.mcp_server_config)
         result["McpServerConfigHttp"] = to_class(MCPServerConfigHTTP, self.mcp_server_config_http)
@@ -15133,22 +8102,6 @@ class RPC:
         result["McpServerConfigHttpType"] = to_enum(MCPServerConfigHTTPType, self.mcp_server_config_http_type)
         result["McpServerConfigStdio"] = to_class(MCPServerConfigStdio, self.mcp_server_config_stdio)
         result["McpServerList"] = to_class(MCPServerList, self.mcp_server_list)
-        result["McpSetEnvValueModeDetails"] = to_enum(MCPSetEnvValueModeDetails, self.mcp_set_env_value_mode_details)
-        result["McpSetEnvValueModeParams"] = to_class(MCPSetEnvValueModeParams, self.mcp_set_env_value_mode_params)
-        result["McpSetEnvValueModeResult"] = to_class(MCPSetEnvValueModeResult, self.mcp_set_env_value_mode_result)
-        result["MetadataContextInfoRequest"] = to_class(MetadataContextInfoRequest, self.metadata_context_info_request)
-        result["MetadataContextInfoResult"] = to_class(MetadataContextInfoResult, self.metadata_context_info_result)
-        result["MetadataIsProcessingResult"] = to_class(MetadataIsProcessingResult, self.metadata_is_processing_result)
-        result["MetadataRecomputeContextTokensRequest"] = to_class(MetadataRecomputeContextTokensRequest, self.metadata_recompute_context_tokens_request)
-        result["MetadataRecomputeContextTokensResult"] = to_class(MetadataRecomputeContextTokensResult, self.metadata_recompute_context_tokens_result)
-        result["MetadataRecordContextChangeRequest"] = to_class(MetadataRecordContextChangeRequest, self.metadata_record_context_change_request)
-        result["MetadataRecordContextChangeResult"] = to_class(MetadataRecordContextChangeResult, self.metadata_record_context_change_result)
-        result["MetadataSetWorkingDirectoryRequest"] = to_class(MetadataSetWorkingDirectoryRequest, self.metadata_set_working_directory_request)
-        result["MetadataSetWorkingDirectoryResult"] = to_class(MetadataSetWorkingDirectoryResult, self.metadata_set_working_directory_result)
-        result["MetadataSnapshotCurrentMode"] = to_enum(MetadataSnapshotCurrentMode, self.metadata_snapshot_current_mode)
-        result["MetadataSnapshotRemoteMetadata"] = to_class(MetadataSnapshotRemoteMetadata, self.metadata_snapshot_remote_metadata)
-        result["MetadataSnapshotRemoteMetadataRepository"] = to_class(MetadataSnapshotRemoteMetadataRepository, self.metadata_snapshot_remote_metadata_repository)
-        result["MetadataSnapshotRemoteMetadataTaskType"] = to_enum(MetadataSnapshotRemoteMetadataTaskType, self.metadata_snapshot_remote_metadata_task_type)
         result["Model"] = to_class(Model, self.model)
         result["ModelBilling"] = to_class(ModelBilling, self.model_billing)
         result["ModelBillingTokenPrices"] = to_class(ModelBillingTokenPrices, self.model_billing_token_prices)
@@ -15165,23 +8118,13 @@ class RPC:
         result["ModelPickerPriceCategory"] = to_enum(ModelPickerPriceCategory, self.model_picker_price_category)
         result["ModelPolicy"] = to_class(ModelPolicy, self.model_policy)
         result["ModelPolicyState"] = to_enum(ModelPolicyState, self.model_policy_state)
-        result["ModelSetReasoningEffortRequest"] = to_class(ModelSetReasoningEffortRequest, self.model_set_reasoning_effort_request)
-        result["ModelSetReasoningEffortResult"] = to_class(ModelSetReasoningEffortResult, self.model_set_reasoning_effort_result)
         result["ModelsListRequest"] = to_class(ModelsListRequest, self.models_list_request)
         result["ModelSwitchToRequest"] = to_class(ModelSwitchToRequest, self.model_switch_to_request)
         result["ModelSwitchToResult"] = to_class(ModelSwitchToResult, self.model_switch_to_result)
         result["ModeSetRequest"] = to_class(ModeSetRequest, self.mode_set_request)
         result["NameGetResult"] = to_class(NameGetResult, self.name_get_result)
-        result["NameSetAutoRequest"] = to_class(NameSetAutoRequest, self.name_set_auto_request)
-        result["NameSetAutoResult"] = to_class(NameSetAutoResult, self.name_set_auto_result)
         result["NameSetRequest"] = to_class(NameSetRequest, self.name_set_request)
-        result["OptionsUpdateEnvValueMode"] = to_enum(MCPSetEnvValueModeDetails, self.options_update_env_value_mode)
-        result["PendingPermissionRequest"] = to_class(PendingPermissionRequest, self.pending_permission_request)
-        result["PendingPermissionRequestList"] = to_class(PendingPermissionRequestList, self.pending_permission_request_list)
         result["PermissionDecision"] = to_class(PermissionDecision, self.permission_decision)
-        result["PermissionDecisionApproved"] = to_class(PermissionDecisionApproved, self.permission_decision_approved)
-        result["PermissionDecisionApprovedForLocation"] = to_class(PermissionDecisionApprovedForLocation, self.permission_decision_approved_for_location)
-        result["PermissionDecisionApprovedForSession"] = to_class(PermissionDecisionApprovedForSession, self.permission_decision_approved_for_session)
         result["PermissionDecisionApproveForLocation"] = to_class(PermissionDecisionApproveForLocation, self.permission_decision_approve_for_location)
         result["PermissionDecisionApproveForLocationApproval"] = to_class(PermissionDecisionApproveForLocationApproval, self.permission_decision_approve_for_location_approval)
         result["PermissionDecisionApproveForLocationApprovalCommands"] = to_class(PermissionDecisionApproveForLocationApprovalCommands, self.permission_decision_approve_for_location_approval_commands)
@@ -15206,50 +8149,14 @@ class RPC:
         result["PermissionDecisionApproveForSessionApprovalWrite"] = to_class(PermissionDecisionApproveForSessionApprovalWrite, self.permission_decision_approve_for_session_approval_write)
         result["PermissionDecisionApproveOnce"] = to_class(PermissionDecisionApproveOnce, self.permission_decision_approve_once)
         result["PermissionDecisionApprovePermanently"] = to_class(PermissionDecisionApprovePermanently, self.permission_decision_approve_permanently)
-        result["PermissionDecisionCancelled"] = to_class(PermissionDecisionCancelled, self.permission_decision_cancelled)
-        result["PermissionDecisionDeniedByContentExclusionPolicy"] = to_class(PermissionDecisionDeniedByContentExclusionPolicy, self.permission_decision_denied_by_content_exclusion_policy)
-        result["PermissionDecisionDeniedByPermissionRequestHook"] = to_class(PermissionDecisionDeniedByPermissionRequestHook, self.permission_decision_denied_by_permission_request_hook)
-        result["PermissionDecisionDeniedByRules"] = to_class(PermissionDecisionDeniedByRules, self.permission_decision_denied_by_rules)
-        result["PermissionDecisionDeniedInteractivelyByUser"] = to_class(PermissionDecisionDeniedInteractivelyByUser, self.permission_decision_denied_interactively_by_user)
-        result["PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser"] = to_class(PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser, self.permission_decision_denied_no_approval_rule_and_could_not_request_from_user)
         result["PermissionDecisionReject"] = to_class(PermissionDecisionReject, self.permission_decision_reject)
         result["PermissionDecisionRequest"] = to_class(PermissionDecisionRequest, self.permission_decision_request)
         result["PermissionDecisionUserNotAvailable"] = to_class(PermissionDecisionUserNotAvailable, self.permission_decision_user_not_available)
-        result["PermissionPathsAddParams"] = to_class(PermissionPathsAddParams, self.permission_paths_add_params)
-        result["PermissionPathsAllowedCheckParams"] = to_class(PermissionPathsAllowedCheckParams, self.permission_paths_allowed_check_params)
-        result["PermissionPathsAllowedCheckResult"] = to_class(PermissionPathsAllowedCheckResult, self.permission_paths_allowed_check_result)
-        result["PermissionPathsConfig"] = to_class(PermissionPathsConfig, self.permission_paths_config)
-        result["PermissionPathsList"] = to_class(PermissionPathsList, self.permission_paths_list)
-        result["PermissionPathsUpdatePrimaryParams"] = to_class(PermissionPathsUpdatePrimaryParams, self.permission_paths_update_primary_params)
-        result["PermissionPathsWorkspaceCheckParams"] = to_class(PermissionPathsWorkspaceCheckParams, self.permission_paths_workspace_check_params)
-        result["PermissionPathsWorkspaceCheckResult"] = to_class(PermissionPathsWorkspaceCheckResult, self.permission_paths_workspace_check_result)
-        result["PermissionPromptShownNotification"] = to_class(PermissionPromptShownNotification, self.permission_prompt_shown_notification)
         result["PermissionRequestResult"] = to_class(PermissionRequestResult, self.permission_request_result)
-        result["PermissionRulesSet"] = to_class(PermissionRulesSet, self.permission_rules_set)
-        result["PermissionsConfigureAdditionalContentExclusionPolicy"] = to_class(PermissionsConfigureAdditionalContentExclusionPolicy, self.permissions_configure_additional_content_exclusion_policy)
-        result["PermissionsConfigureAdditionalContentExclusionPolicyRule"] = to_class(PermissionsConfigureAdditionalContentExclusionPolicyRule, self.permissions_configure_additional_content_exclusion_policy_rule)
-        result["PermissionsConfigureAdditionalContentExclusionPolicyRuleSource"] = to_class(PermissionsConfigureAdditionalContentExclusionPolicyRuleSource, self.permissions_configure_additional_content_exclusion_policy_rule_source)
-        result["PermissionsConfigureAdditionalContentExclusionPolicyScope"] = to_enum(PermissionsConfigureAdditionalContentExclusionPolicyScope, self.permissions_configure_additional_content_exclusion_policy_scope)
-        result["PermissionsConfigureParams"] = to_class(PermissionsConfigureParams, self.permissions_configure_params)
-        result["PermissionsConfigureResult"] = to_class(PermissionsConfigureResult, self.permissions_configure_result)
-        result["PermissionsModifyRulesParams"] = to_class(PermissionsModifyRulesParams, self.permissions_modify_rules_params)
-        result["PermissionsModifyRulesResult"] = to_class(PermissionsModifyRulesResult, self.permissions_modify_rules_result)
-        result["PermissionsModifyRulesScope"] = to_enum(PermissionsModifyRulesScope, self.permissions_modify_rules_scope)
-        result["PermissionsNotifyPromptShownResult"] = to_class(PermissionsNotifyPromptShownResult, self.permissions_notify_prompt_shown_result)
-        result["PermissionsPathsAddResult"] = to_class(PermissionsPathsAddResult, self.permissions_paths_add_result)
-        result["PermissionsPathsListRequest"] = to_class(PermissionsPathsListRequest, self.permissions_paths_list_request)
-        result["PermissionsPathsUpdatePrimaryResult"] = to_class(PermissionsPathsUpdatePrimaryResult, self.permissions_paths_update_primary_result)
-        result["PermissionsPendingRequestsRequest"] = to_class(PermissionsPendingRequestsRequest, self.permissions_pending_requests_request)
         result["PermissionsResetSessionApprovalsRequest"] = to_class(PermissionsResetSessionApprovalsRequest, self.permissions_reset_session_approvals_request)
         result["PermissionsResetSessionApprovalsResult"] = to_class(PermissionsResetSessionApprovalsResult, self.permissions_reset_session_approvals_result)
         result["PermissionsSetApproveAllRequest"] = to_class(PermissionsSetApproveAllRequest, self.permissions_set_approve_all_request)
         result["PermissionsSetApproveAllResult"] = to_class(PermissionsSetApproveAllResult, self.permissions_set_approve_all_result)
-        result["PermissionsSetApproveAllSource"] = to_enum(PermissionsSetApproveAllSource, self.permissions_set_approve_all_source)
-        result["PermissionsSetRequiredRequest"] = to_class(PermissionsSetRequiredRequest, self.permissions_set_required_request)
-        result["PermissionsSetRequiredResult"] = to_class(PermissionsSetRequiredResult, self.permissions_set_required_result)
-        result["PermissionsUrlsSetUnrestrictedModeResult"] = to_class(PermissionsUrlsSetUnrestrictedModeResult, self.permissions_urls_set_unrestricted_mode_result)
-        result["PermissionUrlsConfig"] = to_class(PermissionUrlsConfig, self.permission_urls_config)
-        result["PermissionUrlsSetUnrestrictedModeParams"] = to_class(PermissionUrlsSetUnrestrictedModeParams, self.permission_urls_set_unrestricted_mode_params)
         result["PingRequest"] = to_class(PingRequest, self.ping_request)
         result["PingResult"] = to_class(PingResult, self.ping_result)
         result["PlanReadResult"] = to_class(PlanReadResult, self.plan_read_result)
@@ -15259,45 +8166,13 @@ class RPC:
         result["QueuedCommandHandled"] = to_class(QueuedCommandHandled, self.queued_command_handled)
         result["QueuedCommandNotHandled"] = to_class(QueuedCommandNotHandled, self.queued_command_not_handled)
         result["QueuedCommandResult"] = to_class(QueuedCommandResult, self.queued_command_result)
-        result["QueuePendingItems"] = to_class(QueuePendingItems, self.queue_pending_items)
-        result["QueuePendingItemsKind"] = to_enum(QueuePendingItemsKind, self.queue_pending_items_kind)
-        result["QueuePendingItemsResult"] = to_class(QueuePendingItemsResult, self.queue_pending_items_result)
-        result["QueueRemoveMostRecentResult"] = to_class(QueueRemoveMostRecentResult, self.queue_remove_most_recent_result)
-        result["RegisterEventInterestParams"] = to_class(RegisterEventInterestParams, self.register_event_interest_params)
-        result["RegisterEventInterestResult"] = to_class(RegisterEventInterestResult, self.register_event_interest_result)
-        result["ReleaseEventInterestParams"] = to_class(ReleaseEventInterestParams, self.release_event_interest_params)
         result["RemoteEnableRequest"] = to_class(RemoteEnableRequest, self.remote_enable_request)
         result["RemoteEnableResult"] = to_class(RemoteEnableResult, self.remote_enable_result)
-        result["RemoteNotifySteerableChangedRequest"] = to_class(RemoteNotifySteerableChangedRequest, self.remote_notify_steerable_changed_request)
-        result["RemoteNotifySteerableChangedResult"] = to_class(RemoteNotifySteerableChangedResult, self.remote_notify_steerable_changed_result)
         result["RemoteSessionConnectionResult"] = to_class(RemoteSessionConnectionResult, self.remote_session_connection_result)
         result["RemoteSessionMode"] = to_enum(RemoteSessionMode, self.remote_session_mode)
-        result["ScheduleEntry"] = to_class(ScheduleEntry, self.schedule_entry)
-        result["ScheduleList"] = to_class(ScheduleList, self.schedule_list)
-        result["ScheduleStopRequest"] = to_class(ScheduleStopRequest, self.schedule_stop_request)
-        result["ScheduleStopResult"] = to_class(ScheduleStopResult, self.schedule_stop_result)
-        result["SendAgentMode"] = to_enum(SendAgentMode, self.send_agent_mode)
-        result["SendAttachment"] = to_class(SendAttachment, self.send_attachment)
-        result["SendAttachmentBlob"] = to_class(SendAttachmentBlob, self.send_attachment_blob)
-        result["SendAttachmentDirectory"] = to_class(SendAttachmentDirectory, self.send_attachment_directory)
-        result["SendAttachmentFile"] = to_class(SendAttachmentFile, self.send_attachment_file)
-        result["SendAttachmentFileLineRange"] = to_class(SendAttachmentFileLineRange, self.send_attachment_file_line_range)
-        result["SendAttachmentGithubReference"] = to_class(SendAttachmentGithubReference, self.send_attachment_github_reference)
-        result["SendAttachmentGithubReferenceType"] = to_enum(SendAttachmentGithubReferenceTypeEnum, self.send_attachment_github_reference_type)
-        result["SendAttachmentSelection"] = to_class(SendAttachmentSelection, self.send_attachment_selection)
-        result["SendAttachmentSelectionDetails"] = to_class(SendAttachmentSelectionDetails, self.send_attachment_selection_details)
-        result["SendAttachmentSelectionDetailsEnd"] = to_class(SendAttachmentSelectionDetailsEnd, self.send_attachment_selection_details_end)
-        result["SendAttachmentSelectionDetailsStart"] = to_class(SendAttachmentSelectionDetailsStart, self.send_attachment_selection_details_start)
-        result["SendMode"] = to_enum(SendMode, self.send_mode)
-        result["SendRequest"] = to_class(SendRequest, self.send_request)
-        result["SendResult"] = to_class(SendResult, self.send_result)
         result["ServerSkill"] = to_class(ServerSkill, self.server_skill)
         result["ServerSkillList"] = to_class(ServerSkillList, self.server_skill_list)
         result["SessionAuthStatus"] = to_class(SessionAuthStatus, self.session_auth_status)
-        result["SessionBulkDeleteResult"] = to_class(SessionBulkDeleteResult, self.session_bulk_delete_result)
-        result["SessionContext"] = to_class(SessionContext, self.session_context)
-        result["SessionContextHostType"] = to_enum(SessionContextHostType, self.session_context_host_type)
-        result["SessionEnrichMetadataResult"] = to_class(SessionEnrichMetadataResult, self.session_enrich_metadata_result)
         result["SessionFsAppendFileRequest"] = to_class(SessionFSAppendFileRequest, self.session_fs_append_file_request)
         result["SessionFsError"] = to_class(SessionFSError, self.session_fs_error)
         result["SessionFsErrorCode"] = to_enum(SessionFSErrorCode, self.session_fs_error_code)
@@ -15326,68 +8201,21 @@ class RPC:
         result["SessionFsStatRequest"] = to_class(SessionFSStatRequest, self.session_fs_stat_request)
         result["SessionFsStatResult"] = to_class(SessionFSStatResult, self.session_fs_stat_result)
         result["SessionFsWriteFileRequest"] = to_class(SessionFSWriteFileRequest, self.session_fs_write_file_request)
-        result["SessionInstalledPlugin"] = to_class(SessionInstalledPlugin, self.session_installed_plugin)
-        result["SessionInstalledPluginSource"] = from_union([lambda x: to_class(SessionInstalledPluginSource, x), from_str], self.session_installed_plugin_source)
-        result["SessionInstalledPluginSourceGithub"] = to_class(SessionInstalledPluginSourceGithub, self.session_installed_plugin_source_github)
-        result["SessionInstalledPluginSourceLocal"] = to_class(SessionInstalledPluginSourceLocal, self.session_installed_plugin_source_local)
-        result["SessionInstalledPluginSourceUrl"] = to_class(SessionInstalledPluginSourceURL, self.session_installed_plugin_source_url)
-        result["SessionList"] = to_class(SessionList, self.session_list)
-        result["SessionLoadDeferredRepoHooksResult"] = to_class(SessionLoadDeferredRepoHooksResult, self.session_load_deferred_repo_hooks_result)
         result["SessionLogLevel"] = to_enum(SessionLogLevel, self.session_log_level)
-        result["SessionMetadata"] = to_class(SessionMetadata, self.session_metadata)
-        result["SessionMetadataSnapshot"] = to_class(SessionMetadataSnapshot, self.session_metadata_snapshot)
         result["SessionMode"] = to_enum(SessionMode, self.session_mode)
-        result["SessionPruneResult"] = to_class(SessionPruneResult, self.session_prune_result)
-        result["SessionsBulkDeleteRequest"] = to_class(SessionsBulkDeleteRequest, self.sessions_bulk_delete_request)
-        result["SessionsCheckInUseRequest"] = to_class(SessionsCheckInUseRequest, self.sessions_check_in_use_request)
-        result["SessionsCheckInUseResult"] = to_class(SessionsCheckInUseResult, self.sessions_check_in_use_result)
-        result["SessionsCloseRequest"] = to_class(SessionsCloseRequest, self.sessions_close_request)
-        result["SessionsCloseResult"] = to_class(SessionsCloseResult, self.sessions_close_result)
-        result["SessionsEnrichMetadataRequest"] = to_class(SessionsEnrichMetadataRequest, self.sessions_enrich_metadata_request)
-        result["SessionSetCredentialsParams"] = to_class(SessionSetCredentialsParams, self.session_set_credentials_params)
-        result["SessionSetCredentialsResult"] = to_class(SessionSetCredentialsResult, self.session_set_credentials_result)
-        result["SessionsFindByPrefixRequest"] = to_class(SessionsFindByPrefixRequest, self.sessions_find_by_prefix_request)
-        result["SessionsFindByPrefixResult"] = to_class(SessionsFindByPrefixResult, self.sessions_find_by_prefix_result)
-        result["SessionsFindByTaskIDRequest"] = to_class(SessionsFindByTaskIDRequest, self.sessions_find_by_task_id_request)
-        result["SessionsFindByTaskIDResult"] = to_class(SessionsFindByTaskIDResult, self.sessions_find_by_task_id_result)
         result["SessionsForkRequest"] = to_class(SessionsForkRequest, self.sessions_fork_request)
         result["SessionsForkResult"] = to_class(SessionsForkResult, self.sessions_fork_result)
-        result["SessionsGetEventFilePathRequest"] = to_class(SessionsGetEventFilePathRequest, self.sessions_get_event_file_path_request)
-        result["SessionsGetEventFilePathResult"] = to_class(SessionsGetEventFilePathResult, self.sessions_get_event_file_path_result)
-        result["SessionsGetLastForContextRequest"] = to_class(SessionsGetLastForContextRequest, self.sessions_get_last_for_context_request)
-        result["SessionsGetLastForContextResult"] = to_class(SessionsGetLastForContextResult, self.sessions_get_last_for_context_result)
-        result["SessionsGetPersistedRemoteSteerableRequest"] = to_class(SessionsGetPersistedRemoteSteerableRequest, self.sessions_get_persisted_remote_steerable_request)
-        result["SessionsGetPersistedRemoteSteerableResult"] = to_class(SessionsGetPersistedRemoteSteerableResult, self.sessions_get_persisted_remote_steerable_result)
-        result["SessionSizes"] = to_class(SessionSizes, self.session_sizes)
-        result["SessionsListRequest"] = to_class(SessionsListRequest, self.sessions_list_request)
-        result["SessionsLoadDeferredRepoHooksRequest"] = to_class(SessionsLoadDeferredRepoHooksRequest, self.sessions_load_deferred_repo_hooks_request)
-        result["SessionsPruneOldRequest"] = to_class(SessionsPruneOldRequest, self.sessions_prune_old_request)
-        result["SessionsReleaseLockRequest"] = to_class(SessionsReleaseLockRequest, self.sessions_release_lock_request)
-        result["SessionsReleaseLockResult"] = to_class(SessionsReleaseLockResult, self.sessions_release_lock_result)
-        result["SessionsReloadPluginHooksRequest"] = to_class(SessionsReloadPluginHooksRequest, self.sessions_reload_plugin_hooks_request)
-        result["SessionsReloadPluginHooksResult"] = to_class(SessionsReloadPluginHooksResult, self.sessions_reload_plugin_hooks_result)
-        result["SessionsSaveRequest"] = to_class(SessionsSaveRequest, self.sessions_save_request)
-        result["SessionsSaveResult"] = to_class(SessionsSaveResult, self.sessions_save_result)
-        result["SessionsSetAdditionalPluginsRequest"] = to_class(SessionsSetAdditionalPluginsRequest, self.sessions_set_additional_plugins_request)
-        result["SessionsSetAdditionalPluginsResult"] = to_class(SessionsSetAdditionalPluginsResult, self.sessions_set_additional_plugins_result)
-        result["SessionUpdateOptionsParams"] = to_class(SessionUpdateOptionsParams, self.session_update_options_params)
-        result["SessionUpdateOptionsResult"] = to_class(SessionUpdateOptionsResult, self.session_update_options_result)
-        result["SessionWorkingDirectoryContext"] = to_class(SessionWorkingDirectoryContext, self.session_working_directory_context)
-        result["SessionWorkingDirectoryContextHostType"] = to_enum(SessionContextHostType, self.session_working_directory_context_host_type)
         result["ShellExecRequest"] = to_class(ShellExecRequest, self.shell_exec_request)
         result["ShellExecResult"] = to_class(ShellExecResult, self.shell_exec_result)
         result["ShellKillRequest"] = to_class(ShellKillRequest, self.shell_kill_request)
         result["ShellKillResult"] = to_class(ShellKillResult, self.shell_kill_result)
         result["ShellKillSignal"] = to_enum(ShellKillSignal, self.shell_kill_signal)
-        result["ShutdownRequest"] = to_class(ShutdownRequest, self.shutdown_request)
         result["Skill"] = to_class(Skill, self.skill)
         result["SkillList"] = to_class(SkillList, self.skill_list)
         result["SkillsConfigSetDisabledSkillsRequest"] = to_class(SkillsConfigSetDisabledSkillsRequest, self.skills_config_set_disabled_skills_request)
         result["SkillsDisableRequest"] = to_class(SkillsDisableRequest, self.skills_disable_request)
         result["SkillsDiscoverRequest"] = to_class(SkillsDiscoverRequest, self.skills_discover_request)
         result["SkillsEnableRequest"] = to_class(SkillsEnableRequest, self.skills_enable_request)
-        result["SkillsGetInvokedResult"] = to_class(SkillsGetInvokedResult, self.skills_get_invoked_result)
-        result["SkillsInvokedSkill"] = to_class(SkillsInvokedSkill, self.skills_invoked_skill)
         result["SkillsLoadDiagnostics"] = to_class(SkillsLoadDiagnostics, self.skills_load_diagnostics)
         result["SlashCommandAgentPromptResult"] = to_class(SlashCommandAgentPromptResult, self.slash_command_agent_prompt_result)
         result["SlashCommandCompletedResult"] = to_class(SlashCommandCompletedResult, self.slash_command_completed_result)
@@ -15398,22 +8226,15 @@ class RPC:
         result["SlashCommandKind"] = to_enum(SlashCommandKind, self.slash_command_kind)
         result["SlashCommandTextResult"] = to_class(SlashCommandTextResult, self.slash_command_text_result)
         result["TaskAgentInfo"] = to_class(TaskAgentInfo, self.task_agent_info)
-        result["TaskAgentProgress"] = to_class(TaskAgentProgress, self.task_agent_progress)
         result["TaskExecutionMode"] = to_enum(TaskExecutionMode, self.task_execution_mode)
         result["TaskInfo"] = to_class(TaskInfo, self.task_info)
         result["TaskList"] = to_class(TaskList, self.task_list)
         result["TasksCancelRequest"] = to_class(TasksCancelRequest, self.tasks_cancel_request)
         result["TasksCancelResult"] = to_class(TasksCancelResult, self.tasks_cancel_result)
-        result["TasksGetCurrentPromotableResult"] = to_class(TasksGetCurrentPromotableResult, self.tasks_get_current_promotable_result)
-        result["TasksGetProgressRequest"] = to_class(TasksGetProgressRequest, self.tasks_get_progress_request)
-        result["TasksGetProgressResult"] = to_class(TasksGetProgressResult, self.tasks_get_progress_result)
         result["TaskShellInfo"] = to_class(TaskShellInfo, self.task_shell_info)
         result["TaskShellInfoAttachmentMode"] = to_enum(TaskShellInfoAttachmentMode, self.task_shell_info_attachment_mode)
-        result["TaskShellProgress"] = from_none(self.task_shell_progress)
-        result["TasksPromoteCurrentToBackgroundResult"] = to_class(TasksPromoteCurrentToBackgroundResult, self.tasks_promote_current_to_background_result)
         result["TasksPromoteToBackgroundRequest"] = to_class(TasksPromoteToBackgroundRequest, self.tasks_promote_to_background_request)
         result["TasksPromoteToBackgroundResult"] = to_class(TasksPromoteToBackgroundResult, self.tasks_promote_to_background_result)
-        result["TasksRefreshResult"] = to_class(TasksRefreshResult, self.tasks_refresh_result)
         result["TasksRemoveRequest"] = to_class(TasksRemoveRequest, self.tasks_remove_request)
         result["TasksRemoveResult"] = to_class(TasksRemoveResult, self.tasks_remove_result)
         result["TasksSendMessageRequest"] = to_class(TasksSendMessageRequest, self.tasks_send_message_request)
@@ -15421,14 +8242,9 @@ class RPC:
         result["TasksStartAgentRequest"] = to_class(TasksStartAgentRequest, self.tasks_start_agent_request)
         result["TasksStartAgentResult"] = to_class(TasksStartAgentResult, self.tasks_start_agent_result)
         result["TaskStatus"] = to_enum(TaskStatus, self.task_status)
-        result["TasksWaitForPendingResult"] = to_class(TasksWaitForPendingResult, self.tasks_wait_for_pending_result)
-        result["TelemetrySetFeatureOverridesRequest"] = to_class(TelemetrySetFeatureOverridesRequest, self.telemetry_set_feature_overrides_request)
-        result["TokenAuthInfo"] = to_class(TokenAuthInfo, self.token_auth_info)
         result["Tool"] = to_class(Tool, self.tool)
         result["ToolList"] = to_class(ToolList, self.tool_list)
-        result["ToolsInitializeAndValidateResult"] = to_class(ToolsInitializeAndValidateResult, self.tools_initialize_and_validate_result)
         result["ToolsListRequest"] = to_class(ToolsListRequest, self.tools_list_request)
-        result["UIAutoModeSwitchResponse"] = to_enum(UIAutoModeSwitchResponse, self.ui_auto_mode_switch_response)
         result["UIElicitationArrayAnyOfField"] = to_class(UIElicitationArrayAnyOfField, self.ui_elicitation_array_any_of_field)
         result["UIElicitationArrayAnyOfFieldItems"] = to_class(UIElicitationArrayAnyOfFieldItems, self.ui_elicitation_array_any_of_field_items)
         result["UIElicitationArrayAnyOfFieldItemsAnyOf"] = to_class(UIElicitationArrayAnyOfFieldItemsAnyOf, self.ui_elicitation_array_any_of_field_items_any_of)
@@ -15450,19 +8266,7 @@ class RPC:
         result["UIElicitationStringEnumField"] = to_class(UIElicitationStringEnumField, self.ui_elicitation_string_enum_field)
         result["UIElicitationStringOneOfField"] = to_class(UIElicitationStringOneOfField, self.ui_elicitation_string_one_of_field)
         result["UIElicitationStringOneOfFieldOneOf"] = to_class(UIElicitationStringOneOfFieldOneOf, self.ui_elicitation_string_one_of_field_one_of)
-        result["UIExitPlanModeAction"] = to_enum(UIExitPlanModeAction, self.ui_exit_plan_mode_action)
-        result["UIExitPlanModeResponse"] = to_class(UIExitPlanModeResponse, self.ui_exit_plan_mode_response)
-        result["UIHandlePendingAutoModeSwitchRequest"] = to_class(UIHandlePendingAutoModeSwitchRequest, self.ui_handle_pending_auto_mode_switch_request)
         result["UIHandlePendingElicitationRequest"] = to_class(UIHandlePendingElicitationRequest, self.ui_handle_pending_elicitation_request)
-        result["UIHandlePendingExitPlanModeRequest"] = to_class(UIHandlePendingExitPlanModeRequest, self.ui_handle_pending_exit_plan_mode_request)
-        result["UIHandlePendingResult"] = to_class(UIHandlePendingResult, self.ui_handle_pending_result)
-        result["UIHandlePendingSamplingRequest"] = to_class(UIHandlePendingSamplingRequest, self.ui_handle_pending_sampling_request)
-        result["UIHandlePendingSamplingResponse"] = from_dict(lambda x: x, self.ui_handle_pending_sampling_response)
-        result["UIHandlePendingUserInputRequest"] = to_class(UIHandlePendingUserInputRequest, self.ui_handle_pending_user_input_request)
-        result["UIRegisterDirectAutoModeSwitchHandlerResult"] = to_class(UIRegisterDirectAutoModeSwitchHandlerResult, self.ui_register_direct_auto_mode_switch_handler_result)
-        result["UIUnregisterDirectAutoModeSwitchHandlerRequest"] = to_class(UIUnregisterDirectAutoModeSwitchHandlerRequest, self.ui_unregister_direct_auto_mode_switch_handler_request)
-        result["UIUnregisterDirectAutoModeSwitchHandlerResult"] = to_class(UIUnregisterDirectAutoModeSwitchHandlerResult, self.ui_unregister_direct_auto_mode_switch_handler_result)
-        result["UIUserInputResponse"] = to_class(UIUserInputResponse, self.ui_user_input_response)
         result["UsageGetMetricsResult"] = to_class(UsageGetMetricsResult, self.usage_get_metrics_result)
         result["UsageMetricsCodeChanges"] = to_class(UsageMetricsCodeChanges, self.usage_metrics_code_changes)
         result["UsageMetricsModelMetric"] = to_class(UsageMetricsModelMetric, self.usage_metrics_model_metric)
@@ -15470,29 +8274,11 @@ class RPC:
         result["UsageMetricsModelMetricTokenDetail"] = to_class(UsageMetricsModelMetricTokenDetail, self.usage_metrics_model_metric_token_detail)
         result["UsageMetricsModelMetricUsage"] = to_class(UsageMetricsModelMetricUsage, self.usage_metrics_model_metric_usage)
         result["UsageMetricsTokenDetail"] = to_class(UsageMetricsTokenDetail, self.usage_metrics_token_detail)
-        result["UserAuthInfo"] = to_class(UserAuthInfo, self.user_auth_info)
-        result["UserToolSessionApprovalCommands"] = to_class(UserToolSessionApprovalCommands, self.user_tool_session_approval_commands)
-        result["UserToolSessionApprovalCustomTool"] = to_class(UserToolSessionApprovalCustomTool, self.user_tool_session_approval_custom_tool)
-        result["UserToolSessionApprovalExtensionManagement"] = to_class(UserToolSessionApprovalExtensionManagement, self.user_tool_session_approval_extension_management)
-        result["UserToolSessionApprovalExtensionPermissionAccess"] = to_class(UserToolSessionApprovalExtensionPermissionAccess, self.user_tool_session_approval_extension_permission_access)
-        result["UserToolSessionApprovalMcp"] = to_class(UserToolSessionApprovalMCP, self.user_tool_session_approval_mcp)
-        result["UserToolSessionApprovalMemory"] = to_class(UserToolSessionApprovalMemory, self.user_tool_session_approval_memory)
-        result["UserToolSessionApprovalRead"] = to_class(UserToolSessionApprovalRead, self.user_tool_session_approval_read)
-        result["UserToolSessionApprovalWrite"] = to_class(UserToolSessionApprovalWrite, self.user_tool_session_approval_write)
-        result["WorkspacesCheckpoints"] = to_class(WorkspacesCheckpoints, self.workspaces_checkpoints)
         result["WorkspacesCreateFileRequest"] = to_class(WorkspacesCreateFileRequest, self.workspaces_create_file_request)
         result["WorkspacesGetWorkspaceResult"] = to_class(WorkspacesGetWorkspaceResult, self.workspaces_get_workspace_result)
-        result["WorkspacesListCheckpointsResult"] = to_class(WorkspacesListCheckpointsResult, self.workspaces_list_checkpoints_result)
         result["WorkspacesListFilesResult"] = to_class(WorkspacesListFilesResult, self.workspaces_list_files_result)
-        result["WorkspacesReadCheckpointRequest"] = to_class(WorkspacesReadCheckpointRequest, self.workspaces_read_checkpoint_request)
-        result["WorkspacesReadCheckpointResult"] = to_class(WorkspacesReadCheckpointResult, self.workspaces_read_checkpoint_result)
         result["WorkspacesReadFileRequest"] = to_class(WorkspacesReadFileRequest, self.workspaces_read_file_request)
         result["WorkspacesReadFileResult"] = to_class(WorkspacesReadFileResult, self.workspaces_read_file_result)
-        result["WorkspacesSaveLargePasteRequest"] = to_class(WorkspacesSaveLargePasteRequest, self.workspaces_save_large_paste_request)
-        result["WorkspacesSaveLargePasteResult"] = to_class(WorkspacesSaveLargePasteResult, self.workspaces_save_large_paste_result)
-        result["SessionContextInfo"] = from_union([lambda x: to_class(SessionContextInfo, x), from_none], self.session_context_info)
-        result["TaskProgress"] = from_union([lambda x: to_class(TaskProgressClass, x), from_none], self.task_progress)
-        result["WorkspaceSummary"] = from_union([lambda x: to_class(WorkspaceSummary, x), from_none], self.workspace_summary)
         return result
 
 def rpc_from_dict(s: Any) -> RPC:
@@ -15504,15 +8290,8 @@ def rpc_to_dict(x: RPC) -> Any:
 
 ExternalToolResult = ExternalToolTextResultForLlm
 FilterMapping = dict
-McpExecuteSamplingRequest = dict
-McpExecuteSamplingResult = dict
-OptionsUpdateEnvValueMode = MCPSetEnvValueModeDetails
-SessionWorkingDirectoryContextHostType = SessionContextHostType
 TaskInfoExecutionMode = TaskExecutionMode
 TaskInfoStatus = TaskStatus
-TaskInfoType = TaskAgentProgressType
-TaskProgress = TaskProgressClass
-TaskShellProgress = None
 
 def _timeout_kwargs(timeout: float | None) -> dict:
     """Build keyword arguments for optional timeout forwarding."""
@@ -15548,6 +8327,9 @@ class ServerModelsApi:
 
     async def list(self, params: ModelsListRequest, *, timeout: float | None = None) -> ModelList:
         "Lists Copilot models available to the authenticated user.\n\nArgs:\n    params: Optional GitHub token used to list models for a specific user instead of the global auth context.\n\nReturns:\n    List of Copilot models available to the resolved user, including capabilities and billing metadata."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return ModelList.from_dict(_patch_model_capabilities(await self._client.request("models.list", params_dict, **_timeout_kwargs(timeout))))
 
@@ -15558,6 +8340,9 @@ class ServerToolsApi:
 
     async def list(self, params: ToolsListRequest, *, timeout: float | None = None) -> ToolList:
         "Lists built-in tools available for a model.\n\nArgs:\n    params: Optional model identifier whose tool overrides should be applied to the listing.\n\nReturns:\n    Built-in tools available for the requested model, with their parameters and instructions."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return ToolList.from_dict(await self._client.request("tools.list", params_dict, **_timeout_kwargs(timeout)))
 
@@ -15568,6 +8353,9 @@ class ServerAccountApi:
 
     async def get_quota(self, params: AccountGetQuotaRequest, *, timeout: float | None = None) -> AccountGetQuotaResult:
         "Gets Copilot quota usage for the authenticated user or supplied GitHub token.\n\nArgs:\n    params: Optional GitHub token used to look up quota for a specific user instead of the global auth context.\n\nReturns:\n    Quota usage snapshots for the resolved user, keyed by quota type."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return AccountGetQuotaResult.from_dict(await self._client.request("account.getQuota", params_dict, **_timeout_kwargs(timeout)))
 
@@ -15582,26 +8370,41 @@ class ServerMcpConfigApi:
 
     async def add(self, params: MCPConfigAddRequest, *, timeout: float | None = None) -> None:
         "Adds an MCP server to user configuration.\n\nArgs:\n    params: MCP server name and configuration to add to user configuration."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         await self._client.request("mcp.config.add", params_dict, **_timeout_kwargs(timeout))
 
     async def update(self, params: MCPConfigUpdateRequest, *, timeout: float | None = None) -> None:
         "Updates an MCP server in user configuration.\n\nArgs:\n    params: MCP server name and replacement configuration to write to user configuration."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         await self._client.request("mcp.config.update", params_dict, **_timeout_kwargs(timeout))
 
     async def remove(self, params: MCPConfigRemoveRequest, *, timeout: float | None = None) -> None:
         "Removes an MCP server from user configuration.\n\nArgs:\n    params: MCP server name to remove from user configuration."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         await self._client.request("mcp.config.remove", params_dict, **_timeout_kwargs(timeout))
 
     async def enable(self, params: MCPConfigEnableRequest, *, timeout: float | None = None) -> None:
         "Enables MCP servers in user configuration for new sessions.\n\nArgs:\n    params: MCP server names to enable for new sessions."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         await self._client.request("mcp.config.enable", params_dict, **_timeout_kwargs(timeout))
 
     async def disable(self, params: MCPConfigDisableRequest, *, timeout: float | None = None) -> None:
         "Disables MCP servers in user configuration for new sessions.\n\nArgs:\n    params: MCP server names to disable for new sessions."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         await self._client.request("mcp.config.disable", params_dict, **_timeout_kwargs(timeout))
 
@@ -15613,6 +8416,9 @@ class ServerMcpApi:
 
     async def discover(self, params: MCPDiscoverRequest, *, timeout: float | None = None) -> MCPDiscoverResult:
         "Discovers MCP servers from user, workspace, plugin, and builtin sources.\n\nArgs:\n    params: Optional working directory used as context for MCP server discovery.\n\nReturns:\n    MCP servers discovered from user, workspace, plugin, and built-in sources."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return MCPDiscoverResult.from_dict(await self._client.request("mcp.discover", params_dict, **_timeout_kwargs(timeout)))
 
@@ -15623,6 +8429,9 @@ class ServerSkillsConfigApi:
 
     async def set_disabled_skills(self, params: SkillsConfigSetDisabledSkillsRequest, *, timeout: float | None = None) -> None:
         "Replaces the global list of disabled skills.\n\nArgs:\n    params: Skill names to mark as disabled in global configuration, replacing any previous list."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         await self._client.request("skills.config.setDisabledSkills", params_dict, **_timeout_kwargs(timeout))
 
@@ -15634,6 +8443,9 @@ class ServerSkillsApi:
 
     async def discover(self, params: SkillsDiscoverRequest, *, timeout: float | None = None) -> ServerSkillList:
         "Discovers skills across global and project sources.\n\nArgs:\n    params: Optional project paths and additional skill directories to include in discovery.\n\nReturns:\n    Skills discovered across global and project sources."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return ServerSkillList.from_dict(await self._client.request("skills.discover", params_dict, **_timeout_kwargs(timeout)))
 
@@ -15644,6 +8456,9 @@ class ServerSessionFsApi:
 
     async def set_provider(self, params: SessionFSSetProviderRequest, *, timeout: float | None = None) -> SessionFSSetProviderResult:
         "Registers an SDK client as the session filesystem provider.\n\nArgs:\n    params: Initial working directory, session-state path layout, and path conventions used to register the calling SDK client as the session filesystem provider.\n\nReturns:\n    Indicates whether the calling client was registered as the session filesystem provider."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return SessionFSSetProviderResult.from_dict(await self._client.request("sessionFs.setProvider", params_dict, **_timeout_kwargs(timeout)))
 
@@ -15655,97 +8470,19 @@ class ServerSessionsApi:
 
     async def fork(self, params: SessionsForkRequest, *, timeout: float | None = None) -> SessionsForkResult:
         "Creates a new session by forking persisted history from an existing session.\n\nArgs:\n    params: Source session identifier to fork from, optional event-ID boundary, and optional friendly name for the new session.\n\nReturns:\n    Identifier and optional friendly name assigned to the newly forked session."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return SessionsForkResult.from_dict(await self._client.request("sessions.fork", params_dict, **_timeout_kwargs(timeout)))
 
     async def connect(self, params: ConnectRemoteSessionParams, *, timeout: float | None = None) -> RemoteSessionConnectionResult:
         "Connects to an existing remote session and exposes it as an SDK session.\n\nArgs:\n    params: Remote session connection parameters.\n\nReturns:\n    Remote session connection result."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return RemoteSessionConnectionResult.from_dict(await self._client.request("sessions.connect", params_dict, **_timeout_kwargs(timeout)))
-
-    async def list(self, params: SessionsListRequest, *, timeout: float | None = None) -> SessionList:
-        "Lists persisted sessions, optionally filtered by working-directory context.\n\nArgs:\n    params: Optional metadata-load limit and context filter applied to the returned sessions.\n\nReturns:\n    Persisted sessions matching the filter, ordered most-recently-modified first."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
-        return SessionList.from_dict(await self._client.request("sessions.list", params_dict, **_timeout_kwargs(timeout)))
-
-    async def find_by_task_id(self, params: SessionsFindByTaskIDRequest, *, timeout: float | None = None) -> SessionsFindByTaskIDResult:
-        "Finds the local session bound to a GitHub task ID, if any.\n\nArgs:\n    params: GitHub task ID to look up.\n\nReturns:\n    ID of the local session bound to the given GitHub task, or omitted when none."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
-        return SessionsFindByTaskIDResult.from_dict(await self._client.request("sessions.findByTaskId", params_dict, **_timeout_kwargs(timeout)))
-
-    async def find_by_prefix(self, params: SessionsFindByPrefixRequest, *, timeout: float | None = None) -> SessionsFindByPrefixResult:
-        "Resolves a UUID prefix to a unique session ID, if exactly one session matches.\n\nArgs:\n    params: UUID prefix to resolve to a unique session ID.\n\nReturns:\n    Session ID matching the prefix, omitted when no unique match exists."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
-        return SessionsFindByPrefixResult.from_dict(await self._client.request("sessions.findByPrefix", params_dict, **_timeout_kwargs(timeout)))
-
-    async def get_last_for_context(self, params: SessionsGetLastForContextRequest, *, timeout: float | None = None) -> SessionsGetLastForContextResult:
-        "Returns the most-relevant prior session for a given working-directory context.\n\nArgs:\n    params: Optional working-directory context used to score session relevance.\n\nReturns:\n    Most-relevant session ID for the supplied context, or omitted when no sessions exist."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
-        return SessionsGetLastForContextResult.from_dict(await self._client.request("sessions.getLastForContext", params_dict, **_timeout_kwargs(timeout)))
-
-    async def get_event_file_path(self, params: SessionsGetEventFilePathRequest, *, timeout: float | None = None) -> SessionsGetEventFilePathResult:
-        "Computes the absolute path to a session's persisted events.jsonl file.\n\nArgs:\n    params: Session ID whose event-log file path to compute.\n\nReturns:\n    Absolute path to the session's events.jsonl file on disk."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
-        return SessionsGetEventFilePathResult.from_dict(await self._client.request("sessions.getEventFilePath", params_dict, **_timeout_kwargs(timeout)))
-
-    async def get_sizes(self, *, timeout: float | None = None) -> SessionSizes:
-        "Returns the on-disk byte size of each session's workspace directory.\n\nReturns:\n    Map of sessionId -> on-disk size in bytes for each session's workspace directory."
-        return SessionSizes.from_dict(await self._client.request("sessions.getSizes", {}, **_timeout_kwargs(timeout)))
-
-    async def check_in_use(self, params: SessionsCheckInUseRequest, *, timeout: float | None = None) -> SessionsCheckInUseResult:
-        "Returns the subset of the supplied session IDs that are currently held by another running process.\n\nArgs:\n    params: Session IDs to test for live in-use locks.\n\nReturns:\n    Session IDs from the input set that are currently in use by another process."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
-        return SessionsCheckInUseResult.from_dict(await self._client.request("sessions.checkInUse", params_dict, **_timeout_kwargs(timeout)))
-
-    async def get_persisted_remote_steerable(self, params: SessionsGetPersistedRemoteSteerableRequest, *, timeout: float | None = None) -> SessionsGetPersistedRemoteSteerableResult:
-        "Returns a session's persisted remote-steerable flag, if any has been recorded.\n\nArgs:\n    params: Session ID to look up the persisted remote-steerable flag for.\n\nReturns:\n    The session's persisted remote-steerable flag, or omitted when no value has been persisted."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
-        return SessionsGetPersistedRemoteSteerableResult.from_dict(await self._client.request("sessions.getPersistedRemoteSteerable", params_dict, **_timeout_kwargs(timeout)))
-
-    async def close(self, params: SessionsCloseRequest, *, timeout: float | None = None) -> SessionsCloseResult:
-        "Closes a session: emits shutdown, flushes pending events, releases the in-use lock, and disposes the active session.\n\nArgs:\n    params: Session ID to close.\n\nReturns:\n    Closes a session: emits shutdown, flushes pending events to disk, releases the in-use lock, disposes the active session. Idempotent: succeeds even if the session is not currently active."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
-        return SessionsCloseResult.from_dict(await self._client.request("sessions.close", params_dict, **_timeout_kwargs(timeout)))
-
-    async def bulk_delete(self, params: SessionsBulkDeleteRequest, *, timeout: float | None = None) -> SessionBulkDeleteResult:
-        "Closes, deactivates, and deletes a set of sessions, returning the bytes freed per session.\n\nArgs:\n    params: Session IDs to close, deactivate, and delete from disk.\n\nReturns:\n    Map of sessionId -> bytes freed by removing the session's workspace directory."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
-        return SessionBulkDeleteResult.from_dict(await self._client.request("sessions.bulkDelete", params_dict, **_timeout_kwargs(timeout)))
-
-    async def prune_old(self, params: SessionsPruneOldRequest, *, timeout: float | None = None) -> SessionPruneResult:
-        "Deletes sessions older than the given threshold, with optional dry-run and exclusion list.\n\nArgs:\n    params: Age threshold and optional flags controlling which old sessions are pruned (or simulated when dryRun is true).\n\nReturns:\n    Outcome of the prune operation: deleted IDs, dry-run candidates, skipped IDs, total bytes freed, and the dry-run flag."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
-        return SessionPruneResult.from_dict(await self._client.request("sessions.pruneOld", params_dict, **_timeout_kwargs(timeout)))
-
-    async def save(self, params: SessionsSaveRequest, *, timeout: float | None = None) -> SessionsSaveResult:
-        "Flushes a session's pending events to disk.\n\nArgs:\n    params: Session ID whose pending events should be flushed to disk.\n\nReturns:\n    Flush a session's pending events to disk. No-op when no writer exists for the session (e.g., already closed)."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
-        return SessionsSaveResult.from_dict(await self._client.request("sessions.save", params_dict, **_timeout_kwargs(timeout)))
-
-    async def release_lock(self, params: SessionsReleaseLockRequest, *, timeout: float | None = None) -> SessionsReleaseLockResult:
-        "Releases the in-use lock held by this process for a session.\n\nArgs:\n    params: Session ID whose in-use lock should be released.\n\nReturns:\n    Release the in-use lock held by this process for the given session. No-op when this process does not currently hold a lock for the session."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
-        return SessionsReleaseLockResult.from_dict(await self._client.request("sessions.releaseLock", params_dict, **_timeout_kwargs(timeout)))
-
-    async def enrich_metadata(self, params: SessionsEnrichMetadataRequest, *, timeout: float | None = None) -> SessionEnrichMetadataResult:
-        "Backfills missing summary and context fields on the supplied session metadata records.\n\nArgs:\n    params: Session metadata records to enrich with summary and context information.\n\nReturns:\n    The same metadata records, with summary and context fields backfilled where available."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
-        return SessionEnrichMetadataResult.from_dict(await self._client.request("sessions.enrichMetadata", params_dict, **_timeout_kwargs(timeout)))
-
-    async def reload_plugin_hooks(self, params: SessionsReloadPluginHooksRequest, *, timeout: float | None = None) -> SessionsReloadPluginHooksResult:
-        "Reloads user, plugin, and (optionally) repo hooks on the active session.\n\nArgs:\n    params: Active session ID and an optional flag for deferring repo-level hooks until folder trust.\n\nReturns:\n    Reload all hooks (user, plugin, optionally repo) and apply them to the active session. Call after installing or removing plugins so their hooks take effect immediately. No-op when no active session matches the given sessionId."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
-        return SessionsReloadPluginHooksResult.from_dict(await self._client.request("sessions.reloadPluginHooks", params_dict, **_timeout_kwargs(timeout)))
-
-    async def load_deferred_repo_hooks(self, params: SessionsLoadDeferredRepoHooksRequest, *, timeout: float | None = None) -> SessionLoadDeferredRepoHooksResult:
-        "Loads previously-deferred repo-level hooks on the active session, returning queued startup prompts.\n\nArgs:\n    params: Active session ID whose deferred repo-level hooks should be loaded.\n\nReturns:\n    Queued repo-level startup prompts and the total hook command count after loading."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
-        return SessionLoadDeferredRepoHooksResult.from_dict(await self._client.request("sessions.loadDeferredRepoHooks", params_dict, **_timeout_kwargs(timeout)))
-
-    async def set_additional_plugins(self, params: SessionsSetAdditionalPluginsRequest, *, timeout: float | None = None) -> SessionsSetAdditionalPluginsResult:
-        "Replaces the manager-wide additional plugins registered with the session manager.\n\nArgs:\n    params: Manager-wide additional plugins to register; replaces any previously-configured set.\n\nReturns:\n    Replace the manager-wide additional plugins. New session creations and subsequent hook reloads see the new set; already-running sessions keep their existing hook installation until the next reload."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
-        return SessionsSetAdditionalPluginsResult.from_dict(await self._client.request("sessions.setAdditionalPlugins", params_dict, **_timeout_kwargs(timeout)))
 
 
 class ServerRpc:
@@ -15761,7 +8498,10 @@ class ServerRpc:
         self.sessions = ServerSessionsApi(client)
 
     async def ping(self, params: PingRequest, *, timeout: float | None = None) -> PingResult:
-        "Checks server responsiveness and returns protocol information.\n\nArgs:\n    params: Optional message to echo back to the caller.\n\nReturns:\n    Server liveness response, including the echoed message, current server timestamp, and protocol version."
+        "Checks server responsiveness and returns protocol information.\n\nArgs:\n    params: Optional message to echo back to the caller.\n\nReturns:\n    Server liveness response, including the echoed message, current timestamp, and protocol version."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return PingResult.from_dict(await self._client.request("ping", params_dict, **_timeout_kwargs(timeout)))
 
@@ -15773,166 +8513,205 @@ class _InternalServerRpc:
 
     async def connect(self, params: ConnectRequest, *, timeout: float | None = None) -> ConnectResult:
         "Performs the SDK server connection handshake and validates the optional connection token.\n\nArgs:\n    params: Optional connection token presented by the SDK client during the handshake.\n\nReturns:\n    Handshake result reporting the server's protocol version and package version on success.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return ConnectResult.from_dict(await self._client.request("connect", params_dict, **_timeout_kwargs(timeout)))
 
 
 class AuthApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def get_status(self, *, timeout: float | None = None) -> SessionAuthStatus:
         "Gets authentication status and account metadata for the session.\n\nReturns:\n    Authentication status and account metadata for the session."
-        return SessionAuthStatus.from_dict(await self._client.request("session.auth.getStatus", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+        if self._assert_active is not None:
+            self._assert_active()
 
-    async def set_credentials(self, params: SessionSetCredentialsParams, *, timeout: float | None = None) -> SessionSetCredentialsResult:
-        "Updates the session's auth credentials used for outbound model and API requests.\n\nArgs:\n    params: New auth credentials to install on the session. Omit to leave credentials unchanged.\n\nReturns:\n    Indicates whether the credential update succeeded."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return SessionSetCredentialsResult.from_dict(await self._client.request("session.auth.setCredentials", params_dict, **_timeout_kwargs(timeout)))
+        return SessionAuthStatus.from_dict(await self._client.request("session.auth.getStatus", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
 class ModelApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def get_current(self, *, timeout: float | None = None) -> CurrentModel:
-        "Gets the currently selected model for the session.\n\nReturns:\n    The currently selected model and reasoning effort for the session."
+        "Gets the currently selected model for the session.\n\nReturns:\n    The currently selected model for the session."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return CurrentModel.from_dict(await self._client.request("session.model.getCurrent", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def switch_to(self, params: ModelSwitchToRequest, *, timeout: float | None = None) -> ModelSwitchToResult:
         "Switches the session to a model and optional reasoning configuration.\n\nArgs:\n    params: Target model identifier and optional reasoning effort, summary, and capability overrides.\n\nReturns:\n    The model identifier active on the session after the switch."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return ModelSwitchToResult.from_dict(await self._client.request("session.model.switchTo", params_dict, **_timeout_kwargs(timeout)))
 
-    async def set_reasoning_effort(self, params: ModelSetReasoningEffortRequest, *, timeout: float | None = None) -> ModelSetReasoningEffortResult:
-        "Updates the session's reasoning effort without changing the selected model.\n\nArgs:\n    params: Reasoning effort level to apply to the currently selected model.\n\nReturns:\n    Update the session's reasoning effort without changing the selected model. Use `switchTo` instead when you also need to change the model. The runtime stores the effort on the session and applies it to subsequent turns."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return ModelSetReasoningEffortResult.from_dict(await self._client.request("session.model.setReasoningEffort", params_dict, **_timeout_kwargs(timeout)))
-
 
 class ModeApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def get(self, *, timeout: float | None = None) -> SessionMode:
         "Gets the current agent interaction mode.\n\nReturns:\n    The session mode the agent is operating in"
+        if self._assert_active is not None:
+            self._assert_active()
+
         return SessionMode(await self._client.request("session.mode.get", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def set(self, params: ModeSetRequest, *, timeout: float | None = None) -> None:
         "Sets the current agent interaction mode.\n\nArgs:\n    params: Agent interaction mode to apply to the session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.mode.set", params_dict, **_timeout_kwargs(timeout))
 
 
 class NameApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def get(self, *, timeout: float | None = None) -> NameGetResult:
         "Gets the session's friendly name.\n\nReturns:\n    The session's friendly name, or null when not yet set."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return NameGetResult.from_dict(await self._client.request("session.name.get", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def set(self, params: NameSetRequest, *, timeout: float | None = None) -> None:
         "Sets the session's friendly name.\n\nArgs:\n    params: New friendly name to apply to the session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.name.set", params_dict, **_timeout_kwargs(timeout))
 
-    async def set_auto(self, params: NameSetAutoRequest, *, timeout: float | None = None) -> NameSetAutoResult:
-        "Persists an auto-generated session summary as the session's name when no user-set name exists.\n\nArgs:\n    params: Auto-generated session summary to apply as the session's name when no user-set name exists.\n\nReturns:\n    Indicates whether the auto-generated summary was applied as the session's name."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return NameSetAutoResult.from_dict(await self._client.request("session.name.setAuto", params_dict, **_timeout_kwargs(timeout)))
-
 
 class PlanApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def read(self, *, timeout: float | None = None) -> PlanReadResult:
         "Reads the session plan file from the workspace.\n\nReturns:\n    Existence, contents, and resolved path of the session plan file."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return PlanReadResult.from_dict(await self._client.request("session.plan.read", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def update(self, params: PlanUpdateRequest, *, timeout: float | None = None) -> None:
         "Writes new content to the session plan file.\n\nArgs:\n    params: Replacement contents to write to the session plan file."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.plan.update", params_dict, **_timeout_kwargs(timeout))
 
     async def delete(self, *, timeout: float | None = None) -> None:
         "Deletes the session plan file from the workspace."
+        if self._assert_active is not None:
+            self._assert_active()
+
         await self._client.request("session.plan.delete", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
 
 class WorkspacesApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def get_workspace(self, *, timeout: float | None = None) -> WorkspacesGetWorkspaceResult:
-        "Gets current workspace metadata for the session.\n\nReturns:\n    Current workspace metadata for the session, including its absolute filesystem path when available."
+        "Gets current workspace metadata for the session.\n\nReturns:\n    Current workspace metadata for the session, or null when not available."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return WorkspacesGetWorkspaceResult.from_dict(await self._client.request("session.workspaces.getWorkspace", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def list_files(self, *, timeout: float | None = None) -> WorkspacesListFilesResult:
         "Lists files stored in the session workspace files directory.\n\nReturns:\n    Relative paths of files stored in the session workspace files directory."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return WorkspacesListFilesResult.from_dict(await self._client.request("session.workspaces.listFiles", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def read_file(self, params: WorkspacesReadFileRequest, *, timeout: float | None = None) -> WorkspacesReadFileResult:
         "Reads a file from the session workspace files directory.\n\nArgs:\n    params: Relative path of the workspace file to read.\n\nReturns:\n    Contents of the requested workspace file as a UTF-8 string."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return WorkspacesReadFileResult.from_dict(await self._client.request("session.workspaces.readFile", params_dict, **_timeout_kwargs(timeout)))
 
     async def create_file(self, params: WorkspacesCreateFileRequest, *, timeout: float | None = None) -> None:
         "Creates or overwrites a file in the session workspace files directory.\n\nArgs:\n    params: Relative path and UTF-8 content for the workspace file to create or overwrite."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.workspaces.createFile", params_dict, **_timeout_kwargs(timeout))
 
-    async def list_checkpoints(self, *, timeout: float | None = None) -> WorkspacesListCheckpointsResult:
-        "Lists workspace checkpoints in chronological order.\n\nReturns:\n    Workspace checkpoints in chronological order; empty when the workspace is not enabled."
-        return WorkspacesListCheckpointsResult.from_dict(await self._client.request("session.workspaces.listCheckpoints", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
-
-    async def read_checkpoint(self, params: WorkspacesReadCheckpointRequest, *, timeout: float | None = None) -> WorkspacesReadCheckpointResult:
-        "Reads the content of a workspace checkpoint by number.\n\nArgs:\n    params: Checkpoint number to read.\n\nReturns:\n    Checkpoint content as a UTF-8 string, or null when the checkpoint or workspace is missing."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return WorkspacesReadCheckpointResult.from_dict(await self._client.request("session.workspaces.readCheckpoint", params_dict, **_timeout_kwargs(timeout)))
-
-    async def save_large_paste(self, params: WorkspacesSaveLargePasteRequest, *, timeout: float | None = None) -> WorkspacesSaveLargePasteResult:
-        "Saves pasted content as a UTF-8 file in the session workspace.\n\nArgs:\n    params: Pasted content to save as a UTF-8 file in the session workspace.\n\nReturns:\n    Descriptor for the saved paste file, or null when the workspace is unavailable."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return WorkspacesSaveLargePasteResult.from_dict(await self._client.request("session.workspaces.saveLargePaste", params_dict, **_timeout_kwargs(timeout)))
-
 
 class InstructionsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def get_sources(self, *, timeout: float | None = None) -> InstructionsGetSourcesResult:
         "Gets instruction sources loaded for the session.\n\nReturns:\n    Instruction sources loaded for the session, in merge order."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return InstructionsGetSourcesResult.from_dict(await self._client.request("session.instructions.getSources", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class FleetApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def start(self, params: FleetStartRequest, *, timeout: float | None = None) -> FleetStartResult:
         "Starts fleet mode by submitting the fleet orchestration prompt to the session.\n\nArgs:\n    params: Optional user prompt to combine with the fleet orchestration instructions.\n\nReturns:\n    Indicates whether fleet mode was successfully activated."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return FleetStartResult.from_dict(await self._client.request("session.fleet.start", params_dict, **_timeout_kwargs(timeout)))
@@ -15940,91 +8719,116 @@ class FleetApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class AgentApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def list(self, *, timeout: float | None = None) -> AgentList:
         "Lists custom agents available to the session.\n\nReturns:\n    Custom agents available to the session."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return AgentList.from_dict(await self._client.request("session.agent.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def get_current(self, *, timeout: float | None = None) -> AgentGetCurrentResult:
         "Gets the currently selected custom agent for the session.\n\nReturns:\n    The currently selected custom agent, or null when using the default agent."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return AgentGetCurrentResult.from_dict(await self._client.request("session.agent.getCurrent", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def select(self, params: AgentSelectRequest, *, timeout: float | None = None) -> AgentSelectResult:
         "Selects a custom agent for subsequent turns in the session.\n\nArgs:\n    params: Name of the custom agent to select for subsequent turns.\n\nReturns:\n    The newly selected custom agent."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return AgentSelectResult.from_dict(await self._client.request("session.agent.select", params_dict, **_timeout_kwargs(timeout)))
 
     async def deselect(self, *, timeout: float | None = None) -> None:
         "Clears the selected custom agent and returns the session to the default agent."
+        if self._assert_active is not None:
+            self._assert_active()
+
         await self._client.request("session.agent.deselect", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
     async def reload(self, *, timeout: float | None = None) -> AgentReloadResult:
         "Reloads custom agent definitions and returns the refreshed list.\n\nReturns:\n    Custom agents available to the session after reloading definitions from disk."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return AgentReloadResult.from_dict(await self._client.request("session.agent.reload", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class TasksApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def start_agent(self, params: TasksStartAgentRequest, *, timeout: float | None = None) -> TasksStartAgentResult:
         "Starts a background agent task in the session.\n\nArgs:\n    params: Agent type, prompt, name, and optional description and model override for the new task.\n\nReturns:\n    Identifier assigned to the newly started background agent task."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return TasksStartAgentResult.from_dict(await self._client.request("session.tasks.startAgent", params_dict, **_timeout_kwargs(timeout)))
 
     async def list(self, *, timeout: float | None = None) -> TaskList:
         "Lists background tasks tracked by the session.\n\nReturns:\n    Background tasks currently tracked by the session."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return TaskList.from_dict(await self._client.request("session.tasks.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
-
-    async def refresh(self, *, timeout: float | None = None) -> TasksRefreshResult:
-        "Refreshes metadata for any detached background shells the runtime knows about.\n\nReturns:\n    Refresh metadata for any detached background shells the runtime knows about. Use after a long pause to pick up exit/output state for shells running outside the agent loop."
-        return TasksRefreshResult.from_dict(await self._client.request("session.tasks.refresh", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
-
-    async def wait_for_pending(self, *, timeout: float | None = None) -> TasksWaitForPendingResult:
-        "Waits for all in-flight background tasks and any follow-up turns to settle.\n\nReturns:\n    Wait until all in-flight background tasks (agents + shells) and any follow-up turns scheduled by their completions have settled. Returns when the runtime is fully drained or after an internal timeout (default 10 minutes; configurable via COPILOT_TASK_WAIT_TIMEOUT_SECONDS)."
-        return TasksWaitForPendingResult.from_dict(await self._client.request("session.tasks.waitForPending", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
-
-    async def get_progress(self, params: TasksGetProgressRequest, *, timeout: float | None = None) -> TasksGetProgressResult:
-        "Returns progress information for a background task by ID.\n\nArgs:\n    params: Identifier of the background task to fetch progress for.\n\nReturns:\n    Progress information for the task, or null when no task with that ID is tracked."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return TasksGetProgressResult.from_dict(await self._client.request("session.tasks.getProgress", params_dict, **_timeout_kwargs(timeout)))
-
-    async def get_current_promotable(self, *, timeout: float | None = None) -> TasksGetCurrentPromotableResult:
-        "Returns the first sync-waiting task that can currently be promoted to background mode.\n\nReturns:\n    The first sync-waiting task that can currently be promoted to background mode."
-        return TasksGetCurrentPromotableResult.from_dict(await self._client.request("session.tasks.getCurrentPromotable", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def promote_to_background(self, params: TasksPromoteToBackgroundRequest, *, timeout: float | None = None) -> TasksPromoteToBackgroundResult:
         "Promotes an eligible synchronously-waited task so it continues running in the background.\n\nArgs:\n    params: Identifier of the task to promote to background mode.\n\nReturns:\n    Indicates whether the task was successfully promoted to background mode."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return TasksPromoteToBackgroundResult.from_dict(await self._client.request("session.tasks.promoteToBackground", params_dict, **_timeout_kwargs(timeout)))
 
-    async def promote_current_to_background(self, *, timeout: float | None = None) -> TasksPromoteCurrentToBackgroundResult:
-        "Atomically promotes the first promotable sync-waiting task to background mode and returns it.\n\nReturns:\n    The promoted task as it now exists in background mode, omitted if no promotable task was waiting."
-        return TasksPromoteCurrentToBackgroundResult.from_dict(await self._client.request("session.tasks.promoteCurrentToBackground", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
-
     async def cancel(self, params: TasksCancelRequest, *, timeout: float | None = None) -> TasksCancelResult:
         "Cancels a background task.\n\nArgs:\n    params: Identifier of the background task to cancel.\n\nReturns:\n    Indicates whether the background task was successfully cancelled."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return TasksCancelResult.from_dict(await self._client.request("session.tasks.cancel", params_dict, **_timeout_kwargs(timeout)))
 
     async def remove(self, params: TasksRemoveRequest, *, timeout: float | None = None) -> TasksRemoveResult:
         "Removes a completed or cancelled background task from tracking.\n\nArgs:\n    params: Identifier of the completed or cancelled task to remove from tracking.\n\nReturns:\n    Indicates whether the task was removed. False when the task does not exist or is still running/idle."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return TasksRemoveResult.from_dict(await self._client.request("session.tasks.remove", params_dict, **_timeout_kwargs(timeout)))
 
     async def send_message(self, params: TasksSendMessageRequest, *, timeout: float | None = None) -> TasksSendMessageResult:
         "Sends a message to a background agent task.\n\nArgs:\n    params: Identifier of the target agent task, message content, and optional sender agent ID.\n\nReturns:\n    Indicates whether the message was delivered, with an error message when delivery failed."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return TasksSendMessageResult.from_dict(await self._client.request("session.tasks.sendMessage", params_dict, **_timeout_kwargs(timeout)))
@@ -16032,47 +8836,62 @@ class TasksApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class SkillsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def list(self, *, timeout: float | None = None) -> SkillList:
         "Lists skills available to the session.\n\nReturns:\n    Skills available to the session, with their enabled state."
-        return SkillList.from_dict(await self._client.request("session.skills.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+        if self._assert_active is not None:
+            self._assert_active()
 
-    async def get_invoked(self, *, timeout: float | None = None) -> SkillsGetInvokedResult:
-        "Returns the skills that have been invoked during this session.\n\nReturns:\n    Skills invoked during this session, ordered by invocation time (most recent last)."
-        return SkillsGetInvokedResult.from_dict(await self._client.request("session.skills.getInvoked", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+        return SkillList.from_dict(await self._client.request("session.skills.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def enable(self, params: SkillsEnableRequest, *, timeout: float | None = None) -> None:
         "Enables a skill for the session.\n\nArgs:\n    params: Name of the skill to enable for the session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.skills.enable", params_dict, **_timeout_kwargs(timeout))
 
     async def disable(self, params: SkillsDisableRequest, *, timeout: float | None = None) -> None:
         "Disables a skill for the session.\n\nArgs:\n    params: Name of the skill to disable for the session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.skills.disable", params_dict, **_timeout_kwargs(timeout))
 
     async def reload(self, *, timeout: float | None = None) -> SkillsLoadDiagnostics:
         "Reloads skill definitions for the session.\n\nReturns:\n    Diagnostics from reloading skill definitions, with warnings and errors as separate lists."
-        return SkillsLoadDiagnostics.from_dict(await self._client.request("session.skills.reload", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+        if self._assert_active is not None:
+            self._assert_active()
 
-    async def ensure_loaded(self, *, timeout: float | None = None) -> None:
-        "Ensures the session's skill definitions have been loaded from disk."
-        await self._client.request("session.skills.ensureLoaded", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
+        return SkillsLoadDiagnostics.from_dict(await self._client.request("session.skills.reload", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class McpOauthApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def login(self, params: MCPOauthLoginRequest, *, timeout: float | None = None) -> MCPOauthLoginResult:
         "Starts OAuth authentication for a remote MCP server.\n\nArgs:\n    params: Remote MCP server name and optional overrides controlling reauthentication, OAuth client display name, and the callback success-page copy.\n\nReturns:\n    OAuth authorization URL the caller should open, or empty when cached tokens already authenticated the server."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return MCPOauthLoginResult.from_dict(await self._client.request("session.mcp.oauth.login", params_dict, **_timeout_kwargs(timeout)))
@@ -16080,391 +8899,264 @@ class McpOauthApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class McpApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
-        self.oauth = McpOauthApi(client, session_id)
+        self._assert_active = assert_active
+        self.oauth = McpOauthApi(client, session_id, assert_active)
 
     async def list(self, *, timeout: float | None = None) -> MCPServerList:
         "Lists MCP servers configured for the session and their connection status.\n\nReturns:\n    MCP servers configured for the session, with their connection status."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return MCPServerList.from_dict(await self._client.request("session.mcp.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def enable(self, params: MCPEnableRequest, *, timeout: float | None = None) -> None:
         "Enables an MCP server for the session.\n\nArgs:\n    params: Name of the MCP server to enable for the session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.mcp.enable", params_dict, **_timeout_kwargs(timeout))
 
     async def disable(self, params: MCPDisableRequest, *, timeout: float | None = None) -> None:
         "Disables an MCP server for the session.\n\nArgs:\n    params: Name of the MCP server to disable for the session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.mcp.disable", params_dict, **_timeout_kwargs(timeout))
 
     async def reload(self, *, timeout: float | None = None) -> None:
         "Reloads MCP server connections for the session."
+        if self._assert_active is not None:
+            self._assert_active()
+
         await self._client.request("session.mcp.reload", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
-
-    async def execute_sampling(self, params: MCPExecuteSamplingParams, *, timeout: float | None = None) -> MCPSamplingExecutionResult:
-        "Runs an MCP sampling inference on behalf of an MCP server.\n\nArgs:\n    params: Identifiers and raw MCP CreateMessageRequest params used to run a sampling inference.\n\nReturns:\n    Outcome of an MCP sampling execution: success result, failure error, or cancellation."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return MCPSamplingExecutionResult.from_dict(await self._client.request("session.mcp.executeSampling", params_dict, **_timeout_kwargs(timeout)))
-
-    async def cancel_sampling_execution(self, params: MCPCancelSamplingExecutionParams, *, timeout: float | None = None) -> MCPCancelSamplingExecutionResult:
-        "Cancels an in-flight MCP sampling execution by request ID.\n\nArgs:\n    params: The requestId previously passed to executeSampling that should be cancelled.\n\nReturns:\n    Indicates whether an in-flight sampling execution with the given requestId was found and cancelled."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return MCPCancelSamplingExecutionResult.from_dict(await self._client.request("session.mcp.cancelSamplingExecution", params_dict, **_timeout_kwargs(timeout)))
-
-    async def set_env_value_mode(self, params: MCPSetEnvValueModeParams, *, timeout: float | None = None) -> MCPSetEnvValueModeResult:
-        "Sets how environment-variable values supplied to MCP servers are resolved (direct or indirect).\n\nArgs:\n    params: Mode controlling how MCP server env values are resolved (`direct` or `indirect`).\n\nReturns:\n    Env-value mode recorded on the session after the update."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return MCPSetEnvValueModeResult.from_dict(await self._client.request("session.mcp.setEnvValueMode", params_dict, **_timeout_kwargs(timeout)))
-
-    async def remove_git_hub(self, *, timeout: float | None = None) -> MCPRemoveGitHubResult:
-        "Removes the auto-managed `github` MCP server when present.\n\nReturns:\n    Indicates whether the auto-managed `github` MCP server was removed (false when nothing to remove)."
-        return MCPRemoveGitHubResult.from_dict(await self._client.request("session.mcp.removeGitHub", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class PluginsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def list(self, *, timeout: float | None = None) -> PluginList:
         "Lists plugins installed for the session.\n\nReturns:\n    Plugins installed for the session, with their enabled state and version metadata."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return PluginList.from_dict(await self._client.request("session.plugins.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.
-class OptionsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
-        self._client = client
-        self._session_id = session_id
-
-    async def update(self, params: SessionUpdateOptionsParams, *, timeout: float | None = None) -> SessionUpdateOptionsResult:
-        "Patches the genuinely-mutable subset of session options.\n\nArgs:\n    params: Patch of mutable session options to apply to the running session.\n\nReturns:\n    Indicates whether the session options patch was applied successfully."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return SessionUpdateOptionsResult.from_dict(await self._client.request("session.options.update", params_dict, **_timeout_kwargs(timeout)))
-
-
-# Experimental: this API group is experimental and may change or be removed.
-class LspApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
-        self._client = client
-        self._session_id = session_id
-
-    async def initialize(self, params: LspInitializeRequest, *, timeout: float | None = None) -> None:
-        "Loads the merged LSP configuration set for the session's working directory.\n\nArgs:\n    params: Parameters for (re)loading the merged LSP configuration set."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        await self._client.request("session.lsp.initialize", params_dict, **_timeout_kwargs(timeout))
-
-
-# Experimental: this API group is experimental and may change or be removed.
 class ExtensionsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def list(self, *, timeout: float | None = None) -> ExtensionList:
         "Lists extensions discovered for the session and their current status.\n\nReturns:\n    Extensions discovered for the session, with their current status."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return ExtensionList.from_dict(await self._client.request("session.extensions.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def enable(self, params: ExtensionsEnableRequest, *, timeout: float | None = None) -> None:
         "Enables an extension for the session.\n\nArgs:\n    params: Source-qualified extension identifier to enable for the session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.extensions.enable", params_dict, **_timeout_kwargs(timeout))
 
     async def disable(self, params: ExtensionsDisableRequest, *, timeout: float | None = None) -> None:
         "Disables an extension for the session.\n\nArgs:\n    params: Source-qualified extension identifier to disable for the session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.extensions.disable", params_dict, **_timeout_kwargs(timeout))
 
     async def reload(self, *, timeout: float | None = None) -> None:
         "Reloads extension definitions and processes for the session."
+        if self._assert_active is not None:
+            self._assert_active()
+
         await self._client.request("session.extensions.reload", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
 
 class ToolsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def handle_pending_tool_call(self, params: HandlePendingToolCallRequest, *, timeout: float | None = None) -> HandlePendingToolCallResult:
         "Provides the result for a pending external tool call.\n\nArgs:\n    params: Pending external tool call request ID, with the tool result or an error describing why it failed.\n\nReturns:\n    Indicates whether the external tool call result was handled successfully."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return HandlePendingToolCallResult.from_dict(await self._client.request("session.tools.handlePendingToolCall", params_dict, **_timeout_kwargs(timeout)))
 
-    async def initialize_and_validate(self, *, timeout: float | None = None) -> ToolsInitializeAndValidateResult:
-        "Resolves, builds, and validates the runtime tool list for the session.\n\nReturns:\n    Resolve, build, and validate the runtime tool list for this session. Subagent sessions and consumer flows that need an initialized tool set before `send` invoke this. Default base-class implementation is a no-op for sessions that don't support tool validation."
-        return ToolsInitializeAndValidateResult.from_dict(await self._client.request("session.tools.initializeAndValidate", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
-
 
 class CommandsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def list(self, params: CommandsListRequest | None = None, *, timeout: float | None = None) -> CommandList:
         "Lists slash commands available in the session.\n\nArgs:\n    params: Optional filters controlling which command sources to include in the listing.\n\nReturns:\n    Slash commands available in the session, after applying any include/exclude filters."
+        if self._assert_active is not None:
+            self._assert_active()
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         params_dict["sessionId"] = self._session_id
         return CommandList.from_dict(await self._client.request("session.commands.list", params_dict, **_timeout_kwargs(timeout)))
 
     async def invoke(self, params: CommandsInvokeRequest, *, timeout: float | None = None) -> SlashCommandInvocationResult:
         "Invokes a slash command in the session.\n\nArgs:\n    params: Slash command name and optional raw input string to invoke.\n\nReturns:\n    Result of invoking the slash command (text output, prompt to send to the agent, or completion)."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return SlashCommandInvocationResult.from_dict(await self._client.request("session.commands.invoke", params_dict, **_timeout_kwargs(timeout)))
 
     async def handle_pending_command(self, params: CommandsHandlePendingCommandRequest, *, timeout: float | None = None) -> CommandsHandlePendingCommandResult:
         "Reports completion of a pending client-handled slash command.\n\nArgs:\n    params: Pending command request ID and an optional error if the client handler failed.\n\nReturns:\n    Indicates whether the pending client-handled command was completed successfully."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return CommandsHandlePendingCommandResult.from_dict(await self._client.request("session.commands.handlePendingCommand", params_dict, **_timeout_kwargs(timeout)))
 
-    async def execute(self, params: ExecuteCommandParams, *, timeout: float | None = None) -> ExecuteCommandResult:
-        "Executes a slash command synchronously and returns any error.\n\nArgs:\n    params: Slash command name and argument string to execute synchronously.\n\nReturns:\n    Error message produced while executing the command, if any."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return ExecuteCommandResult.from_dict(await self._client.request("session.commands.execute", params_dict, **_timeout_kwargs(timeout)))
-
-    async def enqueue(self, params: EnqueueCommandParams, *, timeout: float | None = None) -> EnqueueCommandResult:
-        "Enqueues a slash command for FIFO processing on the local session.\n\nArgs:\n    params: Slash-prefixed command string to enqueue for FIFO processing.\n\nReturns:\n    Indicates whether the command was accepted into the local execution queue."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return EnqueueCommandResult.from_dict(await self._client.request("session.commands.enqueue", params_dict, **_timeout_kwargs(timeout)))
-
     async def respond_to_queued_command(self, params: CommandsRespondToQueuedCommandRequest, *, timeout: float | None = None) -> CommandsRespondToQueuedCommandResult:
-        "Reports whether the host actually executed a queued command and whether to continue processing.\n\nArgs:\n    params: Queued-command request ID and the result indicating whether the host executed it (and whether to stop processing further queued commands).\n\nReturns:\n    Indicates whether the queued-command response was matched to a pending request."
+        "Responds to a queued command request from the session.\n\nArgs:\n    params: Queued command request ID and the result indicating whether the client handled it.\n\nReturns:\n    Indicates whether the queued-command response was accepted by the session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return CommandsRespondToQueuedCommandResult.from_dict(await self._client.request("session.commands.respondToQueuedCommand", params_dict, **_timeout_kwargs(timeout)))
 
 
-# Experimental: this API group is experimental and may change or be removed.
-class TelemetryApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
-        self._client = client
-        self._session_id = session_id
-
-    async def set_feature_overrides(self, params: TelemetrySetFeatureOverridesRequest, *, timeout: float | None = None) -> None:
-        "Sets feature override key/value pairs to attach to subsequent telemetry events for the session.\n\nArgs:\n    params: Feature override key/value pairs to attach to subsequent telemetry events from this session."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        await self._client.request("session.telemetry.setFeatureOverrides", params_dict, **_timeout_kwargs(timeout))
-
-
 class UiApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def elicitation(self, params: UIElicitationRequest, *, timeout: float | None = None) -> UIElicitationResponse:
         "Requests structured input from a UI-capable client.\n\nArgs:\n    params: Prompt message and JSON schema describing the form fields to elicit from the user.\n\nReturns:\n    The elicitation response (accept with form values, decline, or cancel)"
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return UIElicitationResponse.from_dict(await self._client.request("session.ui.elicitation", params_dict, **_timeout_kwargs(timeout)))
 
     async def handle_pending_elicitation(self, params: UIHandlePendingElicitationRequest, *, timeout: float | None = None) -> UIElicitationResult:
         "Provides the user response for a pending elicitation request.\n\nArgs:\n    params: Pending elicitation request ID and the user's response (accept/decline/cancel + form values).\n\nReturns:\n    Indicates whether the elicitation response was accepted; false if it was already resolved by another client."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return UIElicitationResult.from_dict(await self._client.request("session.ui.handlePendingElicitation", params_dict, **_timeout_kwargs(timeout)))
 
-    async def handle_pending_user_input(self, params: UIHandlePendingUserInputRequest, *, timeout: float | None = None) -> UIHandlePendingResult:
-        "Resolves a pending `user_input.requested` event with the user's response.\n\nArgs:\n    params: Request ID of a pending `user_input.requested` event and the user's response.\n\nReturns:\n    Indicates whether the pending UI request was resolved by this call."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return UIHandlePendingResult.from_dict(await self._client.request("session.ui.handlePendingUserInput", params_dict, **_timeout_kwargs(timeout)))
-
-    async def handle_pending_sampling(self, params: UIHandlePendingSamplingRequest, *, timeout: float | None = None) -> UIHandlePendingResult:
-        "Resolves a pending `sampling.requested` event with a sampling result, or rejects it.\n\nArgs:\n    params: Request ID of a pending `sampling.requested` event and an optional sampling result payload (omit to reject).\n\nReturns:\n    Indicates whether the pending UI request was resolved by this call."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return UIHandlePendingResult.from_dict(await self._client.request("session.ui.handlePendingSampling", params_dict, **_timeout_kwargs(timeout)))
-
-    async def handle_pending_auto_mode_switch(self, params: UIHandlePendingAutoModeSwitchRequest, *, timeout: float | None = None) -> UIHandlePendingResult:
-        "Resolves a pending `auto_mode_switch.requested` event with the user's accept/decline decision.\n\nArgs:\n    params: Request ID of a pending `auto_mode_switch.requested` event and the user's response.\n\nReturns:\n    Indicates whether the pending UI request was resolved by this call."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return UIHandlePendingResult.from_dict(await self._client.request("session.ui.handlePendingAutoModeSwitch", params_dict, **_timeout_kwargs(timeout)))
-
-    async def handle_pending_exit_plan_mode(self, params: UIHandlePendingExitPlanModeRequest, *, timeout: float | None = None) -> UIHandlePendingResult:
-        "Resolves a pending `exit_plan_mode.requested` event with the user's response.\n\nArgs:\n    params: Request ID of a pending `exit_plan_mode.requested` event and the user's response.\n\nReturns:\n    Indicates whether the pending UI request was resolved by this call."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return UIHandlePendingResult.from_dict(await self._client.request("session.ui.handlePendingExitPlanMode", params_dict, **_timeout_kwargs(timeout)))
-
-    async def register_direct_auto_mode_switch_handler(self, *, timeout: float | None = None) -> UIRegisterDirectAutoModeSwitchHandlerResult:
-        "Registers an in-process handler for auto-mode-switch requests so the server bridge skips dispatch.\n\nReturns:\n    Register an in-process handler for `auto_mode_switch.requested` events. The caller still attaches the actual listener via the standard event-subscription mechanism; this registration solely tells the server bridge to skip its own dispatch (so a remote client doesn't race the in-process handler for the same requestId)."
-        return UIRegisterDirectAutoModeSwitchHandlerResult.from_dict(await self._client.request("session.ui.registerDirectAutoModeSwitchHandler", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
-
-    async def unregister_direct_auto_mode_switch_handler(self, params: UIUnregisterDirectAutoModeSwitchHandlerRequest, *, timeout: float | None = None) -> UIUnregisterDirectAutoModeSwitchHandlerResult:
-        "Unregisters a previously-registered in-process auto-mode-switch handler by its opaque handle.\n\nArgs:\n    params: Opaque handle previously returned by `registerDirectAutoModeSwitchHandler` to release.\n\nReturns:\n    Indicates whether the handle was active and the registration count was decremented."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return UIUnregisterDirectAutoModeSwitchHandlerResult.from_dict(await self._client.request("session.ui.unregisterDirectAutoModeSwitchHandler", params_dict, **_timeout_kwargs(timeout)))
-
-
-class PermissionsPathsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
-        self._client = client
-        self._session_id = session_id
-
-    async def list(self, *, timeout: float | None = None) -> PermissionPathsList:
-        "Returns the session's allowed directories and primary working directory.\n\nReturns:\n    Snapshot of the session's allow-listed directories and primary working directory."
-        return PermissionPathsList.from_dict(await self._client.request("session.permissions.paths.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
-
-    async def add(self, params: PermissionPathsAddParams, *, timeout: float | None = None) -> PermissionsPathsAddResult:
-        "Adds a directory to the session's allow-list.\n\nArgs:\n    params: Directory path to add to the session's allowed directories.\n\nReturns:\n    Indicates whether the operation succeeded."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return PermissionsPathsAddResult.from_dict(await self._client.request("session.permissions.paths.add", params_dict, **_timeout_kwargs(timeout)))
-
-    async def update_primary(self, params: PermissionPathsUpdatePrimaryParams, *, timeout: float | None = None) -> PermissionsPathsUpdatePrimaryResult:
-        "Updates the session's primary working directory used by the permission policy.\n\nArgs:\n    params: Directory path to set as the session's new primary working directory.\n\nReturns:\n    Indicates whether the operation succeeded."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return PermissionsPathsUpdatePrimaryResult.from_dict(await self._client.request("session.permissions.paths.updatePrimary", params_dict, **_timeout_kwargs(timeout)))
-
-    async def is_path_within_allowed_directories(self, params: PermissionPathsAllowedCheckParams, *, timeout: float | None = None) -> PermissionPathsAllowedCheckResult:
-        "Reports whether a path falls within any of the session's allowed directories.\n\nArgs:\n    params: Path to evaluate against the session's allowed directories.\n\nReturns:\n    Indicates whether the supplied path is within the session's allowed directories."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return PermissionPathsAllowedCheckResult.from_dict(await self._client.request("session.permissions.paths.isPathWithinAllowedDirectories", params_dict, **_timeout_kwargs(timeout)))
-
-    async def is_path_within_workspace(self, params: PermissionPathsWorkspaceCheckParams, *, timeout: float | None = None) -> PermissionPathsWorkspaceCheckResult:
-        "Reports whether a path falls within the session's workspace (primary) directory.\n\nArgs:\n    params: Path to evaluate against the session's workspace (primary) directory.\n\nReturns:\n    Indicates whether the supplied path is within the session's workspace directory."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return PermissionPathsWorkspaceCheckResult.from_dict(await self._client.request("session.permissions.paths.isPathWithinWorkspace", params_dict, **_timeout_kwargs(timeout)))
-
-
-class PermissionsUrlsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
-        self._client = client
-        self._session_id = session_id
-
-    async def set_unrestricted_mode(self, params: PermissionUrlsSetUnrestrictedModeParams, *, timeout: float | None = None) -> PermissionsUrlsSetUnrestrictedModeResult:
-        "Toggles the runtime's URL-permission policy between unrestricted and restricted modes.\n\nArgs:\n    params: Whether the URL-permission policy should run in unrestricted mode.\n\nReturns:\n    Indicates whether the operation succeeded."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return PermissionsUrlsSetUnrestrictedModeResult.from_dict(await self._client.request("session.permissions.urls.setUnrestrictedMode", params_dict, **_timeout_kwargs(timeout)))
-
 
 class PermissionsApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
-        self.paths = PermissionsPathsApi(client, session_id)
-        self.urls = PermissionsUrlsApi(client, session_id)
-
-    async def configure(self, params: PermissionsConfigureParams, *, timeout: float | None = None) -> PermissionsConfigureResult:
-        "Replaces selected permission policy fields (rules, paths, URLs, exclusions, allow-all flags) on the session.\n\nArgs:\n    params: Patch of permission policy fields to apply (omit a field to leave it unchanged).\n\nReturns:\n    Indicates whether the operation succeeded."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return PermissionsConfigureResult.from_dict(await self._client.request("session.permissions.configure", params_dict, **_timeout_kwargs(timeout)))
+        self._assert_active = assert_active
 
     async def handle_pending_permission_request(self, params: PermissionDecisionRequest, *, timeout: float | None = None) -> PermissionRequestResult:
         "Provides a decision for a pending tool permission request.\n\nArgs:\n    params: Pending permission request ID and the decision to apply (approve/reject and scope).\n\nReturns:\n    Indicates whether the permission decision was applied; false when the request was already resolved."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return PermissionRequestResult.from_dict(await self._client.request("session.permissions.handlePendingPermissionRequest", params_dict, **_timeout_kwargs(timeout)))
 
-    async def pending_requests(self, *, timeout: float | None = None) -> PendingPermissionRequestList:
-        "Reconstructs the set of pending tool permission requests from the session's event history.\n\nReturns:\n    List of pending permission requests reconstructed from event history."
-        return PendingPermissionRequestList.from_dict(await self._client.request("session.permissions.pendingRequests", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
-
     async def set_approve_all(self, params: PermissionsSetApproveAllRequest, *, timeout: float | None = None) -> PermissionsSetApproveAllResult:
-        "Enables or disables automatic approval of tool permission requests for the session.\n\nArgs:\n    params: Allow-all toggle for tool permission requests, with an optional telemetry source.\n\nReturns:\n    Indicates whether the operation succeeded."
+        "Enables or disables automatic approval of tool permission requests for the session.\n\nArgs:\n    params: Whether to auto-approve all tool permission requests for the rest of the session.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return PermissionsSetApproveAllResult.from_dict(await self._client.request("session.permissions.setApproveAll", params_dict, **_timeout_kwargs(timeout)))
 
-    async def modify_rules(self, params: PermissionsModifyRulesParams, *, timeout: float | None = None) -> PermissionsModifyRulesResult:
-        "Adds or removes session-scoped or location-scoped permission rules.\n\nArgs:\n    params: Scope and add/remove instructions for modifying session- or location-scoped permission rules.\n\nReturns:\n    Indicates whether the operation succeeded."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return PermissionsModifyRulesResult.from_dict(await self._client.request("session.permissions.modifyRules", params_dict, **_timeout_kwargs(timeout)))
-
-    async def set_required(self, params: PermissionsSetRequiredRequest, *, timeout: float | None = None) -> PermissionsSetRequiredResult:
-        "Sets whether the client wants permission prompts bridged into session events.\n\nArgs:\n    params: Toggles whether permission prompts should be bridged into session events for this client.\n\nReturns:\n    Indicates whether the operation succeeded."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return PermissionsSetRequiredResult.from_dict(await self._client.request("session.permissions.setRequired", params_dict, **_timeout_kwargs(timeout)))
-
     async def reset_session_approvals(self, *, timeout: float | None = None) -> PermissionsResetSessionApprovalsResult:
         "Clears session-scoped tool permission approvals.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return PermissionsResetSessionApprovalsResult.from_dict(await self._client.request("session.permissions.resetSessionApprovals", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
-
-    async def notify_prompt_shown(self, params: PermissionPromptShownNotification, *, timeout: float | None = None) -> PermissionsNotifyPromptShownResult:
-        "Notifies the runtime that a permission prompt UI has been shown to the user.\n\nArgs:\n    params: Notification payload describing the permission prompt that the client just rendered.\n\nReturns:\n    Indicates whether the operation succeeded."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return PermissionsNotifyPromptShownResult.from_dict(await self._client.request("session.permissions.notifyPromptShown", params_dict, **_timeout_kwargs(timeout)))
-
-
-# Experimental: this API group is experimental and may change or be removed.
-class MetadataApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
-        self._client = client
-        self._session_id = session_id
-
-    async def snapshot(self, *, timeout: float | None = None) -> SessionMetadataSnapshot:
-        "Returns a snapshot of the session's identifying metadata, mode, agent, and remote info.\n\nReturns:\n    Point-in-time snapshot of slow-changing session identifier and state fields"
-        return SessionMetadataSnapshot.from_dict(await self._client.request("session.metadata.snapshot", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
-
-    async def is_processing(self, *, timeout: float | None = None) -> MetadataIsProcessingResult:
-        "Reports whether the local session is currently processing user/agent messages.\n\nReturns:\n    Indicates whether the local session is currently processing a turn or background continuation."
-        return MetadataIsProcessingResult.from_dict(await self._client.request("session.metadata.isProcessing", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
-
-    async def context_info(self, params: MetadataContextInfoRequest, *, timeout: float | None = None) -> MetadataContextInfoResult:
-        "Returns the token breakdown for the session's current context window for a given model.\n\nArgs:\n    params: Model identifier and token limits used to compute the context-info breakdown.\n\nReturns:\n    Token breakdown for the session's current context window, or null if uninitialized."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return MetadataContextInfoResult.from_dict(await self._client.request("session.metadata.contextInfo", params_dict, **_timeout_kwargs(timeout)))
-
-    async def record_context_change(self, params: MetadataRecordContextChangeRequest, *, timeout: float | None = None) -> MetadataRecordContextChangeResult:
-        "Records a working-directory/git context change and emits a `session.context_changed` event.\n\nArgs:\n    params: Updated working-directory/git context to record on the session.\n\nReturns:\n    Notify the session that its working directory context has changed. Emits a `session.context_changed` event so consumers (telemetry, OTel tracker, ACP, the timeline UI) can react. Use this when the host has detected a cwd/branch/repo change outside the session's normal lifecycle (e.g., after a shell command in interactive mode)."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return MetadataRecordContextChangeResult.from_dict(await self._client.request("session.metadata.recordContextChange", params_dict, **_timeout_kwargs(timeout)))
-
-    async def set_working_directory(self, params: MetadataSetWorkingDirectoryRequest, *, timeout: float | None = None) -> MetadataSetWorkingDirectoryResult:
-        "Updates the session's recorded working directory.\n\nArgs:\n    params: Absolute path to set as the session's new working directory.\n\nReturns:\n    Update the session's working directory. Used by the host when the user explicitly changes cwd (e.g., the `/cd` slash command). The host is responsible for `process.chdir` and any related side-effects (file index, etc.); this method only updates the session's own recorded path."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return MetadataSetWorkingDirectoryResult.from_dict(await self._client.request("session.metadata.setWorkingDirectory", params_dict, **_timeout_kwargs(timeout)))
-
-    async def recompute_context_tokens(self, params: MetadataRecomputeContextTokensRequest, *, timeout: float | None = None) -> MetadataRecomputeContextTokensResult:
-        "Re-tokenizes the session's existing messages against a model and returns aggregate token totals.\n\nArgs:\n    params: Model identifier to use when re-tokenizing the session's existing messages.\n\nReturns:\n    Re-tokenize the session's existing messages against `modelId` and return the token totals. Useful for hosts that want an initial estimate of context usage on session resume, before the next agent turn fires `session.context_info_changed` events. Returns zeros for an empty session."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return MetadataRecomputeContextTokensResult.from_dict(await self._client.request("session.metadata.recomputeContextTokens", params_dict, **_timeout_kwargs(timeout)))
 
 
 class ShellApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def exec(self, params: ShellExecRequest, *, timeout: float | None = None) -> ShellExecResult:
         "Starts a shell command and streams output through session notifications.\n\nArgs:\n    params: Shell command to run, with optional working directory and timeout in milliseconds.\n\nReturns:\n    Identifier of the spawned process, used to correlate streamed output and exit notifications."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return ShellExecResult.from_dict(await self._client.request("session.shell.exec", params_dict, **_timeout_kwargs(timeout)))
 
     async def kill(self, params: ShellKillRequest, *, timeout: float | None = None) -> ShellKillResult:
         "Sends a signal to a shell process previously started via \"shell.exec\".\n\nArgs:\n    params: Identifier of a process previously returned by \"shell.exec\" and the signal to send.\n\nReturns:\n    Indicates whether the signal was delivered; false if the process was unknown or already exited."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return ShellKillResult.from_dict(await self._client.request("session.shell.kill", params_dict, **_timeout_kwargs(timeout)))
@@ -16472,191 +9164,114 @@ class ShellApi:
 
 # Experimental: this API group is experimental and may change or be removed.
 class HistoryApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def compact(self, *, timeout: float | None = None) -> HistoryCompactResult:
-        "Compacts the session history to reduce context usage.\n\nReturns:\n    Compaction outcome with the number of tokens and messages removed, summary text, and the resulting context window breakdown."
+        "Compacts the session history to reduce context usage.\n\nReturns:\n    Compaction outcome with the number of tokens and messages removed and the resulting context window breakdown."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return HistoryCompactResult.from_dict(await self._client.request("session.history.compact", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def truncate(self, params: HistoryTruncateRequest, *, timeout: float | None = None) -> HistoryTruncateResult:
         "Truncates persisted session history to a specific event.\n\nArgs:\n    params: Identifier of the event to truncate to; this event and all later events are removed.\n\nReturns:\n    Number of events that were removed by the truncation."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return HistoryTruncateResult.from_dict(await self._client.request("session.history.truncate", params_dict, **_timeout_kwargs(timeout)))
 
-    async def cancel_background_compaction(self, *, timeout: float | None = None) -> HistoryCancelBackgroundCompactionResult:
-        "Cancels any in-progress background compaction on a local session.\n\nReturns:\n    Indicates whether an in-progress background compaction was cancelled."
-        return HistoryCancelBackgroundCompactionResult.from_dict(await self._client.request("session.history.cancelBackgroundCompaction", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
-
-    async def abort_manual_compaction(self, *, timeout: float | None = None) -> HistoryAbortManualCompactionResult:
-        "Aborts any in-progress manual compaction on a local session.\n\nReturns:\n    Indicates whether an in-progress manual compaction was aborted."
-        return HistoryAbortManualCompactionResult.from_dict(await self._client.request("session.history.abortManualCompaction", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
-
-    async def summarize_for_handoff(self, *, timeout: float | None = None) -> HistorySummarizeForHandoffResult:
-        "Produces a markdown summary of the session's conversation context for hand-off scenarios.\n\nReturns:\n    Markdown summary of the conversation context (empty when not available)."
-        return HistorySummarizeForHandoffResult.from_dict(await self._client.request("session.history.summarizeForHandoff", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
-
-
-# Experimental: this API group is experimental and may change or be removed.
-class QueueApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
-        self._client = client
-        self._session_id = session_id
-
-    async def pending_items(self, *, timeout: float | None = None) -> QueuePendingItemsResult:
-        "Returns the local session's pending user-facing queued items and steering messages.\n\nReturns:\n    Snapshot of the session's pending queued items and immediate-steering messages."
-        return QueuePendingItemsResult.from_dict(await self._client.request("session.queue.pendingItems", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
-
-    async def remove_most_recent(self, *, timeout: float | None = None) -> QueueRemoveMostRecentResult:
-        "Removes the most recently queued user-facing item (LIFO).\n\nReturns:\n    Indicates whether a user-facing pending item was removed."
-        return QueueRemoveMostRecentResult.from_dict(await self._client.request("session.queue.removeMostRecent", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
-
-    async def clear(self, *, timeout: float | None = None) -> None:
-        "Clears all pending queued items on the local session."
-        await self._client.request("session.queue.clear", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
-
-
-# Experimental: this API group is experimental and may change or be removed.
-class EventLogApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
-        self._client = client
-        self._session_id = session_id
-
-    async def read(self, params: EventLogReadRequest, *, timeout: float | None = None) -> EventsReadResult:
-        "Reads a batch of session events from a cursor, optionally waiting for new events.\n\nArgs:\n    params: Cursor, batch size, and optional long-poll/filter parameters for reading session events.\n\nReturns:\n    Batch of session events returned by a read, with cursor and continuation metadata."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return EventsReadResult.from_dict(await self._client.request("session.eventLog.read", params_dict, **_timeout_kwargs(timeout)))
-
-    async def tail(self, *, timeout: float | None = None) -> EventLogTailResult:
-        "Returns a snapshot of the current tail cursor without consuming events.\n\nReturns:\n    Snapshot of the current tail cursor without returning any events. Use this when a consumer wants to subscribe to live events going forward without first paginating through the entire persisted history (which would happen if `read` were called without a cursor on a long-lived session)."
-        return EventLogTailResult.from_dict(await self._client.request("session.eventLog.tail", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
-
-    async def register_interest(self, params: RegisterEventInterestParams, *, timeout: float | None = None) -> RegisterEventInterestResult:
-        "Registers consumer interest in an event type for runtime gating purposes.\n\nArgs:\n    params: Event type to register consumer interest for, used by runtime gating logic.\n\nReturns:\n    Opaque handle representing an event-type interest registration."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return RegisterEventInterestResult.from_dict(await self._client.request("session.eventLog.registerInterest", params_dict, **_timeout_kwargs(timeout)))
-
-    async def release_interest(self, params: ReleaseEventInterestParams, *, timeout: float | None = None) -> EventLogReleaseInterestResult:
-        "Releases a consumer's previously-registered interest in an event type.\n\nArgs:\n    params: Opaque handle previously returned by `registerInterest` to release.\n\nReturns:\n    Indicates whether the operation succeeded."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return EventLogReleaseInterestResult.from_dict(await self._client.request("session.eventLog.releaseInterest", params_dict, **_timeout_kwargs(timeout)))
-
 
 # Experimental: this API group is experimental and may change or be removed.
 class UsageApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def get_metrics(self, *, timeout: float | None = None) -> UsageGetMetricsResult:
         "Gets accumulated usage metrics for the session.\n\nReturns:\n    Accumulated session usage metrics, including premium request cost, token counts, model breakdown, and code-change totals."
+        if self._assert_active is not None:
+            self._assert_active()
+
         return UsageGetMetricsResult.from_dict(await self._client.request("session.usage.getMetrics", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.
 class RemoteApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
+        self._assert_active = assert_active
 
     async def enable(self, params: RemoteEnableRequest, *, timeout: float | None = None) -> RemoteEnableResult:
         "Enables remote session export or steering.\n\nArgs:\n    params: Optional remote session mode (\"off\", \"export\", or \"on\"); defaults to enabling both export and remote steering.\n\nReturns:\n    GitHub URL for the session and a flag indicating whether remote steering is enabled."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return RemoteEnableResult.from_dict(await self._client.request("session.remote.enable", params_dict, **_timeout_kwargs(timeout)))
 
     async def disable(self, *, timeout: float | None = None) -> None:
         "Disables remote session export and steering."
+        if self._assert_active is not None:
+            self._assert_active()
+
         await self._client.request("session.remote.disable", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
-
-    async def notify_steerable_changed(self, params: RemoteNotifySteerableChangedRequest, *, timeout: float | None = None) -> RemoteNotifySteerableChangedResult:
-        "Persists a remote-steerability change emitted by the host as a session event.\n\nArgs:\n    params: New remote-steerability state to persist as a `session.remote_steerable_changed` event.\n\nReturns:\n    Persist a steerability change as a `session.remote_steerable_changed` event. Used by the host (CLI / SDK consumer) when it has just finished enabling or disabling steering on a remote exporter that the runtime does not directly own."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return RemoteNotifySteerableChangedResult.from_dict(await self._client.request("session.remote.notifySteerableChanged", params_dict, **_timeout_kwargs(timeout)))
-
-
-# Experimental: this API group is experimental and may change or be removed.
-class ScheduleApi:
-    def __init__(self, client: "JsonRpcClient", session_id: str):
-        self._client = client
-        self._session_id = session_id
-
-    async def list(self, *, timeout: float | None = None) -> ScheduleList:
-        "Lists the session's currently active scheduled prompts.\n\nReturns:\n    Snapshot of the currently active recurring prompts for this session."
-        return ScheduleList.from_dict(await self._client.request("session.schedule.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
-
-    async def stop(self, params: ScheduleStopRequest, *, timeout: float | None = None) -> ScheduleStopResult:
-        "Removes a scheduled prompt by id.\n\nArgs:\n    params: Identifier of the scheduled prompt to remove.\n\nReturns:\n    Remove a scheduled prompt by id. The result entry is omitted if the id was unknown."
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return ScheduleStopResult.from_dict(await self._client.request("session.schedule.stop", params_dict, **_timeout_kwargs(timeout)))
 
 
 class SessionRpc:
     """Typed session-scoped RPC methods."""
-    def __init__(self, client: "JsonRpcClient", session_id: str):
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
-        self.auth = AuthApi(client, session_id)
-        self.model = ModelApi(client, session_id)
-        self.mode = ModeApi(client, session_id)
-        self.name = NameApi(client, session_id)
-        self.plan = PlanApi(client, session_id)
-        self.workspaces = WorkspacesApi(client, session_id)
-        self.instructions = InstructionsApi(client, session_id)
-        self.fleet = FleetApi(client, session_id)
-        self.agent = AgentApi(client, session_id)
-        self.tasks = TasksApi(client, session_id)
-        self.skills = SkillsApi(client, session_id)
-        self.mcp = McpApi(client, session_id)
-        self.plugins = PluginsApi(client, session_id)
-        self.options = OptionsApi(client, session_id)
-        self.lsp = LspApi(client, session_id)
-        self.extensions = ExtensionsApi(client, session_id)
-        self.tools = ToolsApi(client, session_id)
-        self.commands = CommandsApi(client, session_id)
-        self.telemetry = TelemetryApi(client, session_id)
-        self.ui = UiApi(client, session_id)
-        self.permissions = PermissionsApi(client, session_id)
-        self.metadata = MetadataApi(client, session_id)
-        self.shell = ShellApi(client, session_id)
-        self.history = HistoryApi(client, session_id)
-        self.queue = QueueApi(client, session_id)
-        self.event_log = EventLogApi(client, session_id)
-        self.usage = UsageApi(client, session_id)
-        self.remote = RemoteApi(client, session_id)
-        self.schedule = ScheduleApi(client, session_id)
+        self._assert_active = assert_active
+        self.auth = AuthApi(client, session_id, assert_active)
+        self.model = ModelApi(client, session_id, assert_active)
+        self.mode = ModeApi(client, session_id, assert_active)
+        self.name = NameApi(client, session_id, assert_active)
+        self.plan = PlanApi(client, session_id, assert_active)
+        self.workspaces = WorkspacesApi(client, session_id, assert_active)
+        self.instructions = InstructionsApi(client, session_id, assert_active)
+        self.fleet = FleetApi(client, session_id, assert_active)
+        self.agent = AgentApi(client, session_id, assert_active)
+        self.tasks = TasksApi(client, session_id, assert_active)
+        self.skills = SkillsApi(client, session_id, assert_active)
+        self.mcp = McpApi(client, session_id, assert_active)
+        self.plugins = PluginsApi(client, session_id, assert_active)
+        self.extensions = ExtensionsApi(client, session_id, assert_active)
+        self.tools = ToolsApi(client, session_id, assert_active)
+        self.commands = CommandsApi(client, session_id, assert_active)
+        self.ui = UiApi(client, session_id, assert_active)
+        self.permissions = PermissionsApi(client, session_id, assert_active)
+        self.shell = ShellApi(client, session_id, assert_active)
+        self.history = HistoryApi(client, session_id, assert_active)
+        self.usage = UsageApi(client, session_id, assert_active)
+        self.remote = RemoteApi(client, session_id, assert_active)
 
     async def suspend(self, *, timeout: float | None = None) -> None:
         "Suspends the session while preserving persisted state for later resume."
+        if self._assert_active is not None:
+            self._assert_active()
+
         await self._client.request("session.suspend", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
-    async def send(self, params: SendRequest, *, timeout: float | None = None) -> SendResult:
-        "Sends a user message to the session and returns its message ID.\n\nArgs:\n    params: Parameters for sending a user message to the session\n\nReturns:\n    Result of sending a user message"
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return SendResult.from_dict(await self._client.request("session.send", params_dict, **_timeout_kwargs(timeout)))
-
-    async def abort(self, params: AbortRequest, *, timeout: float | None = None) -> AbortResult:
-        "Aborts the current agent turn.\n\nArgs:\n    params: Parameters for aborting the current turn\n\nReturns:\n    Result of aborting the current turn"
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        return AbortResult.from_dict(await self._client.request("session.abort", params_dict, **_timeout_kwargs(timeout)))
-
-    async def shutdown(self, params: ShutdownRequest, *, timeout: float | None = None) -> None:
-        "Shuts down the session and persists its final state. Awaits any deferred sessionEnd hooks before resolving so user-supplied hook scripts complete before the runtime tears down.\n\nArgs:\n    params: Parameters for shutting down the session"
-        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
-        params_dict["sessionId"] = self._session_id
-        await self._client.request("session.shutdown", params_dict, **_timeout_kwargs(timeout))
-
     async def log(self, params: LogRequest, *, timeout: float | None = None) -> LogResult:
-        "Emits a user-visible session log event.\n\nArgs:\n    params: Message text, optional severity level, persistence flag, optional follow-up URL, and optional tip.\n\nReturns:\n    Identifier of the session event that was emitted for the log message."
+        "Emits a user-visible session log event.\n\nArgs:\n    params: Message text, optional severity level, persistence flag, and optional follow-up URL.\n\nReturns:\n    Identifier of the session event that was emitted for the log message."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return LogResult.from_dict(await self._client.request("session.log", params_dict, **_timeout_kwargs(timeout)))

--- a/python/copilot/generated/rpc.py
+++ b/python/copilot/generated/rpc.py
@@ -5,7 +5,7 @@ Generated from: api.schema.json
 
 from typing import TYPE_CHECKING
 
-from .session_events import EmbeddedBlobResourceContents, EmbeddedTextResourceContents, McpServerSource, McpServerStatus, ReasoningSummary, SessionMode, SkillSource
+from .session_events import AbortReason, EmbeddedBlobResourceContents, EmbeddedTextResourceContents, McpServerSource, McpServerStatus, PermissionPromptRequest, PermissionRule, ReasoningSummary, SessionEvent, SessionMode, ShutdownType, SkillSource, UserToolSessionApproval
 
 if TYPE_CHECKING:
     from .._jsonrpc import JsonRpcClient
@@ -39,12 +39,16 @@ def from_union(fs, x):
             pass
     assert False
 
-def from_int(x: Any) -> int:
-    assert isinstance(x, int) and not isinstance(x, bool)
-    return x
+def to_class(c: type[T], x: Any) -> dict:
+    assert isinstance(x, c)
+    return cast(Any, x).to_dict()
 
 def from_bool(x: Any) -> bool:
     assert isinstance(x, bool)
+    return x
+
+def from_int(x: Any) -> int:
+    assert isinstance(x, int) and not isinstance(x, bool)
     return x
 
 def from_float(x: Any) -> float:
@@ -59,10 +63,6 @@ def from_dict(f: Callable[[Any], T], x: Any) -> dict[str, T]:
     assert isinstance(x, dict)
     return { k: f(v) for (k, v) in x.items() }
 
-def to_class(c: type[T], x: Any) -> dict:
-    assert isinstance(x, c)
-    return cast(Any, x).to_dict()
-
 def from_list(f: Callable[[Any], T], x: Any) -> list[T]:
     assert isinstance(x, list)
     return [f(y) for y in x]
@@ -73,6 +73,49 @@ def to_enum(c: type[EnumT], x: Any) -> EnumT:
 
 def from_datetime(x: Any) -> datetime:
     return dateutil.parser.parse(x)
+
+@dataclass
+class AbortRequest:
+    """Parameters for aborting the current turn"""
+
+    reason: AbortReason | None = None
+    """Finite reason code describing why the current turn was aborted"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'AbortRequest':
+        assert isinstance(obj, dict)
+        reason = from_union([AbortReason, from_none], obj.get("reason"))
+        return AbortRequest(reason)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.reason is not None:
+            result["reason"] = from_union([lambda x: to_enum(AbortReason, x), from_none], self.reason)
+        return result
+
+@dataclass
+class AbortResult:
+    """Result of aborting the current turn"""
+
+    success: bool
+    """Whether the abort completed successfully"""
+
+    error: str | None = None
+    """Error message if the abort failed"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'AbortResult':
+        assert isinstance(obj, dict)
+        success = from_bool(obj.get("success"))
+        error = from_union([from_str, from_none], obj.get("error"))
+        return AbortResult(success, error)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["success"] = from_bool(self.success)
+        if self.error is not None:
+            result["error"] = from_union([from_str, from_none], self.error)
+        return result
 
 @dataclass
 class AccountGetQuotaRequest:
@@ -148,43 +191,15 @@ class AccountQuotaSnapshot:
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class AgentInfo:
-    """Schema for the `AgentInfo` type.
+class AgentInfoSource(Enum):
+    """Where the agent definition was loaded from"""
 
-    The newly selected custom agent
-    """
-    description: str
-    """Description of the agent's purpose"""
-
-    display_name: str
-    """Human-readable display name"""
-
-    name: str
-    """Unique identifier of the custom agent"""
-
-    path: str | None = None
-    """Absolute local file path of the agent definition. Only set for file-based agents loaded
-    from disk; remote agents do not have a path.
-    """
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'AgentInfo':
-        assert isinstance(obj, dict)
-        description = from_str(obj.get("description"))
-        display_name = from_str(obj.get("displayName"))
-        name = from_str(obj.get("name"))
-        path = from_union([from_str, from_none], obj.get("path"))
-        return AgentInfo(description, display_name, name, path)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["description"] = from_str(self.description)
-        result["displayName"] = from_str(self.display_name)
-        result["name"] = from_str(self.name)
-        if self.path is not None:
-            result["path"] = from_union([from_str, from_none], self.path)
-        return result
+    BUILTIN = "builtin"
+    INHERITED = "inherited"
+    PLUGIN = "plugin"
+    PROJECT = "project"
+    REMOTE = "remote"
+    USER = "user"
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
@@ -204,6 +219,39 @@ class AgentSelectRequest:
         result: dict = {}
         result["name"] = from_str(self.name)
         return result
+
+@dataclass
+class CopilotUserResponseEndpoints:
+    """Schema for the `CopilotUserResponseEndpoints` type."""
+
+    api: str | None = None
+    origin_tracker: str | None = None
+    proxy: str | None = None
+    telemetry: str | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'CopilotUserResponseEndpoints':
+        assert isinstance(obj, dict)
+        api = from_union([from_str, from_none], obj.get("api"))
+        origin_tracker = from_union([from_str, from_none], obj.get("origin-tracker"))
+        proxy = from_union([from_str, from_none], obj.get("proxy"))
+        telemetry = from_union([from_str, from_none], obj.get("telemetry"))
+        return CopilotUserResponseEndpoints(api, origin_tracker, proxy, telemetry)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.api is not None:
+            result["api"] = from_union([from_str, from_none], self.api)
+        if self.origin_tracker is not None:
+            result["origin-tracker"] = from_union([from_str, from_none], self.origin_tracker)
+        if self.proxy is not None:
+            result["proxy"] = from_union([from_str, from_none], self.proxy)
+        if self.telemetry is not None:
+            result["telemetry"] = from_union([from_str, from_none], self.telemetry)
+        return result
+
+class APIKeyAuthInfoType(Enum):
+    API_KEY = "api-key"
 
 class AuthInfoType(Enum):
     """Authentication type"""
@@ -328,11 +376,11 @@ class CommandsListRequest:
 
 @dataclass
 class CommandsRespondToQueuedCommandResult:
-    """Indicates whether the queued-command response was accepted by the session."""
+    """Indicates whether the queued-command response was matched to a pending request."""
 
     success: bool
-    """Whether the response was accepted (false if the requestId was not found or already
-    resolved)
+    """Whether a pending queued command with the given request ID was found and resolved. False
+    when the request was already resolved, cancelled, or unknown.
     """
 
     @staticmethod
@@ -459,23 +507,224 @@ class ContentFilterMode(Enum):
     MARKDOWN = "markdown"
     NONE = "none"
 
+class Host(Enum):
+    HTTPS_GITHUB_COM = "https://github.com"
+
+class CopilotAPITokenAuthInfoType(Enum):
+    COPILOT_API_TOKEN = "copilot-api-token"
+
+@dataclass
+class CopilotUserResponseQuotaSnapshotsChat:
+    """Schema for the `CopilotUserResponseQuotaSnapshotsChat` type."""
+
+    entitlement: float | None = None
+    has_quota: bool | None = None
+    overage_count: float | None = None
+    overage_permitted: bool | None = None
+    percent_remaining: float | None = None
+    quota_id: str | None = None
+    quota_remaining: float | None = None
+    quota_reset_at: float | None = None
+    remaining: float | None = None
+    timestamp_utc: str | None = None
+    token_based_billing: bool | None = None
+    unlimited: bool | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'CopilotUserResponseQuotaSnapshotsChat':
+        assert isinstance(obj, dict)
+        entitlement = from_union([from_float, from_none], obj.get("entitlement"))
+        has_quota = from_union([from_bool, from_none], obj.get("has_quota"))
+        overage_count = from_union([from_float, from_none], obj.get("overage_count"))
+        overage_permitted = from_union([from_bool, from_none], obj.get("overage_permitted"))
+        percent_remaining = from_union([from_float, from_none], obj.get("percent_remaining"))
+        quota_id = from_union([from_str, from_none], obj.get("quota_id"))
+        quota_remaining = from_union([from_float, from_none], obj.get("quota_remaining"))
+        quota_reset_at = from_union([from_float, from_none], obj.get("quota_reset_at"))
+        remaining = from_union([from_float, from_none], obj.get("remaining"))
+        timestamp_utc = from_union([from_str, from_none], obj.get("timestamp_utc"))
+        token_based_billing = from_union([from_bool, from_none], obj.get("token_based_billing"))
+        unlimited = from_union([from_bool, from_none], obj.get("unlimited"))
+        return CopilotUserResponseQuotaSnapshotsChat(entitlement, has_quota, overage_count, overage_permitted, percent_remaining, quota_id, quota_remaining, quota_reset_at, remaining, timestamp_utc, token_based_billing, unlimited)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.entitlement is not None:
+            result["entitlement"] = from_union([to_float, from_none], self.entitlement)
+        if self.has_quota is not None:
+            result["has_quota"] = from_union([from_bool, from_none], self.has_quota)
+        if self.overage_count is not None:
+            result["overage_count"] = from_union([to_float, from_none], self.overage_count)
+        if self.overage_permitted is not None:
+            result["overage_permitted"] = from_union([from_bool, from_none], self.overage_permitted)
+        if self.percent_remaining is not None:
+            result["percent_remaining"] = from_union([to_float, from_none], self.percent_remaining)
+        if self.quota_id is not None:
+            result["quota_id"] = from_union([from_str, from_none], self.quota_id)
+        if self.quota_remaining is not None:
+            result["quota_remaining"] = from_union([to_float, from_none], self.quota_remaining)
+        if self.quota_reset_at is not None:
+            result["quota_reset_at"] = from_union([to_float, from_none], self.quota_reset_at)
+        if self.remaining is not None:
+            result["remaining"] = from_union([to_float, from_none], self.remaining)
+        if self.timestamp_utc is not None:
+            result["timestamp_utc"] = from_union([from_str, from_none], self.timestamp_utc)
+        if self.token_based_billing is not None:
+            result["token_based_billing"] = from_union([from_bool, from_none], self.token_based_billing)
+        if self.unlimited is not None:
+            result["unlimited"] = from_union([from_bool, from_none], self.unlimited)
+        return result
+
+@dataclass
+class CopilotUserResponseQuotaSnapshotsCompletions:
+    """Schema for the `CopilotUserResponseQuotaSnapshotsCompletions` type."""
+
+    entitlement: float | None = None
+    has_quota: bool | None = None
+    overage_count: float | None = None
+    overage_permitted: bool | None = None
+    percent_remaining: float | None = None
+    quota_id: str | None = None
+    quota_remaining: float | None = None
+    quota_reset_at: float | None = None
+    remaining: float | None = None
+    timestamp_utc: str | None = None
+    token_based_billing: bool | None = None
+    unlimited: bool | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'CopilotUserResponseQuotaSnapshotsCompletions':
+        assert isinstance(obj, dict)
+        entitlement = from_union([from_float, from_none], obj.get("entitlement"))
+        has_quota = from_union([from_bool, from_none], obj.get("has_quota"))
+        overage_count = from_union([from_float, from_none], obj.get("overage_count"))
+        overage_permitted = from_union([from_bool, from_none], obj.get("overage_permitted"))
+        percent_remaining = from_union([from_float, from_none], obj.get("percent_remaining"))
+        quota_id = from_union([from_str, from_none], obj.get("quota_id"))
+        quota_remaining = from_union([from_float, from_none], obj.get("quota_remaining"))
+        quota_reset_at = from_union([from_float, from_none], obj.get("quota_reset_at"))
+        remaining = from_union([from_float, from_none], obj.get("remaining"))
+        timestamp_utc = from_union([from_str, from_none], obj.get("timestamp_utc"))
+        token_based_billing = from_union([from_bool, from_none], obj.get("token_based_billing"))
+        unlimited = from_union([from_bool, from_none], obj.get("unlimited"))
+        return CopilotUserResponseQuotaSnapshotsCompletions(entitlement, has_quota, overage_count, overage_permitted, percent_remaining, quota_id, quota_remaining, quota_reset_at, remaining, timestamp_utc, token_based_billing, unlimited)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.entitlement is not None:
+            result["entitlement"] = from_union([to_float, from_none], self.entitlement)
+        if self.has_quota is not None:
+            result["has_quota"] = from_union([from_bool, from_none], self.has_quota)
+        if self.overage_count is not None:
+            result["overage_count"] = from_union([to_float, from_none], self.overage_count)
+        if self.overage_permitted is not None:
+            result["overage_permitted"] = from_union([from_bool, from_none], self.overage_permitted)
+        if self.percent_remaining is not None:
+            result["percent_remaining"] = from_union([to_float, from_none], self.percent_remaining)
+        if self.quota_id is not None:
+            result["quota_id"] = from_union([from_str, from_none], self.quota_id)
+        if self.quota_remaining is not None:
+            result["quota_remaining"] = from_union([to_float, from_none], self.quota_remaining)
+        if self.quota_reset_at is not None:
+            result["quota_reset_at"] = from_union([to_float, from_none], self.quota_reset_at)
+        if self.remaining is not None:
+            result["remaining"] = from_union([to_float, from_none], self.remaining)
+        if self.timestamp_utc is not None:
+            result["timestamp_utc"] = from_union([from_str, from_none], self.timestamp_utc)
+        if self.token_based_billing is not None:
+            result["token_based_billing"] = from_union([from_bool, from_none], self.token_based_billing)
+        if self.unlimited is not None:
+            result["unlimited"] = from_union([from_bool, from_none], self.unlimited)
+        return result
+
+@dataclass
+class CopilotUserResponseQuotaSnapshotsPremiumInteractions:
+    """Schema for the `CopilotUserResponseQuotaSnapshotsPremiumInteractions` type."""
+
+    entitlement: float | None = None
+    has_quota: bool | None = None
+    overage_count: float | None = None
+    overage_permitted: bool | None = None
+    percent_remaining: float | None = None
+    quota_id: str | None = None
+    quota_remaining: float | None = None
+    quota_reset_at: float | None = None
+    remaining: float | None = None
+    timestamp_utc: str | None = None
+    token_based_billing: bool | None = None
+    unlimited: bool | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'CopilotUserResponseQuotaSnapshotsPremiumInteractions':
+        assert isinstance(obj, dict)
+        entitlement = from_union([from_float, from_none], obj.get("entitlement"))
+        has_quota = from_union([from_bool, from_none], obj.get("has_quota"))
+        overage_count = from_union([from_float, from_none], obj.get("overage_count"))
+        overage_permitted = from_union([from_bool, from_none], obj.get("overage_permitted"))
+        percent_remaining = from_union([from_float, from_none], obj.get("percent_remaining"))
+        quota_id = from_union([from_str, from_none], obj.get("quota_id"))
+        quota_remaining = from_union([from_float, from_none], obj.get("quota_remaining"))
+        quota_reset_at = from_union([from_float, from_none], obj.get("quota_reset_at"))
+        remaining = from_union([from_float, from_none], obj.get("remaining"))
+        timestamp_utc = from_union([from_str, from_none], obj.get("timestamp_utc"))
+        token_based_billing = from_union([from_bool, from_none], obj.get("token_based_billing"))
+        unlimited = from_union([from_bool, from_none], obj.get("unlimited"))
+        return CopilotUserResponseQuotaSnapshotsPremiumInteractions(entitlement, has_quota, overage_count, overage_permitted, percent_remaining, quota_id, quota_remaining, quota_reset_at, remaining, timestamp_utc, token_based_billing, unlimited)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.entitlement is not None:
+            result["entitlement"] = from_union([to_float, from_none], self.entitlement)
+        if self.has_quota is not None:
+            result["has_quota"] = from_union([from_bool, from_none], self.has_quota)
+        if self.overage_count is not None:
+            result["overage_count"] = from_union([to_float, from_none], self.overage_count)
+        if self.overage_permitted is not None:
+            result["overage_permitted"] = from_union([from_bool, from_none], self.overage_permitted)
+        if self.percent_remaining is not None:
+            result["percent_remaining"] = from_union([to_float, from_none], self.percent_remaining)
+        if self.quota_id is not None:
+            result["quota_id"] = from_union([from_str, from_none], self.quota_id)
+        if self.quota_remaining is not None:
+            result["quota_remaining"] = from_union([to_float, from_none], self.quota_remaining)
+        if self.quota_reset_at is not None:
+            result["quota_reset_at"] = from_union([to_float, from_none], self.quota_reset_at)
+        if self.remaining is not None:
+            result["remaining"] = from_union([to_float, from_none], self.remaining)
+        if self.timestamp_utc is not None:
+            result["timestamp_utc"] = from_union([from_str, from_none], self.timestamp_utc)
+        if self.token_based_billing is not None:
+            result["token_based_billing"] = from_union([from_bool, from_none], self.token_based_billing)
+        if self.unlimited is not None:
+            result["unlimited"] = from_union([from_bool, from_none], self.unlimited)
+        return result
+
 @dataclass
 class CurrentModel:
-    """The currently selected model for the session."""
+    """The currently selected model and reasoning effort for the session."""
 
     model_id: str | None = None
     """Currently active model identifier"""
+
+    reasoning_effort: str | None = None
+    """Reasoning effort level currently applied to the active model, when one is set. Reads
+    `Session.getReasoningEffort()` synchronously after `getSelectedModel()` resolves so the
+    two values are reported as a snapshot.
+    """
 
     @staticmethod
     def from_dict(obj: Any) -> 'CurrentModel':
         assert isinstance(obj, dict)
         model_id = from_union([from_str, from_none], obj.get("modelId"))
-        return CurrentModel(model_id)
+        reasoning_effort = from_union([from_str, from_none], obj.get("reasoningEffort"))
+        return CurrentModel(model_id, reasoning_effort)
 
     def to_dict(self) -> dict:
         result: dict = {}
         if self.model_id is not None:
             result["modelId"] = from_union([from_str, from_none], self.model_id)
+        if self.reasoning_effort is not None:
+            result["reasoningEffort"] = from_union([from_str, from_none], self.reasoning_effort)
         return result
 
 class DiscoveredMCPServerType(Enum):
@@ -485,6 +734,161 @@ class DiscoveredMCPServerType(Enum):
     MEMORY = "memory"
     SSE = "sse"
     STDIO = "stdio"
+
+@dataclass
+class EnqueueCommandParams:
+    """Slash-prefixed command string to enqueue for FIFO processing."""
+
+    command: str
+    """Slash-prefixed command string to enqueue, e.g. '/compact' or '/model gpt-4'. Queued FIFO
+    with any in-flight items; if the session is idle, processing kicks off immediately.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'EnqueueCommandParams':
+        assert isinstance(obj, dict)
+        command = from_str(obj.get("command"))
+        return EnqueueCommandParams(command)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["command"] = from_str(self.command)
+        return result
+
+@dataclass
+class EnqueueCommandResult:
+    """Indicates whether the command was accepted into the local execution queue."""
+
+    queued: bool
+    """True when the command was accepted into the local execution queue. False when the call
+    targets a session that does not support local command queueing (e.g. remote sessions).
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'EnqueueCommandResult':
+        assert isinstance(obj, dict)
+        queued = from_bool(obj.get("queued"))
+        return EnqueueCommandResult(queued)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["queued"] = from_bool(self.queued)
+        return result
+
+class EnvAuthInfoType(Enum):
+    ENV = "env"
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+class EventsAgentScope(Enum):
+    """Agent-scope filter: 'primary' returns only main-agent events plus events whose type
+    starts with 'subagent.' (matching the typed-subscription default behavior); 'all' returns
+    events from all agents (matching wildcard-subscription behavior). Default is 'all' to
+    preserve wildcard semantics for catch-up callers.
+    """
+    ALL = "all"
+    PRIMARY = "primary"
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+class EventLogTypes(Enum):
+    EMPTY = "*"
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class EventLogReleaseInterestResult:
+    """Indicates whether the operation succeeded."""
+
+    success: bool
+    """Whether the operation succeeded"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'EventLogReleaseInterestResult':
+        assert isinstance(obj, dict)
+        success = from_bool(obj.get("success"))
+        return EventLogReleaseInterestResult(success)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["success"] = from_bool(self.success)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class EventLogTailResult:
+    """Snapshot of the current tail cursor without returning any events. Use this when a
+    consumer wants to subscribe to live events going forward without first paginating through
+    the entire persisted history (which would happen if `read` were called without a cursor
+    on a long-lived session).
+    """
+    cursor: str
+    """Opaque cursor pointing at the current tail of the session's persisted-events history.
+    Pass back to `read` to receive only events that arrive AFTER this snapshot. When the
+    session has no events, this returns the same sentinel as an unset cursor (i.e. equivalent
+    to omitting the cursor on a first read).
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'EventLogTailResult':
+        assert isinstance(obj, dict)
+        cursor = from_str(obj.get("cursor"))
+        return EventLogTailResult(cursor)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["cursor"] = from_str(self.cursor)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+class EventsCursorStatus(Enum):
+    """Cursor status: 'ok' means the cursor was applied successfully; 'expired' means the cursor
+    referred to an event that no longer exists in history (e.g. truncated or compacted away)
+    and the read started from the beginning of the remaining history.
+    """
+    EXPIRED = "expired"
+    OK = "ok"
+
+@dataclass
+class ExecuteCommandParams:
+    """Slash command name and argument string to execute synchronously."""
+
+    args: str
+    """Argument string to pass to the command (empty string if none)."""
+
+    command_name: str
+    """Name of the slash command to invoke (without the leading '/')."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ExecuteCommandParams':
+        assert isinstance(obj, dict)
+        args = from_str(obj.get("args"))
+        command_name = from_str(obj.get("commandName"))
+        return ExecuteCommandParams(args, command_name)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["args"] = from_str(self.args)
+        result["commandName"] = from_str(self.command_name)
+        return result
+
+@dataclass
+class ExecuteCommandResult:
+    """Error message produced while executing the command, if any."""
+
+    error: str | None = None
+    """Error message produced while executing the command, if any. Omitted when the handler
+    succeeded.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ExecuteCommandResult':
+        assert isinstance(obj, dict)
+        error = from_union([from_str, from_none], obj.get("error"))
+        return ExecuteCommandResult(error)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.error is not None:
+            result["error"] = from_union([from_str, from_none], self.error)
+        return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 class ExtensionSource(Enum):
@@ -618,6 +1022,9 @@ class FleetStartResult:
         result["started"] = from_bool(self.started)
         return result
 
+class GhCLIAuthInfoType(Enum):
+    GH_CLI = "gh-cli"
+
 @dataclass
 class HandlePendingToolCallResult:
     """Indicates whether the external tool call result was handled successfully."""
@@ -634,6 +1041,48 @@ class HandlePendingToolCallResult:
     def to_dict(self) -> dict:
         result: dict = {}
         result["success"] = from_bool(self.success)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class HistoryAbortManualCompactionResult:
+    """Indicates whether an in-progress manual compaction was aborted."""
+
+    aborted: bool
+    """Whether an in-progress manual compaction was aborted. False when no manual compaction was
+    running, when its abort controller was already aborted, or when the session is remote.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'HistoryAbortManualCompactionResult':
+        assert isinstance(obj, dict)
+        aborted = from_bool(obj.get("aborted"))
+        return HistoryAbortManualCompactionResult(aborted)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["aborted"] = from_bool(self.aborted)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class HistoryCancelBackgroundCompactionResult:
+    """Indicates whether an in-progress background compaction was cancelled."""
+
+    cancelled: bool
+    """Whether an in-progress background compaction was cancelled. False when no compaction was
+    running, when the session is remote, or when the underlying processor was unavailable.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'HistoryCancelBackgroundCompactionResult':
+        assert isinstance(obj, dict)
+        cancelled = from_bool(obj.get("cancelled"))
+        return HistoryCancelBackgroundCompactionResult(cancelled)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["cancelled"] = from_bool(self.cancelled)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -685,6 +1134,27 @@ class HistoryCompactContextWindow:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class HistorySummarizeForHandoffResult:
+    """Markdown summary of the conversation context (empty when not available)."""
+
+    summary: str
+    """Markdown summary of the conversation context produced by an LLM. Empty string when there
+    are no messages or when the session does not support local summarization.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'HistorySummarizeForHandoffResult':
+        assert isinstance(obj, dict)
+        summary = from_str(obj.get("summary"))
+        return HistorySummarizeForHandoffResult(summary)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["summary"] = from_str(self.summary)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class HistoryTruncateRequest:
     """Identifier of the event to truncate to; this event and all later events are removed."""
 
@@ -721,9 +1191,27 @@ class HistoryTruncateResult:
         result["eventsRemoved"] = from_int(self.events_removed)
         return result
 
+class HMACAuthInfoType(Enum):
+    HMAC = "hmac"
+
+class PurpleSource(Enum):
+    GITHUB = "github"
+    LOCAL = "local"
+    URL = "url"
+
+class FluffySource(Enum):
+    GITHUB = "github"
+
+class TentacledSource(Enum):
+    LOCAL = "local"
+
+class StickySource(Enum):
+    URL = "url"
+
 class InstructionsSourcesLocation(Enum):
     """Where this source lives — used for UI grouping"""
 
+    PLUGIN = "plugin"
     REPOSITORY = "repository"
     USER = "user"
     WORKING_DIRECTORY = "working-directory"
@@ -735,6 +1223,7 @@ class InstructionsSourcesType(Enum):
     HOME = "home"
     MODEL = "model"
     NESTED_AGENTS = "nested-agents"
+    PLUGIN = "plugin"
     REPO = "repo"
     VSCODE = "vscode"
 
@@ -762,6 +1251,84 @@ class LogResult:
     def to_dict(self) -> dict:
         result: dict = {}
         result["eventId"] = str(self.event_id)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class LspInitializeRequest:
+    """Parameters for (re)loading the merged LSP configuration set."""
+
+    force: bool | None = None
+    """Force re-initialization even when LSP configs were already loaded for the working
+    directory.
+    """
+    git_root: str | None = None
+    """Git root used as the boundary when traversing for project-level LSP configs (supports
+    monorepos).
+    """
+    working_directory: str | None = None
+    """Working directory used to load project-level LSP configs. Defaults to the session working
+    directory when omitted.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'LspInitializeRequest':
+        assert isinstance(obj, dict)
+        force = from_union([from_bool, from_none], obj.get("force"))
+        git_root = from_union([from_str, from_none], obj.get("gitRoot"))
+        working_directory = from_union([from_str, from_none], obj.get("workingDirectory"))
+        return LspInitializeRequest(force, git_root, working_directory)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.force is not None:
+            result["force"] = from_union([from_bool, from_none], self.force)
+        if self.git_root is not None:
+            result["gitRoot"] = from_union([from_str, from_none], self.git_root)
+        if self.working_directory is not None:
+            result["workingDirectory"] = from_union([from_str, from_none], self.working_directory)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class MCPCancelSamplingExecutionParams:
+    """The requestId previously passed to executeSampling that should be cancelled."""
+
+    request_id: str
+    """The requestId previously passed to executeSampling that should be cancelled"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MCPCancelSamplingExecutionParams':
+        assert isinstance(obj, dict)
+        request_id = from_str(obj.get("requestId"))
+        return MCPCancelSamplingExecutionParams(request_id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["requestId"] = from_str(self.request_id)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class MCPCancelSamplingExecutionResult:
+    """Indicates whether an in-flight sampling execution with the given requestId was found and
+    cancelled.
+    """
+    cancelled: bool
+    """True if an in-flight execution with the given requestId was found and signalled to
+    cancel. False when no such execution is in flight (already completed, never started, or
+    cancelled by another caller).
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MCPCancelSamplingExecutionResult':
+        assert isinstance(obj, dict)
+        cancelled = from_bool(obj.get("cancelled"))
+        return MCPCancelSamplingExecutionResult(cancelled)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["cancelled"] = from_bool(self.cancelled)
         return result
 
 @dataclass
@@ -986,6 +1553,39 @@ class MCPOauthLoginResult:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class MCPRemoveGitHubResult:
+    """Indicates whether the auto-managed `github` MCP server was removed (false when nothing to
+    remove).
+    """
+    removed: bool
+    """True when the auto-managed `github` MCP server was removed; false when no removal
+    happened (e.g. user has explicitly configured a `github` server, or the server was not
+    registered).
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MCPRemoveGitHubResult':
+        assert isinstance(obj, dict)
+        removed = from_bool(obj.get("removed"))
+        return MCPRemoveGitHubResult(removed)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["removed"] = from_bool(self.removed)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+class MCPSamplingExecutionAction(Enum):
+    """Outcome of the sampling inference. 'success' produced a response; 'failure' encountered
+    an error (including agent-side rejection by content filter or criteria); 'cancelled' the
+    caller cancelled this execution via cancelSamplingExecution.
+    """
+    CANCELLED = "cancelled"
+    FAILURE = "failure"
+    SUCCESS = "success"
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class MCPServer:
     """Schema for the `McpServer` type."""
 
@@ -1019,6 +1619,257 @@ class MCPServer:
         if self.source is not None:
             result["source"] = from_union([lambda x: to_enum(McpServerSource, x), from_none], self.source)
         return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+class MCPSetEnvValueModeDetails(Enum):
+    """How environment-variable values supplied to MCP servers are resolved. "direct" passes
+    literal string values; "indirect" treats values as references (e.g. names of environment
+    variables on the host) that the runtime resolves before launch. Defaults to the runtime's
+    startup mode; clients that intentionally launch MCP servers with literal values (e.g. CLI
+    prompt mode and ACP) set this to "direct".
+
+    Mode recorded on the session after the update
+
+    How env values are passed to MCP servers (`direct` inlines literal values; `indirect`
+    resolves at launch).
+    """
+    DIRECT = "direct"
+    INDIRECT = "indirect"
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionContextInfo:
+    """Token-usage breakdown for the session's current context window"""
+
+    buffer_tokens: int
+    """Output reserve plus tokens after the buffer-exhaustion blocking threshold (default 95%)"""
+
+    compaction_threshold: int
+    """Token count at which background compaction starts (configurable percentage of
+    promptTokenLimit)
+    """
+    conversation_tokens: int
+    """Tokens consumed by user/assistant/tool messages"""
+
+    limit: int
+    """Total context limit for /context display. promptTokenLimit + min(32k or 64k,
+    outputTokenLimit) depending on model.
+    """
+    model_name: str
+    """The model used for token counting"""
+
+    prompt_token_limit: int
+    """Maximum prompt tokens allowed by the model (or DEFAULT_TOKEN_LIMIT if unspecified)"""
+
+    system_tokens: int
+    """Tokens consumed by the system prompt"""
+
+    tool_definitions_tokens: int
+    """Tokens consumed by tool definitions sent to the model (excludes deferred tools)"""
+
+    total_tokens: int
+    """Sum of system, conversation and tool-definition tokens"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionContextInfo':
+        assert isinstance(obj, dict)
+        buffer_tokens = from_int(obj.get("bufferTokens"))
+        compaction_threshold = from_int(obj.get("compactionThreshold"))
+        conversation_tokens = from_int(obj.get("conversationTokens"))
+        limit = from_int(obj.get("limit"))
+        model_name = from_str(obj.get("modelName"))
+        prompt_token_limit = from_int(obj.get("promptTokenLimit"))
+        system_tokens = from_int(obj.get("systemTokens"))
+        tool_definitions_tokens = from_int(obj.get("toolDefinitionsTokens"))
+        total_tokens = from_int(obj.get("totalTokens"))
+        return SessionContextInfo(buffer_tokens, compaction_threshold, conversation_tokens, limit, model_name, prompt_token_limit, system_tokens, tool_definitions_tokens, total_tokens)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["bufferTokens"] = from_int(self.buffer_tokens)
+        result["compactionThreshold"] = from_int(self.compaction_threshold)
+        result["conversationTokens"] = from_int(self.conversation_tokens)
+        result["limit"] = from_int(self.limit)
+        result["modelName"] = from_str(self.model_name)
+        result["promptTokenLimit"] = from_int(self.prompt_token_limit)
+        result["systemTokens"] = from_int(self.system_tokens)
+        result["toolDefinitionsTokens"] = from_int(self.tool_definitions_tokens)
+        result["totalTokens"] = from_int(self.total_tokens)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class MetadataIsProcessingResult:
+    """Indicates whether the local session is currently processing a turn or background
+    continuation.
+    """
+    processing: bool
+    """Whether the session is currently processing user/agent messages. False for non-local
+    sessions (which don't run a local agentic loop). Reflects an in-flight turn or background
+    continuation.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MetadataIsProcessingResult':
+        assert isinstance(obj, dict)
+        processing = from_bool(obj.get("processing"))
+        return MetadataIsProcessingResult(processing)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["processing"] = from_bool(self.processing)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class MetadataRecomputeContextTokensResult:
+    """Re-tokenize the session's existing messages against `modelId` and return the token
+    totals. Useful for hosts that want an initial estimate of context usage on session
+    resume, before the next agent turn fires `session.context_info_changed` events. Returns
+    zeros for an empty session.
+    """
+    messages_token_count: int
+    """Tokens contributed by user/assistant/tool messages (excludes system/developer prompts)."""
+
+    system_token_count: int
+    """Tokens contributed by system/developer prompt snapshots."""
+
+    total_tokens: int
+    """Sum of tokens across chat-context and system-context messages currently held by the
+    session.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MetadataRecomputeContextTokensResult':
+        assert isinstance(obj, dict)
+        messages_token_count = from_int(obj.get("messagesTokenCount"))
+        system_token_count = from_int(obj.get("systemTokenCount"))
+        total_tokens = from_int(obj.get("totalTokens"))
+        return MetadataRecomputeContextTokensResult(messages_token_count, system_token_count, total_tokens)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["messagesTokenCount"] = from_int(self.messages_token_count)
+        result["systemTokenCount"] = from_int(self.system_token_count)
+        result["totalTokens"] = from_int(self.total_tokens)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+class SessionContextHostType(Enum):
+    """Hosting platform type of the repository
+
+    Repository host type
+
+    Repository host type, if known
+    """
+    ADO = "ado"
+    GITHUB = "github"
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class MetadataRecordContextChangeResult:
+    """Notify the session that its working directory context has changed. Emits a
+    `session.context_changed` event so consumers (telemetry, OTel tracker, ACP, the timeline
+    UI) can react. Use this when the host has detected a cwd/branch/repo change outside the
+    session's normal lifecycle (e.g., after a shell command in interactive mode).
+    """
+    @staticmethod
+    def from_dict(obj: Any) -> 'MetadataRecordContextChangeResult':
+        assert isinstance(obj, dict)
+        return MetadataRecordContextChangeResult()
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class MetadataSetWorkingDirectoryRequest:
+    """Absolute path to set as the session's new working directory."""
+
+    working_directory: str
+    """Absolute path to set as the session's working directory. The runtime updates the
+    session's recorded cwd so subsequent operations (shell tools, file lookups, telemetry)
+    anchor to it.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MetadataSetWorkingDirectoryRequest':
+        assert isinstance(obj, dict)
+        working_directory = from_str(obj.get("workingDirectory"))
+        return MetadataSetWorkingDirectoryRequest(working_directory)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["workingDirectory"] = from_str(self.working_directory)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class MetadataSetWorkingDirectoryResult:
+    """Update the session's working directory. Used by the host when the user explicitly changes
+    cwd (e.g., the `/cd` slash command). The host is responsible for `process.chdir` and any
+    related side-effects (file index, etc.); this method only updates the session's own
+    recorded path.
+    """
+    working_directory: str
+    """Working directory after the update"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MetadataSetWorkingDirectoryResult':
+        assert isinstance(obj, dict)
+        working_directory = from_str(obj.get("workingDirectory"))
+        return MetadataSetWorkingDirectoryResult(working_directory)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["workingDirectory"] = from_str(self.working_directory)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+class MetadataSnapshotCurrentMode(Enum):
+    """The current agent mode for this session (e.g., 'interactive', 'plan', 'autopilot')"""
+
+    AUTOPILOT = "autopilot"
+    INTERACTIVE = "interactive"
+    PLAN = "plan"
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class MetadataSnapshotRemoteMetadataRepository:
+    """The repository the remote session targets."""
+
+    branch: str
+    """The branch the remote session is operating on."""
+
+    name: str
+    """The GitHub repository name (without owner)."""
+
+    owner: str
+    """The GitHub owner (user or organization) of the target repository."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MetadataSnapshotRemoteMetadataRepository':
+        assert isinstance(obj, dict)
+        branch = from_str(obj.get("branch"))
+        name = from_str(obj.get("name"))
+        owner = from_str(obj.get("owner"))
+        return MetadataSnapshotRemoteMetadataRepository(branch, name, owner)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["branch"] = from_str(self.branch)
+        result["name"] = from_str(self.name)
+        result["owner"] = from_str(self.owner)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+class MetadataSnapshotRemoteMetadataTaskType(Enum):
+    """Whether the remote task originated from Copilot Coding Agent (cca) or a CLI `--remote`
+    invocation.
+    """
+    CCA = "cca"
+    CLI = "cli"
 
 @dataclass
 class ModeSetRequest:
@@ -1204,6 +2055,46 @@ class ModelCapabilitiesOverrideSupports:
         return result
 
 @dataclass
+class ModelSetReasoningEffortRequest:
+    """Reasoning effort level to apply to the currently selected model."""
+
+    reasoning_effort: str
+    """Reasoning effort level to apply to the currently selected model. The host is responsible
+    for validating the value against the model's supported levels before calling.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ModelSetReasoningEffortRequest':
+        assert isinstance(obj, dict)
+        reasoning_effort = from_str(obj.get("reasoningEffort"))
+        return ModelSetReasoningEffortRequest(reasoning_effort)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["reasoningEffort"] = from_str(self.reasoning_effort)
+        return result
+
+@dataclass
+class ModelSetReasoningEffortResult:
+    """Update the session's reasoning effort without changing the selected model. Use `switchTo`
+    instead when you also need to change the model. The runtime stores the effort on the
+    session and applies it to subsequent turns.
+    """
+    reasoning_effort: str
+    """Reasoning effort level recorded on the session after the update"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ModelSetReasoningEffortResult':
+        assert isinstance(obj, dict)
+        reasoning_effort = from_str(obj.get("reasoningEffort"))
+        return ModelSetReasoningEffortResult(reasoning_effort)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["reasoningEffort"] = from_str(self.reasoning_effort)
+        return result
+
+@dataclass
 class ModelSwitchToResult:
     """The model identifier active on the session after the switch."""
 
@@ -1260,6 +2151,47 @@ class NameGetResult:
         return result
 
 @dataclass
+class NameSetAutoRequest:
+    """Auto-generated session summary to apply as the session's name when no user-set name
+    exists.
+    """
+    summary: str
+    """Auto-generated session summary. Empty/whitespace-only values are ignored; values are
+    trimmed before persisting.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'NameSetAutoRequest':
+        assert isinstance(obj, dict)
+        summary = from_str(obj.get("summary"))
+        return NameSetAutoRequest(summary)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["summary"] = from_str(self.summary)
+        return result
+
+@dataclass
+class NameSetAutoResult:
+    """Indicates whether the auto-generated summary was applied as the session's name."""
+
+    applied: bool
+    """Whether the auto-generated summary was persisted. False if the session already has a
+    user-set name, the summary normalized to empty, or the session does not have a workspace.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'NameSetAutoResult':
+        assert isinstance(obj, dict)
+        applied = from_bool(obj.get("applied"))
+        return NameSetAutoResult(applied)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["applied"] = from_bool(self.applied)
+        return result
+
+@dataclass
 class NameSetRequest:
     """New friendly name to apply to the session."""
 
@@ -1277,6 +2209,30 @@ class NameSetRequest:
         result["name"] = from_str(self.name)
         return result
 
+@dataclass
+class PendingPermissionRequest:
+    """Schema for the `PendingPermissionRequest` type."""
+
+    request: PermissionPromptRequest
+    """The user-facing permission prompt details (commands, write, read, mcp, url, memory,
+    custom-tool, path, hook)
+    """
+    request_id: str
+    """Unique identifier for the pending permission request"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PendingPermissionRequest':
+        assert isinstance(obj, dict)
+        request = PermissionPromptRequest.from_dict(obj.get("request"))
+        request_id = from_str(obj.get("requestId"))
+        return PendingPermissionRequest(request, request_id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["request"] = to_class(PermissionPromptRequest, self.request)
+        result["requestId"] = from_str(self.request_id)
+        return result
+
 class ApprovalKind(Enum):
     COMMANDS = "commands"
     CUSTOM_TOOL = "custom-tool"
@@ -1289,10 +2245,19 @@ class ApprovalKind(Enum):
     WRITE = "write"
 
 class PermissionDecisionKind(Enum):
+    APPROVED = "approved"
+    APPROVED_FOR_LOCATION = "approved-for-location"
+    APPROVED_FOR_SESSION = "approved-for-session"
     APPROVE_FOR_LOCATION = "approve-for-location"
     APPROVE_FOR_SESSION = "approve-for-session"
     APPROVE_ONCE = "approve-once"
     APPROVE_PERMANENTLY = "approve-permanently"
+    CANCELLED = "cancelled"
+    DENIED_BY_CONTENT_EXCLUSION_POLICY = "denied-by-content-exclusion-policy"
+    DENIED_BY_PERMISSION_REQUEST_HOOK = "denied-by-permission-request-hook"
+    DENIED_BY_RULES = "denied-by-rules"
+    DENIED_INTERACTIVELY_BY_USER = "denied-interactively-by-user"
+    DENIED_NO_APPROVAL_RULE_AND_COULD_NOT_REQUEST_FROM_USER = "denied-no-approval-rule-and-could-not-request-from-user"
     REJECT = "reject"
     USER_NOT_AVAILABLE = "user-not-available"
 
@@ -1335,11 +2300,192 @@ class PermissionDecisionApproveOnceKind(Enum):
 class PermissionDecisionApprovePermanentlyKind(Enum):
     APPROVE_PERMANENTLY = "approve-permanently"
 
+class PermissionDecisionApprovedKind(Enum):
+    APPROVED = "approved"
+
+class PermissionDecisionApprovedForLocationKind(Enum):
+    APPROVED_FOR_LOCATION = "approved-for-location"
+
+class PermissionDecisionApprovedForSessionKind(Enum):
+    APPROVED_FOR_SESSION = "approved-for-session"
+
+class PermissionDecisionCancelledKind(Enum):
+    CANCELLED = "cancelled"
+
+class PermissionDecisionDeniedByContentExclusionPolicyKind(Enum):
+    DENIED_BY_CONTENT_EXCLUSION_POLICY = "denied-by-content-exclusion-policy"
+
+class PermissionDecisionDeniedByPermissionRequestHookKind(Enum):
+    DENIED_BY_PERMISSION_REQUEST_HOOK = "denied-by-permission-request-hook"
+
+class PermissionDecisionDeniedByRulesKind(Enum):
+    DENIED_BY_RULES = "denied-by-rules"
+
+class PermissionDecisionDeniedInteractivelyByUserKind(Enum):
+    DENIED_INTERACTIVELY_BY_USER = "denied-interactively-by-user"
+
+class PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUserKind(Enum):
+    DENIED_NO_APPROVAL_RULE_AND_COULD_NOT_REQUEST_FROM_USER = "denied-no-approval-rule-and-could-not-request-from-user"
+
 class PermissionDecisionRejectKind(Enum):
     REJECT = "reject"
 
 class PermissionDecisionUserNotAvailableKind(Enum):
     USER_NOT_AVAILABLE = "user-not-available"
+
+@dataclass
+class PermissionPathsAddParams:
+    """Directory path to add to the session's allowed directories."""
+
+    path: str
+    """Directory to add to the allow-list. The runtime resolves and validates the path before
+    adding.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionPathsAddParams':
+        assert isinstance(obj, dict)
+        path = from_str(obj.get("path"))
+        return PermissionPathsAddParams(path)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["path"] = from_str(self.path)
+        return result
+
+@dataclass
+class PermissionPathsAllowedCheckParams:
+    """Path to evaluate against the session's allowed directories."""
+
+    path: str
+    """Path to check against the session's allowed directories"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionPathsAllowedCheckParams':
+        assert isinstance(obj, dict)
+        path = from_str(obj.get("path"))
+        return PermissionPathsAllowedCheckParams(path)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["path"] = from_str(self.path)
+        return result
+
+@dataclass
+class PermissionPathsAllowedCheckResult:
+    """Indicates whether the supplied path is within the session's allowed directories."""
+
+    allowed: bool
+    """Whether the path is within the session's allowed directories"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionPathsAllowedCheckResult':
+        assert isinstance(obj, dict)
+        allowed = from_bool(obj.get("allowed"))
+        return PermissionPathsAllowedCheckResult(allowed)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["allowed"] = from_bool(self.allowed)
+        return result
+
+@dataclass
+class PermissionPathsList:
+    """Snapshot of the session's allow-listed directories and primary working directory."""
+
+    directories: list[str]
+    """All directories currently allowed for tool access on this session."""
+
+    primary: str
+    """The primary working directory for this session."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionPathsList':
+        assert isinstance(obj, dict)
+        directories = from_list(from_str, obj.get("directories"))
+        primary = from_str(obj.get("primary"))
+        return PermissionPathsList(directories, primary)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["directories"] = from_list(from_str, self.directories)
+        result["primary"] = from_str(self.primary)
+        return result
+
+@dataclass
+class PermissionPathsUpdatePrimaryParams:
+    """Directory path to set as the session's new primary working directory."""
+
+    path: str
+    """Directory to set as the new primary working directory for the session's permission policy."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionPathsUpdatePrimaryParams':
+        assert isinstance(obj, dict)
+        path = from_str(obj.get("path"))
+        return PermissionPathsUpdatePrimaryParams(path)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["path"] = from_str(self.path)
+        return result
+
+@dataclass
+class PermissionPathsWorkspaceCheckParams:
+    """Path to evaluate against the session's workspace (primary) directory."""
+
+    path: str
+    """Path to check against the session workspace directory"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionPathsWorkspaceCheckParams':
+        assert isinstance(obj, dict)
+        path = from_str(obj.get("path"))
+        return PermissionPathsWorkspaceCheckParams(path)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["path"] = from_str(self.path)
+        return result
+
+@dataclass
+class PermissionPathsWorkspaceCheckResult:
+    """Indicates whether the supplied path is within the session's workspace directory."""
+
+    allowed: bool
+    """Whether the path is within the session workspace directory"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionPathsWorkspaceCheckResult':
+        assert isinstance(obj, dict)
+        allowed = from_bool(obj.get("allowed"))
+        return PermissionPathsWorkspaceCheckResult(allowed)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["allowed"] = from_bool(self.allowed)
+        return result
+
+@dataclass
+class PermissionPromptShownNotification:
+    """Notification payload describing the permission prompt that the client just rendered."""
+
+    message: str
+    """Human-readable description of the prompt the user is being asked to approve. Used by the
+    runtime to fire the registered `permission_prompt` notification hook (e.g. terminal bell,
+    desktop notification).
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionPromptShownNotification':
+        assert isinstance(obj, dict)
+        message = from_str(obj.get("message"))
+        return PermissionPromptShownNotification(message)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["message"] = from_str(self.message)
+        return result
 
 @dataclass
 class PermissionRequestResult:
@@ -1358,6 +2504,228 @@ class PermissionRequestResult:
     def to_dict(self) -> dict:
         result: dict = {}
         result["success"] = from_bool(self.success)
+        return result
+
+@dataclass
+class PermissionRulesSet:
+    """If specified, replaces the session's approved/denied permission rules. Omit to leave the
+    current rules unchanged.
+    """
+    approved: list[PermissionRule]
+    """Rules that auto-approve matching requests"""
+
+    denied: list[PermissionRule]
+    """Rules that auto-deny matching requests"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionRulesSet':
+        assert isinstance(obj, dict)
+        approved = from_list(PermissionRule.from_dict, obj.get("approved"))
+        denied = from_list(PermissionRule.from_dict, obj.get("denied"))
+        return PermissionRulesSet(approved, denied)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["approved"] = from_list(lambda x: to_class(PermissionRule, x), self.approved)
+        result["denied"] = from_list(lambda x: to_class(PermissionRule, x), self.denied)
+        return result
+
+@dataclass
+class PermissionUrlsConfig:
+    """If specified, replaces the session's URL-permission policy. The runtime constructs a
+    fresh DefaultUrlManager based on these inputs. Omit to leave the current URL policy
+    unchanged.
+    """
+    initial_allowed: list[str] | None = None
+    """Initial list of allowed URL/domain patterns. Patterns may include path components.
+    Ignored when `unrestricted` is true.
+    """
+    unrestricted: bool | None = None
+    """If true, the runtime allows access to all URLs without prompting. Initial allow-list is
+    ignored when this is true.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionUrlsConfig':
+        assert isinstance(obj, dict)
+        initial_allowed = from_union([lambda x: from_list(from_str, x), from_none], obj.get("initialAllowed"))
+        unrestricted = from_union([from_bool, from_none], obj.get("unrestricted"))
+        return PermissionUrlsConfig(initial_allowed, unrestricted)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.initial_allowed is not None:
+            result["initialAllowed"] = from_union([lambda x: from_list(from_str, x), from_none], self.initial_allowed)
+        if self.unrestricted is not None:
+            result["unrestricted"] = from_union([from_bool, from_none], self.unrestricted)
+        return result
+
+@dataclass
+class PermissionUrlsSetUnrestrictedModeParams:
+    """Whether the URL-permission policy should run in unrestricted mode."""
+
+    enabled: bool
+    """Whether to allow access to all URLs without prompting. Toggles the runtime's
+    URL-permission policy in place.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionUrlsSetUnrestrictedModeParams':
+        assert isinstance(obj, dict)
+        enabled = from_bool(obj.get("enabled"))
+        return PermissionUrlsSetUnrestrictedModeParams(enabled)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["enabled"] = from_bool(self.enabled)
+        return result
+
+@dataclass
+class PermissionsConfigureAdditionalContentExclusionPolicyRuleSource:
+    """Schema for the `PermissionsConfigureAdditionalContentExclusionPolicyRuleSource` type."""
+
+    name: str
+    type: str
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsConfigureAdditionalContentExclusionPolicyRuleSource':
+        assert isinstance(obj, dict)
+        name = from_str(obj.get("name"))
+        type = from_str(obj.get("type"))
+        return PermissionsConfigureAdditionalContentExclusionPolicyRuleSource(name, type)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["name"] = from_str(self.name)
+        result["type"] = from_str(self.type)
+        return result
+
+class PermissionsConfigureAdditionalContentExclusionPolicyScope(Enum):
+    """Allowed values for the `PermissionsConfigureAdditionalContentExclusionPolicyScope`
+    enumeration.
+    """
+    ALL = "all"
+    REPO = "repo"
+
+@dataclass
+class PermissionsConfigureResult:
+    """Indicates whether the operation succeeded."""
+
+    success: bool
+    """Whether the operation succeeded"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsConfigureResult':
+        assert isinstance(obj, dict)
+        success = from_bool(obj.get("success"))
+        return PermissionsConfigureResult(success)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["success"] = from_bool(self.success)
+        return result
+
+class PermissionsModifyRulesScope(Enum):
+    """Whether the change applies to ephemeral session-scoped rules (cleared at session end) or
+    to location-scoped rules persisted via the location-permissions config file.
+    """
+    LOCATION = "location"
+    SESSION = "session"
+
+@dataclass
+class PermissionsModifyRulesResult:
+    """Indicates whether the operation succeeded."""
+
+    success: bool
+    """Whether the operation succeeded"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsModifyRulesResult':
+        assert isinstance(obj, dict)
+        success = from_bool(obj.get("success"))
+        return PermissionsModifyRulesResult(success)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["success"] = from_bool(self.success)
+        return result
+
+@dataclass
+class PermissionsNotifyPromptShownResult:
+    """Indicates whether the operation succeeded."""
+
+    success: bool
+    """Whether the operation succeeded"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsNotifyPromptShownResult':
+        assert isinstance(obj, dict)
+        success = from_bool(obj.get("success"))
+        return PermissionsNotifyPromptShownResult(success)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["success"] = from_bool(self.success)
+        return result
+
+@dataclass
+class PermissionsPathsAddResult:
+    """Indicates whether the operation succeeded."""
+
+    success: bool
+    """Whether the operation succeeded"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsPathsAddResult':
+        assert isinstance(obj, dict)
+        success = from_bool(obj.get("success"))
+        return PermissionsPathsAddResult(success)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["success"] = from_bool(self.success)
+        return result
+
+@dataclass
+class PermissionsPathsListRequest:
+    """No parameters; returns the session's allow-listed directories."""
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsPathsListRequest':
+        assert isinstance(obj, dict)
+        return PermissionsPathsListRequest()
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        return result
+
+@dataclass
+class PermissionsPathsUpdatePrimaryResult:
+    """Indicates whether the operation succeeded."""
+
+    success: bool
+    """Whether the operation succeeded"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsPathsUpdatePrimaryResult':
+        assert isinstance(obj, dict)
+        success = from_bool(obj.get("success"))
+        return PermissionsPathsUpdatePrimaryResult(success)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["success"] = from_bool(self.success)
+        return result
+
+@dataclass
+class PermissionsPendingRequestsRequest:
+    """No parameters; returns currently-pending permission requests for the session."""
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsPendingRequestsRequest':
+        assert isinstance(obj, dict)
+        return PermissionsPendingRequestsRequest()
+
+    def to_dict(self) -> dict:
+        result: dict = {}
         return result
 
 @dataclass
@@ -1391,24 +2759,6 @@ class PermissionsResetSessionApprovalsResult:
         return result
 
 @dataclass
-class PermissionsSetApproveAllRequest:
-    """Whether to auto-approve all tool permission requests for the rest of the session."""
-
-    enabled: bool
-    """Whether to auto-approve all tool permission requests"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'PermissionsSetApproveAllRequest':
-        assert isinstance(obj, dict)
-        enabled = from_bool(obj.get("enabled"))
-        return PermissionsSetApproveAllRequest(enabled)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["enabled"] = from_bool(self.enabled)
-        return result
-
-@dataclass
 class PermissionsSetApproveAllResult:
     """Indicates whether the operation succeeded."""
 
@@ -1420,6 +2770,63 @@ class PermissionsSetApproveAllResult:
         assert isinstance(obj, dict)
         success = from_bool(obj.get("success"))
         return PermissionsSetApproveAllResult(success)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["success"] = from_bool(self.success)
+        return result
+
+@dataclass
+class PermissionsSetRequiredRequest:
+    """Toggles whether permission prompts should be bridged into session events for this client."""
+
+    required: bool
+    """Whether the client wants `permission.requested` events bridged from the session-owned
+    permission service. CLI clients that render prompt UI set this to `true` for as long as
+    their listener is mounted; headless callers leave it unset (the default is `false`).
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsSetRequiredRequest':
+        assert isinstance(obj, dict)
+        required = from_bool(obj.get("required"))
+        return PermissionsSetRequiredRequest(required)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["required"] = from_bool(self.required)
+        return result
+
+@dataclass
+class PermissionsSetRequiredResult:
+    """Indicates whether the operation succeeded."""
+
+    success: bool
+    """Whether the operation succeeded"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsSetRequiredResult':
+        assert isinstance(obj, dict)
+        success = from_bool(obj.get("success"))
+        return PermissionsSetRequiredResult(success)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["success"] = from_bool(self.success)
+        return result
+
+@dataclass
+class PermissionsUrlsSetUnrestrictedModeResult:
+    """Indicates whether the operation succeeded."""
+
+    success: bool
+    """Whether the operation succeeded"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsUrlsSetUnrestrictedModeResult':
+        assert isinstance(obj, dict)
+        success = from_bool(obj.get("success"))
+        return PermissionsUrlsSetUnrestrictedModeResult(success)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -1447,8 +2854,8 @@ class PingRequest:
 
 @dataclass
 class PingResult:
-    """Server liveness response, including the echoed message, current timestamp, and protocol
-    version.
+    """Server liveness response, including the echoed message, current server timestamp, and
+    protocol version.
     """
     message: str
     """Echoed message (or default greeting)"""
@@ -1456,22 +2863,22 @@ class PingResult:
     protocol_version: int
     """Server protocol version number"""
 
-    timestamp: int
-    """Server timestamp in milliseconds"""
+    timestamp: datetime
+    """ISO 8601 timestamp when the server handled the ping"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PingResult':
         assert isinstance(obj, dict)
         message = from_str(obj.get("message"))
         protocol_version = from_int(obj.get("protocolVersion"))
-        timestamp = from_int(obj.get("timestamp"))
+        timestamp = from_datetime(obj.get("timestamp"))
         return PingResult(message, protocol_version, timestamp)
 
     def to_dict(self) -> dict:
         result: dict = {}
         result["message"] = from_str(self.message)
         result["protocolVersion"] = from_int(self.protocol_version)
-        result["timestamp"] = from_int(self.timestamp)
+        result["timestamp"] = self.timestamp.isoformat()
         return result
 
 @dataclass
@@ -1555,15 +2962,45 @@ class Plugin:
             result["version"] = from_union([from_str, from_none], self.version)
         return result
 
+# Experimental: this type is part of an experimental API and may change or be removed.
+class QueuePendingItemsKind(Enum):
+    """Whether this item is a queued user message or a queued slash command / model change"""
+
+    COMMAND = "command"
+    MESSAGE = "message"
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class QueueRemoveMostRecentResult:
+    """Indicates whether a user-facing pending item was removed."""
+
+    removed: bool
+    """True if a user-facing pending item was removed (LIFO across both queues); false when no
+    removable items remained.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'QueueRemoveMostRecentResult':
+        assert isinstance(obj, dict)
+        removed = from_bool(obj.get("removed"))
+        return QueueRemoveMostRecentResult(removed)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["removed"] = from_bool(self.removed)
+        return result
+
 @dataclass
 class QueuedCommandHandled:
     """Schema for the `QueuedCommandHandled` type."""
 
     handled: bool
-    """The command was handled"""
+    """The host actually executed the queued command."""
 
     stop_processing_queue: bool | None = None
-    """If true, stop processing remaining queued items"""
+    """When true, the runtime will not process subsequent queued commands until a new request
+    comes in.
+    """
 
     @staticmethod
     def from_dict(obj: Any) -> 'QueuedCommandHandled':
@@ -1584,7 +3021,9 @@ class QueuedCommandNotHandled:
     """Schema for the `QueuedCommandNotHandled` type."""
 
     handled: bool
-    """The command was not handled"""
+    """The host did not execute the queued command. Unblocks the queue without claiming the
+    command was processed (e.g. when the handler threw before completing).
+    """
 
     @staticmethod
     def from_dict(obj: Any) -> 'QueuedCommandNotHandled':
@@ -1595,6 +3034,83 @@ class QueuedCommandNotHandled:
     def to_dict(self) -> dict:
         result: dict = {}
         result["handled"] = from_bool(self.handled)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class RegisterEventInterestParams:
+    """Event type to register consumer interest for, used by runtime gating logic."""
+
+    event_type: str
+    """The event type the consumer wants the runtime to treat as 'observed' for
+    behavior-switching gating. Some runtime code paths inspect whether any consumer is
+    interested in a specific event type and choose a different implementation accordingly
+    (e.g. `mcp.oauth_required`: when interest is registered the runtime delegates the full
+    interactive OAuth flow to the consumer; when no interest is registered the runtime
+    installs a browserless fallback that silently reuses cached tokens). SDK clients that
+    long-poll events do NOT automatically appear as listeners to these gating checks — they
+    must explicitly call `registerInterest` for each event type they want the runtime to
+    count as having a consumer. Multiple registrations for the same event type from the same
+    or different consumers are tracked independently and must each be released. See:
+    `mcp.oauth_required`, `sampling.requested`, `auto_mode_switch.requested`,
+    `user_input.requested`, `elicitation.requested`, `command.queued`,
+    `exit_plan_mode.requested`.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'RegisterEventInterestParams':
+        assert isinstance(obj, dict)
+        event_type = from_str(obj.get("eventType"))
+        return RegisterEventInterestParams(event_type)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["eventType"] = from_str(self.event_type)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class RegisterEventInterestResult:
+    """Opaque handle representing an event-type interest registration."""
+
+    handle: str
+    """Opaque handle for this registration. Pass to releaseInterest to release. Each call to
+    registerInterest produces a fresh handle, even when the same eventType is registered
+    multiple times.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'RegisterEventInterestResult':
+        assert isinstance(obj, dict)
+        handle = from_str(obj.get("handle"))
+        return RegisterEventInterestResult(handle)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["handle"] = from_str(self.handle)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class ReleaseEventInterestParams:
+    """Opaque handle previously returned by `registerInterest` to release."""
+
+    handle: str
+    """Handle returned by a previous `registerInterest` call. Idempotent: releasing an unknown
+    or already-released handle is a no-op (returns success). When the last outstanding handle
+    for an event type is released, the runtime reverts to its 'no consumer' code path for
+    that event type.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ReleaseEventInterestParams':
+        assert isinstance(obj, dict)
+        handle = from_str(obj.get("handle"))
+        return ReleaseEventInterestParams(handle)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["handle"] = from_str(self.handle)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -1629,6 +3145,242 @@ class RemoteEnableResult:
         result["remoteSteerable"] = from_bool(self.remote_steerable)
         if self.url is not None:
             result["url"] = from_union([from_str, from_none], self.url)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class RemoteNotifySteerableChangedRequest:
+    """New remote-steerability state to persist as a `session.remote_steerable_changed` event."""
+
+    remote_steerable: bool
+    """Whether the session now supports remote steering via GitHub. The runtime persists this as
+    a `session.remote_steerable_changed` event so resume/replay sees the up-to-date
+    capability.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'RemoteNotifySteerableChangedRequest':
+        assert isinstance(obj, dict)
+        remote_steerable = from_bool(obj.get("remoteSteerable"))
+        return RemoteNotifySteerableChangedRequest(remote_steerable)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["remoteSteerable"] = from_bool(self.remote_steerable)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class RemoteNotifySteerableChangedResult:
+    """Persist a steerability change as a `session.remote_steerable_changed` event. Used by the
+    host (CLI / SDK consumer) when it has just finished enabling or disabling steering on a
+    remote exporter that the runtime does not directly own.
+    """
+    @staticmethod
+    def from_dict(obj: Any) -> 'RemoteNotifySteerableChangedResult':
+        assert isinstance(obj, dict)
+        return RemoteNotifySteerableChangedResult()
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class ScheduleEntry:
+    """Schema for the `ScheduleEntry` type.
+
+    The removed entry, or omitted if no entry matched.
+    """
+    id: int
+    """Sequential id assigned by the runtime within the session. Stable across resumes (rebuilt
+    from the event log).
+    """
+    interval_ms: int
+    """Interval between scheduled ticks, in milliseconds."""
+
+    next_run_at: datetime
+    """ISO 8601 timestamp when the next tick is scheduled to fire."""
+
+    prompt: str
+    """Prompt text that gets enqueued on every tick."""
+
+    recurring: bool
+    """Whether the schedule re-arms after each tick (`/every`) or fires once (`/after`)."""
+
+    display_prompt: str | None = None
+    """Display-only label for the prompt as shown in the UI (e.g. `/skill-name` for a
+    skill-invocation schedule). The actual enqueued prompt is `prompt`.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ScheduleEntry':
+        assert isinstance(obj, dict)
+        id = from_int(obj.get("id"))
+        interval_ms = from_int(obj.get("intervalMs"))
+        next_run_at = from_datetime(obj.get("nextRunAt"))
+        prompt = from_str(obj.get("prompt"))
+        recurring = from_bool(obj.get("recurring"))
+        display_prompt = from_union([from_str, from_none], obj.get("displayPrompt"))
+        return ScheduleEntry(id, interval_ms, next_run_at, prompt, recurring, display_prompt)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["id"] = from_int(self.id)
+        result["intervalMs"] = from_int(self.interval_ms)
+        result["nextRunAt"] = self.next_run_at.isoformat()
+        result["prompt"] = from_str(self.prompt)
+        result["recurring"] = from_bool(self.recurring)
+        if self.display_prompt is not None:
+            result["displayPrompt"] = from_union([from_str, from_none], self.display_prompt)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class ScheduleStopRequest:
+    """Identifier of the scheduled prompt to remove."""
+
+    id: int
+    """Id of the scheduled prompt to remove."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ScheduleStopRequest':
+        assert isinstance(obj, dict)
+        id = from_int(obj.get("id"))
+        return ScheduleStopRequest(id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["id"] = from_int(self.id)
+        return result
+
+class SendAgentMode(Enum):
+    """The UI mode the agent was in when this message was sent. Defaults to the session's
+    current mode.
+    """
+    AUTOPILOT = "autopilot"
+    INTERACTIVE = "interactive"
+    PLAN = "plan"
+    SHELL = "shell"
+
+@dataclass
+class SendAttachmentFileLineRange:
+    """Optional line range to scope the attachment to a specific section of the file"""
+
+    end: int
+    """End line number (1-based, inclusive)"""
+
+    start: int
+    """Start line number (1-based)"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SendAttachmentFileLineRange':
+        assert isinstance(obj, dict)
+        end = from_int(obj.get("end"))
+        start = from_int(obj.get("start"))
+        return SendAttachmentFileLineRange(end, start)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["end"] = from_int(self.end)
+        result["start"] = from_int(self.start)
+        return result
+
+class SendAttachmentGithubReferenceTypeEnum(Enum):
+    """Type of GitHub reference"""
+
+    DISCUSSION = "discussion"
+    ISSUE = "issue"
+    PR = "pr"
+
+@dataclass
+class SendAttachmentSelectionDetailsEnd:
+    """End position of the selection"""
+
+    character: int
+    """End character offset within the line (0-based)"""
+
+    line: int
+    """End line number (0-based)"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SendAttachmentSelectionDetailsEnd':
+        assert isinstance(obj, dict)
+        character = from_int(obj.get("character"))
+        line = from_int(obj.get("line"))
+        return SendAttachmentSelectionDetailsEnd(character, line)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["character"] = from_int(self.character)
+        result["line"] = from_int(self.line)
+        return result
+
+@dataclass
+class SendAttachmentSelectionDetailsStart:
+    """Start position of the selection"""
+
+    character: int
+    """Start character offset within the line (0-based)"""
+
+    line: int
+    """Start line number (0-based)"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SendAttachmentSelectionDetailsStart':
+        assert isinstance(obj, dict)
+        character = from_int(obj.get("character"))
+        line = from_int(obj.get("line"))
+        return SendAttachmentSelectionDetailsStart(character, line)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["character"] = from_int(self.character)
+        result["line"] = from_int(self.line)
+        return result
+
+class SendAttachmentType(Enum):
+    BLOB = "blob"
+    DIRECTORY = "directory"
+    FILE = "file"
+    GITHUB_REFERENCE = "github_reference"
+    SELECTION = "selection"
+
+class SendAttachmentBlobType(Enum):
+    BLOB = "blob"
+
+class SendAttachmentFileType(Enum):
+    FILE = "file"
+
+class SendAttachmentGithubReferenceType(Enum):
+    GITHUB_REFERENCE = "github_reference"
+
+class SendAttachmentSelectionType(Enum):
+    SELECTION = "selection"
+
+class SendMode(Enum):
+    """How to deliver the message. `enqueue` (default) appends to the message queue. `immediate`
+    interjects during an in-progress turn.
+    """
+    ENQUEUE = "enqueue"
+    IMMEDIATE = "immediate"
+
+@dataclass
+class SendResult:
+    """Result of sending a user message"""
+
+    message_id: str
+    """Unique identifier assigned to the message"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SendResult':
+        assert isinstance(obj, dict)
+        message_id = from_str(obj.get("messageId"))
+        return SendResult(message_id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["messageId"] = from_str(self.message_id)
         return result
 
 @dataclass
@@ -1679,6 +3431,28 @@ class ServerSkill:
             result["path"] = from_union([from_str, from_none], self.path)
         if self.project_path is not None:
             result["projectPath"] = from_union([from_str, from_none], self.project_path)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionBulkDeleteResult:
+    """Map of sessionId -> bytes freed by removing the session's workspace directory."""
+
+    freed_bytes: dict[str, int]
+    """Map of sessionId -> bytes freed by removing the session's workspace directory. Sessions
+    whose deletion failed are omitted from this map (failures are logged on the server but
+    not surfaced per-id; check the map for absent IDs to detect them).
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionBulkDeleteResult':
+        assert isinstance(obj, dict)
+        freed_bytes = from_dict(from_int, obj.get("freedBytes"))
+        return SessionBulkDeleteResult(freed_bytes)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["freedBytes"] = from_dict(from_int, self.freed_bytes)
         return result
 
 @dataclass
@@ -2086,6 +3860,303 @@ class SessionFSWriteFileRequest:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class SessionLoadDeferredRepoHooksResult:
+    """Queued repo-level startup prompts and the total hook command count after loading."""
+
+    hook_count: int
+    """Total hook command count (user + plugin + repo) loaded for the session by this call.
+    Captured atomically with startupPrompts so callers don't need to read a separate counter.
+    """
+    startup_prompts: list[str]
+    """Repo-level startup prompts queued from repo hook configs. Empty on resume, when no repo
+    configs were pending, or when disableAllHooks is set.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionLoadDeferredRepoHooksResult':
+        assert isinstance(obj, dict)
+        hook_count = from_int(obj.get("hookCount"))
+        startup_prompts = from_list(from_str, obj.get("startupPrompts"))
+        return SessionLoadDeferredRepoHooksResult(hook_count, startup_prompts)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["hookCount"] = from_int(self.hook_count)
+        result["startupPrompts"] = from_list(from_str, self.startup_prompts)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionPruneResult:
+    """Outcome of the prune operation: deleted IDs, dry-run candidates, skipped IDs, total bytes
+    freed, and the dry-run flag.
+    """
+    candidates: list[str]
+    """Session IDs that would be deleted in dry-run mode (always empty otherwise)"""
+
+    deleted: list[str]
+    """Session IDs that were deleted (always empty in dry-run mode)"""
+
+    dry_run: bool
+    """True when no deletions were actually performed"""
+
+    freed_bytes: int
+    """Total bytes freed (actual when not dry-run, projected when dry-run)"""
+
+    skipped: list[str]
+    """Session IDs that were skipped (e.g., named sessions)"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionPruneResult':
+        assert isinstance(obj, dict)
+        candidates = from_list(from_str, obj.get("candidates"))
+        deleted = from_list(from_str, obj.get("deleted"))
+        dry_run = from_bool(obj.get("dryRun"))
+        freed_bytes = from_int(obj.get("freedBytes"))
+        skipped = from_list(from_str, obj.get("skipped"))
+        return SessionPruneResult(candidates, deleted, dry_run, freed_bytes, skipped)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["candidates"] = from_list(from_str, self.candidates)
+        result["deleted"] = from_list(from_str, self.deleted)
+        result["dryRun"] = from_bool(self.dry_run)
+        result["freedBytes"] = from_int(self.freed_bytes)
+        result["skipped"] = from_list(from_str, self.skipped)
+        return result
+
+@dataclass
+class SessionSetCredentialsResult:
+    """Indicates whether the credential update succeeded."""
+
+    success: bool
+    """Whether the operation succeeded"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionSetCredentialsResult':
+        assert isinstance(obj, dict)
+        success = from_bool(obj.get("success"))
+        return SessionSetCredentialsResult(success)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["success"] = from_bool(self.success)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionSizes:
+    """Map of sessionId -> on-disk size in bytes for each session's workspace directory."""
+
+    sizes: dict[str, int]
+    """Map of sessionId -> on-disk size in bytes for the session's workspace directory"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionSizes':
+        assert isinstance(obj, dict)
+        sizes = from_dict(from_int, obj.get("sizes"))
+        return SessionSizes(sizes)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["sizes"] = from_dict(from_int, self.sizes)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionUpdateOptionsResult:
+    """Indicates whether the session options patch was applied successfully."""
+
+    success: bool
+    """Whether the operation succeeded"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionUpdateOptionsResult':
+        assert isinstance(obj, dict)
+        success = from_bool(obj.get("success"))
+        return SessionUpdateOptionsResult(success)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["success"] = from_bool(self.success)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsBulkDeleteRequest:
+    """Session IDs to close, deactivate, and delete from disk."""
+
+    session_ids: list[str]
+    """Session IDs to close, deactivate, and delete from disk"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsBulkDeleteRequest':
+        assert isinstance(obj, dict)
+        session_ids = from_list(from_str, obj.get("sessionIds"))
+        return SessionsBulkDeleteRequest(session_ids)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["sessionIds"] = from_list(from_str, self.session_ids)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsCheckInUseRequest:
+    """Session IDs to test for live in-use locks."""
+
+    session_ids: list[str]
+    """Session IDs to test for live in-use locks"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsCheckInUseRequest':
+        assert isinstance(obj, dict)
+        session_ids = from_list(from_str, obj.get("sessionIds"))
+        return SessionsCheckInUseRequest(session_ids)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["sessionIds"] = from_list(from_str, self.session_ids)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsCheckInUseResult:
+    """Session IDs from the input set that are currently in use by another process."""
+
+    in_use: list[str]
+    """Session IDs from the input set that are currently held by another running process via an
+    alive lock file
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsCheckInUseResult':
+        assert isinstance(obj, dict)
+        in_use = from_list(from_str, obj.get("inUse"))
+        return SessionsCheckInUseResult(in_use)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["inUse"] = from_list(from_str, self.in_use)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsCloseRequest:
+    """Session ID to close."""
+
+    session_id: str
+    """Session ID to close"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsCloseRequest':
+        assert isinstance(obj, dict)
+        session_id = from_str(obj.get("sessionId"))
+        return SessionsCloseRequest(session_id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["sessionId"] = from_str(self.session_id)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsCloseResult:
+    """Closes a session: emits shutdown, flushes pending events to disk, releases the in-use
+    lock, disposes the active session. Idempotent: succeeds even if the session is not
+    currently active.
+    """
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsCloseResult':
+        assert isinstance(obj, dict)
+        return SessionsCloseResult()
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsFindByPrefixRequest:
+    """UUID prefix to resolve to a unique session ID."""
+
+    prefix: str
+    """UUID prefix (>=7 hex chars, <36 chars). Returns the unique session ID, or undefined when
+    there is no match or the prefix matches multiple sessions.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsFindByPrefixRequest':
+        assert isinstance(obj, dict)
+        prefix = from_str(obj.get("prefix"))
+        return SessionsFindByPrefixRequest(prefix)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["prefix"] = from_str(self.prefix)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsFindByPrefixResult:
+    """Session ID matching the prefix, omitted when no unique match exists."""
+
+    session_id: str | None = None
+    """Omitted when no unique session matches the prefix (no match or ambiguous)"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsFindByPrefixResult':
+        assert isinstance(obj, dict)
+        session_id = from_union([from_str, from_none], obj.get("sessionId"))
+        return SessionsFindByPrefixResult(session_id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.session_id is not None:
+            result["sessionId"] = from_union([from_str, from_none], self.session_id)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsFindByTaskIDRequest:
+    """GitHub task ID to look up."""
+
+    task_id: str
+    """GitHub task ID to look up"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsFindByTaskIDRequest':
+        assert isinstance(obj, dict)
+        task_id = from_str(obj.get("taskId"))
+        return SessionsFindByTaskIDRequest(task_id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["taskId"] = from_str(self.task_id)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsFindByTaskIDResult:
+    """ID of the local session bound to the given GitHub task, or omitted when none."""
+
+    session_id: str | None = None
+    """Omitted when no local session is bound to that GitHub task"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsFindByTaskIDResult':
+        assert isinstance(obj, dict)
+        session_id = from_union([from_str, from_none], obj.get("sessionId"))
+        return SessionsFindByTaskIDResult(session_id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.session_id is not None:
+            result["sessionId"] = from_union([from_str, from_none], self.session_id)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class SessionsForkRequest:
     """Source session identifier to fork from, optional event-ID boundary, and optional friendly
     name for the new session.
@@ -2141,6 +4212,327 @@ class SessionsForkResult:
         result["sessionId"] = from_str(self.session_id)
         if self.name is not None:
             result["name"] = from_union([from_str, from_none], self.name)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsGetEventFilePathRequest:
+    """Session ID whose event-log file path to compute."""
+
+    session_id: str
+    """Session ID whose event-log file path to compute"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsGetEventFilePathRequest':
+        assert isinstance(obj, dict)
+        session_id = from_str(obj.get("sessionId"))
+        return SessionsGetEventFilePathRequest(session_id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["sessionId"] = from_str(self.session_id)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsGetEventFilePathResult:
+    """Absolute path to the session's events.jsonl file on disk."""
+
+    file_path: str
+    """Absolute path to the session's events.jsonl file"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsGetEventFilePathResult':
+        assert isinstance(obj, dict)
+        file_path = from_str(obj.get("filePath"))
+        return SessionsGetEventFilePathResult(file_path)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["filePath"] = from_str(self.file_path)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsGetLastForContextResult:
+    """Most-relevant session ID for the supplied context, or omitted when no sessions exist."""
+
+    session_id: str | None = None
+    """Most-relevant session ID for the supplied context, or omitted when no sessions exist"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsGetLastForContextResult':
+        assert isinstance(obj, dict)
+        session_id = from_union([from_str, from_none], obj.get("sessionId"))
+        return SessionsGetLastForContextResult(session_id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.session_id is not None:
+            result["sessionId"] = from_union([from_str, from_none], self.session_id)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsGetPersistedRemoteSteerableRequest:
+    """Session ID to look up the persisted remote-steerable flag for."""
+
+    session_id: str
+    """Session ID to look up the persisted remote-steerable flag for"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsGetPersistedRemoteSteerableRequest':
+        assert isinstance(obj, dict)
+        session_id = from_str(obj.get("sessionId"))
+        return SessionsGetPersistedRemoteSteerableRequest(session_id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["sessionId"] = from_str(self.session_id)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsGetPersistedRemoteSteerableResult:
+    """The session's persisted remote-steerable flag, or omitted when no value has been
+    persisted.
+    """
+    remote_steerable: bool | None = None
+    """The session's persisted remote-steerable flag if recorded; omitted when no value has been
+    persisted
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsGetPersistedRemoteSteerableResult':
+        assert isinstance(obj, dict)
+        remote_steerable = from_union([from_bool, from_none], obj.get("remoteSteerable"))
+        return SessionsGetPersistedRemoteSteerableResult(remote_steerable)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.remote_steerable is not None:
+            result["remoteSteerable"] = from_union([from_bool, from_none], self.remote_steerable)
+        return result
+
+@dataclass
+class Filter:
+    """Optional filter applied to the returned sessions"""
+
+    branch: str | None = None
+    """Match sessions whose context.branch equals this value"""
+
+    cwd: str | None = None
+    """Match sessions whose context.cwd equals this value"""
+
+    git_root: str | None = None
+    """Match sessions whose context.gitRoot equals this value"""
+
+    repository: str | None = None
+    """Match sessions whose context.repository equals this value"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'Filter':
+        assert isinstance(obj, dict)
+        branch = from_union([from_str, from_none], obj.get("branch"))
+        cwd = from_union([from_str, from_none], obj.get("cwd"))
+        git_root = from_union([from_str, from_none], obj.get("gitRoot"))
+        repository = from_union([from_str, from_none], obj.get("repository"))
+        return Filter(branch, cwd, git_root, repository)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.branch is not None:
+            result["branch"] = from_union([from_str, from_none], self.branch)
+        if self.cwd is not None:
+            result["cwd"] = from_union([from_str, from_none], self.cwd)
+        if self.git_root is not None:
+            result["gitRoot"] = from_union([from_str, from_none], self.git_root)
+        if self.repository is not None:
+            result["repository"] = from_union([from_str, from_none], self.repository)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsLoadDeferredRepoHooksRequest:
+    """Active session ID whose deferred repo-level hooks should be loaded."""
+
+    session_id: str
+    """Active session ID whose deferred repo-level hooks should be loaded"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsLoadDeferredRepoHooksRequest':
+        assert isinstance(obj, dict)
+        session_id = from_str(obj.get("sessionId"))
+        return SessionsLoadDeferredRepoHooksRequest(session_id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["sessionId"] = from_str(self.session_id)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsPruneOldRequest:
+    """Age threshold and optional flags controlling which old sessions are pruned (or simulated
+    when dryRun is true).
+    """
+    older_than_days: int
+    """Delete sessions whose modifiedTime is at least this many days old"""
+
+    dry_run: bool | None = None
+    """When true, only report what would be deleted without performing any deletion"""
+
+    exclude_session_ids: list[str] | None = None
+    """Session IDs that should never be considered for pruning"""
+
+    include_named: bool | None = None
+    """When true, named sessions (set via /rename) are also eligible for pruning"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsPruneOldRequest':
+        assert isinstance(obj, dict)
+        older_than_days = from_int(obj.get("olderThanDays"))
+        dry_run = from_union([from_bool, from_none], obj.get("dryRun"))
+        exclude_session_ids = from_union([lambda x: from_list(from_str, x), from_none], obj.get("excludeSessionIds"))
+        include_named = from_union([from_bool, from_none], obj.get("includeNamed"))
+        return SessionsPruneOldRequest(older_than_days, dry_run, exclude_session_ids, include_named)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["olderThanDays"] = from_int(self.older_than_days)
+        if self.dry_run is not None:
+            result["dryRun"] = from_union([from_bool, from_none], self.dry_run)
+        if self.exclude_session_ids is not None:
+            result["excludeSessionIds"] = from_union([lambda x: from_list(from_str, x), from_none], self.exclude_session_ids)
+        if self.include_named is not None:
+            result["includeNamed"] = from_union([from_bool, from_none], self.include_named)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsReleaseLockRequest:
+    """Session ID whose in-use lock should be released."""
+
+    session_id: str
+    """Session ID whose in-use lock should be released"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsReleaseLockRequest':
+        assert isinstance(obj, dict)
+        session_id = from_str(obj.get("sessionId"))
+        return SessionsReleaseLockRequest(session_id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["sessionId"] = from_str(self.session_id)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsReleaseLockResult:
+    """Release the in-use lock held by this process for the given session. No-op when this
+    process does not currently hold a lock for the session.
+    """
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsReleaseLockResult':
+        assert isinstance(obj, dict)
+        return SessionsReleaseLockResult()
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsReloadPluginHooksRequest:
+    """Active session ID and an optional flag for deferring repo-level hooks until folder trust."""
+
+    session_id: str
+    """Active session ID to reload hooks for"""
+
+    defer_repo_hooks: bool | None = None
+    """When true, skip repo-level hooks. Use before folder trust is confirmed;
+    loadDeferredRepoHooks loads them post-trust.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsReloadPluginHooksRequest':
+        assert isinstance(obj, dict)
+        session_id = from_str(obj.get("sessionId"))
+        defer_repo_hooks = from_union([from_bool, from_none], obj.get("deferRepoHooks"))
+        return SessionsReloadPluginHooksRequest(session_id, defer_repo_hooks)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["sessionId"] = from_str(self.session_id)
+        if self.defer_repo_hooks is not None:
+            result["deferRepoHooks"] = from_union([from_bool, from_none], self.defer_repo_hooks)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsReloadPluginHooksResult:
+    """Reload all hooks (user, plugin, optionally repo) and apply them to the active session.
+    Call after installing or removing plugins so their hooks take effect immediately. No-op
+    when no active session matches the given sessionId.
+    """
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsReloadPluginHooksResult':
+        assert isinstance(obj, dict)
+        return SessionsReloadPluginHooksResult()
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsSaveRequest:
+    """Session ID whose pending events should be flushed to disk."""
+
+    session_id: str
+    """Session ID whose pending events should be flushed to disk"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsSaveRequest':
+        assert isinstance(obj, dict)
+        session_id = from_str(obj.get("sessionId"))
+        return SessionsSaveRequest(session_id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["sessionId"] = from_str(self.session_id)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsSaveResult:
+    """Flush a session's pending events to disk. No-op when no writer exists for the session
+    (e.g., already closed).
+    """
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsSaveResult':
+        assert isinstance(obj, dict)
+        return SessionsSaveResult()
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsSetAdditionalPluginsResult:
+    """Replace the manager-wide additional plugins. New session creations and subsequent hook
+    reloads see the new set; already-running sessions keep their existing hook installation
+    until the next reload.
+    """
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsSetAdditionalPluginsResult':
+        assert isinstance(obj, dict)
+        return SessionsSetAdditionalPluginsResult()
+
+    def to_dict(self) -> dict:
+        result: dict = {}
         return result
 
 @dataclass
@@ -2218,6 +4610,32 @@ class ShellKillResult:
         result["killed"] = from_bool(self.killed)
         return result
 
+@dataclass
+class ShutdownRequest:
+    """Parameters for shutting down the session"""
+
+    reason: str | None = None
+    """Optional human-readable reason. Typically the message of the error that triggered
+    shutdown when type is 'error'.
+    """
+    type: ShutdownType | None = None
+    """Why the session is being shut down. Defaults to "routine" when omitted."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ShutdownRequest':
+        assert isinstance(obj, dict)
+        reason = from_union([from_str, from_none], obj.get("reason"))
+        type = from_union([ShutdownType, from_none], obj.get("type"))
+        return ShutdownRequest(reason, type)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.reason is not None:
+            result["reason"] = from_union([from_str, from_none], self.reason)
+        if self.type is not None:
+            result["type"] = from_union([lambda x: to_enum(ShutdownType, x), from_none], self.type)
+        return result
+
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
 class Skill:
@@ -2241,6 +4659,9 @@ class Skill:
     path: str | None = None
     """Absolute path to the skill file"""
 
+    plugin_name: str | None = None
+    """Name of the plugin that provides the skill, when source is 'plugin'"""
+
     @staticmethod
     def from_dict(obj: Any) -> 'Skill':
         assert isinstance(obj, dict)
@@ -2250,7 +4671,8 @@ class Skill:
         source = SkillSource(obj.get("source"))
         user_invocable = from_bool(obj.get("userInvocable"))
         path = from_union([from_str, from_none], obj.get("path"))
-        return Skill(description, enabled, name, source, user_invocable, path)
+        plugin_name = from_union([from_str, from_none], obj.get("pluginName"))
+        return Skill(description, enabled, name, source, user_invocable, path, plugin_name)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -2261,6 +4683,8 @@ class Skill:
         result["userInvocable"] = from_bool(self.user_invocable)
         if self.path is not None:
             result["path"] = from_union([from_str, from_none], self.path)
+        if self.plugin_name is not None:
+            result["pluginName"] = from_union([from_str, from_none], self.plugin_name)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -2328,6 +4752,46 @@ class SkillsEnableRequest:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class SkillsInvokedSkill:
+    """Schema for the `SkillsInvokedSkill` type."""
+
+    content: str
+    """Full content of the skill file"""
+
+    invoked_at_turn: int
+    """Turn number when the skill was invoked"""
+
+    name: str
+    """Unique identifier for the skill"""
+
+    path: str
+    """Path to the SKILL.md file"""
+
+    allowed_tools: list[str] | None = None
+    """Tools that should be auto-approved when this skill is active, captured at invocation time"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SkillsInvokedSkill':
+        assert isinstance(obj, dict)
+        content = from_str(obj.get("content"))
+        invoked_at_turn = from_int(obj.get("invokedAtTurn"))
+        name = from_str(obj.get("name"))
+        path = from_str(obj.get("path"))
+        allowed_tools = from_union([lambda x: from_list(from_str, x), from_none], obj.get("allowedTools"))
+        return SkillsInvokedSkill(content, invoked_at_turn, name, path, allowed_tools)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["content"] = from_str(self.content)
+        result["invokedAtTurn"] = from_int(self.invoked_at_turn)
+        result["name"] = from_str(self.name)
+        result["path"] = from_str(self.path)
+        if self.allowed_tools is not None:
+            result["allowedTools"] = from_union([lambda x: from_list(from_str, x), from_none], self.allowed_tools)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class SkillsLoadDiagnostics:
     """Diagnostics from reloading skill definitions, with warnings and errors as separate lists."""
 
@@ -2381,6 +4845,31 @@ class TaskStatus(Enum):
 class TaskAgentInfoType(Enum):
     AGENT = "agent"
 
+@dataclass
+class RecentActivity:
+    message: str
+    """Display message, e.g., "▸ bash", "✓ edit src/foo.ts\""""
+
+    timestamp: datetime
+    """ISO 8601 timestamp when this event occurred"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'RecentActivity':
+        assert isinstance(obj, dict)
+        message = from_str(obj.get("message"))
+        timestamp = from_datetime(obj.get("timestamp"))
+        return RecentActivity(message, timestamp)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["message"] = from_str(self.message)
+        result["timestamp"] = self.timestamp.isoformat()
+        return result
+
+class TaskAgentProgressType(Enum):
+    AGENT = "agent"
+    SHELL = "shell"
+
 # Experimental: this type is part of an experimental API and may change or be removed.
 class TaskShellInfoAttachmentMode(Enum):
     """Whether the shell runs inside a managed PTY session or as an independent background
@@ -2388,10 +4877,6 @@ class TaskShellInfoAttachmentMode(Enum):
     """
     ATTACHED = "attached"
     DETACHED = "detached"
-
-class TaskInfoType(Enum):
-    AGENT = "agent"
-    SHELL = "shell"
 
 class TaskShellInfoType(Enum):
     SHELL = "shell"
@@ -2436,6 +4921,25 @@ class TasksCancelResult:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class TasksGetProgressRequest:
+    """Identifier of the background task to fetch progress for."""
+
+    id: str
+    """Task identifier (agent ID or shell ID)"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'TasksGetProgressRequest':
+        assert isinstance(obj, dict)
+        id = from_str(obj.get("id"))
+        return TasksGetProgressRequest(id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["id"] = from_str(self.id)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class TasksPromoteToBackgroundRequest:
     """Identifier of the task to promote to background mode."""
 
@@ -2470,6 +4974,21 @@ class TasksPromoteToBackgroundResult:
     def to_dict(self) -> dict:
         result: dict = {}
         result["promoted"] = from_bool(self.promoted)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class TasksRefreshResult:
+    """Refresh metadata for any detached background shells the runtime knows about. Use after a
+    long pause to pick up exit/output state for shells running outside the agent loop.
+    """
+    @staticmethod
+    def from_dict(obj: Any) -> 'TasksRefreshResult':
+        assert isinstance(obj, dict)
+        return TasksRefreshResult()
+
+    def to_dict(self) -> dict:
+        result: dict = {}
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -2628,6 +5147,48 @@ class TasksStartAgentResult:
         result["agentId"] = from_str(self.agent_id)
         return result
 
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class TasksWaitForPendingResult:
+    """Wait until all in-flight background tasks (agents + shells) and any follow-up turns
+    scheduled by their completions have settled. Returns when the runtime is fully drained or
+    after an internal timeout (default 10 minutes; configurable via
+    COPILOT_TASK_WAIT_TIMEOUT_SECONDS).
+    """
+    @staticmethod
+    def from_dict(obj: Any) -> 'TasksWaitForPendingResult':
+        assert isinstance(obj, dict)
+        return TasksWaitForPendingResult()
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class TelemetrySetFeatureOverridesRequest:
+    """Feature override key/value pairs to attach to subsequent telemetry events from this
+    session.
+    """
+    features: dict[str, str]
+    """Override key/value pairs to attach to subsequent telemetry events from this session.
+    Replaces any previously-set overrides.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'TelemetrySetFeatureOverridesRequest':
+        assert isinstance(obj, dict)
+        features = from_dict(from_str, obj.get("features"))
+        return TelemetrySetFeatureOverridesRequest(features)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["features"] = from_dict(from_str, self.features)
+        return result
+
+class TokenAuthInfoType(Enum):
+    TOKEN = "token"
+
 @dataclass
 class Tool:
     """Schema for the `Tool` type."""
@@ -2671,6 +5232,21 @@ class Tool:
         return result
 
 @dataclass
+class ToolsInitializeAndValidateResult:
+    """Resolve, build, and validate the runtime tool list for this session. Subagent sessions
+    and consumer flows that need an initialized tool set before `send` invoke this. Default
+    base-class implementation is a no-op for sessions that don't support tool validation.
+    """
+    @staticmethod
+    def from_dict(obj: Any) -> 'ToolsInitializeAndValidateResult':
+        assert isinstance(obj, dict)
+        return ToolsInitializeAndValidateResult()
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        return result
+
+@dataclass
 class ToolsListRequest:
     """Optional model identifier whose tool overrides should be applied to the listing."""
 
@@ -2690,6 +5266,14 @@ class ToolsListRequest:
         if self.model is not None:
             result["model"] = from_union([from_str, from_none], self.model)
         return result
+
+class UIAutoModeSwitchResponse(Enum):
+    """User's choice for auto-mode switching: yes (allow this turn), yes_always (allow + persist
+    as setting), or no (decline).
+    """
+    NO = "no"
+    YES = "yes"
+    YES_ALWAYS = "yes_always"
 
 @dataclass
 class UIElicitationArrayAnyOfFieldItemsAnyOf:
@@ -2800,10 +5384,158 @@ class UIElicitationSchemaPropertyNumberType(Enum):
     INTEGER = "integer"
     NUMBER = "number"
 
+class UIExitPlanModeAction(Enum):
+    """The action the user selected. Defaults to 'autopilot' when autoApproveEdits is true,
+    otherwise 'interactive'.
+    """
+    AUTOPILOT = "autopilot"
+    AUTOPILOT_FLEET = "autopilot_fleet"
+    EXIT_ONLY = "exit_only"
+    INTERACTIVE = "interactive"
+
+@dataclass
+class UIHandlePendingResult:
+    """Indicates whether the pending UI request was resolved by this call."""
+
+    success: bool
+    """True if the request was still pending and was resolved by this call. False if the request
+    ID was unknown, already resolved by another client (e.g. GitHub), expired, or otherwise
+    no longer pending.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UIHandlePendingResult':
+        assert isinstance(obj, dict)
+        success = from_bool(obj.get("success"))
+        return UIHandlePendingResult(success)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["success"] = from_bool(self.success)
+        return result
+
+@dataclass
+class UIHandlePendingSamplingRequest:
+    """Request ID of a pending `sampling.requested` event and an optional sampling result
+    payload (omit to reject).
+    """
+    request_id: str
+    """The unique request ID from the sampling.requested event"""
+
+    response: dict[str, Any] | None = None
+    """Optional sampling result payload. Omit to reject/cancel the sampling request without
+    providing a result.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UIHandlePendingSamplingRequest':
+        assert isinstance(obj, dict)
+        request_id = from_str(obj.get("requestId"))
+        response = from_union([lambda x: from_dict(lambda x: x, x), from_none], obj.get("response"))
+        return UIHandlePendingSamplingRequest(request_id, response)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["requestId"] = from_str(self.request_id)
+        if self.response is not None:
+            result["response"] = from_union([lambda x: from_dict(lambda x: x, x), from_none], self.response)
+        return result
+
+@dataclass
+class UIUserInputResponse:
+    """Schema for the `UIUserInputResponse` type."""
+
+    answer: str
+    """The user's answer text"""
+
+    was_freeform: bool
+    """True if the user typed a freeform response, false if they selected a presented choice.
+    Used by telemetry to differentiate between free text input and choice selection.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UIUserInputResponse':
+        assert isinstance(obj, dict)
+        answer = from_str(obj.get("answer"))
+        was_freeform = from_bool(obj.get("wasFreeform"))
+        return UIUserInputResponse(answer, was_freeform)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["answer"] = from_str(self.answer)
+        result["wasFreeform"] = from_bool(self.was_freeform)
+        return result
+
+@dataclass
+class UIRegisterDirectAutoModeSwitchHandlerResult:
+    """Register an in-process handler for `auto_mode_switch.requested` events. The caller still
+    attaches the actual listener via the standard event-subscription mechanism; this
+    registration solely tells the server bridge to skip its own dispatch (so a remote client
+    doesn't race the in-process handler for the same requestId).
+    """
+    handle: str
+    """Opaque handle representing the registration. Pass this same handle to
+    `unregisterDirectAutoModeSwitchHandler` when the in-process handler is no longer active.
+    Multiple registrations are reference-counted; the server bridge will only dispatch
+    auto-mode-switch requests when no handles are active.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UIRegisterDirectAutoModeSwitchHandlerResult':
+        assert isinstance(obj, dict)
+        handle = from_str(obj.get("handle"))
+        return UIRegisterDirectAutoModeSwitchHandlerResult(handle)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["handle"] = from_str(self.handle)
+        return result
+
+@dataclass
+class UIUnregisterDirectAutoModeSwitchHandlerRequest:
+    """Opaque handle previously returned by `registerDirectAutoModeSwitchHandler` to release."""
+
+    handle: str
+    """Handle previously returned by `registerDirectAutoModeSwitchHandler`"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UIUnregisterDirectAutoModeSwitchHandlerRequest':
+        assert isinstance(obj, dict)
+        handle = from_str(obj.get("handle"))
+        return UIUnregisterDirectAutoModeSwitchHandlerRequest(handle)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["handle"] = from_str(self.handle)
+        return result
+
+@dataclass
+class UIUnregisterDirectAutoModeSwitchHandlerResult:
+    """Indicates whether the handle was active and the registration count was decremented."""
+
+    unregistered: bool
+    """True if the handle was active and decremented the counter; false if the handle was
+    unknown.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UIUnregisterDirectAutoModeSwitchHandlerResult':
+        assert isinstance(obj, dict)
+        unregistered = from_bool(obj.get("unregistered"))
+        return UIUnregisterDirectAutoModeSwitchHandlerResult(unregistered)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["unregistered"] = from_bool(self.unregistered)
+        return result
+
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
 class UsageMetricsCodeChanges:
     """Aggregated code change metrics"""
+
+    files_modified: list[str]
+    """Distinct file paths modified during the session"""
 
     files_modified_count: int
     """Number of distinct files modified"""
@@ -2817,13 +5549,15 @@ class UsageMetricsCodeChanges:
     @staticmethod
     def from_dict(obj: Any) -> 'UsageMetricsCodeChanges':
         assert isinstance(obj, dict)
+        files_modified = from_list(from_str, obj.get("filesModified"))
         files_modified_count = from_int(obj.get("filesModifiedCount"))
         lines_added = from_int(obj.get("linesAdded"))
         lines_removed = from_int(obj.get("linesRemoved"))
-        return UsageMetricsCodeChanges(files_modified_count, lines_added, lines_removed)
+        return UsageMetricsCodeChanges(files_modified, files_modified_count, lines_added, lines_removed)
 
     def to_dict(self) -> dict:
         result: dict = {}
+        result["filesModified"] = from_list(from_str, self.files_modified)
         result["filesModifiedCount"] = from_int(self.files_modified_count)
         result["linesAdded"] = from_int(self.lines_added)
         result["linesRemoved"] = from_int(self.lines_removed)
@@ -2931,6 +5665,37 @@ class UsageMetricsTokenDetail:
         result["tokenCount"] = from_int(self.token_count)
         return result
 
+class UserAuthInfoType(Enum):
+    USER = "user"
+
+@dataclass
+class WorkspacesCheckpoints:
+    """Schema for the `WorkspacesCheckpoints` type."""
+
+    filename: str
+    """Filename of the checkpoint within the workspace checkpoints directory"""
+
+    number: int
+    """Checkpoint number assigned by the workspace manager"""
+
+    title: str
+    """Human-readable checkpoint title"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'WorkspacesCheckpoints':
+        assert isinstance(obj, dict)
+        filename = from_str(obj.get("filename"))
+        number = from_int(obj.get("number"))
+        title = from_str(obj.get("title"))
+        return WorkspacesCheckpoints(filename, number, title)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["filename"] = from_str(self.filename)
+        result["number"] = from_int(self.number)
+        result["title"] = from_str(self.title)
+        return result
+
 @dataclass
 class WorkspacesCreateFileRequest:
     """Relative path and UTF-8 content for the workspace file to create or overwrite."""
@@ -2954,10 +5719,6 @@ class WorkspacesCreateFileRequest:
         result["path"] = from_str(self.path)
         return result
 
-class HostType(Enum):
-    ADO = "ado"
-    GITHUB = "github"
-
 @dataclass
 class WorkspacesListFilesResult:
     """Relative paths of files stored in the session workspace files directory."""
@@ -2974,6 +5735,42 @@ class WorkspacesListFilesResult:
     def to_dict(self) -> dict:
         result: dict = {}
         result["files"] = from_list(from_str, self.files)
+        return result
+
+@dataclass
+class WorkspacesReadCheckpointRequest:
+    """Checkpoint number to read."""
+
+    number: int
+    """Checkpoint number to read"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'WorkspacesReadCheckpointRequest':
+        assert isinstance(obj, dict)
+        number = from_int(obj.get("number"))
+        return WorkspacesReadCheckpointRequest(number)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["number"] = from_int(self.number)
+        return result
+
+@dataclass
+class WorkspacesReadCheckpointResult:
+    """Checkpoint content as a UTF-8 string, or null when the checkpoint or workspace is missing."""
+
+    content: str | None = None
+    """Checkpoint content as a UTF-8 string, or null when the checkpoint or workspace is missing"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'WorkspacesReadCheckpointResult':
+        assert isinstance(obj, dict)
+        content = from_union([from_none, from_str], obj.get("content"))
+        return WorkspacesReadCheckpointResult(content)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["content"] = from_union([from_none, from_str], self.content)
         return result
 
 @dataclass
@@ -3013,6 +5810,50 @@ class WorkspacesReadFileResult:
         return result
 
 @dataclass
+class WorkspacesSaveLargePasteRequest:
+    """Pasted content to save as a UTF-8 file in the session workspace."""
+
+    content: str
+    """Pasted content to save as a UTF-8 file"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'WorkspacesSaveLargePasteRequest':
+        assert isinstance(obj, dict)
+        content = from_str(obj.get("content"))
+        return WorkspacesSaveLargePasteRequest(content)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["content"] = from_str(self.content)
+        return result
+
+@dataclass
+class Saved:
+    filename: str
+    """Filename within the workspace files directory"""
+
+    file_path: str
+    """Absolute filesystem path to the saved paste file"""
+
+    size_bytes: int
+    """Size of the saved file in bytes"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'Saved':
+        assert isinstance(obj, dict)
+        filename = from_str(obj.get("filename"))
+        file_path = from_str(obj.get("filePath"))
+        size_bytes = from_int(obj.get("sizeBytes"))
+        return Saved(filename, file_path, size_bytes)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["filename"] = from_str(self.filename)
+        result["filePath"] = from_str(self.file_path)
+        result["sizeBytes"] = from_int(self.size_bytes)
+        return result
+
+@dataclass
 class AccountGetQuotaResult:
     """Quota usage snapshots for the resolved user, keyed by quota type."""
 
@@ -3028,83 +5869,6 @@ class AccountGetQuotaResult:
     def to_dict(self) -> dict:
         result: dict = {}
         result["quotaSnapshots"] = from_dict(lambda x: to_class(AccountQuotaSnapshot, x), self.quota_snapshots)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class AgentGetCurrentResult:
-    """The currently selected custom agent, or null when using the default agent."""
-
-    agent: AgentInfo | None = None
-    """Currently selected custom agent, or null if using the default agent"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'AgentGetCurrentResult':
-        assert isinstance(obj, dict)
-        agent = from_union([AgentInfo.from_dict, from_none], obj.get("agent"))
-        return AgentGetCurrentResult(agent)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        if self.agent is not None:
-            result["agent"] = from_union([lambda x: to_class(AgentInfo, x), from_none], self.agent)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class AgentList:
-    """Custom agents available to the session."""
-
-    agents: list[AgentInfo]
-    """Available custom agents"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'AgentList':
-        assert isinstance(obj, dict)
-        agents = from_list(AgentInfo.from_dict, obj.get("agents"))
-        return AgentList(agents)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["agents"] = from_list(lambda x: to_class(AgentInfo, x), self.agents)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class AgentReloadResult:
-    """Custom agents available to the session after reloading definitions from disk."""
-
-    agents: list[AgentInfo]
-    """Reloaded custom agents"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'AgentReloadResult':
-        assert isinstance(obj, dict)
-        agents = from_list(AgentInfo.from_dict, obj.get("agents"))
-        return AgentReloadResult(agents)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["agents"] = from_list(lambda x: to_class(AgentInfo, x), self.agents)
-        return result
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-@dataclass
-class AgentSelectResult:
-    """The newly selected custom agent."""
-
-    agent: AgentInfo
-    """The newly selected custom agent"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'AgentSelectResult':
-        assert isinstance(obj, dict)
-        agent = AgentInfo.from_dict(obj.get("agent"))
-        return AgentSelectResult(agent)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["agent"] = to_class(AgentInfo, self.agent)
         return result
 
 @dataclass
@@ -3192,6 +5956,34 @@ class SlashCommandInput:
             result["preserveMultilineInput"] = from_union([from_bool, from_none], self.preserve_multiline_input)
         if self.required is not None:
             result["required"] = from_union([from_bool, from_none], self.required)
+        return result
+
+@dataclass
+class SendAttachmentDirectory:
+    """Directory attachment"""
+
+    display_name: str
+    """User-facing display name for the attachment"""
+
+    path: str
+    """Absolute directory path"""
+
+    type: SlashCommandInputCompletion
+    """Attachment type discriminator"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SendAttachmentDirectory':
+        assert isinstance(obj, dict)
+        display_name = from_str(obj.get("displayName"))
+        path = from_str(obj.get("path"))
+        type = SlashCommandInputCompletion(obj.get("type"))
+        return SendAttachmentDirectory(display_name, path, type)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["displayName"] = from_str(self.display_name)
+        result["path"] = from_str(self.path)
+        result["type"] = to_enum(SlashCommandInputCompletion, self.type)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -3332,6 +6124,72 @@ class MCPServerConfigStdio:
         return result
 
 @dataclass
+class CopilotUserResponseQuotaSnapshots:
+    """Schema for the `CopilotUserResponseQuotaSnapshotsChat` type.
+
+    Schema for the `CopilotUserResponseQuotaSnapshotsCompletions` type.
+
+    Schema for the `CopilotUserResponseQuotaSnapshotsPremiumInteractions` type.
+    """
+    entitlement: float | None = None
+    has_quota: bool | None = None
+    overage_count: float | None = None
+    overage_permitted: bool | None = None
+    percent_remaining: float | None = None
+    quota_id: str | None = None
+    quota_remaining: float | None = None
+    quota_reset_at: float | None = None
+    remaining: float | None = None
+    timestamp_utc: str | None = None
+    token_based_billing: bool | None = None
+    unlimited: bool | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'CopilotUserResponseQuotaSnapshots':
+        assert isinstance(obj, dict)
+        entitlement = from_union([from_float, from_none], obj.get("entitlement"))
+        has_quota = from_union([from_bool, from_none], obj.get("has_quota"))
+        overage_count = from_union([from_float, from_none], obj.get("overage_count"))
+        overage_permitted = from_union([from_bool, from_none], obj.get("overage_permitted"))
+        percent_remaining = from_union([from_float, from_none], obj.get("percent_remaining"))
+        quota_id = from_union([from_str, from_none], obj.get("quota_id"))
+        quota_remaining = from_union([from_float, from_none], obj.get("quota_remaining"))
+        quota_reset_at = from_union([from_float, from_none], obj.get("quota_reset_at"))
+        remaining = from_union([from_float, from_none], obj.get("remaining"))
+        timestamp_utc = from_union([from_str, from_none], obj.get("timestamp_utc"))
+        token_based_billing = from_union([from_bool, from_none], obj.get("token_based_billing"))
+        unlimited = from_union([from_bool, from_none], obj.get("unlimited"))
+        return CopilotUserResponseQuotaSnapshots(entitlement, has_quota, overage_count, overage_permitted, percent_remaining, quota_id, quota_remaining, quota_reset_at, remaining, timestamp_utc, token_based_billing, unlimited)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.entitlement is not None:
+            result["entitlement"] = from_union([to_float, from_none], self.entitlement)
+        if self.has_quota is not None:
+            result["has_quota"] = from_union([from_bool, from_none], self.has_quota)
+        if self.overage_count is not None:
+            result["overage_count"] = from_union([to_float, from_none], self.overage_count)
+        if self.overage_permitted is not None:
+            result["overage_permitted"] = from_union([from_bool, from_none], self.overage_permitted)
+        if self.percent_remaining is not None:
+            result["percent_remaining"] = from_union([to_float, from_none], self.percent_remaining)
+        if self.quota_id is not None:
+            result["quota_id"] = from_union([from_str, from_none], self.quota_id)
+        if self.quota_remaining is not None:
+            result["quota_remaining"] = from_union([to_float, from_none], self.quota_remaining)
+        if self.quota_reset_at is not None:
+            result["quota_reset_at"] = from_union([to_float, from_none], self.quota_reset_at)
+        if self.remaining is not None:
+            result["remaining"] = from_union([to_float, from_none], self.remaining)
+        if self.timestamp_utc is not None:
+            result["timestamp_utc"] = from_union([from_str, from_none], self.timestamp_utc)
+        if self.token_based_billing is not None:
+            result["token_based_billing"] = from_union([from_bool, from_none], self.token_based_billing)
+        if self.unlimited is not None:
+            result["unlimited"] = from_union([from_bool, from_none], self.unlimited)
+        return result
+
+@dataclass
 class DiscoveredMCPServer:
     """Schema for the `DiscoveredMcpServer` type."""
 
@@ -3363,6 +6221,102 @@ class DiscoveredMCPServer:
         result["source"] = to_enum(McpServerSource, self.source)
         if self.type is not None:
             result["type"] = from_union([lambda x: to_enum(DiscoveredMCPServerType, x), from_none], self.type)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class EventLogReadRequest:
+    """Cursor, batch size, and optional long-poll/filter parameters for reading session events."""
+
+    agent_scope: EventsAgentScope | None = None
+    """Agent-scope filter: 'primary' returns only main-agent events plus events whose type
+    starts with 'subagent.' (matching the typed-subscription default behavior); 'all' returns
+    events from all agents (matching wildcard-subscription behavior). Default is 'all' to
+    preserve wildcard semantics for catch-up callers.
+    """
+    cursor: str | None = None
+    """Opaque cursor returned by a previous read. Omit on the first call to start from the
+    beginning of the session's persisted history.
+    """
+    max: int | None = None
+    """Maximum number of events to return in this batch (1–1000, default 200)."""
+
+    types: list[str] | EventLogTypes | None = None
+    """Either '*' to receive all event types, or a non-empty list of event types to receive"""
+
+    wait_ms: int | None = None
+    """Milliseconds to wait for new events when the cursor is at the tail of history. 0
+    (default) returns immediately even if no events are available. Capped at 30000ms.
+    Ephemeral events that arrive during the wait are delivered in this batch but are NOT
+    replayable on a subsequent read (use a non-zero waitMs in your next call to capture
+    future ephemerals as they happen).
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'EventLogReadRequest':
+        assert isinstance(obj, dict)
+        agent_scope = from_union([EventsAgentScope, from_none], obj.get("agentScope"))
+        cursor = from_union([from_str, from_none], obj.get("cursor"))
+        max = from_union([from_int, from_none], obj.get("max"))
+        types = from_union([lambda x: from_list(from_str, x), EventLogTypes, from_none], obj.get("types"))
+        wait_ms = from_union([from_int, from_none], obj.get("waitMs"))
+        return EventLogReadRequest(agent_scope, cursor, max, types, wait_ms)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.agent_scope is not None:
+            result["agentScope"] = from_union([lambda x: to_enum(EventsAgentScope, x), from_none], self.agent_scope)
+        if self.cursor is not None:
+            result["cursor"] = from_union([from_str, from_none], self.cursor)
+        if self.max is not None:
+            result["max"] = from_union([from_int, from_none], self.max)
+        if self.types is not None:
+            result["types"] = from_union([lambda x: from_list(from_str, x), lambda x: to_enum(EventLogTypes, x), from_none], self.types)
+        if self.wait_ms is not None:
+            result["waitMs"] = from_union([from_int, from_none], self.wait_ms)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class EventsReadResult:
+    """Batch of session events returned by a read, with cursor and continuation metadata."""
+
+    cursor: str
+    """Opaque cursor for the next read. Pass back unchanged in the next read.cursor to continue
+    from where this read left off. Always present, even when no events were returned.
+    """
+    cursor_status: EventsCursorStatus
+    """Cursor status: 'ok' means the cursor was applied successfully; 'expired' means the cursor
+    referred to an event that no longer exists in history (e.g. truncated or compacted away)
+    and the read started from the beginning of the remaining history.
+    """
+    events: list[SessionEvent]
+    """Events are delivered in two batches per read: persisted events first (in append order),
+    then ephemeral events (in seq order). When `waitMs > 0` and the catch-up batches were
+    empty, post-wait events follow the same two-batch ordering. Persisted and ephemeral
+    events do not interleave within a single read.
+    """
+    has_more: bool
+    """True when the read returned `max` events and more events are available immediately. When
+    false, the next read with a non-zero `waitMs` will block until a new event arrives or the
+    wait expires.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'EventsReadResult':
+        assert isinstance(obj, dict)
+        cursor = from_str(obj.get("cursor"))
+        cursor_status = EventsCursorStatus(obj.get("cursorStatus"))
+        events = from_list(SessionEvent.from_dict, obj.get("events"))
+        has_more = from_bool(obj.get("hasMore"))
+        return EventsReadResult(cursor, cursor_status, events, has_more)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["cursor"] = from_str(self.cursor)
+        result["cursorStatus"] = to_enum(EventsCursorStatus, self.cursor_status)
+        result["events"] = from_list(lambda x: to_class(SessionEvent, x), self.events)
+        result["hasMore"] = from_bool(self.has_more)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -3570,7 +6524,7 @@ class ExternalToolTextResultForLlmContentTerminal:
     cwd: str | None = None
     """Working directory where the command was executed"""
 
-    exit_code: float | None = None
+    exit_code: int | None = None
     """Process exit code, if the command has completed"""
 
     @staticmethod
@@ -3579,7 +6533,7 @@ class ExternalToolTextResultForLlmContentTerminal:
         text = from_str(obj.get("text"))
         type = ExternalToolTextResultForLlmContentTerminalType(obj.get("type"))
         cwd = from_union([from_str, from_none], obj.get("cwd"))
-        exit_code = from_union([from_float, from_none], obj.get("exitCode"))
+        exit_code = from_union([from_int, from_none], obj.get("exitCode"))
         return ExternalToolTextResultForLlmContentTerminal(text, type, cwd, exit_code)
 
     def to_dict(self) -> dict:
@@ -3589,7 +6543,7 @@ class ExternalToolTextResultForLlmContentTerminal:
         if self.cwd is not None:
             result["cwd"] = from_union([from_str, from_none], self.cwd)
         if self.exit_code is not None:
-            result["exitCode"] = from_union([to_float, from_none], self.exit_code)
+            result["exitCode"] = from_union([from_int, from_none], self.exit_code)
         return result
 
 @dataclass
@@ -3661,8 +6615,8 @@ class SlashCommandTextResult:
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
 class HistoryCompactResult:
-    """Compaction outcome with the number of tokens and messages removed and the resulting
-    context window breakdown.
+    """Compaction outcome with the number of tokens and messages removed, summary text, and the
+    resulting context window breakdown.
     """
     messages_removed: int
     """Number of messages removed during compaction"""
@@ -3676,6 +6630,11 @@ class HistoryCompactResult:
     context_window: HistoryCompactContextWindow | None = None
     """Post-compaction context window usage breakdown"""
 
+    summary_content: str | None = None
+    """Summary text produced by compaction. Omitted when compaction did not produce a summary
+    (e.g. failure path).
+    """
+
     @staticmethod
     def from_dict(obj: Any) -> 'HistoryCompactResult':
         assert isinstance(obj, dict)
@@ -3683,7 +6642,8 @@ class HistoryCompactResult:
         success = from_bool(obj.get("success"))
         tokens_removed = from_int(obj.get("tokensRemoved"))
         context_window = from_union([HistoryCompactContextWindow.from_dict, from_none], obj.get("contextWindow"))
-        return HistoryCompactResult(messages_removed, success, tokens_removed, context_window)
+        summary_content = from_union([from_str, from_none], obj.get("summaryContent"))
+        return HistoryCompactResult(messages_removed, success, tokens_removed, context_window, summary_content)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -3692,6 +6652,176 @@ class HistoryCompactResult:
         result["tokensRemoved"] = from_int(self.tokens_removed)
         if self.context_window is not None:
             result["contextWindow"] = from_union([lambda x: to_class(HistoryCompactContextWindow, x), from_none], self.context_window)
+        if self.summary_content is not None:
+            result["summaryContent"] = from_union([from_str, from_none], self.summary_content)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class InstalledPluginSourceGithub:
+    """Schema for the `InstalledPluginSourceGithub` type."""
+
+    repo: str
+    source: FluffySource
+    """Constant value. Always "github"."""
+
+    path: str | None = None
+    ref: str | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'InstalledPluginSourceGithub':
+        assert isinstance(obj, dict)
+        repo = from_str(obj.get("repo"))
+        source = FluffySource(obj.get("source"))
+        path = from_union([from_str, from_none], obj.get("path"))
+        ref = from_union([from_str, from_none], obj.get("ref"))
+        return InstalledPluginSourceGithub(repo, source, path, ref)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["repo"] = from_str(self.repo)
+        result["source"] = to_enum(FluffySource, self.source)
+        if self.path is not None:
+            result["path"] = from_union([from_str, from_none], self.path)
+        if self.ref is not None:
+            result["ref"] = from_union([from_str, from_none], self.ref)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionInstalledPluginSourceGithub:
+    """Schema for the `SessionInstalledPluginSourceGithub` type."""
+
+    repo: str
+    source: FluffySource
+    """Constant value. Always "github"."""
+
+    path: str | None = None
+    ref: str | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionInstalledPluginSourceGithub':
+        assert isinstance(obj, dict)
+        repo = from_str(obj.get("repo"))
+        source = FluffySource(obj.get("source"))
+        path = from_union([from_str, from_none], obj.get("path"))
+        ref = from_union([from_str, from_none], obj.get("ref"))
+        return SessionInstalledPluginSourceGithub(repo, source, path, ref)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["repo"] = from_str(self.repo)
+        result["source"] = to_enum(FluffySource, self.source)
+        if self.path is not None:
+            result["path"] = from_union([from_str, from_none], self.path)
+        if self.ref is not None:
+            result["ref"] = from_union([from_str, from_none], self.ref)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class InstalledPluginSourceLocal:
+    """Schema for the `InstalledPluginSourceLocal` type."""
+
+    path: str
+    source: TentacledSource
+    """Constant value. Always "local"."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'InstalledPluginSourceLocal':
+        assert isinstance(obj, dict)
+        path = from_str(obj.get("path"))
+        source = TentacledSource(obj.get("source"))
+        return InstalledPluginSourceLocal(path, source)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["path"] = from_str(self.path)
+        result["source"] = to_enum(TentacledSource, self.source)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionInstalledPluginSourceLocal:
+    """Schema for the `SessionInstalledPluginSourceLocal` type."""
+
+    path: str
+    source: TentacledSource
+    """Constant value. Always "local"."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionInstalledPluginSourceLocal':
+        assert isinstance(obj, dict)
+        path = from_str(obj.get("path"))
+        source = TentacledSource(obj.get("source"))
+        return SessionInstalledPluginSourceLocal(path, source)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["path"] = from_str(self.path)
+        result["source"] = to_enum(TentacledSource, self.source)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class InstalledPluginSourceURL:
+    """Schema for the `InstalledPluginSourceUrl` type."""
+
+    source: StickySource
+    """Constant value. Always "url"."""
+
+    url: str
+    path: str | None = None
+    ref: str | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'InstalledPluginSourceURL':
+        assert isinstance(obj, dict)
+        source = StickySource(obj.get("source"))
+        url = from_str(obj.get("url"))
+        path = from_union([from_str, from_none], obj.get("path"))
+        ref = from_union([from_str, from_none], obj.get("ref"))
+        return InstalledPluginSourceURL(source, url, path, ref)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["source"] = to_enum(StickySource, self.source)
+        result["url"] = from_str(self.url)
+        if self.path is not None:
+            result["path"] = from_union([from_str, from_none], self.path)
+        if self.ref is not None:
+            result["ref"] = from_union([from_str, from_none], self.ref)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionInstalledPluginSourceURL:
+    """Schema for the `SessionInstalledPluginSourceUrl` type."""
+
+    source: StickySource
+    """Constant value. Always "url"."""
+
+    url: str
+    path: str | None = None
+    ref: str | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionInstalledPluginSourceURL':
+        assert isinstance(obj, dict)
+        source = StickySource(obj.get("source"))
+        url = from_str(obj.get("url"))
+        path = from_union([from_str, from_none], obj.get("path"))
+        ref = from_union([from_str, from_none], obj.get("ref"))
+        return SessionInstalledPluginSourceURL(source, url, path, ref)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["source"] = to_enum(StickySource, self.source)
+        result["url"] = from_str(self.url)
+        if self.path is not None:
+            result["path"] = from_union([from_str, from_none], self.path)
+        if self.ref is not None:
+            result["ref"] = from_union([from_str, from_none], self.ref)
         return result
 
 @dataclass
@@ -3716,8 +6846,12 @@ class InstructionsSources:
     type: InstructionsSourcesType
     """Category of instruction source — used for merge logic"""
 
-    apply_to: str | None = None
-    """Glob pattern from frontmatter — when set, this instruction applies only to matching files"""
+    apply_to: list[str] | None = None
+    """Glob pattern(s) from frontmatter — when set, this instruction applies only to matching
+    files
+    """
+    default_disabled: bool | None = None
+    """When true, this source starts disabled and must be toggled on by the user"""
 
     description: str | None = None
     """Short description (body after frontmatter) for use in instruction tables"""
@@ -3731,9 +6865,10 @@ class InstructionsSources:
         location = InstructionsSourcesLocation(obj.get("location"))
         source_path = from_str(obj.get("sourcePath"))
         type = InstructionsSourcesType(obj.get("type"))
-        apply_to = from_union([from_str, from_none], obj.get("applyTo"))
+        apply_to = from_union([lambda x: from_list(from_str, x), from_none], obj.get("applyTo"))
+        default_disabled = from_union([from_bool, from_none], obj.get("defaultDisabled"))
         description = from_union([from_str, from_none], obj.get("description"))
-        return InstructionsSources(content, id, label, location, source_path, type, apply_to, description)
+        return InstructionsSources(content, id, label, location, source_path, type, apply_to, default_disabled, description)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -3744,15 +6879,18 @@ class InstructionsSources:
         result["sourcePath"] = from_str(self.source_path)
         result["type"] = to_enum(InstructionsSourcesType, self.type)
         if self.apply_to is not None:
-            result["applyTo"] = from_union([from_str, from_none], self.apply_to)
+            result["applyTo"] = from_union([lambda x: from_list(from_str, x), from_none], self.apply_to)
+        if self.default_disabled is not None:
+            result["defaultDisabled"] = from_union([from_bool, from_none], self.default_disabled)
         if self.description is not None:
             result["description"] = from_union([from_str, from_none], self.description)
         return result
 
 @dataclass
 class LogRequest:
-    """Message text, optional severity level, persistence flag, and optional follow-up URL."""
-
+    """Message text, optional severity level, persistence flag, optional follow-up URL, and
+    optional tip.
+    """
     message: str
     """Human-readable message"""
 
@@ -3763,6 +6901,13 @@ class LogRequest:
     """Log severity level. Determines how the message is displayed in the timeline. Defaults to
     "info".
     """
+    tip: str | None = None
+    """Optional actionable tip displayed alongside the message. Only honored on `level: "info"`."""
+
+    type: str | None = None
+    """Domain category for this log entry (e.g., "mcp", "subscription", "policy", "model"). Maps
+    to `infoType`/`warningType`/`errorType` on the emitted event. Defaults to "notification".
+    """
     url: str | None = None
     """Optional URL the user can open in their browser for more details"""
 
@@ -3772,8 +6917,10 @@ class LogRequest:
         message = from_str(obj.get("message"))
         ephemeral = from_union([from_bool, from_none], obj.get("ephemeral"))
         level = from_union([SessionLogLevel, from_none], obj.get("level"))
+        tip = from_union([from_str, from_none], obj.get("tip"))
+        type = from_union([from_str, from_none], obj.get("type"))
         url = from_union([from_str, from_none], obj.get("url"))
-        return LogRequest(message, ephemeral, level, url)
+        return LogRequest(message, ephemeral, level, tip, type, url)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -3782,6 +6929,10 @@ class LogRequest:
             result["ephemeral"] = from_union([from_bool, from_none], self.ephemeral)
         if self.level is not None:
             result["level"] = from_union([lambda x: to_enum(SessionLogLevel, x), from_none], self.level)
+        if self.tip is not None:
+            result["tip"] = from_union([from_str, from_none], self.tip)
+        if self.type is not None:
+            result["type"] = from_union([from_str, from_none], self.type)
         if self.url is not None:
             result["url"] = from_union([from_str, from_none], self.url)
         return result
@@ -3977,6 +7128,42 @@ class MCPServerConfigHTTP:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class MCPSamplingExecutionResult:
+    """Outcome of an MCP sampling execution: success result, failure error, or cancellation."""
+
+    action: MCPSamplingExecutionAction
+    """Outcome of the sampling inference. 'success' produced a response; 'failure' encountered
+    an error (including agent-side rejection by content filter or criteria); 'cancelled' the
+    caller cancelled this execution via cancelSamplingExecution.
+    """
+    error: str | None = None
+    """Error description, present when action='failure'."""
+
+    result: dict[str, Any] | None = None
+    """MCP CreateMessageResult payload (with optional 'tools' extension), present when
+    action='success'. Treated as opaque at the schema layer; consumers should
+    construct/consume it per the MCP CreateMessageResult shape.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MCPSamplingExecutionResult':
+        assert isinstance(obj, dict)
+        action = MCPSamplingExecutionAction(obj.get("action"))
+        error = from_union([from_str, from_none], obj.get("error"))
+        result = from_union([lambda x: from_dict(lambda x: x, x), from_none], obj.get("result"))
+        return MCPSamplingExecutionResult(action, error, result)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["action"] = to_enum(MCPSamplingExecutionAction, self.action)
+        if self.error is not None:
+            result["error"] = from_union([from_str, from_none], self.error)
+        if self.result is not None:
+            result["result"] = from_union([lambda x: from_dict(lambda x: x, x), from_none], self.result)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class MCPServerList:
     """MCP servers configured for the session, with their connection status."""
 
@@ -3992,6 +7179,296 @@ class MCPServerList:
     def to_dict(self) -> dict:
         result: dict = {}
         result["servers"] = from_list(lambda x: to_class(MCPServer, x), self.servers)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class MCPSetEnvValueModeParams:
+    """Mode controlling how MCP server env values are resolved (`direct` or `indirect`)."""
+
+    mode: MCPSetEnvValueModeDetails
+    """How environment-variable values supplied to MCP servers are resolved. "direct" passes
+    literal string values; "indirect" treats values as references (e.g. names of environment
+    variables on the host) that the runtime resolves before launch. Defaults to the runtime's
+    startup mode; clients that intentionally launch MCP servers with literal values (e.g. CLI
+    prompt mode and ACP) set this to "direct".
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MCPSetEnvValueModeParams':
+        assert isinstance(obj, dict)
+        mode = MCPSetEnvValueModeDetails(obj.get("mode"))
+        return MCPSetEnvValueModeParams(mode)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["mode"] = to_enum(MCPSetEnvValueModeDetails, self.mode)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class MCPSetEnvValueModeResult:
+    """Env-value mode recorded on the session after the update."""
+
+    mode: MCPSetEnvValueModeDetails
+    """Mode recorded on the session after the update"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MCPSetEnvValueModeResult':
+        assert isinstance(obj, dict)
+        mode = MCPSetEnvValueModeDetails(obj.get("mode"))
+        return MCPSetEnvValueModeResult(mode)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["mode"] = to_enum(MCPSetEnvValueModeDetails, self.mode)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class MetadataContextInfoResult:
+    """Token breakdown for the session's current context window, or null if uninitialized."""
+
+    context_info: SessionContextInfo | None = None
+    """Token breakdown for the current context window, or null if the session has not yet been
+    initialized (no system prompt or tool metadata cached).
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MetadataContextInfoResult':
+        assert isinstance(obj, dict)
+        context_info = from_union([SessionContextInfo.from_dict, from_none], obj.get("contextInfo"))
+        return MetadataContextInfoResult(context_info)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.context_info is not None:
+            result["contextInfo"] = from_union([lambda x: to_class(SessionContextInfo, x), from_none], self.context_info)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionWorkingDirectoryContext:
+    """Updated working directory and git context. Emitted as the new payload of
+    `session.context_changed`.
+    """
+    cwd: str
+    """Current working directory path"""
+
+    base_commit: str | None = None
+    """Merge-base commit SHA (fork point from the remote default branch)"""
+
+    branch: str | None = None
+    """Current git branch name"""
+
+    git_root: str | None = None
+    """Root directory of the git repository, resolved via git rev-parse"""
+
+    head_commit: str | None = None
+    """Head commit of the current git branch"""
+
+    host_type: SessionContextHostType | None = None
+    """Hosting platform type of the repository"""
+
+    repository: str | None = None
+    """Repository identifier derived from the git remote URL ("owner/name" for GitHub,
+    "org/project/repo" for Azure DevOps)
+    """
+    repository_host: str | None = None
+    """Raw host string from the git remote URL (e.g. "github.com", "dev.azure.com")"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionWorkingDirectoryContext':
+        assert isinstance(obj, dict)
+        cwd = from_str(obj.get("cwd"))
+        base_commit = from_union([from_str, from_none], obj.get("baseCommit"))
+        branch = from_union([from_str, from_none], obj.get("branch"))
+        git_root = from_union([from_str, from_none], obj.get("gitRoot"))
+        head_commit = from_union([from_str, from_none], obj.get("headCommit"))
+        host_type = from_union([SessionContextHostType, from_none], obj.get("hostType"))
+        repository = from_union([from_str, from_none], obj.get("repository"))
+        repository_host = from_union([from_str, from_none], obj.get("repositoryHost"))
+        return SessionWorkingDirectoryContext(cwd, base_commit, branch, git_root, head_commit, host_type, repository, repository_host)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["cwd"] = from_str(self.cwd)
+        if self.base_commit is not None:
+            result["baseCommit"] = from_union([from_str, from_none], self.base_commit)
+        if self.branch is not None:
+            result["branch"] = from_union([from_str, from_none], self.branch)
+        if self.git_root is not None:
+            result["gitRoot"] = from_union([from_str, from_none], self.git_root)
+        if self.head_commit is not None:
+            result["headCommit"] = from_union([from_str, from_none], self.head_commit)
+        if self.host_type is not None:
+            result["hostType"] = from_union([lambda x: to_enum(SessionContextHostType, x), from_none], self.host_type)
+        if self.repository is not None:
+            result["repository"] = from_union([from_str, from_none], self.repository)
+        if self.repository_host is not None:
+            result["repositoryHost"] = from_union([from_str, from_none], self.repository_host)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionContext:
+    """Schema for the `SessionContext` type.
+
+    Optional working-directory context used to score session relevance. When omitted the
+    most-recently-modified session wins.
+    """
+    cwd: str
+    """Most recent working directory for this session"""
+
+    branch: str | None = None
+    """Active git branch"""
+
+    git_root: str | None = None
+    """Git repository root, if the cwd was inside a git repo"""
+
+    host_type: SessionContextHostType | None = None
+    """Repository host type"""
+
+    repository: str | None = None
+    """Repository slug in `owner/name` form, when known"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionContext':
+        assert isinstance(obj, dict)
+        cwd = from_str(obj.get("cwd"))
+        branch = from_union([from_str, from_none], obj.get("branch"))
+        git_root = from_union([from_str, from_none], obj.get("gitRoot"))
+        host_type = from_union([SessionContextHostType, from_none], obj.get("hostType"))
+        repository = from_union([from_str, from_none], obj.get("repository"))
+        return SessionContext(cwd, branch, git_root, host_type, repository)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["cwd"] = from_str(self.cwd)
+        if self.branch is not None:
+            result["branch"] = from_union([from_str, from_none], self.branch)
+        if self.git_root is not None:
+            result["gitRoot"] = from_union([from_str, from_none], self.git_root)
+        if self.host_type is not None:
+            result["hostType"] = from_union([lambda x: to_enum(SessionContextHostType, x), from_none], self.host_type)
+        if self.repository is not None:
+            result["repository"] = from_union([from_str, from_none], self.repository)
+        return result
+
+@dataclass
+class Workspace:
+    id: UUID
+    branch: str | None = None
+    chronicle_sync_dismissed: bool | None = None
+    created_at: datetime | None = None
+    cwd: str | None = None
+    git_root: str | None = None
+    host_type: SessionContextHostType | None = None
+    mc_last_event_id: str | None = None
+    mc_session_id: str | None = None
+    mc_task_id: str | None = None
+    name: str | None = None
+    remote_steerable: bool | None = None
+    repository: str | None = None
+    summary_count: int | None = None
+    updated_at: datetime | None = None
+    user_named: bool | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'Workspace':
+        assert isinstance(obj, dict)
+        id = UUID(obj.get("id"))
+        branch = from_union([from_str, from_none], obj.get("branch"))
+        chronicle_sync_dismissed = from_union([from_bool, from_none], obj.get("chronicle_sync_dismissed"))
+        created_at = from_union([from_datetime, from_none], obj.get("created_at"))
+        cwd = from_union([from_str, from_none], obj.get("cwd"))
+        git_root = from_union([from_str, from_none], obj.get("git_root"))
+        host_type = from_union([SessionContextHostType, from_none], obj.get("host_type"))
+        mc_last_event_id = from_union([from_str, from_none], obj.get("mc_last_event_id"))
+        mc_session_id = from_union([from_str, from_none], obj.get("mc_session_id"))
+        mc_task_id = from_union([from_str, from_none], obj.get("mc_task_id"))
+        name = from_union([from_str, from_none], obj.get("name"))
+        remote_steerable = from_union([from_bool, from_none], obj.get("remote_steerable"))
+        repository = from_union([from_str, from_none], obj.get("repository"))
+        summary_count = from_union([from_int, from_none], obj.get("summary_count"))
+        updated_at = from_union([from_datetime, from_none], obj.get("updated_at"))
+        user_named = from_union([from_bool, from_none], obj.get("user_named"))
+        return Workspace(id, branch, chronicle_sync_dismissed, created_at, cwd, git_root, host_type, mc_last_event_id, mc_session_id, mc_task_id, name, remote_steerable, repository, summary_count, updated_at, user_named)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["id"] = str(self.id)
+        if self.branch is not None:
+            result["branch"] = from_union([from_str, from_none], self.branch)
+        if self.chronicle_sync_dismissed is not None:
+            result["chronicle_sync_dismissed"] = from_union([from_bool, from_none], self.chronicle_sync_dismissed)
+        if self.created_at is not None:
+            result["created_at"] = from_union([lambda x: x.isoformat(), from_none], self.created_at)
+        if self.cwd is not None:
+            result["cwd"] = from_union([from_str, from_none], self.cwd)
+        if self.git_root is not None:
+            result["git_root"] = from_union([from_str, from_none], self.git_root)
+        if self.host_type is not None:
+            result["host_type"] = from_union([lambda x: to_enum(SessionContextHostType, x), from_none], self.host_type)
+        if self.mc_last_event_id is not None:
+            result["mc_last_event_id"] = from_union([from_str, from_none], self.mc_last_event_id)
+        if self.mc_session_id is not None:
+            result["mc_session_id"] = from_union([from_str, from_none], self.mc_session_id)
+        if self.mc_task_id is not None:
+            result["mc_task_id"] = from_union([from_str, from_none], self.mc_task_id)
+        if self.name is not None:
+            result["name"] = from_union([from_str, from_none], self.name)
+        if self.remote_steerable is not None:
+            result["remote_steerable"] = from_union([from_bool, from_none], self.remote_steerable)
+        if self.repository is not None:
+            result["repository"] = from_union([from_str, from_none], self.repository)
+        if self.summary_count is not None:
+            result["summary_count"] = from_union([from_int, from_none], self.summary_count)
+        if self.updated_at is not None:
+            result["updated_at"] = from_union([lambda x: x.isoformat(), from_none], self.updated_at)
+        if self.user_named is not None:
+            result["user_named"] = from_union([from_bool, from_none], self.user_named)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class MetadataSnapshotRemoteMetadata:
+    """Remote-session-specific metadata. Populated only when `isRemote` is true. Fields are
+    immutable for the lifetime of the session.
+    """
+    repository: MetadataSnapshotRemoteMetadataRepository
+    """The repository the remote session targets."""
+
+    pull_request_number: int | None = None
+    """The pull request number the remote session is associated with, if any."""
+
+    resource_id: str | None = None
+    """The original resource identifier (task ID or PR node ID), preserved across event-replay
+    reconstructions. Falls back to `sessionId` when absent.
+    """
+    task_type: MetadataSnapshotRemoteMetadataTaskType | None = None
+    """Whether the remote task originated from Copilot Coding Agent (cca) or a CLI `--remote`
+    invocation.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MetadataSnapshotRemoteMetadata':
+        assert isinstance(obj, dict)
+        repository = MetadataSnapshotRemoteMetadataRepository.from_dict(obj.get("repository"))
+        pull_request_number = from_union([from_int, from_none], obj.get("pullRequestNumber"))
+        resource_id = from_union([from_str, from_none], obj.get("resourceId"))
+        task_type = from_union([MetadataSnapshotRemoteMetadataTaskType, from_none], obj.get("taskType"))
+        return MetadataSnapshotRemoteMetadata(repository, pull_request_number, resource_id, task_type)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["repository"] = to_class(MetadataSnapshotRemoteMetadataRepository, self.repository)
+        if self.pull_request_number is not None:
+            result["pullRequestNumber"] = from_union([from_int, from_none], self.pull_request_number)
+        if self.resource_id is not None:
+            result["resourceId"] = from_union([from_str, from_none], self.resource_id)
+        if self.task_type is not None:
+            result["taskType"] = from_union([lambda x: to_enum(MetadataSnapshotRemoteMetadataTaskType, x), from_none], self.task_type)
         return result
 
 @dataclass
@@ -4118,6 +7595,28 @@ class ModelCapabilitiesOverrideLimits:
         return result
 
 @dataclass
+class PendingPermissionRequestList:
+    """List of pending permission requests reconstructed from event history."""
+
+    items: list[PendingPermissionRequest]
+    """Pending permission prompts reconstructed from the session's event history. Equivalent to
+    the set of `permission.requested` events that have not yet been followed by a matching
+    `permission.completed` event. Used by clients (e.g. the CLI) to hydrate UI for prompts
+    that were emitted before the client attached to the session.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PendingPermissionRequestList':
+        assert isinstance(obj, dict)
+        items = from_list(PendingPermissionRequest.from_dict, obj.get("items"))
+        return PendingPermissionRequestList(items)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["items"] = from_list(lambda x: to_class(PendingPermissionRequest, x), self.items)
+        return result
+
+@dataclass
 class PermissionDecisionApproveForLocationApprovalCommands:
     """Schema for the `PermissionDecisionApproveForLocationApprovalCommands` type."""
 
@@ -4164,6 +7663,29 @@ class PermissionDecisionApproveForSessionApprovalCommands:
         return result
 
 @dataclass
+class UserToolSessionApprovalCommands:
+    """Schema for the `UserToolSessionApprovalCommands` type."""
+
+    command_identifiers: list[str]
+    """Command identifiers approved by the user"""
+
+    kind: PermissionDecisionApproveForLocationApprovalCommandsKind
+    """Command approval kind"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UserToolSessionApprovalCommands':
+        assert isinstance(obj, dict)
+        command_identifiers = from_list(from_str, obj.get("commandIdentifiers"))
+        kind = PermissionDecisionApproveForLocationApprovalCommandsKind(obj.get("kind"))
+        return UserToolSessionApprovalCommands(command_identifiers, kind)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["commandIdentifiers"] = from_list(from_str, self.command_identifiers)
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalCommandsKind, self.kind)
+        return result
+
+@dataclass
 class PermissionDecisionApproveForLocationApprovalCustomTool:
     """Schema for the `PermissionDecisionApproveForLocationApprovalCustomTool` type."""
 
@@ -4202,6 +7724,29 @@ class PermissionDecisionApproveForSessionApprovalCustomTool:
         kind = PermissionDecisionApproveForLocationApprovalCustomToolKind(obj.get("kind"))
         tool_name = from_str(obj.get("toolName"))
         return PermissionDecisionApproveForSessionApprovalCustomTool(kind, tool_name)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalCustomToolKind, self.kind)
+        result["toolName"] = from_str(self.tool_name)
+        return result
+
+@dataclass
+class UserToolSessionApprovalCustomTool:
+    """Schema for the `UserToolSessionApprovalCustomTool` type."""
+
+    kind: PermissionDecisionApproveForLocationApprovalCustomToolKind
+    """Custom tool approval kind"""
+
+    tool_name: str
+    """Custom tool name"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UserToolSessionApprovalCustomTool':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionApproveForLocationApprovalCustomToolKind(obj.get("kind"))
+        tool_name = from_str(obj.get("toolName"))
+        return UserToolSessionApprovalCustomTool(kind, tool_name)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -4318,6 +7863,34 @@ class PermissionDecisionApproveForSessionApprovalMCP:
         return result
 
 @dataclass
+class UserToolSessionApprovalMCP:
+    """Schema for the `UserToolSessionApprovalMcp` type."""
+
+    kind: PermissionDecisionApproveForLocationApprovalMCPKind
+    """MCP tool approval kind"""
+
+    server_name: str
+    """MCP server name"""
+
+    tool_name: str | None = None
+    """Optional MCP tool name, or null for all tools on the server"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UserToolSessionApprovalMCP':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionApproveForLocationApprovalMCPKind(obj.get("kind"))
+        server_name = from_str(obj.get("serverName"))
+        tool_name = from_union([from_none, from_str], obj.get("toolName"))
+        return UserToolSessionApprovalMCP(kind, server_name, tool_name)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalMCPKind, self.kind)
+        result["serverName"] = from_str(self.server_name)
+        result["toolName"] = from_union([from_none, from_str], self.tool_name)
+        return result
+
+@dataclass
 class PermissionDecisionApproveForLocationApprovalMCPSampling:
     """Schema for the `PermissionDecisionApproveForLocationApprovalMcpSampling` type."""
 
@@ -4400,6 +7973,24 @@ class PermissionDecisionApproveForSessionApprovalMemory:
         return result
 
 @dataclass
+class UserToolSessionApprovalMemory:
+    """Schema for the `UserToolSessionApprovalMemory` type."""
+
+    kind: PermissionDecisionApproveForLocationApprovalMemoryKind
+    """Memory approval kind"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UserToolSessionApprovalMemory':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionApproveForLocationApprovalMemoryKind(obj.get("kind"))
+        return UserToolSessionApprovalMemory(kind)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalMemoryKind, self.kind)
+        return result
+
+@dataclass
 class PermissionDecisionApproveForLocationApprovalRead:
     """Schema for the `PermissionDecisionApproveForLocationApprovalRead` type."""
 
@@ -4429,6 +8020,24 @@ class PermissionDecisionApproveForSessionApprovalRead:
         assert isinstance(obj, dict)
         kind = PermissionDecisionApproveForLocationApprovalReadKind(obj.get("kind"))
         return PermissionDecisionApproveForSessionApprovalRead(kind)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalReadKind, self.kind)
+        return result
+
+@dataclass
+class UserToolSessionApprovalRead:
+    """Schema for the `UserToolSessionApprovalRead` type."""
+
+    kind: PermissionDecisionApproveForLocationApprovalReadKind
+    """Read approval kind"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UserToolSessionApprovalRead':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionApproveForLocationApprovalReadKind(obj.get("kind"))
+        return UserToolSessionApprovalRead(kind)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -4472,11 +8081,29 @@ class PermissionDecisionApproveForSessionApprovalWrite:
         return result
 
 @dataclass
+class UserToolSessionApprovalWrite:
+    """Schema for the `UserToolSessionApprovalWrite` type."""
+
+    kind: PermissionDecisionApproveForLocationApprovalWriteKind
+    """Write approval kind"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UserToolSessionApprovalWrite':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionApproveForLocationApprovalWriteKind(obj.get("kind"))
+        return UserToolSessionApprovalWrite(kind)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalWriteKind, self.kind)
+        return result
+
+@dataclass
 class PermissionDecisionApproveOnce:
     """Schema for the `PermissionDecisionApproveOnce` type."""
 
     kind: PermissionDecisionApproveOnceKind
-    """The permission request was approved for this one instance"""
+    """Approve this single request only"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecisionApproveOnce':
@@ -4494,10 +8121,10 @@ class PermissionDecisionApprovePermanently:
     """Schema for the `PermissionDecisionApprovePermanently` type."""
 
     domain: str
-    """The URL domain to approve permanently"""
+    """URL domain to approve permanently"""
 
     kind: PermissionDecisionApprovePermanentlyKind
-    """Approved and persisted across sessions"""
+    """Approve and persist across sessions (URL prompts only)"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecisionApprovePermanently':
@@ -4513,14 +8140,236 @@ class PermissionDecisionApprovePermanently:
         return result
 
 @dataclass
-class PermissionDecisionReject:
-    """Schema for the `PermissionDecisionReject` type."""
+class PermissionDecisionApproved:
+    """Schema for the `PermissionDecisionApproved` type."""
 
-    kind: PermissionDecisionRejectKind
+    kind: PermissionDecisionApprovedKind
+    """The permission request was approved"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApproved':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionApprovedKind(obj.get("kind"))
+        return PermissionDecisionApproved(kind)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionApprovedKind, self.kind)
+        return result
+
+@dataclass
+class PermissionDecisionApprovedForLocation:
+    """Schema for the `PermissionDecisionApprovedForLocation` type."""
+
+    approval: UserToolSessionApproval
+    """The approval to persist for this location"""
+
+    kind: PermissionDecisionApprovedForLocationKind
+    """Approved and persisted for this project location"""
+
+    location_key: str
+    """The location key (git root or cwd) to persist the approval to"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForLocation':
+        assert isinstance(obj, dict)
+        approval = UserToolSessionApproval.from_dict(obj.get("approval"))
+        kind = PermissionDecisionApprovedForLocationKind(obj.get("kind"))
+        location_key = from_str(obj.get("locationKey"))
+        return PermissionDecisionApprovedForLocation(approval, kind, location_key)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["approval"] = to_class(UserToolSessionApproval, self.approval)
+        result["kind"] = to_enum(PermissionDecisionApprovedForLocationKind, self.kind)
+        result["locationKey"] = from_str(self.location_key)
+        return result
+
+@dataclass
+class PermissionDecisionApprovedForSession:
+    """Schema for the `PermissionDecisionApprovedForSession` type."""
+
+    approval: UserToolSessionApproval
+    """The approval to add as a session-scoped rule"""
+
+    kind: PermissionDecisionApprovedForSessionKind
+    """Approved and remembered for the rest of the session"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovedForSession':
+        assert isinstance(obj, dict)
+        approval = UserToolSessionApproval.from_dict(obj.get("approval"))
+        kind = PermissionDecisionApprovedForSessionKind(obj.get("kind"))
+        return PermissionDecisionApprovedForSession(approval, kind)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["approval"] = to_class(UserToolSessionApproval, self.approval)
+        result["kind"] = to_enum(PermissionDecisionApprovedForSessionKind, self.kind)
+        return result
+
+@dataclass
+class PermissionDecisionCancelled:
+    """Schema for the `PermissionDecisionCancelled` type."""
+
+    kind: PermissionDecisionCancelledKind
+    """The permission request was cancelled before a response was used"""
+
+    reason: str | None = None
+    """Optional explanation of why the request was cancelled"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionCancelled':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionCancelledKind(obj.get("kind"))
+        reason = from_union([from_str, from_none], obj.get("reason"))
+        return PermissionDecisionCancelled(kind, reason)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionCancelledKind, self.kind)
+        if self.reason is not None:
+            result["reason"] = from_union([from_str, from_none], self.reason)
+        return result
+
+@dataclass
+class PermissionDecisionDeniedByContentExclusionPolicy:
+    """Schema for the `PermissionDecisionDeniedByContentExclusionPolicy` type."""
+
+    kind: PermissionDecisionDeniedByContentExclusionPolicyKind
+    """Denied by the organization's content exclusion policy"""
+
+    message: str
+    """Human-readable explanation of why the path was excluded"""
+
+    path: str
+    """File path that triggered the exclusion"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionDeniedByContentExclusionPolicy':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionDeniedByContentExclusionPolicyKind(obj.get("kind"))
+        message = from_str(obj.get("message"))
+        path = from_str(obj.get("path"))
+        return PermissionDecisionDeniedByContentExclusionPolicy(kind, message, path)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionDeniedByContentExclusionPolicyKind, self.kind)
+        result["message"] = from_str(self.message)
+        result["path"] = from_str(self.path)
+        return result
+
+@dataclass
+class PermissionDecisionDeniedByPermissionRequestHook:
+    """Schema for the `PermissionDecisionDeniedByPermissionRequestHook` type."""
+
+    kind: PermissionDecisionDeniedByPermissionRequestHookKind
+    """Denied by a permission request hook registered by an extension or plugin"""
+
+    interrupt: bool | None = None
+    """Whether to interrupt the current agent turn"""
+
+    message: str | None = None
+    """Optional message from the hook explaining the denial"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionDeniedByPermissionRequestHook':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionDeniedByPermissionRequestHookKind(obj.get("kind"))
+        interrupt = from_union([from_bool, from_none], obj.get("interrupt"))
+        message = from_union([from_str, from_none], obj.get("message"))
+        return PermissionDecisionDeniedByPermissionRequestHook(kind, interrupt, message)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionDeniedByPermissionRequestHookKind, self.kind)
+        if self.interrupt is not None:
+            result["interrupt"] = from_union([from_bool, from_none], self.interrupt)
+        if self.message is not None:
+            result["message"] = from_union([from_str, from_none], self.message)
+        return result
+
+@dataclass
+class PermissionDecisionDeniedByRules:
+    """Schema for the `PermissionDecisionDeniedByRules` type."""
+
+    kind: PermissionDecisionDeniedByRulesKind
+    """Denied because approval rules explicitly blocked it"""
+
+    rules: list[PermissionRule]
+    """Rules that denied the request"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionDeniedByRules':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionDeniedByRulesKind(obj.get("kind"))
+        rules = from_list(PermissionRule.from_dict, obj.get("rules"))
+        return PermissionDecisionDeniedByRules(kind, rules)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionDeniedByRulesKind, self.kind)
+        result["rules"] = from_list(lambda x: to_class(PermissionRule, x), self.rules)
+        return result
+
+@dataclass
+class PermissionDecisionDeniedInteractivelyByUser:
+    """Schema for the `PermissionDecisionDeniedInteractivelyByUser` type."""
+
+    kind: PermissionDecisionDeniedInteractivelyByUserKind
     """Denied by the user during an interactive prompt"""
 
     feedback: str | None = None
     """Optional feedback from the user explaining the denial"""
+
+    force_reject: bool | None = None
+    """Whether to force-reject the current agent turn"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionDeniedInteractivelyByUser':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionDeniedInteractivelyByUserKind(obj.get("kind"))
+        feedback = from_union([from_str, from_none], obj.get("feedback"))
+        force_reject = from_union([from_bool, from_none], obj.get("forceReject"))
+        return PermissionDecisionDeniedInteractivelyByUser(kind, feedback, force_reject)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionDeniedInteractivelyByUserKind, self.kind)
+        if self.feedback is not None:
+            result["feedback"] = from_union([from_str, from_none], self.feedback)
+        if self.force_reject is not None:
+            result["forceReject"] = from_union([from_bool, from_none], self.force_reject)
+        return result
+
+@dataclass
+class PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser:
+    """Schema for the `PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser` type."""
+
+    kind: PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUserKind
+    """Denied because no approval rule matched and user confirmation was unavailable"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUserKind(obj.get("kind"))
+        return PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser(kind)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUserKind, self.kind)
+        return result
+
+@dataclass
+class PermissionDecisionReject:
+    """Schema for the `PermissionDecisionReject` type."""
+
+    kind: PermissionDecisionRejectKind
+    """Reject the request"""
+
+    feedback: str | None = None
+    """Optional feedback explaining the rejection"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecisionReject':
@@ -4541,7 +8390,7 @@ class PermissionDecisionUserNotAvailable:
     """Schema for the `PermissionDecisionUserNotAvailable` type."""
 
     kind: PermissionDecisionUserNotAvailableKind
-    """Denied because user confirmation was unavailable"""
+    """No user is available to confirm the request"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecisionUserNotAvailable':
@@ -4552,6 +8401,76 @@ class PermissionDecisionUserNotAvailable:
     def to_dict(self) -> dict:
         result: dict = {}
         result["kind"] = to_enum(PermissionDecisionUserNotAvailableKind, self.kind)
+        return result
+
+@dataclass
+class PermissionsConfigureAdditionalContentExclusionPolicyRule:
+    """Schema for the `PermissionsConfigureAdditionalContentExclusionPolicyRule` type."""
+
+    paths: list[str]
+    source: PermissionsConfigureAdditionalContentExclusionPolicyRuleSource
+    """Schema for the `PermissionsConfigureAdditionalContentExclusionPolicyRuleSource` type."""
+
+    if_any_match: list[str] | None = None
+    if_none_match: list[str] | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsConfigureAdditionalContentExclusionPolicyRule':
+        assert isinstance(obj, dict)
+        paths = from_list(from_str, obj.get("paths"))
+        source = PermissionsConfigureAdditionalContentExclusionPolicyRuleSource.from_dict(obj.get("source"))
+        if_any_match = from_union([lambda x: from_list(from_str, x), from_none], obj.get("ifAnyMatch"))
+        if_none_match = from_union([lambda x: from_list(from_str, x), from_none], obj.get("ifNoneMatch"))
+        return PermissionsConfigureAdditionalContentExclusionPolicyRule(paths, source, if_any_match, if_none_match)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["paths"] = from_list(from_str, self.paths)
+        result["source"] = to_class(PermissionsConfigureAdditionalContentExclusionPolicyRuleSource, self.source)
+        if self.if_any_match is not None:
+            result["ifAnyMatch"] = from_union([lambda x: from_list(from_str, x), from_none], self.if_any_match)
+        if self.if_none_match is not None:
+            result["ifNoneMatch"] = from_union([lambda x: from_list(from_str, x), from_none], self.if_none_match)
+        return result
+
+@dataclass
+class PermissionsModifyRulesParams:
+    """Scope and add/remove instructions for modifying session- or location-scoped permission
+    rules.
+    """
+    scope: PermissionsModifyRulesScope
+    """Whether the change applies to ephemeral session-scoped rules (cleared at session end) or
+    to location-scoped rules persisted via the location-permissions config file.
+    """
+    add: list[PermissionRule] | None = None
+    """Rules to add to the scope. Applied before `remove`/`removeAll`."""
+
+    remove: list[PermissionRule] | None = None
+    """Specific rules to remove from the scope. Ignored when `removeAll` is true."""
+
+    remove_all: bool | None = None
+    """When true, removes every rule currently in the scope (after any `add` is applied). Useful
+    for clearing the location scope wholesale.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsModifyRulesParams':
+        assert isinstance(obj, dict)
+        scope = PermissionsModifyRulesScope(obj.get("scope"))
+        add = from_union([lambda x: from_list(PermissionRule.from_dict, x), from_none], obj.get("add"))
+        remove = from_union([lambda x: from_list(PermissionRule.from_dict, x), from_none], obj.get("remove"))
+        remove_all = from_union([from_bool, from_none], obj.get("removeAll"))
+        return PermissionsModifyRulesParams(scope, add, remove, remove_all)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["scope"] = to_enum(PermissionsModifyRulesScope, self.scope)
+        if self.add is not None:
+            result["add"] = from_union([lambda x: from_list(lambda x: to_class(PermissionRule, x), x), from_none], self.add)
+        if self.remove is not None:
+            result["remove"] = from_union([lambda x: from_list(lambda x: to_class(PermissionRule, x), x), from_none], self.remove)
+        if self.remove_all is not None:
+            result["removeAll"] = from_union([from_bool, from_none], self.remove_all)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -4573,21 +8492,48 @@ class PluginList:
         result["plugins"] = from_list(lambda x: to_class(Plugin, x), self.plugins)
         return result
 
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class QueuePendingItems:
+    """Schema for the `QueuePendingItems` type."""
+
+    display_text: str
+    """Human-readable text to display for this queue entry in the UI"""
+
+    kind: QueuePendingItemsKind
+    """Whether this item is a queued user message or a queued slash command / model change"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'QueuePendingItems':
+        assert isinstance(obj, dict)
+        display_text = from_str(obj.get("displayText"))
+        kind = QueuePendingItemsKind(obj.get("kind"))
+        return QueuePendingItems(display_text, kind)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["displayText"] = from_str(self.display_text)
+        result["kind"] = to_enum(QueuePendingItemsKind, self.kind)
+        return result
+
 @dataclass
 class QueuedCommandResult:
-    """Result of the queued command execution
+    """Result of the queued command execution.
 
     Schema for the `QueuedCommandHandled` type.
 
     Schema for the `QueuedCommandNotHandled` type.
     """
     handled: bool
-    """The command was handled
+    """The host actually executed the queued command.
 
-    The command was not handled
+    The host did not execute the queued command. Unblocks the queue without claiming the
+    command was processed (e.g. when the handler threw before completing).
     """
     stop_processing_queue: bool | None = None
-    """If true, stop processing remaining queued items"""
+    """When true, the runtime will not process subsequent queued commands until a new request
+    comes in.
+    """
 
     @staticmethod
     def from_dict(obj: Any) -> 'QueuedCommandResult':
@@ -4624,6 +8570,179 @@ class RemoteEnableRequest:
         result: dict = {}
         if self.mode is not None:
             result["mode"] = from_union([lambda x: to_enum(RemoteSessionMode, x), from_none], self.mode)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class ScheduleList:
+    """Snapshot of the currently active recurring prompts for this session."""
+
+    entries: list[ScheduleEntry]
+    """Active scheduled prompts, ordered by id."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ScheduleList':
+        assert isinstance(obj, dict)
+        entries = from_list(ScheduleEntry.from_dict, obj.get("entries"))
+        return ScheduleList(entries)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["entries"] = from_list(lambda x: to_class(ScheduleEntry, x), self.entries)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class ScheduleStopResult:
+    """Remove a scheduled prompt by id. The result entry is omitted if the id was unknown."""
+
+    entry: ScheduleEntry | None = None
+    """The removed entry, or omitted if no entry matched."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ScheduleStopResult':
+        assert isinstance(obj, dict)
+        entry = from_union([ScheduleEntry.from_dict, from_none], obj.get("entry"))
+        return ScheduleStopResult(entry)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.entry is not None:
+            result["entry"] = from_union([lambda x: to_class(ScheduleEntry, x), from_none], self.entry)
+        return result
+
+@dataclass
+class SendAttachmentSelectionDetails:
+    """Position range of the selection within the file"""
+
+    end: SendAttachmentSelectionDetailsEnd
+    """End position of the selection"""
+
+    start: SendAttachmentSelectionDetailsStart
+    """Start position of the selection"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SendAttachmentSelectionDetails':
+        assert isinstance(obj, dict)
+        end = SendAttachmentSelectionDetailsEnd.from_dict(obj.get("end"))
+        start = SendAttachmentSelectionDetailsStart.from_dict(obj.get("start"))
+        return SendAttachmentSelectionDetails(end, start)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["end"] = to_class(SendAttachmentSelectionDetailsEnd, self.end)
+        result["start"] = to_class(SendAttachmentSelectionDetailsStart, self.start)
+        return result
+
+@dataclass
+class SendAttachmentBlob:
+    """Blob attachment with inline base64-encoded data"""
+
+    data: str
+    """Base64-encoded content"""
+
+    mime_type: str
+    """MIME type of the inline data"""
+
+    type: SendAttachmentBlobType
+    """Attachment type discriminator"""
+
+    display_name: str | None = None
+    """User-facing display name for the attachment"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SendAttachmentBlob':
+        assert isinstance(obj, dict)
+        data = from_str(obj.get("data"))
+        mime_type = from_str(obj.get("mimeType"))
+        type = SendAttachmentBlobType(obj.get("type"))
+        display_name = from_union([from_str, from_none], obj.get("displayName"))
+        return SendAttachmentBlob(data, mime_type, type, display_name)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["data"] = from_str(self.data)
+        result["mimeType"] = from_str(self.mime_type)
+        result["type"] = to_enum(SendAttachmentBlobType, self.type)
+        if self.display_name is not None:
+            result["displayName"] = from_union([from_str, from_none], self.display_name)
+        return result
+
+@dataclass
+class SendAttachmentFile:
+    """File attachment"""
+
+    display_name: str
+    """User-facing display name for the attachment"""
+
+    path: str
+    """Absolute file path"""
+
+    type: SendAttachmentFileType
+    """Attachment type discriminator"""
+
+    line_range: SendAttachmentFileLineRange | None = None
+    """Optional line range to scope the attachment to a specific section of the file"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SendAttachmentFile':
+        assert isinstance(obj, dict)
+        display_name = from_str(obj.get("displayName"))
+        path = from_str(obj.get("path"))
+        type = SendAttachmentFileType(obj.get("type"))
+        line_range = from_union([SendAttachmentFileLineRange.from_dict, from_none], obj.get("lineRange"))
+        return SendAttachmentFile(display_name, path, type, line_range)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["displayName"] = from_str(self.display_name)
+        result["path"] = from_str(self.path)
+        result["type"] = to_enum(SendAttachmentFileType, self.type)
+        if self.line_range is not None:
+            result["lineRange"] = from_union([lambda x: to_class(SendAttachmentFileLineRange, x), from_none], self.line_range)
+        return result
+
+@dataclass
+class SendAttachmentGithubReference:
+    """GitHub issue, pull request, or discussion reference"""
+
+    number: int
+    """Issue, pull request, or discussion number"""
+
+    reference_type: SendAttachmentGithubReferenceTypeEnum
+    """Type of GitHub reference"""
+
+    state: str
+    """Current state of the referenced item (e.g., open, closed, merged)"""
+
+    title: str
+    """Title of the referenced item"""
+
+    type: SendAttachmentGithubReferenceType
+    """Attachment type discriminator"""
+
+    url: str
+    """URL to the referenced item on GitHub"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SendAttachmentGithubReference':
+        assert isinstance(obj, dict)
+        number = from_int(obj.get("number"))
+        reference_type = SendAttachmentGithubReferenceTypeEnum(obj.get("referenceType"))
+        state = from_str(obj.get("state"))
+        title = from_str(obj.get("title"))
+        type = SendAttachmentGithubReferenceType(obj.get("type"))
+        url = from_str(obj.get("url"))
+        return SendAttachmentGithubReference(number, reference_type, state, title, type, url)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["number"] = from_int(self.number)
+        result["referenceType"] = to_enum(SendAttachmentGithubReferenceTypeEnum, self.reference_type)
+        result["state"] = from_str(self.state)
+        result["title"] = from_str(self.title)
+        result["type"] = to_enum(SendAttachmentGithubReferenceType, self.type)
+        result["url"] = from_str(self.url)
         return result
 
 @dataclass
@@ -4762,6 +8881,35 @@ class SessionFSSqliteQueryRequest:
             result["params"] = from_union([lambda x: from_dict(lambda x: from_union([from_none, to_float, from_str], x), x), from_none], self.params)
         return result
 
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsListRequest:
+    """Optional metadata-load limit and context filter applied to the returned sessions."""
+
+    filter: Filter | None = None
+    """Optional filter applied to the returned sessions"""
+
+    metadata_limit: int | None = None
+    """When provided, only the first N sessions (sorted by modification time, newest first) load
+    full metadata; remaining sessions return basic info only. Use 0 to return only basic info
+    for every session.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsListRequest':
+        assert isinstance(obj, dict)
+        filter = from_union([Filter.from_dict, from_none], obj.get("filter"))
+        metadata_limit = from_union([from_int, from_none], obj.get("metadataLimit"))
+        return SessionsListRequest(filter, metadata_limit)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.filter is not None:
+            result["filter"] = from_union([lambda x: to_class(Filter, x), from_none], self.filter)
+        if self.metadata_limit is not None:
+            result["metadataLimit"] = from_union([from_int, from_none], self.metadata_limit)
+        return result
+
 @dataclass
 class ShellKillRequest:
     """Identifier of a process previously returned by "shell.exec" and the signal to send."""
@@ -4784,6 +8932,90 @@ class ShellKillRequest:
         result["processId"] = from_str(self.process_id)
         if self.signal is not None:
             result["signal"] = from_union([lambda x: to_enum(ShellKillSignal, x), from_none], self.signal)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class AgentInfo:
+    """Schema for the `AgentInfo` type.
+
+    The newly selected custom agent
+    """
+    description: str
+    """Description of the agent's purpose"""
+
+    display_name: str
+    """Human-readable display name"""
+
+    id: str
+    """Stable identifier for selection. For most agents this is the same as `name`; for
+    plugin/builtin agents it may differ. Always populated; defaults to `name` when no
+    distinct id was assigned.
+    """
+    name: str
+    """Unique identifier of the custom agent"""
+
+    mcp_servers: dict[str, Any] | None = None
+    """MCP server configurations attached to this agent, keyed by server name. Server config
+    shape mirrors the MCP `mcpServers` schema.
+    """
+    model: str | None = None
+    """Preferred model id for this agent. When omitted, inherits the outer agent's model."""
+
+    path: str | None = None
+    """Absolute local file path of the agent definition. Only set for file-based agents loaded
+    from disk; remote agents do not have a path.
+    """
+    skills: list[str] | None = None
+    """Skill names preloaded into this agent's context. Omitted means none."""
+
+    source: AgentInfoSource | None = None
+    """Where the agent definition was loaded from"""
+
+    tools: list[str] | None = None
+    """Allowed tool names for this agent. Empty array means none; omitted means inherit defaults."""
+
+    user_invocable: bool | None = None
+    """Whether the agent can be selected directly by the user. Agents marked `false` are
+    subagent-only.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'AgentInfo':
+        assert isinstance(obj, dict)
+        description = from_str(obj.get("description"))
+        display_name = from_str(obj.get("displayName"))
+        id = from_str(obj.get("id"))
+        name = from_str(obj.get("name"))
+        mcp_servers = from_union([lambda x: from_dict(lambda x: x, x), from_none], obj.get("mcpServers"))
+        model = from_union([from_str, from_none], obj.get("model"))
+        path = from_union([from_str, from_none], obj.get("path"))
+        skills = from_union([lambda x: from_list(from_str, x), from_none], obj.get("skills"))
+        source = from_union([AgentInfoSource, from_none], obj.get("source"))
+        tools = from_union([lambda x: from_list(from_str, x), from_none], obj.get("tools"))
+        user_invocable = from_union([from_bool, from_none], obj.get("userInvocable"))
+        return AgentInfo(description, display_name, id, name, mcp_servers, model, path, skills, source, tools, user_invocable)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["description"] = from_str(self.description)
+        result["displayName"] = from_str(self.display_name)
+        result["id"] = from_str(self.id)
+        result["name"] = from_str(self.name)
+        if self.mcp_servers is not None:
+            result["mcpServers"] = from_union([lambda x: from_dict(lambda x: x, x), from_none], self.mcp_servers)
+        if self.model is not None:
+            result["model"] = from_union([from_str, from_none], self.model)
+        if self.path is not None:
+            result["path"] = from_union([from_str, from_none], self.path)
+        if self.skills is not None:
+            result["skills"] = from_union([lambda x: from_list(from_str, x), from_none], self.skills)
+        if self.source is not None:
+            result["source"] = from_union([lambda x: to_enum(AgentInfoSource, x), from_none], self.source)
+        if self.tools is not None:
+            result["tools"] = from_union([lambda x: from_list(from_str, x), from_none], self.tools)
+        if self.user_invocable is not None:
+            result["userInvocable"] = from_union([from_bool, from_none], self.user_invocable)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -4821,6 +9053,25 @@ class SkillsConfigSetDisabledSkillsRequest:
     def to_dict(self) -> dict:
         result: dict = {}
         result["disabledSkills"] = from_list(from_str, self.disabled_skills)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SkillsGetInvokedResult:
+    """Skills invoked during this session, ordered by invocation time (most recent last)."""
+
+    skills: list[SkillsInvokedSkill]
+    """Skills invoked during this session, ordered by invocation time (most recent last)"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SkillsGetInvokedResult':
+        assert isinstance(obj, dict)
+        skills = from_list(SkillsInvokedSkill.from_dict, obj.get("skills"))
+        return SkillsGetInvokedResult(skills)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["skills"] = from_list(lambda x: to_class(SkillsInvokedSkill, x), self.skills)
         return result
 
 @dataclass
@@ -4895,6 +9146,90 @@ class SlashCommandCompletedResult:
             result["message"] = from_union([from_str, from_none], self.message)
         if self.runtime_settings_changed is not None:
             result["runtimeSettingsChanged"] = from_union([from_bool, from_none], self.runtime_settings_changed)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class TaskAgentProgress:
+    """Schema for the `TaskAgentProgress` type."""
+
+    type: TaskAgentProgressType
+    """Progress kind"""
+
+    latest_intent: str | None = None
+    """The most recent intent reported by the agent"""
+
+    recent_activity: list[RecentActivity] | None = None
+    """Recent tool execution events converted to display lines"""
+
+    pid: int | None = None
+    """Process ID when available"""
+
+    recent_output: str | None = None
+    """Recent stdout/stderr lines from the running shell command"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'TaskAgentProgress':
+        assert isinstance(obj, dict)
+        type = TaskAgentProgressType(obj.get("type"))
+        latest_intent = from_union([from_str, from_none], obj.get("latestIntent"))
+        recent_activity = from_union([lambda x: from_list(RecentActivity.from_dict, x), from_none], obj.get("recentActivity"))
+        pid = from_union([from_int, from_none], obj.get("pid"))
+        recent_output = from_union([from_str, from_none], obj.get("recentOutput"))
+        return TaskAgentProgress(type, latest_intent, recent_activity, pid, recent_output)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["type"] = to_enum(TaskAgentProgressType, self.type)
+        if self.latest_intent is not None:
+            result["latestIntent"] = from_union([from_str, from_none], self.latest_intent)
+        if self.recent_activity is not None:
+            result["recentActivity"] = from_union([lambda x: from_list(lambda x: to_class(RecentActivity, x), x), from_none], self.recent_activity)
+        if self.pid is not None:
+            result["pid"] = from_union([from_int, from_none], self.pid)
+        if self.recent_output is not None:
+            result["recentOutput"] = from_union([from_str, from_none], self.recent_output)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class TaskProgressClass:
+    type: TaskAgentProgressType
+    """Progress kind"""
+
+    latest_intent: str | None = None
+    """The most recent intent reported by the agent"""
+
+    recent_activity: list[RecentActivity] | None = None
+    """Recent tool execution events converted to display lines"""
+
+    pid: int | None = None
+    """Process ID when available"""
+
+    recent_output: str | None = None
+    """Recent stdout/stderr lines from the running shell command"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'TaskProgressClass':
+        assert isinstance(obj, dict)
+        type = TaskAgentProgressType(obj.get("type"))
+        latest_intent = from_union([from_str, from_none], obj.get("latestIntent"))
+        recent_activity = from_union([lambda x: from_list(RecentActivity.from_dict, x), from_none], obj.get("recentActivity"))
+        pid = from_union([from_int, from_none], obj.get("pid"))
+        recent_output = from_union([from_str, from_none], obj.get("recentOutput"))
+        return TaskProgressClass(type, latest_intent, recent_activity, pid, recent_output)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["type"] = to_enum(TaskAgentProgressType, self.type)
+        if self.latest_intent is not None:
+            result["latestIntent"] = from_union([from_str, from_none], self.latest_intent)
+        if self.recent_activity is not None:
+            result["recentActivity"] = from_union([lambda x: from_list(lambda x: to_class(RecentActivity, x), x), from_none], self.recent_activity)
+        if self.pid is not None:
+            result["pid"] = from_union([from_int, from_none], self.pid)
+        if self.recent_output is not None:
+            result["recentOutput"] = from_union([from_str, from_none], self.recent_output)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -4993,6 +9328,31 @@ class ToolList:
     def to_dict(self) -> dict:
         result: dict = {}
         result["tools"] = from_list(lambda x: to_class(Tool, x), self.tools)
+        return result
+
+@dataclass
+class UIHandlePendingAutoModeSwitchRequest:
+    """Request ID of a pending `auto_mode_switch.requested` event and the user's response."""
+
+    request_id: str
+    """The unique request ID from the auto_mode_switch.requested event"""
+
+    response: UIAutoModeSwitchResponse
+    """User's choice for auto-mode switching: yes (allow this turn), yes_always (allow + persist
+    as setting), or no (decline).
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UIHandlePendingAutoModeSwitchRequest':
+        assert isinstance(obj, dict)
+        request_id = from_str(obj.get("requestId"))
+        response = UIAutoModeSwitchResponse(obj.get("response"))
+        return UIHandlePendingAutoModeSwitchRequest(request_id, response)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["requestId"] = from_str(self.request_id)
+        result["response"] = to_enum(UIAutoModeSwitchResponse, self.response)
         return result
 
 @dataclass
@@ -5130,10 +9490,10 @@ class UIElicitationSchemaPropertyString:
     format: UIElicitationSchemaPropertyStringFormat | None = None
     """Optional format hint that constrains the accepted input."""
 
-    max_length: float | None = None
+    max_length: int | None = None
     """Maximum number of characters allowed."""
 
-    min_length: float | None = None
+    min_length: int | None = None
     """Minimum number of characters required."""
 
     title: str | None = None
@@ -5146,8 +9506,8 @@ class UIElicitationSchemaPropertyString:
         default = from_union([from_str, from_none], obj.get("default"))
         description = from_union([from_str, from_none], obj.get("description"))
         format = from_union([UIElicitationSchemaPropertyStringFormat, from_none], obj.get("format"))
-        max_length = from_union([from_float, from_none], obj.get("maxLength"))
-        min_length = from_union([from_float, from_none], obj.get("minLength"))
+        max_length = from_union([from_int, from_none], obj.get("maxLength"))
+        min_length = from_union([from_int, from_none], obj.get("minLength"))
         title = from_union([from_str, from_none], obj.get("title"))
         return UIElicitationSchemaPropertyString(type, default, description, format, max_length, min_length, title)
 
@@ -5161,9 +9521,9 @@ class UIElicitationSchemaPropertyString:
         if self.format is not None:
             result["format"] = from_union([lambda x: to_enum(UIElicitationSchemaPropertyStringFormat, x), from_none], self.format)
         if self.max_length is not None:
-            result["maxLength"] = from_union([to_float, from_none], self.max_length)
+            result["maxLength"] = from_union([from_int, from_none], self.max_length)
         if self.min_length is not None:
-            result["minLength"] = from_union([to_float, from_none], self.min_length)
+            result["minLength"] = from_union([from_int, from_none], self.min_length)
         if self.title is not None:
             result["title"] = from_union([from_str, from_none], self.title)
         return result
@@ -5317,6 +9677,67 @@ class UIElicitationSchemaPropertyNumber:
             result["title"] = from_union([from_str, from_none], self.title)
         return result
 
+@dataclass
+class UIExitPlanModeResponse:
+    """Schema for the `UIExitPlanModeResponse` type."""
+
+    approved: bool
+    """Whether the plan was approved."""
+
+    auto_approve_edits: bool | None = None
+    """Whether subsequent edits should be auto-approved without confirmation."""
+
+    feedback: str | None = None
+    """Feedback from the user when they declined the plan or requested changes."""
+
+    selected_action: UIExitPlanModeAction | None = None
+    """The action the user selected. Defaults to 'autopilot' when autoApproveEdits is true,
+    otherwise 'interactive'.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UIExitPlanModeResponse':
+        assert isinstance(obj, dict)
+        approved = from_bool(obj.get("approved"))
+        auto_approve_edits = from_union([from_bool, from_none], obj.get("autoApproveEdits"))
+        feedback = from_union([from_str, from_none], obj.get("feedback"))
+        selected_action = from_union([UIExitPlanModeAction, from_none], obj.get("selectedAction"))
+        return UIExitPlanModeResponse(approved, auto_approve_edits, feedback, selected_action)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["approved"] = from_bool(self.approved)
+        if self.auto_approve_edits is not None:
+            result["autoApproveEdits"] = from_union([from_bool, from_none], self.auto_approve_edits)
+        if self.feedback is not None:
+            result["feedback"] = from_union([from_str, from_none], self.feedback)
+        if self.selected_action is not None:
+            result["selectedAction"] = from_union([lambda x: to_enum(UIExitPlanModeAction, x), from_none], self.selected_action)
+        return result
+
+@dataclass
+class UIHandlePendingUserInputRequest:
+    """Request ID of a pending `user_input.requested` event and the user's response."""
+
+    request_id: str
+    """The unique request ID from the user_input.requested event"""
+
+    response: UIUserInputResponse
+    """Schema for the `UIUserInputResponse` type."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UIHandlePendingUserInputRequest':
+        assert isinstance(obj, dict)
+        request_id = from_str(obj.get("requestId"))
+        response = UIUserInputResponse.from_dict(obj.get("response"))
+        return UIHandlePendingUserInputRequest(request_id, response)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["requestId"] = from_str(self.request_id)
+        result["response"] = to_class(UIUserInputResponse, self.response)
+        return result
+
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
 class UsageMetricsModelMetric:
@@ -5354,78 +9775,23 @@ class UsageMetricsModelMetric:
         return result
 
 @dataclass
-class Workspace:
-    id: UUID
-    branch: str | None = None
-    chronicle_sync_dismissed: bool | None = None
-    created_at: datetime | None = None
-    cwd: str | None = None
-    git_root: str | None = None
-    host_type: HostType | None = None
-    mc_last_event_id: str | None = None
-    mc_session_id: str | None = None
-    mc_task_id: str | None = None
-    name: str | None = None
-    remote_steerable: bool | None = None
-    repository: str | None = None
-    summary_count: int | None = None
-    updated_at: datetime | None = None
-    user_named: bool | None = None
+class WorkspacesSaveLargePasteResult:
+    """Descriptor for the saved paste file, or null when the workspace is unavailable."""
+
+    saved: Saved | None = None
+    """Saved-paste descriptor, or null when the workspace is unavailable (e.g. CCA runtime,
+    non-infinite sessions, remote sessions)
+    """
 
     @staticmethod
-    def from_dict(obj: Any) -> 'Workspace':
+    def from_dict(obj: Any) -> 'WorkspacesSaveLargePasteResult':
         assert isinstance(obj, dict)
-        id = UUID(obj.get("id"))
-        branch = from_union([from_str, from_none], obj.get("branch"))
-        chronicle_sync_dismissed = from_union([from_bool, from_none], obj.get("chronicle_sync_dismissed"))
-        created_at = from_union([from_datetime, from_none], obj.get("created_at"))
-        cwd = from_union([from_str, from_none], obj.get("cwd"))
-        git_root = from_union([from_str, from_none], obj.get("git_root"))
-        host_type = from_union([HostType, from_none], obj.get("host_type"))
-        mc_last_event_id = from_union([from_str, from_none], obj.get("mc_last_event_id"))
-        mc_session_id = from_union([from_str, from_none], obj.get("mc_session_id"))
-        mc_task_id = from_union([from_str, from_none], obj.get("mc_task_id"))
-        name = from_union([from_str, from_none], obj.get("name"))
-        remote_steerable = from_union([from_bool, from_none], obj.get("remote_steerable"))
-        repository = from_union([from_str, from_none], obj.get("repository"))
-        summary_count = from_union([from_int, from_none], obj.get("summary_count"))
-        updated_at = from_union([from_datetime, from_none], obj.get("updated_at"))
-        user_named = from_union([from_bool, from_none], obj.get("user_named"))
-        return Workspace(id, branch, chronicle_sync_dismissed, created_at, cwd, git_root, host_type, mc_last_event_id, mc_session_id, mc_task_id, name, remote_steerable, repository, summary_count, updated_at, user_named)
+        saved = from_union([Saved.from_dict, from_none], obj.get("saved"))
+        return WorkspacesSaveLargePasteResult(saved)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["id"] = str(self.id)
-        if self.branch is not None:
-            result["branch"] = from_union([from_str, from_none], self.branch)
-        if self.chronicle_sync_dismissed is not None:
-            result["chronicle_sync_dismissed"] = from_union([from_bool, from_none], self.chronicle_sync_dismissed)
-        if self.created_at is not None:
-            result["created_at"] = from_union([lambda x: x.isoformat(), from_none], self.created_at)
-        if self.cwd is not None:
-            result["cwd"] = from_union([from_str, from_none], self.cwd)
-        if self.git_root is not None:
-            result["git_root"] = from_union([from_str, from_none], self.git_root)
-        if self.host_type is not None:
-            result["host_type"] = from_union([lambda x: to_enum(HostType, x), from_none], self.host_type)
-        if self.mc_last_event_id is not None:
-            result["mc_last_event_id"] = from_union([from_str, from_none], self.mc_last_event_id)
-        if self.mc_session_id is not None:
-            result["mc_session_id"] = from_union([from_str, from_none], self.mc_session_id)
-        if self.mc_task_id is not None:
-            result["mc_task_id"] = from_union([from_str, from_none], self.mc_task_id)
-        if self.name is not None:
-            result["name"] = from_union([from_str, from_none], self.name)
-        if self.remote_steerable is not None:
-            result["remote_steerable"] = from_union([from_bool, from_none], self.remote_steerable)
-        if self.repository is not None:
-            result["repository"] = from_union([from_str, from_none], self.repository)
-        if self.summary_count is not None:
-            result["summary_count"] = from_union([from_int, from_none], self.summary_count)
-        if self.updated_at is not None:
-            result["updated_at"] = from_union([lambda x: x.isoformat(), from_none], self.updated_at)
-        if self.user_named is not None:
-            result["user_named"] = from_union([from_bool, from_none], self.user_named)
+        result["saved"] = from_union([lambda x: to_class(Saved, x), from_none], self.saved)
         return result
 
 @dataclass
@@ -5502,6 +9868,118 @@ class RemoteSessionConnectionResult:
         result: dict = {}
         result["metadata"] = to_class(ConnectedRemoteSessionMetadata, self.metadata)
         result["sessionId"] = from_str(self.session_id)
+        return result
+
+@dataclass
+class CopilotUserResponse:
+    """Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the
+    GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this
+    verbatim and does not re-fetch when set.
+    """
+    access_type_sku: str | None = None
+    analytics_tracking_id: str | None = None
+    assigned_date: Any = None
+    can_signup_for_limited: bool | None = None
+    chat_enabled: bool | None = None
+    cli_remote_control_enabled: bool | None = None
+    cloud_session_storage_enabled: bool | None = None
+    codex_agent_enabled: bool | None = None
+    copilot_plan: str | None = None
+    copilotignore_enabled: bool | None = None
+    endpoints: CopilotUserResponseEndpoints | None = None
+    """Schema for the `CopilotUserResponseEndpoints` type."""
+
+    is_mcp_enabled: Any = None
+    limited_user_quotas: dict[str, float] | None = None
+    limited_user_reset_date: str | None = None
+    login: str | None = None
+    monthly_quotas: dict[str, float] | None = None
+    organization_list: Any = None
+    organization_login_list: list[str] | None = None
+    quota_reset_date: str | None = None
+    quota_reset_date_utc: str | None = None
+    quota_snapshots: dict[str, CopilotUserResponseQuotaSnapshots | None] | None = None
+    """Schema for the `CopilotUserResponseQuotaSnapshots` type."""
+
+    restricted_telemetry: bool | None = None
+    token_based_billing: bool | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'CopilotUserResponse':
+        assert isinstance(obj, dict)
+        access_type_sku = from_union([from_str, from_none], obj.get("access_type_sku"))
+        analytics_tracking_id = from_union([from_str, from_none], obj.get("analytics_tracking_id"))
+        assigned_date = obj.get("assigned_date")
+        can_signup_for_limited = from_union([from_bool, from_none], obj.get("can_signup_for_limited"))
+        chat_enabled = from_union([from_bool, from_none], obj.get("chat_enabled"))
+        cli_remote_control_enabled = from_union([from_bool, from_none], obj.get("cli_remote_control_enabled"))
+        cloud_session_storage_enabled = from_union([from_bool, from_none], obj.get("cloud_session_storage_enabled"))
+        codex_agent_enabled = from_union([from_bool, from_none], obj.get("codex_agent_enabled"))
+        copilot_plan = from_union([from_str, from_none], obj.get("copilot_plan"))
+        copilotignore_enabled = from_union([from_bool, from_none], obj.get("copilotignore_enabled"))
+        endpoints = from_union([CopilotUserResponseEndpoints.from_dict, from_none], obj.get("endpoints"))
+        is_mcp_enabled = obj.get("is_mcp_enabled")
+        limited_user_quotas = from_union([lambda x: from_dict(from_float, x), from_none], obj.get("limited_user_quotas"))
+        limited_user_reset_date = from_union([from_str, from_none], obj.get("limited_user_reset_date"))
+        login = from_union([from_str, from_none], obj.get("login"))
+        monthly_quotas = from_union([lambda x: from_dict(from_float, x), from_none], obj.get("monthly_quotas"))
+        organization_list = obj.get("organization_list")
+        organization_login_list = from_union([lambda x: from_list(from_str, x), from_none], obj.get("organization_login_list"))
+        quota_reset_date = from_union([from_str, from_none], obj.get("quota_reset_date"))
+        quota_reset_date_utc = from_union([from_str, from_none], obj.get("quota_reset_date_utc"))
+        quota_snapshots = from_union([lambda x: from_dict(lambda x: from_union([CopilotUserResponseQuotaSnapshots.from_dict, from_none], x), x), from_none], obj.get("quota_snapshots"))
+        restricted_telemetry = from_union([from_bool, from_none], obj.get("restricted_telemetry"))
+        token_based_billing = from_union([from_bool, from_none], obj.get("token_based_billing"))
+        return CopilotUserResponse(access_type_sku, analytics_tracking_id, assigned_date, can_signup_for_limited, chat_enabled, cli_remote_control_enabled, cloud_session_storage_enabled, codex_agent_enabled, copilot_plan, copilotignore_enabled, endpoints, is_mcp_enabled, limited_user_quotas, limited_user_reset_date, login, monthly_quotas, organization_list, organization_login_list, quota_reset_date, quota_reset_date_utc, quota_snapshots, restricted_telemetry, token_based_billing)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.access_type_sku is not None:
+            result["access_type_sku"] = from_union([from_str, from_none], self.access_type_sku)
+        if self.analytics_tracking_id is not None:
+            result["analytics_tracking_id"] = from_union([from_str, from_none], self.analytics_tracking_id)
+        if self.assigned_date is not None:
+            result["assigned_date"] = self.assigned_date
+        if self.can_signup_for_limited is not None:
+            result["can_signup_for_limited"] = from_union([from_bool, from_none], self.can_signup_for_limited)
+        if self.chat_enabled is not None:
+            result["chat_enabled"] = from_union([from_bool, from_none], self.chat_enabled)
+        if self.cli_remote_control_enabled is not None:
+            result["cli_remote_control_enabled"] = from_union([from_bool, from_none], self.cli_remote_control_enabled)
+        if self.cloud_session_storage_enabled is not None:
+            result["cloud_session_storage_enabled"] = from_union([from_bool, from_none], self.cloud_session_storage_enabled)
+        if self.codex_agent_enabled is not None:
+            result["codex_agent_enabled"] = from_union([from_bool, from_none], self.codex_agent_enabled)
+        if self.copilot_plan is not None:
+            result["copilot_plan"] = from_union([from_str, from_none], self.copilot_plan)
+        if self.copilotignore_enabled is not None:
+            result["copilotignore_enabled"] = from_union([from_bool, from_none], self.copilotignore_enabled)
+        if self.endpoints is not None:
+            result["endpoints"] = from_union([lambda x: to_class(CopilotUserResponseEndpoints, x), from_none], self.endpoints)
+        if self.is_mcp_enabled is not None:
+            result["is_mcp_enabled"] = self.is_mcp_enabled
+        if self.limited_user_quotas is not None:
+            result["limited_user_quotas"] = from_union([lambda x: from_dict(to_float, x), from_none], self.limited_user_quotas)
+        if self.limited_user_reset_date is not None:
+            result["limited_user_reset_date"] = from_union([from_str, from_none], self.limited_user_reset_date)
+        if self.login is not None:
+            result["login"] = from_union([from_str, from_none], self.login)
+        if self.monthly_quotas is not None:
+            result["monthly_quotas"] = from_union([lambda x: from_dict(to_float, x), from_none], self.monthly_quotas)
+        if self.organization_list is not None:
+            result["organization_list"] = self.organization_list
+        if self.organization_login_list is not None:
+            result["organization_login_list"] = from_union([lambda x: from_list(from_str, x), from_none], self.organization_login_list)
+        if self.quota_reset_date is not None:
+            result["quota_reset_date"] = from_union([from_str, from_none], self.quota_reset_date)
+        if self.quota_reset_date_utc is not None:
+            result["quota_reset_date_utc"] = from_union([from_str, from_none], self.quota_reset_date_utc)
+        if self.quota_snapshots is not None:
+            result["quota_snapshots"] = from_union([lambda x: from_dict(lambda x: from_union([lambda x: to_class(CopilotUserResponseQuotaSnapshots, x), from_none], x), x), from_none], self.quota_snapshots)
+        if self.restricted_telemetry is not None:
+            result["restricted_telemetry"] = from_union([from_bool, from_none], self.restricted_telemetry)
+        if self.token_based_billing is not None:
+            result["token_based_billing"] = from_union([from_bool, from_none], self.token_based_billing)
         return result
 
 @dataclass
@@ -5590,6 +10068,53 @@ class PermissionDecisionApproveForSessionApprovalExtensionPermissionAccess:
         return result
 
 @dataclass
+class UserToolSessionApprovalExtensionManagement:
+    """Schema for the `UserToolSessionApprovalExtensionManagement` type."""
+
+    kind: PermissionDecisionApproveForLocationApprovalExtensionManagementKind
+    """Extension management approval kind"""
+
+    operation: str | None = None
+    """Optional operation identifier"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UserToolSessionApprovalExtensionManagement':
+        assert isinstance(obj, dict)
+        kind = PermissionDecisionApproveForLocationApprovalExtensionManagementKind(obj.get("kind"))
+        operation = from_union([from_str, from_none], obj.get("operation"))
+        return UserToolSessionApprovalExtensionManagement(kind, operation)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalExtensionManagementKind, self.kind)
+        if self.operation is not None:
+            result["operation"] = from_union([from_str, from_none], self.operation)
+        return result
+
+@dataclass
+class UserToolSessionApprovalExtensionPermissionAccess:
+    """Schema for the `UserToolSessionApprovalExtensionPermissionAccess` type."""
+
+    extension_name: str
+    """Extension name"""
+
+    kind: PermissionDecisionApproveForLocationApprovalExtensionPermissionAccessKind
+    """Extension permission access approval kind"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UserToolSessionApprovalExtensionPermissionAccess':
+        assert isinstance(obj, dict)
+        extension_name = from_str(obj.get("extensionName"))
+        kind = PermissionDecisionApproveForLocationApprovalExtensionPermissionAccessKind(obj.get("kind"))
+        return UserToolSessionApprovalExtensionPermissionAccess(extension_name, kind)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["extensionName"] = from_str(self.extension_name)
+        result["kind"] = to_enum(PermissionDecisionApproveForLocationApprovalExtensionPermissionAccessKind, self.kind)
+        return result
+
+@dataclass
 class ExternalToolTextResultForLlmContent:
     """A content block within a tool result, which may be text, terminal output, image, audio,
     or a resource
@@ -5617,7 +10142,7 @@ class ExternalToolTextResultForLlmContent:
     cwd: str | None = None
     """Working directory where the command was executed"""
 
-    exit_code: float | None = None
+    exit_code: int | None = None
     """Process exit code, if the command has completed"""
 
     data: str | None = None
@@ -5641,7 +10166,7 @@ class ExternalToolTextResultForLlmContent:
     name: str | None = None
     """Resource name identifier"""
 
-    size: float | None = None
+    size: int | None = None
     """Size of the resource in bytes"""
 
     title: str | None = None
@@ -5659,13 +10184,13 @@ class ExternalToolTextResultForLlmContent:
         type = ExternalToolTextResultForLlmContentType(obj.get("type"))
         text = from_union([from_str, from_none], obj.get("text"))
         cwd = from_union([from_str, from_none], obj.get("cwd"))
-        exit_code = from_union([from_float, from_none], obj.get("exitCode"))
+        exit_code = from_union([from_int, from_none], obj.get("exitCode"))
         data = from_union([from_str, from_none], obj.get("data"))
         mime_type = from_union([from_str, from_none], obj.get("mimeType"))
         description = from_union([from_str, from_none], obj.get("description"))
         icons = from_union([lambda x: from_list(ExternalToolTextResultForLlmContentResourceLinkIcon.from_dict, x), from_none], obj.get("icons"))
         name = from_union([from_str, from_none], obj.get("name"))
-        size = from_union([from_float, from_none], obj.get("size"))
+        size = from_union([from_int, from_none], obj.get("size"))
         title = from_union([from_str, from_none], obj.get("title"))
         uri = from_union([from_str, from_none], obj.get("uri"))
         resource = from_union([(lambda x: from_union([EmbeddedTextResourceContents.from_dict, EmbeddedBlobResourceContents.from_dict], x)), from_none], obj.get("resource"))
@@ -5679,7 +10204,7 @@ class ExternalToolTextResultForLlmContent:
         if self.cwd is not None:
             result["cwd"] = from_union([from_str, from_none], self.cwd)
         if self.exit_code is not None:
-            result["exitCode"] = from_union([to_float, from_none], self.exit_code)
+            result["exitCode"] = from_union([from_int, from_none], self.exit_code)
         if self.data is not None:
             result["data"] = from_union([from_str, from_none], self.data)
         if self.mime_type is not None:
@@ -5691,7 +10216,7 @@ class ExternalToolTextResultForLlmContent:
         if self.name is not None:
             result["name"] = from_union([from_str, from_none], self.name)
         if self.size is not None:
-            result["size"] = from_union([to_float, from_none], self.size)
+            result["size"] = from_union([from_int, from_none], self.size)
         if self.title is not None:
             result["title"] = from_union([from_str, from_none], self.title)
         if self.uri is not None:
@@ -5722,7 +10247,7 @@ class ExternalToolTextResultForLlmContentResourceLink:
     mime_type: str | None = None
     """MIME type of the resource content"""
 
-    size: float | None = None
+    size: int | None = None
     """Size of the resource in bytes"""
 
     title: str | None = None
@@ -5737,7 +10262,7 @@ class ExternalToolTextResultForLlmContentResourceLink:
         description = from_union([from_str, from_none], obj.get("description"))
         icons = from_union([lambda x: from_list(ExternalToolTextResultForLlmContentResourceLinkIcon.from_dict, x), from_none], obj.get("icons"))
         mime_type = from_union([from_str, from_none], obj.get("mimeType"))
-        size = from_union([from_float, from_none], obj.get("size"))
+        size = from_union([from_int, from_none], obj.get("size"))
         title = from_union([from_str, from_none], obj.get("title"))
         return ExternalToolTextResultForLlmContentResourceLink(name, type, uri, description, icons, mime_type, size, title)
 
@@ -5753,9 +10278,97 @@ class ExternalToolTextResultForLlmContentResourceLink:
         if self.mime_type is not None:
             result["mimeType"] = from_union([from_str, from_none], self.mime_type)
         if self.size is not None:
-            result["size"] = from_union([to_float, from_none], self.size)
+            result["size"] = from_union([from_int, from_none], self.size)
         if self.title is not None:
             result["title"] = from_union([from_str, from_none], self.title)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class InstalledPluginSource:
+    """Schema for the `InstalledPluginSourceGithub` type.
+
+    Schema for the `InstalledPluginSourceUrl` type.
+
+    Schema for the `InstalledPluginSourceLocal` type.
+    """
+    source: PurpleSource
+    """Constant value. Always "github".
+
+    Constant value. Always "url".
+
+    Constant value. Always "local".
+    """
+    path: str | None = None
+    ref: str | None = None
+    repo: str | None = None
+    url: str | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'InstalledPluginSource':
+        assert isinstance(obj, dict)
+        source = PurpleSource(obj.get("source"))
+        path = from_union([from_str, from_none], obj.get("path"))
+        ref = from_union([from_str, from_none], obj.get("ref"))
+        repo = from_union([from_str, from_none], obj.get("repo"))
+        url = from_union([from_str, from_none], obj.get("url"))
+        return InstalledPluginSource(source, path, ref, repo, url)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["source"] = to_enum(PurpleSource, self.source)
+        if self.path is not None:
+            result["path"] = from_union([from_str, from_none], self.path)
+        if self.ref is not None:
+            result["ref"] = from_union([from_str, from_none], self.ref)
+        if self.repo is not None:
+            result["repo"] = from_union([from_str, from_none], self.repo)
+        if self.url is not None:
+            result["url"] = from_union([from_str, from_none], self.url)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionInstalledPluginSource:
+    """Schema for the `SessionInstalledPluginSourceGithub` type.
+
+    Schema for the `SessionInstalledPluginSourceUrl` type.
+
+    Schema for the `SessionInstalledPluginSourceLocal` type.
+    """
+    source: PurpleSource
+    """Constant value. Always "github".
+
+    Constant value. Always "url".
+
+    Constant value. Always "local".
+    """
+    path: str | None = None
+    ref: str | None = None
+    repo: str | None = None
+    url: str | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionInstalledPluginSource':
+        assert isinstance(obj, dict)
+        source = PurpleSource(obj.get("source"))
+        path = from_union([from_str, from_none], obj.get("path"))
+        ref = from_union([from_str, from_none], obj.get("ref"))
+        repo = from_union([from_str, from_none], obj.get("repo"))
+        url = from_union([from_str, from_none], obj.get("url"))
+        return SessionInstalledPluginSource(source, path, ref, repo, url)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["source"] = to_enum(PurpleSource, self.source)
+        if self.path is not None:
+            result["path"] = from_union([from_str, from_none], self.path)
+        if self.ref is not None:
+            result["ref"] = from_union([from_str, from_none], self.ref)
+        if self.repo is not None:
+            result["repo"] = from_union([from_str, from_none], self.repo)
+        if self.url is not None:
+            result["url"] = from_union([from_str, from_none], self.url)
         return result
 
 @dataclass
@@ -5840,6 +10453,265 @@ class MCPConfigUpdateRequest:
         result["name"] = from_str(self.name)
         return result
 
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class MetadataRecordContextChangeRequest:
+    """Updated working-directory/git context to record on the session."""
+
+    context: SessionWorkingDirectoryContext
+    """Updated working directory and git context. Emitted as the new payload of
+    `session.context_changed`.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MetadataRecordContextChangeRequest':
+        assert isinstance(obj, dict)
+        context = SessionWorkingDirectoryContext.from_dict(obj.get("context"))
+        return MetadataRecordContextChangeRequest(context)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["context"] = to_class(SessionWorkingDirectoryContext, self.context)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionMetadata:
+    """Schema for the `SessionMetadata` type."""
+
+    is_remote: bool
+    """True for remote (GitHub) sessions; false for local"""
+
+    modified_time: str
+    """Last-modified time of the session's persisted state, as ISO 8601"""
+
+    session_id: str
+    """Stable session identifier"""
+
+    start_time: str
+    """Session creation time as an ISO 8601 timestamp"""
+
+    context: SessionContext | None = None
+    """Schema for the `SessionContext` type."""
+
+    mc_task_id: str | None = None
+    """GitHub task ID, when this local session is bound to one. Only present for local sessions
+    exported to remote control.
+    """
+    name: str | None = None
+    """Optional human-friendly name set via /rename"""
+
+    summary: str | None = None
+    """Short summary of the session, when one has been derived"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionMetadata':
+        assert isinstance(obj, dict)
+        is_remote = from_bool(obj.get("isRemote"))
+        modified_time = from_str(obj.get("modifiedTime"))
+        session_id = from_str(obj.get("sessionId"))
+        start_time = from_str(obj.get("startTime"))
+        context = from_union([SessionContext.from_dict, from_none], obj.get("context"))
+        mc_task_id = from_union([from_str, from_none], obj.get("mcTaskId"))
+        name = from_union([from_str, from_none], obj.get("name"))
+        summary = from_union([from_str, from_none], obj.get("summary"))
+        return SessionMetadata(is_remote, modified_time, session_id, start_time, context, mc_task_id, name, summary)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["isRemote"] = from_bool(self.is_remote)
+        result["modifiedTime"] = from_str(self.modified_time)
+        result["sessionId"] = from_str(self.session_id)
+        result["startTime"] = from_str(self.start_time)
+        if self.context is not None:
+            result["context"] = from_union([lambda x: to_class(SessionContext, x), from_none], self.context)
+        if self.mc_task_id is not None:
+            result["mcTaskId"] = from_union([from_str, from_none], self.mc_task_id)
+        if self.name is not None:
+            result["name"] = from_union([from_str, from_none], self.name)
+        if self.summary is not None:
+            result["summary"] = from_union([from_str, from_none], self.summary)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsGetLastForContextRequest:
+    """Optional working-directory context used to score session relevance."""
+
+    context: SessionContext | None = None
+    """Optional working-directory context used to score session relevance. When omitted the
+    most-recently-modified session wins.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsGetLastForContextRequest':
+        assert isinstance(obj, dict)
+        context = from_union([SessionContext.from_dict, from_none], obj.get("context"))
+        return SessionsGetLastForContextRequest(context)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.context is not None:
+            result["context"] = from_union([lambda x: to_class(SessionContext, x), from_none], self.context)
+        return result
+
+@dataclass
+class PermissionPathsConfig:
+    """If specified, replaces the session's path-permission policy. The runtime constructs the
+    appropriate PathManager based on these inputs (rooted at the session's working
+    directory). Omit to leave the current path policy unchanged.
+    """
+    additional_directories: list[str] | None = None
+    """Additional directories to allow tool access to (in addition to the session's working
+    directory). When `unrestricted` is true, these are still pre-populated on the
+    UnrestrictedPathManager so they remain visible via getDirectories() (e.g. for @-mention
+    completion).
+    """
+    include_temp_directory: bool | None = None
+    """Whether to include the system temp directory in the allowed list (defaults to true).
+    Ignored when `unrestricted` is true.
+    """
+    unrestricted: bool | None = None
+    """If true, the runtime allows access to all paths without prompting. Equivalent to
+    constructing an UnrestrictedPathManager.
+    """
+    workspace_path: str | None = None
+    """Workspace root path (special-cased to be allowed even before the directory exists).
+    Ignored when `unrestricted` is true.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionPathsConfig':
+        assert isinstance(obj, dict)
+        additional_directories = from_union([lambda x: from_list(from_str, x), from_none], obj.get("additionalDirectories"))
+        include_temp_directory = from_union([from_bool, from_none], obj.get("includeTempDirectory"))
+        unrestricted = from_union([from_bool, from_none], obj.get("unrestricted"))
+        workspace_path = from_union([from_str, from_none], obj.get("workspacePath"))
+        return PermissionPathsConfig(additional_directories, include_temp_directory, unrestricted, workspace_path)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.additional_directories is not None:
+            result["additionalDirectories"] = from_union([lambda x: from_list(from_str, x), from_none], self.additional_directories)
+        if self.include_temp_directory is not None:
+            result["includeTempDirectory"] = from_union([from_bool, from_none], self.include_temp_directory)
+        if self.unrestricted is not None:
+            result["unrestricted"] = from_union([from_bool, from_none], self.unrestricted)
+        if self.workspace_path is not None:
+            result["workspacePath"] = from_union([from_str, from_none], self.workspace_path)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class WorkspaceSummary:
+    """Public-facing projection of workspace metadata for SDK / TUI consumers"""
+
+    id: UUID
+    """Workspace identifier (1:1 with sessionId)"""
+
+    branch: str | None = None
+    """Branch checked out at session start, if any"""
+
+    created_at: datetime | None = None
+    """ISO 8601 timestamp when the workspace was created"""
+
+    cwd: str | None = None
+    """Current working directory at session start"""
+
+    git_root: str | None = None
+    """Resolved git root for cwd, if any"""
+
+    host_type: SessionContextHostType | None = None
+    """Repository host type, if known"""
+
+    name: str | None = None
+    """Display name for the session, if set"""
+
+    repository: str | None = None
+    """Repository identifier in 'owner/repo' or 'org/project/repo' format, if any"""
+
+    updated_at: datetime | None = None
+    """ISO 8601 timestamp when the workspace was last updated"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'WorkspaceSummary':
+        assert isinstance(obj, dict)
+        id = UUID(obj.get("id"))
+        branch = from_union([from_str, from_none], obj.get("branch"))
+        created_at = from_union([from_datetime, from_none], obj.get("created_at"))
+        cwd = from_union([from_str, from_none], obj.get("cwd"))
+        git_root = from_union([from_str, from_none], obj.get("git_root"))
+        host_type = from_union([SessionContextHostType, from_none], obj.get("host_type"))
+        name = from_union([from_str, from_none], obj.get("name"))
+        repository = from_union([from_str, from_none], obj.get("repository"))
+        updated_at = from_union([from_datetime, from_none], obj.get("updated_at"))
+        return WorkspaceSummary(id, branch, created_at, cwd, git_root, host_type, name, repository, updated_at)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["id"] = str(self.id)
+        if self.branch is not None:
+            result["branch"] = from_union([from_str, from_none], self.branch)
+        if self.created_at is not None:
+            result["created_at"] = from_union([lambda x: x.isoformat(), from_none], self.created_at)
+        if self.cwd is not None:
+            result["cwd"] = from_union([from_str, from_none], self.cwd)
+        if self.git_root is not None:
+            result["git_root"] = from_union([from_str, from_none], self.git_root)
+        if self.host_type is not None:
+            result["host_type"] = from_union([lambda x: to_enum(SessionContextHostType, x), from_none], self.host_type)
+        if self.name is not None:
+            result["name"] = from_union([from_str, from_none], self.name)
+        if self.repository is not None:
+            result["repository"] = from_union([from_str, from_none], self.repository)
+        if self.updated_at is not None:
+            result["updated_at"] = from_union([lambda x: x.isoformat(), from_none], self.updated_at)
+        return result
+
+@dataclass
+class WorkspacesGetWorkspaceResult:
+    """Current workspace metadata for the session, including its absolute filesystem path when
+    available.
+    """
+    path: str | None = None
+    """Absolute filesystem path to the workspace directory. Omitted when the session has no
+    workspace (e.g. remote sessions).
+    """
+    workspace: Workspace | None = None
+    """Current workspace metadata, or null if not available"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'WorkspacesGetWorkspaceResult':
+        assert isinstance(obj, dict)
+        path = from_union([from_str, from_none], obj.get("path"))
+        workspace = from_union([Workspace.from_dict, from_none], obj.get("workspace"))
+        return WorkspacesGetWorkspaceResult(path, workspace)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.path is not None:
+            result["path"] = from_union([from_str, from_none], self.path)
+        result["workspace"] = from_union([lambda x: to_class(Workspace, x), from_none], self.workspace)
+        return result
+
+@dataclass
+class WorkspacesListCheckpointsResult:
+    """Workspace checkpoints in chronological order; empty when the workspace is not enabled."""
+
+    checkpoints: list[WorkspacesCheckpoints]
+    """Workspace checkpoints in chronological order. Empty when workspace is not enabled."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'WorkspacesListCheckpointsResult':
+        assert isinstance(obj, dict)
+        checkpoints = from_list(WorkspacesCheckpoints.from_dict, obj.get("checkpoints"))
+        return WorkspacesListCheckpointsResult(checkpoints)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["checkpoints"] = from_list(lambda x: to_class(WorkspacesCheckpoints, x), self.checkpoints)
+        return result
+
 @dataclass
 class ModelCapabilitiesOverride:
     """Override individual model capabilities resolved by the runtime"""
@@ -5866,14 +10738,68 @@ class ModelCapabilitiesOverride:
         return result
 
 @dataclass
-class CommandsRespondToQueuedCommandRequest:
-    """Queued command request ID and the result indicating whether the client handled it."""
+class PermissionsConfigureAdditionalContentExclusionPolicy:
+    """Schema for the `PermissionsConfigureAdditionalContentExclusionPolicy` type."""
 
+    last_updated_at: float | str
+    rules: list[PermissionsConfigureAdditionalContentExclusionPolicyRule]
+    scope: PermissionsConfigureAdditionalContentExclusionPolicyScope
+    """Allowed values for the `PermissionsConfigureAdditionalContentExclusionPolicyScope`
+    enumeration.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsConfigureAdditionalContentExclusionPolicy':
+        assert isinstance(obj, dict)
+        last_updated_at = from_union([from_float, from_str], obj.get("last_updated_at"))
+        rules = from_list(PermissionsConfigureAdditionalContentExclusionPolicyRule.from_dict, obj.get("rules"))
+        scope = PermissionsConfigureAdditionalContentExclusionPolicyScope(obj.get("scope"))
+        return PermissionsConfigureAdditionalContentExclusionPolicy(last_updated_at, rules, scope)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["last_updated_at"] = from_union([to_float, from_str], self.last_updated_at)
+        result["rules"] = from_list(lambda x: to_class(PermissionsConfigureAdditionalContentExclusionPolicyRule, x), self.rules)
+        result["scope"] = to_enum(PermissionsConfigureAdditionalContentExclusionPolicyScope, self.scope)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class QueuePendingItemsResult:
+    """Snapshot of the session's pending queued items and immediate-steering messages."""
+
+    items: list[QueuePendingItems]
+    """Pending queued items in submission order. Includes user messages, queued slash commands,
+    and queued model changes; omits internal system items.
+    """
+    steering_messages: list[str]
+    """Display text for messages currently in the immediate steering queue (interjections sent
+    during a running turn).
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'QueuePendingItemsResult':
+        assert isinstance(obj, dict)
+        items = from_list(QueuePendingItems.from_dict, obj.get("items"))
+        steering_messages = from_list(from_str, obj.get("steeringMessages"))
+        return QueuePendingItemsResult(items, steering_messages)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["items"] = from_list(lambda x: to_class(QueuePendingItems, x), self.items)
+        result["steeringMessages"] = from_list(from_str, self.steering_messages)
+        return result
+
+@dataclass
+class CommandsRespondToQueuedCommandRequest:
+    """Queued-command request ID and the result indicating whether the host executed it (and
+    whether to stop processing further queued commands).
+    """
     request_id: str
-    """Request ID from the queued command event"""
+    """Request ID from the `command.queued` event the host is responding to."""
 
     result: QueuedCommandResult
-    """Result of the queued command execution"""
+    """Result of the queued command execution."""
 
     @staticmethod
     def from_dict(obj: Any) -> 'CommandsRespondToQueuedCommandRequest':
@@ -5886,6 +10812,154 @@ class CommandsRespondToQueuedCommandRequest:
         result: dict = {}
         result["requestId"] = from_str(self.request_id)
         result["result"] = to_class(QueuedCommandResult, self.result)
+        return result
+
+@dataclass
+class SendAttachment:
+    """A user message attachment — a file, directory, code selection, blob, or GitHub reference
+
+    File attachment
+
+    Directory attachment
+
+    Code selection attachment from an editor
+
+    GitHub issue, pull request, or discussion reference
+
+    Blob attachment with inline base64-encoded data
+    """
+    type: SendAttachmentType
+    """Attachment type discriminator"""
+
+    display_name: str | None = None
+    """User-facing display name for the attachment
+
+    User-facing display name for the selection
+    """
+    line_range: SendAttachmentFileLineRange | None = None
+    """Optional line range to scope the attachment to a specific section of the file"""
+
+    path: str | None = None
+    """Absolute file path
+
+    Absolute directory path
+    """
+    file_path: str | None = None
+    """Absolute path to the file containing the selection"""
+
+    selection: SendAttachmentSelectionDetails | None = None
+    """Position range of the selection within the file"""
+
+    text: str | None = None
+    """The selected text content"""
+
+    number: int | None = None
+    """Issue, pull request, or discussion number"""
+
+    reference_type: SendAttachmentGithubReferenceTypeEnum | None = None
+    """Type of GitHub reference"""
+
+    state: str | None = None
+    """Current state of the referenced item (e.g., open, closed, merged)"""
+
+    title: str | None = None
+    """Title of the referenced item"""
+
+    url: str | None = None
+    """URL to the referenced item on GitHub"""
+
+    data: str | None = None
+    """Base64-encoded content"""
+
+    mime_type: str | None = None
+    """MIME type of the inline data"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SendAttachment':
+        assert isinstance(obj, dict)
+        type = SendAttachmentType(obj.get("type"))
+        display_name = from_union([from_str, from_none], obj.get("displayName"))
+        line_range = from_union([SendAttachmentFileLineRange.from_dict, from_none], obj.get("lineRange"))
+        path = from_union([from_str, from_none], obj.get("path"))
+        file_path = from_union([from_str, from_none], obj.get("filePath"))
+        selection = from_union([SendAttachmentSelectionDetails.from_dict, from_none], obj.get("selection"))
+        text = from_union([from_str, from_none], obj.get("text"))
+        number = from_union([from_int, from_none], obj.get("number"))
+        reference_type = from_union([SendAttachmentGithubReferenceTypeEnum, from_none], obj.get("referenceType"))
+        state = from_union([from_str, from_none], obj.get("state"))
+        title = from_union([from_str, from_none], obj.get("title"))
+        url = from_union([from_str, from_none], obj.get("url"))
+        data = from_union([from_str, from_none], obj.get("data"))
+        mime_type = from_union([from_str, from_none], obj.get("mimeType"))
+        return SendAttachment(type, display_name, line_range, path, file_path, selection, text, number, reference_type, state, title, url, data, mime_type)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["type"] = to_enum(SendAttachmentType, self.type)
+        if self.display_name is not None:
+            result["displayName"] = from_union([from_str, from_none], self.display_name)
+        if self.line_range is not None:
+            result["lineRange"] = from_union([lambda x: to_class(SendAttachmentFileLineRange, x), from_none], self.line_range)
+        if self.path is not None:
+            result["path"] = from_union([from_str, from_none], self.path)
+        if self.file_path is not None:
+            result["filePath"] = from_union([from_str, from_none], self.file_path)
+        if self.selection is not None:
+            result["selection"] = from_union([lambda x: to_class(SendAttachmentSelectionDetails, x), from_none], self.selection)
+        if self.text is not None:
+            result["text"] = from_union([from_str, from_none], self.text)
+        if self.number is not None:
+            result["number"] = from_union([from_int, from_none], self.number)
+        if self.reference_type is not None:
+            result["referenceType"] = from_union([lambda x: to_enum(SendAttachmentGithubReferenceTypeEnum, x), from_none], self.reference_type)
+        if self.state is not None:
+            result["state"] = from_union([from_str, from_none], self.state)
+        if self.title is not None:
+            result["title"] = from_union([from_str, from_none], self.title)
+        if self.url is not None:
+            result["url"] = from_union([from_str, from_none], self.url)
+        if self.data is not None:
+            result["data"] = from_union([from_str, from_none], self.data)
+        if self.mime_type is not None:
+            result["mimeType"] = from_union([from_str, from_none], self.mime_type)
+        return result
+
+@dataclass
+class SendAttachmentSelection:
+    """Code selection attachment from an editor"""
+
+    display_name: str
+    """User-facing display name for the selection"""
+
+    file_path: str
+    """Absolute path to the file containing the selection"""
+
+    selection: SendAttachmentSelectionDetails
+    """Position range of the selection within the file"""
+
+    text: str
+    """The selected text content"""
+
+    type: SendAttachmentSelectionType
+    """Attachment type discriminator"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SendAttachmentSelection':
+        assert isinstance(obj, dict)
+        display_name = from_str(obj.get("displayName"))
+        file_path = from_str(obj.get("filePath"))
+        selection = SendAttachmentSelectionDetails.from_dict(obj.get("selection"))
+        text = from_str(obj.get("text"))
+        type = SendAttachmentSelectionType(obj.get("type"))
+        return SendAttachmentSelection(display_name, file_path, selection, text, type)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["displayName"] = from_str(self.display_name)
+        result["filePath"] = from_str(self.file_path)
+        result["selection"] = to_class(SendAttachmentSelectionDetails, self.selection)
+        result["text"] = from_str(self.text)
+        result["type"] = to_enum(SendAttachmentSelectionType, self.type)
         return result
 
 @dataclass
@@ -5953,8 +11027,8 @@ class SessionFSSqliteQueryResult:
     error: SessionFSError | None = None
     """Describes a filesystem error."""
 
-    last_insert_rowid: float | None = None
-    """Last inserted row ID (for INSERT)"""
+    last_insert_rowid: int | None = None
+    """SQLite last_insert_rowid() value for INSERT."""
 
     @staticmethod
     def from_dict(obj: Any) -> 'SessionFSSqliteQueryResult':
@@ -5963,7 +11037,7 @@ class SessionFSSqliteQueryResult:
         rows = from_list(lambda x: from_dict(lambda x: x, x), obj.get("rows"))
         rows_affected = from_int(obj.get("rowsAffected"))
         error = from_union([SessionFSError.from_dict, from_none], obj.get("error"))
-        last_insert_rowid = from_union([from_float, from_none], obj.get("lastInsertRowid"))
+        last_insert_rowid = from_union([from_int, from_none], obj.get("lastInsertRowid"))
         return SessionFSSqliteQueryResult(columns, rows, rows_affected, error, last_insert_rowid)
 
     def to_dict(self) -> dict:
@@ -5974,7 +11048,7 @@ class SessionFSSqliteQueryResult:
         if self.error is not None:
             result["error"] = from_union([lambda x: to_class(SessionFSError, x), from_none], self.error)
         if self.last_insert_rowid is not None:
-            result["lastInsertRowid"] = from_union([to_float, from_none], self.last_insert_rowid)
+            result["lastInsertRowid"] = from_union([from_int, from_none], self.last_insert_rowid)
         return result
 
 @dataclass
@@ -6044,6 +11118,83 @@ class SessionFSReaddirWithTypesResult:
         result["entries"] = from_list(lambda x: to_class(SessionFSReaddirWithTypesEntry, x), self.entries)
         if self.error is not None:
             result["error"] = from_union([lambda x: to_class(SessionFSError, x), from_none], self.error)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class AgentGetCurrentResult:
+    """The currently selected custom agent, or null when using the default agent."""
+
+    agent: AgentInfo | None = None
+    """Currently selected custom agent, or null if using the default agent"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'AgentGetCurrentResult':
+        assert isinstance(obj, dict)
+        agent = from_union([AgentInfo.from_dict, from_none], obj.get("agent"))
+        return AgentGetCurrentResult(agent)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.agent is not None:
+            result["agent"] = from_union([lambda x: to_class(AgentInfo, x), from_none], self.agent)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class AgentList:
+    """Custom agents available to the session."""
+
+    agents: list[AgentInfo]
+    """Available custom agents"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'AgentList':
+        assert isinstance(obj, dict)
+        agents = from_list(AgentInfo.from_dict, obj.get("agents"))
+        return AgentList(agents)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["agents"] = from_list(lambda x: to_class(AgentInfo, x), self.agents)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class AgentReloadResult:
+    """Custom agents available to the session after reloading definitions from disk."""
+
+    agents: list[AgentInfo]
+    """Reloaded custom agents"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'AgentReloadResult':
+        assert isinstance(obj, dict)
+        agents = from_list(AgentInfo.from_dict, obj.get("agents"))
+        return AgentReloadResult(agents)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["agents"] = from_list(lambda x: to_class(AgentInfo, x), self.agents)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class AgentSelectResult:
+    """The newly selected custom agent."""
+
+    agent: AgentInfo
+    """The newly selected custom agent"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'AgentSelectResult':
+        assert isinstance(obj, dict)
+        agent = AgentInfo.from_dict(obj.get("agent"))
+        return AgentSelectResult(agent)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["agent"] = to_class(AgentInfo, self.agent)
         return result
 
 @dataclass
@@ -6124,6 +11275,28 @@ class SlashCommandInvocationResult:
             result["message"] = from_union([from_str, from_none], self.message)
         return result
 
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class TasksGetProgressResult:
+    """Progress information for the task, or null when no task with that ID is tracked."""
+
+    progress: TaskProgressClass | None = None
+    """Progress information for the task, discriminated by type. Returns null when no task with
+    this ID is currently tracked.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'TasksGetProgressResult':
+        assert isinstance(obj, dict)
+        progress = from_union([TaskProgressClass.from_dict, from_none], obj.get("progress"))
+        return TasksGetProgressResult(progress)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.progress is not None:
+            result["progress"] = from_union([lambda x: to_class(TaskProgressClass, x), from_none], self.progress)
+        return result
+
 @dataclass
 class UIElicitationArrayAnyOfField:
     """Multi-select string field where each option pairs a value with a display label."""
@@ -6140,10 +11313,10 @@ class UIElicitationArrayAnyOfField:
     description: str | None = None
     """Help text describing the field."""
 
-    max_items: float | None = None
+    max_items: int | None = None
     """Maximum number of items the user may select."""
 
-    min_items: float | None = None
+    min_items: int | None = None
     """Minimum number of items the user must select."""
 
     title: str | None = None
@@ -6156,8 +11329,8 @@ class UIElicitationArrayAnyOfField:
         type = UIElicitationArrayAnyOfFieldType(obj.get("type"))
         default = from_union([lambda x: from_list(from_str, x), from_none], obj.get("default"))
         description = from_union([from_str, from_none], obj.get("description"))
-        max_items = from_union([from_float, from_none], obj.get("maxItems"))
-        min_items = from_union([from_float, from_none], obj.get("minItems"))
+        max_items = from_union([from_int, from_none], obj.get("maxItems"))
+        min_items = from_union([from_int, from_none], obj.get("minItems"))
         title = from_union([from_str, from_none], obj.get("title"))
         return UIElicitationArrayAnyOfField(items, type, default, description, max_items, min_items, title)
 
@@ -6170,9 +11343,9 @@ class UIElicitationArrayAnyOfField:
         if self.description is not None:
             result["description"] = from_union([from_str, from_none], self.description)
         if self.max_items is not None:
-            result["maxItems"] = from_union([to_float, from_none], self.max_items)
+            result["maxItems"] = from_union([from_int, from_none], self.max_items)
         if self.min_items is not None:
-            result["minItems"] = from_union([to_float, from_none], self.min_items)
+            result["minItems"] = from_union([from_int, from_none], self.min_items)
         if self.title is not None:
             result["title"] = from_union([from_str, from_none], self.title)
         return result
@@ -6193,10 +11366,10 @@ class UIElicitationArrayEnumField:
     description: str | None = None
     """Help text describing the field."""
 
-    max_items: float | None = None
+    max_items: int | None = None
     """Maximum number of items the user may select."""
 
-    min_items: float | None = None
+    min_items: int | None = None
     """Minimum number of items the user must select."""
 
     title: str | None = None
@@ -6209,8 +11382,8 @@ class UIElicitationArrayEnumField:
         type = UIElicitationArrayAnyOfFieldType(obj.get("type"))
         default = from_union([lambda x: from_list(from_str, x), from_none], obj.get("default"))
         description = from_union([from_str, from_none], obj.get("description"))
-        max_items = from_union([from_float, from_none], obj.get("maxItems"))
-        min_items = from_union([from_float, from_none], obj.get("minItems"))
+        max_items = from_union([from_int, from_none], obj.get("maxItems"))
+        min_items = from_union([from_int, from_none], obj.get("minItems"))
         title = from_union([from_str, from_none], obj.get("title"))
         return UIElicitationArrayEnumField(items, type, default, description, max_items, min_items, title)
 
@@ -6223,9 +11396,9 @@ class UIElicitationArrayEnumField:
         if self.description is not None:
             result["description"] = from_union([from_str, from_none], self.description)
         if self.max_items is not None:
-            result["maxItems"] = from_union([to_float, from_none], self.max_items)
+            result["maxItems"] = from_union([from_int, from_none], self.max_items)
         if self.min_items is not None:
-            result["minItems"] = from_union([to_float, from_none], self.min_items)
+            result["minItems"] = from_union([from_int, from_none], self.min_items)
         if self.title is not None:
             result["title"] = from_union([from_str, from_none], self.title)
         return result
@@ -6282,19 +11455,19 @@ class UIElicitationSchemaProperty:
     items: UIElicitationArrayFieldItems | None = None
     """Schema applied to each item in the array."""
 
-    max_items: float | None = None
+    max_items: int | None = None
     """Maximum number of items the user may select."""
 
-    min_items: float | None = None
+    min_items: int | None = None
     """Minimum number of items the user must select."""
 
     format: UIElicitationSchemaPropertyStringFormat | None = None
     """Optional format hint that constrains the accepted input."""
 
-    max_length: float | None = None
+    max_length: int | None = None
     """Maximum number of characters allowed."""
 
-    min_length: float | None = None
+    min_length: int | None = None
     """Minimum number of characters required."""
 
     maximum: float | None = None
@@ -6314,11 +11487,11 @@ class UIElicitationSchemaProperty:
         title = from_union([from_str, from_none], obj.get("title"))
         one_of = from_union([lambda x: from_list(UIElicitationStringOneOfFieldOneOf.from_dict, x), from_none], obj.get("oneOf"))
         items = from_union([UIElicitationArrayFieldItems.from_dict, from_none], obj.get("items"))
-        max_items = from_union([from_float, from_none], obj.get("maxItems"))
-        min_items = from_union([from_float, from_none], obj.get("minItems"))
+        max_items = from_union([from_int, from_none], obj.get("maxItems"))
+        min_items = from_union([from_int, from_none], obj.get("minItems"))
         format = from_union([UIElicitationSchemaPropertyStringFormat, from_none], obj.get("format"))
-        max_length = from_union([from_float, from_none], obj.get("maxLength"))
-        min_length = from_union([from_float, from_none], obj.get("minLength"))
+        max_length = from_union([from_int, from_none], obj.get("maxLength"))
+        min_length = from_union([from_int, from_none], obj.get("minLength"))
         maximum = from_union([from_float, from_none], obj.get("maximum"))
         minimum = from_union([from_float, from_none], obj.get("minimum"))
         return UIElicitationSchemaProperty(type, default, description, enum, enum_names, title, one_of, items, max_items, min_items, format, max_length, min_length, maximum, minimum)
@@ -6341,15 +11514,15 @@ class UIElicitationSchemaProperty:
         if self.items is not None:
             result["items"] = from_union([lambda x: to_class(UIElicitationArrayFieldItems, x), from_none], self.items)
         if self.max_items is not None:
-            result["maxItems"] = from_union([to_float, from_none], self.max_items)
+            result["maxItems"] = from_union([from_int, from_none], self.max_items)
         if self.min_items is not None:
-            result["minItems"] = from_union([to_float, from_none], self.min_items)
+            result["minItems"] = from_union([from_int, from_none], self.min_items)
         if self.format is not None:
             result["format"] = from_union([lambda x: to_enum(UIElicitationSchemaPropertyStringFormat, x), from_none], self.format)
         if self.max_length is not None:
-            result["maxLength"] = from_union([to_float, from_none], self.max_length)
+            result["maxLength"] = from_union([from_int, from_none], self.max_length)
         if self.min_length is not None:
-            result["minLength"] = from_union([to_float, from_none], self.min_length)
+            result["minLength"] = from_union([from_int, from_none], self.min_length)
         if self.maximum is not None:
             result["maximum"] = from_union([to_float, from_none], self.maximum)
         if self.minimum is not None:
@@ -6380,6 +11553,29 @@ class UIHandlePendingElicitationRequest:
         result["result"] = to_class(UIElicitationResponse, self.result)
         return result
 
+@dataclass
+class UIHandlePendingExitPlanModeRequest:
+    """Request ID of a pending `exit_plan_mode.requested` event and the user's response."""
+
+    request_id: str
+    """The unique request ID from the exit_plan_mode.requested event"""
+
+    response: UIExitPlanModeResponse
+    """Schema for the `UIExitPlanModeResponse` type."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UIHandlePendingExitPlanModeRequest':
+        assert isinstance(obj, dict)
+        request_id = from_str(obj.get("requestId"))
+        response = UIExitPlanModeResponse.from_dict(obj.get("response"))
+        return UIHandlePendingExitPlanModeRequest(request_id, response)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["requestId"] = from_str(self.request_id)
+        result["response"] = to_class(UIExitPlanModeResponse, self.response)
+        return result
+
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
 class UsageGetMetricsResult:
@@ -6398,10 +11594,10 @@ class UsageGetMetricsResult:
     model_metrics: dict[str, UsageMetricsModelMetric]
     """Per-model token and request metrics, keyed by model identifier"""
 
-    session_start_time: int
-    """Session start timestamp (epoch milliseconds)"""
+    session_start_time: datetime
+    """ISO 8601 timestamp when the session started"""
 
-    total_api_duration_ms: float
+    total_api_duration_ms: int
     """Total time spent in model API calls (milliseconds)"""
 
     total_premium_request_cost: float
@@ -6427,8 +11623,8 @@ class UsageGetMetricsResult:
         last_call_input_tokens = from_int(obj.get("lastCallInputTokens"))
         last_call_output_tokens = from_int(obj.get("lastCallOutputTokens"))
         model_metrics = from_dict(UsageMetricsModelMetric.from_dict, obj.get("modelMetrics"))
-        session_start_time = from_int(obj.get("sessionStartTime"))
-        total_api_duration_ms = from_float(obj.get("totalApiDurationMs"))
+        session_start_time = from_datetime(obj.get("sessionStartTime"))
+        total_api_duration_ms = from_int(obj.get("totalApiDurationMs"))
         total_premium_request_cost = from_float(obj.get("totalPremiumRequestCost"))
         total_user_requests = from_int(obj.get("totalUserRequests"))
         current_model = from_union([from_str, from_none], obj.get("currentModel"))
@@ -6442,8 +11638,8 @@ class UsageGetMetricsResult:
         result["lastCallInputTokens"] = from_int(self.last_call_input_tokens)
         result["lastCallOutputTokens"] = from_int(self.last_call_output_tokens)
         result["modelMetrics"] = from_dict(lambda x: to_class(UsageMetricsModelMetric, x), self.model_metrics)
-        result["sessionStartTime"] = from_int(self.session_start_time)
-        result["totalApiDurationMs"] = to_float(self.total_api_duration_ms)
+        result["sessionStartTime"] = self.session_start_time.isoformat()
+        result["totalApiDurationMs"] = from_int(self.total_api_duration_ms)
         result["totalPremiumRequestCost"] = to_float(self.total_premium_request_cost)
         result["totalUserRequests"] = from_int(self.total_user_requests)
         if self.current_model is not None:
@@ -6452,24 +11648,6 @@ class UsageGetMetricsResult:
             result["tokenDetails"] = from_union([lambda x: from_dict(lambda x: to_class(UsageMetricsTokenDetail, x), x), from_none], self.token_details)
         if self.total_nano_aiu is not None:
             result["totalNanoAiu"] = from_union([from_int, from_none], self.total_nano_aiu)
-        return result
-
-@dataclass
-class WorkspacesGetWorkspaceResult:
-    """Current workspace metadata for the session, or null when not available."""
-
-    workspace: Workspace | None = None
-    """Current workspace metadata, or null if not available"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'WorkspacesGetWorkspaceResult':
-        assert isinstance(obj, dict)
-        workspace = from_union([Workspace.from_dict, from_none], obj.get("workspace"))
-        return WorkspacesGetWorkspaceResult(workspace)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["workspace"] = from_union([lambda x: to_class(Workspace, x), from_none], self.workspace)
         return result
 
 @dataclass
@@ -6491,8 +11669,283 @@ class CommandList:
         return result
 
 @dataclass
+class APIKeyAuthInfo:
+    """Schema for the `ApiKeyAuthInfo` type."""
+
+    api_key: str
+    """The API key. Treat as a secret."""
+
+    host: str
+    """Authentication host."""
+
+    type: APIKeyAuthInfoType
+    """API-key authentication for non-GitHub LLM providers (e.g. when running BYOM-style)."""
+
+    copilot_user: CopilotUserResponse | None = None
+    """Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the
+    GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this
+    verbatim and does not re-fetch when set.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'APIKeyAuthInfo':
+        assert isinstance(obj, dict)
+        api_key = from_str(obj.get("apiKey"))
+        host = from_str(obj.get("host"))
+        type = APIKeyAuthInfoType(obj.get("type"))
+        copilot_user = from_union([CopilotUserResponse.from_dict, from_none], obj.get("copilotUser"))
+        return APIKeyAuthInfo(api_key, host, type, copilot_user)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["apiKey"] = from_str(self.api_key)
+        result["host"] = from_str(self.host)
+        result["type"] = to_enum(APIKeyAuthInfoType, self.type)
+        if self.copilot_user is not None:
+            result["copilotUser"] = from_union([lambda x: to_class(CopilotUserResponse, x), from_none], self.copilot_user)
+        return result
+
+@dataclass
+class CopilotAPITokenAuthInfo:
+    """Schema for the `CopilotApiTokenAuthInfo` type."""
+
+    host: Host
+    """Authentication host (always the public GitHub host)."""
+
+    type: CopilotAPITokenAuthInfoType
+    """Direct Copilot API authentication via the `GITHUB_COPILOT_API_TOKEN` + `COPILOT_API_URL`
+    environment-variable pair. The token itself is read from the environment by the runtime,
+    not carried in this struct.
+    """
+    copilot_user: CopilotUserResponse | None = None
+    """Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the
+    GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this
+    verbatim and does not re-fetch when set.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'CopilotAPITokenAuthInfo':
+        assert isinstance(obj, dict)
+        host = Host(obj.get("host"))
+        type = CopilotAPITokenAuthInfoType(obj.get("type"))
+        copilot_user = from_union([CopilotUserResponse.from_dict, from_none], obj.get("copilotUser"))
+        return CopilotAPITokenAuthInfo(host, type, copilot_user)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["host"] = to_enum(Host, self.host)
+        result["type"] = to_enum(CopilotAPITokenAuthInfoType, self.type)
+        if self.copilot_user is not None:
+            result["copilotUser"] = from_union([lambda x: to_class(CopilotUserResponse, x), from_none], self.copilot_user)
+        return result
+
+@dataclass
+class EnvAuthInfo:
+    """Schema for the `EnvAuthInfo` type."""
+
+    env_var: str
+    """Name of the environment variable the token was sourced from."""
+
+    host: str
+    """Authentication host (e.g. https://github.com or a GHES host)."""
+
+    token: str
+    """The token value itself. Treat as a secret."""
+
+    type: EnvAuthInfoType
+    """Personal access token (PAT) or server-to-server token sourced from an environment
+    variable.
+    """
+    copilot_user: CopilotUserResponse | None = None
+    """Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the
+    GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this
+    verbatim and does not re-fetch when set.
+    """
+    login: str | None = None
+    """User login associated with the token. Undefined for server-to-server tokens (those
+    starting with `ghs_`).
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'EnvAuthInfo':
+        assert isinstance(obj, dict)
+        env_var = from_str(obj.get("envVar"))
+        host = from_str(obj.get("host"))
+        token = from_str(obj.get("token"))
+        type = EnvAuthInfoType(obj.get("type"))
+        copilot_user = from_union([CopilotUserResponse.from_dict, from_none], obj.get("copilotUser"))
+        login = from_union([from_str, from_none], obj.get("login"))
+        return EnvAuthInfo(env_var, host, token, type, copilot_user, login)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["envVar"] = from_str(self.env_var)
+        result["host"] = from_str(self.host)
+        result["token"] = from_str(self.token)
+        result["type"] = to_enum(EnvAuthInfoType, self.type)
+        if self.copilot_user is not None:
+            result["copilotUser"] = from_union([lambda x: to_class(CopilotUserResponse, x), from_none], self.copilot_user)
+        if self.login is not None:
+            result["login"] = from_union([from_str, from_none], self.login)
+        return result
+
+@dataclass
+class GhCLIAuthInfo:
+    """Schema for the `GhCliAuthInfo` type."""
+
+    host: str
+    """Authentication host."""
+
+    login: str
+    """User login as reported by `gh auth status`."""
+
+    token: str
+    """The token returned by `gh auth token`. Treat as a secret."""
+
+    type: GhCLIAuthInfoType
+    """Authentication via the `gh` CLI's saved credentials."""
+
+    copilot_user: CopilotUserResponse | None = None
+    """Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the
+    GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this
+    verbatim and does not re-fetch when set.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'GhCLIAuthInfo':
+        assert isinstance(obj, dict)
+        host = from_str(obj.get("host"))
+        login = from_str(obj.get("login"))
+        token = from_str(obj.get("token"))
+        type = GhCLIAuthInfoType(obj.get("type"))
+        copilot_user = from_union([CopilotUserResponse.from_dict, from_none], obj.get("copilotUser"))
+        return GhCLIAuthInfo(host, login, token, type, copilot_user)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["host"] = from_str(self.host)
+        result["login"] = from_str(self.login)
+        result["token"] = from_str(self.token)
+        result["type"] = to_enum(GhCLIAuthInfoType, self.type)
+        if self.copilot_user is not None:
+            result["copilotUser"] = from_union([lambda x: to_class(CopilotUserResponse, x), from_none], self.copilot_user)
+        return result
+
+@dataclass
+class HMACAuthInfo:
+    """Schema for the `HMACAuthInfo` type."""
+
+    hmac: str
+    """HMAC secret used to sign requests."""
+
+    host: Host
+    """Authentication host. HMAC auth always targets the public GitHub host."""
+
+    type: HMACAuthInfoType
+    """HMAC-based authentication used by GitHub-internal services."""
+
+    copilot_user: CopilotUserResponse | None = None
+    """Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the
+    GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this
+    verbatim and does not re-fetch when set.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'HMACAuthInfo':
+        assert isinstance(obj, dict)
+        hmac = from_str(obj.get("hmac"))
+        host = Host(obj.get("host"))
+        type = HMACAuthInfoType(obj.get("type"))
+        copilot_user = from_union([CopilotUserResponse.from_dict, from_none], obj.get("copilotUser"))
+        return HMACAuthInfo(hmac, host, type, copilot_user)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["hmac"] = from_str(self.hmac)
+        result["host"] = to_enum(Host, self.host)
+        result["type"] = to_enum(HMACAuthInfoType, self.type)
+        if self.copilot_user is not None:
+            result["copilotUser"] = from_union([lambda x: to_class(CopilotUserResponse, x), from_none], self.copilot_user)
+        return result
+
+@dataclass
+class TokenAuthInfo:
+    """Schema for the `TokenAuthInfo` type."""
+
+    host: str
+    """Authentication host."""
+
+    token: str
+    """The token value itself. Treat as a secret."""
+
+    type: TokenAuthInfoType
+    """SDK-side token authentication; the host configured the token directly via the SDK."""
+
+    copilot_user: CopilotUserResponse | None = None
+    """Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the
+    GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this
+    verbatim and does not re-fetch when set.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'TokenAuthInfo':
+        assert isinstance(obj, dict)
+        host = from_str(obj.get("host"))
+        token = from_str(obj.get("token"))
+        type = TokenAuthInfoType(obj.get("type"))
+        copilot_user = from_union([CopilotUserResponse.from_dict, from_none], obj.get("copilotUser"))
+        return TokenAuthInfo(host, token, type, copilot_user)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["host"] = from_str(self.host)
+        result["token"] = from_str(self.token)
+        result["type"] = to_enum(TokenAuthInfoType, self.type)
+        if self.copilot_user is not None:
+            result["copilotUser"] = from_union([lambda x: to_class(CopilotUserResponse, x), from_none], self.copilot_user)
+        return result
+
+@dataclass
+class UserAuthInfo:
+    """Schema for the `UserAuthInfo` type."""
+
+    host: str
+    """Authentication host."""
+
+    login: str
+    """OAuth user login."""
+
+    type: UserAuthInfoType
+    """OAuth user authentication. The token itself is held in the runtime's secret token store
+    (keyed by host+login) and is NOT carried in this struct.
+    """
+    copilot_user: CopilotUserResponse | None = None
+    """Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the
+    GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this
+    verbatim and does not re-fetch when set.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UserAuthInfo':
+        assert isinstance(obj, dict)
+        host = from_str(obj.get("host"))
+        login = from_str(obj.get("login"))
+        type = UserAuthInfoType(obj.get("type"))
+        copilot_user = from_union([CopilotUserResponse.from_dict, from_none], obj.get("copilotUser"))
+        return UserAuthInfo(host, login, type, copilot_user)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["host"] = from_str(self.host)
+        result["login"] = from_str(self.login)
+        result["type"] = to_enum(UserAuthInfoType, self.type)
+        if self.copilot_user is not None:
+            result["copilotUser"] = from_union([lambda x: to_class(CopilotUserResponse, x), from_none], self.copilot_user)
+        return result
+
+@dataclass
 class PermissionDecisionApproveForLocationApproval:
-    """The approval to persist for this location
+    """Approval to persist for this location
 
     Schema for the `PermissionDecisionApproveForLocationApprovalCommands` type.
 
@@ -6578,7 +12031,7 @@ class PermissionDecisionApproveForLocationApproval:
 
 @dataclass
 class PermissionDecisionApproveForIonApproval:
-    """The approval to add as a session-scoped rule
+    """Session-scoped approval to remember (tool prompts only; omitted for path/url prompts)
 
     Schema for the `PermissionDecisionApproveForSessionApprovalCommands` type.
 
@@ -6599,7 +12052,7 @@ class PermissionDecisionApproveForIonApproval:
     Schema for the `PermissionDecisionApproveForSessionApprovalExtensionPermissionAccess`
     type.
 
-    The approval to persist for this location
+    Approval to persist for this location
 
     Schema for the `PermissionDecisionApproveForLocationApprovalCommands` type.
 
@@ -6619,8 +12072,15 @@ class PermissionDecisionApproveForIonApproval:
 
     Schema for the `PermissionDecisionApproveForLocationApprovalExtensionPermissionAccess`
     type.
+
+    The approval to add as a session-scoped rule
+
+    The approval to persist for this location
     """
-    kind: ApprovalKind
+    command_identifiers: list[str] | None = None
+    """Command identifiers covered by this approval."""
+
+    kind: ApprovalKind | None = None
     """Approval scoped to specific command identifiers.
 
     Approval covering read-only filesystem operations.
@@ -6639,9 +12099,6 @@ class PermissionDecisionApproveForIonApproval:
 
     Approval covering an extension's request to access a permission-gated capability.
     """
-    command_identifiers: list[str] | None = None
-    """Command identifiers covered by this approval."""
-
     server_name: str | None = None
     """MCP server name."""
 
@@ -6657,22 +12114,26 @@ class PermissionDecisionApproveForIonApproval:
     extension_name: str | None = None
     """Extension name."""
 
+    external_ref_marker_external_ref_user_tool_session_approval: str | None = None
+
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecisionApproveForIonApproval':
         assert isinstance(obj, dict)
-        kind = ApprovalKind(obj.get("kind"))
         command_identifiers = from_union([lambda x: from_list(from_str, x), from_none], obj.get("commandIdentifiers"))
+        kind = from_union([ApprovalKind, from_none], obj.get("kind"))
         server_name = from_union([from_str, from_none], obj.get("serverName"))
         tool_name = from_union([from_none, from_str], obj.get("toolName"))
         operation = from_union([from_str, from_none], obj.get("operation"))
         extension_name = from_union([from_str, from_none], obj.get("extensionName"))
-        return PermissionDecisionApproveForIonApproval(kind, command_identifiers, server_name, tool_name, operation, extension_name)
+        external_ref_marker_external_ref_user_tool_session_approval = from_union([from_str, from_none], obj.get("__externalRefMarker___ExternalRef_UserToolSessionApproval"))
+        return PermissionDecisionApproveForIonApproval(command_identifiers, kind, server_name, tool_name, operation, extension_name, external_ref_marker_external_ref_user_tool_session_approval)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["kind"] = to_enum(ApprovalKind, self.kind)
         if self.command_identifiers is not None:
             result["commandIdentifiers"] = from_union([lambda x: from_list(from_str, x), from_none], self.command_identifiers)
+        if self.kind is not None:
+            result["kind"] = from_union([lambda x: to_enum(ApprovalKind, x), from_none], self.kind)
         if self.server_name is not None:
             result["serverName"] = from_union([from_str, from_none], self.server_name)
         if self.tool_name is not None:
@@ -6681,11 +12142,13 @@ class PermissionDecisionApproveForIonApproval:
             result["operation"] = from_union([from_str, from_none], self.operation)
         if self.extension_name is not None:
             result["extensionName"] = from_union([from_str, from_none], self.extension_name)
+        if self.external_ref_marker_external_ref_user_tool_session_approval is not None:
+            result["__externalRefMarker___ExternalRef_UserToolSessionApproval"] = from_union([from_str, from_none], self.external_ref_marker_external_ref_user_tool_session_approval)
         return result
 
 @dataclass
 class PermissionDecisionApproveForSessionApproval:
-    """The approval to add as a session-scoped rule
+    """Session-scoped approval to remember (tool prompts only; omitted for path/url prompts)
 
     Schema for the `PermissionDecisionApproveForSessionApprovalCommands` type.
 
@@ -6824,6 +12287,425 @@ class ExternalToolTextResultForLlm:
             result["toolTelemetry"] = from_union([lambda x: from_dict(lambda x: x, x), from_none], self.tool_telemetry)
         return result
 
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class InstalledPlugin:
+    """Schema for the `InstalledPlugin` type."""
+
+    enabled: bool
+    """Whether the plugin is currently enabled"""
+
+    installed_at: str
+    """Installation timestamp"""
+
+    marketplace: str
+    """Marketplace the plugin came from (empty string for direct repo installs)"""
+
+    name: str
+    """Plugin name"""
+
+    cache_path: str | None = None
+    """Path where the plugin is cached locally"""
+
+    source: InstalledPluginSource | str | None = None
+    """Source for direct repo installs (when marketplace is empty)"""
+
+    version: str | None = None
+    """Version installed (if available)"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'InstalledPlugin':
+        assert isinstance(obj, dict)
+        enabled = from_bool(obj.get("enabled"))
+        installed_at = from_str(obj.get("installed_at"))
+        marketplace = from_str(obj.get("marketplace"))
+        name = from_str(obj.get("name"))
+        cache_path = from_union([from_str, from_none], obj.get("cache_path"))
+        source = from_union([InstalledPluginSource.from_dict, from_str, from_none], obj.get("source"))
+        version = from_union([from_str, from_none], obj.get("version"))
+        return InstalledPlugin(enabled, installed_at, marketplace, name, cache_path, source, version)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["enabled"] = from_bool(self.enabled)
+        result["installed_at"] = from_str(self.installed_at)
+        result["marketplace"] = from_str(self.marketplace)
+        result["name"] = from_str(self.name)
+        if self.cache_path is not None:
+            result["cache_path"] = from_union([from_str, from_none], self.cache_path)
+        if self.source is not None:
+            result["source"] = from_union([lambda x: to_class(InstalledPluginSource, x), from_str, from_none], self.source)
+        if self.version is not None:
+            result["version"] = from_union([from_str, from_none], self.version)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionInstalledPlugin:
+    """Schema for the `SessionInstalledPlugin` type."""
+
+    enabled: bool
+    """Whether the plugin is currently enabled"""
+
+    installed_at: str
+    """Installation timestamp (ISO-8601)"""
+
+    marketplace: str
+    """Marketplace the plugin came from (empty string for direct repo installs)"""
+
+    name: str
+    """Plugin name"""
+
+    cache_path: str | None = None
+    """Path where the plugin is cached locally"""
+
+    source: SessionInstalledPluginSource | str | None = None
+    """Source descriptor for direct repo installs (when marketplace is empty)"""
+
+    version: str | None = None
+    """Installed version, if known"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionInstalledPlugin':
+        assert isinstance(obj, dict)
+        enabled = from_bool(obj.get("enabled"))
+        installed_at = from_str(obj.get("installed_at"))
+        marketplace = from_str(obj.get("marketplace"))
+        name = from_str(obj.get("name"))
+        cache_path = from_union([from_str, from_none], obj.get("cache_path"))
+        source = from_union([SessionInstalledPluginSource.from_dict, from_str, from_none], obj.get("source"))
+        version = from_union([from_str, from_none], obj.get("version"))
+        return SessionInstalledPlugin(enabled, installed_at, marketplace, name, cache_path, source, version)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["enabled"] = from_bool(self.enabled)
+        result["installed_at"] = from_str(self.installed_at)
+        result["marketplace"] = from_str(self.marketplace)
+        result["name"] = from_str(self.name)
+        if self.cache_path is not None:
+            result["cache_path"] = from_union([from_str, from_none], self.cache_path)
+        if self.source is not None:
+            result["source"] = from_union([lambda x: to_class(SessionInstalledPluginSource, x), from_str, from_none], self.source)
+        if self.version is not None:
+            result["version"] = from_union([from_str, from_none], self.version)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionEnrichMetadataResult:
+    """The same metadata records, with summary and context fields backfilled where available."""
+
+    sessions: list[SessionMetadata]
+    """Same records, with summary and context backfilled"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionEnrichMetadataResult':
+        assert isinstance(obj, dict)
+        sessions = from_list(SessionMetadata.from_dict, obj.get("sessions"))
+        return SessionEnrichMetadataResult(sessions)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["sessions"] = from_list(lambda x: to_class(SessionMetadata, x), self.sessions)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionList:
+    """Persisted sessions matching the filter, ordered most-recently-modified first."""
+
+    sessions: list[SessionMetadata]
+    """Sessions ordered most-recently-modified first"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionList':
+        assert isinstance(obj, dict)
+        sessions = from_list(SessionMetadata.from_dict, obj.get("sessions"))
+        return SessionList(sessions)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["sessions"] = from_list(lambda x: to_class(SessionMetadata, x), self.sessions)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsEnrichMetadataRequest:
+    """Session metadata records to enrich with summary and context information."""
+
+    sessions: list[SessionMetadata]
+    """Session metadata records to enrich. Records that already have summary and context are
+    returned unchanged.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsEnrichMetadataRequest':
+        assert isinstance(obj, dict)
+        sessions = from_list(SessionMetadata.from_dict, obj.get("sessions"))
+        return SessionsEnrichMetadataRequest(sessions)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["sessions"] = from_list(lambda x: to_class(SessionMetadata, x), self.sessions)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionMetadataSnapshot:
+    """Point-in-time snapshot of slow-changing session identifier and state fields"""
+
+    already_in_use: bool
+    """True when the session was detected to be in use by another process at construction time.
+    Local consumers may surface a confirmation prompt before fully attaching. Always false
+    for new sessions.
+    """
+    current_mode: MetadataSnapshotCurrentMode
+    """The current agent mode for this session (e.g., 'interactive', 'plan', 'autopilot')"""
+
+    is_remote: bool
+    """Whether this is a remote session (i.e., one whose runtime executes elsewhere and is
+    steered through this process)
+    """
+    modified_time: datetime
+    """ISO 8601 timestamp of when the session's persisted state was last modified on disk. For
+    new sessions, equals startTime. For resumed sessions, reflects the previous modification
+    time at construction.
+    """
+    session_id: str
+    """The unique identifier of the session"""
+
+    start_time: datetime
+    """ISO 8601 timestamp of when the session started"""
+
+    working_directory: str
+    """Absolute path to the session's current working directory"""
+
+    initial_name: str | None = None
+    """User-provided name supplied at session construction (via `--name`), if any. Immutable
+    after construction.
+    """
+    remote_metadata: MetadataSnapshotRemoteMetadata | None = None
+    """Remote-session-specific metadata. Populated only when `isRemote` is true. Fields are
+    immutable for the lifetime of the session.
+    """
+    selected_model: str | None = None
+    """Currently selected model identifier, if any"""
+
+    summary: str | None = None
+    """Short human-readable summary of the session, if known. Omitted when no summary has been
+    generated.
+    """
+    workspace: WorkspaceSummary | None = None
+    """Public-facing workspace metadata for this session, or null if the session has no
+    associated workspace. Excludes runtime-internal fields (GitHub IDs, summary count,
+    internal flags).
+    """
+    workspace_path: str | None = None
+    """Absolute path to the session's workspace directory on disk, or null if the session has no
+    associated workspace
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionMetadataSnapshot':
+        assert isinstance(obj, dict)
+        already_in_use = from_bool(obj.get("alreadyInUse"))
+        current_mode = MetadataSnapshotCurrentMode(obj.get("currentMode"))
+        is_remote = from_bool(obj.get("isRemote"))
+        modified_time = from_datetime(obj.get("modifiedTime"))
+        session_id = from_str(obj.get("sessionId"))
+        start_time = from_datetime(obj.get("startTime"))
+        working_directory = from_str(obj.get("workingDirectory"))
+        initial_name = from_union([from_str, from_none], obj.get("initialName"))
+        remote_metadata = from_union([MetadataSnapshotRemoteMetadata.from_dict, from_none], obj.get("remoteMetadata"))
+        selected_model = from_union([from_str, from_none], obj.get("selectedModel"))
+        summary = from_union([from_str, from_none], obj.get("summary"))
+        workspace = from_union([WorkspaceSummary.from_dict, from_none], obj.get("workspace"))
+        workspace_path = from_union([from_none, from_str], obj.get("workspacePath"))
+        return SessionMetadataSnapshot(already_in_use, current_mode, is_remote, modified_time, session_id, start_time, working_directory, initial_name, remote_metadata, selected_model, summary, workspace, workspace_path)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["alreadyInUse"] = from_bool(self.already_in_use)
+        result["currentMode"] = to_enum(MetadataSnapshotCurrentMode, self.current_mode)
+        result["isRemote"] = from_bool(self.is_remote)
+        result["modifiedTime"] = self.modified_time.isoformat()
+        result["sessionId"] = from_str(self.session_id)
+        result["startTime"] = self.start_time.isoformat()
+        result["workingDirectory"] = from_str(self.working_directory)
+        if self.initial_name is not None:
+            result["initialName"] = from_union([from_str, from_none], self.initial_name)
+        if self.remote_metadata is not None:
+            result["remoteMetadata"] = from_union([lambda x: to_class(MetadataSnapshotRemoteMetadata, x), from_none], self.remote_metadata)
+        if self.selected_model is not None:
+            result["selectedModel"] = from_union([from_str, from_none], self.selected_model)
+        if self.summary is not None:
+            result["summary"] = from_union([from_str, from_none], self.summary)
+        if self.workspace is not None:
+            result["workspace"] = from_union([lambda x: to_class(WorkspaceSummary, x), from_none], self.workspace)
+        result["workspacePath"] = from_union([from_none, from_str], self.workspace_path)
+        return result
+
+@dataclass
+class PermissionsConfigureParams:
+    """Patch of permission policy fields to apply (omit a field to leave it unchanged)."""
+
+    additional_content_exclusion_policies: list[PermissionsConfigureAdditionalContentExclusionPolicy] | None = None
+    """If specified, replaces the host-supplied GitHub Content Exclusion policies on the session
+    (combined with natively-discovered policies when evaluating tool/file access). Omit to
+    leave the current policies unchanged.
+    """
+    approve_all_read_permission_requests: bool | None = None
+    """If specified, sets whether path/URL read permission requests are auto-approved. Omit to
+    leave the current value unchanged.
+    """
+    approve_all_tool_permission_requests: bool | None = None
+    """If specified, sets whether tool permission requests are auto-approved without prompting.
+    Omit to leave the current value unchanged.
+    """
+    paths: PermissionPathsConfig | None = None
+    """If specified, replaces the session's path-permission policy. The runtime constructs the
+    appropriate PathManager based on these inputs (rooted at the session's working
+    directory). Omit to leave the current path policy unchanged.
+    """
+    rules: PermissionRulesSet | None = None
+    """If specified, replaces the session's approved/denied permission rules. Omit to leave the
+    current rules unchanged.
+    """
+    urls: PermissionUrlsConfig | None = None
+    """If specified, replaces the session's URL-permission policy. The runtime constructs a
+    fresh DefaultUrlManager based on these inputs. Omit to leave the current URL policy
+    unchanged.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsConfigureParams':
+        assert isinstance(obj, dict)
+        additional_content_exclusion_policies = from_union([lambda x: from_list(PermissionsConfigureAdditionalContentExclusionPolicy.from_dict, x), from_none], obj.get("additionalContentExclusionPolicies"))
+        approve_all_read_permission_requests = from_union([from_bool, from_none], obj.get("approveAllReadPermissionRequests"))
+        approve_all_tool_permission_requests = from_union([from_bool, from_none], obj.get("approveAllToolPermissionRequests"))
+        paths = from_union([PermissionPathsConfig.from_dict, from_none], obj.get("paths"))
+        rules = from_union([PermissionRulesSet.from_dict, from_none], obj.get("rules"))
+        urls = from_union([PermissionUrlsConfig.from_dict, from_none], obj.get("urls"))
+        return PermissionsConfigureParams(additional_content_exclusion_policies, approve_all_read_permission_requests, approve_all_tool_permission_requests, paths, rules, urls)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.additional_content_exclusion_policies is not None:
+            result["additionalContentExclusionPolicies"] = from_union([lambda x: from_list(lambda x: to_class(PermissionsConfigureAdditionalContentExclusionPolicy, x), x), from_none], self.additional_content_exclusion_policies)
+        if self.approve_all_read_permission_requests is not None:
+            result["approveAllReadPermissionRequests"] = from_union([from_bool, from_none], self.approve_all_read_permission_requests)
+        if self.approve_all_tool_permission_requests is not None:
+            result["approveAllToolPermissionRequests"] = from_union([from_bool, from_none], self.approve_all_tool_permission_requests)
+        if self.paths is not None:
+            result["paths"] = from_union([lambda x: to_class(PermissionPathsConfig, x), from_none], self.paths)
+        if self.rules is not None:
+            result["rules"] = from_union([lambda x: to_class(PermissionRulesSet, x), from_none], self.rules)
+        if self.urls is not None:
+            result["urls"] = from_union([lambda x: to_class(PermissionUrlsConfig, x), from_none], self.urls)
+        return result
+
+@dataclass
+class SendRequest:
+    """Parameters for sending a user message to the session"""
+
+    prompt: str
+    """The user message text"""
+
+    agent_mode: SendAgentMode | None = None
+    """The UI mode the agent was in when this message was sent. Defaults to the session's
+    current mode.
+    """
+    attachments: list[SendAttachment] | None = None
+    """Optional attachments (files, directories, selections, blobs, GitHub references) to
+    include with the message
+    """
+    billable: bool | None = None
+    """If false, this message will not trigger a Premium Request Unit charge. User messages
+    default to billable.
+    """
+    display_prompt: str | None = None
+    """If provided, this is shown in the timeline instead of `prompt`"""
+
+    mode: SendMode | None = None
+    """How to deliver the message. `enqueue` (default) appends to the message queue. `immediate`
+    interjects during an in-progress turn.
+    """
+    prepend: bool | None = None
+    """If true, adds the message to the front of the queue instead of the end"""
+
+    request_headers: dict[str, str] | None = None
+    """Custom HTTP headers to include in outbound model requests for this turn. Merged with
+    session-level provider headers; per-turn headers augment and overwrite session-level
+    headers with the same key.
+    """
+    required_tool: str | None = None
+    """If set, the request will fail if the named tool is not available when this message is
+    among the user messages at the start of the current exchange
+    """
+    source: Any = None
+    """Optional provenance tag copied to the resulting user.message event. Supported values are
+    `system`, `command-*`, and `schedule-*`.
+    """
+    traceparent: str | None = None
+    """W3C Trace Context traceparent header for distributed tracing of this agent turn"""
+
+    tracestate: str | None = None
+    """W3C Trace Context tracestate header for distributed tracing"""
+
+    wait: bool | None = None
+    """If true, await completion of the agentic loop for this message before returning. Defaults
+    to false (fire-and-forget). When true, the result still contains the same `messageId`;
+    the caller can rely on the agent having processed the message before the call resolves.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SendRequest':
+        assert isinstance(obj, dict)
+        prompt = from_str(obj.get("prompt"))
+        agent_mode = from_union([SendAgentMode, from_none], obj.get("agentMode"))
+        attachments = from_union([lambda x: from_list(SendAttachment.from_dict, x), from_none], obj.get("attachments"))
+        billable = from_union([from_bool, from_none], obj.get("billable"))
+        display_prompt = from_union([from_str, from_none], obj.get("displayPrompt"))
+        mode = from_union([SendMode, from_none], obj.get("mode"))
+        prepend = from_union([from_bool, from_none], obj.get("prepend"))
+        request_headers = from_union([lambda x: from_dict(from_str, x), from_none], obj.get("requestHeaders"))
+        required_tool = from_union([from_str, from_none], obj.get("requiredTool"))
+        source = obj.get("source")
+        traceparent = from_union([from_str, from_none], obj.get("traceparent"))
+        tracestate = from_union([from_str, from_none], obj.get("tracestate"))
+        wait = from_union([from_bool, from_none], obj.get("wait"))
+        return SendRequest(prompt, agent_mode, attachments, billable, display_prompt, mode, prepend, request_headers, required_tool, source, traceparent, tracestate, wait)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["prompt"] = from_str(self.prompt)
+        if self.agent_mode is not None:
+            result["agentMode"] = from_union([lambda x: to_enum(SendAgentMode, x), from_none], self.agent_mode)
+        if self.attachments is not None:
+            result["attachments"] = from_union([lambda x: from_list(lambda x: to_class(SendAttachment, x), x), from_none], self.attachments)
+        if self.billable is not None:
+            result["billable"] = from_union([from_bool, from_none], self.billable)
+        if self.display_prompt is not None:
+            result["displayPrompt"] = from_union([from_str, from_none], self.display_prompt)
+        if self.mode is not None:
+            result["mode"] = from_union([lambda x: to_enum(SendMode, x), from_none], self.mode)
+        if self.prepend is not None:
+            result["prepend"] = from_union([from_bool, from_none], self.prepend)
+        if self.request_headers is not None:
+            result["requestHeaders"] = from_union([lambda x: from_dict(from_str, x), from_none], self.request_headers)
+        if self.required_tool is not None:
+            result["requiredTool"] = from_union([from_str, from_none], self.required_tool)
+        if self.source is not None:
+            result["source"] = self.source
+        if self.traceparent is not None:
+            result["traceparent"] = from_union([from_str, from_none], self.traceparent)
+        if self.tracestate is not None:
+            result["tracestate"] = from_union([from_str, from_none], self.tracestate)
+        if self.wait is not None:
+            result["wait"] = from_union([from_bool, from_none], self.wait)
+        return result
+
 @dataclass
 class UIElicitationSchema:
     """JSON Schema describing the form fields to present to the user"""
@@ -6854,17 +12736,125 @@ class UIElicitationSchema:
         return result
 
 @dataclass
+class AuthInfo:
+    """The new auth credentials to install on the session. When omitted or `undefined`, the call
+    is a no-op and the session's existing credentials are preserved. The runtime stores the
+    value verbatim and uses it for outbound model/API requests; it does NOT re-validate or
+    re-fetch the associated Copilot user response. Several variants carry secret material;
+    treat this method's params as containing secrets at rest and in transit.
+
+    Schema for the `HMACAuthInfo` type.
+
+    Schema for the `EnvAuthInfo` type.
+
+    Schema for the `TokenAuthInfo` type.
+
+    Schema for the `CopilotApiTokenAuthInfo` type.
+
+    Schema for the `UserAuthInfo` type.
+
+    Schema for the `GhCliAuthInfo` type.
+
+    Schema for the `ApiKeyAuthInfo` type.
+    """
+    host: str
+    """Authentication host. HMAC auth always targets the public GitHub host.
+
+    Authentication host (e.g. https://github.com or a GHES host).
+
+    Authentication host.
+
+    Authentication host (always the public GitHub host).
+    """
+    type: AuthInfoType
+    """HMAC-based authentication used by GitHub-internal services.
+
+    Personal access token (PAT) or server-to-server token sourced from an environment
+    variable.
+
+    SDK-side token authentication; the host configured the token directly via the SDK.
+
+    Direct Copilot API authentication via the `GITHUB_COPILOT_API_TOKEN` + `COPILOT_API_URL`
+    environment-variable pair. The token itself is read from the environment by the runtime,
+    not carried in this struct.
+
+    OAuth user authentication. The token itself is held in the runtime's secret token store
+    (keyed by host+login) and is NOT carried in this struct.
+
+    Authentication via the `gh` CLI's saved credentials.
+
+    API-key authentication for non-GitHub LLM providers (e.g. when running BYOM-style).
+    """
+    copilot_user: CopilotUserResponse | None = None
+    """Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the
+    GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this
+    verbatim and does not re-fetch when set.
+    """
+    hmac: str | None = None
+    """HMAC secret used to sign requests."""
+
+    env_var: str | None = None
+    """Name of the environment variable the token was sourced from."""
+
+    login: str | None = None
+    """User login associated with the token. Undefined for server-to-server tokens (those
+    starting with `ghs_`).
+
+    OAuth user login.
+
+    User login as reported by `gh auth status`.
+    """
+    token: str | None = None
+    """The token value itself. Treat as a secret.
+
+    The token returned by `gh auth token`. Treat as a secret.
+    """
+    api_key: str | None = None
+    """The API key. Treat as a secret."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'AuthInfo':
+        assert isinstance(obj, dict)
+        host = from_str(obj.get("host"))
+        type = AuthInfoType(obj.get("type"))
+        copilot_user = from_union([CopilotUserResponse.from_dict, from_none], obj.get("copilotUser"))
+        hmac = from_union([from_str, from_none], obj.get("hmac"))
+        env_var = from_union([from_str, from_none], obj.get("envVar"))
+        login = from_union([from_str, from_none], obj.get("login"))
+        token = from_union([from_str, from_none], obj.get("token"))
+        api_key = from_union([from_str, from_none], obj.get("apiKey"))
+        return AuthInfo(host, type, copilot_user, hmac, env_var, login, token, api_key)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["host"] = from_str(self.host)
+        result["type"] = to_enum(AuthInfoType, self.type)
+        if self.copilot_user is not None:
+            result["copilotUser"] = from_union([lambda x: to_class(CopilotUserResponse, x), from_none], self.copilot_user)
+        if self.hmac is not None:
+            result["hmac"] = from_union([from_str, from_none], self.hmac)
+        if self.env_var is not None:
+            result["envVar"] = from_union([from_str, from_none], self.env_var)
+        if self.login is not None:
+            result["login"] = from_union([from_str, from_none], self.login)
+        if self.token is not None:
+            result["token"] = from_union([from_str, from_none], self.token)
+        if self.api_key is not None:
+            result["apiKey"] = from_union([from_str, from_none], self.api_key)
+        return result
+
+@dataclass
 class PermissionDecisionApproveForLocation:
     """Schema for the `PermissionDecisionApproveForLocation` type."""
 
     approval: PermissionDecisionApproveForLocationApproval
-    """The approval to persist for this location"""
+    """Approval to persist for this location"""
 
     kind: PermissionDecisionApproveForLocationKind
-    """Approved and persisted for this project location"""
+    """Approve and persist for this project location"""
 
     location_key: str
-    """The location key (git root or cwd) to persist the approval to"""
+    """Location key (git root or cwd) to persist the approval to"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecisionApproveForLocation':
@@ -6886,13 +12876,13 @@ class PermissionDecisionApproveForSession:
     """Schema for the `PermissionDecisionApproveForSession` type."""
 
     kind: PermissionDecisionApproveForSessionKind
-    """Approved and remembered for the rest of the session"""
+    """Approve and remember for the rest of the session"""
 
     approval: PermissionDecisionApproveForSessionApproval | None = None
-    """The approval to add as a session-scoped rule"""
+    """Session-scoped approval to remember (tool prompts only; omitted for path/url prompts)"""
 
     domain: str | None = None
-    """The URL domain to approve for this session"""
+    """URL domain to approve for the rest of the session (URL prompts only)"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecisionApproveForSession':
@@ -6942,6 +12932,266 @@ class HandlePendingToolCallRequest:
             result["result"] = from_union([lambda x: to_class(ExternalToolTextResultForLlm, x), from_str, from_none], self.result)
         return result
 
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsSetAdditionalPluginsRequest:
+    """Manager-wide additional plugins to register; replaces any previously-configured set."""
+
+    plugins: list[InstalledPlugin]
+    """Manager-wide additional plugins to register. Replaces any previously-configured set. Pass
+    an empty array to clear.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsSetAdditionalPluginsRequest':
+        assert isinstance(obj, dict)
+        plugins = from_list(InstalledPlugin.from_dict, obj.get("plugins"))
+        return SessionsSetAdditionalPluginsRequest(plugins)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["plugins"] = from_list(lambda x: to_class(InstalledPlugin, x), self.plugins)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionUpdateOptionsParams:
+    """Patch of mutable session options to apply to the running session."""
+
+    additional_content_exclusion_policies: list[Any] | None = None
+    """Additional content-exclusion policies to merge into the session's policy set. Opaque
+    shape; see `ContentExclusionApiResponse` in the runtime.
+    """
+    agent_context: str | None = None
+    """Runtime context discriminator (e.g., `cli`, `actions`)."""
+
+    ask_user_disabled: bool | None = None
+    """Whether to disable the `ask_user` tool (encourages autonomous behavior)."""
+
+    available_tools: list[str] | None = None
+    """Allowlist of tool names available to this session."""
+
+    client_name: str | None = None
+    """Identifier of the client driving the session."""
+
+    coauthor_enabled: bool | None = None
+    """Whether to include the `Co-authored-by` trailer in commit messages."""
+
+    continue_on_auto_mode: bool | None = None
+    """Whether to allow auto-mode continuation across turns."""
+
+    copilot_url: str | None = None
+    """Override URL for the Copilot API endpoint."""
+
+    custom_agents_local_only: bool | None = None
+    """Whether to default custom agents to local-only execution."""
+
+    disabled_instruction_sources: list[str] | None = None
+    """Instruction source IDs to exclude from the system prompt."""
+
+    disabled_skills: list[str] | None = None
+    """Skill IDs that should be excluded from this session."""
+
+    enable_on_demand_instruction_discovery: bool | None = None
+    """Whether to discover custom instructions on demand after successful file views (AGENTS.md
+    / CLAUDE.md / .github/copilot-instructions.md surfacing). Combined with
+    `skipCustomInstructions` and the runtime-side `ON_DEMAND_INSTRUCTIONS` feature flag.
+    """
+    enable_reasoning_summaries: bool | None = None
+    """Whether to surface reasoning-summary events from the model."""
+
+    enable_script_safety: bool | None = None
+    """Whether shell-script safety heuristics are enabled."""
+
+    enable_streaming: bool | None = None
+    """Whether to stream model responses."""
+
+    env_value_mode: MCPSetEnvValueModeDetails | None = None
+    """How env values are passed to MCP servers (`direct` inlines literal values; `indirect`
+    resolves at launch).
+    """
+    events_log_directory: str | None = None
+    """Override directory for the session-events log. When unset, the runtime's default events
+    log directory is used.
+    """
+    excluded_tools: list[str] | None = None
+    """Denylist of tool names for this session."""
+
+    feature_flags: dict[str, bool] | None = None
+    """Map of feature-flag IDs to their boolean enabled state."""
+
+    installed_plugins: list[SessionInstalledPlugin] | None = None
+    """Full set of installed plugins for the session. Replaces the existing list; the runtime
+    invalidates the skills cache only when the list materially changes.
+    """
+    integration_id: str | None = None
+    """Stable integration identifier used for analytics and rate-limit attribution."""
+
+    is_experimental_mode: bool | None = None
+    """Whether experimental capabilities are enabled."""
+
+    log_interactive_shells: bool | None = None
+    """Whether interactive shell sessions are logged."""
+
+    lsp_client_name: str | None = None
+    """Identifier sent to LSP-style integrations."""
+
+    manage_schedule_enabled: bool | None = None
+    """Whether to expose the `manage_schedule` tool to the agent. The runtime always owns the
+    per-session schedule registry; this flag only controls tool exposure (typically gated to
+    staff users).
+    """
+    model: str | None = None
+    """The model ID to use for assistant turns."""
+
+    provider: Any = None
+    """Custom model-provider configuration (BYOK). Opaque shape; see `ProviderConfig` in the
+    runtime.
+    """
+    reasoning_effort: str | None = None
+    """Reasoning effort for the selected model (model-defined enum)."""
+
+    running_in_interactive_mode: bool | None = None
+    """Whether the session is running in an interactive UI."""
+
+    sandbox_config: Any = None
+    """Sandbox configuration shape; opaque to SDK consumers. See `SandboxConfig` in the runtime."""
+
+    shell_init_profile: str | None = None
+    """Shell init profile (`None` or `NonInteractive`)."""
+
+    shell_process_flags: list[str] | None = None
+    """Per-shell process flags (e.g., `pwsh` arguments)."""
+
+    skill_directories: list[str] | None = None
+    """Additional directories to search for skills."""
+
+    skip_custom_instructions: bool | None = None
+    """Whether to skip loading custom instruction sources."""
+
+    trajectory_file: str | None = None
+    """Optional path for trajectory output."""
+
+    working_directory: str | None = None
+    """Absolute working-directory path for shell tools."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionUpdateOptionsParams':
+        assert isinstance(obj, dict)
+        additional_content_exclusion_policies = from_union([lambda x: from_list(lambda x: x, x), from_none], obj.get("additionalContentExclusionPolicies"))
+        agent_context = from_union([from_str, from_none], obj.get("agentContext"))
+        ask_user_disabled = from_union([from_bool, from_none], obj.get("askUserDisabled"))
+        available_tools = from_union([lambda x: from_list(from_str, x), from_none], obj.get("availableTools"))
+        client_name = from_union([from_str, from_none], obj.get("clientName"))
+        coauthor_enabled = from_union([from_bool, from_none], obj.get("coauthorEnabled"))
+        continue_on_auto_mode = from_union([from_bool, from_none], obj.get("continueOnAutoMode"))
+        copilot_url = from_union([from_str, from_none], obj.get("copilotUrl"))
+        custom_agents_local_only = from_union([from_bool, from_none], obj.get("customAgentsLocalOnly"))
+        disabled_instruction_sources = from_union([lambda x: from_list(from_str, x), from_none], obj.get("disabledInstructionSources"))
+        disabled_skills = from_union([lambda x: from_list(from_str, x), from_none], obj.get("disabledSkills"))
+        enable_on_demand_instruction_discovery = from_union([from_bool, from_none], obj.get("enableOnDemandInstructionDiscovery"))
+        enable_reasoning_summaries = from_union([from_bool, from_none], obj.get("enableReasoningSummaries"))
+        enable_script_safety = from_union([from_bool, from_none], obj.get("enableScriptSafety"))
+        enable_streaming = from_union([from_bool, from_none], obj.get("enableStreaming"))
+        env_value_mode = from_union([MCPSetEnvValueModeDetails, from_none], obj.get("envValueMode"))
+        events_log_directory = from_union([from_str, from_none], obj.get("eventsLogDirectory"))
+        excluded_tools = from_union([lambda x: from_list(from_str, x), from_none], obj.get("excludedTools"))
+        feature_flags = from_union([lambda x: from_dict(from_bool, x), from_none], obj.get("featureFlags"))
+        installed_plugins = from_union([lambda x: from_list(SessionInstalledPlugin.from_dict, x), from_none], obj.get("installedPlugins"))
+        integration_id = from_union([from_str, from_none], obj.get("integrationId"))
+        is_experimental_mode = from_union([from_bool, from_none], obj.get("isExperimentalMode"))
+        log_interactive_shells = from_union([from_bool, from_none], obj.get("logInteractiveShells"))
+        lsp_client_name = from_union([from_str, from_none], obj.get("lspClientName"))
+        manage_schedule_enabled = from_union([from_bool, from_none], obj.get("manageScheduleEnabled"))
+        model = from_union([from_str, from_none], obj.get("model"))
+        provider = obj.get("provider")
+        reasoning_effort = from_union([from_str, from_none], obj.get("reasoningEffort"))
+        running_in_interactive_mode = from_union([from_bool, from_none], obj.get("runningInInteractiveMode"))
+        sandbox_config = obj.get("sandboxConfig")
+        shell_init_profile = from_union([from_str, from_none], obj.get("shellInitProfile"))
+        shell_process_flags = from_union([lambda x: from_list(from_str, x), from_none], obj.get("shellProcessFlags"))
+        skill_directories = from_union([lambda x: from_list(from_str, x), from_none], obj.get("skillDirectories"))
+        skip_custom_instructions = from_union([from_bool, from_none], obj.get("skipCustomInstructions"))
+        trajectory_file = from_union([from_str, from_none], obj.get("trajectoryFile"))
+        working_directory = from_union([from_str, from_none], obj.get("workingDirectory"))
+        return SessionUpdateOptionsParams(additional_content_exclusion_policies, agent_context, ask_user_disabled, available_tools, client_name, coauthor_enabled, continue_on_auto_mode, copilot_url, custom_agents_local_only, disabled_instruction_sources, disabled_skills, enable_on_demand_instruction_discovery, enable_reasoning_summaries, enable_script_safety, enable_streaming, env_value_mode, events_log_directory, excluded_tools, feature_flags, installed_plugins, integration_id, is_experimental_mode, log_interactive_shells, lsp_client_name, manage_schedule_enabled, model, provider, reasoning_effort, running_in_interactive_mode, sandbox_config, shell_init_profile, shell_process_flags, skill_directories, skip_custom_instructions, trajectory_file, working_directory)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.additional_content_exclusion_policies is not None:
+            result["additionalContentExclusionPolicies"] = from_union([lambda x: from_list(lambda x: x, x), from_none], self.additional_content_exclusion_policies)
+        if self.agent_context is not None:
+            result["agentContext"] = from_union([from_str, from_none], self.agent_context)
+        if self.ask_user_disabled is not None:
+            result["askUserDisabled"] = from_union([from_bool, from_none], self.ask_user_disabled)
+        if self.available_tools is not None:
+            result["availableTools"] = from_union([lambda x: from_list(from_str, x), from_none], self.available_tools)
+        if self.client_name is not None:
+            result["clientName"] = from_union([from_str, from_none], self.client_name)
+        if self.coauthor_enabled is not None:
+            result["coauthorEnabled"] = from_union([from_bool, from_none], self.coauthor_enabled)
+        if self.continue_on_auto_mode is not None:
+            result["continueOnAutoMode"] = from_union([from_bool, from_none], self.continue_on_auto_mode)
+        if self.copilot_url is not None:
+            result["copilotUrl"] = from_union([from_str, from_none], self.copilot_url)
+        if self.custom_agents_local_only is not None:
+            result["customAgentsLocalOnly"] = from_union([from_bool, from_none], self.custom_agents_local_only)
+        if self.disabled_instruction_sources is not None:
+            result["disabledInstructionSources"] = from_union([lambda x: from_list(from_str, x), from_none], self.disabled_instruction_sources)
+        if self.disabled_skills is not None:
+            result["disabledSkills"] = from_union([lambda x: from_list(from_str, x), from_none], self.disabled_skills)
+        if self.enable_on_demand_instruction_discovery is not None:
+            result["enableOnDemandInstructionDiscovery"] = from_union([from_bool, from_none], self.enable_on_demand_instruction_discovery)
+        if self.enable_reasoning_summaries is not None:
+            result["enableReasoningSummaries"] = from_union([from_bool, from_none], self.enable_reasoning_summaries)
+        if self.enable_script_safety is not None:
+            result["enableScriptSafety"] = from_union([from_bool, from_none], self.enable_script_safety)
+        if self.enable_streaming is not None:
+            result["enableStreaming"] = from_union([from_bool, from_none], self.enable_streaming)
+        if self.env_value_mode is not None:
+            result["envValueMode"] = from_union([lambda x: to_enum(MCPSetEnvValueModeDetails, x), from_none], self.env_value_mode)
+        if self.events_log_directory is not None:
+            result["eventsLogDirectory"] = from_union([from_str, from_none], self.events_log_directory)
+        if self.excluded_tools is not None:
+            result["excludedTools"] = from_union([lambda x: from_list(from_str, x), from_none], self.excluded_tools)
+        if self.feature_flags is not None:
+            result["featureFlags"] = from_union([lambda x: from_dict(from_bool, x), from_none], self.feature_flags)
+        if self.installed_plugins is not None:
+            result["installedPlugins"] = from_union([lambda x: from_list(lambda x: to_class(SessionInstalledPlugin, x), x), from_none], self.installed_plugins)
+        if self.integration_id is not None:
+            result["integrationId"] = from_union([from_str, from_none], self.integration_id)
+        if self.is_experimental_mode is not None:
+            result["isExperimentalMode"] = from_union([from_bool, from_none], self.is_experimental_mode)
+        if self.log_interactive_shells is not None:
+            result["logInteractiveShells"] = from_union([from_bool, from_none], self.log_interactive_shells)
+        if self.lsp_client_name is not None:
+            result["lspClientName"] = from_union([from_str, from_none], self.lsp_client_name)
+        if self.manage_schedule_enabled is not None:
+            result["manageScheduleEnabled"] = from_union([from_bool, from_none], self.manage_schedule_enabled)
+        if self.model is not None:
+            result["model"] = from_union([from_str, from_none], self.model)
+        if self.provider is not None:
+            result["provider"] = self.provider
+        if self.reasoning_effort is not None:
+            result["reasoningEffort"] = from_union([from_str, from_none], self.reasoning_effort)
+        if self.running_in_interactive_mode is not None:
+            result["runningInInteractiveMode"] = from_union([from_bool, from_none], self.running_in_interactive_mode)
+        if self.sandbox_config is not None:
+            result["sandboxConfig"] = self.sandbox_config
+        if self.shell_init_profile is not None:
+            result["shellInitProfile"] = from_union([from_str, from_none], self.shell_init_profile)
+        if self.shell_process_flags is not None:
+            result["shellProcessFlags"] = from_union([lambda x: from_list(from_str, x), from_none], self.shell_process_flags)
+        if self.skill_directories is not None:
+            result["skillDirectories"] = from_union([lambda x: from_list(from_str, x), from_none], self.skill_directories)
+        if self.skip_custom_instructions is not None:
+            result["skipCustomInstructions"] = from_union([from_bool, from_none], self.skip_custom_instructions)
+        if self.trajectory_file is not None:
+            result["trajectoryFile"] = from_union([from_str, from_none], self.trajectory_file)
+        if self.working_directory is not None:
+            result["workingDirectory"] = from_union([from_str, from_none], self.working_directory)
+        return result
+
 @dataclass
 class UIElicitationRequest:
     """Prompt message and JSON schema describing the form fields to elicit from the user."""
@@ -6966,8 +13216,32 @@ class UIElicitationRequest:
         return result
 
 @dataclass
+class SessionSetCredentialsParams:
+    """New auth credentials to install on the session. Omit to leave credentials unchanged."""
+
+    credentials: AuthInfo | None = None
+    """The new auth credentials to install on the session. When omitted or `undefined`, the call
+    is a no-op and the session's existing credentials are preserved. The runtime stores the
+    value verbatim and uses it for outbound model/API requests; it does NOT re-validate or
+    re-fetch the associated Copilot user response. Several variants carry secret material;
+    treat this method's params as containing secrets at rest and in transit.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionSetCredentialsParams':
+        assert isinstance(obj, dict)
+        credentials = from_union([AuthInfo.from_dict, from_none], obj.get("credentials"))
+        return SessionSetCredentialsParams(credentials)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.credentials is not None:
+            result["credentials"] = from_union([lambda x: to_class(AuthInfo, x), from_none], self.credentials)
+        return result
+
+@dataclass
 class PermissionDecision:
-    """Decision to apply to a pending permission request.
+    """The client's response to the pending permission prompt
 
     Schema for the `PermissionDecisionApproveOnce` type.
 
@@ -6980,35 +13254,99 @@ class PermissionDecision:
     Schema for the `PermissionDecisionReject` type.
 
     Schema for the `PermissionDecisionUserNotAvailable` type.
+
+    Schema for the `PermissionDecisionApproved` type.
+
+    Schema for the `PermissionDecisionApprovedForSession` type.
+
+    Schema for the `PermissionDecisionApprovedForLocation` type.
+
+    Schema for the `PermissionDecisionCancelled` type.
+
+    Schema for the `PermissionDecisionDeniedByRules` type.
+
+    Schema for the `PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser` type.
+
+    Schema for the `PermissionDecisionDeniedInteractivelyByUser` type.
+
+    Schema for the `PermissionDecisionDeniedByContentExclusionPolicy` type.
+
+    Schema for the `PermissionDecisionDeniedByPermissionRequestHook` type.
     """
     kind: PermissionDecisionKind
-    """The permission request was approved for this one instance
+    """Approve this single request only
+
+    Approve and remember for the rest of the session
+
+    Approve and persist for this project location
+
+    Approve and persist across sessions (URL prompts only)
+
+    Reject the request
+
+    No user is available to confirm the request
+
+    The permission request was approved
 
     Approved and remembered for the rest of the session
 
     Approved and persisted for this project location
 
-    Approved and persisted across sessions
+    The permission request was cancelled before a response was used
+
+    Denied because approval rules explicitly blocked it
+
+    Denied because no approval rule matched and user confirmation was unavailable
 
     Denied by the user during an interactive prompt
 
-    Denied because user confirmation was unavailable
+    Denied by the organization's content exclusion policy
+
+    Denied by a permission request hook registered by an extension or plugin
     """
     approval: PermissionDecisionApproveForIonApproval | None = None
-    """The approval to add as a session-scoped rule
+    """Session-scoped approval to remember (tool prompts only; omitted for path/url prompts)
+
+    Approval to persist for this location
+
+    The approval to add as a session-scoped rule
 
     The approval to persist for this location
     """
     domain: str | None = None
-    """The URL domain to approve for this session
+    """URL domain to approve for the rest of the session (URL prompts only)
 
-    The URL domain to approve permanently
+    URL domain to approve permanently
     """
     location_key: str | None = None
-    """The location key (git root or cwd) to persist the approval to"""
+    """Location key (git root or cwd) to persist the approval to
 
+    The location key (git root or cwd) to persist the approval to
+    """
     feedback: str | None = None
-    """Optional feedback from the user explaining the denial"""
+    """Optional feedback explaining the rejection
+
+    Optional feedback from the user explaining the denial
+    """
+    reason: str | None = None
+    """Optional explanation of why the request was cancelled"""
+
+    rules: list[PermissionRule] | None = None
+    """Rules that denied the request"""
+
+    force_reject: bool | None = None
+    """Whether to force-reject the current agent turn"""
+
+    message: str | None = None
+    """Human-readable explanation of why the path was excluded
+
+    Optional message from the hook explaining the denial
+    """
+    path: str | None = None
+    """File path that triggered the exclusion"""
+
+    interrupt: bool | None = None
+    """Whether to interrupt the current agent turn"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecision':
@@ -7018,7 +13356,13 @@ class PermissionDecision:
         domain = from_union([from_str, from_none], obj.get("domain"))
         location_key = from_union([from_str, from_none], obj.get("locationKey"))
         feedback = from_union([from_str, from_none], obj.get("feedback"))
-        return PermissionDecision(kind, approval, domain, location_key, feedback)
+        reason = from_union([from_str, from_none], obj.get("reason"))
+        rules = from_union([lambda x: from_list(PermissionRule.from_dict, x), from_none], obj.get("rules"))
+        force_reject = from_union([from_bool, from_none], obj.get("forceReject"))
+        message = from_union([from_str, from_none], obj.get("message"))
+        path = from_union([from_str, from_none], obj.get("path"))
+        interrupt = from_union([from_bool, from_none], obj.get("interrupt"))
+        return PermissionDecision(kind, approval, domain, location_key, feedback, reason, rules, force_reject, message, path, interrupt)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -7031,6 +13375,18 @@ class PermissionDecision:
             result["locationKey"] = from_union([from_str, from_none], self.location_key)
         if self.feedback is not None:
             result["feedback"] = from_union([from_str, from_none], self.feedback)
+        if self.reason is not None:
+            result["reason"] = from_union([from_str, from_none], self.reason)
+        if self.rules is not None:
+            result["rules"] = from_union([lambda x: from_list(lambda x: to_class(PermissionRule, x), x), from_none], self.rules)
+        if self.force_reject is not None:
+            result["forceReject"] = from_union([from_bool, from_none], self.force_reject)
+        if self.message is not None:
+            result["message"] = from_union([from_str, from_none], self.message)
+        if self.path is not None:
+            result["path"] = from_union([from_str, from_none], self.path)
+        if self.interrupt is not None:
+            result["interrupt"] = from_union([from_bool, from_none], self.interrupt)
         return result
 
 @dataclass
@@ -7041,7 +13397,7 @@ class PermissionDecisionRequest:
     """Request ID of the pending permission request"""
 
     result: PermissionDecision
-    """Decision to apply to a pending permission request."""
+    """The client's response to the pending permission prompt"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecisionRequest':
@@ -7054,6 +13410,99 @@ class PermissionDecisionRequest:
         result: dict = {}
         result["requestId"] = from_str(self.request_id)
         result["result"] = to_class(PermissionDecision, self.result)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class MCPExecuteSamplingParams:
+    """Identifiers and raw MCP CreateMessageRequest params used to run a sampling inference."""
+
+    mcp_request_id: float | str
+    """The original MCP JSON-RPC request ID (string or number). Used by the runtime to correlate
+    the inference with the originating MCP request for telemetry; this is distinct from
+    `requestId` (which is the schema-level cancellation handle).
+    """
+    request: dict[str, Any]
+    """Raw MCP CreateMessageRequest params, as received in the `sampling.requested` event.
+    Treated as opaque at the schema layer; the runtime converts the embedded MCP messages
+    into the OpenAI chat-completion shape internally.
+    """
+    request_id: str
+    """Caller-provided unique identifier for this sampling execution. Use this same ID with
+    cancelSamplingExecution to cancel the in-flight call. Must be unique within the session
+    for the lifetime of the call.
+    """
+    server_name: str
+    """Name of the MCP server that initiated the sampling request"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MCPExecuteSamplingParams':
+        assert isinstance(obj, dict)
+        mcp_request_id = from_union([from_float, from_str], obj.get("mcpRequestId"))
+        request = from_dict(lambda x: x, obj.get("request"))
+        request_id = from_str(obj.get("requestId"))
+        server_name = from_str(obj.get("serverName"))
+        return MCPExecuteSamplingParams(mcp_request_id, request, request_id, server_name)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["mcpRequestId"] = from_union([to_float, from_str], self.mcp_request_id)
+        result["request"] = from_dict(lambda x: x, self.request)
+        result["requestId"] = from_str(self.request_id)
+        result["serverName"] = from_str(self.server_name)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class MetadataContextInfoRequest:
+    """Model identifier and token limits used to compute the context-info breakdown."""
+
+    output_token_limit: int
+    """Maximum output tokens allowed by the target model. Pass 0 if unknown."""
+
+    prompt_token_limit: int
+    """Maximum prompt tokens allowed by the target model. Pass 0 to use the runtime default."""
+
+    selected_model: str | None = None
+    """Model identifier used for tokenization. Omit to use the session default. Used both for
+    token counting and to compute display values.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MetadataContextInfoRequest':
+        assert isinstance(obj, dict)
+        output_token_limit = from_int(obj.get("outputTokenLimit"))
+        prompt_token_limit = from_int(obj.get("promptTokenLimit"))
+        selected_model = from_union([from_str, from_none], obj.get("selectedModel"))
+        return MetadataContextInfoRequest(output_token_limit, prompt_token_limit, selected_model)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["outputTokenLimit"] = from_int(self.output_token_limit)
+        result["promptTokenLimit"] = from_int(self.prompt_token_limit)
+        if self.selected_model is not None:
+            result["selectedModel"] = from_union([from_str, from_none], self.selected_model)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class MetadataRecomputeContextTokensRequest:
+    """Model identifier to use when re-tokenizing the session's existing messages."""
+
+    model_id: str
+    """Model identifier used for tokenization. The runtime token-counts both chat-context and
+    system-context messages against this model.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MetadataRecomputeContextTokensRequest':
+        assert isinstance(obj, dict)
+        model_id = from_str(obj.get("modelId"))
+        return MetadataRecomputeContextTokensRequest(model_id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["modelId"] = from_str(self.model_id)
         return result
 
 @dataclass
@@ -7207,6 +13656,38 @@ class ModelSwitchToRequest:
             result["reasoningSummary"] = from_union([lambda x: to_enum(ReasoningSummary, x), from_none], self.reasoning_summary)
         return result
 
+class PermissionsSetApproveAllSource(Enum):
+    """Optional source for allow-all telemetry. Defaults to `rpc` when omitted for SDK callers."""
+
+    AUTOPILOT_CONFIRMATION = "autopilot_confirmation"
+    CLI_FLAG = "cli_flag"
+    RPC = "rpc"
+    SLASH_COMMAND = "slash_command"
+
+@dataclass
+class PermissionsSetApproveAllRequest:
+    """Allow-all toggle for tool permission requests, with an optional telemetry source."""
+
+    enabled: bool
+    """Whether to auto-approve all tool permission requests"""
+
+    source: PermissionsSetApproveAllSource | None = None
+    """Optional source for allow-all telemetry. Defaults to `rpc` when omitted for SDK callers."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionsSetApproveAllRequest':
+        assert isinstance(obj, dict)
+        enabled = from_bool(obj.get("enabled"))
+        source = from_union([PermissionsSetApproveAllSource, from_none], obj.get("source"))
+        return PermissionsSetApproveAllRequest(enabled, source)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["enabled"] = from_bool(self.enabled)
+        if self.source is not None:
+            result["source"] = from_union([lambda x: to_enum(PermissionsSetApproveAllSource, x), from_none], self.source)
+        return result
+
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
 class TaskAgentInfo:
@@ -7328,6 +13809,14 @@ class TaskAgentInfo:
 class TaskInfo:
     """Schema for the `TaskInfo` type.
 
+    The first sync-waiting task (agent first, then shell) that can currently be promoted to
+    background mode. Omitted if no such task exists. The returned task is guaranteed to have
+    executionMode='sync' and canPromoteToBackground=true at the time of the call.
+
+    The promoted task as it now exists in background mode, omitted if no promotable task was
+    waiting. Atomic operation: avoids the race window of getCurrentPromotable +
+    promoteToBackground.
+
     Schema for the `TaskAgentInfo` type.
 
     Schema for the `TaskShellInfo` type.
@@ -7344,7 +13833,7 @@ class TaskInfo:
     status: TaskStatus
     """Current lifecycle status of the task"""
 
-    type: TaskInfoType
+    type: TaskAgentProgressType
     """Task kind"""
 
     active_started_at: datetime | None = None
@@ -7410,7 +13899,7 @@ class TaskInfo:
         id = from_str(obj.get("id"))
         started_at = from_datetime(obj.get("startedAt"))
         status = TaskStatus(obj.get("status"))
-        type = TaskInfoType(obj.get("type"))
+        type = TaskAgentProgressType(obj.get("type"))
         active_started_at = from_union([from_datetime, from_none], obj.get("activeStartedAt"))
         active_time_ms = from_union([from_int, from_none], obj.get("activeTimeMs"))
         agent_type = from_union([from_str, from_none], obj.get("agentType"))
@@ -7436,7 +13925,7 @@ class TaskInfo:
         result["id"] = from_str(self.id)
         result["startedAt"] = self.started_at.isoformat()
         result["status"] = to_enum(TaskStatus, self.status)
-        result["type"] = to_enum(TaskInfoType, self.type)
+        result["type"] = to_enum(TaskAgentProgressType, self.type)
         if self.active_started_at is not None:
             result["activeStartedAt"] = from_union([lambda x: x.isoformat(), from_none], self.active_started_at)
         if self.active_time_ms is not None:
@@ -7492,17 +13981,69 @@ class TaskList:
         result["tasks"] = from_list(lambda x: to_class(TaskInfo, x), self.tasks)
         return result
 
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class TasksGetCurrentPromotableResult:
+    """The first sync-waiting task that can currently be promoted to background mode."""
+
+    task: TaskInfo | None = None
+    """The first sync-waiting task (agent first, then shell) that can currently be promoted to
+    background mode. Omitted if no such task exists. The returned task is guaranteed to have
+    executionMode='sync' and canPromoteToBackground=true at the time of the call.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'TasksGetCurrentPromotableResult':
+        assert isinstance(obj, dict)
+        task = from_union([TaskInfo.from_dict, from_none], obj.get("task"))
+        return TasksGetCurrentPromotableResult(task)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.task is not None:
+            result["task"] = from_union([lambda x: to_class(TaskInfo, x), from_none], self.task)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class TasksPromoteCurrentToBackgroundResult:
+    """The promoted task as it now exists in background mode, omitted if no promotable task was
+    waiting.
+    """
+    task: TaskInfo | None = None
+    """The promoted task as it now exists in background mode, omitted if no promotable task was
+    waiting. Atomic operation: avoids the race window of getCurrentPromotable +
+    promoteToBackground.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'TasksPromoteCurrentToBackgroundResult':
+        assert isinstance(obj, dict)
+        task = from_union([TaskInfo.from_dict, from_none], obj.get("task"))
+        return TasksPromoteCurrentToBackgroundResult(task)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.task is not None:
+            result["task"] = from_union([lambda x: to_class(TaskInfo, x), from_none], self.task)
+        return result
+
 @dataclass
 class RPC:
+    abort_request: AbortRequest
+    abort_result: AbortResult
     account_get_quota_request: AccountGetQuotaRequest
     account_get_quota_result: AccountGetQuotaResult
     account_quota_snapshot: AccountQuotaSnapshot
     agent_get_current_result: AgentGetCurrentResult
     agent_info: AgentInfo
+    agent_info_source: AgentInfoSource
     agent_list: AgentList
     agent_reload_result: AgentReloadResult
     agent_select_request: AgentSelectRequest
     agent_select_result: AgentSelectResult
+    api_key_auth_info: APIKeyAuthInfo
+    auth_info: AuthInfo
     auth_info_type: AuthInfoType
     command_list: CommandList
     commands_handle_pending_command_request: CommandsHandlePendingCommandRequest
@@ -7518,9 +14059,28 @@ class RPC:
     connect_request: ConnectRequest
     connect_result: ConnectResult
     content_filter_mode: ContentFilterMode
+    copilot_api_token_auth_info: CopilotAPITokenAuthInfo
+    copilot_user_response: CopilotUserResponse
+    copilot_user_response_endpoints: CopilotUserResponseEndpoints
+    copilot_user_response_quota_snapshots: dict[str, CopilotUserResponseQuotaSnapshots | None]
+    copilot_user_response_quota_snapshots_chat: CopilotUserResponseQuotaSnapshotsChat
+    copilot_user_response_quota_snapshots_completions: CopilotUserResponseQuotaSnapshotsCompletions
+    copilot_user_response_quota_snapshots_premium_interactions: CopilotUserResponseQuotaSnapshotsPremiumInteractions
     current_model: CurrentModel
     discovered_mcp_server: DiscoveredMCPServer
     discovered_mcp_server_type: DiscoveredMCPServerType
+    enqueue_command_params: EnqueueCommandParams
+    enqueue_command_result: EnqueueCommandResult
+    env_auth_info: EnvAuthInfo
+    event_log_read_request: EventLogReadRequest
+    event_log_release_interest_result: EventLogReleaseInterestResult
+    event_log_tail_result: EventLogTailResult
+    event_log_types: list[str] | EventLogTypes
+    events_agent_scope: EventsAgentScope
+    events_cursor_status: EventsCursorStatus
+    events_read_result: EventsReadResult
+    execute_command_params: ExecuteCommandParams
+    execute_command_result: ExecuteCommandResult
     extension: Extension
     extension_list: ExtensionList
     extensions_disable_request: ExtensionsDisableRequest
@@ -7544,18 +14104,31 @@ class RPC:
     filter_mapping: dict[str, ContentFilterMode] | ContentFilterMode
     fleet_start_request: FleetStartRequest
     fleet_start_result: FleetStartResult
+    gh_cli_auth_info: GhCLIAuthInfo
     handle_pending_tool_call_request: HandlePendingToolCallRequest
     handle_pending_tool_call_result: HandlePendingToolCallResult
+    history_abort_manual_compaction_result: HistoryAbortManualCompactionResult
+    history_cancel_background_compaction_result: HistoryCancelBackgroundCompactionResult
     history_compact_context_window: HistoryCompactContextWindow
     history_compact_result: HistoryCompactResult
+    history_summarize_for_handoff_result: HistorySummarizeForHandoffResult
     history_truncate_request: HistoryTruncateRequest
     history_truncate_result: HistoryTruncateResult
+    hmac_auth_info: HMACAuthInfo
+    installed_plugin: InstalledPlugin
+    installed_plugin_source: InstalledPluginSource | str
+    installed_plugin_source_github: InstalledPluginSourceGithub
+    installed_plugin_source_local: InstalledPluginSourceLocal
+    installed_plugin_source_url: InstalledPluginSourceURL
     instructions_get_sources_result: InstructionsGetSourcesResult
     instructions_sources: InstructionsSources
     instructions_sources_location: InstructionsSourcesLocation
     instructions_sources_type: InstructionsSourcesType
     log_request: LogRequest
     log_result: LogResult
+    lsp_initialize_request: LspInitializeRequest
+    mcp_cancel_sampling_execution_params: MCPCancelSamplingExecutionParams
+    mcp_cancel_sampling_execution_result: MCPCancelSamplingExecutionResult
     mcp_config_add_request: MCPConfigAddRequest
     mcp_config_disable_request: MCPConfigDisableRequest
     mcp_config_enable_request: MCPConfigEnableRequest
@@ -7566,8 +14139,14 @@ class RPC:
     mcp_discover_request: MCPDiscoverRequest
     mcp_discover_result: MCPDiscoverResult
     mcp_enable_request: MCPEnableRequest
+    mcp_execute_sampling_params: MCPExecuteSamplingParams
+    mcp_execute_sampling_request: dict[str, Any]
+    mcp_execute_sampling_result: dict[str, Any]
     mcp_oauth_login_request: MCPOauthLoginRequest
     mcp_oauth_login_result: MCPOauthLoginResult
+    mcp_remove_git_hub_result: MCPRemoveGitHubResult
+    mcp_sampling_execution_action: MCPSamplingExecutionAction
+    mcp_sampling_execution_result: MCPSamplingExecutionResult
     mcp_server: MCPServer
     mcp_server_config: MCPServerConfig
     mcp_server_config_http: MCPServerConfigHTTP
@@ -7576,6 +14155,22 @@ class RPC:
     mcp_server_config_http_type: MCPServerConfigHTTPType
     mcp_server_config_stdio: MCPServerConfigStdio
     mcp_server_list: MCPServerList
+    mcp_set_env_value_mode_details: MCPSetEnvValueModeDetails
+    mcp_set_env_value_mode_params: MCPSetEnvValueModeParams
+    mcp_set_env_value_mode_result: MCPSetEnvValueModeResult
+    metadata_context_info_request: MetadataContextInfoRequest
+    metadata_context_info_result: MetadataContextInfoResult
+    metadata_is_processing_result: MetadataIsProcessingResult
+    metadata_recompute_context_tokens_request: MetadataRecomputeContextTokensRequest
+    metadata_recompute_context_tokens_result: MetadataRecomputeContextTokensResult
+    metadata_record_context_change_request: MetadataRecordContextChangeRequest
+    metadata_record_context_change_result: MetadataRecordContextChangeResult
+    metadata_set_working_directory_request: MetadataSetWorkingDirectoryRequest
+    metadata_set_working_directory_result: MetadataSetWorkingDirectoryResult
+    metadata_snapshot_current_mode: MetadataSnapshotCurrentMode
+    metadata_snapshot_remote_metadata: MetadataSnapshotRemoteMetadata
+    metadata_snapshot_remote_metadata_repository: MetadataSnapshotRemoteMetadataRepository
+    metadata_snapshot_remote_metadata_task_type: MetadataSnapshotRemoteMetadataTaskType
     model: Model
     model_billing: ModelBilling
     model_billing_token_prices: ModelBillingTokenPrices
@@ -7592,13 +14187,23 @@ class RPC:
     model_picker_price_category: ModelPickerPriceCategory
     model_policy: ModelPolicy
     model_policy_state: ModelPolicyState
+    model_set_reasoning_effort_request: ModelSetReasoningEffortRequest
+    model_set_reasoning_effort_result: ModelSetReasoningEffortResult
     models_list_request: ModelsListRequest
     model_switch_to_request: ModelSwitchToRequest
     model_switch_to_result: ModelSwitchToResult
     mode_set_request: ModeSetRequest
     name_get_result: NameGetResult
+    name_set_auto_request: NameSetAutoRequest
+    name_set_auto_result: NameSetAutoResult
     name_set_request: NameSetRequest
+    options_update_env_value_mode: MCPSetEnvValueModeDetails
+    pending_permission_request: PendingPermissionRequest
+    pending_permission_request_list: PendingPermissionRequestList
     permission_decision: PermissionDecision
+    permission_decision_approved: PermissionDecisionApproved
+    permission_decision_approved_for_location: PermissionDecisionApprovedForLocation
+    permission_decision_approved_for_session: PermissionDecisionApprovedForSession
     permission_decision_approve_for_location: PermissionDecisionApproveForLocation
     permission_decision_approve_for_location_approval: PermissionDecisionApproveForLocationApproval
     permission_decision_approve_for_location_approval_commands: PermissionDecisionApproveForLocationApprovalCommands
@@ -7623,14 +14228,50 @@ class RPC:
     permission_decision_approve_for_session_approval_write: PermissionDecisionApproveForSessionApprovalWrite
     permission_decision_approve_once: PermissionDecisionApproveOnce
     permission_decision_approve_permanently: PermissionDecisionApprovePermanently
+    permission_decision_cancelled: PermissionDecisionCancelled
+    permission_decision_denied_by_content_exclusion_policy: PermissionDecisionDeniedByContentExclusionPolicy
+    permission_decision_denied_by_permission_request_hook: PermissionDecisionDeniedByPermissionRequestHook
+    permission_decision_denied_by_rules: PermissionDecisionDeniedByRules
+    permission_decision_denied_interactively_by_user: PermissionDecisionDeniedInteractivelyByUser
+    permission_decision_denied_no_approval_rule_and_could_not_request_from_user: PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser
     permission_decision_reject: PermissionDecisionReject
     permission_decision_request: PermissionDecisionRequest
     permission_decision_user_not_available: PermissionDecisionUserNotAvailable
+    permission_paths_add_params: PermissionPathsAddParams
+    permission_paths_allowed_check_params: PermissionPathsAllowedCheckParams
+    permission_paths_allowed_check_result: PermissionPathsAllowedCheckResult
+    permission_paths_config: PermissionPathsConfig
+    permission_paths_list: PermissionPathsList
+    permission_paths_update_primary_params: PermissionPathsUpdatePrimaryParams
+    permission_paths_workspace_check_params: PermissionPathsWorkspaceCheckParams
+    permission_paths_workspace_check_result: PermissionPathsWorkspaceCheckResult
+    permission_prompt_shown_notification: PermissionPromptShownNotification
     permission_request_result: PermissionRequestResult
+    permission_rules_set: PermissionRulesSet
+    permissions_configure_additional_content_exclusion_policy: PermissionsConfigureAdditionalContentExclusionPolicy
+    permissions_configure_additional_content_exclusion_policy_rule: PermissionsConfigureAdditionalContentExclusionPolicyRule
+    permissions_configure_additional_content_exclusion_policy_rule_source: PermissionsConfigureAdditionalContentExclusionPolicyRuleSource
+    permissions_configure_additional_content_exclusion_policy_scope: PermissionsConfigureAdditionalContentExclusionPolicyScope
+    permissions_configure_params: PermissionsConfigureParams
+    permissions_configure_result: PermissionsConfigureResult
+    permissions_modify_rules_params: PermissionsModifyRulesParams
+    permissions_modify_rules_result: PermissionsModifyRulesResult
+    permissions_modify_rules_scope: PermissionsModifyRulesScope
+    permissions_notify_prompt_shown_result: PermissionsNotifyPromptShownResult
+    permissions_paths_add_result: PermissionsPathsAddResult
+    permissions_paths_list_request: PermissionsPathsListRequest
+    permissions_paths_update_primary_result: PermissionsPathsUpdatePrimaryResult
+    permissions_pending_requests_request: PermissionsPendingRequestsRequest
     permissions_reset_session_approvals_request: PermissionsResetSessionApprovalsRequest
     permissions_reset_session_approvals_result: PermissionsResetSessionApprovalsResult
     permissions_set_approve_all_request: PermissionsSetApproveAllRequest
     permissions_set_approve_all_result: PermissionsSetApproveAllResult
+    permissions_set_approve_all_source: PermissionsSetApproveAllSource
+    permissions_set_required_request: PermissionsSetRequiredRequest
+    permissions_set_required_result: PermissionsSetRequiredResult
+    permissions_urls_set_unrestricted_mode_result: PermissionsUrlsSetUnrestrictedModeResult
+    permission_urls_config: PermissionUrlsConfig
+    permission_urls_set_unrestricted_mode_params: PermissionUrlsSetUnrestrictedModeParams
     ping_request: PingRequest
     ping_result: PingResult
     plan_read_result: PlanReadResult
@@ -7640,13 +14281,45 @@ class RPC:
     queued_command_handled: QueuedCommandHandled
     queued_command_not_handled: QueuedCommandNotHandled
     queued_command_result: QueuedCommandResult
+    queue_pending_items: QueuePendingItems
+    queue_pending_items_kind: QueuePendingItemsKind
+    queue_pending_items_result: QueuePendingItemsResult
+    queue_remove_most_recent_result: QueueRemoveMostRecentResult
+    register_event_interest_params: RegisterEventInterestParams
+    register_event_interest_result: RegisterEventInterestResult
+    release_event_interest_params: ReleaseEventInterestParams
     remote_enable_request: RemoteEnableRequest
     remote_enable_result: RemoteEnableResult
+    remote_notify_steerable_changed_request: RemoteNotifySteerableChangedRequest
+    remote_notify_steerable_changed_result: RemoteNotifySteerableChangedResult
     remote_session_connection_result: RemoteSessionConnectionResult
     remote_session_mode: RemoteSessionMode
+    schedule_entry: ScheduleEntry
+    schedule_list: ScheduleList
+    schedule_stop_request: ScheduleStopRequest
+    schedule_stop_result: ScheduleStopResult
+    send_agent_mode: SendAgentMode
+    send_attachment: SendAttachment
+    send_attachment_blob: SendAttachmentBlob
+    send_attachment_directory: SendAttachmentDirectory
+    send_attachment_file: SendAttachmentFile
+    send_attachment_file_line_range: SendAttachmentFileLineRange
+    send_attachment_github_reference: SendAttachmentGithubReference
+    send_attachment_github_reference_type: SendAttachmentGithubReferenceTypeEnum
+    send_attachment_selection: SendAttachmentSelection
+    send_attachment_selection_details: SendAttachmentSelectionDetails
+    send_attachment_selection_details_end: SendAttachmentSelectionDetailsEnd
+    send_attachment_selection_details_start: SendAttachmentSelectionDetailsStart
+    send_mode: SendMode
+    send_request: SendRequest
+    send_result: SendResult
     server_skill: ServerSkill
     server_skill_list: ServerSkillList
     session_auth_status: SessionAuthStatus
+    session_bulk_delete_result: SessionBulkDeleteResult
+    session_context: SessionContext
+    session_context_host_type: SessionContextHostType
+    session_enrich_metadata_result: SessionEnrichMetadataResult
     session_fs_append_file_request: SessionFSAppendFileRequest
     session_fs_error: SessionFSError
     session_fs_error_code: SessionFSErrorCode
@@ -7675,21 +14348,68 @@ class RPC:
     session_fs_stat_request: SessionFSStatRequest
     session_fs_stat_result: SessionFSStatResult
     session_fs_write_file_request: SessionFSWriteFileRequest
+    session_installed_plugin: SessionInstalledPlugin
+    session_installed_plugin_source: SessionInstalledPluginSource | str
+    session_installed_plugin_source_github: SessionInstalledPluginSourceGithub
+    session_installed_plugin_source_local: SessionInstalledPluginSourceLocal
+    session_installed_plugin_source_url: SessionInstalledPluginSourceURL
+    session_list: SessionList
+    session_load_deferred_repo_hooks_result: SessionLoadDeferredRepoHooksResult
     session_log_level: SessionLogLevel
+    session_metadata: SessionMetadata
+    session_metadata_snapshot: SessionMetadataSnapshot
     session_mode: SessionMode
+    session_prune_result: SessionPruneResult
+    sessions_bulk_delete_request: SessionsBulkDeleteRequest
+    sessions_check_in_use_request: SessionsCheckInUseRequest
+    sessions_check_in_use_result: SessionsCheckInUseResult
+    sessions_close_request: SessionsCloseRequest
+    sessions_close_result: SessionsCloseResult
+    sessions_enrich_metadata_request: SessionsEnrichMetadataRequest
+    session_set_credentials_params: SessionSetCredentialsParams
+    session_set_credentials_result: SessionSetCredentialsResult
+    sessions_find_by_prefix_request: SessionsFindByPrefixRequest
+    sessions_find_by_prefix_result: SessionsFindByPrefixResult
+    sessions_find_by_task_id_request: SessionsFindByTaskIDRequest
+    sessions_find_by_task_id_result: SessionsFindByTaskIDResult
     sessions_fork_request: SessionsForkRequest
     sessions_fork_result: SessionsForkResult
+    sessions_get_event_file_path_request: SessionsGetEventFilePathRequest
+    sessions_get_event_file_path_result: SessionsGetEventFilePathResult
+    sessions_get_last_for_context_request: SessionsGetLastForContextRequest
+    sessions_get_last_for_context_result: SessionsGetLastForContextResult
+    sessions_get_persisted_remote_steerable_request: SessionsGetPersistedRemoteSteerableRequest
+    sessions_get_persisted_remote_steerable_result: SessionsGetPersistedRemoteSteerableResult
+    session_sizes: SessionSizes
+    sessions_list_request: SessionsListRequest
+    sessions_load_deferred_repo_hooks_request: SessionsLoadDeferredRepoHooksRequest
+    sessions_prune_old_request: SessionsPruneOldRequest
+    sessions_release_lock_request: SessionsReleaseLockRequest
+    sessions_release_lock_result: SessionsReleaseLockResult
+    sessions_reload_plugin_hooks_request: SessionsReloadPluginHooksRequest
+    sessions_reload_plugin_hooks_result: SessionsReloadPluginHooksResult
+    sessions_save_request: SessionsSaveRequest
+    sessions_save_result: SessionsSaveResult
+    sessions_set_additional_plugins_request: SessionsSetAdditionalPluginsRequest
+    sessions_set_additional_plugins_result: SessionsSetAdditionalPluginsResult
+    session_update_options_params: SessionUpdateOptionsParams
+    session_update_options_result: SessionUpdateOptionsResult
+    session_working_directory_context: SessionWorkingDirectoryContext
+    session_working_directory_context_host_type: SessionContextHostType
     shell_exec_request: ShellExecRequest
     shell_exec_result: ShellExecResult
     shell_kill_request: ShellKillRequest
     shell_kill_result: ShellKillResult
     shell_kill_signal: ShellKillSignal
+    shutdown_request: ShutdownRequest
     skill: Skill
     skill_list: SkillList
     skills_config_set_disabled_skills_request: SkillsConfigSetDisabledSkillsRequest
     skills_disable_request: SkillsDisableRequest
     skills_discover_request: SkillsDiscoverRequest
     skills_enable_request: SkillsEnableRequest
+    skills_get_invoked_result: SkillsGetInvokedResult
+    skills_invoked_skill: SkillsInvokedSkill
     skills_load_diagnostics: SkillsLoadDiagnostics
     slash_command_agent_prompt_result: SlashCommandAgentPromptResult
     slash_command_completed_result: SlashCommandCompletedResult
@@ -7700,15 +14420,22 @@ class RPC:
     slash_command_kind: SlashCommandKind
     slash_command_text_result: SlashCommandTextResult
     task_agent_info: TaskAgentInfo
+    task_agent_progress: TaskAgentProgress
     task_execution_mode: TaskExecutionMode
     task_info: TaskInfo
     task_list: TaskList
     tasks_cancel_request: TasksCancelRequest
     tasks_cancel_result: TasksCancelResult
+    tasks_get_current_promotable_result: TasksGetCurrentPromotableResult
+    tasks_get_progress_request: TasksGetProgressRequest
+    tasks_get_progress_result: TasksGetProgressResult
     task_shell_info: TaskShellInfo
     task_shell_info_attachment_mode: TaskShellInfoAttachmentMode
+    task_shell_progress: None
+    tasks_promote_current_to_background_result: TasksPromoteCurrentToBackgroundResult
     tasks_promote_to_background_request: TasksPromoteToBackgroundRequest
     tasks_promote_to_background_result: TasksPromoteToBackgroundResult
+    tasks_refresh_result: TasksRefreshResult
     tasks_remove_request: TasksRemoveRequest
     tasks_remove_result: TasksRemoveResult
     tasks_send_message_request: TasksSendMessageRequest
@@ -7716,9 +14443,14 @@ class RPC:
     tasks_start_agent_request: TasksStartAgentRequest
     tasks_start_agent_result: TasksStartAgentResult
     task_status: TaskStatus
+    tasks_wait_for_pending_result: TasksWaitForPendingResult
+    telemetry_set_feature_overrides_request: TelemetrySetFeatureOverridesRequest
+    token_auth_info: TokenAuthInfo
     tool: Tool
     tool_list: ToolList
+    tools_initialize_and_validate_result: ToolsInitializeAndValidateResult
     tools_list_request: ToolsListRequest
+    ui_auto_mode_switch_response: UIAutoModeSwitchResponse
     ui_elicitation_array_any_of_field: UIElicitationArrayAnyOfField
     ui_elicitation_array_any_of_field_items: UIElicitationArrayAnyOfFieldItems
     ui_elicitation_array_any_of_field_items_any_of: UIElicitationArrayAnyOfFieldItemsAnyOf
@@ -7740,7 +14472,19 @@ class RPC:
     ui_elicitation_string_enum_field: UIElicitationStringEnumField
     ui_elicitation_string_one_of_field: UIElicitationStringOneOfField
     ui_elicitation_string_one_of_field_one_of: UIElicitationStringOneOfFieldOneOf
+    ui_exit_plan_mode_action: UIExitPlanModeAction
+    ui_exit_plan_mode_response: UIExitPlanModeResponse
+    ui_handle_pending_auto_mode_switch_request: UIHandlePendingAutoModeSwitchRequest
     ui_handle_pending_elicitation_request: UIHandlePendingElicitationRequest
+    ui_handle_pending_exit_plan_mode_request: UIHandlePendingExitPlanModeRequest
+    ui_handle_pending_result: UIHandlePendingResult
+    ui_handle_pending_sampling_request: UIHandlePendingSamplingRequest
+    ui_handle_pending_sampling_response: dict[str, Any]
+    ui_handle_pending_user_input_request: UIHandlePendingUserInputRequest
+    ui_register_direct_auto_mode_switch_handler_result: UIRegisterDirectAutoModeSwitchHandlerResult
+    ui_unregister_direct_auto_mode_switch_handler_request: UIUnregisterDirectAutoModeSwitchHandlerRequest
+    ui_unregister_direct_auto_mode_switch_handler_result: UIUnregisterDirectAutoModeSwitchHandlerResult
+    ui_user_input_response: UIUserInputResponse
     usage_get_metrics_result: UsageGetMetricsResult
     usage_metrics_code_changes: UsageMetricsCodeChanges
     usage_metrics_model_metric: UsageMetricsModelMetric
@@ -7748,24 +14492,47 @@ class RPC:
     usage_metrics_model_metric_token_detail: UsageMetricsModelMetricTokenDetail
     usage_metrics_model_metric_usage: UsageMetricsModelMetricUsage
     usage_metrics_token_detail: UsageMetricsTokenDetail
+    user_auth_info: UserAuthInfo
+    user_tool_session_approval_commands: UserToolSessionApprovalCommands
+    user_tool_session_approval_custom_tool: UserToolSessionApprovalCustomTool
+    user_tool_session_approval_extension_management: UserToolSessionApprovalExtensionManagement
+    user_tool_session_approval_extension_permission_access: UserToolSessionApprovalExtensionPermissionAccess
+    user_tool_session_approval_mcp: UserToolSessionApprovalMCP
+    user_tool_session_approval_memory: UserToolSessionApprovalMemory
+    user_tool_session_approval_read: UserToolSessionApprovalRead
+    user_tool_session_approval_write: UserToolSessionApprovalWrite
+    workspaces_checkpoints: WorkspacesCheckpoints
     workspaces_create_file_request: WorkspacesCreateFileRequest
     workspaces_get_workspace_result: WorkspacesGetWorkspaceResult
+    workspaces_list_checkpoints_result: WorkspacesListCheckpointsResult
     workspaces_list_files_result: WorkspacesListFilesResult
+    workspaces_read_checkpoint_request: WorkspacesReadCheckpointRequest
+    workspaces_read_checkpoint_result: WorkspacesReadCheckpointResult
     workspaces_read_file_request: WorkspacesReadFileRequest
     workspaces_read_file_result: WorkspacesReadFileResult
+    workspaces_save_large_paste_request: WorkspacesSaveLargePasteRequest
+    workspaces_save_large_paste_result: WorkspacesSaveLargePasteResult
+    session_context_info: SessionContextInfo | None = None
+    task_progress: TaskProgressClass | None = None
+    workspace_summary: WorkspaceSummary | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> 'RPC':
         assert isinstance(obj, dict)
+        abort_request = AbortRequest.from_dict(obj.get("AbortRequest"))
+        abort_result = AbortResult.from_dict(obj.get("AbortResult"))
         account_get_quota_request = AccountGetQuotaRequest.from_dict(obj.get("AccountGetQuotaRequest"))
         account_get_quota_result = AccountGetQuotaResult.from_dict(obj.get("AccountGetQuotaResult"))
         account_quota_snapshot = AccountQuotaSnapshot.from_dict(obj.get("AccountQuotaSnapshot"))
         agent_get_current_result = AgentGetCurrentResult.from_dict(obj.get("AgentGetCurrentResult"))
         agent_info = AgentInfo.from_dict(obj.get("AgentInfo"))
+        agent_info_source = AgentInfoSource(obj.get("AgentInfoSource"))
         agent_list = AgentList.from_dict(obj.get("AgentList"))
         agent_reload_result = AgentReloadResult.from_dict(obj.get("AgentReloadResult"))
         agent_select_request = AgentSelectRequest.from_dict(obj.get("AgentSelectRequest"))
         agent_select_result = AgentSelectResult.from_dict(obj.get("AgentSelectResult"))
+        api_key_auth_info = APIKeyAuthInfo.from_dict(obj.get("ApiKeyAuthInfo"))
+        auth_info = AuthInfo.from_dict(obj.get("AuthInfo"))
         auth_info_type = AuthInfoType(obj.get("AuthInfoType"))
         command_list = CommandList.from_dict(obj.get("CommandList"))
         commands_handle_pending_command_request = CommandsHandlePendingCommandRequest.from_dict(obj.get("CommandsHandlePendingCommandRequest"))
@@ -7781,9 +14548,28 @@ class RPC:
         connect_request = ConnectRequest.from_dict(obj.get("ConnectRequest"))
         connect_result = ConnectResult.from_dict(obj.get("ConnectResult"))
         content_filter_mode = ContentFilterMode(obj.get("ContentFilterMode"))
+        copilot_api_token_auth_info = CopilotAPITokenAuthInfo.from_dict(obj.get("CopilotApiTokenAuthInfo"))
+        copilot_user_response = CopilotUserResponse.from_dict(obj.get("CopilotUserResponse"))
+        copilot_user_response_endpoints = CopilotUserResponseEndpoints.from_dict(obj.get("CopilotUserResponseEndpoints"))
+        copilot_user_response_quota_snapshots = from_dict(lambda x: from_union([CopilotUserResponseQuotaSnapshots.from_dict, from_none], x), obj.get("CopilotUserResponseQuotaSnapshots"))
+        copilot_user_response_quota_snapshots_chat = CopilotUserResponseQuotaSnapshotsChat.from_dict(obj.get("CopilotUserResponseQuotaSnapshotsChat"))
+        copilot_user_response_quota_snapshots_completions = CopilotUserResponseQuotaSnapshotsCompletions.from_dict(obj.get("CopilotUserResponseQuotaSnapshotsCompletions"))
+        copilot_user_response_quota_snapshots_premium_interactions = CopilotUserResponseQuotaSnapshotsPremiumInteractions.from_dict(obj.get("CopilotUserResponseQuotaSnapshotsPremiumInteractions"))
         current_model = CurrentModel.from_dict(obj.get("CurrentModel"))
         discovered_mcp_server = DiscoveredMCPServer.from_dict(obj.get("DiscoveredMcpServer"))
         discovered_mcp_server_type = DiscoveredMCPServerType(obj.get("DiscoveredMcpServerType"))
+        enqueue_command_params = EnqueueCommandParams.from_dict(obj.get("EnqueueCommandParams"))
+        enqueue_command_result = EnqueueCommandResult.from_dict(obj.get("EnqueueCommandResult"))
+        env_auth_info = EnvAuthInfo.from_dict(obj.get("EnvAuthInfo"))
+        event_log_read_request = EventLogReadRequest.from_dict(obj.get("EventLogReadRequest"))
+        event_log_release_interest_result = EventLogReleaseInterestResult.from_dict(obj.get("EventLogReleaseInterestResult"))
+        event_log_tail_result = EventLogTailResult.from_dict(obj.get("EventLogTailResult"))
+        event_log_types = from_union([lambda x: from_list(from_str, x), EventLogTypes], obj.get("EventLogTypes"))
+        events_agent_scope = EventsAgentScope(obj.get("EventsAgentScope"))
+        events_cursor_status = EventsCursorStatus(obj.get("EventsCursorStatus"))
+        events_read_result = EventsReadResult.from_dict(obj.get("EventsReadResult"))
+        execute_command_params = ExecuteCommandParams.from_dict(obj.get("ExecuteCommandParams"))
+        execute_command_result = ExecuteCommandResult.from_dict(obj.get("ExecuteCommandResult"))
         extension = Extension.from_dict(obj.get("Extension"))
         extension_list = ExtensionList.from_dict(obj.get("ExtensionList"))
         extensions_disable_request = ExtensionsDisableRequest.from_dict(obj.get("ExtensionsDisableRequest"))
@@ -7807,18 +14593,31 @@ class RPC:
         filter_mapping = from_union([lambda x: from_dict(ContentFilterMode, x), ContentFilterMode], obj.get("FilterMapping"))
         fleet_start_request = FleetStartRequest.from_dict(obj.get("FleetStartRequest"))
         fleet_start_result = FleetStartResult.from_dict(obj.get("FleetStartResult"))
+        gh_cli_auth_info = GhCLIAuthInfo.from_dict(obj.get("GhCliAuthInfo"))
         handle_pending_tool_call_request = HandlePendingToolCallRequest.from_dict(obj.get("HandlePendingToolCallRequest"))
         handle_pending_tool_call_result = HandlePendingToolCallResult.from_dict(obj.get("HandlePendingToolCallResult"))
+        history_abort_manual_compaction_result = HistoryAbortManualCompactionResult.from_dict(obj.get("HistoryAbortManualCompactionResult"))
+        history_cancel_background_compaction_result = HistoryCancelBackgroundCompactionResult.from_dict(obj.get("HistoryCancelBackgroundCompactionResult"))
         history_compact_context_window = HistoryCompactContextWindow.from_dict(obj.get("HistoryCompactContextWindow"))
         history_compact_result = HistoryCompactResult.from_dict(obj.get("HistoryCompactResult"))
+        history_summarize_for_handoff_result = HistorySummarizeForHandoffResult.from_dict(obj.get("HistorySummarizeForHandoffResult"))
         history_truncate_request = HistoryTruncateRequest.from_dict(obj.get("HistoryTruncateRequest"))
         history_truncate_result = HistoryTruncateResult.from_dict(obj.get("HistoryTruncateResult"))
+        hmac_auth_info = HMACAuthInfo.from_dict(obj.get("HMACAuthInfo"))
+        installed_plugin = InstalledPlugin.from_dict(obj.get("InstalledPlugin"))
+        installed_plugin_source = from_union([InstalledPluginSource.from_dict, from_str], obj.get("InstalledPluginSource"))
+        installed_plugin_source_github = InstalledPluginSourceGithub.from_dict(obj.get("InstalledPluginSourceGithub"))
+        installed_plugin_source_local = InstalledPluginSourceLocal.from_dict(obj.get("InstalledPluginSourceLocal"))
+        installed_plugin_source_url = InstalledPluginSourceURL.from_dict(obj.get("InstalledPluginSourceUrl"))
         instructions_get_sources_result = InstructionsGetSourcesResult.from_dict(obj.get("InstructionsGetSourcesResult"))
         instructions_sources = InstructionsSources.from_dict(obj.get("InstructionsSources"))
         instructions_sources_location = InstructionsSourcesLocation(obj.get("InstructionsSourcesLocation"))
         instructions_sources_type = InstructionsSourcesType(obj.get("InstructionsSourcesType"))
         log_request = LogRequest.from_dict(obj.get("LogRequest"))
         log_result = LogResult.from_dict(obj.get("LogResult"))
+        lsp_initialize_request = LspInitializeRequest.from_dict(obj.get("LspInitializeRequest"))
+        mcp_cancel_sampling_execution_params = MCPCancelSamplingExecutionParams.from_dict(obj.get("McpCancelSamplingExecutionParams"))
+        mcp_cancel_sampling_execution_result = MCPCancelSamplingExecutionResult.from_dict(obj.get("McpCancelSamplingExecutionResult"))
         mcp_config_add_request = MCPConfigAddRequest.from_dict(obj.get("McpConfigAddRequest"))
         mcp_config_disable_request = MCPConfigDisableRequest.from_dict(obj.get("McpConfigDisableRequest"))
         mcp_config_enable_request = MCPConfigEnableRequest.from_dict(obj.get("McpConfigEnableRequest"))
@@ -7829,8 +14628,14 @@ class RPC:
         mcp_discover_request = MCPDiscoverRequest.from_dict(obj.get("McpDiscoverRequest"))
         mcp_discover_result = MCPDiscoverResult.from_dict(obj.get("McpDiscoverResult"))
         mcp_enable_request = MCPEnableRequest.from_dict(obj.get("McpEnableRequest"))
+        mcp_execute_sampling_params = MCPExecuteSamplingParams.from_dict(obj.get("McpExecuteSamplingParams"))
+        mcp_execute_sampling_request = from_dict(lambda x: x, obj.get("McpExecuteSamplingRequest"))
+        mcp_execute_sampling_result = from_dict(lambda x: x, obj.get("McpExecuteSamplingResult"))
         mcp_oauth_login_request = MCPOauthLoginRequest.from_dict(obj.get("McpOauthLoginRequest"))
         mcp_oauth_login_result = MCPOauthLoginResult.from_dict(obj.get("McpOauthLoginResult"))
+        mcp_remove_git_hub_result = MCPRemoveGitHubResult.from_dict(obj.get("McpRemoveGitHubResult"))
+        mcp_sampling_execution_action = MCPSamplingExecutionAction(obj.get("McpSamplingExecutionAction"))
+        mcp_sampling_execution_result = MCPSamplingExecutionResult.from_dict(obj.get("McpSamplingExecutionResult"))
         mcp_server = MCPServer.from_dict(obj.get("McpServer"))
         mcp_server_config = MCPServerConfig.from_dict(obj.get("McpServerConfig"))
         mcp_server_config_http = MCPServerConfigHTTP.from_dict(obj.get("McpServerConfigHttp"))
@@ -7839,6 +14644,22 @@ class RPC:
         mcp_server_config_http_type = MCPServerConfigHTTPType(obj.get("McpServerConfigHttpType"))
         mcp_server_config_stdio = MCPServerConfigStdio.from_dict(obj.get("McpServerConfigStdio"))
         mcp_server_list = MCPServerList.from_dict(obj.get("McpServerList"))
+        mcp_set_env_value_mode_details = MCPSetEnvValueModeDetails(obj.get("McpSetEnvValueModeDetails"))
+        mcp_set_env_value_mode_params = MCPSetEnvValueModeParams.from_dict(obj.get("McpSetEnvValueModeParams"))
+        mcp_set_env_value_mode_result = MCPSetEnvValueModeResult.from_dict(obj.get("McpSetEnvValueModeResult"))
+        metadata_context_info_request = MetadataContextInfoRequest.from_dict(obj.get("MetadataContextInfoRequest"))
+        metadata_context_info_result = MetadataContextInfoResult.from_dict(obj.get("MetadataContextInfoResult"))
+        metadata_is_processing_result = MetadataIsProcessingResult.from_dict(obj.get("MetadataIsProcessingResult"))
+        metadata_recompute_context_tokens_request = MetadataRecomputeContextTokensRequest.from_dict(obj.get("MetadataRecomputeContextTokensRequest"))
+        metadata_recompute_context_tokens_result = MetadataRecomputeContextTokensResult.from_dict(obj.get("MetadataRecomputeContextTokensResult"))
+        metadata_record_context_change_request = MetadataRecordContextChangeRequest.from_dict(obj.get("MetadataRecordContextChangeRequest"))
+        metadata_record_context_change_result = MetadataRecordContextChangeResult.from_dict(obj.get("MetadataRecordContextChangeResult"))
+        metadata_set_working_directory_request = MetadataSetWorkingDirectoryRequest.from_dict(obj.get("MetadataSetWorkingDirectoryRequest"))
+        metadata_set_working_directory_result = MetadataSetWorkingDirectoryResult.from_dict(obj.get("MetadataSetWorkingDirectoryResult"))
+        metadata_snapshot_current_mode = MetadataSnapshotCurrentMode(obj.get("MetadataSnapshotCurrentMode"))
+        metadata_snapshot_remote_metadata = MetadataSnapshotRemoteMetadata.from_dict(obj.get("MetadataSnapshotRemoteMetadata"))
+        metadata_snapshot_remote_metadata_repository = MetadataSnapshotRemoteMetadataRepository.from_dict(obj.get("MetadataSnapshotRemoteMetadataRepository"))
+        metadata_snapshot_remote_metadata_task_type = MetadataSnapshotRemoteMetadataTaskType(obj.get("MetadataSnapshotRemoteMetadataTaskType"))
         model = Model.from_dict(obj.get("Model"))
         model_billing = ModelBilling.from_dict(obj.get("ModelBilling"))
         model_billing_token_prices = ModelBillingTokenPrices.from_dict(obj.get("ModelBillingTokenPrices"))
@@ -7855,13 +14676,23 @@ class RPC:
         model_picker_price_category = ModelPickerPriceCategory(obj.get("ModelPickerPriceCategory"))
         model_policy = ModelPolicy.from_dict(obj.get("ModelPolicy"))
         model_policy_state = ModelPolicyState(obj.get("ModelPolicyState"))
+        model_set_reasoning_effort_request = ModelSetReasoningEffortRequest.from_dict(obj.get("ModelSetReasoningEffortRequest"))
+        model_set_reasoning_effort_result = ModelSetReasoningEffortResult.from_dict(obj.get("ModelSetReasoningEffortResult"))
         models_list_request = ModelsListRequest.from_dict(obj.get("ModelsListRequest"))
         model_switch_to_request = ModelSwitchToRequest.from_dict(obj.get("ModelSwitchToRequest"))
         model_switch_to_result = ModelSwitchToResult.from_dict(obj.get("ModelSwitchToResult"))
         mode_set_request = ModeSetRequest.from_dict(obj.get("ModeSetRequest"))
         name_get_result = NameGetResult.from_dict(obj.get("NameGetResult"))
+        name_set_auto_request = NameSetAutoRequest.from_dict(obj.get("NameSetAutoRequest"))
+        name_set_auto_result = NameSetAutoResult.from_dict(obj.get("NameSetAutoResult"))
         name_set_request = NameSetRequest.from_dict(obj.get("NameSetRequest"))
+        options_update_env_value_mode = MCPSetEnvValueModeDetails(obj.get("OptionsUpdateEnvValueMode"))
+        pending_permission_request = PendingPermissionRequest.from_dict(obj.get("PendingPermissionRequest"))
+        pending_permission_request_list = PendingPermissionRequestList.from_dict(obj.get("PendingPermissionRequestList"))
         permission_decision = PermissionDecision.from_dict(obj.get("PermissionDecision"))
+        permission_decision_approved = PermissionDecisionApproved.from_dict(obj.get("PermissionDecisionApproved"))
+        permission_decision_approved_for_location = PermissionDecisionApprovedForLocation.from_dict(obj.get("PermissionDecisionApprovedForLocation"))
+        permission_decision_approved_for_session = PermissionDecisionApprovedForSession.from_dict(obj.get("PermissionDecisionApprovedForSession"))
         permission_decision_approve_for_location = PermissionDecisionApproveForLocation.from_dict(obj.get("PermissionDecisionApproveForLocation"))
         permission_decision_approve_for_location_approval = PermissionDecisionApproveForLocationApproval.from_dict(obj.get("PermissionDecisionApproveForLocationApproval"))
         permission_decision_approve_for_location_approval_commands = PermissionDecisionApproveForLocationApprovalCommands.from_dict(obj.get("PermissionDecisionApproveForLocationApprovalCommands"))
@@ -7886,14 +14717,50 @@ class RPC:
         permission_decision_approve_for_session_approval_write = PermissionDecisionApproveForSessionApprovalWrite.from_dict(obj.get("PermissionDecisionApproveForSessionApprovalWrite"))
         permission_decision_approve_once = PermissionDecisionApproveOnce.from_dict(obj.get("PermissionDecisionApproveOnce"))
         permission_decision_approve_permanently = PermissionDecisionApprovePermanently.from_dict(obj.get("PermissionDecisionApprovePermanently"))
+        permission_decision_cancelled = PermissionDecisionCancelled.from_dict(obj.get("PermissionDecisionCancelled"))
+        permission_decision_denied_by_content_exclusion_policy = PermissionDecisionDeniedByContentExclusionPolicy.from_dict(obj.get("PermissionDecisionDeniedByContentExclusionPolicy"))
+        permission_decision_denied_by_permission_request_hook = PermissionDecisionDeniedByPermissionRequestHook.from_dict(obj.get("PermissionDecisionDeniedByPermissionRequestHook"))
+        permission_decision_denied_by_rules = PermissionDecisionDeniedByRules.from_dict(obj.get("PermissionDecisionDeniedByRules"))
+        permission_decision_denied_interactively_by_user = PermissionDecisionDeniedInteractivelyByUser.from_dict(obj.get("PermissionDecisionDeniedInteractivelyByUser"))
+        permission_decision_denied_no_approval_rule_and_could_not_request_from_user = PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser.from_dict(obj.get("PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser"))
         permission_decision_reject = PermissionDecisionReject.from_dict(obj.get("PermissionDecisionReject"))
         permission_decision_request = PermissionDecisionRequest.from_dict(obj.get("PermissionDecisionRequest"))
         permission_decision_user_not_available = PermissionDecisionUserNotAvailable.from_dict(obj.get("PermissionDecisionUserNotAvailable"))
+        permission_paths_add_params = PermissionPathsAddParams.from_dict(obj.get("PermissionPathsAddParams"))
+        permission_paths_allowed_check_params = PermissionPathsAllowedCheckParams.from_dict(obj.get("PermissionPathsAllowedCheckParams"))
+        permission_paths_allowed_check_result = PermissionPathsAllowedCheckResult.from_dict(obj.get("PermissionPathsAllowedCheckResult"))
+        permission_paths_config = PermissionPathsConfig.from_dict(obj.get("PermissionPathsConfig"))
+        permission_paths_list = PermissionPathsList.from_dict(obj.get("PermissionPathsList"))
+        permission_paths_update_primary_params = PermissionPathsUpdatePrimaryParams.from_dict(obj.get("PermissionPathsUpdatePrimaryParams"))
+        permission_paths_workspace_check_params = PermissionPathsWorkspaceCheckParams.from_dict(obj.get("PermissionPathsWorkspaceCheckParams"))
+        permission_paths_workspace_check_result = PermissionPathsWorkspaceCheckResult.from_dict(obj.get("PermissionPathsWorkspaceCheckResult"))
+        permission_prompt_shown_notification = PermissionPromptShownNotification.from_dict(obj.get("PermissionPromptShownNotification"))
         permission_request_result = PermissionRequestResult.from_dict(obj.get("PermissionRequestResult"))
+        permission_rules_set = PermissionRulesSet.from_dict(obj.get("PermissionRulesSet"))
+        permissions_configure_additional_content_exclusion_policy = PermissionsConfigureAdditionalContentExclusionPolicy.from_dict(obj.get("PermissionsConfigureAdditionalContentExclusionPolicy"))
+        permissions_configure_additional_content_exclusion_policy_rule = PermissionsConfigureAdditionalContentExclusionPolicyRule.from_dict(obj.get("PermissionsConfigureAdditionalContentExclusionPolicyRule"))
+        permissions_configure_additional_content_exclusion_policy_rule_source = PermissionsConfigureAdditionalContentExclusionPolicyRuleSource.from_dict(obj.get("PermissionsConfigureAdditionalContentExclusionPolicyRuleSource"))
+        permissions_configure_additional_content_exclusion_policy_scope = PermissionsConfigureAdditionalContentExclusionPolicyScope(obj.get("PermissionsConfigureAdditionalContentExclusionPolicyScope"))
+        permissions_configure_params = PermissionsConfigureParams.from_dict(obj.get("PermissionsConfigureParams"))
+        permissions_configure_result = PermissionsConfigureResult.from_dict(obj.get("PermissionsConfigureResult"))
+        permissions_modify_rules_params = PermissionsModifyRulesParams.from_dict(obj.get("PermissionsModifyRulesParams"))
+        permissions_modify_rules_result = PermissionsModifyRulesResult.from_dict(obj.get("PermissionsModifyRulesResult"))
+        permissions_modify_rules_scope = PermissionsModifyRulesScope(obj.get("PermissionsModifyRulesScope"))
+        permissions_notify_prompt_shown_result = PermissionsNotifyPromptShownResult.from_dict(obj.get("PermissionsNotifyPromptShownResult"))
+        permissions_paths_add_result = PermissionsPathsAddResult.from_dict(obj.get("PermissionsPathsAddResult"))
+        permissions_paths_list_request = PermissionsPathsListRequest.from_dict(obj.get("PermissionsPathsListRequest"))
+        permissions_paths_update_primary_result = PermissionsPathsUpdatePrimaryResult.from_dict(obj.get("PermissionsPathsUpdatePrimaryResult"))
+        permissions_pending_requests_request = PermissionsPendingRequestsRequest.from_dict(obj.get("PermissionsPendingRequestsRequest"))
         permissions_reset_session_approvals_request = PermissionsResetSessionApprovalsRequest.from_dict(obj.get("PermissionsResetSessionApprovalsRequest"))
         permissions_reset_session_approvals_result = PermissionsResetSessionApprovalsResult.from_dict(obj.get("PermissionsResetSessionApprovalsResult"))
         permissions_set_approve_all_request = PermissionsSetApproveAllRequest.from_dict(obj.get("PermissionsSetApproveAllRequest"))
         permissions_set_approve_all_result = PermissionsSetApproveAllResult.from_dict(obj.get("PermissionsSetApproveAllResult"))
+        permissions_set_approve_all_source = PermissionsSetApproveAllSource(obj.get("PermissionsSetApproveAllSource"))
+        permissions_set_required_request = PermissionsSetRequiredRequest.from_dict(obj.get("PermissionsSetRequiredRequest"))
+        permissions_set_required_result = PermissionsSetRequiredResult.from_dict(obj.get("PermissionsSetRequiredResult"))
+        permissions_urls_set_unrestricted_mode_result = PermissionsUrlsSetUnrestrictedModeResult.from_dict(obj.get("PermissionsUrlsSetUnrestrictedModeResult"))
+        permission_urls_config = PermissionUrlsConfig.from_dict(obj.get("PermissionUrlsConfig"))
+        permission_urls_set_unrestricted_mode_params = PermissionUrlsSetUnrestrictedModeParams.from_dict(obj.get("PermissionUrlsSetUnrestrictedModeParams"))
         ping_request = PingRequest.from_dict(obj.get("PingRequest"))
         ping_result = PingResult.from_dict(obj.get("PingResult"))
         plan_read_result = PlanReadResult.from_dict(obj.get("PlanReadResult"))
@@ -7903,13 +14770,45 @@ class RPC:
         queued_command_handled = QueuedCommandHandled.from_dict(obj.get("QueuedCommandHandled"))
         queued_command_not_handled = QueuedCommandNotHandled.from_dict(obj.get("QueuedCommandNotHandled"))
         queued_command_result = QueuedCommandResult.from_dict(obj.get("QueuedCommandResult"))
+        queue_pending_items = QueuePendingItems.from_dict(obj.get("QueuePendingItems"))
+        queue_pending_items_kind = QueuePendingItemsKind(obj.get("QueuePendingItemsKind"))
+        queue_pending_items_result = QueuePendingItemsResult.from_dict(obj.get("QueuePendingItemsResult"))
+        queue_remove_most_recent_result = QueueRemoveMostRecentResult.from_dict(obj.get("QueueRemoveMostRecentResult"))
+        register_event_interest_params = RegisterEventInterestParams.from_dict(obj.get("RegisterEventInterestParams"))
+        register_event_interest_result = RegisterEventInterestResult.from_dict(obj.get("RegisterEventInterestResult"))
+        release_event_interest_params = ReleaseEventInterestParams.from_dict(obj.get("ReleaseEventInterestParams"))
         remote_enable_request = RemoteEnableRequest.from_dict(obj.get("RemoteEnableRequest"))
         remote_enable_result = RemoteEnableResult.from_dict(obj.get("RemoteEnableResult"))
+        remote_notify_steerable_changed_request = RemoteNotifySteerableChangedRequest.from_dict(obj.get("RemoteNotifySteerableChangedRequest"))
+        remote_notify_steerable_changed_result = RemoteNotifySteerableChangedResult.from_dict(obj.get("RemoteNotifySteerableChangedResult"))
         remote_session_connection_result = RemoteSessionConnectionResult.from_dict(obj.get("RemoteSessionConnectionResult"))
         remote_session_mode = RemoteSessionMode(obj.get("RemoteSessionMode"))
+        schedule_entry = ScheduleEntry.from_dict(obj.get("ScheduleEntry"))
+        schedule_list = ScheduleList.from_dict(obj.get("ScheduleList"))
+        schedule_stop_request = ScheduleStopRequest.from_dict(obj.get("ScheduleStopRequest"))
+        schedule_stop_result = ScheduleStopResult.from_dict(obj.get("ScheduleStopResult"))
+        send_agent_mode = SendAgentMode(obj.get("SendAgentMode"))
+        send_attachment = SendAttachment.from_dict(obj.get("SendAttachment"))
+        send_attachment_blob = SendAttachmentBlob.from_dict(obj.get("SendAttachmentBlob"))
+        send_attachment_directory = SendAttachmentDirectory.from_dict(obj.get("SendAttachmentDirectory"))
+        send_attachment_file = SendAttachmentFile.from_dict(obj.get("SendAttachmentFile"))
+        send_attachment_file_line_range = SendAttachmentFileLineRange.from_dict(obj.get("SendAttachmentFileLineRange"))
+        send_attachment_github_reference = SendAttachmentGithubReference.from_dict(obj.get("SendAttachmentGithubReference"))
+        send_attachment_github_reference_type = SendAttachmentGithubReferenceTypeEnum(obj.get("SendAttachmentGithubReferenceType"))
+        send_attachment_selection = SendAttachmentSelection.from_dict(obj.get("SendAttachmentSelection"))
+        send_attachment_selection_details = SendAttachmentSelectionDetails.from_dict(obj.get("SendAttachmentSelectionDetails"))
+        send_attachment_selection_details_end = SendAttachmentSelectionDetailsEnd.from_dict(obj.get("SendAttachmentSelectionDetailsEnd"))
+        send_attachment_selection_details_start = SendAttachmentSelectionDetailsStart.from_dict(obj.get("SendAttachmentSelectionDetailsStart"))
+        send_mode = SendMode(obj.get("SendMode"))
+        send_request = SendRequest.from_dict(obj.get("SendRequest"))
+        send_result = SendResult.from_dict(obj.get("SendResult"))
         server_skill = ServerSkill.from_dict(obj.get("ServerSkill"))
         server_skill_list = ServerSkillList.from_dict(obj.get("ServerSkillList"))
         session_auth_status = SessionAuthStatus.from_dict(obj.get("SessionAuthStatus"))
+        session_bulk_delete_result = SessionBulkDeleteResult.from_dict(obj.get("SessionBulkDeleteResult"))
+        session_context = SessionContext.from_dict(obj.get("SessionContext"))
+        session_context_host_type = SessionContextHostType(obj.get("SessionContextHostType"))
+        session_enrich_metadata_result = SessionEnrichMetadataResult.from_dict(obj.get("SessionEnrichMetadataResult"))
         session_fs_append_file_request = SessionFSAppendFileRequest.from_dict(obj.get("SessionFsAppendFileRequest"))
         session_fs_error = SessionFSError.from_dict(obj.get("SessionFsError"))
         session_fs_error_code = SessionFSErrorCode(obj.get("SessionFsErrorCode"))
@@ -7938,21 +14837,68 @@ class RPC:
         session_fs_stat_request = SessionFSStatRequest.from_dict(obj.get("SessionFsStatRequest"))
         session_fs_stat_result = SessionFSStatResult.from_dict(obj.get("SessionFsStatResult"))
         session_fs_write_file_request = SessionFSWriteFileRequest.from_dict(obj.get("SessionFsWriteFileRequest"))
+        session_installed_plugin = SessionInstalledPlugin.from_dict(obj.get("SessionInstalledPlugin"))
+        session_installed_plugin_source = from_union([SessionInstalledPluginSource.from_dict, from_str], obj.get("SessionInstalledPluginSource"))
+        session_installed_plugin_source_github = SessionInstalledPluginSourceGithub.from_dict(obj.get("SessionInstalledPluginSourceGithub"))
+        session_installed_plugin_source_local = SessionInstalledPluginSourceLocal.from_dict(obj.get("SessionInstalledPluginSourceLocal"))
+        session_installed_plugin_source_url = SessionInstalledPluginSourceURL.from_dict(obj.get("SessionInstalledPluginSourceUrl"))
+        session_list = SessionList.from_dict(obj.get("SessionList"))
+        session_load_deferred_repo_hooks_result = SessionLoadDeferredRepoHooksResult.from_dict(obj.get("SessionLoadDeferredRepoHooksResult"))
         session_log_level = SessionLogLevel(obj.get("SessionLogLevel"))
+        session_metadata = SessionMetadata.from_dict(obj.get("SessionMetadata"))
+        session_metadata_snapshot = SessionMetadataSnapshot.from_dict(obj.get("SessionMetadataSnapshot"))
         session_mode = SessionMode(obj.get("SessionMode"))
+        session_prune_result = SessionPruneResult.from_dict(obj.get("SessionPruneResult"))
+        sessions_bulk_delete_request = SessionsBulkDeleteRequest.from_dict(obj.get("SessionsBulkDeleteRequest"))
+        sessions_check_in_use_request = SessionsCheckInUseRequest.from_dict(obj.get("SessionsCheckInUseRequest"))
+        sessions_check_in_use_result = SessionsCheckInUseResult.from_dict(obj.get("SessionsCheckInUseResult"))
+        sessions_close_request = SessionsCloseRequest.from_dict(obj.get("SessionsCloseRequest"))
+        sessions_close_result = SessionsCloseResult.from_dict(obj.get("SessionsCloseResult"))
+        sessions_enrich_metadata_request = SessionsEnrichMetadataRequest.from_dict(obj.get("SessionsEnrichMetadataRequest"))
+        session_set_credentials_params = SessionSetCredentialsParams.from_dict(obj.get("SessionSetCredentialsParams"))
+        session_set_credentials_result = SessionSetCredentialsResult.from_dict(obj.get("SessionSetCredentialsResult"))
+        sessions_find_by_prefix_request = SessionsFindByPrefixRequest.from_dict(obj.get("SessionsFindByPrefixRequest"))
+        sessions_find_by_prefix_result = SessionsFindByPrefixResult.from_dict(obj.get("SessionsFindByPrefixResult"))
+        sessions_find_by_task_id_request = SessionsFindByTaskIDRequest.from_dict(obj.get("SessionsFindByTaskIDRequest"))
+        sessions_find_by_task_id_result = SessionsFindByTaskIDResult.from_dict(obj.get("SessionsFindByTaskIDResult"))
         sessions_fork_request = SessionsForkRequest.from_dict(obj.get("SessionsForkRequest"))
         sessions_fork_result = SessionsForkResult.from_dict(obj.get("SessionsForkResult"))
+        sessions_get_event_file_path_request = SessionsGetEventFilePathRequest.from_dict(obj.get("SessionsGetEventFilePathRequest"))
+        sessions_get_event_file_path_result = SessionsGetEventFilePathResult.from_dict(obj.get("SessionsGetEventFilePathResult"))
+        sessions_get_last_for_context_request = SessionsGetLastForContextRequest.from_dict(obj.get("SessionsGetLastForContextRequest"))
+        sessions_get_last_for_context_result = SessionsGetLastForContextResult.from_dict(obj.get("SessionsGetLastForContextResult"))
+        sessions_get_persisted_remote_steerable_request = SessionsGetPersistedRemoteSteerableRequest.from_dict(obj.get("SessionsGetPersistedRemoteSteerableRequest"))
+        sessions_get_persisted_remote_steerable_result = SessionsGetPersistedRemoteSteerableResult.from_dict(obj.get("SessionsGetPersistedRemoteSteerableResult"))
+        session_sizes = SessionSizes.from_dict(obj.get("SessionSizes"))
+        sessions_list_request = SessionsListRequest.from_dict(obj.get("SessionsListRequest"))
+        sessions_load_deferred_repo_hooks_request = SessionsLoadDeferredRepoHooksRequest.from_dict(obj.get("SessionsLoadDeferredRepoHooksRequest"))
+        sessions_prune_old_request = SessionsPruneOldRequest.from_dict(obj.get("SessionsPruneOldRequest"))
+        sessions_release_lock_request = SessionsReleaseLockRequest.from_dict(obj.get("SessionsReleaseLockRequest"))
+        sessions_release_lock_result = SessionsReleaseLockResult.from_dict(obj.get("SessionsReleaseLockResult"))
+        sessions_reload_plugin_hooks_request = SessionsReloadPluginHooksRequest.from_dict(obj.get("SessionsReloadPluginHooksRequest"))
+        sessions_reload_plugin_hooks_result = SessionsReloadPluginHooksResult.from_dict(obj.get("SessionsReloadPluginHooksResult"))
+        sessions_save_request = SessionsSaveRequest.from_dict(obj.get("SessionsSaveRequest"))
+        sessions_save_result = SessionsSaveResult.from_dict(obj.get("SessionsSaveResult"))
+        sessions_set_additional_plugins_request = SessionsSetAdditionalPluginsRequest.from_dict(obj.get("SessionsSetAdditionalPluginsRequest"))
+        sessions_set_additional_plugins_result = SessionsSetAdditionalPluginsResult.from_dict(obj.get("SessionsSetAdditionalPluginsResult"))
+        session_update_options_params = SessionUpdateOptionsParams.from_dict(obj.get("SessionUpdateOptionsParams"))
+        session_update_options_result = SessionUpdateOptionsResult.from_dict(obj.get("SessionUpdateOptionsResult"))
+        session_working_directory_context = SessionWorkingDirectoryContext.from_dict(obj.get("SessionWorkingDirectoryContext"))
+        session_working_directory_context_host_type = SessionContextHostType(obj.get("SessionWorkingDirectoryContextHostType"))
         shell_exec_request = ShellExecRequest.from_dict(obj.get("ShellExecRequest"))
         shell_exec_result = ShellExecResult.from_dict(obj.get("ShellExecResult"))
         shell_kill_request = ShellKillRequest.from_dict(obj.get("ShellKillRequest"))
         shell_kill_result = ShellKillResult.from_dict(obj.get("ShellKillResult"))
         shell_kill_signal = ShellKillSignal(obj.get("ShellKillSignal"))
+        shutdown_request = ShutdownRequest.from_dict(obj.get("ShutdownRequest"))
         skill = Skill.from_dict(obj.get("Skill"))
         skill_list = SkillList.from_dict(obj.get("SkillList"))
         skills_config_set_disabled_skills_request = SkillsConfigSetDisabledSkillsRequest.from_dict(obj.get("SkillsConfigSetDisabledSkillsRequest"))
         skills_disable_request = SkillsDisableRequest.from_dict(obj.get("SkillsDisableRequest"))
         skills_discover_request = SkillsDiscoverRequest.from_dict(obj.get("SkillsDiscoverRequest"))
         skills_enable_request = SkillsEnableRequest.from_dict(obj.get("SkillsEnableRequest"))
+        skills_get_invoked_result = SkillsGetInvokedResult.from_dict(obj.get("SkillsGetInvokedResult"))
+        skills_invoked_skill = SkillsInvokedSkill.from_dict(obj.get("SkillsInvokedSkill"))
         skills_load_diagnostics = SkillsLoadDiagnostics.from_dict(obj.get("SkillsLoadDiagnostics"))
         slash_command_agent_prompt_result = SlashCommandAgentPromptResult.from_dict(obj.get("SlashCommandAgentPromptResult"))
         slash_command_completed_result = SlashCommandCompletedResult.from_dict(obj.get("SlashCommandCompletedResult"))
@@ -7963,15 +14909,22 @@ class RPC:
         slash_command_kind = SlashCommandKind(obj.get("SlashCommandKind"))
         slash_command_text_result = SlashCommandTextResult.from_dict(obj.get("SlashCommandTextResult"))
         task_agent_info = TaskAgentInfo.from_dict(obj.get("TaskAgentInfo"))
+        task_agent_progress = TaskAgentProgress.from_dict(obj.get("TaskAgentProgress"))
         task_execution_mode = TaskExecutionMode(obj.get("TaskExecutionMode"))
         task_info = TaskInfo.from_dict(obj.get("TaskInfo"))
         task_list = TaskList.from_dict(obj.get("TaskList"))
         tasks_cancel_request = TasksCancelRequest.from_dict(obj.get("TasksCancelRequest"))
         tasks_cancel_result = TasksCancelResult.from_dict(obj.get("TasksCancelResult"))
+        tasks_get_current_promotable_result = TasksGetCurrentPromotableResult.from_dict(obj.get("TasksGetCurrentPromotableResult"))
+        tasks_get_progress_request = TasksGetProgressRequest.from_dict(obj.get("TasksGetProgressRequest"))
+        tasks_get_progress_result = TasksGetProgressResult.from_dict(obj.get("TasksGetProgressResult"))
         task_shell_info = TaskShellInfo.from_dict(obj.get("TaskShellInfo"))
         task_shell_info_attachment_mode = TaskShellInfoAttachmentMode(obj.get("TaskShellInfoAttachmentMode"))
+        task_shell_progress = from_none(obj.get("TaskShellProgress"))
+        tasks_promote_current_to_background_result = TasksPromoteCurrentToBackgroundResult.from_dict(obj.get("TasksPromoteCurrentToBackgroundResult"))
         tasks_promote_to_background_request = TasksPromoteToBackgroundRequest.from_dict(obj.get("TasksPromoteToBackgroundRequest"))
         tasks_promote_to_background_result = TasksPromoteToBackgroundResult.from_dict(obj.get("TasksPromoteToBackgroundResult"))
+        tasks_refresh_result = TasksRefreshResult.from_dict(obj.get("TasksRefreshResult"))
         tasks_remove_request = TasksRemoveRequest.from_dict(obj.get("TasksRemoveRequest"))
         tasks_remove_result = TasksRemoveResult.from_dict(obj.get("TasksRemoveResult"))
         tasks_send_message_request = TasksSendMessageRequest.from_dict(obj.get("TasksSendMessageRequest"))
@@ -7979,9 +14932,14 @@ class RPC:
         tasks_start_agent_request = TasksStartAgentRequest.from_dict(obj.get("TasksStartAgentRequest"))
         tasks_start_agent_result = TasksStartAgentResult.from_dict(obj.get("TasksStartAgentResult"))
         task_status = TaskStatus(obj.get("TaskStatus"))
+        tasks_wait_for_pending_result = TasksWaitForPendingResult.from_dict(obj.get("TasksWaitForPendingResult"))
+        telemetry_set_feature_overrides_request = TelemetrySetFeatureOverridesRequest.from_dict(obj.get("TelemetrySetFeatureOverridesRequest"))
+        token_auth_info = TokenAuthInfo.from_dict(obj.get("TokenAuthInfo"))
         tool = Tool.from_dict(obj.get("Tool"))
         tool_list = ToolList.from_dict(obj.get("ToolList"))
+        tools_initialize_and_validate_result = ToolsInitializeAndValidateResult.from_dict(obj.get("ToolsInitializeAndValidateResult"))
         tools_list_request = ToolsListRequest.from_dict(obj.get("ToolsListRequest"))
+        ui_auto_mode_switch_response = UIAutoModeSwitchResponse(obj.get("UIAutoModeSwitchResponse"))
         ui_elicitation_array_any_of_field = UIElicitationArrayAnyOfField.from_dict(obj.get("UIElicitationArrayAnyOfField"))
         ui_elicitation_array_any_of_field_items = UIElicitationArrayAnyOfFieldItems.from_dict(obj.get("UIElicitationArrayAnyOfFieldItems"))
         ui_elicitation_array_any_of_field_items_any_of = UIElicitationArrayAnyOfFieldItemsAnyOf.from_dict(obj.get("UIElicitationArrayAnyOfFieldItemsAnyOf"))
@@ -8003,7 +14961,19 @@ class RPC:
         ui_elicitation_string_enum_field = UIElicitationStringEnumField.from_dict(obj.get("UIElicitationStringEnumField"))
         ui_elicitation_string_one_of_field = UIElicitationStringOneOfField.from_dict(obj.get("UIElicitationStringOneOfField"))
         ui_elicitation_string_one_of_field_one_of = UIElicitationStringOneOfFieldOneOf.from_dict(obj.get("UIElicitationStringOneOfFieldOneOf"))
+        ui_exit_plan_mode_action = UIExitPlanModeAction(obj.get("UIExitPlanModeAction"))
+        ui_exit_plan_mode_response = UIExitPlanModeResponse.from_dict(obj.get("UIExitPlanModeResponse"))
+        ui_handle_pending_auto_mode_switch_request = UIHandlePendingAutoModeSwitchRequest.from_dict(obj.get("UIHandlePendingAutoModeSwitchRequest"))
         ui_handle_pending_elicitation_request = UIHandlePendingElicitationRequest.from_dict(obj.get("UIHandlePendingElicitationRequest"))
+        ui_handle_pending_exit_plan_mode_request = UIHandlePendingExitPlanModeRequest.from_dict(obj.get("UIHandlePendingExitPlanModeRequest"))
+        ui_handle_pending_result = UIHandlePendingResult.from_dict(obj.get("UIHandlePendingResult"))
+        ui_handle_pending_sampling_request = UIHandlePendingSamplingRequest.from_dict(obj.get("UIHandlePendingSamplingRequest"))
+        ui_handle_pending_sampling_response = from_dict(lambda x: x, obj.get("UIHandlePendingSamplingResponse"))
+        ui_handle_pending_user_input_request = UIHandlePendingUserInputRequest.from_dict(obj.get("UIHandlePendingUserInputRequest"))
+        ui_register_direct_auto_mode_switch_handler_result = UIRegisterDirectAutoModeSwitchHandlerResult.from_dict(obj.get("UIRegisterDirectAutoModeSwitchHandlerResult"))
+        ui_unregister_direct_auto_mode_switch_handler_request = UIUnregisterDirectAutoModeSwitchHandlerRequest.from_dict(obj.get("UIUnregisterDirectAutoModeSwitchHandlerRequest"))
+        ui_unregister_direct_auto_mode_switch_handler_result = UIUnregisterDirectAutoModeSwitchHandlerResult.from_dict(obj.get("UIUnregisterDirectAutoModeSwitchHandlerResult"))
+        ui_user_input_response = UIUserInputResponse.from_dict(obj.get("UIUserInputResponse"))
         usage_get_metrics_result = UsageGetMetricsResult.from_dict(obj.get("UsageGetMetricsResult"))
         usage_metrics_code_changes = UsageMetricsCodeChanges.from_dict(obj.get("UsageMetricsCodeChanges"))
         usage_metrics_model_metric = UsageMetricsModelMetric.from_dict(obj.get("UsageMetricsModelMetric"))
@@ -8011,24 +14981,47 @@ class RPC:
         usage_metrics_model_metric_token_detail = UsageMetricsModelMetricTokenDetail.from_dict(obj.get("UsageMetricsModelMetricTokenDetail"))
         usage_metrics_model_metric_usage = UsageMetricsModelMetricUsage.from_dict(obj.get("UsageMetricsModelMetricUsage"))
         usage_metrics_token_detail = UsageMetricsTokenDetail.from_dict(obj.get("UsageMetricsTokenDetail"))
+        user_auth_info = UserAuthInfo.from_dict(obj.get("UserAuthInfo"))
+        user_tool_session_approval_commands = UserToolSessionApprovalCommands.from_dict(obj.get("UserToolSessionApprovalCommands"))
+        user_tool_session_approval_custom_tool = UserToolSessionApprovalCustomTool.from_dict(obj.get("UserToolSessionApprovalCustomTool"))
+        user_tool_session_approval_extension_management = UserToolSessionApprovalExtensionManagement.from_dict(obj.get("UserToolSessionApprovalExtensionManagement"))
+        user_tool_session_approval_extension_permission_access = UserToolSessionApprovalExtensionPermissionAccess.from_dict(obj.get("UserToolSessionApprovalExtensionPermissionAccess"))
+        user_tool_session_approval_mcp = UserToolSessionApprovalMCP.from_dict(obj.get("UserToolSessionApprovalMcp"))
+        user_tool_session_approval_memory = UserToolSessionApprovalMemory.from_dict(obj.get("UserToolSessionApprovalMemory"))
+        user_tool_session_approval_read = UserToolSessionApprovalRead.from_dict(obj.get("UserToolSessionApprovalRead"))
+        user_tool_session_approval_write = UserToolSessionApprovalWrite.from_dict(obj.get("UserToolSessionApprovalWrite"))
+        workspaces_checkpoints = WorkspacesCheckpoints.from_dict(obj.get("WorkspacesCheckpoints"))
         workspaces_create_file_request = WorkspacesCreateFileRequest.from_dict(obj.get("WorkspacesCreateFileRequest"))
         workspaces_get_workspace_result = WorkspacesGetWorkspaceResult.from_dict(obj.get("WorkspacesGetWorkspaceResult"))
+        workspaces_list_checkpoints_result = WorkspacesListCheckpointsResult.from_dict(obj.get("WorkspacesListCheckpointsResult"))
         workspaces_list_files_result = WorkspacesListFilesResult.from_dict(obj.get("WorkspacesListFilesResult"))
+        workspaces_read_checkpoint_request = WorkspacesReadCheckpointRequest.from_dict(obj.get("WorkspacesReadCheckpointRequest"))
+        workspaces_read_checkpoint_result = WorkspacesReadCheckpointResult.from_dict(obj.get("WorkspacesReadCheckpointResult"))
         workspaces_read_file_request = WorkspacesReadFileRequest.from_dict(obj.get("WorkspacesReadFileRequest"))
         workspaces_read_file_result = WorkspacesReadFileResult.from_dict(obj.get("WorkspacesReadFileResult"))
-        return RPC(account_get_quota_request, account_get_quota_result, account_quota_snapshot, agent_get_current_result, agent_info, agent_list, agent_reload_result, agent_select_request, agent_select_result, auth_info_type, command_list, commands_handle_pending_command_request, commands_handle_pending_command_result, commands_invoke_request, commands_list_request, commands_respond_to_queued_command_request, commands_respond_to_queued_command_result, connected_remote_session_metadata, connected_remote_session_metadata_kind, connected_remote_session_metadata_repository, connect_remote_session_params, connect_request, connect_result, content_filter_mode, current_model, discovered_mcp_server, discovered_mcp_server_type, extension, extension_list, extensions_disable_request, extensions_enable_request, extension_source, extension_status, external_tool_result, external_tool_text_result_for_llm, external_tool_text_result_for_llm_binary_results_for_llm, external_tool_text_result_for_llm_binary_results_for_llm_type, external_tool_text_result_for_llm_content, external_tool_text_result_for_llm_content_audio, external_tool_text_result_for_llm_content_image, external_tool_text_result_for_llm_content_resource, external_tool_text_result_for_llm_content_resource_details, external_tool_text_result_for_llm_content_resource_link, external_tool_text_result_for_llm_content_resource_link_icon, external_tool_text_result_for_llm_content_resource_link_icon_theme, external_tool_text_result_for_llm_content_terminal, external_tool_text_result_for_llm_content_text, filter_mapping, fleet_start_request, fleet_start_result, handle_pending_tool_call_request, handle_pending_tool_call_result, history_compact_context_window, history_compact_result, history_truncate_request, history_truncate_result, instructions_get_sources_result, instructions_sources, instructions_sources_location, instructions_sources_type, log_request, log_result, mcp_config_add_request, mcp_config_disable_request, mcp_config_enable_request, mcp_config_list, mcp_config_remove_request, mcp_config_update_request, mcp_disable_request, mcp_discover_request, mcp_discover_result, mcp_enable_request, mcp_oauth_login_request, mcp_oauth_login_result, mcp_server, mcp_server_config, mcp_server_config_http, mcp_server_config_http_auth, mcp_server_config_http_oauth_grant_type, mcp_server_config_http_type, mcp_server_config_stdio, mcp_server_list, model, model_billing, model_billing_token_prices, model_capabilities, model_capabilities_limits, model_capabilities_limits_vision, model_capabilities_override, model_capabilities_override_limits, model_capabilities_override_limits_vision, model_capabilities_override_supports, model_capabilities_supports, model_list, model_picker_category, model_picker_price_category, model_policy, model_policy_state, models_list_request, model_switch_to_request, model_switch_to_result, mode_set_request, name_get_result, name_set_request, permission_decision, permission_decision_approve_for_location, permission_decision_approve_for_location_approval, permission_decision_approve_for_location_approval_commands, permission_decision_approve_for_location_approval_custom_tool, permission_decision_approve_for_location_approval_extension_management, permission_decision_approve_for_location_approval_extension_permission_access, permission_decision_approve_for_location_approval_mcp, permission_decision_approve_for_location_approval_mcp_sampling, permission_decision_approve_for_location_approval_memory, permission_decision_approve_for_location_approval_read, permission_decision_approve_for_location_approval_write, permission_decision_approve_for_session, permission_decision_approve_for_session_approval, permission_decision_approve_for_session_approval_commands, permission_decision_approve_for_session_approval_custom_tool, permission_decision_approve_for_session_approval_extension_management, permission_decision_approve_for_session_approval_extension_permission_access, permission_decision_approve_for_session_approval_mcp, permission_decision_approve_for_session_approval_mcp_sampling, permission_decision_approve_for_session_approval_memory, permission_decision_approve_for_session_approval_read, permission_decision_approve_for_session_approval_write, permission_decision_approve_once, permission_decision_approve_permanently, permission_decision_reject, permission_decision_request, permission_decision_user_not_available, permission_request_result, permissions_reset_session_approvals_request, permissions_reset_session_approvals_result, permissions_set_approve_all_request, permissions_set_approve_all_result, ping_request, ping_result, plan_read_result, plan_update_request, plugin, plugin_list, queued_command_handled, queued_command_not_handled, queued_command_result, remote_enable_request, remote_enable_result, remote_session_connection_result, remote_session_mode, server_skill, server_skill_list, session_auth_status, session_fs_append_file_request, session_fs_error, session_fs_error_code, session_fs_exists_request, session_fs_exists_result, session_fs_mkdir_request, session_fs_readdir_request, session_fs_readdir_result, session_fs_readdir_with_types_entry, session_fs_readdir_with_types_entry_type, session_fs_readdir_with_types_request, session_fs_readdir_with_types_result, session_fs_read_file_request, session_fs_read_file_result, session_fs_rename_request, session_fs_rm_request, session_fs_set_provider_capabilities, session_fs_set_provider_conventions, session_fs_set_provider_request, session_fs_set_provider_result, session_fs_sqlite_exists_request, session_fs_sqlite_exists_result, session_fs_sqlite_query_request, session_fs_sqlite_query_result, session_fs_sqlite_query_type, session_fs_stat_request, session_fs_stat_result, session_fs_write_file_request, session_log_level, session_mode, sessions_fork_request, sessions_fork_result, shell_exec_request, shell_exec_result, shell_kill_request, shell_kill_result, shell_kill_signal, skill, skill_list, skills_config_set_disabled_skills_request, skills_disable_request, skills_discover_request, skills_enable_request, skills_load_diagnostics, slash_command_agent_prompt_result, slash_command_completed_result, slash_command_info, slash_command_input, slash_command_input_completion, slash_command_invocation_result, slash_command_kind, slash_command_text_result, task_agent_info, task_execution_mode, task_info, task_list, tasks_cancel_request, tasks_cancel_result, task_shell_info, task_shell_info_attachment_mode, tasks_promote_to_background_request, tasks_promote_to_background_result, tasks_remove_request, tasks_remove_result, tasks_send_message_request, tasks_send_message_result, tasks_start_agent_request, tasks_start_agent_result, task_status, tool, tool_list, tools_list_request, ui_elicitation_array_any_of_field, ui_elicitation_array_any_of_field_items, ui_elicitation_array_any_of_field_items_any_of, ui_elicitation_array_enum_field, ui_elicitation_array_enum_field_items, ui_elicitation_field_value, ui_elicitation_request, ui_elicitation_response, ui_elicitation_response_action, ui_elicitation_response_content, ui_elicitation_result, ui_elicitation_schema, ui_elicitation_schema_property, ui_elicitation_schema_property_boolean, ui_elicitation_schema_property_number, ui_elicitation_schema_property_number_type, ui_elicitation_schema_property_string, ui_elicitation_schema_property_string_format, ui_elicitation_string_enum_field, ui_elicitation_string_one_of_field, ui_elicitation_string_one_of_field_one_of, ui_handle_pending_elicitation_request, usage_get_metrics_result, usage_metrics_code_changes, usage_metrics_model_metric, usage_metrics_model_metric_requests, usage_metrics_model_metric_token_detail, usage_metrics_model_metric_usage, usage_metrics_token_detail, workspaces_create_file_request, workspaces_get_workspace_result, workspaces_list_files_result, workspaces_read_file_request, workspaces_read_file_result)
+        workspaces_save_large_paste_request = WorkspacesSaveLargePasteRequest.from_dict(obj.get("WorkspacesSaveLargePasteRequest"))
+        workspaces_save_large_paste_result = WorkspacesSaveLargePasteResult.from_dict(obj.get("WorkspacesSaveLargePasteResult"))
+        session_context_info = from_union([SessionContextInfo.from_dict, from_none], obj.get("SessionContextInfo"))
+        task_progress = from_union([TaskProgressClass.from_dict, from_none], obj.get("TaskProgress"))
+        workspace_summary = from_union([WorkspaceSummary.from_dict, from_none], obj.get("WorkspaceSummary"))
+        return RPC(abort_request, abort_result, account_get_quota_request, account_get_quota_result, account_quota_snapshot, agent_get_current_result, agent_info, agent_info_source, agent_list, agent_reload_result, agent_select_request, agent_select_result, api_key_auth_info, auth_info, auth_info_type, command_list, commands_handle_pending_command_request, commands_handle_pending_command_result, commands_invoke_request, commands_list_request, commands_respond_to_queued_command_request, commands_respond_to_queued_command_result, connected_remote_session_metadata, connected_remote_session_metadata_kind, connected_remote_session_metadata_repository, connect_remote_session_params, connect_request, connect_result, content_filter_mode, copilot_api_token_auth_info, copilot_user_response, copilot_user_response_endpoints, copilot_user_response_quota_snapshots, copilot_user_response_quota_snapshots_chat, copilot_user_response_quota_snapshots_completions, copilot_user_response_quota_snapshots_premium_interactions, current_model, discovered_mcp_server, discovered_mcp_server_type, enqueue_command_params, enqueue_command_result, env_auth_info, event_log_read_request, event_log_release_interest_result, event_log_tail_result, event_log_types, events_agent_scope, events_cursor_status, events_read_result, execute_command_params, execute_command_result, extension, extension_list, extensions_disable_request, extensions_enable_request, extension_source, extension_status, external_tool_result, external_tool_text_result_for_llm, external_tool_text_result_for_llm_binary_results_for_llm, external_tool_text_result_for_llm_binary_results_for_llm_type, external_tool_text_result_for_llm_content, external_tool_text_result_for_llm_content_audio, external_tool_text_result_for_llm_content_image, external_tool_text_result_for_llm_content_resource, external_tool_text_result_for_llm_content_resource_details, external_tool_text_result_for_llm_content_resource_link, external_tool_text_result_for_llm_content_resource_link_icon, external_tool_text_result_for_llm_content_resource_link_icon_theme, external_tool_text_result_for_llm_content_terminal, external_tool_text_result_for_llm_content_text, filter_mapping, fleet_start_request, fleet_start_result, gh_cli_auth_info, handle_pending_tool_call_request, handle_pending_tool_call_result, history_abort_manual_compaction_result, history_cancel_background_compaction_result, history_compact_context_window, history_compact_result, history_summarize_for_handoff_result, history_truncate_request, history_truncate_result, hmac_auth_info, installed_plugin, installed_plugin_source, installed_plugin_source_github, installed_plugin_source_local, installed_plugin_source_url, instructions_get_sources_result, instructions_sources, instructions_sources_location, instructions_sources_type, log_request, log_result, lsp_initialize_request, mcp_cancel_sampling_execution_params, mcp_cancel_sampling_execution_result, mcp_config_add_request, mcp_config_disable_request, mcp_config_enable_request, mcp_config_list, mcp_config_remove_request, mcp_config_update_request, mcp_disable_request, mcp_discover_request, mcp_discover_result, mcp_enable_request, mcp_execute_sampling_params, mcp_execute_sampling_request, mcp_execute_sampling_result, mcp_oauth_login_request, mcp_oauth_login_result, mcp_remove_git_hub_result, mcp_sampling_execution_action, mcp_sampling_execution_result, mcp_server, mcp_server_config, mcp_server_config_http, mcp_server_config_http_auth, mcp_server_config_http_oauth_grant_type, mcp_server_config_http_type, mcp_server_config_stdio, mcp_server_list, mcp_set_env_value_mode_details, mcp_set_env_value_mode_params, mcp_set_env_value_mode_result, metadata_context_info_request, metadata_context_info_result, metadata_is_processing_result, metadata_recompute_context_tokens_request, metadata_recompute_context_tokens_result, metadata_record_context_change_request, metadata_record_context_change_result, metadata_set_working_directory_request, metadata_set_working_directory_result, metadata_snapshot_current_mode, metadata_snapshot_remote_metadata, metadata_snapshot_remote_metadata_repository, metadata_snapshot_remote_metadata_task_type, model, model_billing, model_billing_token_prices, model_capabilities, model_capabilities_limits, model_capabilities_limits_vision, model_capabilities_override, model_capabilities_override_limits, model_capabilities_override_limits_vision, model_capabilities_override_supports, model_capabilities_supports, model_list, model_picker_category, model_picker_price_category, model_policy, model_policy_state, model_set_reasoning_effort_request, model_set_reasoning_effort_result, models_list_request, model_switch_to_request, model_switch_to_result, mode_set_request, name_get_result, name_set_auto_request, name_set_auto_result, name_set_request, options_update_env_value_mode, pending_permission_request, pending_permission_request_list, permission_decision, permission_decision_approved, permission_decision_approved_for_location, permission_decision_approved_for_session, permission_decision_approve_for_location, permission_decision_approve_for_location_approval, permission_decision_approve_for_location_approval_commands, permission_decision_approve_for_location_approval_custom_tool, permission_decision_approve_for_location_approval_extension_management, permission_decision_approve_for_location_approval_extension_permission_access, permission_decision_approve_for_location_approval_mcp, permission_decision_approve_for_location_approval_mcp_sampling, permission_decision_approve_for_location_approval_memory, permission_decision_approve_for_location_approval_read, permission_decision_approve_for_location_approval_write, permission_decision_approve_for_session, permission_decision_approve_for_session_approval, permission_decision_approve_for_session_approval_commands, permission_decision_approve_for_session_approval_custom_tool, permission_decision_approve_for_session_approval_extension_management, permission_decision_approve_for_session_approval_extension_permission_access, permission_decision_approve_for_session_approval_mcp, permission_decision_approve_for_session_approval_mcp_sampling, permission_decision_approve_for_session_approval_memory, permission_decision_approve_for_session_approval_read, permission_decision_approve_for_session_approval_write, permission_decision_approve_once, permission_decision_approve_permanently, permission_decision_cancelled, permission_decision_denied_by_content_exclusion_policy, permission_decision_denied_by_permission_request_hook, permission_decision_denied_by_rules, permission_decision_denied_interactively_by_user, permission_decision_denied_no_approval_rule_and_could_not_request_from_user, permission_decision_reject, permission_decision_request, permission_decision_user_not_available, permission_paths_add_params, permission_paths_allowed_check_params, permission_paths_allowed_check_result, permission_paths_config, permission_paths_list, permission_paths_update_primary_params, permission_paths_workspace_check_params, permission_paths_workspace_check_result, permission_prompt_shown_notification, permission_request_result, permission_rules_set, permissions_configure_additional_content_exclusion_policy, permissions_configure_additional_content_exclusion_policy_rule, permissions_configure_additional_content_exclusion_policy_rule_source, permissions_configure_additional_content_exclusion_policy_scope, permissions_configure_params, permissions_configure_result, permissions_modify_rules_params, permissions_modify_rules_result, permissions_modify_rules_scope, permissions_notify_prompt_shown_result, permissions_paths_add_result, permissions_paths_list_request, permissions_paths_update_primary_result, permissions_pending_requests_request, permissions_reset_session_approvals_request, permissions_reset_session_approvals_result, permissions_set_approve_all_request, permissions_set_approve_all_result, permissions_set_approve_all_source, permissions_set_required_request, permissions_set_required_result, permissions_urls_set_unrestricted_mode_result, permission_urls_config, permission_urls_set_unrestricted_mode_params, ping_request, ping_result, plan_read_result, plan_update_request, plugin, plugin_list, queued_command_handled, queued_command_not_handled, queued_command_result, queue_pending_items, queue_pending_items_kind, queue_pending_items_result, queue_remove_most_recent_result, register_event_interest_params, register_event_interest_result, release_event_interest_params, remote_enable_request, remote_enable_result, remote_notify_steerable_changed_request, remote_notify_steerable_changed_result, remote_session_connection_result, remote_session_mode, schedule_entry, schedule_list, schedule_stop_request, schedule_stop_result, send_agent_mode, send_attachment, send_attachment_blob, send_attachment_directory, send_attachment_file, send_attachment_file_line_range, send_attachment_github_reference, send_attachment_github_reference_type, send_attachment_selection, send_attachment_selection_details, send_attachment_selection_details_end, send_attachment_selection_details_start, send_mode, send_request, send_result, server_skill, server_skill_list, session_auth_status, session_bulk_delete_result, session_context, session_context_host_type, session_enrich_metadata_result, session_fs_append_file_request, session_fs_error, session_fs_error_code, session_fs_exists_request, session_fs_exists_result, session_fs_mkdir_request, session_fs_readdir_request, session_fs_readdir_result, session_fs_readdir_with_types_entry, session_fs_readdir_with_types_entry_type, session_fs_readdir_with_types_request, session_fs_readdir_with_types_result, session_fs_read_file_request, session_fs_read_file_result, session_fs_rename_request, session_fs_rm_request, session_fs_set_provider_capabilities, session_fs_set_provider_conventions, session_fs_set_provider_request, session_fs_set_provider_result, session_fs_sqlite_exists_request, session_fs_sqlite_exists_result, session_fs_sqlite_query_request, session_fs_sqlite_query_result, session_fs_sqlite_query_type, session_fs_stat_request, session_fs_stat_result, session_fs_write_file_request, session_installed_plugin, session_installed_plugin_source, session_installed_plugin_source_github, session_installed_plugin_source_local, session_installed_plugin_source_url, session_list, session_load_deferred_repo_hooks_result, session_log_level, session_metadata, session_metadata_snapshot, session_mode, session_prune_result, sessions_bulk_delete_request, sessions_check_in_use_request, sessions_check_in_use_result, sessions_close_request, sessions_close_result, sessions_enrich_metadata_request, session_set_credentials_params, session_set_credentials_result, sessions_find_by_prefix_request, sessions_find_by_prefix_result, sessions_find_by_task_id_request, sessions_find_by_task_id_result, sessions_fork_request, sessions_fork_result, sessions_get_event_file_path_request, sessions_get_event_file_path_result, sessions_get_last_for_context_request, sessions_get_last_for_context_result, sessions_get_persisted_remote_steerable_request, sessions_get_persisted_remote_steerable_result, session_sizes, sessions_list_request, sessions_load_deferred_repo_hooks_request, sessions_prune_old_request, sessions_release_lock_request, sessions_release_lock_result, sessions_reload_plugin_hooks_request, sessions_reload_plugin_hooks_result, sessions_save_request, sessions_save_result, sessions_set_additional_plugins_request, sessions_set_additional_plugins_result, session_update_options_params, session_update_options_result, session_working_directory_context, session_working_directory_context_host_type, shell_exec_request, shell_exec_result, shell_kill_request, shell_kill_result, shell_kill_signal, shutdown_request, skill, skill_list, skills_config_set_disabled_skills_request, skills_disable_request, skills_discover_request, skills_enable_request, skills_get_invoked_result, skills_invoked_skill, skills_load_diagnostics, slash_command_agent_prompt_result, slash_command_completed_result, slash_command_info, slash_command_input, slash_command_input_completion, slash_command_invocation_result, slash_command_kind, slash_command_text_result, task_agent_info, task_agent_progress, task_execution_mode, task_info, task_list, tasks_cancel_request, tasks_cancel_result, tasks_get_current_promotable_result, tasks_get_progress_request, tasks_get_progress_result, task_shell_info, task_shell_info_attachment_mode, task_shell_progress, tasks_promote_current_to_background_result, tasks_promote_to_background_request, tasks_promote_to_background_result, tasks_refresh_result, tasks_remove_request, tasks_remove_result, tasks_send_message_request, tasks_send_message_result, tasks_start_agent_request, tasks_start_agent_result, task_status, tasks_wait_for_pending_result, telemetry_set_feature_overrides_request, token_auth_info, tool, tool_list, tools_initialize_and_validate_result, tools_list_request, ui_auto_mode_switch_response, ui_elicitation_array_any_of_field, ui_elicitation_array_any_of_field_items, ui_elicitation_array_any_of_field_items_any_of, ui_elicitation_array_enum_field, ui_elicitation_array_enum_field_items, ui_elicitation_field_value, ui_elicitation_request, ui_elicitation_response, ui_elicitation_response_action, ui_elicitation_response_content, ui_elicitation_result, ui_elicitation_schema, ui_elicitation_schema_property, ui_elicitation_schema_property_boolean, ui_elicitation_schema_property_number, ui_elicitation_schema_property_number_type, ui_elicitation_schema_property_string, ui_elicitation_schema_property_string_format, ui_elicitation_string_enum_field, ui_elicitation_string_one_of_field, ui_elicitation_string_one_of_field_one_of, ui_exit_plan_mode_action, ui_exit_plan_mode_response, ui_handle_pending_auto_mode_switch_request, ui_handle_pending_elicitation_request, ui_handle_pending_exit_plan_mode_request, ui_handle_pending_result, ui_handle_pending_sampling_request, ui_handle_pending_sampling_response, ui_handle_pending_user_input_request, ui_register_direct_auto_mode_switch_handler_result, ui_unregister_direct_auto_mode_switch_handler_request, ui_unregister_direct_auto_mode_switch_handler_result, ui_user_input_response, usage_get_metrics_result, usage_metrics_code_changes, usage_metrics_model_metric, usage_metrics_model_metric_requests, usage_metrics_model_metric_token_detail, usage_metrics_model_metric_usage, usage_metrics_token_detail, user_auth_info, user_tool_session_approval_commands, user_tool_session_approval_custom_tool, user_tool_session_approval_extension_management, user_tool_session_approval_extension_permission_access, user_tool_session_approval_mcp, user_tool_session_approval_memory, user_tool_session_approval_read, user_tool_session_approval_write, workspaces_checkpoints, workspaces_create_file_request, workspaces_get_workspace_result, workspaces_list_checkpoints_result, workspaces_list_files_result, workspaces_read_checkpoint_request, workspaces_read_checkpoint_result, workspaces_read_file_request, workspaces_read_file_result, workspaces_save_large_paste_request, workspaces_save_large_paste_result, session_context_info, task_progress, workspace_summary)
 
     def to_dict(self) -> dict:
         result: dict = {}
+        result["AbortRequest"] = to_class(AbortRequest, self.abort_request)
+        result["AbortResult"] = to_class(AbortResult, self.abort_result)
         result["AccountGetQuotaRequest"] = to_class(AccountGetQuotaRequest, self.account_get_quota_request)
         result["AccountGetQuotaResult"] = to_class(AccountGetQuotaResult, self.account_get_quota_result)
         result["AccountQuotaSnapshot"] = to_class(AccountQuotaSnapshot, self.account_quota_snapshot)
         result["AgentGetCurrentResult"] = to_class(AgentGetCurrentResult, self.agent_get_current_result)
         result["AgentInfo"] = to_class(AgentInfo, self.agent_info)
+        result["AgentInfoSource"] = to_enum(AgentInfoSource, self.agent_info_source)
         result["AgentList"] = to_class(AgentList, self.agent_list)
         result["AgentReloadResult"] = to_class(AgentReloadResult, self.agent_reload_result)
         result["AgentSelectRequest"] = to_class(AgentSelectRequest, self.agent_select_request)
         result["AgentSelectResult"] = to_class(AgentSelectResult, self.agent_select_result)
+        result["ApiKeyAuthInfo"] = to_class(APIKeyAuthInfo, self.api_key_auth_info)
+        result["AuthInfo"] = to_class(AuthInfo, self.auth_info)
         result["AuthInfoType"] = to_enum(AuthInfoType, self.auth_info_type)
         result["CommandList"] = to_class(CommandList, self.command_list)
         result["CommandsHandlePendingCommandRequest"] = to_class(CommandsHandlePendingCommandRequest, self.commands_handle_pending_command_request)
@@ -8044,9 +15037,28 @@ class RPC:
         result["ConnectRequest"] = to_class(ConnectRequest, self.connect_request)
         result["ConnectResult"] = to_class(ConnectResult, self.connect_result)
         result["ContentFilterMode"] = to_enum(ContentFilterMode, self.content_filter_mode)
+        result["CopilotApiTokenAuthInfo"] = to_class(CopilotAPITokenAuthInfo, self.copilot_api_token_auth_info)
+        result["CopilotUserResponse"] = to_class(CopilotUserResponse, self.copilot_user_response)
+        result["CopilotUserResponseEndpoints"] = to_class(CopilotUserResponseEndpoints, self.copilot_user_response_endpoints)
+        result["CopilotUserResponseQuotaSnapshots"] = from_dict(lambda x: from_union([lambda x: to_class(CopilotUserResponseQuotaSnapshots, x), from_none], x), self.copilot_user_response_quota_snapshots)
+        result["CopilotUserResponseQuotaSnapshotsChat"] = to_class(CopilotUserResponseQuotaSnapshotsChat, self.copilot_user_response_quota_snapshots_chat)
+        result["CopilotUserResponseQuotaSnapshotsCompletions"] = to_class(CopilotUserResponseQuotaSnapshotsCompletions, self.copilot_user_response_quota_snapshots_completions)
+        result["CopilotUserResponseQuotaSnapshotsPremiumInteractions"] = to_class(CopilotUserResponseQuotaSnapshotsPremiumInteractions, self.copilot_user_response_quota_snapshots_premium_interactions)
         result["CurrentModel"] = to_class(CurrentModel, self.current_model)
         result["DiscoveredMcpServer"] = to_class(DiscoveredMCPServer, self.discovered_mcp_server)
         result["DiscoveredMcpServerType"] = to_enum(DiscoveredMCPServerType, self.discovered_mcp_server_type)
+        result["EnqueueCommandParams"] = to_class(EnqueueCommandParams, self.enqueue_command_params)
+        result["EnqueueCommandResult"] = to_class(EnqueueCommandResult, self.enqueue_command_result)
+        result["EnvAuthInfo"] = to_class(EnvAuthInfo, self.env_auth_info)
+        result["EventLogReadRequest"] = to_class(EventLogReadRequest, self.event_log_read_request)
+        result["EventLogReleaseInterestResult"] = to_class(EventLogReleaseInterestResult, self.event_log_release_interest_result)
+        result["EventLogTailResult"] = to_class(EventLogTailResult, self.event_log_tail_result)
+        result["EventLogTypes"] = from_union([lambda x: from_list(from_str, x), lambda x: to_enum(EventLogTypes, x)], self.event_log_types)
+        result["EventsAgentScope"] = to_enum(EventsAgentScope, self.events_agent_scope)
+        result["EventsCursorStatus"] = to_enum(EventsCursorStatus, self.events_cursor_status)
+        result["EventsReadResult"] = to_class(EventsReadResult, self.events_read_result)
+        result["ExecuteCommandParams"] = to_class(ExecuteCommandParams, self.execute_command_params)
+        result["ExecuteCommandResult"] = to_class(ExecuteCommandResult, self.execute_command_result)
         result["Extension"] = to_class(Extension, self.extension)
         result["ExtensionList"] = to_class(ExtensionList, self.extension_list)
         result["ExtensionsDisableRequest"] = to_class(ExtensionsDisableRequest, self.extensions_disable_request)
@@ -8070,18 +15082,31 @@ class RPC:
         result["FilterMapping"] = from_union([lambda x: from_dict(lambda x: to_enum(ContentFilterMode, x), x), lambda x: to_enum(ContentFilterMode, x)], self.filter_mapping)
         result["FleetStartRequest"] = to_class(FleetStartRequest, self.fleet_start_request)
         result["FleetStartResult"] = to_class(FleetStartResult, self.fleet_start_result)
+        result["GhCliAuthInfo"] = to_class(GhCLIAuthInfo, self.gh_cli_auth_info)
         result["HandlePendingToolCallRequest"] = to_class(HandlePendingToolCallRequest, self.handle_pending_tool_call_request)
         result["HandlePendingToolCallResult"] = to_class(HandlePendingToolCallResult, self.handle_pending_tool_call_result)
+        result["HistoryAbortManualCompactionResult"] = to_class(HistoryAbortManualCompactionResult, self.history_abort_manual_compaction_result)
+        result["HistoryCancelBackgroundCompactionResult"] = to_class(HistoryCancelBackgroundCompactionResult, self.history_cancel_background_compaction_result)
         result["HistoryCompactContextWindow"] = to_class(HistoryCompactContextWindow, self.history_compact_context_window)
         result["HistoryCompactResult"] = to_class(HistoryCompactResult, self.history_compact_result)
+        result["HistorySummarizeForHandoffResult"] = to_class(HistorySummarizeForHandoffResult, self.history_summarize_for_handoff_result)
         result["HistoryTruncateRequest"] = to_class(HistoryTruncateRequest, self.history_truncate_request)
         result["HistoryTruncateResult"] = to_class(HistoryTruncateResult, self.history_truncate_result)
+        result["HMACAuthInfo"] = to_class(HMACAuthInfo, self.hmac_auth_info)
+        result["InstalledPlugin"] = to_class(InstalledPlugin, self.installed_plugin)
+        result["InstalledPluginSource"] = from_union([lambda x: to_class(InstalledPluginSource, x), from_str], self.installed_plugin_source)
+        result["InstalledPluginSourceGithub"] = to_class(InstalledPluginSourceGithub, self.installed_plugin_source_github)
+        result["InstalledPluginSourceLocal"] = to_class(InstalledPluginSourceLocal, self.installed_plugin_source_local)
+        result["InstalledPluginSourceUrl"] = to_class(InstalledPluginSourceURL, self.installed_plugin_source_url)
         result["InstructionsGetSourcesResult"] = to_class(InstructionsGetSourcesResult, self.instructions_get_sources_result)
         result["InstructionsSources"] = to_class(InstructionsSources, self.instructions_sources)
         result["InstructionsSourcesLocation"] = to_enum(InstructionsSourcesLocation, self.instructions_sources_location)
         result["InstructionsSourcesType"] = to_enum(InstructionsSourcesType, self.instructions_sources_type)
         result["LogRequest"] = to_class(LogRequest, self.log_request)
         result["LogResult"] = to_class(LogResult, self.log_result)
+        result["LspInitializeRequest"] = to_class(LspInitializeRequest, self.lsp_initialize_request)
+        result["McpCancelSamplingExecutionParams"] = to_class(MCPCancelSamplingExecutionParams, self.mcp_cancel_sampling_execution_params)
+        result["McpCancelSamplingExecutionResult"] = to_class(MCPCancelSamplingExecutionResult, self.mcp_cancel_sampling_execution_result)
         result["McpConfigAddRequest"] = to_class(MCPConfigAddRequest, self.mcp_config_add_request)
         result["McpConfigDisableRequest"] = to_class(MCPConfigDisableRequest, self.mcp_config_disable_request)
         result["McpConfigEnableRequest"] = to_class(MCPConfigEnableRequest, self.mcp_config_enable_request)
@@ -8092,8 +15117,14 @@ class RPC:
         result["McpDiscoverRequest"] = to_class(MCPDiscoverRequest, self.mcp_discover_request)
         result["McpDiscoverResult"] = to_class(MCPDiscoverResult, self.mcp_discover_result)
         result["McpEnableRequest"] = to_class(MCPEnableRequest, self.mcp_enable_request)
+        result["McpExecuteSamplingParams"] = to_class(MCPExecuteSamplingParams, self.mcp_execute_sampling_params)
+        result["McpExecuteSamplingRequest"] = from_dict(lambda x: x, self.mcp_execute_sampling_request)
+        result["McpExecuteSamplingResult"] = from_dict(lambda x: x, self.mcp_execute_sampling_result)
         result["McpOauthLoginRequest"] = to_class(MCPOauthLoginRequest, self.mcp_oauth_login_request)
         result["McpOauthLoginResult"] = to_class(MCPOauthLoginResult, self.mcp_oauth_login_result)
+        result["McpRemoveGitHubResult"] = to_class(MCPRemoveGitHubResult, self.mcp_remove_git_hub_result)
+        result["McpSamplingExecutionAction"] = to_enum(MCPSamplingExecutionAction, self.mcp_sampling_execution_action)
+        result["McpSamplingExecutionResult"] = to_class(MCPSamplingExecutionResult, self.mcp_sampling_execution_result)
         result["McpServer"] = to_class(MCPServer, self.mcp_server)
         result["McpServerConfig"] = to_class(MCPServerConfig, self.mcp_server_config)
         result["McpServerConfigHttp"] = to_class(MCPServerConfigHTTP, self.mcp_server_config_http)
@@ -8102,6 +15133,22 @@ class RPC:
         result["McpServerConfigHttpType"] = to_enum(MCPServerConfigHTTPType, self.mcp_server_config_http_type)
         result["McpServerConfigStdio"] = to_class(MCPServerConfigStdio, self.mcp_server_config_stdio)
         result["McpServerList"] = to_class(MCPServerList, self.mcp_server_list)
+        result["McpSetEnvValueModeDetails"] = to_enum(MCPSetEnvValueModeDetails, self.mcp_set_env_value_mode_details)
+        result["McpSetEnvValueModeParams"] = to_class(MCPSetEnvValueModeParams, self.mcp_set_env_value_mode_params)
+        result["McpSetEnvValueModeResult"] = to_class(MCPSetEnvValueModeResult, self.mcp_set_env_value_mode_result)
+        result["MetadataContextInfoRequest"] = to_class(MetadataContextInfoRequest, self.metadata_context_info_request)
+        result["MetadataContextInfoResult"] = to_class(MetadataContextInfoResult, self.metadata_context_info_result)
+        result["MetadataIsProcessingResult"] = to_class(MetadataIsProcessingResult, self.metadata_is_processing_result)
+        result["MetadataRecomputeContextTokensRequest"] = to_class(MetadataRecomputeContextTokensRequest, self.metadata_recompute_context_tokens_request)
+        result["MetadataRecomputeContextTokensResult"] = to_class(MetadataRecomputeContextTokensResult, self.metadata_recompute_context_tokens_result)
+        result["MetadataRecordContextChangeRequest"] = to_class(MetadataRecordContextChangeRequest, self.metadata_record_context_change_request)
+        result["MetadataRecordContextChangeResult"] = to_class(MetadataRecordContextChangeResult, self.metadata_record_context_change_result)
+        result["MetadataSetWorkingDirectoryRequest"] = to_class(MetadataSetWorkingDirectoryRequest, self.metadata_set_working_directory_request)
+        result["MetadataSetWorkingDirectoryResult"] = to_class(MetadataSetWorkingDirectoryResult, self.metadata_set_working_directory_result)
+        result["MetadataSnapshotCurrentMode"] = to_enum(MetadataSnapshotCurrentMode, self.metadata_snapshot_current_mode)
+        result["MetadataSnapshotRemoteMetadata"] = to_class(MetadataSnapshotRemoteMetadata, self.metadata_snapshot_remote_metadata)
+        result["MetadataSnapshotRemoteMetadataRepository"] = to_class(MetadataSnapshotRemoteMetadataRepository, self.metadata_snapshot_remote_metadata_repository)
+        result["MetadataSnapshotRemoteMetadataTaskType"] = to_enum(MetadataSnapshotRemoteMetadataTaskType, self.metadata_snapshot_remote_metadata_task_type)
         result["Model"] = to_class(Model, self.model)
         result["ModelBilling"] = to_class(ModelBilling, self.model_billing)
         result["ModelBillingTokenPrices"] = to_class(ModelBillingTokenPrices, self.model_billing_token_prices)
@@ -8118,13 +15165,23 @@ class RPC:
         result["ModelPickerPriceCategory"] = to_enum(ModelPickerPriceCategory, self.model_picker_price_category)
         result["ModelPolicy"] = to_class(ModelPolicy, self.model_policy)
         result["ModelPolicyState"] = to_enum(ModelPolicyState, self.model_policy_state)
+        result["ModelSetReasoningEffortRequest"] = to_class(ModelSetReasoningEffortRequest, self.model_set_reasoning_effort_request)
+        result["ModelSetReasoningEffortResult"] = to_class(ModelSetReasoningEffortResult, self.model_set_reasoning_effort_result)
         result["ModelsListRequest"] = to_class(ModelsListRequest, self.models_list_request)
         result["ModelSwitchToRequest"] = to_class(ModelSwitchToRequest, self.model_switch_to_request)
         result["ModelSwitchToResult"] = to_class(ModelSwitchToResult, self.model_switch_to_result)
         result["ModeSetRequest"] = to_class(ModeSetRequest, self.mode_set_request)
         result["NameGetResult"] = to_class(NameGetResult, self.name_get_result)
+        result["NameSetAutoRequest"] = to_class(NameSetAutoRequest, self.name_set_auto_request)
+        result["NameSetAutoResult"] = to_class(NameSetAutoResult, self.name_set_auto_result)
         result["NameSetRequest"] = to_class(NameSetRequest, self.name_set_request)
+        result["OptionsUpdateEnvValueMode"] = to_enum(MCPSetEnvValueModeDetails, self.options_update_env_value_mode)
+        result["PendingPermissionRequest"] = to_class(PendingPermissionRequest, self.pending_permission_request)
+        result["PendingPermissionRequestList"] = to_class(PendingPermissionRequestList, self.pending_permission_request_list)
         result["PermissionDecision"] = to_class(PermissionDecision, self.permission_decision)
+        result["PermissionDecisionApproved"] = to_class(PermissionDecisionApproved, self.permission_decision_approved)
+        result["PermissionDecisionApprovedForLocation"] = to_class(PermissionDecisionApprovedForLocation, self.permission_decision_approved_for_location)
+        result["PermissionDecisionApprovedForSession"] = to_class(PermissionDecisionApprovedForSession, self.permission_decision_approved_for_session)
         result["PermissionDecisionApproveForLocation"] = to_class(PermissionDecisionApproveForLocation, self.permission_decision_approve_for_location)
         result["PermissionDecisionApproveForLocationApproval"] = to_class(PermissionDecisionApproveForLocationApproval, self.permission_decision_approve_for_location_approval)
         result["PermissionDecisionApproveForLocationApprovalCommands"] = to_class(PermissionDecisionApproveForLocationApprovalCommands, self.permission_decision_approve_for_location_approval_commands)
@@ -8149,14 +15206,50 @@ class RPC:
         result["PermissionDecisionApproveForSessionApprovalWrite"] = to_class(PermissionDecisionApproveForSessionApprovalWrite, self.permission_decision_approve_for_session_approval_write)
         result["PermissionDecisionApproveOnce"] = to_class(PermissionDecisionApproveOnce, self.permission_decision_approve_once)
         result["PermissionDecisionApprovePermanently"] = to_class(PermissionDecisionApprovePermanently, self.permission_decision_approve_permanently)
+        result["PermissionDecisionCancelled"] = to_class(PermissionDecisionCancelled, self.permission_decision_cancelled)
+        result["PermissionDecisionDeniedByContentExclusionPolicy"] = to_class(PermissionDecisionDeniedByContentExclusionPolicy, self.permission_decision_denied_by_content_exclusion_policy)
+        result["PermissionDecisionDeniedByPermissionRequestHook"] = to_class(PermissionDecisionDeniedByPermissionRequestHook, self.permission_decision_denied_by_permission_request_hook)
+        result["PermissionDecisionDeniedByRules"] = to_class(PermissionDecisionDeniedByRules, self.permission_decision_denied_by_rules)
+        result["PermissionDecisionDeniedInteractivelyByUser"] = to_class(PermissionDecisionDeniedInteractivelyByUser, self.permission_decision_denied_interactively_by_user)
+        result["PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser"] = to_class(PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser, self.permission_decision_denied_no_approval_rule_and_could_not_request_from_user)
         result["PermissionDecisionReject"] = to_class(PermissionDecisionReject, self.permission_decision_reject)
         result["PermissionDecisionRequest"] = to_class(PermissionDecisionRequest, self.permission_decision_request)
         result["PermissionDecisionUserNotAvailable"] = to_class(PermissionDecisionUserNotAvailable, self.permission_decision_user_not_available)
+        result["PermissionPathsAddParams"] = to_class(PermissionPathsAddParams, self.permission_paths_add_params)
+        result["PermissionPathsAllowedCheckParams"] = to_class(PermissionPathsAllowedCheckParams, self.permission_paths_allowed_check_params)
+        result["PermissionPathsAllowedCheckResult"] = to_class(PermissionPathsAllowedCheckResult, self.permission_paths_allowed_check_result)
+        result["PermissionPathsConfig"] = to_class(PermissionPathsConfig, self.permission_paths_config)
+        result["PermissionPathsList"] = to_class(PermissionPathsList, self.permission_paths_list)
+        result["PermissionPathsUpdatePrimaryParams"] = to_class(PermissionPathsUpdatePrimaryParams, self.permission_paths_update_primary_params)
+        result["PermissionPathsWorkspaceCheckParams"] = to_class(PermissionPathsWorkspaceCheckParams, self.permission_paths_workspace_check_params)
+        result["PermissionPathsWorkspaceCheckResult"] = to_class(PermissionPathsWorkspaceCheckResult, self.permission_paths_workspace_check_result)
+        result["PermissionPromptShownNotification"] = to_class(PermissionPromptShownNotification, self.permission_prompt_shown_notification)
         result["PermissionRequestResult"] = to_class(PermissionRequestResult, self.permission_request_result)
+        result["PermissionRulesSet"] = to_class(PermissionRulesSet, self.permission_rules_set)
+        result["PermissionsConfigureAdditionalContentExclusionPolicy"] = to_class(PermissionsConfigureAdditionalContentExclusionPolicy, self.permissions_configure_additional_content_exclusion_policy)
+        result["PermissionsConfigureAdditionalContentExclusionPolicyRule"] = to_class(PermissionsConfigureAdditionalContentExclusionPolicyRule, self.permissions_configure_additional_content_exclusion_policy_rule)
+        result["PermissionsConfigureAdditionalContentExclusionPolicyRuleSource"] = to_class(PermissionsConfigureAdditionalContentExclusionPolicyRuleSource, self.permissions_configure_additional_content_exclusion_policy_rule_source)
+        result["PermissionsConfigureAdditionalContentExclusionPolicyScope"] = to_enum(PermissionsConfigureAdditionalContentExclusionPolicyScope, self.permissions_configure_additional_content_exclusion_policy_scope)
+        result["PermissionsConfigureParams"] = to_class(PermissionsConfigureParams, self.permissions_configure_params)
+        result["PermissionsConfigureResult"] = to_class(PermissionsConfigureResult, self.permissions_configure_result)
+        result["PermissionsModifyRulesParams"] = to_class(PermissionsModifyRulesParams, self.permissions_modify_rules_params)
+        result["PermissionsModifyRulesResult"] = to_class(PermissionsModifyRulesResult, self.permissions_modify_rules_result)
+        result["PermissionsModifyRulesScope"] = to_enum(PermissionsModifyRulesScope, self.permissions_modify_rules_scope)
+        result["PermissionsNotifyPromptShownResult"] = to_class(PermissionsNotifyPromptShownResult, self.permissions_notify_prompt_shown_result)
+        result["PermissionsPathsAddResult"] = to_class(PermissionsPathsAddResult, self.permissions_paths_add_result)
+        result["PermissionsPathsListRequest"] = to_class(PermissionsPathsListRequest, self.permissions_paths_list_request)
+        result["PermissionsPathsUpdatePrimaryResult"] = to_class(PermissionsPathsUpdatePrimaryResult, self.permissions_paths_update_primary_result)
+        result["PermissionsPendingRequestsRequest"] = to_class(PermissionsPendingRequestsRequest, self.permissions_pending_requests_request)
         result["PermissionsResetSessionApprovalsRequest"] = to_class(PermissionsResetSessionApprovalsRequest, self.permissions_reset_session_approvals_request)
         result["PermissionsResetSessionApprovalsResult"] = to_class(PermissionsResetSessionApprovalsResult, self.permissions_reset_session_approvals_result)
         result["PermissionsSetApproveAllRequest"] = to_class(PermissionsSetApproveAllRequest, self.permissions_set_approve_all_request)
         result["PermissionsSetApproveAllResult"] = to_class(PermissionsSetApproveAllResult, self.permissions_set_approve_all_result)
+        result["PermissionsSetApproveAllSource"] = to_enum(PermissionsSetApproveAllSource, self.permissions_set_approve_all_source)
+        result["PermissionsSetRequiredRequest"] = to_class(PermissionsSetRequiredRequest, self.permissions_set_required_request)
+        result["PermissionsSetRequiredResult"] = to_class(PermissionsSetRequiredResult, self.permissions_set_required_result)
+        result["PermissionsUrlsSetUnrestrictedModeResult"] = to_class(PermissionsUrlsSetUnrestrictedModeResult, self.permissions_urls_set_unrestricted_mode_result)
+        result["PermissionUrlsConfig"] = to_class(PermissionUrlsConfig, self.permission_urls_config)
+        result["PermissionUrlsSetUnrestrictedModeParams"] = to_class(PermissionUrlsSetUnrestrictedModeParams, self.permission_urls_set_unrestricted_mode_params)
         result["PingRequest"] = to_class(PingRequest, self.ping_request)
         result["PingResult"] = to_class(PingResult, self.ping_result)
         result["PlanReadResult"] = to_class(PlanReadResult, self.plan_read_result)
@@ -8166,13 +15259,45 @@ class RPC:
         result["QueuedCommandHandled"] = to_class(QueuedCommandHandled, self.queued_command_handled)
         result["QueuedCommandNotHandled"] = to_class(QueuedCommandNotHandled, self.queued_command_not_handled)
         result["QueuedCommandResult"] = to_class(QueuedCommandResult, self.queued_command_result)
+        result["QueuePendingItems"] = to_class(QueuePendingItems, self.queue_pending_items)
+        result["QueuePendingItemsKind"] = to_enum(QueuePendingItemsKind, self.queue_pending_items_kind)
+        result["QueuePendingItemsResult"] = to_class(QueuePendingItemsResult, self.queue_pending_items_result)
+        result["QueueRemoveMostRecentResult"] = to_class(QueueRemoveMostRecentResult, self.queue_remove_most_recent_result)
+        result["RegisterEventInterestParams"] = to_class(RegisterEventInterestParams, self.register_event_interest_params)
+        result["RegisterEventInterestResult"] = to_class(RegisterEventInterestResult, self.register_event_interest_result)
+        result["ReleaseEventInterestParams"] = to_class(ReleaseEventInterestParams, self.release_event_interest_params)
         result["RemoteEnableRequest"] = to_class(RemoteEnableRequest, self.remote_enable_request)
         result["RemoteEnableResult"] = to_class(RemoteEnableResult, self.remote_enable_result)
+        result["RemoteNotifySteerableChangedRequest"] = to_class(RemoteNotifySteerableChangedRequest, self.remote_notify_steerable_changed_request)
+        result["RemoteNotifySteerableChangedResult"] = to_class(RemoteNotifySteerableChangedResult, self.remote_notify_steerable_changed_result)
         result["RemoteSessionConnectionResult"] = to_class(RemoteSessionConnectionResult, self.remote_session_connection_result)
         result["RemoteSessionMode"] = to_enum(RemoteSessionMode, self.remote_session_mode)
+        result["ScheduleEntry"] = to_class(ScheduleEntry, self.schedule_entry)
+        result["ScheduleList"] = to_class(ScheduleList, self.schedule_list)
+        result["ScheduleStopRequest"] = to_class(ScheduleStopRequest, self.schedule_stop_request)
+        result["ScheduleStopResult"] = to_class(ScheduleStopResult, self.schedule_stop_result)
+        result["SendAgentMode"] = to_enum(SendAgentMode, self.send_agent_mode)
+        result["SendAttachment"] = to_class(SendAttachment, self.send_attachment)
+        result["SendAttachmentBlob"] = to_class(SendAttachmentBlob, self.send_attachment_blob)
+        result["SendAttachmentDirectory"] = to_class(SendAttachmentDirectory, self.send_attachment_directory)
+        result["SendAttachmentFile"] = to_class(SendAttachmentFile, self.send_attachment_file)
+        result["SendAttachmentFileLineRange"] = to_class(SendAttachmentFileLineRange, self.send_attachment_file_line_range)
+        result["SendAttachmentGithubReference"] = to_class(SendAttachmentGithubReference, self.send_attachment_github_reference)
+        result["SendAttachmentGithubReferenceType"] = to_enum(SendAttachmentGithubReferenceTypeEnum, self.send_attachment_github_reference_type)
+        result["SendAttachmentSelection"] = to_class(SendAttachmentSelection, self.send_attachment_selection)
+        result["SendAttachmentSelectionDetails"] = to_class(SendAttachmentSelectionDetails, self.send_attachment_selection_details)
+        result["SendAttachmentSelectionDetailsEnd"] = to_class(SendAttachmentSelectionDetailsEnd, self.send_attachment_selection_details_end)
+        result["SendAttachmentSelectionDetailsStart"] = to_class(SendAttachmentSelectionDetailsStart, self.send_attachment_selection_details_start)
+        result["SendMode"] = to_enum(SendMode, self.send_mode)
+        result["SendRequest"] = to_class(SendRequest, self.send_request)
+        result["SendResult"] = to_class(SendResult, self.send_result)
         result["ServerSkill"] = to_class(ServerSkill, self.server_skill)
         result["ServerSkillList"] = to_class(ServerSkillList, self.server_skill_list)
         result["SessionAuthStatus"] = to_class(SessionAuthStatus, self.session_auth_status)
+        result["SessionBulkDeleteResult"] = to_class(SessionBulkDeleteResult, self.session_bulk_delete_result)
+        result["SessionContext"] = to_class(SessionContext, self.session_context)
+        result["SessionContextHostType"] = to_enum(SessionContextHostType, self.session_context_host_type)
+        result["SessionEnrichMetadataResult"] = to_class(SessionEnrichMetadataResult, self.session_enrich_metadata_result)
         result["SessionFsAppendFileRequest"] = to_class(SessionFSAppendFileRequest, self.session_fs_append_file_request)
         result["SessionFsError"] = to_class(SessionFSError, self.session_fs_error)
         result["SessionFsErrorCode"] = to_enum(SessionFSErrorCode, self.session_fs_error_code)
@@ -8201,21 +15326,68 @@ class RPC:
         result["SessionFsStatRequest"] = to_class(SessionFSStatRequest, self.session_fs_stat_request)
         result["SessionFsStatResult"] = to_class(SessionFSStatResult, self.session_fs_stat_result)
         result["SessionFsWriteFileRequest"] = to_class(SessionFSWriteFileRequest, self.session_fs_write_file_request)
+        result["SessionInstalledPlugin"] = to_class(SessionInstalledPlugin, self.session_installed_plugin)
+        result["SessionInstalledPluginSource"] = from_union([lambda x: to_class(SessionInstalledPluginSource, x), from_str], self.session_installed_plugin_source)
+        result["SessionInstalledPluginSourceGithub"] = to_class(SessionInstalledPluginSourceGithub, self.session_installed_plugin_source_github)
+        result["SessionInstalledPluginSourceLocal"] = to_class(SessionInstalledPluginSourceLocal, self.session_installed_plugin_source_local)
+        result["SessionInstalledPluginSourceUrl"] = to_class(SessionInstalledPluginSourceURL, self.session_installed_plugin_source_url)
+        result["SessionList"] = to_class(SessionList, self.session_list)
+        result["SessionLoadDeferredRepoHooksResult"] = to_class(SessionLoadDeferredRepoHooksResult, self.session_load_deferred_repo_hooks_result)
         result["SessionLogLevel"] = to_enum(SessionLogLevel, self.session_log_level)
+        result["SessionMetadata"] = to_class(SessionMetadata, self.session_metadata)
+        result["SessionMetadataSnapshot"] = to_class(SessionMetadataSnapshot, self.session_metadata_snapshot)
         result["SessionMode"] = to_enum(SessionMode, self.session_mode)
+        result["SessionPruneResult"] = to_class(SessionPruneResult, self.session_prune_result)
+        result["SessionsBulkDeleteRequest"] = to_class(SessionsBulkDeleteRequest, self.sessions_bulk_delete_request)
+        result["SessionsCheckInUseRequest"] = to_class(SessionsCheckInUseRequest, self.sessions_check_in_use_request)
+        result["SessionsCheckInUseResult"] = to_class(SessionsCheckInUseResult, self.sessions_check_in_use_result)
+        result["SessionsCloseRequest"] = to_class(SessionsCloseRequest, self.sessions_close_request)
+        result["SessionsCloseResult"] = to_class(SessionsCloseResult, self.sessions_close_result)
+        result["SessionsEnrichMetadataRequest"] = to_class(SessionsEnrichMetadataRequest, self.sessions_enrich_metadata_request)
+        result["SessionSetCredentialsParams"] = to_class(SessionSetCredentialsParams, self.session_set_credentials_params)
+        result["SessionSetCredentialsResult"] = to_class(SessionSetCredentialsResult, self.session_set_credentials_result)
+        result["SessionsFindByPrefixRequest"] = to_class(SessionsFindByPrefixRequest, self.sessions_find_by_prefix_request)
+        result["SessionsFindByPrefixResult"] = to_class(SessionsFindByPrefixResult, self.sessions_find_by_prefix_result)
+        result["SessionsFindByTaskIDRequest"] = to_class(SessionsFindByTaskIDRequest, self.sessions_find_by_task_id_request)
+        result["SessionsFindByTaskIDResult"] = to_class(SessionsFindByTaskIDResult, self.sessions_find_by_task_id_result)
         result["SessionsForkRequest"] = to_class(SessionsForkRequest, self.sessions_fork_request)
         result["SessionsForkResult"] = to_class(SessionsForkResult, self.sessions_fork_result)
+        result["SessionsGetEventFilePathRequest"] = to_class(SessionsGetEventFilePathRequest, self.sessions_get_event_file_path_request)
+        result["SessionsGetEventFilePathResult"] = to_class(SessionsGetEventFilePathResult, self.sessions_get_event_file_path_result)
+        result["SessionsGetLastForContextRequest"] = to_class(SessionsGetLastForContextRequest, self.sessions_get_last_for_context_request)
+        result["SessionsGetLastForContextResult"] = to_class(SessionsGetLastForContextResult, self.sessions_get_last_for_context_result)
+        result["SessionsGetPersistedRemoteSteerableRequest"] = to_class(SessionsGetPersistedRemoteSteerableRequest, self.sessions_get_persisted_remote_steerable_request)
+        result["SessionsGetPersistedRemoteSteerableResult"] = to_class(SessionsGetPersistedRemoteSteerableResult, self.sessions_get_persisted_remote_steerable_result)
+        result["SessionSizes"] = to_class(SessionSizes, self.session_sizes)
+        result["SessionsListRequest"] = to_class(SessionsListRequest, self.sessions_list_request)
+        result["SessionsLoadDeferredRepoHooksRequest"] = to_class(SessionsLoadDeferredRepoHooksRequest, self.sessions_load_deferred_repo_hooks_request)
+        result["SessionsPruneOldRequest"] = to_class(SessionsPruneOldRequest, self.sessions_prune_old_request)
+        result["SessionsReleaseLockRequest"] = to_class(SessionsReleaseLockRequest, self.sessions_release_lock_request)
+        result["SessionsReleaseLockResult"] = to_class(SessionsReleaseLockResult, self.sessions_release_lock_result)
+        result["SessionsReloadPluginHooksRequest"] = to_class(SessionsReloadPluginHooksRequest, self.sessions_reload_plugin_hooks_request)
+        result["SessionsReloadPluginHooksResult"] = to_class(SessionsReloadPluginHooksResult, self.sessions_reload_plugin_hooks_result)
+        result["SessionsSaveRequest"] = to_class(SessionsSaveRequest, self.sessions_save_request)
+        result["SessionsSaveResult"] = to_class(SessionsSaveResult, self.sessions_save_result)
+        result["SessionsSetAdditionalPluginsRequest"] = to_class(SessionsSetAdditionalPluginsRequest, self.sessions_set_additional_plugins_request)
+        result["SessionsSetAdditionalPluginsResult"] = to_class(SessionsSetAdditionalPluginsResult, self.sessions_set_additional_plugins_result)
+        result["SessionUpdateOptionsParams"] = to_class(SessionUpdateOptionsParams, self.session_update_options_params)
+        result["SessionUpdateOptionsResult"] = to_class(SessionUpdateOptionsResult, self.session_update_options_result)
+        result["SessionWorkingDirectoryContext"] = to_class(SessionWorkingDirectoryContext, self.session_working_directory_context)
+        result["SessionWorkingDirectoryContextHostType"] = to_enum(SessionContextHostType, self.session_working_directory_context_host_type)
         result["ShellExecRequest"] = to_class(ShellExecRequest, self.shell_exec_request)
         result["ShellExecResult"] = to_class(ShellExecResult, self.shell_exec_result)
         result["ShellKillRequest"] = to_class(ShellKillRequest, self.shell_kill_request)
         result["ShellKillResult"] = to_class(ShellKillResult, self.shell_kill_result)
         result["ShellKillSignal"] = to_enum(ShellKillSignal, self.shell_kill_signal)
+        result["ShutdownRequest"] = to_class(ShutdownRequest, self.shutdown_request)
         result["Skill"] = to_class(Skill, self.skill)
         result["SkillList"] = to_class(SkillList, self.skill_list)
         result["SkillsConfigSetDisabledSkillsRequest"] = to_class(SkillsConfigSetDisabledSkillsRequest, self.skills_config_set_disabled_skills_request)
         result["SkillsDisableRequest"] = to_class(SkillsDisableRequest, self.skills_disable_request)
         result["SkillsDiscoverRequest"] = to_class(SkillsDiscoverRequest, self.skills_discover_request)
         result["SkillsEnableRequest"] = to_class(SkillsEnableRequest, self.skills_enable_request)
+        result["SkillsGetInvokedResult"] = to_class(SkillsGetInvokedResult, self.skills_get_invoked_result)
+        result["SkillsInvokedSkill"] = to_class(SkillsInvokedSkill, self.skills_invoked_skill)
         result["SkillsLoadDiagnostics"] = to_class(SkillsLoadDiagnostics, self.skills_load_diagnostics)
         result["SlashCommandAgentPromptResult"] = to_class(SlashCommandAgentPromptResult, self.slash_command_agent_prompt_result)
         result["SlashCommandCompletedResult"] = to_class(SlashCommandCompletedResult, self.slash_command_completed_result)
@@ -8226,15 +15398,22 @@ class RPC:
         result["SlashCommandKind"] = to_enum(SlashCommandKind, self.slash_command_kind)
         result["SlashCommandTextResult"] = to_class(SlashCommandTextResult, self.slash_command_text_result)
         result["TaskAgentInfo"] = to_class(TaskAgentInfo, self.task_agent_info)
+        result["TaskAgentProgress"] = to_class(TaskAgentProgress, self.task_agent_progress)
         result["TaskExecutionMode"] = to_enum(TaskExecutionMode, self.task_execution_mode)
         result["TaskInfo"] = to_class(TaskInfo, self.task_info)
         result["TaskList"] = to_class(TaskList, self.task_list)
         result["TasksCancelRequest"] = to_class(TasksCancelRequest, self.tasks_cancel_request)
         result["TasksCancelResult"] = to_class(TasksCancelResult, self.tasks_cancel_result)
+        result["TasksGetCurrentPromotableResult"] = to_class(TasksGetCurrentPromotableResult, self.tasks_get_current_promotable_result)
+        result["TasksGetProgressRequest"] = to_class(TasksGetProgressRequest, self.tasks_get_progress_request)
+        result["TasksGetProgressResult"] = to_class(TasksGetProgressResult, self.tasks_get_progress_result)
         result["TaskShellInfo"] = to_class(TaskShellInfo, self.task_shell_info)
         result["TaskShellInfoAttachmentMode"] = to_enum(TaskShellInfoAttachmentMode, self.task_shell_info_attachment_mode)
+        result["TaskShellProgress"] = from_none(self.task_shell_progress)
+        result["TasksPromoteCurrentToBackgroundResult"] = to_class(TasksPromoteCurrentToBackgroundResult, self.tasks_promote_current_to_background_result)
         result["TasksPromoteToBackgroundRequest"] = to_class(TasksPromoteToBackgroundRequest, self.tasks_promote_to_background_request)
         result["TasksPromoteToBackgroundResult"] = to_class(TasksPromoteToBackgroundResult, self.tasks_promote_to_background_result)
+        result["TasksRefreshResult"] = to_class(TasksRefreshResult, self.tasks_refresh_result)
         result["TasksRemoveRequest"] = to_class(TasksRemoveRequest, self.tasks_remove_request)
         result["TasksRemoveResult"] = to_class(TasksRemoveResult, self.tasks_remove_result)
         result["TasksSendMessageRequest"] = to_class(TasksSendMessageRequest, self.tasks_send_message_request)
@@ -8242,9 +15421,14 @@ class RPC:
         result["TasksStartAgentRequest"] = to_class(TasksStartAgentRequest, self.tasks_start_agent_request)
         result["TasksStartAgentResult"] = to_class(TasksStartAgentResult, self.tasks_start_agent_result)
         result["TaskStatus"] = to_enum(TaskStatus, self.task_status)
+        result["TasksWaitForPendingResult"] = to_class(TasksWaitForPendingResult, self.tasks_wait_for_pending_result)
+        result["TelemetrySetFeatureOverridesRequest"] = to_class(TelemetrySetFeatureOverridesRequest, self.telemetry_set_feature_overrides_request)
+        result["TokenAuthInfo"] = to_class(TokenAuthInfo, self.token_auth_info)
         result["Tool"] = to_class(Tool, self.tool)
         result["ToolList"] = to_class(ToolList, self.tool_list)
+        result["ToolsInitializeAndValidateResult"] = to_class(ToolsInitializeAndValidateResult, self.tools_initialize_and_validate_result)
         result["ToolsListRequest"] = to_class(ToolsListRequest, self.tools_list_request)
+        result["UIAutoModeSwitchResponse"] = to_enum(UIAutoModeSwitchResponse, self.ui_auto_mode_switch_response)
         result["UIElicitationArrayAnyOfField"] = to_class(UIElicitationArrayAnyOfField, self.ui_elicitation_array_any_of_field)
         result["UIElicitationArrayAnyOfFieldItems"] = to_class(UIElicitationArrayAnyOfFieldItems, self.ui_elicitation_array_any_of_field_items)
         result["UIElicitationArrayAnyOfFieldItemsAnyOf"] = to_class(UIElicitationArrayAnyOfFieldItemsAnyOf, self.ui_elicitation_array_any_of_field_items_any_of)
@@ -8266,7 +15450,19 @@ class RPC:
         result["UIElicitationStringEnumField"] = to_class(UIElicitationStringEnumField, self.ui_elicitation_string_enum_field)
         result["UIElicitationStringOneOfField"] = to_class(UIElicitationStringOneOfField, self.ui_elicitation_string_one_of_field)
         result["UIElicitationStringOneOfFieldOneOf"] = to_class(UIElicitationStringOneOfFieldOneOf, self.ui_elicitation_string_one_of_field_one_of)
+        result["UIExitPlanModeAction"] = to_enum(UIExitPlanModeAction, self.ui_exit_plan_mode_action)
+        result["UIExitPlanModeResponse"] = to_class(UIExitPlanModeResponse, self.ui_exit_plan_mode_response)
+        result["UIHandlePendingAutoModeSwitchRequest"] = to_class(UIHandlePendingAutoModeSwitchRequest, self.ui_handle_pending_auto_mode_switch_request)
         result["UIHandlePendingElicitationRequest"] = to_class(UIHandlePendingElicitationRequest, self.ui_handle_pending_elicitation_request)
+        result["UIHandlePendingExitPlanModeRequest"] = to_class(UIHandlePendingExitPlanModeRequest, self.ui_handle_pending_exit_plan_mode_request)
+        result["UIHandlePendingResult"] = to_class(UIHandlePendingResult, self.ui_handle_pending_result)
+        result["UIHandlePendingSamplingRequest"] = to_class(UIHandlePendingSamplingRequest, self.ui_handle_pending_sampling_request)
+        result["UIHandlePendingSamplingResponse"] = from_dict(lambda x: x, self.ui_handle_pending_sampling_response)
+        result["UIHandlePendingUserInputRequest"] = to_class(UIHandlePendingUserInputRequest, self.ui_handle_pending_user_input_request)
+        result["UIRegisterDirectAutoModeSwitchHandlerResult"] = to_class(UIRegisterDirectAutoModeSwitchHandlerResult, self.ui_register_direct_auto_mode_switch_handler_result)
+        result["UIUnregisterDirectAutoModeSwitchHandlerRequest"] = to_class(UIUnregisterDirectAutoModeSwitchHandlerRequest, self.ui_unregister_direct_auto_mode_switch_handler_request)
+        result["UIUnregisterDirectAutoModeSwitchHandlerResult"] = to_class(UIUnregisterDirectAutoModeSwitchHandlerResult, self.ui_unregister_direct_auto_mode_switch_handler_result)
+        result["UIUserInputResponse"] = to_class(UIUserInputResponse, self.ui_user_input_response)
         result["UsageGetMetricsResult"] = to_class(UsageGetMetricsResult, self.usage_get_metrics_result)
         result["UsageMetricsCodeChanges"] = to_class(UsageMetricsCodeChanges, self.usage_metrics_code_changes)
         result["UsageMetricsModelMetric"] = to_class(UsageMetricsModelMetric, self.usage_metrics_model_metric)
@@ -8274,11 +15470,29 @@ class RPC:
         result["UsageMetricsModelMetricTokenDetail"] = to_class(UsageMetricsModelMetricTokenDetail, self.usage_metrics_model_metric_token_detail)
         result["UsageMetricsModelMetricUsage"] = to_class(UsageMetricsModelMetricUsage, self.usage_metrics_model_metric_usage)
         result["UsageMetricsTokenDetail"] = to_class(UsageMetricsTokenDetail, self.usage_metrics_token_detail)
+        result["UserAuthInfo"] = to_class(UserAuthInfo, self.user_auth_info)
+        result["UserToolSessionApprovalCommands"] = to_class(UserToolSessionApprovalCommands, self.user_tool_session_approval_commands)
+        result["UserToolSessionApprovalCustomTool"] = to_class(UserToolSessionApprovalCustomTool, self.user_tool_session_approval_custom_tool)
+        result["UserToolSessionApprovalExtensionManagement"] = to_class(UserToolSessionApprovalExtensionManagement, self.user_tool_session_approval_extension_management)
+        result["UserToolSessionApprovalExtensionPermissionAccess"] = to_class(UserToolSessionApprovalExtensionPermissionAccess, self.user_tool_session_approval_extension_permission_access)
+        result["UserToolSessionApprovalMcp"] = to_class(UserToolSessionApprovalMCP, self.user_tool_session_approval_mcp)
+        result["UserToolSessionApprovalMemory"] = to_class(UserToolSessionApprovalMemory, self.user_tool_session_approval_memory)
+        result["UserToolSessionApprovalRead"] = to_class(UserToolSessionApprovalRead, self.user_tool_session_approval_read)
+        result["UserToolSessionApprovalWrite"] = to_class(UserToolSessionApprovalWrite, self.user_tool_session_approval_write)
+        result["WorkspacesCheckpoints"] = to_class(WorkspacesCheckpoints, self.workspaces_checkpoints)
         result["WorkspacesCreateFileRequest"] = to_class(WorkspacesCreateFileRequest, self.workspaces_create_file_request)
         result["WorkspacesGetWorkspaceResult"] = to_class(WorkspacesGetWorkspaceResult, self.workspaces_get_workspace_result)
+        result["WorkspacesListCheckpointsResult"] = to_class(WorkspacesListCheckpointsResult, self.workspaces_list_checkpoints_result)
         result["WorkspacesListFilesResult"] = to_class(WorkspacesListFilesResult, self.workspaces_list_files_result)
+        result["WorkspacesReadCheckpointRequest"] = to_class(WorkspacesReadCheckpointRequest, self.workspaces_read_checkpoint_request)
+        result["WorkspacesReadCheckpointResult"] = to_class(WorkspacesReadCheckpointResult, self.workspaces_read_checkpoint_result)
         result["WorkspacesReadFileRequest"] = to_class(WorkspacesReadFileRequest, self.workspaces_read_file_request)
         result["WorkspacesReadFileResult"] = to_class(WorkspacesReadFileResult, self.workspaces_read_file_result)
+        result["WorkspacesSaveLargePasteRequest"] = to_class(WorkspacesSaveLargePasteRequest, self.workspaces_save_large_paste_request)
+        result["WorkspacesSaveLargePasteResult"] = to_class(WorkspacesSaveLargePasteResult, self.workspaces_save_large_paste_result)
+        result["SessionContextInfo"] = from_union([lambda x: to_class(SessionContextInfo, x), from_none], self.session_context_info)
+        result["TaskProgress"] = from_union([lambda x: to_class(TaskProgressClass, x), from_none], self.task_progress)
+        result["WorkspaceSummary"] = from_union([lambda x: to_class(WorkspaceSummary, x), from_none], self.workspace_summary)
         return result
 
 def rpc_from_dict(s: Any) -> RPC:
@@ -8290,8 +15504,15 @@ def rpc_to_dict(x: RPC) -> Any:
 
 ExternalToolResult = ExternalToolTextResultForLlm
 FilterMapping = dict
+McpExecuteSamplingRequest = dict
+McpExecuteSamplingResult = dict
+OptionsUpdateEnvValueMode = MCPSetEnvValueModeDetails
+SessionWorkingDirectoryContextHostType = SessionContextHostType
 TaskInfoExecutionMode = TaskExecutionMode
 TaskInfoStatus = TaskStatus
+TaskInfoType = TaskAgentProgressType
+TaskProgress = TaskProgressClass
+TaskShellProgress = None
 
 def _timeout_kwargs(timeout: float | None) -> dict:
     """Build keyword arguments for optional timeout forwarding."""
@@ -8463,6 +15684,111 @@ class ServerSessionsApi:
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return RemoteSessionConnectionResult.from_dict(await self._client.request("sessions.connect", params_dict, **_timeout_kwargs(timeout)))
 
+    async def list(self, params: SessionsListRequest | None = None, *, timeout: float | None = None) -> SessionList:
+        "Lists persisted sessions, optionally filtered by working-directory context.\n\nArgs:\n    params: Optional metadata-load limit and context filter applied to the returned sessions.\n\nReturns:\n    Persisted sessions matching the filter, ordered most-recently-modified first."
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
+        return SessionList.from_dict(await self._client.request("sessions.list", params_dict, **_timeout_kwargs(timeout)))
+
+    async def find_by_task_id(self, params: SessionsFindByTaskIDRequest, *, timeout: float | None = None) -> SessionsFindByTaskIDResult:
+        "Finds the local session bound to a GitHub task ID, if any.\n\nArgs:\n    params: GitHub task ID to look up.\n\nReturns:\n    ID of the local session bound to the given GitHub task, or omitted when none."
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        return SessionsFindByTaskIDResult.from_dict(await self._client.request("sessions.findByTaskId", params_dict, **_timeout_kwargs(timeout)))
+
+    async def find_by_prefix(self, params: SessionsFindByPrefixRequest, *, timeout: float | None = None) -> SessionsFindByPrefixResult:
+        "Resolves a UUID prefix to a unique session ID, if exactly one session matches.\n\nArgs:\n    params: UUID prefix to resolve to a unique session ID.\n\nReturns:\n    Session ID matching the prefix, omitted when no unique match exists."
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        return SessionsFindByPrefixResult.from_dict(await self._client.request("sessions.findByPrefix", params_dict, **_timeout_kwargs(timeout)))
+
+    async def get_last_for_context(self, params: SessionsGetLastForContextRequest | None = None, *, timeout: float | None = None) -> SessionsGetLastForContextResult:
+        "Returns the most-relevant prior session for a given working-directory context.\n\nArgs:\n    params: Optional working-directory context used to score session relevance.\n\nReturns:\n    Most-relevant session ID for the supplied context, or omitted when no sessions exist."
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
+        return SessionsGetLastForContextResult.from_dict(await self._client.request("sessions.getLastForContext", params_dict, **_timeout_kwargs(timeout)))
+
+    async def get_event_file_path(self, params: SessionsGetEventFilePathRequest | None = None, *, timeout: float | None = None) -> SessionsGetEventFilePathResult:
+        "Computes the absolute path to a session's persisted events.jsonl file.\n\nArgs:\n    params: Session ID whose event-log file path to compute.\n\nReturns:\n    Absolute path to the session's events.jsonl file on disk."
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
+        return SessionsGetEventFilePathResult.from_dict(await self._client.request("sessions.getEventFilePath", params_dict, **_timeout_kwargs(timeout)))
+
+    async def get_sizes(self, *, timeout: float | None = None) -> SessionSizes:
+        "Returns the on-disk byte size of each session's workspace directory.\n\nReturns:\n    Map of sessionId -> on-disk size in bytes for each session's workspace directory."
+        return SessionSizes.from_dict(await self._client.request("sessions.getSizes", {}, **_timeout_kwargs(timeout)))
+
+    async def check_in_use(self, params: SessionsCheckInUseRequest, *, timeout: float | None = None) -> SessionsCheckInUseResult:
+        "Returns the subset of the supplied session IDs that are currently held by another running process.\n\nArgs:\n    params: Session IDs to test for live in-use locks.\n\nReturns:\n    Session IDs from the input set that are currently in use by another process."
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        return SessionsCheckInUseResult.from_dict(await self._client.request("sessions.checkInUse", params_dict, **_timeout_kwargs(timeout)))
+
+    async def get_persisted_remote_steerable(self, params: SessionsGetPersistedRemoteSteerableRequest | None = None, *, timeout: float | None = None) -> SessionsGetPersistedRemoteSteerableResult:
+        "Returns a session's persisted remote-steerable flag, if any has been recorded.\n\nArgs:\n    params: Session ID to look up the persisted remote-steerable flag for.\n\nReturns:\n    The session's persisted remote-steerable flag, or omitted when no value has been persisted."
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
+        return SessionsGetPersistedRemoteSteerableResult.from_dict(await self._client.request("sessions.getPersistedRemoteSteerable", params_dict, **_timeout_kwargs(timeout)))
+
+    async def close(self, params: SessionsCloseRequest | None = None, *, timeout: float | None = None) -> SessionsCloseResult:
+        "Closes a session: emits shutdown, flushes pending events, releases the in-use lock, and disposes the active session.\n\nArgs:\n    params: Session ID to close.\n\nReturns:\n    Closes a session: emits shutdown, flushes pending events to disk, releases the in-use lock, disposes the active session. Idempotent: succeeds even if the session is not currently active."
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
+        return SessionsCloseResult.from_dict(await self._client.request("sessions.close", params_dict, **_timeout_kwargs(timeout)))
+
+    async def bulk_delete(self, params: SessionsBulkDeleteRequest, *, timeout: float | None = None) -> SessionBulkDeleteResult:
+        "Closes, deactivates, and deletes a set of sessions, returning the bytes freed per session.\n\nArgs:\n    params: Session IDs to close, deactivate, and delete from disk.\n\nReturns:\n    Map of sessionId -> bytes freed by removing the session's workspace directory."
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        return SessionBulkDeleteResult.from_dict(await self._client.request("sessions.bulkDelete", params_dict, **_timeout_kwargs(timeout)))
+
+    async def prune_old(self, params: SessionsPruneOldRequest, *, timeout: float | None = None) -> SessionPruneResult:
+        "Deletes sessions older than the given threshold, with optional dry-run and exclusion list.\n\nArgs:\n    params: Age threshold and optional flags controlling which old sessions are pruned (or simulated when dryRun is true).\n\nReturns:\n    Outcome of the prune operation: deleted IDs, dry-run candidates, skipped IDs, total bytes freed, and the dry-run flag."
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        return SessionPruneResult.from_dict(await self._client.request("sessions.pruneOld", params_dict, **_timeout_kwargs(timeout)))
+
+    async def save(self, params: SessionsSaveRequest | None = None, *, timeout: float | None = None) -> SessionsSaveResult:
+        "Flushes a session's pending events to disk.\n\nArgs:\n    params: Session ID whose pending events should be flushed to disk.\n\nReturns:\n    Flush a session's pending events to disk. No-op when no writer exists for the session (e.g., already closed)."
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
+        return SessionsSaveResult.from_dict(await self._client.request("sessions.save", params_dict, **_timeout_kwargs(timeout)))
+
+    async def release_lock(self, params: SessionsReleaseLockRequest | None = None, *, timeout: float | None = None) -> SessionsReleaseLockResult:
+        "Releases the in-use lock held by this process for a session.\n\nArgs:\n    params: Session ID whose in-use lock should be released.\n\nReturns:\n    Release the in-use lock held by this process for the given session. No-op when this process does not currently hold a lock for the session."
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
+        return SessionsReleaseLockResult.from_dict(await self._client.request("sessions.releaseLock", params_dict, **_timeout_kwargs(timeout)))
+
+    async def enrich_metadata(self, params: SessionsEnrichMetadataRequest, *, timeout: float | None = None) -> SessionEnrichMetadataResult:
+        "Backfills missing summary and context fields on the supplied session metadata records.\n\nArgs:\n    params: Session metadata records to enrich with summary and context information.\n\nReturns:\n    The same metadata records, with summary and context fields backfilled where available."
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        return SessionEnrichMetadataResult.from_dict(await self._client.request("sessions.enrichMetadata", params_dict, **_timeout_kwargs(timeout)))
+
+    async def reload_plugin_hooks(self, params: SessionsReloadPluginHooksRequest | None = None, *, timeout: float | None = None) -> SessionsReloadPluginHooksResult:
+        "Reloads user, plugin, and (optionally) repo hooks on the active session.\n\nArgs:\n    params: Active session ID and an optional flag for deferring repo-level hooks until folder trust.\n\nReturns:\n    Reload all hooks (user, plugin, optionally repo) and apply them to the active session. Call after installing or removing plugins so their hooks take effect immediately. No-op when no active session matches the given sessionId."
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
+        return SessionsReloadPluginHooksResult.from_dict(await self._client.request("sessions.reloadPluginHooks", params_dict, **_timeout_kwargs(timeout)))
+
+    async def load_deferred_repo_hooks(self, params: SessionsLoadDeferredRepoHooksRequest | None = None, *, timeout: float | None = None) -> SessionLoadDeferredRepoHooksResult:
+        "Loads previously-deferred repo-level hooks on the active session, returning queued startup prompts.\n\nArgs:\n    params: Active session ID whose deferred repo-level hooks should be loaded.\n\nReturns:\n    Queued repo-level startup prompts and the total hook command count after loading."
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
+        return SessionLoadDeferredRepoHooksResult.from_dict(await self._client.request("sessions.loadDeferredRepoHooks", params_dict, **_timeout_kwargs(timeout)))
+
+    async def set_additional_plugins(self, params: SessionsSetAdditionalPluginsRequest, *, timeout: float | None = None) -> SessionsSetAdditionalPluginsResult:
+        "Replaces the manager-wide additional plugins registered with the session manager.\n\nArgs:\n    params: Manager-wide additional plugins to register; replaces any previously-configured set.\n\nReturns:\n    Replace the manager-wide additional plugins. New session creations and subsequent hook reloads see the new set; already-running sessions keep their existing hook installation until the next reload."
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        return SessionsSetAdditionalPluginsResult.from_dict(await self._client.request("sessions.setAdditionalPlugins", params_dict, **_timeout_kwargs(timeout)))
+
 
 class ServerRpc:
     """Typed server-scoped RPC methods."""
@@ -8477,7 +15803,7 @@ class ServerRpc:
         self.sessions = ServerSessionsApi(client)
 
     async def ping(self, params: PingRequest | None = None, *, timeout: float | None = None) -> PingResult:
-        "Checks server responsiveness and returns protocol information.\n\nArgs:\n    params: Optional message to echo back to the caller.\n\nReturns:\n    Server liveness response, including the echoed message, current timestamp, and protocol version."
+        "Checks server responsiveness and returns protocol information.\n\nArgs:\n    params: Optional message to echo back to the caller.\n\nReturns:\n    Server liveness response, including the echoed message, current server timestamp, and protocol version."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return PingResult.from_dict(await self._client.request("ping", params_dict, **_timeout_kwargs(timeout)))
 
@@ -8506,6 +15832,15 @@ class AuthApi:
 
         return SessionAuthStatus.from_dict(await self._client.request("session.auth.getStatus", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
+    async def set_credentials(self, params: SessionSetCredentialsParams | None = None, *, timeout: float | None = None) -> SessionSetCredentialsResult:
+        "Updates the session's auth credentials used for outbound model and API requests.\n\nArgs:\n    params: New auth credentials to install on the session. Omit to leave credentials unchanged.\n\nReturns:\n    Indicates whether the credential update succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
+        params_dict["sessionId"] = self._session_id
+        return SessionSetCredentialsResult.from_dict(await self._client.request("session.auth.setCredentials", params_dict, **_timeout_kwargs(timeout)))
+
 
 class ModelApi:
     def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
@@ -8514,7 +15849,7 @@ class ModelApi:
         self._assert_active = assert_active
 
     async def get_current(self, *, timeout: float | None = None) -> CurrentModel:
-        "Gets the currently selected model for the session.\n\nReturns:\n    The currently selected model for the session."
+        "Gets the currently selected model for the session.\n\nReturns:\n    The currently selected model and reasoning effort for the session."
         if self._assert_active is not None:
             self._assert_active()
 
@@ -8530,6 +15865,17 @@ class ModelApi:
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return ModelSwitchToResult.from_dict(await self._client.request("session.model.switchTo", params_dict, **_timeout_kwargs(timeout)))
+
+    async def set_reasoning_effort(self, params: ModelSetReasoningEffortRequest, *, timeout: float | None = None) -> ModelSetReasoningEffortResult:
+        "Updates the session's reasoning effort without changing the selected model.\n\nArgs:\n    params: Reasoning effort level to apply to the currently selected model.\n\nReturns:\n    Update the session's reasoning effort without changing the selected model. Use `switchTo` instead when you also need to change the model. The runtime stores the effort on the session and applies it to subsequent turns."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return ModelSetReasoningEffortResult.from_dict(await self._client.request("session.model.setReasoningEffort", params_dict, **_timeout_kwargs(timeout)))
 
 
 class ModeApi:
@@ -8581,6 +15927,17 @@ class NameApi:
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.name.set", params_dict, **_timeout_kwargs(timeout))
 
+    async def set_auto(self, params: NameSetAutoRequest, *, timeout: float | None = None) -> NameSetAutoResult:
+        "Persists an auto-generated session summary as the session's name when no user-set name exists.\n\nArgs:\n    params: Auto-generated session summary to apply as the session's name when no user-set name exists.\n\nReturns:\n    Indicates whether the auto-generated summary was applied as the session's name."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return NameSetAutoResult.from_dict(await self._client.request("session.name.setAuto", params_dict, **_timeout_kwargs(timeout)))
+
 
 class PlanApi:
     def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
@@ -8621,7 +15978,7 @@ class WorkspacesApi:
         self._assert_active = assert_active
 
     async def get_workspace(self, *, timeout: float | None = None) -> WorkspacesGetWorkspaceResult:
-        "Gets current workspace metadata for the session.\n\nReturns:\n    Current workspace metadata for the session, or null when not available."
+        "Gets current workspace metadata for the session.\n\nReturns:\n    Current workspace metadata for the session, including its absolute filesystem path when available."
         if self._assert_active is not None:
             self._assert_active()
 
@@ -8655,6 +16012,35 @@ class WorkspacesApi:
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         await self._client.request("session.workspaces.createFile", params_dict, **_timeout_kwargs(timeout))
+
+    async def list_checkpoints(self, *, timeout: float | None = None) -> WorkspacesListCheckpointsResult:
+        "Lists workspace checkpoints in chronological order.\n\nReturns:\n    Workspace checkpoints in chronological order; empty when the workspace is not enabled."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return WorkspacesListCheckpointsResult.from_dict(await self._client.request("session.workspaces.listCheckpoints", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def read_checkpoint(self, params: WorkspacesReadCheckpointRequest, *, timeout: float | None = None) -> WorkspacesReadCheckpointResult:
+        "Reads the content of a workspace checkpoint by number.\n\nArgs:\n    params: Checkpoint number to read.\n\nReturns:\n    Checkpoint content as a UTF-8 string, or null when the checkpoint or workspace is missing."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return WorkspacesReadCheckpointResult.from_dict(await self._client.request("session.workspaces.readCheckpoint", params_dict, **_timeout_kwargs(timeout)))
+
+    async def save_large_paste(self, params: WorkspacesSaveLargePasteRequest, *, timeout: float | None = None) -> WorkspacesSaveLargePasteResult:
+        "Saves pasted content as a UTF-8 file in the session workspace.\n\nArgs:\n    params: Pasted content to save as a UTF-8 file in the session workspace.\n\nReturns:\n    Descriptor for the saved paste file, or null when the workspace is unavailable."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return WorkspacesSaveLargePasteResult.from_dict(await self._client.request("session.workspaces.saveLargePaste", params_dict, **_timeout_kwargs(timeout)))
 
 
 class InstructionsApi:
@@ -8760,6 +16146,38 @@ class TasksApi:
 
         return TaskList.from_dict(await self._client.request("session.tasks.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
+    async def refresh(self, *, timeout: float | None = None) -> TasksRefreshResult:
+        "Refreshes metadata for any detached background shells the runtime knows about.\n\nReturns:\n    Refresh metadata for any detached background shells the runtime knows about. Use after a long pause to pick up exit/output state for shells running outside the agent loop."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return TasksRefreshResult.from_dict(await self._client.request("session.tasks.refresh", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def wait_for_pending(self, *, timeout: float | None = None) -> TasksWaitForPendingResult:
+        "Waits for all in-flight background tasks and any follow-up turns to settle.\n\nReturns:\n    Wait until all in-flight background tasks (agents + shells) and any follow-up turns scheduled by their completions have settled. Returns when the runtime is fully drained or after an internal timeout (default 10 minutes; configurable via COPILOT_TASK_WAIT_TIMEOUT_SECONDS)."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return TasksWaitForPendingResult.from_dict(await self._client.request("session.tasks.waitForPending", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def get_progress(self, params: TasksGetProgressRequest, *, timeout: float | None = None) -> TasksGetProgressResult:
+        "Returns progress information for a background task by ID.\n\nArgs:\n    params: Identifier of the background task to fetch progress for.\n\nReturns:\n    Progress information for the task, or null when no task with that ID is tracked."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return TasksGetProgressResult.from_dict(await self._client.request("session.tasks.getProgress", params_dict, **_timeout_kwargs(timeout)))
+
+    async def get_current_promotable(self, *, timeout: float | None = None) -> TasksGetCurrentPromotableResult:
+        "Returns the first sync-waiting task that can currently be promoted to background mode.\n\nReturns:\n    The first sync-waiting task that can currently be promoted to background mode."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return TasksGetCurrentPromotableResult.from_dict(await self._client.request("session.tasks.getCurrentPromotable", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
     async def promote_to_background(self, params: TasksPromoteToBackgroundRequest, *, timeout: float | None = None) -> TasksPromoteToBackgroundResult:
         "Promotes an eligible synchronously-waited task so it continues running in the background.\n\nArgs:\n    params: Identifier of the task to promote to background mode.\n\nReturns:\n    Indicates whether the task was successfully promoted to background mode."
         if self._assert_active is not None:
@@ -8770,6 +16188,13 @@ class TasksApi:
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return TasksPromoteToBackgroundResult.from_dict(await self._client.request("session.tasks.promoteToBackground", params_dict, **_timeout_kwargs(timeout)))
+
+    async def promote_current_to_background(self, *, timeout: float | None = None) -> TasksPromoteCurrentToBackgroundResult:
+        "Atomically promotes the first promotable sync-waiting task to background mode and returns it.\n\nReturns:\n    The promoted task as it now exists in background mode, omitted if no promotable task was waiting."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return TasksPromoteCurrentToBackgroundResult.from_dict(await self._client.request("session.tasks.promoteCurrentToBackground", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def cancel(self, params: TasksCancelRequest, *, timeout: float | None = None) -> TasksCancelResult:
         "Cancels a background task.\n\nArgs:\n    params: Identifier of the background task to cancel.\n\nReturns:\n    Indicates whether the background task was successfully cancelled."
@@ -8819,6 +16244,13 @@ class SkillsApi:
 
         return SkillList.from_dict(await self._client.request("session.skills.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
+    async def get_invoked(self, *, timeout: float | None = None) -> SkillsGetInvokedResult:
+        "Returns the skills that have been invoked during this session.\n\nReturns:\n    Skills invoked during this session, ordered by invocation time (most recent last)."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return SkillsGetInvokedResult.from_dict(await self._client.request("session.skills.getInvoked", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
     async def enable(self, params: SkillsEnableRequest, *, timeout: float | None = None) -> None:
         "Enables a skill for the session.\n\nArgs:\n    params: Name of the skill to enable for the session."
         if self._assert_active is not None:
@@ -8847,6 +16279,13 @@ class SkillsApi:
             self._assert_active()
 
         return SkillsLoadDiagnostics.from_dict(await self._client.request("session.skills.reload", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def ensure_loaded(self, *, timeout: float | None = None) -> None:
+        "Ensures the session's skill definitions have been loaded from disk."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        await self._client.request("session.skills.ensureLoaded", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
 
 # Experimental: this API group is experimental and may change or be removed.
@@ -8912,6 +16351,46 @@ class McpApi:
 
         await self._client.request("session.mcp.reload", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
+    async def execute_sampling(self, params: MCPExecuteSamplingParams, *, timeout: float | None = None) -> MCPSamplingExecutionResult:
+        "Runs an MCP sampling inference on behalf of an MCP server.\n\nArgs:\n    params: Identifiers and raw MCP CreateMessageRequest params used to run a sampling inference.\n\nReturns:\n    Outcome of an MCP sampling execution: success result, failure error, or cancellation."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return MCPSamplingExecutionResult.from_dict(await self._client.request("session.mcp.executeSampling", params_dict, **_timeout_kwargs(timeout)))
+
+    async def cancel_sampling_execution(self, params: MCPCancelSamplingExecutionParams, *, timeout: float | None = None) -> MCPCancelSamplingExecutionResult:
+        "Cancels an in-flight MCP sampling execution by request ID.\n\nArgs:\n    params: The requestId previously passed to executeSampling that should be cancelled.\n\nReturns:\n    Indicates whether an in-flight sampling execution with the given requestId was found and cancelled."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return MCPCancelSamplingExecutionResult.from_dict(await self._client.request("session.mcp.cancelSamplingExecution", params_dict, **_timeout_kwargs(timeout)))
+
+    async def set_env_value_mode(self, params: MCPSetEnvValueModeParams, *, timeout: float | None = None) -> MCPSetEnvValueModeResult:
+        "Sets how environment-variable values supplied to MCP servers are resolved (direct or indirect).\n\nArgs:\n    params: Mode controlling how MCP server env values are resolved (`direct` or `indirect`).\n\nReturns:\n    Env-value mode recorded on the session after the update."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return MCPSetEnvValueModeResult.from_dict(await self._client.request("session.mcp.setEnvValueMode", params_dict, **_timeout_kwargs(timeout)))
+
+    async def remove_git_hub(self, *, timeout: float | None = None) -> MCPRemoveGitHubResult:
+        "Removes the auto-managed `github` MCP server when present.\n\nReturns:\n    Indicates whether the auto-managed `github` MCP server was removed (false when nothing to remove)."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return MCPRemoveGitHubResult.from_dict(await self._client.request("session.mcp.removeGitHub", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
 
 # Experimental: this API group is experimental and may change or be removed.
 class PluginsApi:
@@ -8926,6 +16405,40 @@ class PluginsApi:
             self._assert_active()
 
         return PluginList.from_dict(await self._client.request("session.plugins.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+
+# Experimental: this API group is experimental and may change or be removed.
+class OptionsApi:
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
+        self._client = client
+        self._session_id = session_id
+        self._assert_active = assert_active
+
+    async def update(self, params: SessionUpdateOptionsParams | None = None, *, timeout: float | None = None) -> SessionUpdateOptionsResult:
+        "Patches the genuinely-mutable subset of session options.\n\nArgs:\n    params: Patch of mutable session options to apply to the running session.\n\nReturns:\n    Indicates whether the session options patch was applied successfully."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
+        params_dict["sessionId"] = self._session_id
+        return SessionUpdateOptionsResult.from_dict(await self._client.request("session.options.update", params_dict, **_timeout_kwargs(timeout)))
+
+
+# Experimental: this API group is experimental and may change or be removed.
+class LspApi:
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
+        self._client = client
+        self._session_id = session_id
+        self._assert_active = assert_active
+
+    async def initialize(self, params: LspInitializeRequest | None = None, *, timeout: float | None = None) -> None:
+        "Loads the merged LSP configuration set for the session's working directory.\n\nArgs:\n    params: Parameters for (re)loading the merged LSP configuration set."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
+        params_dict["sessionId"] = self._session_id
+        await self._client.request("session.lsp.initialize", params_dict, **_timeout_kwargs(timeout))
 
 
 # Experimental: this API group is experimental and may change or be removed.
@@ -8989,6 +16502,13 @@ class ToolsApi:
         params_dict["sessionId"] = self._session_id
         return HandlePendingToolCallResult.from_dict(await self._client.request("session.tools.handlePendingToolCall", params_dict, **_timeout_kwargs(timeout)))
 
+    async def initialize_and_validate(self, *, timeout: float | None = None) -> ToolsInitializeAndValidateResult:
+        "Resolves, builds, and validates the runtime tool list for the session.\n\nReturns:\n    Resolve, build, and validate the runtime tool list for this session. Subagent sessions and consumer flows that need an initialized tool set before `send` invoke this. Default base-class implementation is a no-op for sessions that don't support tool validation."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return ToolsInitializeAndValidateResult.from_dict(await self._client.request("session.tools.initializeAndValidate", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
 
 class CommandsApi:
     def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
@@ -9027,8 +16547,30 @@ class CommandsApi:
         params_dict["sessionId"] = self._session_id
         return CommandsHandlePendingCommandResult.from_dict(await self._client.request("session.commands.handlePendingCommand", params_dict, **_timeout_kwargs(timeout)))
 
+    async def execute(self, params: ExecuteCommandParams, *, timeout: float | None = None) -> ExecuteCommandResult:
+        "Executes a slash command synchronously and returns any error.\n\nArgs:\n    params: Slash command name and argument string to execute synchronously.\n\nReturns:\n    Error message produced while executing the command, if any."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return ExecuteCommandResult.from_dict(await self._client.request("session.commands.execute", params_dict, **_timeout_kwargs(timeout)))
+
+    async def enqueue(self, params: EnqueueCommandParams, *, timeout: float | None = None) -> EnqueueCommandResult:
+        "Enqueues a slash command for FIFO processing on the local session.\n\nArgs:\n    params: Slash-prefixed command string to enqueue for FIFO processing.\n\nReturns:\n    Indicates whether the command was accepted into the local execution queue."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return EnqueueCommandResult.from_dict(await self._client.request("session.commands.enqueue", params_dict, **_timeout_kwargs(timeout)))
+
     async def respond_to_queued_command(self, params: CommandsRespondToQueuedCommandRequest, *, timeout: float | None = None) -> CommandsRespondToQueuedCommandResult:
-        "Responds to a queued command request from the session.\n\nArgs:\n    params: Queued command request ID and the result indicating whether the client handled it.\n\nReturns:\n    Indicates whether the queued-command response was accepted by the session."
+        "Reports whether the host actually executed a queued command and whether to continue processing.\n\nArgs:\n    params: Queued-command request ID and the result indicating whether the host executed it (and whether to stop processing further queued commands).\n\nReturns:\n    Indicates whether the queued-command response was matched to a pending request."
         if self._assert_active is not None:
             self._assert_active()
         if params is None:
@@ -9037,6 +16579,25 @@ class CommandsApi:
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return CommandsRespondToQueuedCommandResult.from_dict(await self._client.request("session.commands.respondToQueuedCommand", params_dict, **_timeout_kwargs(timeout)))
+
+
+# Experimental: this API group is experimental and may change or be removed.
+class TelemetryApi:
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
+        self._client = client
+        self._session_id = session_id
+        self._assert_active = assert_active
+
+    async def set_feature_overrides(self, params: TelemetrySetFeatureOverridesRequest, *, timeout: float | None = None) -> None:
+        "Sets feature override key/value pairs to attach to subsequent telemetry events for the session.\n\nArgs:\n    params: Feature override key/value pairs to attach to subsequent telemetry events from this session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        await self._client.request("session.telemetry.setFeatureOverrides", params_dict, **_timeout_kwargs(timeout))
 
 
 class UiApi:
@@ -9067,12 +16628,161 @@ class UiApi:
         params_dict["sessionId"] = self._session_id
         return UIElicitationResult.from_dict(await self._client.request("session.ui.handlePendingElicitation", params_dict, **_timeout_kwargs(timeout)))
 
+    async def handle_pending_user_input(self, params: UIHandlePendingUserInputRequest, *, timeout: float | None = None) -> UIHandlePendingResult:
+        "Resolves a pending `user_input.requested` event with the user's response.\n\nArgs:\n    params: Request ID of a pending `user_input.requested` event and the user's response.\n\nReturns:\n    Indicates whether the pending UI request was resolved by this call."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return UIHandlePendingResult.from_dict(await self._client.request("session.ui.handlePendingUserInput", params_dict, **_timeout_kwargs(timeout)))
+
+    async def handle_pending_sampling(self, params: UIHandlePendingSamplingRequest, *, timeout: float | None = None) -> UIHandlePendingResult:
+        "Resolves a pending `sampling.requested` event with a sampling result, or rejects it.\n\nArgs:\n    params: Request ID of a pending `sampling.requested` event and an optional sampling result payload (omit to reject).\n\nReturns:\n    Indicates whether the pending UI request was resolved by this call."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return UIHandlePendingResult.from_dict(await self._client.request("session.ui.handlePendingSampling", params_dict, **_timeout_kwargs(timeout)))
+
+    async def handle_pending_auto_mode_switch(self, params: UIHandlePendingAutoModeSwitchRequest, *, timeout: float | None = None) -> UIHandlePendingResult:
+        "Resolves a pending `auto_mode_switch.requested` event with the user's accept/decline decision.\n\nArgs:\n    params: Request ID of a pending `auto_mode_switch.requested` event and the user's response.\n\nReturns:\n    Indicates whether the pending UI request was resolved by this call."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return UIHandlePendingResult.from_dict(await self._client.request("session.ui.handlePendingAutoModeSwitch", params_dict, **_timeout_kwargs(timeout)))
+
+    async def handle_pending_exit_plan_mode(self, params: UIHandlePendingExitPlanModeRequest, *, timeout: float | None = None) -> UIHandlePendingResult:
+        "Resolves a pending `exit_plan_mode.requested` event with the user's response.\n\nArgs:\n    params: Request ID of a pending `exit_plan_mode.requested` event and the user's response.\n\nReturns:\n    Indicates whether the pending UI request was resolved by this call."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return UIHandlePendingResult.from_dict(await self._client.request("session.ui.handlePendingExitPlanMode", params_dict, **_timeout_kwargs(timeout)))
+
+    async def register_direct_auto_mode_switch_handler(self, *, timeout: float | None = None) -> UIRegisterDirectAutoModeSwitchHandlerResult:
+        "Registers an in-process handler for auto-mode-switch requests so the server bridge skips dispatch.\n\nReturns:\n    Register an in-process handler for `auto_mode_switch.requested` events. The caller still attaches the actual listener via the standard event-subscription mechanism; this registration solely tells the server bridge to skip its own dispatch (so a remote client doesn't race the in-process handler for the same requestId)."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return UIRegisterDirectAutoModeSwitchHandlerResult.from_dict(await self._client.request("session.ui.registerDirectAutoModeSwitchHandler", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def unregister_direct_auto_mode_switch_handler(self, params: UIUnregisterDirectAutoModeSwitchHandlerRequest, *, timeout: float | None = None) -> UIUnregisterDirectAutoModeSwitchHandlerResult:
+        "Unregisters a previously-registered in-process auto-mode-switch handler by its opaque handle.\n\nArgs:\n    params: Opaque handle previously returned by `registerDirectAutoModeSwitchHandler` to release.\n\nReturns:\n    Indicates whether the handle was active and the registration count was decremented."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return UIUnregisterDirectAutoModeSwitchHandlerResult.from_dict(await self._client.request("session.ui.unregisterDirectAutoModeSwitchHandler", params_dict, **_timeout_kwargs(timeout)))
+
+
+class PermissionsPathsApi:
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
+        self._client = client
+        self._session_id = session_id
+        self._assert_active = assert_active
+
+    async def list(self, *, timeout: float | None = None) -> PermissionPathsList:
+        "Returns the session's allowed directories and primary working directory.\n\nReturns:\n    Snapshot of the session's allow-listed directories and primary working directory."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return PermissionPathsList.from_dict(await self._client.request("session.permissions.paths.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def add(self, params: PermissionPathsAddParams, *, timeout: float | None = None) -> PermissionsPathsAddResult:
+        "Adds a directory to the session's allow-list.\n\nArgs:\n    params: Directory path to add to the session's allowed directories.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return PermissionsPathsAddResult.from_dict(await self._client.request("session.permissions.paths.add", params_dict, **_timeout_kwargs(timeout)))
+
+    async def update_primary(self, params: PermissionPathsUpdatePrimaryParams, *, timeout: float | None = None) -> PermissionsPathsUpdatePrimaryResult:
+        "Updates the session's primary working directory used by the permission policy.\n\nArgs:\n    params: Directory path to set as the session's new primary working directory.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return PermissionsPathsUpdatePrimaryResult.from_dict(await self._client.request("session.permissions.paths.updatePrimary", params_dict, **_timeout_kwargs(timeout)))
+
+    async def is_path_within_allowed_directories(self, params: PermissionPathsAllowedCheckParams, *, timeout: float | None = None) -> PermissionPathsAllowedCheckResult:
+        "Reports whether a path falls within any of the session's allowed directories.\n\nArgs:\n    params: Path to evaluate against the session's allowed directories.\n\nReturns:\n    Indicates whether the supplied path is within the session's allowed directories."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return PermissionPathsAllowedCheckResult.from_dict(await self._client.request("session.permissions.paths.isPathWithinAllowedDirectories", params_dict, **_timeout_kwargs(timeout)))
+
+    async def is_path_within_workspace(self, params: PermissionPathsWorkspaceCheckParams, *, timeout: float | None = None) -> PermissionPathsWorkspaceCheckResult:
+        "Reports whether a path falls within the session's workspace (primary) directory.\n\nArgs:\n    params: Path to evaluate against the session's workspace (primary) directory.\n\nReturns:\n    Indicates whether the supplied path is within the session's workspace directory."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return PermissionPathsWorkspaceCheckResult.from_dict(await self._client.request("session.permissions.paths.isPathWithinWorkspace", params_dict, **_timeout_kwargs(timeout)))
+
+
+class PermissionsUrlsApi:
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
+        self._client = client
+        self._session_id = session_id
+        self._assert_active = assert_active
+
+    async def set_unrestricted_mode(self, params: PermissionUrlsSetUnrestrictedModeParams, *, timeout: float | None = None) -> PermissionsUrlsSetUnrestrictedModeResult:
+        "Toggles the runtime's URL-permission policy between unrestricted and restricted modes.\n\nArgs:\n    params: Whether the URL-permission policy should run in unrestricted mode.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return PermissionsUrlsSetUnrestrictedModeResult.from_dict(await self._client.request("session.permissions.urls.setUnrestrictedMode", params_dict, **_timeout_kwargs(timeout)))
+
 
 class PermissionsApi:
     def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
         self._client = client
         self._session_id = session_id
         self._assert_active = assert_active
+        self.paths = PermissionsPathsApi(client, session_id, assert_active)
+        self.urls = PermissionsUrlsApi(client, session_id, assert_active)
+
+    async def configure(self, params: PermissionsConfigureParams | None = None, *, timeout: float | None = None) -> PermissionsConfigureResult:
+        "Replaces selected permission policy fields (rules, paths, URLs, exclusions, allow-all flags) on the session.\n\nArgs:\n    params: Patch of permission policy fields to apply (omit a field to leave it unchanged).\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
+        params_dict["sessionId"] = self._session_id
+        return PermissionsConfigureResult.from_dict(await self._client.request("session.permissions.configure", params_dict, **_timeout_kwargs(timeout)))
 
     async def handle_pending_permission_request(self, params: PermissionDecisionRequest, *, timeout: float | None = None) -> PermissionRequestResult:
         "Provides a decision for a pending tool permission request.\n\nArgs:\n    params: Pending permission request ID and the decision to apply (approve/reject and scope).\n\nReturns:\n    Indicates whether the permission decision was applied; false when the request was already resolved."
@@ -9085,8 +16795,15 @@ class PermissionsApi:
         params_dict["sessionId"] = self._session_id
         return PermissionRequestResult.from_dict(await self._client.request("session.permissions.handlePendingPermissionRequest", params_dict, **_timeout_kwargs(timeout)))
 
+    async def pending_requests(self, *, timeout: float | None = None) -> PendingPermissionRequestList:
+        "Reconstructs the set of pending tool permission requests from the session's event history.\n\nReturns:\n    List of pending permission requests reconstructed from event history."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return PendingPermissionRequestList.from_dict(await self._client.request("session.permissions.pendingRequests", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
     async def set_approve_all(self, params: PermissionsSetApproveAllRequest, *, timeout: float | None = None) -> PermissionsSetApproveAllResult:
-        "Enables or disables automatic approval of tool permission requests for the session.\n\nArgs:\n    params: Whether to auto-approve all tool permission requests for the rest of the session.\n\nReturns:\n    Indicates whether the operation succeeded."
+        "Enables or disables automatic approval of tool permission requests for the session.\n\nArgs:\n    params: Allow-all toggle for tool permission requests, with an optional telemetry source.\n\nReturns:\n    Indicates whether the operation succeeded."
         if self._assert_active is not None:
             self._assert_active()
         if params is None:
@@ -9096,12 +16813,111 @@ class PermissionsApi:
         params_dict["sessionId"] = self._session_id
         return PermissionsSetApproveAllResult.from_dict(await self._client.request("session.permissions.setApproveAll", params_dict, **_timeout_kwargs(timeout)))
 
+    async def modify_rules(self, params: PermissionsModifyRulesParams, *, timeout: float | None = None) -> PermissionsModifyRulesResult:
+        "Adds or removes session-scoped or location-scoped permission rules.\n\nArgs:\n    params: Scope and add/remove instructions for modifying session- or location-scoped permission rules.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return PermissionsModifyRulesResult.from_dict(await self._client.request("session.permissions.modifyRules", params_dict, **_timeout_kwargs(timeout)))
+
+    async def set_required(self, params: PermissionsSetRequiredRequest, *, timeout: float | None = None) -> PermissionsSetRequiredResult:
+        "Sets whether the client wants permission prompts bridged into session events.\n\nArgs:\n    params: Toggles whether permission prompts should be bridged into session events for this client.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return PermissionsSetRequiredResult.from_dict(await self._client.request("session.permissions.setRequired", params_dict, **_timeout_kwargs(timeout)))
+
     async def reset_session_approvals(self, *, timeout: float | None = None) -> PermissionsResetSessionApprovalsResult:
         "Clears session-scoped tool permission approvals.\n\nReturns:\n    Indicates whether the operation succeeded."
         if self._assert_active is not None:
             self._assert_active()
 
         return PermissionsResetSessionApprovalsResult.from_dict(await self._client.request("session.permissions.resetSessionApprovals", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def notify_prompt_shown(self, params: PermissionPromptShownNotification, *, timeout: float | None = None) -> PermissionsNotifyPromptShownResult:
+        "Notifies the runtime that a permission prompt UI has been shown to the user.\n\nArgs:\n    params: Notification payload describing the permission prompt that the client just rendered.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return PermissionsNotifyPromptShownResult.from_dict(await self._client.request("session.permissions.notifyPromptShown", params_dict, **_timeout_kwargs(timeout)))
+
+
+# Experimental: this API group is experimental and may change or be removed.
+class MetadataApi:
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
+        self._client = client
+        self._session_id = session_id
+        self._assert_active = assert_active
+
+    async def snapshot(self, *, timeout: float | None = None) -> SessionMetadataSnapshot:
+        "Returns a snapshot of the session's identifying metadata, mode, agent, and remote info.\n\nReturns:\n    Point-in-time snapshot of slow-changing session identifier and state fields"
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return SessionMetadataSnapshot.from_dict(await self._client.request("session.metadata.snapshot", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def is_processing(self, *, timeout: float | None = None) -> MetadataIsProcessingResult:
+        "Reports whether the local session is currently processing user/agent messages.\n\nReturns:\n    Indicates whether the local session is currently processing a turn or background continuation."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return MetadataIsProcessingResult.from_dict(await self._client.request("session.metadata.isProcessing", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def context_info(self, params: MetadataContextInfoRequest, *, timeout: float | None = None) -> MetadataContextInfoResult:
+        "Returns the token breakdown for the session's current context window for a given model.\n\nArgs:\n    params: Model identifier and token limits used to compute the context-info breakdown.\n\nReturns:\n    Token breakdown for the session's current context window, or null if uninitialized."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return MetadataContextInfoResult.from_dict(await self._client.request("session.metadata.contextInfo", params_dict, **_timeout_kwargs(timeout)))
+
+    async def record_context_change(self, params: MetadataRecordContextChangeRequest, *, timeout: float | None = None) -> MetadataRecordContextChangeResult:
+        "Records a working-directory/git context change and emits a `session.context_changed` event.\n\nArgs:\n    params: Updated working-directory/git context to record on the session.\n\nReturns:\n    Notify the session that its working directory context has changed. Emits a `session.context_changed` event so consumers (telemetry, OTel tracker, ACP, the timeline UI) can react. Use this when the host has detected a cwd/branch/repo change outside the session's normal lifecycle (e.g., after a shell command in interactive mode)."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return MetadataRecordContextChangeResult.from_dict(await self._client.request("session.metadata.recordContextChange", params_dict, **_timeout_kwargs(timeout)))
+
+    async def set_working_directory(self, params: MetadataSetWorkingDirectoryRequest, *, timeout: float | None = None) -> MetadataSetWorkingDirectoryResult:
+        "Updates the session's recorded working directory.\n\nArgs:\n    params: Absolute path to set as the session's new working directory.\n\nReturns:\n    Update the session's working directory. Used by the host when the user explicitly changes cwd (e.g., the `/cd` slash command). The host is responsible for `process.chdir` and any related side-effects (file index, etc.); this method only updates the session's own recorded path."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return MetadataSetWorkingDirectoryResult.from_dict(await self._client.request("session.metadata.setWorkingDirectory", params_dict, **_timeout_kwargs(timeout)))
+
+    async def recompute_context_tokens(self, params: MetadataRecomputeContextTokensRequest, *, timeout: float | None = None) -> MetadataRecomputeContextTokensResult:
+        "Re-tokenizes the session's existing messages against a model and returns aggregate token totals.\n\nArgs:\n    params: Model identifier to use when re-tokenizing the session's existing messages.\n\nReturns:\n    Re-tokenize the session's existing messages against `modelId` and return the token totals. Useful for hosts that want an initial estimate of context usage on session resume, before the next agent turn fires `session.context_info_changed` events. Returns zeros for an empty session."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return MetadataRecomputeContextTokensResult.from_dict(await self._client.request("session.metadata.recomputeContextTokens", params_dict, **_timeout_kwargs(timeout)))
 
 
 class ShellApi:
@@ -9141,7 +16957,7 @@ class HistoryApi:
         self._assert_active = assert_active
 
     async def compact(self, *, timeout: float | None = None) -> HistoryCompactResult:
-        "Compacts the session history to reduce context usage.\n\nReturns:\n    Compaction outcome with the number of tokens and messages removed and the resulting context window breakdown."
+        "Compacts the session history to reduce context usage.\n\nReturns:\n    Compaction outcome with the number of tokens and messages removed, summary text, and the resulting context window breakdown."
         if self._assert_active is not None:
             self._assert_active()
 
@@ -9157,6 +16973,102 @@ class HistoryApi:
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return HistoryTruncateResult.from_dict(await self._client.request("session.history.truncate", params_dict, **_timeout_kwargs(timeout)))
+
+    async def cancel_background_compaction(self, *, timeout: float | None = None) -> HistoryCancelBackgroundCompactionResult:
+        "Cancels any in-progress background compaction on a local session.\n\nReturns:\n    Indicates whether an in-progress background compaction was cancelled."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return HistoryCancelBackgroundCompactionResult.from_dict(await self._client.request("session.history.cancelBackgroundCompaction", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def abort_manual_compaction(self, *, timeout: float | None = None) -> HistoryAbortManualCompactionResult:
+        "Aborts any in-progress manual compaction on a local session.\n\nReturns:\n    Indicates whether an in-progress manual compaction was aborted."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return HistoryAbortManualCompactionResult.from_dict(await self._client.request("session.history.abortManualCompaction", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def summarize_for_handoff(self, *, timeout: float | None = None) -> HistorySummarizeForHandoffResult:
+        "Produces a markdown summary of the session's conversation context for hand-off scenarios.\n\nReturns:\n    Markdown summary of the conversation context (empty when not available)."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return HistorySummarizeForHandoffResult.from_dict(await self._client.request("session.history.summarizeForHandoff", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+
+# Experimental: this API group is experimental and may change or be removed.
+class QueueApi:
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
+        self._client = client
+        self._session_id = session_id
+        self._assert_active = assert_active
+
+    async def pending_items(self, *, timeout: float | None = None) -> QueuePendingItemsResult:
+        "Returns the local session's pending user-facing queued items and steering messages.\n\nReturns:\n    Snapshot of the session's pending queued items and immediate-steering messages."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return QueuePendingItemsResult.from_dict(await self._client.request("session.queue.pendingItems", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def remove_most_recent(self, *, timeout: float | None = None) -> QueueRemoveMostRecentResult:
+        "Removes the most recently queued user-facing item (LIFO).\n\nReturns:\n    Indicates whether a user-facing pending item was removed."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return QueueRemoveMostRecentResult.from_dict(await self._client.request("session.queue.removeMostRecent", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def clear(self, *, timeout: float | None = None) -> None:
+        "Clears all pending queued items on the local session."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        await self._client.request("session.queue.clear", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
+
+
+# Experimental: this API group is experimental and may change or be removed.
+class EventLogApi:
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
+        self._client = client
+        self._session_id = session_id
+        self._assert_active = assert_active
+
+    async def read(self, params: EventLogReadRequest | None = None, *, timeout: float | None = None) -> EventsReadResult:
+        "Reads a batch of session events from a cursor, optionally waiting for new events.\n\nArgs:\n    params: Cursor, batch size, and optional long-poll/filter parameters for reading session events.\n\nReturns:\n    Batch of session events returned by a read, with cursor and continuation metadata."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
+        params_dict["sessionId"] = self._session_id
+        return EventsReadResult.from_dict(await self._client.request("session.eventLog.read", params_dict, **_timeout_kwargs(timeout)))
+
+    async def tail(self, *, timeout: float | None = None) -> EventLogTailResult:
+        "Returns a snapshot of the current tail cursor without consuming events.\n\nReturns:\n    Snapshot of the current tail cursor without returning any events. Use this when a consumer wants to subscribe to live events going forward without first paginating through the entire persisted history (which would happen if `read` were called without a cursor on a long-lived session)."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return EventLogTailResult.from_dict(await self._client.request("session.eventLog.tail", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def register_interest(self, params: RegisterEventInterestParams, *, timeout: float | None = None) -> RegisterEventInterestResult:
+        "Registers consumer interest in an event type for runtime gating purposes.\n\nArgs:\n    params: Event type to register consumer interest for, used by runtime gating logic.\n\nReturns:\n    Opaque handle representing an event-type interest registration."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return RegisterEventInterestResult.from_dict(await self._client.request("session.eventLog.registerInterest", params_dict, **_timeout_kwargs(timeout)))
+
+    async def release_interest(self, params: ReleaseEventInterestParams, *, timeout: float | None = None) -> EventLogReleaseInterestResult:
+        "Releases a consumer's previously-registered interest in an event type.\n\nArgs:\n    params: Opaque handle previously returned by `registerInterest` to release.\n\nReturns:\n    Indicates whether the operation succeeded."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return EventLogReleaseInterestResult.from_dict(await self._client.request("session.eventLog.releaseInterest", params_dict, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.
@@ -9197,6 +17109,43 @@ class RemoteApi:
 
         await self._client.request("session.remote.disable", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
+    async def notify_steerable_changed(self, params: RemoteNotifySteerableChangedRequest, *, timeout: float | None = None) -> RemoteNotifySteerableChangedResult:
+        "Persists a remote-steerability change emitted by the host as a session event.\n\nArgs:\n    params: New remote-steerability state to persist as a `session.remote_steerable_changed` event.\n\nReturns:\n    Persist a steerability change as a `session.remote_steerable_changed` event. Used by the host (CLI / SDK consumer) when it has just finished enabling or disabling steering on a remote exporter that the runtime does not directly own."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return RemoteNotifySteerableChangedResult.from_dict(await self._client.request("session.remote.notifySteerableChanged", params_dict, **_timeout_kwargs(timeout)))
+
+
+# Experimental: this API group is experimental and may change or be removed.
+class ScheduleApi:
+    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):
+        self._client = client
+        self._session_id = session_id
+        self._assert_active = assert_active
+
+    async def list(self, *, timeout: float | None = None) -> ScheduleList:
+        "Lists the session's currently active scheduled prompts.\n\nReturns:\n    Snapshot of the currently active recurring prompts for this session."
+        if self._assert_active is not None:
+            self._assert_active()
+
+        return ScheduleList.from_dict(await self._client.request("session.schedule.list", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def stop(self, params: ScheduleStopRequest, *, timeout: float | None = None) -> ScheduleStopResult:
+        "Removes a scheduled prompt by id.\n\nArgs:\n    params: Identifier of the scheduled prompt to remove.\n\nReturns:\n    Remove a scheduled prompt by id. The result entry is omitted if the id was unknown."
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return ScheduleStopResult.from_dict(await self._client.request("session.schedule.stop", params_dict, **_timeout_kwargs(timeout)))
+
 
 class SessionRpc:
     """Typed session-scoped RPC methods."""
@@ -9217,15 +17166,22 @@ class SessionRpc:
         self.skills = SkillsApi(client, session_id, assert_active)
         self.mcp = McpApi(client, session_id, assert_active)
         self.plugins = PluginsApi(client, session_id, assert_active)
+        self.options = OptionsApi(client, session_id, assert_active)
+        self.lsp = LspApi(client, session_id, assert_active)
         self.extensions = ExtensionsApi(client, session_id, assert_active)
         self.tools = ToolsApi(client, session_id, assert_active)
         self.commands = CommandsApi(client, session_id, assert_active)
+        self.telemetry = TelemetryApi(client, session_id, assert_active)
         self.ui = UiApi(client, session_id, assert_active)
         self.permissions = PermissionsApi(client, session_id, assert_active)
+        self.metadata = MetadataApi(client, session_id, assert_active)
         self.shell = ShellApi(client, session_id, assert_active)
         self.history = HistoryApi(client, session_id, assert_active)
+        self.queue = QueueApi(client, session_id, assert_active)
+        self.event_log = EventLogApi(client, session_id, assert_active)
         self.usage = UsageApi(client, session_id, assert_active)
         self.remote = RemoteApi(client, session_id, assert_active)
+        self.schedule = ScheduleApi(client, session_id, assert_active)
 
     async def suspend(self, *, timeout: float | None = None) -> None:
         "Suspends the session while preserving persisted state for later resume."
@@ -9234,8 +17190,37 @@ class SessionRpc:
 
         await self._client.request("session.suspend", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
 
+    async def send(self, params: SendRequest, *, timeout: float | None = None) -> SendResult:
+        "Sends a user message to the session and returns its message ID.\n\nArgs:\n    params: Parameters for sending a user message to the session\n\nReturns:\n    Result of sending a user message"
+        if self._assert_active is not None:
+            self._assert_active()
+        if params is None:
+            raise TypeError("params is required")
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return SendResult.from_dict(await self._client.request("session.send", params_dict, **_timeout_kwargs(timeout)))
+
+    async def abort(self, params: AbortRequest | None = None, *, timeout: float | None = None) -> AbortResult:
+        "Aborts the current agent turn.\n\nArgs:\n    params: Parameters for aborting the current turn\n\nReturns:\n    Result of aborting the current turn"
+        if self._assert_active is not None:
+            self._assert_active()
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
+        params_dict["sessionId"] = self._session_id
+        return AbortResult.from_dict(await self._client.request("session.abort", params_dict, **_timeout_kwargs(timeout)))
+
+    async def shutdown(self, params: ShutdownRequest | None = None, *, timeout: float | None = None) -> None:
+        "Shuts down the session and persists its final state. Awaits any deferred sessionEnd hooks before resolving so user-supplied hook scripts complete before the runtime tears down.\n\nArgs:\n    params: Parameters for shutting down the session"
+        if self._assert_active is not None:
+            self._assert_active()
+
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
+        params_dict["sessionId"] = self._session_id
+        await self._client.request("session.shutdown", params_dict, **_timeout_kwargs(timeout))
+
     async def log(self, params: LogRequest, *, timeout: float | None = None) -> LogResult:
-        "Emits a user-visible session log event.\n\nArgs:\n    params: Message text, optional severity level, persistence flag, and optional follow-up URL.\n\nReturns:\n    Identifier of the session event that was emitted for the log message."
+        "Emits a user-visible session log event.\n\nArgs:\n    params: Message text, optional severity level, persistence flag, optional follow-up URL, and optional tip.\n\nReturns:\n    Identifier of the session event that was emitted for the log message."
         if self._assert_active is not None:
             self._assert_active()
         if params is None:

--- a/python/copilot/generated/session_events.py
+++ b/python/copilot/generated/session_events.py
@@ -325,7 +325,7 @@ class AssistantMessageData:
     encrypted_content: str | None = None
     interaction_id: str | None = None
     model: str | None = None
-    output_tokens: float | None = None
+    output_tokens: int | None = None
     # Deprecated: this field is deprecated.
     parent_tool_call_id: str | None = None
     phase: str | None = None
@@ -345,7 +345,7 @@ class AssistantMessageData:
         encrypted_content = from_union([from_none, from_str], obj.get("encryptedContent"))
         interaction_id = from_union([from_none, from_str], obj.get("interactionId"))
         model = from_union([from_none, from_str], obj.get("model"))
-        output_tokens = from_union([from_none, from_float], obj.get("outputTokens"))
+        output_tokens = from_union([from_none, from_int], obj.get("outputTokens"))
         parent_tool_call_id = from_union([from_none, from_str], obj.get("parentToolCallId"))
         phase = from_union([from_none, from_str], obj.get("phase"))
         reasoning_opaque = from_union([from_none, from_str], obj.get("reasoningOpaque"))
@@ -386,7 +386,7 @@ class AssistantMessageData:
         if self.model is not None:
             result["model"] = from_union([from_none, from_str], self.model)
         if self.output_tokens is not None:
-            result["outputTokens"] = from_union([from_none, to_float], self.output_tokens)
+            result["outputTokens"] = from_union([from_none, to_int], self.output_tokens)
         if self.parent_tool_call_id is not None:
             result["parentToolCallId"] = from_union([from_none, from_str], self.parent_tool_call_id)
         if self.phase is not None:
@@ -559,19 +559,19 @@ class AssistantReasoningDeltaData:
 @dataclass
 class AssistantStreamingDeltaData:
     "Streaming response progress with cumulative byte count"
-    total_response_size_bytes: float
+    total_response_size_bytes: int
 
     @staticmethod
     def from_dict(obj: Any) -> "AssistantStreamingDeltaData":
         assert isinstance(obj, dict)
-        total_response_size_bytes = from_float(obj.get("totalResponseSizeBytes"))
+        total_response_size_bytes = from_int(obj.get("totalResponseSizeBytes"))
         return AssistantStreamingDeltaData(
             total_response_size_bytes=total_response_size_bytes,
         )
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["totalResponseSizeBytes"] = to_float(self.total_response_size_bytes)
+        result["totalResponseSizeBytes"] = to_int(self.total_response_size_bytes)
         return result
 
 
@@ -622,13 +622,13 @@ class AssistantTurnStartData:
 class AssistantUsageCopilotUsage:
     "Per-request cost and usage data from the CAPI copilot_usage response field"
     token_details: list[AssistantUsageCopilotUsageTokenDetail]
-    total_nano_aiu: float
+    total_nano_aiu: int
 
     @staticmethod
     def from_dict(obj: Any) -> "AssistantUsageCopilotUsage":
         assert isinstance(obj, dict)
         token_details = from_list(AssistantUsageCopilotUsageTokenDetail.from_dict, obj.get("tokenDetails"))
-        total_nano_aiu = from_float(obj.get("totalNanoAiu"))
+        total_nano_aiu = from_int(obj.get("totalNanoAiu"))
         return AssistantUsageCopilotUsage(
             token_details=token_details,
             total_nano_aiu=total_nano_aiu,
@@ -637,24 +637,24 @@ class AssistantUsageCopilotUsage:
     def to_dict(self) -> dict:
         result: dict = {}
         result["tokenDetails"] = from_list(lambda x: to_class(AssistantUsageCopilotUsageTokenDetail, x), self.token_details)
-        result["totalNanoAiu"] = to_float(self.total_nano_aiu)
+        result["totalNanoAiu"] = to_int(self.total_nano_aiu)
         return result
 
 
 @dataclass
 class AssistantUsageCopilotUsageTokenDetail:
     "Token usage detail for a single billing category"
-    batch_size: float
-    cost_per_batch: float
-    token_count: float
+    batch_size: int
+    cost_per_batch: int
+    token_count: int
     token_type: str
 
     @staticmethod
     def from_dict(obj: Any) -> "AssistantUsageCopilotUsageTokenDetail":
         assert isinstance(obj, dict)
-        batch_size = from_float(obj.get("batchSize"))
-        cost_per_batch = from_float(obj.get("costPerBatch"))
-        token_count = from_float(obj.get("tokenCount"))
+        batch_size = from_int(obj.get("batchSize"))
+        cost_per_batch = from_int(obj.get("costPerBatch"))
+        token_count = from_int(obj.get("tokenCount"))
         token_type = from_str(obj.get("tokenType"))
         return AssistantUsageCopilotUsageTokenDetail(
             batch_size=batch_size,
@@ -665,9 +665,9 @@ class AssistantUsageCopilotUsageTokenDetail:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["batchSize"] = to_float(self.batch_size)
-        result["costPerBatch"] = to_float(self.cost_per_batch)
-        result["tokenCount"] = to_float(self.token_count)
+        result["batchSize"] = to_int(self.batch_size)
+        result["costPerBatch"] = to_int(self.cost_per_batch)
+        result["tokenCount"] = to_int(self.token_count)
         result["tokenType"] = from_str(self.token_type)
         return result
 
@@ -678,21 +678,21 @@ class AssistantUsageData:
     model: str
     api_call_id: str | None = None
     api_endpoint: AssistantUsageApiEndpoint | None = None
-    cache_read_tokens: float | None = None
-    cache_write_tokens: float | None = None
+    cache_read_tokens: int | None = None
+    cache_write_tokens: int | None = None
     copilot_usage: AssistantUsageCopilotUsage | None = None
     cost: float | None = None
     duration: timedelta | None = None
     initiator: str | None = None
-    input_tokens: float | None = None
+    input_tokens: int | None = None
     inter_token_latency: timedelta | None = None
-    output_tokens: float | None = None
+    output_tokens: int | None = None
     # Deprecated: this field is deprecated.
     parent_tool_call_id: str | None = None
     provider_call_id: str | None = None
     quota_snapshots: dict[str, AssistantUsageQuotaSnapshot] | None = None
     reasoning_effort: str | None = None
-    reasoning_tokens: float | None = None
+    reasoning_tokens: int | None = None
     ttft: timedelta | None = None
 
     @staticmethod
@@ -701,20 +701,20 @@ class AssistantUsageData:
         model = from_str(obj.get("model"))
         api_call_id = from_union([from_none, from_str], obj.get("apiCallId"))
         api_endpoint = from_union([from_none, lambda x: parse_enum(AssistantUsageApiEndpoint, x)], obj.get("apiEndpoint"))
-        cache_read_tokens = from_union([from_none, from_float], obj.get("cacheReadTokens"))
-        cache_write_tokens = from_union([from_none, from_float], obj.get("cacheWriteTokens"))
+        cache_read_tokens = from_union([from_none, from_int], obj.get("cacheReadTokens"))
+        cache_write_tokens = from_union([from_none, from_int], obj.get("cacheWriteTokens"))
         copilot_usage = from_union([from_none, AssistantUsageCopilotUsage.from_dict], obj.get("copilotUsage"))
         cost = from_union([from_none, from_float], obj.get("cost"))
         duration = from_union([from_none, from_timedelta], obj.get("duration"))
         initiator = from_union([from_none, from_str], obj.get("initiator"))
-        input_tokens = from_union([from_none, from_float], obj.get("inputTokens"))
+        input_tokens = from_union([from_none, from_int], obj.get("inputTokens"))
         inter_token_latency = from_union([from_none, from_timedelta], obj.get("interTokenLatencyMs"))
-        output_tokens = from_union([from_none, from_float], obj.get("outputTokens"))
+        output_tokens = from_union([from_none, from_int], obj.get("outputTokens"))
         parent_tool_call_id = from_union([from_none, from_str], obj.get("parentToolCallId"))
         provider_call_id = from_union([from_none, from_str], obj.get("providerCallId"))
         quota_snapshots = from_union([from_none, lambda x: from_dict(AssistantUsageQuotaSnapshot.from_dict, x)], obj.get("quotaSnapshots"))
         reasoning_effort = from_union([from_none, from_str], obj.get("reasoningEffort"))
-        reasoning_tokens = from_union([from_none, from_float], obj.get("reasoningTokens"))
+        reasoning_tokens = from_union([from_none, from_int], obj.get("reasoningTokens"))
         ttft = from_union([from_none, from_timedelta], obj.get("ttftMs"))
         return AssistantUsageData(
             model=model,
@@ -745,23 +745,23 @@ class AssistantUsageData:
         if self.api_endpoint is not None:
             result["apiEndpoint"] = from_union([from_none, lambda x: to_enum(AssistantUsageApiEndpoint, x)], self.api_endpoint)
         if self.cache_read_tokens is not None:
-            result["cacheReadTokens"] = from_union([from_none, to_float], self.cache_read_tokens)
+            result["cacheReadTokens"] = from_union([from_none, to_int], self.cache_read_tokens)
         if self.cache_write_tokens is not None:
-            result["cacheWriteTokens"] = from_union([from_none, to_float], self.cache_write_tokens)
+            result["cacheWriteTokens"] = from_union([from_none, to_int], self.cache_write_tokens)
         if self.copilot_usage is not None:
             result["copilotUsage"] = from_union([from_none, lambda x: to_class(AssistantUsageCopilotUsage, x)], self.copilot_usage)
         if self.cost is not None:
             result["cost"] = from_union([from_none, to_float], self.cost)
         if self.duration is not None:
-            result["duration"] = from_union([from_none, to_timedelta], self.duration)
+            result["duration"] = from_union([from_none, to_timedelta_int], self.duration)
         if self.initiator is not None:
             result["initiator"] = from_union([from_none, from_str], self.initiator)
         if self.input_tokens is not None:
-            result["inputTokens"] = from_union([from_none, to_float], self.input_tokens)
+            result["inputTokens"] = from_union([from_none, to_int], self.input_tokens)
         if self.inter_token_latency is not None:
             result["interTokenLatencyMs"] = from_union([from_none, to_timedelta], self.inter_token_latency)
         if self.output_tokens is not None:
-            result["outputTokens"] = from_union([from_none, to_float], self.output_tokens)
+            result["outputTokens"] = from_union([from_none, to_int], self.output_tokens)
         if self.parent_tool_call_id is not None:
             result["parentToolCallId"] = from_union([from_none, from_str], self.parent_tool_call_id)
         if self.provider_call_id is not None:
@@ -771,34 +771,34 @@ class AssistantUsageData:
         if self.reasoning_effort is not None:
             result["reasoningEffort"] = from_union([from_none, from_str], self.reasoning_effort)
         if self.reasoning_tokens is not None:
-            result["reasoningTokens"] = from_union([from_none, to_float], self.reasoning_tokens)
+            result["reasoningTokens"] = from_union([from_none, to_int], self.reasoning_tokens)
         if self.ttft is not None:
-            result["ttftMs"] = from_union([from_none, to_timedelta], self.ttft)
+            result["ttftMs"] = from_union([from_none, to_timedelta_int], self.ttft)
         return result
 
 
 @dataclass
 class AssistantUsageQuotaSnapshot:
     "Schema for the `AssistantUsageQuotaSnapshot` type."
-    entitlement_requests: float
+    entitlement_requests: int
     is_unlimited_entitlement: bool
     overage: float
     overage_allowed_with_exhausted_quota: bool
     remaining_percentage: float
     usage_allowed_with_exhausted_quota: bool
-    used_requests: float
+    used_requests: int
     reset_date: datetime | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "AssistantUsageQuotaSnapshot":
         assert isinstance(obj, dict)
-        entitlement_requests = from_float(obj.get("entitlementRequests"))
+        entitlement_requests = from_int(obj.get("entitlementRequests"))
         is_unlimited_entitlement = from_bool(obj.get("isUnlimitedEntitlement"))
         overage = from_float(obj.get("overage"))
         overage_allowed_with_exhausted_quota = from_bool(obj.get("overageAllowedWithExhaustedQuota"))
         remaining_percentage = from_float(obj.get("remainingPercentage"))
         usage_allowed_with_exhausted_quota = from_bool(obj.get("usageAllowedWithExhaustedQuota"))
-        used_requests = from_float(obj.get("usedRequests"))
+        used_requests = from_int(obj.get("usedRequests"))
         reset_date = from_union([from_none, from_datetime], obj.get("resetDate"))
         return AssistantUsageQuotaSnapshot(
             entitlement_requests=entitlement_requests,
@@ -813,13 +813,13 @@ class AssistantUsageQuotaSnapshot:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["entitlementRequests"] = to_float(self.entitlement_requests)
+        result["entitlementRequests"] = to_int(self.entitlement_requests)
         result["isUnlimitedEntitlement"] = from_bool(self.is_unlimited_entitlement)
         result["overage"] = to_float(self.overage)
         result["overageAllowedWithExhaustedQuota"] = from_bool(self.overage_allowed_with_exhausted_quota)
         result["remainingPercentage"] = to_float(self.remaining_percentage)
         result["usageAllowedWithExhaustedQuota"] = from_bool(self.usage_allowed_with_exhausted_quota)
-        result["usedRequests"] = to_float(self.used_requests)
+        result["usedRequests"] = to_int(self.used_requests)
         if self.reset_date is not None:
             result["resetDate"] = from_union([from_none, to_datetime], self.reset_date)
         return result
@@ -853,14 +853,14 @@ class AutoModeSwitchRequestedData:
     "Auto mode switch request notification requiring user approval"
     request_id: str
     error_code: str | None = None
-    retry_after_seconds: float | None = None
+    retry_after_seconds: int | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "AutoModeSwitchRequestedData":
         assert isinstance(obj, dict)
         request_id = from_str(obj.get("requestId"))
         error_code = from_union([from_none, from_str], obj.get("errorCode"))
-        retry_after_seconds = from_union([from_none, from_float], obj.get("retryAfterSeconds"))
+        retry_after_seconds = from_union([from_none, from_int], obj.get("retryAfterSeconds"))
         return AutoModeSwitchRequestedData(
             request_id=request_id,
             error_code=error_code,
@@ -873,7 +873,7 @@ class AutoModeSwitchRequestedData:
         if self.error_code is not None:
             result["errorCode"] = from_union([from_none, from_str], self.error_code)
         if self.retry_after_seconds is not None:
-            result["retryAfterSeconds"] = from_union([from_none, to_float], self.retry_after_seconds)
+            result["retryAfterSeconds"] = from_union([from_none, to_int], self.retry_after_seconds)
         return result
 
 
@@ -1036,24 +1036,24 @@ class CommandsChangedData:
 @dataclass
 class CompactionCompleteCompactionTokensUsed:
     "Token usage breakdown for the compaction LLM call (aligned with assistant.usage format)"
-    cache_read_tokens: float | None = None
-    cache_write_tokens: float | None = None
+    cache_read_tokens: int | None = None
+    cache_write_tokens: int | None = None
     copilot_usage: CompactionCompleteCompactionTokensUsedCopilotUsage | None = None
     duration: timedelta | None = None
-    input_tokens: float | None = None
+    input_tokens: int | None = None
     model: str | None = None
-    output_tokens: float | None = None
+    output_tokens: int | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "CompactionCompleteCompactionTokensUsed":
         assert isinstance(obj, dict)
-        cache_read_tokens = from_union([from_none, from_float], obj.get("cacheReadTokens"))
-        cache_write_tokens = from_union([from_none, from_float], obj.get("cacheWriteTokens"))
+        cache_read_tokens = from_union([from_none, from_int], obj.get("cacheReadTokens"))
+        cache_write_tokens = from_union([from_none, from_int], obj.get("cacheWriteTokens"))
         copilot_usage = from_union([from_none, CompactionCompleteCompactionTokensUsedCopilotUsage.from_dict], obj.get("copilotUsage"))
         duration = from_union([from_none, from_timedelta], obj.get("duration"))
-        input_tokens = from_union([from_none, from_float], obj.get("inputTokens"))
+        input_tokens = from_union([from_none, from_int], obj.get("inputTokens"))
         model = from_union([from_none, from_str], obj.get("model"))
-        output_tokens = from_union([from_none, from_float], obj.get("outputTokens"))
+        output_tokens = from_union([from_none, from_int], obj.get("outputTokens"))
         return CompactionCompleteCompactionTokensUsed(
             cache_read_tokens=cache_read_tokens,
             cache_write_tokens=cache_write_tokens,
@@ -1067,19 +1067,19 @@ class CompactionCompleteCompactionTokensUsed:
     def to_dict(self) -> dict:
         result: dict = {}
         if self.cache_read_tokens is not None:
-            result["cacheReadTokens"] = from_union([from_none, to_float], self.cache_read_tokens)
+            result["cacheReadTokens"] = from_union([from_none, to_int], self.cache_read_tokens)
         if self.cache_write_tokens is not None:
-            result["cacheWriteTokens"] = from_union([from_none, to_float], self.cache_write_tokens)
+            result["cacheWriteTokens"] = from_union([from_none, to_int], self.cache_write_tokens)
         if self.copilot_usage is not None:
             result["copilotUsage"] = from_union([from_none, lambda x: to_class(CompactionCompleteCompactionTokensUsedCopilotUsage, x)], self.copilot_usage)
         if self.duration is not None:
-            result["duration"] = from_union([from_none, to_timedelta], self.duration)
+            result["duration"] = from_union([from_none, to_timedelta_int], self.duration)
         if self.input_tokens is not None:
-            result["inputTokens"] = from_union([from_none, to_float], self.input_tokens)
+            result["inputTokens"] = from_union([from_none, to_int], self.input_tokens)
         if self.model is not None:
             result["model"] = from_union([from_none, from_str], self.model)
         if self.output_tokens is not None:
-            result["outputTokens"] = from_union([from_none, to_float], self.output_tokens)
+            result["outputTokens"] = from_union([from_none, to_int], self.output_tokens)
         return result
 
 
@@ -1087,13 +1087,13 @@ class CompactionCompleteCompactionTokensUsed:
 class CompactionCompleteCompactionTokensUsedCopilotUsage:
     "Per-request cost and usage data from the CAPI copilot_usage response field"
     token_details: list[CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail]
-    total_nano_aiu: float
+    total_nano_aiu: int
 
     @staticmethod
     def from_dict(obj: Any) -> "CompactionCompleteCompactionTokensUsedCopilotUsage":
         assert isinstance(obj, dict)
         token_details = from_list(CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail.from_dict, obj.get("tokenDetails"))
-        total_nano_aiu = from_float(obj.get("totalNanoAiu"))
+        total_nano_aiu = from_int(obj.get("totalNanoAiu"))
         return CompactionCompleteCompactionTokensUsedCopilotUsage(
             token_details=token_details,
             total_nano_aiu=total_nano_aiu,
@@ -1102,24 +1102,24 @@ class CompactionCompleteCompactionTokensUsedCopilotUsage:
     def to_dict(self) -> dict:
         result: dict = {}
         result["tokenDetails"] = from_list(lambda x: to_class(CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail, x), self.token_details)
-        result["totalNanoAiu"] = to_float(self.total_nano_aiu)
+        result["totalNanoAiu"] = to_int(self.total_nano_aiu)
         return result
 
 
 @dataclass
 class CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail:
     "Token usage detail for a single billing category"
-    batch_size: float
-    cost_per_batch: float
-    token_count: float
+    batch_size: int
+    cost_per_batch: int
+    token_count: int
     token_type: str
 
     @staticmethod
     def from_dict(obj: Any) -> "CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail":
         assert isinstance(obj, dict)
-        batch_size = from_float(obj.get("batchSize"))
-        cost_per_batch = from_float(obj.get("costPerBatch"))
-        token_count = from_float(obj.get("tokenCount"))
+        batch_size = from_int(obj.get("batchSize"))
+        cost_per_batch = from_int(obj.get("costPerBatch"))
+        token_count = from_int(obj.get("tokenCount"))
         token_type = from_str(obj.get("tokenType"))
         return CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail(
             batch_size=batch_size,
@@ -1130,9 +1130,9 @@ class CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["batchSize"] = to_float(self.batch_size)
-        result["costPerBatch"] = to_float(self.cost_per_batch)
-        result["tokenCount"] = to_float(self.token_count)
+        result["batchSize"] = to_int(self.batch_size)
+        result["costPerBatch"] = to_int(self.cost_per_batch)
+        result["tokenCount"] = to_int(self.token_count)
         result["tokenType"] = from_str(self.token_type)
         return result
 
@@ -1786,7 +1786,7 @@ class ModelCallFailureData:
         if self.api_call_id is not None:
             result["apiCallId"] = from_union([from_none, from_str], self.api_call_id)
         if self.duration is not None:
-            result["durationMs"] = from_union([from_none, to_timedelta], self.duration)
+            result["durationMs"] = from_union([from_none, to_timedelta_int], self.duration)
         if self.error_message is not None:
             result["errorMessage"] = from_union([from_none, from_str], self.error_message)
         if self.initiator is not None:
@@ -2402,39 +2402,39 @@ class SessionBackgroundTasksChangedData:
 class SessionCompactionCompleteData:
     "Conversation compaction results including success status, metrics, and optional error details"
     success: bool
-    checkpoint_number: float | None = None
+    checkpoint_number: int | None = None
     checkpoint_path: str | None = None
     compaction_tokens_used: CompactionCompleteCompactionTokensUsed | None = None
-    conversation_tokens: float | None = None
+    conversation_tokens: int | None = None
     error: str | None = None
-    messages_removed: float | None = None
-    post_compaction_tokens: float | None = None
-    pre_compaction_messages_length: float | None = None
-    pre_compaction_tokens: float | None = None
+    messages_removed: int | None = None
+    post_compaction_tokens: int | None = None
+    pre_compaction_messages_length: int | None = None
+    pre_compaction_tokens: int | None = None
     request_id: str | None = None
     summary_content: str | None = None
-    system_tokens: float | None = None
-    tokens_removed: float | None = None
-    tool_definitions_tokens: float | None = None
+    system_tokens: int | None = None
+    tokens_removed: int | None = None
+    tool_definitions_tokens: int | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "SessionCompactionCompleteData":
         assert isinstance(obj, dict)
         success = from_bool(obj.get("success"))
-        checkpoint_number = from_union([from_none, from_float], obj.get("checkpointNumber"))
+        checkpoint_number = from_union([from_none, from_int], obj.get("checkpointNumber"))
         checkpoint_path = from_union([from_none, from_str], obj.get("checkpointPath"))
         compaction_tokens_used = from_union([from_none, CompactionCompleteCompactionTokensUsed.from_dict], obj.get("compactionTokensUsed"))
-        conversation_tokens = from_union([from_none, from_float], obj.get("conversationTokens"))
+        conversation_tokens = from_union([from_none, from_int], obj.get("conversationTokens"))
         error = from_union([from_none, from_str], obj.get("error"))
-        messages_removed = from_union([from_none, from_float], obj.get("messagesRemoved"))
-        post_compaction_tokens = from_union([from_none, from_float], obj.get("postCompactionTokens"))
-        pre_compaction_messages_length = from_union([from_none, from_float], obj.get("preCompactionMessagesLength"))
-        pre_compaction_tokens = from_union([from_none, from_float], obj.get("preCompactionTokens"))
+        messages_removed = from_union([from_none, from_int], obj.get("messagesRemoved"))
+        post_compaction_tokens = from_union([from_none, from_int], obj.get("postCompactionTokens"))
+        pre_compaction_messages_length = from_union([from_none, from_int], obj.get("preCompactionMessagesLength"))
+        pre_compaction_tokens = from_union([from_none, from_int], obj.get("preCompactionTokens"))
         request_id = from_union([from_none, from_str], obj.get("requestId"))
         summary_content = from_union([from_none, from_str], obj.get("summaryContent"))
-        system_tokens = from_union([from_none, from_float], obj.get("systemTokens"))
-        tokens_removed = from_union([from_none, from_float], obj.get("tokensRemoved"))
-        tool_definitions_tokens = from_union([from_none, from_float], obj.get("toolDefinitionsTokens"))
+        system_tokens = from_union([from_none, from_int], obj.get("systemTokens"))
+        tokens_removed = from_union([from_none, from_int], obj.get("tokensRemoved"))
+        tool_definitions_tokens = from_union([from_none, from_int], obj.get("toolDefinitionsTokens"))
         return SessionCompactionCompleteData(
             success=success,
             checkpoint_number=checkpoint_number,
@@ -2457,49 +2457,49 @@ class SessionCompactionCompleteData:
         result: dict = {}
         result["success"] = from_bool(self.success)
         if self.checkpoint_number is not None:
-            result["checkpointNumber"] = from_union([from_none, to_float], self.checkpoint_number)
+            result["checkpointNumber"] = from_union([from_none, to_int], self.checkpoint_number)
         if self.checkpoint_path is not None:
             result["checkpointPath"] = from_union([from_none, from_str], self.checkpoint_path)
         if self.compaction_tokens_used is not None:
             result["compactionTokensUsed"] = from_union([from_none, lambda x: to_class(CompactionCompleteCompactionTokensUsed, x)], self.compaction_tokens_used)
         if self.conversation_tokens is not None:
-            result["conversationTokens"] = from_union([from_none, to_float], self.conversation_tokens)
+            result["conversationTokens"] = from_union([from_none, to_int], self.conversation_tokens)
         if self.error is not None:
             result["error"] = from_union([from_none, from_str], self.error)
         if self.messages_removed is not None:
-            result["messagesRemoved"] = from_union([from_none, to_float], self.messages_removed)
+            result["messagesRemoved"] = from_union([from_none, to_int], self.messages_removed)
         if self.post_compaction_tokens is not None:
-            result["postCompactionTokens"] = from_union([from_none, to_float], self.post_compaction_tokens)
+            result["postCompactionTokens"] = from_union([from_none, to_int], self.post_compaction_tokens)
         if self.pre_compaction_messages_length is not None:
-            result["preCompactionMessagesLength"] = from_union([from_none, to_float], self.pre_compaction_messages_length)
+            result["preCompactionMessagesLength"] = from_union([from_none, to_int], self.pre_compaction_messages_length)
         if self.pre_compaction_tokens is not None:
-            result["preCompactionTokens"] = from_union([from_none, to_float], self.pre_compaction_tokens)
+            result["preCompactionTokens"] = from_union([from_none, to_int], self.pre_compaction_tokens)
         if self.request_id is not None:
             result["requestId"] = from_union([from_none, from_str], self.request_id)
         if self.summary_content is not None:
             result["summaryContent"] = from_union([from_none, from_str], self.summary_content)
         if self.system_tokens is not None:
-            result["systemTokens"] = from_union([from_none, to_float], self.system_tokens)
+            result["systemTokens"] = from_union([from_none, to_int], self.system_tokens)
         if self.tokens_removed is not None:
-            result["tokensRemoved"] = from_union([from_none, to_float], self.tokens_removed)
+            result["tokensRemoved"] = from_union([from_none, to_int], self.tokens_removed)
         if self.tool_definitions_tokens is not None:
-            result["toolDefinitionsTokens"] = from_union([from_none, to_float], self.tool_definitions_tokens)
+            result["toolDefinitionsTokens"] = from_union([from_none, to_int], self.tool_definitions_tokens)
         return result
 
 
 @dataclass
 class SessionCompactionStartData:
     "Context window breakdown at the start of LLM-powered conversation compaction"
-    conversation_tokens: float | None = None
-    system_tokens: float | None = None
-    tool_definitions_tokens: float | None = None
+    conversation_tokens: int | None = None
+    system_tokens: int | None = None
+    tool_definitions_tokens: int | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "SessionCompactionStartData":
         assert isinstance(obj, dict)
-        conversation_tokens = from_union([from_none, from_float], obj.get("conversationTokens"))
-        system_tokens = from_union([from_none, from_float], obj.get("systemTokens"))
-        tool_definitions_tokens = from_union([from_none, from_float], obj.get("toolDefinitionsTokens"))
+        conversation_tokens = from_union([from_none, from_int], obj.get("conversationTokens"))
+        system_tokens = from_union([from_none, from_int], obj.get("systemTokens"))
+        tool_definitions_tokens = from_union([from_none, from_int], obj.get("toolDefinitionsTokens"))
         return SessionCompactionStartData(
             conversation_tokens=conversation_tokens,
             system_tokens=system_tokens,
@@ -2509,11 +2509,11 @@ class SessionCompactionStartData:
     def to_dict(self) -> dict:
         result: dict = {}
         if self.conversation_tokens is not None:
-            result["conversationTokens"] = from_union([from_none, to_float], self.conversation_tokens)
+            result["conversationTokens"] = from_union([from_none, to_int], self.conversation_tokens)
         if self.system_tokens is not None:
-            result["systemTokens"] = from_union([from_none, to_float], self.system_tokens)
+            result["systemTokens"] = from_union([from_none, to_int], self.system_tokens)
         if self.tool_definitions_tokens is not None:
-            result["toolDefinitionsTokens"] = from_union([from_none, to_float], self.tool_definitions_tokens)
+            result["toolDefinitionsTokens"] = from_union([from_none, to_int], self.tool_definitions_tokens)
         return result
 
 
@@ -2963,7 +2963,7 @@ class SessionRemoteSteerableChangedData:
 @dataclass
 class SessionResumeData:
     "Session resume metadata including current context and event count"
-    event_count: float
+    event_count: int
     resume_time: datetime
     already_in_use: bool | None = None
     context: WorkingDirectoryContext | None = None
@@ -2977,7 +2977,7 @@ class SessionResumeData:
     @staticmethod
     def from_dict(obj: Any) -> "SessionResumeData":
         assert isinstance(obj, dict)
-        event_count = from_float(obj.get("eventCount"))
+        event_count = from_int(obj.get("eventCount"))
         resume_time = from_datetime(obj.get("resumeTime"))
         already_in_use = from_union([from_none, from_bool], obj.get("alreadyInUse"))
         context = from_union([from_none, WorkingDirectoryContext.from_dict], obj.get("context"))
@@ -3002,7 +3002,7 @@ class SessionResumeData:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["eventCount"] = to_float(self.event_count)
+        result["eventCount"] = to_int(self.event_count)
         result["resumeTime"] = to_datetime(self.resume_time)
         if self.already_in_use is not None:
             result["alreadyInUse"] = from_union([from_none, from_bool], self.already_in_use)
@@ -3084,36 +3084,36 @@ class SessionShutdownData:
     "Session termination metrics including usage statistics, code changes, and shutdown reason"
     code_changes: ShutdownCodeChanges
     model_metrics: dict[str, ShutdownModelMetric]
-    session_start_time: float
+    session_start_time: int
     shutdown_type: ShutdownType
     total_api_duration: timedelta
-    total_premium_requests: float
-    conversation_tokens: float | None = None
+    total_premium_requests: int
+    conversation_tokens: int | None = None
     current_model: str | None = None
-    current_tokens: float | None = None
+    current_tokens: int | None = None
     error_reason: str | None = None
-    system_tokens: float | None = None
+    system_tokens: int | None = None
     token_details: dict[str, ShutdownTokenDetail] | None = None
-    tool_definitions_tokens: float | None = None
-    total_nano_aiu: float | None = None
+    tool_definitions_tokens: int | None = None
+    total_nano_aiu: int | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "SessionShutdownData":
         assert isinstance(obj, dict)
         code_changes = ShutdownCodeChanges.from_dict(obj.get("codeChanges"))
         model_metrics = from_dict(ShutdownModelMetric.from_dict, obj.get("modelMetrics"))
-        session_start_time = from_float(obj.get("sessionStartTime"))
+        session_start_time = from_int(obj.get("sessionStartTime"))
         shutdown_type = parse_enum(ShutdownType, obj.get("shutdownType"))
         total_api_duration = from_timedelta(obj.get("totalApiDurationMs"))
-        total_premium_requests = from_float(obj.get("totalPremiumRequests"))
-        conversation_tokens = from_union([from_none, from_float], obj.get("conversationTokens"))
+        total_premium_requests = from_int(obj.get("totalPremiumRequests"))
+        conversation_tokens = from_union([from_none, from_int], obj.get("conversationTokens"))
         current_model = from_union([from_none, from_str], obj.get("currentModel"))
-        current_tokens = from_union([from_none, from_float], obj.get("currentTokens"))
+        current_tokens = from_union([from_none, from_int], obj.get("currentTokens"))
         error_reason = from_union([from_none, from_str], obj.get("errorReason"))
-        system_tokens = from_union([from_none, from_float], obj.get("systemTokens"))
+        system_tokens = from_union([from_none, from_int], obj.get("systemTokens"))
         token_details = from_union([from_none, lambda x: from_dict(ShutdownTokenDetail.from_dict, x)], obj.get("tokenDetails"))
-        tool_definitions_tokens = from_union([from_none, from_float], obj.get("toolDefinitionsTokens"))
-        total_nano_aiu = from_union([from_none, from_float], obj.get("totalNanoAiu"))
+        tool_definitions_tokens = from_union([from_none, from_int], obj.get("toolDefinitionsTokens"))
+        total_nano_aiu = from_union([from_none, from_int], obj.get("totalNanoAiu"))
         return SessionShutdownData(
             code_changes=code_changes,
             model_metrics=model_metrics,
@@ -3135,26 +3135,26 @@ class SessionShutdownData:
         result: dict = {}
         result["codeChanges"] = to_class(ShutdownCodeChanges, self.code_changes)
         result["modelMetrics"] = from_dict(lambda x: to_class(ShutdownModelMetric, x), self.model_metrics)
-        result["sessionStartTime"] = to_float(self.session_start_time)
+        result["sessionStartTime"] = to_int(self.session_start_time)
         result["shutdownType"] = to_enum(ShutdownType, self.shutdown_type)
-        result["totalApiDurationMs"] = to_timedelta(self.total_api_duration)
-        result["totalPremiumRequests"] = to_float(self.total_premium_requests)
+        result["totalApiDurationMs"] = to_timedelta_int(self.total_api_duration)
+        result["totalPremiumRequests"] = to_int(self.total_premium_requests)
         if self.conversation_tokens is not None:
-            result["conversationTokens"] = from_union([from_none, to_float], self.conversation_tokens)
+            result["conversationTokens"] = from_union([from_none, to_int], self.conversation_tokens)
         if self.current_model is not None:
             result["currentModel"] = from_union([from_none, from_str], self.current_model)
         if self.current_tokens is not None:
-            result["currentTokens"] = from_union([from_none, to_float], self.current_tokens)
+            result["currentTokens"] = from_union([from_none, to_int], self.current_tokens)
         if self.error_reason is not None:
             result["errorReason"] = from_union([from_none, from_str], self.error_reason)
         if self.system_tokens is not None:
-            result["systemTokens"] = from_union([from_none, to_float], self.system_tokens)
+            result["systemTokens"] = from_union([from_none, to_int], self.system_tokens)
         if self.token_details is not None:
             result["tokenDetails"] = from_union([from_none, lambda x: from_dict(lambda x: to_class(ShutdownTokenDetail, x), x)], self.token_details)
         if self.tool_definitions_tokens is not None:
-            result["toolDefinitionsTokens"] = from_union([from_none, to_float], self.tool_definitions_tokens)
+            result["toolDefinitionsTokens"] = from_union([from_none, to_int], self.tool_definitions_tokens)
         if self.total_nano_aiu is not None:
-            result["totalNanoAiu"] = from_union([from_none, to_float], self.total_nano_aiu)
+            result["totalNanoAiu"] = from_union([from_none, to_int], self.total_nano_aiu)
         return result
 
 
@@ -3180,13 +3180,13 @@ class SessionSkillsLoadedData:
 @dataclass
 class SessionSnapshotRewindData:
     "Session rewind details including target event and count of removed events"
-    events_removed: float
+    events_removed: int
     up_to_event_id: str
 
     @staticmethod
     def from_dict(obj: Any) -> "SessionSnapshotRewindData":
         assert isinstance(obj, dict)
-        events_removed = from_float(obj.get("eventsRemoved"))
+        events_removed = from_int(obj.get("eventsRemoved"))
         up_to_event_id = from_str(obj.get("upToEventId"))
         return SessionSnapshotRewindData(
             events_removed=events_removed,
@@ -3195,7 +3195,7 @@ class SessionSnapshotRewindData:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["eventsRemoved"] = to_float(self.events_removed)
+        result["eventsRemoved"] = to_int(self.events_removed)
         result["upToEventId"] = from_str(self.up_to_event_id)
         return result
 
@@ -3207,7 +3207,7 @@ class SessionStartData:
     producer: str
     session_id: str
     start_time: datetime
-    version: float
+    version: int
     already_in_use: bool | None = None
     context: WorkingDirectoryContext | None = None
     detached_from_spawning_parent_session_id: str | None = None
@@ -3223,7 +3223,7 @@ class SessionStartData:
         producer = from_str(obj.get("producer"))
         session_id = from_str(obj.get("sessionId"))
         start_time = from_datetime(obj.get("startTime"))
-        version = from_float(obj.get("version"))
+        version = from_int(obj.get("version"))
         already_in_use = from_union([from_none, from_bool], obj.get("alreadyInUse"))
         context = from_union([from_none, WorkingDirectoryContext.from_dict], obj.get("context"))
         detached_from_spawning_parent_session_id = from_union([from_none, from_str], obj.get("detachedFromSpawningParentSessionId"))
@@ -3252,7 +3252,7 @@ class SessionStartData:
         result["producer"] = from_str(self.producer)
         result["sessionId"] = from_str(self.session_id)
         result["startTime"] = to_datetime(self.start_time)
-        result["version"] = to_float(self.version)
+        result["version"] = to_int(self.version)
         if self.already_in_use is not None:
             result["alreadyInUse"] = from_union([from_none, from_bool], self.already_in_use)
         if self.context is not None:
@@ -3336,26 +3336,26 @@ class SessionToolsUpdatedData:
 @dataclass
 class SessionTruncationData:
     "Conversation truncation statistics including token counts and removed content metrics"
-    messages_removed_during_truncation: float
+    messages_removed_during_truncation: int
     performed_by: str
-    post_truncation_messages_length: float
-    post_truncation_tokens_in_messages: float
-    pre_truncation_messages_length: float
-    pre_truncation_tokens_in_messages: float
-    token_limit: float
-    tokens_removed_during_truncation: float
+    post_truncation_messages_length: int
+    post_truncation_tokens_in_messages: int
+    pre_truncation_messages_length: int
+    pre_truncation_tokens_in_messages: int
+    token_limit: int
+    tokens_removed_during_truncation: int
 
     @staticmethod
     def from_dict(obj: Any) -> "SessionTruncationData":
         assert isinstance(obj, dict)
-        messages_removed_during_truncation = from_float(obj.get("messagesRemovedDuringTruncation"))
+        messages_removed_during_truncation = from_int(obj.get("messagesRemovedDuringTruncation"))
         performed_by = from_str(obj.get("performedBy"))
-        post_truncation_messages_length = from_float(obj.get("postTruncationMessagesLength"))
-        post_truncation_tokens_in_messages = from_float(obj.get("postTruncationTokensInMessages"))
-        pre_truncation_messages_length = from_float(obj.get("preTruncationMessagesLength"))
-        pre_truncation_tokens_in_messages = from_float(obj.get("preTruncationTokensInMessages"))
-        token_limit = from_float(obj.get("tokenLimit"))
-        tokens_removed_during_truncation = from_float(obj.get("tokensRemovedDuringTruncation"))
+        post_truncation_messages_length = from_int(obj.get("postTruncationMessagesLength"))
+        post_truncation_tokens_in_messages = from_int(obj.get("postTruncationTokensInMessages"))
+        pre_truncation_messages_length = from_int(obj.get("preTruncationMessagesLength"))
+        pre_truncation_tokens_in_messages = from_int(obj.get("preTruncationTokensInMessages"))
+        token_limit = from_int(obj.get("tokenLimit"))
+        tokens_removed_during_truncation = from_int(obj.get("tokensRemovedDuringTruncation"))
         return SessionTruncationData(
             messages_removed_during_truncation=messages_removed_during_truncation,
             performed_by=performed_by,
@@ -3369,38 +3369,38 @@ class SessionTruncationData:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["messagesRemovedDuringTruncation"] = to_float(self.messages_removed_during_truncation)
+        result["messagesRemovedDuringTruncation"] = to_int(self.messages_removed_during_truncation)
         result["performedBy"] = from_str(self.performed_by)
-        result["postTruncationMessagesLength"] = to_float(self.post_truncation_messages_length)
-        result["postTruncationTokensInMessages"] = to_float(self.post_truncation_tokens_in_messages)
-        result["preTruncationMessagesLength"] = to_float(self.pre_truncation_messages_length)
-        result["preTruncationTokensInMessages"] = to_float(self.pre_truncation_tokens_in_messages)
-        result["tokenLimit"] = to_float(self.token_limit)
-        result["tokensRemovedDuringTruncation"] = to_float(self.tokens_removed_during_truncation)
+        result["postTruncationMessagesLength"] = to_int(self.post_truncation_messages_length)
+        result["postTruncationTokensInMessages"] = to_int(self.post_truncation_tokens_in_messages)
+        result["preTruncationMessagesLength"] = to_int(self.pre_truncation_messages_length)
+        result["preTruncationTokensInMessages"] = to_int(self.pre_truncation_tokens_in_messages)
+        result["tokenLimit"] = to_int(self.token_limit)
+        result["tokensRemovedDuringTruncation"] = to_int(self.tokens_removed_during_truncation)
         return result
 
 
 @dataclass
 class SessionUsageInfoData:
     "Current context window usage statistics including token and message counts"
-    current_tokens: float
-    messages_length: float
-    token_limit: float
-    conversation_tokens: float | None = None
+    current_tokens: int
+    messages_length: int
+    token_limit: int
+    conversation_tokens: int | None = None
     is_initial: bool | None = None
-    system_tokens: float | None = None
-    tool_definitions_tokens: float | None = None
+    system_tokens: int | None = None
+    tool_definitions_tokens: int | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "SessionUsageInfoData":
         assert isinstance(obj, dict)
-        current_tokens = from_float(obj.get("currentTokens"))
-        messages_length = from_float(obj.get("messagesLength"))
-        token_limit = from_float(obj.get("tokenLimit"))
-        conversation_tokens = from_union([from_none, from_float], obj.get("conversationTokens"))
+        current_tokens = from_int(obj.get("currentTokens"))
+        messages_length = from_int(obj.get("messagesLength"))
+        token_limit = from_int(obj.get("tokenLimit"))
+        conversation_tokens = from_union([from_none, from_int], obj.get("conversationTokens"))
         is_initial = from_union([from_none, from_bool], obj.get("isInitial"))
-        system_tokens = from_union([from_none, from_float], obj.get("systemTokens"))
-        tool_definitions_tokens = from_union([from_none, from_float], obj.get("toolDefinitionsTokens"))
+        system_tokens = from_union([from_none, from_int], obj.get("systemTokens"))
+        tool_definitions_tokens = from_union([from_none, from_int], obj.get("toolDefinitionsTokens"))
         return SessionUsageInfoData(
             current_tokens=current_tokens,
             messages_length=messages_length,
@@ -3413,17 +3413,17 @@ class SessionUsageInfoData:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["currentTokens"] = to_float(self.current_tokens)
-        result["messagesLength"] = to_float(self.messages_length)
-        result["tokenLimit"] = to_float(self.token_limit)
+        result["currentTokens"] = to_int(self.current_tokens)
+        result["messagesLength"] = to_int(self.messages_length)
+        result["tokenLimit"] = to_int(self.token_limit)
         if self.conversation_tokens is not None:
-            result["conversationTokens"] = from_union([from_none, to_float], self.conversation_tokens)
+            result["conversationTokens"] = from_union([from_none, to_int], self.conversation_tokens)
         if self.is_initial is not None:
             result["isInitial"] = from_union([from_none, from_bool], self.is_initial)
         if self.system_tokens is not None:
-            result["systemTokens"] = from_union([from_none, to_float], self.system_tokens)
+            result["systemTokens"] = from_union([from_none, to_int], self.system_tokens)
         if self.tool_definitions_tokens is not None:
-            result["toolDefinitionsTokens"] = from_union([from_none, to_float], self.tool_definitions_tokens)
+            result["toolDefinitionsTokens"] = from_union([from_none, to_int], self.tool_definitions_tokens)
         return result
 
 
@@ -3482,15 +3482,15 @@ class SessionWorkspaceFileChangedData:
 class ShutdownCodeChanges:
     "Aggregate code change metrics for the session"
     files_modified: list[str]
-    lines_added: float
-    lines_removed: float
+    lines_added: int
+    lines_removed: int
 
     @staticmethod
     def from_dict(obj: Any) -> "ShutdownCodeChanges":
         assert isinstance(obj, dict)
         files_modified = from_list(from_str, obj.get("filesModified"))
-        lines_added = from_float(obj.get("linesAdded"))
-        lines_removed = from_float(obj.get("linesRemoved"))
+        lines_added = from_int(obj.get("linesAdded"))
+        lines_removed = from_int(obj.get("linesRemoved"))
         return ShutdownCodeChanges(
             files_modified=files_modified,
             lines_added=lines_added,
@@ -3500,8 +3500,8 @@ class ShutdownCodeChanges:
     def to_dict(self) -> dict:
         result: dict = {}
         result["filesModified"] = from_list(from_str, self.files_modified)
-        result["linesAdded"] = to_float(self.lines_added)
-        result["linesRemoved"] = to_float(self.lines_removed)
+        result["linesAdded"] = to_int(self.lines_added)
+        result["linesRemoved"] = to_int(self.lines_removed)
         return result
 
 
@@ -3511,7 +3511,7 @@ class ShutdownModelMetric:
     requests: ShutdownModelMetricRequests
     usage: ShutdownModelMetricUsage
     token_details: dict[str, ShutdownModelMetricTokenDetail] | None = None
-    total_nano_aiu: float | None = None
+    total_nano_aiu: int | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "ShutdownModelMetric":
@@ -3519,7 +3519,7 @@ class ShutdownModelMetric:
         requests = ShutdownModelMetricRequests.from_dict(obj.get("requests"))
         usage = ShutdownModelMetricUsage.from_dict(obj.get("usage"))
         token_details = from_union([from_none, lambda x: from_dict(ShutdownModelMetricTokenDetail.from_dict, x)], obj.get("tokenDetails"))
-        total_nano_aiu = from_union([from_none, from_float], obj.get("totalNanoAiu"))
+        total_nano_aiu = from_union([from_none, from_int], obj.get("totalNanoAiu"))
         return ShutdownModelMetric(
             requests=requests,
             usage=usage,
@@ -3534,7 +3534,7 @@ class ShutdownModelMetric:
         if self.token_details is not None:
             result["tokenDetails"] = from_union([from_none, lambda x: from_dict(lambda x: to_class(ShutdownModelMetricTokenDetail, x), x)], self.token_details)
         if self.total_nano_aiu is not None:
-            result["totalNanoAiu"] = from_union([from_none, to_float], self.total_nano_aiu)
+            result["totalNanoAiu"] = from_union([from_none, to_int], self.total_nano_aiu)
         return result
 
 
@@ -3542,13 +3542,13 @@ class ShutdownModelMetric:
 class ShutdownModelMetricRequests:
     "Request count and cost metrics"
     cost: float
-    count: float
+    count: int
 
     @staticmethod
     def from_dict(obj: Any) -> "ShutdownModelMetricRequests":
         assert isinstance(obj, dict)
         cost = from_float(obj.get("cost"))
-        count = from_float(obj.get("count"))
+        count = from_int(obj.get("count"))
         return ShutdownModelMetricRequests(
             cost=cost,
             count=count,
@@ -3557,46 +3557,46 @@ class ShutdownModelMetricRequests:
     def to_dict(self) -> dict:
         result: dict = {}
         result["cost"] = to_float(self.cost)
-        result["count"] = to_float(self.count)
+        result["count"] = to_int(self.count)
         return result
 
 
 @dataclass
 class ShutdownModelMetricTokenDetail:
     "Schema for the `ShutdownModelMetricTokenDetail` type."
-    token_count: float
+    token_count: int
 
     @staticmethod
     def from_dict(obj: Any) -> "ShutdownModelMetricTokenDetail":
         assert isinstance(obj, dict)
-        token_count = from_float(obj.get("tokenCount"))
+        token_count = from_int(obj.get("tokenCount"))
         return ShutdownModelMetricTokenDetail(
             token_count=token_count,
         )
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["tokenCount"] = to_float(self.token_count)
+        result["tokenCount"] = to_int(self.token_count)
         return result
 
 
 @dataclass
 class ShutdownModelMetricUsage:
     "Token usage breakdown"
-    cache_read_tokens: float
-    cache_write_tokens: float
-    input_tokens: float
-    output_tokens: float
-    reasoning_tokens: float | None = None
+    cache_read_tokens: int
+    cache_write_tokens: int
+    input_tokens: int
+    output_tokens: int
+    reasoning_tokens: int | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "ShutdownModelMetricUsage":
         assert isinstance(obj, dict)
-        cache_read_tokens = from_float(obj.get("cacheReadTokens"))
-        cache_write_tokens = from_float(obj.get("cacheWriteTokens"))
-        input_tokens = from_float(obj.get("inputTokens"))
-        output_tokens = from_float(obj.get("outputTokens"))
-        reasoning_tokens = from_union([from_none, from_float], obj.get("reasoningTokens"))
+        cache_read_tokens = from_int(obj.get("cacheReadTokens"))
+        cache_write_tokens = from_int(obj.get("cacheWriteTokens"))
+        input_tokens = from_int(obj.get("inputTokens"))
+        output_tokens = from_int(obj.get("outputTokens"))
+        reasoning_tokens = from_union([from_none, from_int], obj.get("reasoningTokens"))
         return ShutdownModelMetricUsage(
             cache_read_tokens=cache_read_tokens,
             cache_write_tokens=cache_write_tokens,
@@ -3607,31 +3607,31 @@ class ShutdownModelMetricUsage:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["cacheReadTokens"] = to_float(self.cache_read_tokens)
-        result["cacheWriteTokens"] = to_float(self.cache_write_tokens)
-        result["inputTokens"] = to_float(self.input_tokens)
-        result["outputTokens"] = to_float(self.output_tokens)
+        result["cacheReadTokens"] = to_int(self.cache_read_tokens)
+        result["cacheWriteTokens"] = to_int(self.cache_write_tokens)
+        result["inputTokens"] = to_int(self.input_tokens)
+        result["outputTokens"] = to_int(self.output_tokens)
         if self.reasoning_tokens is not None:
-            result["reasoningTokens"] = from_union([from_none, to_float], self.reasoning_tokens)
+            result["reasoningTokens"] = from_union([from_none, to_int], self.reasoning_tokens)
         return result
 
 
 @dataclass
 class ShutdownTokenDetail:
     "Schema for the `ShutdownTokenDetail` type."
-    token_count: float
+    token_count: int
 
     @staticmethod
     def from_dict(obj: Any) -> "ShutdownTokenDetail":
         assert isinstance(obj, dict)
-        token_count = from_float(obj.get("tokenCount"))
+        token_count = from_int(obj.get("tokenCount"))
         return ShutdownTokenDetail(
             token_count=token_count,
         )
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["tokenCount"] = to_float(self.token_count)
+        result["tokenCount"] = to_int(self.token_count)
         return result
 
 
@@ -3730,8 +3730,8 @@ class SubagentCompletedData:
     tool_call_id: str
     duration: timedelta | None = None
     model: str | None = None
-    total_tokens: float | None = None
-    total_tool_calls: float | None = None
+    total_tokens: int | None = None
+    total_tool_calls: int | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "SubagentCompletedData":
@@ -3741,8 +3741,8 @@ class SubagentCompletedData:
         tool_call_id = from_str(obj.get("toolCallId"))
         duration = from_union([from_none, from_timedelta], obj.get("durationMs"))
         model = from_union([from_none, from_str], obj.get("model"))
-        total_tokens = from_union([from_none, from_float], obj.get("totalTokens"))
-        total_tool_calls = from_union([from_none, from_float], obj.get("totalToolCalls"))
+        total_tokens = from_union([from_none, from_int], obj.get("totalTokens"))
+        total_tool_calls = from_union([from_none, from_int], obj.get("totalToolCalls"))
         return SubagentCompletedData(
             agent_display_name=agent_display_name,
             agent_name=agent_name,
@@ -3759,13 +3759,13 @@ class SubagentCompletedData:
         result["agentName"] = from_str(self.agent_name)
         result["toolCallId"] = from_str(self.tool_call_id)
         if self.duration is not None:
-            result["durationMs"] = from_union([from_none, to_timedelta], self.duration)
+            result["durationMs"] = from_union([from_none, to_timedelta_int], self.duration)
         if self.model is not None:
             result["model"] = from_union([from_none, from_str], self.model)
         if self.total_tokens is not None:
-            result["totalTokens"] = from_union([from_none, to_float], self.total_tokens)
+            result["totalTokens"] = from_union([from_none, to_int], self.total_tokens)
         if self.total_tool_calls is not None:
-            result["totalToolCalls"] = from_union([from_none, to_float], self.total_tool_calls)
+            result["totalToolCalls"] = from_union([from_none, to_int], self.total_tool_calls)
         return result
 
 
@@ -3790,8 +3790,8 @@ class SubagentFailedData:
     tool_call_id: str
     duration: timedelta | None = None
     model: str | None = None
-    total_tokens: float | None = None
-    total_tool_calls: float | None = None
+    total_tokens: int | None = None
+    total_tool_calls: int | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "SubagentFailedData":
@@ -3802,8 +3802,8 @@ class SubagentFailedData:
         tool_call_id = from_str(obj.get("toolCallId"))
         duration = from_union([from_none, from_timedelta], obj.get("durationMs"))
         model = from_union([from_none, from_str], obj.get("model"))
-        total_tokens = from_union([from_none, from_float], obj.get("totalTokens"))
-        total_tool_calls = from_union([from_none, from_float], obj.get("totalToolCalls"))
+        total_tokens = from_union([from_none, from_int], obj.get("totalTokens"))
+        total_tool_calls = from_union([from_none, from_int], obj.get("totalToolCalls"))
         return SubagentFailedData(
             agent_display_name=agent_display_name,
             agent_name=agent_name,
@@ -3822,13 +3822,13 @@ class SubagentFailedData:
         result["error"] = from_str(self.error)
         result["toolCallId"] = from_str(self.tool_call_id)
         if self.duration is not None:
-            result["durationMs"] = from_union([from_none, to_timedelta], self.duration)
+            result["durationMs"] = from_union([from_none, to_timedelta_int], self.duration)
         if self.model is not None:
             result["model"] = from_union([from_none, from_str], self.model)
         if self.total_tokens is not None:
-            result["totalTokens"] = from_union([from_none, to_float], self.total_tokens)
+            result["totalTokens"] = from_union([from_none, to_int], self.total_tokens)
         if self.total_tool_calls is not None:
-            result["totalToolCalls"] = from_union([from_none, to_float], self.total_tool_calls)
+            result["totalToolCalls"] = from_union([from_none, to_int], self.total_tool_calls)
         return result
 
 
@@ -3961,7 +3961,7 @@ class SystemNotification:
     agent_type: str | None = None
     description: str | None = None
     entry_id: str | None = None
-    exit_code: float | None = None
+    exit_code: int | None = None
     prompt: str | None = None
     sender_name: str | None = None
     sender_type: str | None = None
@@ -3980,7 +3980,7 @@ class SystemNotification:
         agent_type = from_union([from_none, from_str], obj.get("agentType"))
         description = from_union([from_none, from_str], obj.get("description"))
         entry_id = from_union([from_none, from_str], obj.get("entryId"))
-        exit_code = from_union([from_none, from_float], obj.get("exitCode"))
+        exit_code = from_union([from_none, from_int], obj.get("exitCode"))
         prompt = from_union([from_none, from_str], obj.get("prompt"))
         sender_name = from_union([from_none, from_str], obj.get("senderName"))
         sender_type = from_union([from_none, from_str], obj.get("senderType"))
@@ -4020,7 +4020,7 @@ class SystemNotification:
         if self.entry_id is not None:
             result["entryId"] = from_union([from_none, from_str], self.entry_id)
         if self.exit_code is not None:
-            result["exitCode"] = from_union([from_none, to_float], self.exit_code)
+            result["exitCode"] = from_union([from_none, to_int], self.exit_code)
         if self.prompt is not None:
             result["prompt"] = from_union([from_none, from_str], self.prompt)
         if self.sender_name is not None:
@@ -4072,12 +4072,12 @@ class ToolExecutionCompleteContent:
     cwd: str | None = None
     data: str | None = None
     description: str | None = None
-    exit_code: float | None = None
+    exit_code: int | None = None
     icons: list[ToolExecutionCompleteContentResourceLinkIcon] | None = None
     mime_type: str | None = None
     name: str | None = None
     resource: ToolExecutionCompleteContentResourceDetails | None = None
-    size: float | None = None
+    size: int | None = None
     text: str | None = None
     title: str | None = None
     uri: str | None = None
@@ -4089,12 +4089,12 @@ class ToolExecutionCompleteContent:
         cwd = from_union([from_none, from_str], obj.get("cwd"))
         data = from_union([from_none, from_str], obj.get("data"))
         description = from_union([from_none, from_str], obj.get("description"))
-        exit_code = from_union([from_none, from_float], obj.get("exitCode"))
+        exit_code = from_union([from_none, from_int], obj.get("exitCode"))
         icons = from_union([from_none, lambda x: from_list(ToolExecutionCompleteContentResourceLinkIcon.from_dict, x)], obj.get("icons"))
         mime_type = from_union([from_none, from_str], obj.get("mimeType"))
         name = from_union([from_none, from_str], obj.get("name"))
         resource = from_union([from_none, lambda x: from_union([EmbeddedTextResourceContents.from_dict, EmbeddedBlobResourceContents.from_dict], x)], obj.get("resource"))
-        size = from_union([from_none, from_float], obj.get("size"))
+        size = from_union([from_none, from_int], obj.get("size"))
         text = from_union([from_none, from_str], obj.get("text"))
         title = from_union([from_none, from_str], obj.get("title"))
         uri = from_union([from_none, from_str], obj.get("uri"))
@@ -4124,7 +4124,7 @@ class ToolExecutionCompleteContent:
         if self.description is not None:
             result["description"] = from_union([from_none, from_str], self.description)
         if self.exit_code is not None:
-            result["exitCode"] = from_union([from_none, to_float], self.exit_code)
+            result["exitCode"] = from_union([from_none, to_int], self.exit_code)
         if self.icons is not None:
             result["icons"] = from_union([from_none, lambda x: from_list(lambda x: to_class(ToolExecutionCompleteContentResourceLinkIcon, x), x)], self.icons)
         if self.mime_type is not None:
@@ -4134,7 +4134,7 @@ class ToolExecutionCompleteContent:
         if self.resource is not None:
             result["resource"] = from_union([from_none, lambda x: from_union([lambda x: to_class(EmbeddedTextResourceContents, x), lambda x: to_class(EmbeddedBlobResourceContents, x)], x)], self.resource)
         if self.size is not None:
-            result["size"] = from_union([from_none, to_float], self.size)
+            result["size"] = from_union([from_none, to_int], self.size)
         if self.text is not None:
             result["text"] = from_union([from_none, from_str], self.text)
         if self.title is not None:
@@ -4494,7 +4494,7 @@ class UserMessageAttachment:
     file_path: str | None = None
     line_range: UserMessageAttachmentFileLineRange | None = None
     mime_type: str | None = None
-    number: float | None = None
+    number: int | None = None
     path: str | None = None
     reference_type: UserMessageAttachmentGithubReferenceType | None = None
     selection: UserMessageAttachmentSelectionDetails | None = None
@@ -4512,7 +4512,7 @@ class UserMessageAttachment:
         file_path = from_union([from_none, from_str], obj.get("filePath"))
         line_range = from_union([from_none, UserMessageAttachmentFileLineRange.from_dict], obj.get("lineRange"))
         mime_type = from_union([from_none, from_str], obj.get("mimeType"))
-        number = from_union([from_none, from_float], obj.get("number"))
+        number = from_union([from_none, from_int], obj.get("number"))
         path = from_union([from_none, from_str], obj.get("path"))
         reference_type = from_union([from_none, lambda x: parse_enum(UserMessageAttachmentGithubReferenceType, x)], obj.get("referenceType"))
         selection = from_union([from_none, UserMessageAttachmentSelectionDetails.from_dict], obj.get("selection"))
@@ -4551,7 +4551,7 @@ class UserMessageAttachment:
         if self.mime_type is not None:
             result["mimeType"] = from_union([from_none, from_str], self.mime_type)
         if self.number is not None:
-            result["number"] = from_union([from_none, to_float], self.number)
+            result["number"] = from_union([from_none, to_int], self.number)
         if self.path is not None:
             result["path"] = from_union([from_none, from_str], self.path)
         if self.reference_type is not None:
@@ -4572,14 +4572,14 @@ class UserMessageAttachment:
 @dataclass
 class UserMessageAttachmentFileLineRange:
     "Optional line range to scope the attachment to a specific section of the file"
-    end: float
-    start: float
+    end: int
+    start: int
 
     @staticmethod
     def from_dict(obj: Any) -> "UserMessageAttachmentFileLineRange":
         assert isinstance(obj, dict)
-        end = from_float(obj.get("end"))
-        start = from_float(obj.get("start"))
+        end = from_int(obj.get("end"))
+        start = from_int(obj.get("start"))
         return UserMessageAttachmentFileLineRange(
             end=end,
             start=start,
@@ -4587,8 +4587,8 @@ class UserMessageAttachmentFileLineRange:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["end"] = to_float(self.end)
-        result["start"] = to_float(self.start)
+        result["end"] = to_int(self.end)
+        result["start"] = to_int(self.start)
         return result
 
 
@@ -4618,14 +4618,14 @@ class UserMessageAttachmentSelectionDetails:
 @dataclass
 class UserMessageAttachmentSelectionDetailsEnd:
     "End position of the selection"
-    character: float
-    line: float
+    character: int
+    line: int
 
     @staticmethod
     def from_dict(obj: Any) -> "UserMessageAttachmentSelectionDetailsEnd":
         assert isinstance(obj, dict)
-        character = from_float(obj.get("character"))
-        line = from_float(obj.get("line"))
+        character = from_int(obj.get("character"))
+        line = from_int(obj.get("line"))
         return UserMessageAttachmentSelectionDetailsEnd(
             character=character,
             line=line,
@@ -4633,22 +4633,22 @@ class UserMessageAttachmentSelectionDetailsEnd:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["character"] = to_float(self.character)
-        result["line"] = to_float(self.line)
+        result["character"] = to_int(self.character)
+        result["line"] = to_int(self.line)
         return result
 
 
 @dataclass
 class UserMessageAttachmentSelectionDetailsStart:
     "Start position of the selection"
-    character: float
-    line: float
+    character: int
+    line: int
 
     @staticmethod
     def from_dict(obj: Any) -> "UserMessageAttachmentSelectionDetailsStart":
         assert isinstance(obj, dict)
-        character = from_float(obj.get("character"))
-        line = from_float(obj.get("line"))
+        character = from_int(obj.get("character"))
+        line = from_int(obj.get("line"))
         return UserMessageAttachmentSelectionDetailsStart(
             character=character,
             line=line,
@@ -4656,8 +4656,8 @@ class UserMessageAttachmentSelectionDetailsStart:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["character"] = to_float(self.character)
-        result["line"] = to_float(self.line)
+        result["character"] = to_int(self.character)
+        result["line"] = to_int(self.line)
         return result
 
 

--- a/python/copilot/generated/session_events.py
+++ b/python/copilot/generated/session_events.py
@@ -325,7 +325,7 @@ class AssistantMessageData:
     encrypted_content: str | None = None
     interaction_id: str | None = None
     model: str | None = None
-    output_tokens: int | None = None
+    output_tokens: float | None = None
     # Deprecated: this field is deprecated.
     parent_tool_call_id: str | None = None
     phase: str | None = None
@@ -345,7 +345,7 @@ class AssistantMessageData:
         encrypted_content = from_union([from_none, from_str], obj.get("encryptedContent"))
         interaction_id = from_union([from_none, from_str], obj.get("interactionId"))
         model = from_union([from_none, from_str], obj.get("model"))
-        output_tokens = from_union([from_none, from_int], obj.get("outputTokens"))
+        output_tokens = from_union([from_none, from_float], obj.get("outputTokens"))
         parent_tool_call_id = from_union([from_none, from_str], obj.get("parentToolCallId"))
         phase = from_union([from_none, from_str], obj.get("phase"))
         reasoning_opaque = from_union([from_none, from_str], obj.get("reasoningOpaque"))
@@ -386,7 +386,7 @@ class AssistantMessageData:
         if self.model is not None:
             result["model"] = from_union([from_none, from_str], self.model)
         if self.output_tokens is not None:
-            result["outputTokens"] = from_union([from_none, to_int], self.output_tokens)
+            result["outputTokens"] = from_union([from_none, to_float], self.output_tokens)
         if self.parent_tool_call_id is not None:
             result["parentToolCallId"] = from_union([from_none, from_str], self.parent_tool_call_id)
         if self.phase is not None:
@@ -559,19 +559,19 @@ class AssistantReasoningDeltaData:
 @dataclass
 class AssistantStreamingDeltaData:
     "Streaming response progress with cumulative byte count"
-    total_response_size_bytes: int
+    total_response_size_bytes: float
 
     @staticmethod
     def from_dict(obj: Any) -> "AssistantStreamingDeltaData":
         assert isinstance(obj, dict)
-        total_response_size_bytes = from_int(obj.get("totalResponseSizeBytes"))
+        total_response_size_bytes = from_float(obj.get("totalResponseSizeBytes"))
         return AssistantStreamingDeltaData(
             total_response_size_bytes=total_response_size_bytes,
         )
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["totalResponseSizeBytes"] = to_int(self.total_response_size_bytes)
+        result["totalResponseSizeBytes"] = to_float(self.total_response_size_bytes)
         return result
 
 
@@ -622,13 +622,13 @@ class AssistantTurnStartData:
 class AssistantUsageCopilotUsage:
     "Per-request cost and usage data from the CAPI copilot_usage response field"
     token_details: list[AssistantUsageCopilotUsageTokenDetail]
-    total_nano_aiu: int
+    total_nano_aiu: float
 
     @staticmethod
     def from_dict(obj: Any) -> "AssistantUsageCopilotUsage":
         assert isinstance(obj, dict)
         token_details = from_list(AssistantUsageCopilotUsageTokenDetail.from_dict, obj.get("tokenDetails"))
-        total_nano_aiu = from_int(obj.get("totalNanoAiu"))
+        total_nano_aiu = from_float(obj.get("totalNanoAiu"))
         return AssistantUsageCopilotUsage(
             token_details=token_details,
             total_nano_aiu=total_nano_aiu,
@@ -637,24 +637,24 @@ class AssistantUsageCopilotUsage:
     def to_dict(self) -> dict:
         result: dict = {}
         result["tokenDetails"] = from_list(lambda x: to_class(AssistantUsageCopilotUsageTokenDetail, x), self.token_details)
-        result["totalNanoAiu"] = to_int(self.total_nano_aiu)
+        result["totalNanoAiu"] = to_float(self.total_nano_aiu)
         return result
 
 
 @dataclass
 class AssistantUsageCopilotUsageTokenDetail:
     "Token usage detail for a single billing category"
-    batch_size: int
-    cost_per_batch: int
-    token_count: int
+    batch_size: float
+    cost_per_batch: float
+    token_count: float
     token_type: str
 
     @staticmethod
     def from_dict(obj: Any) -> "AssistantUsageCopilotUsageTokenDetail":
         assert isinstance(obj, dict)
-        batch_size = from_int(obj.get("batchSize"))
-        cost_per_batch = from_int(obj.get("costPerBatch"))
-        token_count = from_int(obj.get("tokenCount"))
+        batch_size = from_float(obj.get("batchSize"))
+        cost_per_batch = from_float(obj.get("costPerBatch"))
+        token_count = from_float(obj.get("tokenCount"))
         token_type = from_str(obj.get("tokenType"))
         return AssistantUsageCopilotUsageTokenDetail(
             batch_size=batch_size,
@@ -665,9 +665,9 @@ class AssistantUsageCopilotUsageTokenDetail:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["batchSize"] = to_int(self.batch_size)
-        result["costPerBatch"] = to_int(self.cost_per_batch)
-        result["tokenCount"] = to_int(self.token_count)
+        result["batchSize"] = to_float(self.batch_size)
+        result["costPerBatch"] = to_float(self.cost_per_batch)
+        result["tokenCount"] = to_float(self.token_count)
         result["tokenType"] = from_str(self.token_type)
         return result
 
@@ -678,21 +678,21 @@ class AssistantUsageData:
     model: str
     api_call_id: str | None = None
     api_endpoint: AssistantUsageApiEndpoint | None = None
-    cache_read_tokens: int | None = None
-    cache_write_tokens: int | None = None
+    cache_read_tokens: float | None = None
+    cache_write_tokens: float | None = None
     copilot_usage: AssistantUsageCopilotUsage | None = None
     cost: float | None = None
     duration: timedelta | None = None
     initiator: str | None = None
-    input_tokens: int | None = None
+    input_tokens: float | None = None
     inter_token_latency: timedelta | None = None
-    output_tokens: int | None = None
+    output_tokens: float | None = None
     # Deprecated: this field is deprecated.
     parent_tool_call_id: str | None = None
     provider_call_id: str | None = None
     quota_snapshots: dict[str, AssistantUsageQuotaSnapshot] | None = None
     reasoning_effort: str | None = None
-    reasoning_tokens: int | None = None
+    reasoning_tokens: float | None = None
     ttft: timedelta | None = None
 
     @staticmethod
@@ -701,20 +701,20 @@ class AssistantUsageData:
         model = from_str(obj.get("model"))
         api_call_id = from_union([from_none, from_str], obj.get("apiCallId"))
         api_endpoint = from_union([from_none, lambda x: parse_enum(AssistantUsageApiEndpoint, x)], obj.get("apiEndpoint"))
-        cache_read_tokens = from_union([from_none, from_int], obj.get("cacheReadTokens"))
-        cache_write_tokens = from_union([from_none, from_int], obj.get("cacheWriteTokens"))
+        cache_read_tokens = from_union([from_none, from_float], obj.get("cacheReadTokens"))
+        cache_write_tokens = from_union([from_none, from_float], obj.get("cacheWriteTokens"))
         copilot_usage = from_union([from_none, AssistantUsageCopilotUsage.from_dict], obj.get("copilotUsage"))
         cost = from_union([from_none, from_float], obj.get("cost"))
         duration = from_union([from_none, from_timedelta], obj.get("duration"))
         initiator = from_union([from_none, from_str], obj.get("initiator"))
-        input_tokens = from_union([from_none, from_int], obj.get("inputTokens"))
+        input_tokens = from_union([from_none, from_float], obj.get("inputTokens"))
         inter_token_latency = from_union([from_none, from_timedelta], obj.get("interTokenLatencyMs"))
-        output_tokens = from_union([from_none, from_int], obj.get("outputTokens"))
+        output_tokens = from_union([from_none, from_float], obj.get("outputTokens"))
         parent_tool_call_id = from_union([from_none, from_str], obj.get("parentToolCallId"))
         provider_call_id = from_union([from_none, from_str], obj.get("providerCallId"))
         quota_snapshots = from_union([from_none, lambda x: from_dict(AssistantUsageQuotaSnapshot.from_dict, x)], obj.get("quotaSnapshots"))
         reasoning_effort = from_union([from_none, from_str], obj.get("reasoningEffort"))
-        reasoning_tokens = from_union([from_none, from_int], obj.get("reasoningTokens"))
+        reasoning_tokens = from_union([from_none, from_float], obj.get("reasoningTokens"))
         ttft = from_union([from_none, from_timedelta], obj.get("ttftMs"))
         return AssistantUsageData(
             model=model,
@@ -745,23 +745,23 @@ class AssistantUsageData:
         if self.api_endpoint is not None:
             result["apiEndpoint"] = from_union([from_none, lambda x: to_enum(AssistantUsageApiEndpoint, x)], self.api_endpoint)
         if self.cache_read_tokens is not None:
-            result["cacheReadTokens"] = from_union([from_none, to_int], self.cache_read_tokens)
+            result["cacheReadTokens"] = from_union([from_none, to_float], self.cache_read_tokens)
         if self.cache_write_tokens is not None:
-            result["cacheWriteTokens"] = from_union([from_none, to_int], self.cache_write_tokens)
+            result["cacheWriteTokens"] = from_union([from_none, to_float], self.cache_write_tokens)
         if self.copilot_usage is not None:
             result["copilotUsage"] = from_union([from_none, lambda x: to_class(AssistantUsageCopilotUsage, x)], self.copilot_usage)
         if self.cost is not None:
             result["cost"] = from_union([from_none, to_float], self.cost)
         if self.duration is not None:
-            result["duration"] = from_union([from_none, to_timedelta_int], self.duration)
+            result["duration"] = from_union([from_none, to_timedelta], self.duration)
         if self.initiator is not None:
             result["initiator"] = from_union([from_none, from_str], self.initiator)
         if self.input_tokens is not None:
-            result["inputTokens"] = from_union([from_none, to_int], self.input_tokens)
+            result["inputTokens"] = from_union([from_none, to_float], self.input_tokens)
         if self.inter_token_latency is not None:
             result["interTokenLatencyMs"] = from_union([from_none, to_timedelta], self.inter_token_latency)
         if self.output_tokens is not None:
-            result["outputTokens"] = from_union([from_none, to_int], self.output_tokens)
+            result["outputTokens"] = from_union([from_none, to_float], self.output_tokens)
         if self.parent_tool_call_id is not None:
             result["parentToolCallId"] = from_union([from_none, from_str], self.parent_tool_call_id)
         if self.provider_call_id is not None:
@@ -771,34 +771,34 @@ class AssistantUsageData:
         if self.reasoning_effort is not None:
             result["reasoningEffort"] = from_union([from_none, from_str], self.reasoning_effort)
         if self.reasoning_tokens is not None:
-            result["reasoningTokens"] = from_union([from_none, to_int], self.reasoning_tokens)
+            result["reasoningTokens"] = from_union([from_none, to_float], self.reasoning_tokens)
         if self.ttft is not None:
-            result["ttftMs"] = from_union([from_none, to_timedelta_int], self.ttft)
+            result["ttftMs"] = from_union([from_none, to_timedelta], self.ttft)
         return result
 
 
 @dataclass
 class AssistantUsageQuotaSnapshot:
     "Schema for the `AssistantUsageQuotaSnapshot` type."
-    entitlement_requests: int
+    entitlement_requests: float
     is_unlimited_entitlement: bool
     overage: float
     overage_allowed_with_exhausted_quota: bool
     remaining_percentage: float
     usage_allowed_with_exhausted_quota: bool
-    used_requests: int
+    used_requests: float
     reset_date: datetime | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "AssistantUsageQuotaSnapshot":
         assert isinstance(obj, dict)
-        entitlement_requests = from_int(obj.get("entitlementRequests"))
+        entitlement_requests = from_float(obj.get("entitlementRequests"))
         is_unlimited_entitlement = from_bool(obj.get("isUnlimitedEntitlement"))
         overage = from_float(obj.get("overage"))
         overage_allowed_with_exhausted_quota = from_bool(obj.get("overageAllowedWithExhaustedQuota"))
         remaining_percentage = from_float(obj.get("remainingPercentage"))
         usage_allowed_with_exhausted_quota = from_bool(obj.get("usageAllowedWithExhaustedQuota"))
-        used_requests = from_int(obj.get("usedRequests"))
+        used_requests = from_float(obj.get("usedRequests"))
         reset_date = from_union([from_none, from_datetime], obj.get("resetDate"))
         return AssistantUsageQuotaSnapshot(
             entitlement_requests=entitlement_requests,
@@ -813,13 +813,13 @@ class AssistantUsageQuotaSnapshot:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["entitlementRequests"] = to_int(self.entitlement_requests)
+        result["entitlementRequests"] = to_float(self.entitlement_requests)
         result["isUnlimitedEntitlement"] = from_bool(self.is_unlimited_entitlement)
         result["overage"] = to_float(self.overage)
         result["overageAllowedWithExhaustedQuota"] = from_bool(self.overage_allowed_with_exhausted_quota)
         result["remainingPercentage"] = to_float(self.remaining_percentage)
         result["usageAllowedWithExhaustedQuota"] = from_bool(self.usage_allowed_with_exhausted_quota)
-        result["usedRequests"] = to_int(self.used_requests)
+        result["usedRequests"] = to_float(self.used_requests)
         if self.reset_date is not None:
             result["resetDate"] = from_union([from_none, to_datetime], self.reset_date)
         return result
@@ -853,14 +853,14 @@ class AutoModeSwitchRequestedData:
     "Auto mode switch request notification requiring user approval"
     request_id: str
     error_code: str | None = None
-    retry_after_seconds: int | None = None
+    retry_after_seconds: float | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "AutoModeSwitchRequestedData":
         assert isinstance(obj, dict)
         request_id = from_str(obj.get("requestId"))
         error_code = from_union([from_none, from_str], obj.get("errorCode"))
-        retry_after_seconds = from_union([from_none, from_int], obj.get("retryAfterSeconds"))
+        retry_after_seconds = from_union([from_none, from_float], obj.get("retryAfterSeconds"))
         return AutoModeSwitchRequestedData(
             request_id=request_id,
             error_code=error_code,
@@ -873,7 +873,7 @@ class AutoModeSwitchRequestedData:
         if self.error_code is not None:
             result["errorCode"] = from_union([from_none, from_str], self.error_code)
         if self.retry_after_seconds is not None:
-            result["retryAfterSeconds"] = from_union([from_none, to_int], self.retry_after_seconds)
+            result["retryAfterSeconds"] = from_union([from_none, to_float], self.retry_after_seconds)
         return result
 
 
@@ -1036,24 +1036,24 @@ class CommandsChangedData:
 @dataclass
 class CompactionCompleteCompactionTokensUsed:
     "Token usage breakdown for the compaction LLM call (aligned with assistant.usage format)"
-    cache_read_tokens: int | None = None
-    cache_write_tokens: int | None = None
+    cache_read_tokens: float | None = None
+    cache_write_tokens: float | None = None
     copilot_usage: CompactionCompleteCompactionTokensUsedCopilotUsage | None = None
     duration: timedelta | None = None
-    input_tokens: int | None = None
+    input_tokens: float | None = None
     model: str | None = None
-    output_tokens: int | None = None
+    output_tokens: float | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "CompactionCompleteCompactionTokensUsed":
         assert isinstance(obj, dict)
-        cache_read_tokens = from_union([from_none, from_int], obj.get("cacheReadTokens"))
-        cache_write_tokens = from_union([from_none, from_int], obj.get("cacheWriteTokens"))
+        cache_read_tokens = from_union([from_none, from_float], obj.get("cacheReadTokens"))
+        cache_write_tokens = from_union([from_none, from_float], obj.get("cacheWriteTokens"))
         copilot_usage = from_union([from_none, CompactionCompleteCompactionTokensUsedCopilotUsage.from_dict], obj.get("copilotUsage"))
         duration = from_union([from_none, from_timedelta], obj.get("duration"))
-        input_tokens = from_union([from_none, from_int], obj.get("inputTokens"))
+        input_tokens = from_union([from_none, from_float], obj.get("inputTokens"))
         model = from_union([from_none, from_str], obj.get("model"))
-        output_tokens = from_union([from_none, from_int], obj.get("outputTokens"))
+        output_tokens = from_union([from_none, from_float], obj.get("outputTokens"))
         return CompactionCompleteCompactionTokensUsed(
             cache_read_tokens=cache_read_tokens,
             cache_write_tokens=cache_write_tokens,
@@ -1067,19 +1067,19 @@ class CompactionCompleteCompactionTokensUsed:
     def to_dict(self) -> dict:
         result: dict = {}
         if self.cache_read_tokens is not None:
-            result["cacheReadTokens"] = from_union([from_none, to_int], self.cache_read_tokens)
+            result["cacheReadTokens"] = from_union([from_none, to_float], self.cache_read_tokens)
         if self.cache_write_tokens is not None:
-            result["cacheWriteTokens"] = from_union([from_none, to_int], self.cache_write_tokens)
+            result["cacheWriteTokens"] = from_union([from_none, to_float], self.cache_write_tokens)
         if self.copilot_usage is not None:
             result["copilotUsage"] = from_union([from_none, lambda x: to_class(CompactionCompleteCompactionTokensUsedCopilotUsage, x)], self.copilot_usage)
         if self.duration is not None:
-            result["duration"] = from_union([from_none, to_timedelta_int], self.duration)
+            result["duration"] = from_union([from_none, to_timedelta], self.duration)
         if self.input_tokens is not None:
-            result["inputTokens"] = from_union([from_none, to_int], self.input_tokens)
+            result["inputTokens"] = from_union([from_none, to_float], self.input_tokens)
         if self.model is not None:
             result["model"] = from_union([from_none, from_str], self.model)
         if self.output_tokens is not None:
-            result["outputTokens"] = from_union([from_none, to_int], self.output_tokens)
+            result["outputTokens"] = from_union([from_none, to_float], self.output_tokens)
         return result
 
 
@@ -1087,13 +1087,13 @@ class CompactionCompleteCompactionTokensUsed:
 class CompactionCompleteCompactionTokensUsedCopilotUsage:
     "Per-request cost and usage data from the CAPI copilot_usage response field"
     token_details: list[CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail]
-    total_nano_aiu: int
+    total_nano_aiu: float
 
     @staticmethod
     def from_dict(obj: Any) -> "CompactionCompleteCompactionTokensUsedCopilotUsage":
         assert isinstance(obj, dict)
         token_details = from_list(CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail.from_dict, obj.get("tokenDetails"))
-        total_nano_aiu = from_int(obj.get("totalNanoAiu"))
+        total_nano_aiu = from_float(obj.get("totalNanoAiu"))
         return CompactionCompleteCompactionTokensUsedCopilotUsage(
             token_details=token_details,
             total_nano_aiu=total_nano_aiu,
@@ -1102,24 +1102,24 @@ class CompactionCompleteCompactionTokensUsedCopilotUsage:
     def to_dict(self) -> dict:
         result: dict = {}
         result["tokenDetails"] = from_list(lambda x: to_class(CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail, x), self.token_details)
-        result["totalNanoAiu"] = to_int(self.total_nano_aiu)
+        result["totalNanoAiu"] = to_float(self.total_nano_aiu)
         return result
 
 
 @dataclass
 class CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail:
     "Token usage detail for a single billing category"
-    batch_size: int
-    cost_per_batch: int
-    token_count: int
+    batch_size: float
+    cost_per_batch: float
+    token_count: float
     token_type: str
 
     @staticmethod
     def from_dict(obj: Any) -> "CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail":
         assert isinstance(obj, dict)
-        batch_size = from_int(obj.get("batchSize"))
-        cost_per_batch = from_int(obj.get("costPerBatch"))
-        token_count = from_int(obj.get("tokenCount"))
+        batch_size = from_float(obj.get("batchSize"))
+        cost_per_batch = from_float(obj.get("costPerBatch"))
+        token_count = from_float(obj.get("tokenCount"))
         token_type = from_str(obj.get("tokenType"))
         return CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail(
             batch_size=batch_size,
@@ -1130,9 +1130,9 @@ class CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["batchSize"] = to_int(self.batch_size)
-        result["costPerBatch"] = to_int(self.cost_per_batch)
-        result["tokenCount"] = to_int(self.token_count)
+        result["batchSize"] = to_float(self.batch_size)
+        result["costPerBatch"] = to_float(self.cost_per_batch)
+        result["tokenCount"] = to_float(self.token_count)
         result["tokenType"] = from_str(self.token_type)
         return result
 
@@ -1786,7 +1786,7 @@ class ModelCallFailureData:
         if self.api_call_id is not None:
             result["apiCallId"] = from_union([from_none, from_str], self.api_call_id)
         if self.duration is not None:
-            result["durationMs"] = from_union([from_none, to_timedelta_int], self.duration)
+            result["durationMs"] = from_union([from_none, to_timedelta], self.duration)
         if self.error_message is not None:
             result["errorMessage"] = from_union([from_none, from_str], self.error_message)
         if self.initiator is not None:
@@ -2402,39 +2402,39 @@ class SessionBackgroundTasksChangedData:
 class SessionCompactionCompleteData:
     "Conversation compaction results including success status, metrics, and optional error details"
     success: bool
-    checkpoint_number: int | None = None
+    checkpoint_number: float | None = None
     checkpoint_path: str | None = None
     compaction_tokens_used: CompactionCompleteCompactionTokensUsed | None = None
-    conversation_tokens: int | None = None
+    conversation_tokens: float | None = None
     error: str | None = None
-    messages_removed: int | None = None
-    post_compaction_tokens: int | None = None
-    pre_compaction_messages_length: int | None = None
-    pre_compaction_tokens: int | None = None
+    messages_removed: float | None = None
+    post_compaction_tokens: float | None = None
+    pre_compaction_messages_length: float | None = None
+    pre_compaction_tokens: float | None = None
     request_id: str | None = None
     summary_content: str | None = None
-    system_tokens: int | None = None
-    tokens_removed: int | None = None
-    tool_definitions_tokens: int | None = None
+    system_tokens: float | None = None
+    tokens_removed: float | None = None
+    tool_definitions_tokens: float | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "SessionCompactionCompleteData":
         assert isinstance(obj, dict)
         success = from_bool(obj.get("success"))
-        checkpoint_number = from_union([from_none, from_int], obj.get("checkpointNumber"))
+        checkpoint_number = from_union([from_none, from_float], obj.get("checkpointNumber"))
         checkpoint_path = from_union([from_none, from_str], obj.get("checkpointPath"))
         compaction_tokens_used = from_union([from_none, CompactionCompleteCompactionTokensUsed.from_dict], obj.get("compactionTokensUsed"))
-        conversation_tokens = from_union([from_none, from_int], obj.get("conversationTokens"))
+        conversation_tokens = from_union([from_none, from_float], obj.get("conversationTokens"))
         error = from_union([from_none, from_str], obj.get("error"))
-        messages_removed = from_union([from_none, from_int], obj.get("messagesRemoved"))
-        post_compaction_tokens = from_union([from_none, from_int], obj.get("postCompactionTokens"))
-        pre_compaction_messages_length = from_union([from_none, from_int], obj.get("preCompactionMessagesLength"))
-        pre_compaction_tokens = from_union([from_none, from_int], obj.get("preCompactionTokens"))
+        messages_removed = from_union([from_none, from_float], obj.get("messagesRemoved"))
+        post_compaction_tokens = from_union([from_none, from_float], obj.get("postCompactionTokens"))
+        pre_compaction_messages_length = from_union([from_none, from_float], obj.get("preCompactionMessagesLength"))
+        pre_compaction_tokens = from_union([from_none, from_float], obj.get("preCompactionTokens"))
         request_id = from_union([from_none, from_str], obj.get("requestId"))
         summary_content = from_union([from_none, from_str], obj.get("summaryContent"))
-        system_tokens = from_union([from_none, from_int], obj.get("systemTokens"))
-        tokens_removed = from_union([from_none, from_int], obj.get("tokensRemoved"))
-        tool_definitions_tokens = from_union([from_none, from_int], obj.get("toolDefinitionsTokens"))
+        system_tokens = from_union([from_none, from_float], obj.get("systemTokens"))
+        tokens_removed = from_union([from_none, from_float], obj.get("tokensRemoved"))
+        tool_definitions_tokens = from_union([from_none, from_float], obj.get("toolDefinitionsTokens"))
         return SessionCompactionCompleteData(
             success=success,
             checkpoint_number=checkpoint_number,
@@ -2457,49 +2457,49 @@ class SessionCompactionCompleteData:
         result: dict = {}
         result["success"] = from_bool(self.success)
         if self.checkpoint_number is not None:
-            result["checkpointNumber"] = from_union([from_none, to_int], self.checkpoint_number)
+            result["checkpointNumber"] = from_union([from_none, to_float], self.checkpoint_number)
         if self.checkpoint_path is not None:
             result["checkpointPath"] = from_union([from_none, from_str], self.checkpoint_path)
         if self.compaction_tokens_used is not None:
             result["compactionTokensUsed"] = from_union([from_none, lambda x: to_class(CompactionCompleteCompactionTokensUsed, x)], self.compaction_tokens_used)
         if self.conversation_tokens is not None:
-            result["conversationTokens"] = from_union([from_none, to_int], self.conversation_tokens)
+            result["conversationTokens"] = from_union([from_none, to_float], self.conversation_tokens)
         if self.error is not None:
             result["error"] = from_union([from_none, from_str], self.error)
         if self.messages_removed is not None:
-            result["messagesRemoved"] = from_union([from_none, to_int], self.messages_removed)
+            result["messagesRemoved"] = from_union([from_none, to_float], self.messages_removed)
         if self.post_compaction_tokens is not None:
-            result["postCompactionTokens"] = from_union([from_none, to_int], self.post_compaction_tokens)
+            result["postCompactionTokens"] = from_union([from_none, to_float], self.post_compaction_tokens)
         if self.pre_compaction_messages_length is not None:
-            result["preCompactionMessagesLength"] = from_union([from_none, to_int], self.pre_compaction_messages_length)
+            result["preCompactionMessagesLength"] = from_union([from_none, to_float], self.pre_compaction_messages_length)
         if self.pre_compaction_tokens is not None:
-            result["preCompactionTokens"] = from_union([from_none, to_int], self.pre_compaction_tokens)
+            result["preCompactionTokens"] = from_union([from_none, to_float], self.pre_compaction_tokens)
         if self.request_id is not None:
             result["requestId"] = from_union([from_none, from_str], self.request_id)
         if self.summary_content is not None:
             result["summaryContent"] = from_union([from_none, from_str], self.summary_content)
         if self.system_tokens is not None:
-            result["systemTokens"] = from_union([from_none, to_int], self.system_tokens)
+            result["systemTokens"] = from_union([from_none, to_float], self.system_tokens)
         if self.tokens_removed is not None:
-            result["tokensRemoved"] = from_union([from_none, to_int], self.tokens_removed)
+            result["tokensRemoved"] = from_union([from_none, to_float], self.tokens_removed)
         if self.tool_definitions_tokens is not None:
-            result["toolDefinitionsTokens"] = from_union([from_none, to_int], self.tool_definitions_tokens)
+            result["toolDefinitionsTokens"] = from_union([from_none, to_float], self.tool_definitions_tokens)
         return result
 
 
 @dataclass
 class SessionCompactionStartData:
     "Context window breakdown at the start of LLM-powered conversation compaction"
-    conversation_tokens: int | None = None
-    system_tokens: int | None = None
-    tool_definitions_tokens: int | None = None
+    conversation_tokens: float | None = None
+    system_tokens: float | None = None
+    tool_definitions_tokens: float | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "SessionCompactionStartData":
         assert isinstance(obj, dict)
-        conversation_tokens = from_union([from_none, from_int], obj.get("conversationTokens"))
-        system_tokens = from_union([from_none, from_int], obj.get("systemTokens"))
-        tool_definitions_tokens = from_union([from_none, from_int], obj.get("toolDefinitionsTokens"))
+        conversation_tokens = from_union([from_none, from_float], obj.get("conversationTokens"))
+        system_tokens = from_union([from_none, from_float], obj.get("systemTokens"))
+        tool_definitions_tokens = from_union([from_none, from_float], obj.get("toolDefinitionsTokens"))
         return SessionCompactionStartData(
             conversation_tokens=conversation_tokens,
             system_tokens=system_tokens,
@@ -2509,11 +2509,11 @@ class SessionCompactionStartData:
     def to_dict(self) -> dict:
         result: dict = {}
         if self.conversation_tokens is not None:
-            result["conversationTokens"] = from_union([from_none, to_int], self.conversation_tokens)
+            result["conversationTokens"] = from_union([from_none, to_float], self.conversation_tokens)
         if self.system_tokens is not None:
-            result["systemTokens"] = from_union([from_none, to_int], self.system_tokens)
+            result["systemTokens"] = from_union([from_none, to_float], self.system_tokens)
         if self.tool_definitions_tokens is not None:
-            result["toolDefinitionsTokens"] = from_union([from_none, to_int], self.tool_definitions_tokens)
+            result["toolDefinitionsTokens"] = from_union([from_none, to_float], self.tool_definitions_tokens)
         return result
 
 
@@ -2963,7 +2963,7 @@ class SessionRemoteSteerableChangedData:
 @dataclass
 class SessionResumeData:
     "Session resume metadata including current context and event count"
-    event_count: int
+    event_count: float
     resume_time: datetime
     already_in_use: bool | None = None
     context: WorkingDirectoryContext | None = None
@@ -2977,7 +2977,7 @@ class SessionResumeData:
     @staticmethod
     def from_dict(obj: Any) -> "SessionResumeData":
         assert isinstance(obj, dict)
-        event_count = from_int(obj.get("eventCount"))
+        event_count = from_float(obj.get("eventCount"))
         resume_time = from_datetime(obj.get("resumeTime"))
         already_in_use = from_union([from_none, from_bool], obj.get("alreadyInUse"))
         context = from_union([from_none, WorkingDirectoryContext.from_dict], obj.get("context"))
@@ -3002,7 +3002,7 @@ class SessionResumeData:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["eventCount"] = to_int(self.event_count)
+        result["eventCount"] = to_float(self.event_count)
         result["resumeTime"] = to_datetime(self.resume_time)
         if self.already_in_use is not None:
             result["alreadyInUse"] = from_union([from_none, from_bool], self.already_in_use)
@@ -3084,36 +3084,36 @@ class SessionShutdownData:
     "Session termination metrics including usage statistics, code changes, and shutdown reason"
     code_changes: ShutdownCodeChanges
     model_metrics: dict[str, ShutdownModelMetric]
-    session_start_time: int
+    session_start_time: float
     shutdown_type: ShutdownType
     total_api_duration: timedelta
-    total_premium_requests: int
-    conversation_tokens: int | None = None
+    total_premium_requests: float
+    conversation_tokens: float | None = None
     current_model: str | None = None
-    current_tokens: int | None = None
+    current_tokens: float | None = None
     error_reason: str | None = None
-    system_tokens: int | None = None
+    system_tokens: float | None = None
     token_details: dict[str, ShutdownTokenDetail] | None = None
-    tool_definitions_tokens: int | None = None
-    total_nano_aiu: int | None = None
+    tool_definitions_tokens: float | None = None
+    total_nano_aiu: float | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "SessionShutdownData":
         assert isinstance(obj, dict)
         code_changes = ShutdownCodeChanges.from_dict(obj.get("codeChanges"))
         model_metrics = from_dict(ShutdownModelMetric.from_dict, obj.get("modelMetrics"))
-        session_start_time = from_int(obj.get("sessionStartTime"))
+        session_start_time = from_float(obj.get("sessionStartTime"))
         shutdown_type = parse_enum(ShutdownType, obj.get("shutdownType"))
         total_api_duration = from_timedelta(obj.get("totalApiDurationMs"))
-        total_premium_requests = from_int(obj.get("totalPremiumRequests"))
-        conversation_tokens = from_union([from_none, from_int], obj.get("conversationTokens"))
+        total_premium_requests = from_float(obj.get("totalPremiumRequests"))
+        conversation_tokens = from_union([from_none, from_float], obj.get("conversationTokens"))
         current_model = from_union([from_none, from_str], obj.get("currentModel"))
-        current_tokens = from_union([from_none, from_int], obj.get("currentTokens"))
+        current_tokens = from_union([from_none, from_float], obj.get("currentTokens"))
         error_reason = from_union([from_none, from_str], obj.get("errorReason"))
-        system_tokens = from_union([from_none, from_int], obj.get("systemTokens"))
+        system_tokens = from_union([from_none, from_float], obj.get("systemTokens"))
         token_details = from_union([from_none, lambda x: from_dict(ShutdownTokenDetail.from_dict, x)], obj.get("tokenDetails"))
-        tool_definitions_tokens = from_union([from_none, from_int], obj.get("toolDefinitionsTokens"))
-        total_nano_aiu = from_union([from_none, from_int], obj.get("totalNanoAiu"))
+        tool_definitions_tokens = from_union([from_none, from_float], obj.get("toolDefinitionsTokens"))
+        total_nano_aiu = from_union([from_none, from_float], obj.get("totalNanoAiu"))
         return SessionShutdownData(
             code_changes=code_changes,
             model_metrics=model_metrics,
@@ -3135,26 +3135,26 @@ class SessionShutdownData:
         result: dict = {}
         result["codeChanges"] = to_class(ShutdownCodeChanges, self.code_changes)
         result["modelMetrics"] = from_dict(lambda x: to_class(ShutdownModelMetric, x), self.model_metrics)
-        result["sessionStartTime"] = to_int(self.session_start_time)
+        result["sessionStartTime"] = to_float(self.session_start_time)
         result["shutdownType"] = to_enum(ShutdownType, self.shutdown_type)
-        result["totalApiDurationMs"] = to_timedelta_int(self.total_api_duration)
-        result["totalPremiumRequests"] = to_int(self.total_premium_requests)
+        result["totalApiDurationMs"] = to_timedelta(self.total_api_duration)
+        result["totalPremiumRequests"] = to_float(self.total_premium_requests)
         if self.conversation_tokens is not None:
-            result["conversationTokens"] = from_union([from_none, to_int], self.conversation_tokens)
+            result["conversationTokens"] = from_union([from_none, to_float], self.conversation_tokens)
         if self.current_model is not None:
             result["currentModel"] = from_union([from_none, from_str], self.current_model)
         if self.current_tokens is not None:
-            result["currentTokens"] = from_union([from_none, to_int], self.current_tokens)
+            result["currentTokens"] = from_union([from_none, to_float], self.current_tokens)
         if self.error_reason is not None:
             result["errorReason"] = from_union([from_none, from_str], self.error_reason)
         if self.system_tokens is not None:
-            result["systemTokens"] = from_union([from_none, to_int], self.system_tokens)
+            result["systemTokens"] = from_union([from_none, to_float], self.system_tokens)
         if self.token_details is not None:
             result["tokenDetails"] = from_union([from_none, lambda x: from_dict(lambda x: to_class(ShutdownTokenDetail, x), x)], self.token_details)
         if self.tool_definitions_tokens is not None:
-            result["toolDefinitionsTokens"] = from_union([from_none, to_int], self.tool_definitions_tokens)
+            result["toolDefinitionsTokens"] = from_union([from_none, to_float], self.tool_definitions_tokens)
         if self.total_nano_aiu is not None:
-            result["totalNanoAiu"] = from_union([from_none, to_int], self.total_nano_aiu)
+            result["totalNanoAiu"] = from_union([from_none, to_float], self.total_nano_aiu)
         return result
 
 
@@ -3180,13 +3180,13 @@ class SessionSkillsLoadedData:
 @dataclass
 class SessionSnapshotRewindData:
     "Session rewind details including target event and count of removed events"
-    events_removed: int
+    events_removed: float
     up_to_event_id: str
 
     @staticmethod
     def from_dict(obj: Any) -> "SessionSnapshotRewindData":
         assert isinstance(obj, dict)
-        events_removed = from_int(obj.get("eventsRemoved"))
+        events_removed = from_float(obj.get("eventsRemoved"))
         up_to_event_id = from_str(obj.get("upToEventId"))
         return SessionSnapshotRewindData(
             events_removed=events_removed,
@@ -3195,7 +3195,7 @@ class SessionSnapshotRewindData:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["eventsRemoved"] = to_int(self.events_removed)
+        result["eventsRemoved"] = to_float(self.events_removed)
         result["upToEventId"] = from_str(self.up_to_event_id)
         return result
 
@@ -3207,7 +3207,7 @@ class SessionStartData:
     producer: str
     session_id: str
     start_time: datetime
-    version: int
+    version: float
     already_in_use: bool | None = None
     context: WorkingDirectoryContext | None = None
     detached_from_spawning_parent_session_id: str | None = None
@@ -3223,7 +3223,7 @@ class SessionStartData:
         producer = from_str(obj.get("producer"))
         session_id = from_str(obj.get("sessionId"))
         start_time = from_datetime(obj.get("startTime"))
-        version = from_int(obj.get("version"))
+        version = from_float(obj.get("version"))
         already_in_use = from_union([from_none, from_bool], obj.get("alreadyInUse"))
         context = from_union([from_none, WorkingDirectoryContext.from_dict], obj.get("context"))
         detached_from_spawning_parent_session_id = from_union([from_none, from_str], obj.get("detachedFromSpawningParentSessionId"))
@@ -3252,7 +3252,7 @@ class SessionStartData:
         result["producer"] = from_str(self.producer)
         result["sessionId"] = from_str(self.session_id)
         result["startTime"] = to_datetime(self.start_time)
-        result["version"] = to_int(self.version)
+        result["version"] = to_float(self.version)
         if self.already_in_use is not None:
             result["alreadyInUse"] = from_union([from_none, from_bool], self.already_in_use)
         if self.context is not None:
@@ -3336,26 +3336,26 @@ class SessionToolsUpdatedData:
 @dataclass
 class SessionTruncationData:
     "Conversation truncation statistics including token counts and removed content metrics"
-    messages_removed_during_truncation: int
+    messages_removed_during_truncation: float
     performed_by: str
-    post_truncation_messages_length: int
-    post_truncation_tokens_in_messages: int
-    pre_truncation_messages_length: int
-    pre_truncation_tokens_in_messages: int
-    token_limit: int
-    tokens_removed_during_truncation: int
+    post_truncation_messages_length: float
+    post_truncation_tokens_in_messages: float
+    pre_truncation_messages_length: float
+    pre_truncation_tokens_in_messages: float
+    token_limit: float
+    tokens_removed_during_truncation: float
 
     @staticmethod
     def from_dict(obj: Any) -> "SessionTruncationData":
         assert isinstance(obj, dict)
-        messages_removed_during_truncation = from_int(obj.get("messagesRemovedDuringTruncation"))
+        messages_removed_during_truncation = from_float(obj.get("messagesRemovedDuringTruncation"))
         performed_by = from_str(obj.get("performedBy"))
-        post_truncation_messages_length = from_int(obj.get("postTruncationMessagesLength"))
-        post_truncation_tokens_in_messages = from_int(obj.get("postTruncationTokensInMessages"))
-        pre_truncation_messages_length = from_int(obj.get("preTruncationMessagesLength"))
-        pre_truncation_tokens_in_messages = from_int(obj.get("preTruncationTokensInMessages"))
-        token_limit = from_int(obj.get("tokenLimit"))
-        tokens_removed_during_truncation = from_int(obj.get("tokensRemovedDuringTruncation"))
+        post_truncation_messages_length = from_float(obj.get("postTruncationMessagesLength"))
+        post_truncation_tokens_in_messages = from_float(obj.get("postTruncationTokensInMessages"))
+        pre_truncation_messages_length = from_float(obj.get("preTruncationMessagesLength"))
+        pre_truncation_tokens_in_messages = from_float(obj.get("preTruncationTokensInMessages"))
+        token_limit = from_float(obj.get("tokenLimit"))
+        tokens_removed_during_truncation = from_float(obj.get("tokensRemovedDuringTruncation"))
         return SessionTruncationData(
             messages_removed_during_truncation=messages_removed_during_truncation,
             performed_by=performed_by,
@@ -3369,38 +3369,38 @@ class SessionTruncationData:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["messagesRemovedDuringTruncation"] = to_int(self.messages_removed_during_truncation)
+        result["messagesRemovedDuringTruncation"] = to_float(self.messages_removed_during_truncation)
         result["performedBy"] = from_str(self.performed_by)
-        result["postTruncationMessagesLength"] = to_int(self.post_truncation_messages_length)
-        result["postTruncationTokensInMessages"] = to_int(self.post_truncation_tokens_in_messages)
-        result["preTruncationMessagesLength"] = to_int(self.pre_truncation_messages_length)
-        result["preTruncationTokensInMessages"] = to_int(self.pre_truncation_tokens_in_messages)
-        result["tokenLimit"] = to_int(self.token_limit)
-        result["tokensRemovedDuringTruncation"] = to_int(self.tokens_removed_during_truncation)
+        result["postTruncationMessagesLength"] = to_float(self.post_truncation_messages_length)
+        result["postTruncationTokensInMessages"] = to_float(self.post_truncation_tokens_in_messages)
+        result["preTruncationMessagesLength"] = to_float(self.pre_truncation_messages_length)
+        result["preTruncationTokensInMessages"] = to_float(self.pre_truncation_tokens_in_messages)
+        result["tokenLimit"] = to_float(self.token_limit)
+        result["tokensRemovedDuringTruncation"] = to_float(self.tokens_removed_during_truncation)
         return result
 
 
 @dataclass
 class SessionUsageInfoData:
     "Current context window usage statistics including token and message counts"
-    current_tokens: int
-    messages_length: int
-    token_limit: int
-    conversation_tokens: int | None = None
+    current_tokens: float
+    messages_length: float
+    token_limit: float
+    conversation_tokens: float | None = None
     is_initial: bool | None = None
-    system_tokens: int | None = None
-    tool_definitions_tokens: int | None = None
+    system_tokens: float | None = None
+    tool_definitions_tokens: float | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "SessionUsageInfoData":
         assert isinstance(obj, dict)
-        current_tokens = from_int(obj.get("currentTokens"))
-        messages_length = from_int(obj.get("messagesLength"))
-        token_limit = from_int(obj.get("tokenLimit"))
-        conversation_tokens = from_union([from_none, from_int], obj.get("conversationTokens"))
+        current_tokens = from_float(obj.get("currentTokens"))
+        messages_length = from_float(obj.get("messagesLength"))
+        token_limit = from_float(obj.get("tokenLimit"))
+        conversation_tokens = from_union([from_none, from_float], obj.get("conversationTokens"))
         is_initial = from_union([from_none, from_bool], obj.get("isInitial"))
-        system_tokens = from_union([from_none, from_int], obj.get("systemTokens"))
-        tool_definitions_tokens = from_union([from_none, from_int], obj.get("toolDefinitionsTokens"))
+        system_tokens = from_union([from_none, from_float], obj.get("systemTokens"))
+        tool_definitions_tokens = from_union([from_none, from_float], obj.get("toolDefinitionsTokens"))
         return SessionUsageInfoData(
             current_tokens=current_tokens,
             messages_length=messages_length,
@@ -3413,17 +3413,17 @@ class SessionUsageInfoData:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["currentTokens"] = to_int(self.current_tokens)
-        result["messagesLength"] = to_int(self.messages_length)
-        result["tokenLimit"] = to_int(self.token_limit)
+        result["currentTokens"] = to_float(self.current_tokens)
+        result["messagesLength"] = to_float(self.messages_length)
+        result["tokenLimit"] = to_float(self.token_limit)
         if self.conversation_tokens is not None:
-            result["conversationTokens"] = from_union([from_none, to_int], self.conversation_tokens)
+            result["conversationTokens"] = from_union([from_none, to_float], self.conversation_tokens)
         if self.is_initial is not None:
             result["isInitial"] = from_union([from_none, from_bool], self.is_initial)
         if self.system_tokens is not None:
-            result["systemTokens"] = from_union([from_none, to_int], self.system_tokens)
+            result["systemTokens"] = from_union([from_none, to_float], self.system_tokens)
         if self.tool_definitions_tokens is not None:
-            result["toolDefinitionsTokens"] = from_union([from_none, to_int], self.tool_definitions_tokens)
+            result["toolDefinitionsTokens"] = from_union([from_none, to_float], self.tool_definitions_tokens)
         return result
 
 
@@ -3482,15 +3482,15 @@ class SessionWorkspaceFileChangedData:
 class ShutdownCodeChanges:
     "Aggregate code change metrics for the session"
     files_modified: list[str]
-    lines_added: int
-    lines_removed: int
+    lines_added: float
+    lines_removed: float
 
     @staticmethod
     def from_dict(obj: Any) -> "ShutdownCodeChanges":
         assert isinstance(obj, dict)
         files_modified = from_list(from_str, obj.get("filesModified"))
-        lines_added = from_int(obj.get("linesAdded"))
-        lines_removed = from_int(obj.get("linesRemoved"))
+        lines_added = from_float(obj.get("linesAdded"))
+        lines_removed = from_float(obj.get("linesRemoved"))
         return ShutdownCodeChanges(
             files_modified=files_modified,
             lines_added=lines_added,
@@ -3500,8 +3500,8 @@ class ShutdownCodeChanges:
     def to_dict(self) -> dict:
         result: dict = {}
         result["filesModified"] = from_list(from_str, self.files_modified)
-        result["linesAdded"] = to_int(self.lines_added)
-        result["linesRemoved"] = to_int(self.lines_removed)
+        result["linesAdded"] = to_float(self.lines_added)
+        result["linesRemoved"] = to_float(self.lines_removed)
         return result
 
 
@@ -3511,7 +3511,7 @@ class ShutdownModelMetric:
     requests: ShutdownModelMetricRequests
     usage: ShutdownModelMetricUsage
     token_details: dict[str, ShutdownModelMetricTokenDetail] | None = None
-    total_nano_aiu: int | None = None
+    total_nano_aiu: float | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "ShutdownModelMetric":
@@ -3519,7 +3519,7 @@ class ShutdownModelMetric:
         requests = ShutdownModelMetricRequests.from_dict(obj.get("requests"))
         usage = ShutdownModelMetricUsage.from_dict(obj.get("usage"))
         token_details = from_union([from_none, lambda x: from_dict(ShutdownModelMetricTokenDetail.from_dict, x)], obj.get("tokenDetails"))
-        total_nano_aiu = from_union([from_none, from_int], obj.get("totalNanoAiu"))
+        total_nano_aiu = from_union([from_none, from_float], obj.get("totalNanoAiu"))
         return ShutdownModelMetric(
             requests=requests,
             usage=usage,
@@ -3534,7 +3534,7 @@ class ShutdownModelMetric:
         if self.token_details is not None:
             result["tokenDetails"] = from_union([from_none, lambda x: from_dict(lambda x: to_class(ShutdownModelMetricTokenDetail, x), x)], self.token_details)
         if self.total_nano_aiu is not None:
-            result["totalNanoAiu"] = from_union([from_none, to_int], self.total_nano_aiu)
+            result["totalNanoAiu"] = from_union([from_none, to_float], self.total_nano_aiu)
         return result
 
 
@@ -3542,13 +3542,13 @@ class ShutdownModelMetric:
 class ShutdownModelMetricRequests:
     "Request count and cost metrics"
     cost: float
-    count: int
+    count: float
 
     @staticmethod
     def from_dict(obj: Any) -> "ShutdownModelMetricRequests":
         assert isinstance(obj, dict)
         cost = from_float(obj.get("cost"))
-        count = from_int(obj.get("count"))
+        count = from_float(obj.get("count"))
         return ShutdownModelMetricRequests(
             cost=cost,
             count=count,
@@ -3557,46 +3557,46 @@ class ShutdownModelMetricRequests:
     def to_dict(self) -> dict:
         result: dict = {}
         result["cost"] = to_float(self.cost)
-        result["count"] = to_int(self.count)
+        result["count"] = to_float(self.count)
         return result
 
 
 @dataclass
 class ShutdownModelMetricTokenDetail:
     "Schema for the `ShutdownModelMetricTokenDetail` type."
-    token_count: int
+    token_count: float
 
     @staticmethod
     def from_dict(obj: Any) -> "ShutdownModelMetricTokenDetail":
         assert isinstance(obj, dict)
-        token_count = from_int(obj.get("tokenCount"))
+        token_count = from_float(obj.get("tokenCount"))
         return ShutdownModelMetricTokenDetail(
             token_count=token_count,
         )
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["tokenCount"] = to_int(self.token_count)
+        result["tokenCount"] = to_float(self.token_count)
         return result
 
 
 @dataclass
 class ShutdownModelMetricUsage:
     "Token usage breakdown"
-    cache_read_tokens: int
-    cache_write_tokens: int
-    input_tokens: int
-    output_tokens: int
-    reasoning_tokens: int | None = None
+    cache_read_tokens: float
+    cache_write_tokens: float
+    input_tokens: float
+    output_tokens: float
+    reasoning_tokens: float | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "ShutdownModelMetricUsage":
         assert isinstance(obj, dict)
-        cache_read_tokens = from_int(obj.get("cacheReadTokens"))
-        cache_write_tokens = from_int(obj.get("cacheWriteTokens"))
-        input_tokens = from_int(obj.get("inputTokens"))
-        output_tokens = from_int(obj.get("outputTokens"))
-        reasoning_tokens = from_union([from_none, from_int], obj.get("reasoningTokens"))
+        cache_read_tokens = from_float(obj.get("cacheReadTokens"))
+        cache_write_tokens = from_float(obj.get("cacheWriteTokens"))
+        input_tokens = from_float(obj.get("inputTokens"))
+        output_tokens = from_float(obj.get("outputTokens"))
+        reasoning_tokens = from_union([from_none, from_float], obj.get("reasoningTokens"))
         return ShutdownModelMetricUsage(
             cache_read_tokens=cache_read_tokens,
             cache_write_tokens=cache_write_tokens,
@@ -3607,31 +3607,31 @@ class ShutdownModelMetricUsage:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["cacheReadTokens"] = to_int(self.cache_read_tokens)
-        result["cacheWriteTokens"] = to_int(self.cache_write_tokens)
-        result["inputTokens"] = to_int(self.input_tokens)
-        result["outputTokens"] = to_int(self.output_tokens)
+        result["cacheReadTokens"] = to_float(self.cache_read_tokens)
+        result["cacheWriteTokens"] = to_float(self.cache_write_tokens)
+        result["inputTokens"] = to_float(self.input_tokens)
+        result["outputTokens"] = to_float(self.output_tokens)
         if self.reasoning_tokens is not None:
-            result["reasoningTokens"] = from_union([from_none, to_int], self.reasoning_tokens)
+            result["reasoningTokens"] = from_union([from_none, to_float], self.reasoning_tokens)
         return result
 
 
 @dataclass
 class ShutdownTokenDetail:
     "Schema for the `ShutdownTokenDetail` type."
-    token_count: int
+    token_count: float
 
     @staticmethod
     def from_dict(obj: Any) -> "ShutdownTokenDetail":
         assert isinstance(obj, dict)
-        token_count = from_int(obj.get("tokenCount"))
+        token_count = from_float(obj.get("tokenCount"))
         return ShutdownTokenDetail(
             token_count=token_count,
         )
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["tokenCount"] = to_int(self.token_count)
+        result["tokenCount"] = to_float(self.token_count)
         return result
 
 
@@ -3730,8 +3730,8 @@ class SubagentCompletedData:
     tool_call_id: str
     duration: timedelta | None = None
     model: str | None = None
-    total_tokens: int | None = None
-    total_tool_calls: int | None = None
+    total_tokens: float | None = None
+    total_tool_calls: float | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "SubagentCompletedData":
@@ -3741,8 +3741,8 @@ class SubagentCompletedData:
         tool_call_id = from_str(obj.get("toolCallId"))
         duration = from_union([from_none, from_timedelta], obj.get("durationMs"))
         model = from_union([from_none, from_str], obj.get("model"))
-        total_tokens = from_union([from_none, from_int], obj.get("totalTokens"))
-        total_tool_calls = from_union([from_none, from_int], obj.get("totalToolCalls"))
+        total_tokens = from_union([from_none, from_float], obj.get("totalTokens"))
+        total_tool_calls = from_union([from_none, from_float], obj.get("totalToolCalls"))
         return SubagentCompletedData(
             agent_display_name=agent_display_name,
             agent_name=agent_name,
@@ -3759,13 +3759,13 @@ class SubagentCompletedData:
         result["agentName"] = from_str(self.agent_name)
         result["toolCallId"] = from_str(self.tool_call_id)
         if self.duration is not None:
-            result["durationMs"] = from_union([from_none, to_timedelta_int], self.duration)
+            result["durationMs"] = from_union([from_none, to_timedelta], self.duration)
         if self.model is not None:
             result["model"] = from_union([from_none, from_str], self.model)
         if self.total_tokens is not None:
-            result["totalTokens"] = from_union([from_none, to_int], self.total_tokens)
+            result["totalTokens"] = from_union([from_none, to_float], self.total_tokens)
         if self.total_tool_calls is not None:
-            result["totalToolCalls"] = from_union([from_none, to_int], self.total_tool_calls)
+            result["totalToolCalls"] = from_union([from_none, to_float], self.total_tool_calls)
         return result
 
 
@@ -3790,8 +3790,8 @@ class SubagentFailedData:
     tool_call_id: str
     duration: timedelta | None = None
     model: str | None = None
-    total_tokens: int | None = None
-    total_tool_calls: int | None = None
+    total_tokens: float | None = None
+    total_tool_calls: float | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "SubagentFailedData":
@@ -3802,8 +3802,8 @@ class SubagentFailedData:
         tool_call_id = from_str(obj.get("toolCallId"))
         duration = from_union([from_none, from_timedelta], obj.get("durationMs"))
         model = from_union([from_none, from_str], obj.get("model"))
-        total_tokens = from_union([from_none, from_int], obj.get("totalTokens"))
-        total_tool_calls = from_union([from_none, from_int], obj.get("totalToolCalls"))
+        total_tokens = from_union([from_none, from_float], obj.get("totalTokens"))
+        total_tool_calls = from_union([from_none, from_float], obj.get("totalToolCalls"))
         return SubagentFailedData(
             agent_display_name=agent_display_name,
             agent_name=agent_name,
@@ -3822,13 +3822,13 @@ class SubagentFailedData:
         result["error"] = from_str(self.error)
         result["toolCallId"] = from_str(self.tool_call_id)
         if self.duration is not None:
-            result["durationMs"] = from_union([from_none, to_timedelta_int], self.duration)
+            result["durationMs"] = from_union([from_none, to_timedelta], self.duration)
         if self.model is not None:
             result["model"] = from_union([from_none, from_str], self.model)
         if self.total_tokens is not None:
-            result["totalTokens"] = from_union([from_none, to_int], self.total_tokens)
+            result["totalTokens"] = from_union([from_none, to_float], self.total_tokens)
         if self.total_tool_calls is not None:
-            result["totalToolCalls"] = from_union([from_none, to_int], self.total_tool_calls)
+            result["totalToolCalls"] = from_union([from_none, to_float], self.total_tool_calls)
         return result
 
 
@@ -3961,7 +3961,7 @@ class SystemNotification:
     agent_type: str | None = None
     description: str | None = None
     entry_id: str | None = None
-    exit_code: int | None = None
+    exit_code: float | None = None
     prompt: str | None = None
     sender_name: str | None = None
     sender_type: str | None = None
@@ -3980,7 +3980,7 @@ class SystemNotification:
         agent_type = from_union([from_none, from_str], obj.get("agentType"))
         description = from_union([from_none, from_str], obj.get("description"))
         entry_id = from_union([from_none, from_str], obj.get("entryId"))
-        exit_code = from_union([from_none, from_int], obj.get("exitCode"))
+        exit_code = from_union([from_none, from_float], obj.get("exitCode"))
         prompt = from_union([from_none, from_str], obj.get("prompt"))
         sender_name = from_union([from_none, from_str], obj.get("senderName"))
         sender_type = from_union([from_none, from_str], obj.get("senderType"))
@@ -4020,7 +4020,7 @@ class SystemNotification:
         if self.entry_id is not None:
             result["entryId"] = from_union([from_none, from_str], self.entry_id)
         if self.exit_code is not None:
-            result["exitCode"] = from_union([from_none, to_int], self.exit_code)
+            result["exitCode"] = from_union([from_none, to_float], self.exit_code)
         if self.prompt is not None:
             result["prompt"] = from_union([from_none, from_str], self.prompt)
         if self.sender_name is not None:
@@ -4072,12 +4072,12 @@ class ToolExecutionCompleteContent:
     cwd: str | None = None
     data: str | None = None
     description: str | None = None
-    exit_code: int | None = None
+    exit_code: float | None = None
     icons: list[ToolExecutionCompleteContentResourceLinkIcon] | None = None
     mime_type: str | None = None
     name: str | None = None
     resource: ToolExecutionCompleteContentResourceDetails | None = None
-    size: int | None = None
+    size: float | None = None
     text: str | None = None
     title: str | None = None
     uri: str | None = None
@@ -4089,12 +4089,12 @@ class ToolExecutionCompleteContent:
         cwd = from_union([from_none, from_str], obj.get("cwd"))
         data = from_union([from_none, from_str], obj.get("data"))
         description = from_union([from_none, from_str], obj.get("description"))
-        exit_code = from_union([from_none, from_int], obj.get("exitCode"))
+        exit_code = from_union([from_none, from_float], obj.get("exitCode"))
         icons = from_union([from_none, lambda x: from_list(ToolExecutionCompleteContentResourceLinkIcon.from_dict, x)], obj.get("icons"))
         mime_type = from_union([from_none, from_str], obj.get("mimeType"))
         name = from_union([from_none, from_str], obj.get("name"))
         resource = from_union([from_none, lambda x: from_union([EmbeddedTextResourceContents.from_dict, EmbeddedBlobResourceContents.from_dict], x)], obj.get("resource"))
-        size = from_union([from_none, from_int], obj.get("size"))
+        size = from_union([from_none, from_float], obj.get("size"))
         text = from_union([from_none, from_str], obj.get("text"))
         title = from_union([from_none, from_str], obj.get("title"))
         uri = from_union([from_none, from_str], obj.get("uri"))
@@ -4124,7 +4124,7 @@ class ToolExecutionCompleteContent:
         if self.description is not None:
             result["description"] = from_union([from_none, from_str], self.description)
         if self.exit_code is not None:
-            result["exitCode"] = from_union([from_none, to_int], self.exit_code)
+            result["exitCode"] = from_union([from_none, to_float], self.exit_code)
         if self.icons is not None:
             result["icons"] = from_union([from_none, lambda x: from_list(lambda x: to_class(ToolExecutionCompleteContentResourceLinkIcon, x), x)], self.icons)
         if self.mime_type is not None:
@@ -4134,7 +4134,7 @@ class ToolExecutionCompleteContent:
         if self.resource is not None:
             result["resource"] = from_union([from_none, lambda x: from_union([lambda x: to_class(EmbeddedTextResourceContents, x), lambda x: to_class(EmbeddedBlobResourceContents, x)], x)], self.resource)
         if self.size is not None:
-            result["size"] = from_union([from_none, to_int], self.size)
+            result["size"] = from_union([from_none, to_float], self.size)
         if self.text is not None:
             result["text"] = from_union([from_none, from_str], self.text)
         if self.title is not None:
@@ -4494,7 +4494,7 @@ class UserMessageAttachment:
     file_path: str | None = None
     line_range: UserMessageAttachmentFileLineRange | None = None
     mime_type: str | None = None
-    number: int | None = None
+    number: float | None = None
     path: str | None = None
     reference_type: UserMessageAttachmentGithubReferenceType | None = None
     selection: UserMessageAttachmentSelectionDetails | None = None
@@ -4512,7 +4512,7 @@ class UserMessageAttachment:
         file_path = from_union([from_none, from_str], obj.get("filePath"))
         line_range = from_union([from_none, UserMessageAttachmentFileLineRange.from_dict], obj.get("lineRange"))
         mime_type = from_union([from_none, from_str], obj.get("mimeType"))
-        number = from_union([from_none, from_int], obj.get("number"))
+        number = from_union([from_none, from_float], obj.get("number"))
         path = from_union([from_none, from_str], obj.get("path"))
         reference_type = from_union([from_none, lambda x: parse_enum(UserMessageAttachmentGithubReferenceType, x)], obj.get("referenceType"))
         selection = from_union([from_none, UserMessageAttachmentSelectionDetails.from_dict], obj.get("selection"))
@@ -4551,7 +4551,7 @@ class UserMessageAttachment:
         if self.mime_type is not None:
             result["mimeType"] = from_union([from_none, from_str], self.mime_type)
         if self.number is not None:
-            result["number"] = from_union([from_none, to_int], self.number)
+            result["number"] = from_union([from_none, to_float], self.number)
         if self.path is not None:
             result["path"] = from_union([from_none, from_str], self.path)
         if self.reference_type is not None:
@@ -4572,14 +4572,14 @@ class UserMessageAttachment:
 @dataclass
 class UserMessageAttachmentFileLineRange:
     "Optional line range to scope the attachment to a specific section of the file"
-    end: int
-    start: int
+    end: float
+    start: float
 
     @staticmethod
     def from_dict(obj: Any) -> "UserMessageAttachmentFileLineRange":
         assert isinstance(obj, dict)
-        end = from_int(obj.get("end"))
-        start = from_int(obj.get("start"))
+        end = from_float(obj.get("end"))
+        start = from_float(obj.get("start"))
         return UserMessageAttachmentFileLineRange(
             end=end,
             start=start,
@@ -4587,8 +4587,8 @@ class UserMessageAttachmentFileLineRange:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["end"] = to_int(self.end)
-        result["start"] = to_int(self.start)
+        result["end"] = to_float(self.end)
+        result["start"] = to_float(self.start)
         return result
 
 
@@ -4618,14 +4618,14 @@ class UserMessageAttachmentSelectionDetails:
 @dataclass
 class UserMessageAttachmentSelectionDetailsEnd:
     "End position of the selection"
-    character: int
-    line: int
+    character: float
+    line: float
 
     @staticmethod
     def from_dict(obj: Any) -> "UserMessageAttachmentSelectionDetailsEnd":
         assert isinstance(obj, dict)
-        character = from_int(obj.get("character"))
-        line = from_int(obj.get("line"))
+        character = from_float(obj.get("character"))
+        line = from_float(obj.get("line"))
         return UserMessageAttachmentSelectionDetailsEnd(
             character=character,
             line=line,
@@ -4633,22 +4633,22 @@ class UserMessageAttachmentSelectionDetailsEnd:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["character"] = to_int(self.character)
-        result["line"] = to_int(self.line)
+        result["character"] = to_float(self.character)
+        result["line"] = to_float(self.line)
         return result
 
 
 @dataclass
 class UserMessageAttachmentSelectionDetailsStart:
     "Start position of the selection"
-    character: int
-    line: int
+    character: float
+    line: float
 
     @staticmethod
     def from_dict(obj: Any) -> "UserMessageAttachmentSelectionDetailsStart":
         assert isinstance(obj, dict)
-        character = from_int(obj.get("character"))
-        line = from_int(obj.get("line"))
+        character = from_float(obj.get("character"))
+        line = from_float(obj.get("line"))
         return UserMessageAttachmentSelectionDetailsStart(
             character=character,
             line=line,
@@ -4656,8 +4656,8 @@ class UserMessageAttachmentSelectionDetailsStart:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["character"] = to_int(self.character)
-        result["line"] = to_int(self.line)
+        result["character"] = to_float(self.character)
+        result["line"] = to_float(self.line)
         return result
 
 

--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -1134,6 +1134,8 @@ class CopilotSession:
             client: The internal client connection to the Copilot CLI.
             workspace_path: Path to the session workspace directory
                 (when infinite sessions enabled).
+            on_disconnected: Internal-only callback invoked when the owning
+                client should unregister this disconnected session.
         """
         self.session_id = session_id
         self._client = client

--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -1116,7 +1116,11 @@ class CopilotSession:
     """
 
     def __init__(
-        self, session_id: str, client: Any, workspace_path: os.PathLike[str] | str | None = None
+        self,
+        session_id: str,
+        client: Any,
+        workspace_path: os.PathLike[str] | str | None = None,
+        on_disconnected: Callable[[CopilotSession], None] | None = None,
     ):
         """
         Initialize a new CopilotSession.
@@ -1158,12 +1162,16 @@ class CopilotSession:
         self._client_session_apis = ClientSessionApiHandlers()
         self._rpc: SessionRpc | None = None
         self._destroyed = False
+        self._disconnect_task: asyncio.Task[None] | None = None
+        self._disconnect_lock = threading.Lock()
+        self._on_disconnected = on_disconnected
 
     @property
     def rpc(self) -> SessionRpc:
         """Typed session-scoped RPC methods."""
+        self._assert_not_destroyed()
         if self._rpc is None:
-            self._rpc = SessionRpc(self._client, self.session_id)
+            self._rpc = SessionRpc(self._client, self.session_id, self._assert_not_destroyed)
         return self._rpc
 
     @property
@@ -1186,6 +1194,7 @@ class CopilotSession:
             >>> if ui_caps.get("elicitation"):
             ...     ok = await session.ui.confirm("Deploy to production?")
         """
+        self._assert_not_destroyed()
         return SessionUiApi(self)
 
     @functools.cached_property
@@ -1235,6 +1244,7 @@ class CopilotSession:
             ...     attachments=[{"type": "file", "path": "./src/main.py"}],
             ... )
         """
+        self._assert_not_destroyed()
         params: dict[str, Any] = {
             "sessionId": self.session_id,
             "prompt": prompt,
@@ -1301,6 +1311,7 @@ class CopilotSession:
             ...         case AssistantMessageData() as data:
             ...             print(data.content)
         """
+        self._assert_not_destroyed()
         total_start = time.perf_counter()
         idle_event = asyncio.Event()
         error_event: Exception | None = None
@@ -1403,6 +1414,7 @@ class CopilotSession:
             >>> # Later, to stop receiving events:
             >>> unsubscribe()
         """
+        self._assert_not_destroyed()
         with self._event_handlers_lock:
             self._event_handlers.add(handler)
 
@@ -1838,6 +1850,7 @@ class CopilotSession:
 
     def _assert_elicitation(self) -> None:
         """Raises if the host does not support elicitation."""
+        self._assert_not_destroyed()
         ui_caps = self._capabilities.get("ui", {})
         if not ui_caps.get("elicitation"):
             raise RuntimeError(
@@ -2235,6 +2248,7 @@ class CopilotSession:
             ...         case AssistantMessageData() as data:
             ...             print(f"Assistant: {data.content}")
         """
+        self._assert_not_destroyed()
         response = await self._client.request("session.getMessages", {"sessionId": self.session_id})
         # Convert dict events to SessionEvent objects
         events_dicts = response["events"]
@@ -2263,31 +2277,54 @@ class CopilotSession:
             >>> # Clean up when done — session can still be resumed later
             >>> await session.disconnect()
         """
-        # Ensure that the check and update of _destroyed are atomic so that
-        # only the first caller proceeds to send the destroy RPC.
-        with self._event_handlers_lock:
+        with self._disconnect_lock:
+            if self._destroyed:
+                return
+            if self._disconnect_task is None:
+                self._disconnect_task = asyncio.create_task(self._disconnect_core())
+            disconnect_task = self._disconnect_task
+
+        await asyncio.shield(disconnect_task)
+
+    async def _disconnect_core(self) -> None:
+        try:
+            await self._client.request("session.destroy", {"sessionId": self.session_id})
+        finally:
+            self._mark_disconnected()
+
+    def _assert_not_destroyed(self) -> None:
+        if self._destroyed:
+            raise RuntimeError("Session has been disconnected.")
+
+    def _mark_disconnected(self) -> None:
+        with self._disconnect_lock:
             if self._destroyed:
                 return
             self._destroyed = True
 
-        try:
-            await self._client.request("session.destroy", {"sessionId": self.session_id})
-        finally:
-            # Clear handlers even if the request fails.
-            with self._event_handlers_lock:
-                self._event_handlers.clear()
-            with self._tool_handlers_lock:
-                self._tool_handlers.clear()
-            with self._permission_handler_lock:
-                self._permission_handler = None
-            with self._command_handlers_lock:
-                self._command_handlers.clear()
-            with self._elicitation_handler_lock:
-                self._elicitation_handler = None
-            with self._exit_plan_mode_handler_lock:
-                self._exit_plan_mode_handler = None
-            with self._auto_mode_switch_handler_lock:
-                self._auto_mode_switch_handler = None
+        self._rpc = None
+        with self._event_handlers_lock:
+            self._event_handlers.clear()
+        with self._tool_handlers_lock:
+            self._tool_handlers.clear()
+        with self._permission_handler_lock:
+            self._permission_handler = None
+        with self._user_input_handler_lock:
+            self._user_input_handler = None
+        with self._command_handlers_lock:
+            self._command_handlers.clear()
+        with self._elicitation_handler_lock:
+            self._elicitation_handler = None
+        with self._exit_plan_mode_handler_lock:
+            self._exit_plan_mode_handler = None
+        with self._auto_mode_switch_handler_lock:
+            self._auto_mode_switch_handler = None
+        with self._hooks_lock:
+            self._hooks = None
+        with self._transform_callbacks_lock:
+            self._transform_callbacks = None
+        if self._on_disconnected is not None:
+            self._on_disconnected(self)
 
     async def destroy(self) -> None:
         """
@@ -2346,6 +2383,7 @@ class CopilotSession:
             >>> await asyncio.sleep(5)
             >>> await session.abort()
         """
+        self._assert_not_destroyed()
         await self._client.request("session.abort", {"sessionId": self.session_id})
 
     async def set_model(
@@ -2374,6 +2412,7 @@ class CopilotSession:
             >>> await session.set_model("gpt-4.1")
             >>> await session.set_model("claude-sonnet-4.6", reasoning_effort="high")
         """
+        self._assert_not_destroyed()
         rpc_caps = None
         if model_capabilities is not None:
             from .client import _capabilities_to_dict
@@ -2416,6 +2455,7 @@ class CopilotSession:
             >>> await session.log("Operation failed", level="error")
             >>> await session.log("Temporary status update", ephemeral=True)
         """
+        self._assert_not_destroyed()
         params = LogRequest(
             message=message,
             level=SessionLogLevel(level) if level is not None else None,

--- a/python/e2e/test_client_e2e.py
+++ b/python/e2e/test_client_e2e.py
@@ -13,7 +13,7 @@ from copilot.client import (
 )
 from copilot.session import PermissionHandler
 
-from .testharness import CLI_PATH
+from .testharness import CLI_PATH, mark_inactive_for_resume
 
 
 class TestClient:
@@ -270,6 +270,7 @@ class TestClient:
         try:
             await client.start()
             session = await client.create_session()
+            mark_inactive_for_resume(session)
             resumed = await client.resume_session(session.session_id)
 
             assert resumed.session_id == session.session_id

--- a/python/e2e/test_commands_e2e.py
+++ b/python/e2e/test_commands_e2e.py
@@ -20,6 +20,7 @@ from copilot.client import ExternalServerConfig, SubprocessConfig
 from copilot.session import CommandDefinition, PermissionHandler
 
 from .testharness.context import SNAPSHOTS_DIR, get_cli_path_for_tests
+from .testharness.helper import mark_inactive_for_resume
 from .testharness.proxy import CapiProxy
 
 pytestmark = pytest.mark.asyncio(loop_scope="module")
@@ -258,6 +259,7 @@ class TestCommandsLifecycle:
         )
         session_id = session1.session_id
 
+        mark_inactive_for_resume(session1)
         session2 = await ctx.client.resume_session(
             session_id,
             on_permission_request=PermissionHandler.approve_all,

--- a/python/e2e/test_mcp_and_agents_e2e.py
+++ b/python/e2e/test_mcp_and_agents_e2e.py
@@ -8,7 +8,7 @@ import pytest
 
 from copilot.session import CustomAgentConfig, MCPServerConfig, PermissionHandler
 
-from .testharness import E2ETestContext, get_final_assistant_message
+from .testharness import E2ETestContext, get_final_assistant_message, mark_inactive_for_resume
 
 TEST_MCP_SERVER = str(
     (Path(__file__).parents[2] / "test" / "harness" / "test-mcp-server.mjs").resolve()
@@ -64,6 +64,7 @@ class TestMCPServers:
             }
         }
 
+        mark_inactive_for_resume(session1)
         session2 = await ctx.client.resume_session(
             session_id,
             on_permission_request=PermissionHandler.approve_all,
@@ -157,6 +158,7 @@ class TestCustomAgents:
             }
         ]
 
+        mark_inactive_for_resume(session1)
         session2 = await ctx.client.resume_session(
             session_id,
             on_permission_request=PermissionHandler.approve_all,

--- a/python/e2e/test_permissions_e2e.py
+++ b/python/e2e/test_permissions_e2e.py
@@ -13,7 +13,7 @@ from copilot.generated.session_events import (
 )
 from copilot.session import PermissionHandler, PermissionRequestResult
 
-from .testharness import E2ETestContext
+from .testharness import E2ETestContext, mark_inactive_for_resume
 from .testharness.helper import read_file, write_file
 
 pytestmark = pytest.mark.asyncio(loop_scope="module")
@@ -140,6 +140,7 @@ class TestPermissions:
         def deny_all(request, invocation):
             return PermissionRequestResult()
 
+        mark_inactive_for_resume(session1)
         session2 = await ctx.client.resume_session(session_id, on_permission_request=deny_all)
 
         denied_events = []
@@ -218,6 +219,7 @@ class TestPermissions:
             permission_requests.append(request)
             return PermissionRequestResult(kind="approve-once")
 
+        mark_inactive_for_resume(session1)
         session2 = await ctx.client.resume_session(
             session_id, on_permission_request=on_permission_request
         )

--- a/python/e2e/test_session_config_e2e.py
+++ b/python/e2e/test_session_config_e2e.py
@@ -9,7 +9,7 @@ import pytest
 from copilot import ModelCapabilitiesOverride, ModelSupportsOverride
 from copilot.session import PermissionHandler
 
-from .testharness import E2ETestContext
+from .testharness import E2ETestContext, mark_inactive_for_resume
 
 pytestmark = pytest.mark.asyncio(loop_scope="module")
 
@@ -217,6 +217,7 @@ class TestSessionConfig:
         )
         session_id = session1.session_id
 
+        mark_inactive_for_resume(session1)
         session2 = await ctx.client.resume_session(
             session_id,
             on_permission_request=PermissionHandler.approve_all,
@@ -314,6 +315,7 @@ class TestSessionConfig:
         )
         session_id = session1.session_id
 
+        mark_inactive_for_resume(session1)
         session2 = await ctx.client.resume_session(
             session_id,
             on_permission_request=PermissionHandler.approve_all,
@@ -335,6 +337,7 @@ class TestSessionConfig:
         session_id = session1.session_id
 
         resume_instruction = "End the response with RESUME_SYSTEM_MESSAGE_SENTINEL."
+        mark_inactive_for_resume(session1)
         session2 = await ctx.client.resume_session(
             session_id,
             on_permission_request=PermissionHandler.approve_all,
@@ -394,6 +397,7 @@ class TestSessionConfig:
             working_directory=project_dir,
         )
 
+        mark_inactive_for_resume(session1)
         session2 = await ctx.client.resume_session(
             session1.session_id,
             on_permission_request=PermissionHandler.approve_all,
@@ -416,6 +420,7 @@ class TestSessionConfig:
         )
         session_id = session1.session_id
 
+        mark_inactive_for_resume(session1)
         session2 = await ctx.client.resume_session(
             session_id,
             on_permission_request=PermissionHandler.approve_all,

--- a/python/e2e/test_session_e2e.py
+++ b/python/e2e/test_session_e2e.py
@@ -11,7 +11,12 @@ from copilot.generated.session_events import SessionModelChangeData
 from copilot.session import PermissionHandler
 from copilot.tools import Tool, ToolResult
 
-from .testharness import E2ETestContext, get_final_assistant_message, get_next_event_of_type
+from .testharness import (
+    E2ETestContext,
+    get_final_assistant_message,
+    get_next_event_of_type,
+    mark_inactive_for_resume,
+)
 
 pytestmark = pytest.mark.asyncio(loop_scope="module")
 
@@ -31,7 +36,7 @@ class TestSessions:
 
         await session.disconnect()
 
-        with pytest.raises(Exception, match="Session not found"):
+        with pytest.raises(Exception, match="Session has been disconnected"):
             await session.get_messages()
 
     async def test_should_have_stateful_conversation(self, ctx: E2ETestContext):
@@ -216,6 +221,7 @@ class TestSessions:
         assert "2" in answer.data.content
 
         # Resume using the same client
+        mark_inactive_for_resume(session1)
         session2 = await ctx.client.resume_session(
             session_id, on_permission_request=PermissionHandler.approve_all
         )
@@ -457,6 +463,7 @@ class TestSessions:
         session_id = session.session_id
 
         # Resume the session with a provider
+        mark_inactive_for_resume(session)
         session2 = await ctx.client.resume_session(
             session_id,
             on_permission_request=PermissionHandler.approve_all,

--- a/python/e2e/testharness/__init__.py
+++ b/python/e2e/testharness/__init__.py
@@ -1,7 +1,7 @@
 """Test harness for E2E tests."""
 
 from .context import CLI_PATH, DEFAULT_GITHUB_TOKEN, E2ETestContext
-from .helper import get_final_assistant_message, get_next_event_of_type
+from .helper import get_final_assistant_message, get_next_event_of_type, mark_inactive_for_resume
 from .proxy import CapiProxy
 
 __all__ = [
@@ -11,4 +11,5 @@ __all__ = [
     "CapiProxy",
     "get_final_assistant_message",
     "get_next_event_of_type",
+    "mark_inactive_for_resume",
 ]

--- a/python/e2e/testharness/helper.py
+++ b/python/e2e/testharness/helper.py
@@ -139,6 +139,11 @@ def read_file(work_dir: str, filename: str) -> str:
         return f.read()
 
 
+def mark_inactive_for_resume(session: CopilotSession) -> None:
+    """Clear local active-session tracking without destroying the server session."""
+    session._mark_disconnected()
+
+
 async def get_next_event_of_type(session: CopilotSession, event_type: str, timeout: float = 30.0):
     """
     Wait for and return the next event of a specific type from a session.

--- a/python/test_client.py
+++ b/python/test_client.py
@@ -231,9 +231,7 @@ class TestSessionLifecycle:
             raise RuntimeError("boom")
 
         with pytest.raises(RuntimeError, match="boom"):
-            await client.resume_session(
-                "session-1", create_session_fs_handler=failing_handler
-            )
+            await client.resume_session("session-1", create_session_fs_handler=failing_handler)
 
         session = captured["session"]
         assert session.session_id not in client._sessions
@@ -302,9 +300,7 @@ class TestSessionLifecycle:
             return object()
 
         with pytest.raises(RuntimeError, match="already active"):
-            await client.resume_session(
-                "session-1", create_session_fs_handler=create_provider
-            )
+            await client.resume_session("session-1", create_session_fs_handler=create_provider)
 
         session = captured["session"]
         assert client._sessions["session-1"] is existing

--- a/python/test_client.py
+++ b/python/test_client.py
@@ -19,7 +19,7 @@ from copilot.client import (
     ModelSupports,
     SubprocessConfig,
 )
-from copilot.session import PermissionHandler, PermissionRequestResult
+from copilot.session import CopilotSession, PermissionHandler, PermissionRequestResult
 from e2e.testharness import CLI_PATH
 
 
@@ -72,6 +72,7 @@ class TestPermissionHandlerOptional:
             session = await client.create_session(
                 on_permission_request=PermissionHandler.approve_all
             )
+            session._mark_disconnected()
             resumed = await client.resume_session(session.session_id, on_permission_request=None)
             assert resumed.session_id == session.session_id
         finally:
@@ -113,6 +114,204 @@ class TestCreateSessionConfig:
             }
         finally:
             await client.force_stop()
+
+
+class TestSessionLifecycle:
+    @pytest.mark.asyncio
+    async def test_direct_disconnect_unregisters_after_destroy_request(self):
+        sessions = {}
+
+        async def request(method, params):
+            if method == "session.destroy":
+                assert sessions["session-1"] is session
+            return {}
+
+        rpc_client = AsyncMock()
+        rpc_client.request = AsyncMock(side_effect=request)
+
+        def unregister(candidate):
+            if sessions.get(candidate.session_id) is candidate:
+                del sessions[candidate.session_id]
+
+        session = CopilotSession(
+            "session-1",
+            rpc_client,
+            on_disconnected=unregister,
+        )
+        sessions[session.session_id] = session
+
+        await session.disconnect()
+
+        rpc_client.request.assert_awaited_with("session.destroy", {"sessionId": "session-1"})
+        assert "session-1" not in sessions
+        with pytest.raises(RuntimeError, match="disconnected"):
+            await session.send("hello")
+
+    def test_stale_session_disconnect_does_not_unregister_replacement(self):
+        sessions = {}
+
+        def unregister(candidate):
+            if sessions.get(candidate.session_id) is candidate:
+                del sessions[candidate.session_id]
+
+        rpc_client = AsyncMock()
+        stale = CopilotSession("session-1", rpc_client, on_disconnected=unregister)
+        replacement = CopilotSession("session-1", rpc_client, on_disconnected=unregister)
+        sessions["session-1"] = replacement
+
+        stale._mark_disconnected()
+
+        assert sessions["session-1"] is replacement
+        replacement._mark_disconnected()
+
+    def test_rejects_duplicate_active_session_registration(self):
+        client = CopilotClient(SubprocessConfig(cli_path=CLI_PATH, log_level="error"))
+        rpc_client = AsyncMock()
+        first = CopilotSession("session-1", rpc_client)
+        second = CopilotSession("session-1", rpc_client)
+
+        client._register_session(first)
+
+        with pytest.raises(RuntimeError, match="already active"):
+            client._register_session(second)
+
+        first._mark_disconnected()
+
+    @pytest.mark.asyncio
+    async def test_failed_create_session_fs_setup_marks_session_disconnected(self):
+        client = CopilotClient(
+            SubprocessConfig(
+                cli_path=CLI_PATH,
+                log_level="error",
+                session_fs={
+                    "initial_cwd": "/",
+                    "session_state_path": "/session-state",
+                    "conventions": "posix",
+                },
+            )
+        )
+        rpc_client = AsyncMock()
+        rpc_client.request = AsyncMock()
+        client._client = rpc_client
+        captured = {}
+
+        def failing_handler(session):
+            captured["session"] = session
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await client.create_session(create_session_fs_handler=failing_handler)
+
+        session = captured["session"]
+        assert session.session_id not in client._sessions
+        with pytest.raises(RuntimeError, match="disconnected"):
+            await session.send("hello")
+        rpc_client.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failed_resume_session_fs_setup_marks_session_disconnected(self):
+        client = CopilotClient(
+            SubprocessConfig(
+                cli_path=CLI_PATH,
+                log_level="error",
+                session_fs={
+                    "initial_cwd": "/",
+                    "session_state_path": "/session-state",
+                    "conventions": "posix",
+                },
+            )
+        )
+        rpc_client = AsyncMock()
+        rpc_client.request = AsyncMock()
+        client._client = rpc_client
+        captured = {}
+
+        def failing_handler(session):
+            captured["session"] = session
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await client.resume_session(
+                "session-1", create_session_fs_handler=failing_handler
+            )
+
+        session = captured["session"]
+        assert session.session_id not in client._sessions
+        with pytest.raises(RuntimeError, match="disconnected"):
+            await session.send("hello")
+        rpc_client.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_create_marks_captured_session_disconnected(self):
+        client = CopilotClient(
+            SubprocessConfig(
+                cli_path=CLI_PATH,
+                log_level="error",
+                session_fs={
+                    "initial_cwd": "/",
+                    "session_state_path": "/session-state",
+                    "conventions": "posix",
+                },
+            )
+        )
+        rpc_client = AsyncMock()
+        rpc_client.request = AsyncMock()
+        client._client = rpc_client
+        existing = CopilotSession("session-1", rpc_client)
+        client._register_session(existing)
+        captured = {}
+
+        def create_provider(session):
+            captured["session"] = session
+            return object()
+
+        with pytest.raises(RuntimeError, match="already active"):
+            await client.create_session(
+                session_id="session-1", create_session_fs_handler=create_provider
+            )
+
+        session = captured["session"]
+        assert client._sessions["session-1"] is existing
+        with pytest.raises(RuntimeError, match="disconnected"):
+            await session.send("hello")
+        rpc_client.request.assert_not_called()
+        existing._mark_disconnected()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_resume_marks_captured_session_disconnected(self):
+        client = CopilotClient(
+            SubprocessConfig(
+                cli_path=CLI_PATH,
+                log_level="error",
+                session_fs={
+                    "initial_cwd": "/",
+                    "session_state_path": "/session-state",
+                    "conventions": "posix",
+                },
+            )
+        )
+        rpc_client = AsyncMock()
+        rpc_client.request = AsyncMock()
+        client._client = rpc_client
+        existing = CopilotSession("session-1", rpc_client)
+        client._register_session(existing)
+        captured = {}
+
+        def create_provider(session):
+            captured["session"] = session
+            return object()
+
+        with pytest.raises(RuntimeError, match="already active"):
+            await client.resume_session(
+                "session-1", create_session_fs_handler=create_provider
+            )
+
+        session = captured["session"]
+        assert client._sessions["session-1"] is existing
+        with pytest.raises(RuntimeError, match="disconnected"):
+            await session.send("hello")
+        rpc_client.request.assert_not_called()
+        existing._mark_disconnected()
 
 
 class TestURLParsing:
@@ -338,6 +537,7 @@ class TestOverridesBuiltInTool:
             def grep(params) -> str:
                 return "ok"
 
+            session._mark_disconnected()
             await client.resume_session(
                 session.session_id,
                 on_permission_request=PermissionHandler.approve_all,
@@ -573,6 +773,7 @@ class TestSessionConfigForwarding:
                 return await original_request(method, params)
 
             client._client.request = mock_request
+            session._mark_disconnected()
             await client.resume_session(
                 session.session_id,
                 on_permission_request=PermissionHandler.approve_all,
@@ -624,6 +825,7 @@ class TestSessionConfigForwarding:
                 return await original_request(method, params)
 
             client._client.request = mock_request
+            session._mark_disconnected()
             await client.resume_session(
                 session.session_id,
                 on_permission_request=PermissionHandler.approve_all,
@@ -691,6 +893,7 @@ class TestSessionConfigForwarding:
                 return await original_request(method, params)
 
             client._client.request = mock_request
+            session._mark_disconnected()
             await client.resume_session(
                 session.session_id,
                 on_permission_request=PermissionHandler.approve_all,
@@ -789,6 +992,7 @@ class TestSessionConfigForwarding:
                 return await original_request(method, params)
 
             client._client.request = mock_request
+            session._mark_disconnected()
             await client.resume_session(
                 session.session_id,
                 on_permission_request=PermissionHandler.approve_all,
@@ -864,6 +1068,7 @@ class TestSessionConfigForwarding:
                 return await original_request(method, params)
 
             client._client.request = mock_request
+            session._mark_disconnected()
             await client.resume_session(
                 session.session_id,
                 on_permission_request=PermissionHandler.approve_all,
@@ -894,6 +1099,7 @@ class TestSessionConfigForwarding:
                 return await original_request(method, params)
 
             client._client.request = mock_request
+            session._mark_disconnected()
             await client.resume_session(
                 session.session_id,
                 on_permission_request=PermissionHandler.approve_all,
@@ -923,6 +1129,7 @@ class TestSessionConfigForwarding:
                 return await original_request(method, params)
 
             client._client.request = mock_request
+            session._mark_disconnected()
             await client.resume_session(
                 session.session_id,
                 on_permission_request=PermissionHandler.approve_all,
@@ -952,6 +1159,7 @@ class TestSessionConfigForwarding:
                 return await original_request(method, params)
 
             client._client.request = mock_request
+            session._mark_disconnected()
             await client.resume_session(
                 session.session_id,
                 on_permission_request=PermissionHandler.approve_all,

--- a/python/test_commands_and_elicitation.py
+++ b/python/test_commands_and_elicitation.py
@@ -107,6 +107,7 @@ class TestCommands:
 
             client._client.request = mock_request
 
+            session._mark_disconnected()
             await client.resume_session(
                 session.session_id,
                 on_permission_request=PermissionHandler.approve_all,
@@ -525,6 +526,7 @@ class TestOnElicitationContext:
 
             client._client.request = mock_request
 
+            session._mark_disconnected()
             await client.resume_session(
                 session.session_id,
                 on_permission_request=PermissionHandler.approve_all,

--- a/python/test_rpc_generated.py
+++ b/python/test_rpc_generated.py
@@ -22,3 +22,29 @@ async def test_commands_invoke_deserializes_slash_command_result():
     assert result.kind is SlashCommandInvocationResultKind.TEXT
     assert result.text == "hello"
     assert result.markdown is True
+
+
+@pytest.mark.asyncio
+async def test_generated_rpc_rejects_missing_required_params():
+    client = AsyncMock()
+    api = CommandsApi(client, "sess-1")
+
+    with pytest.raises(TypeError, match="params is required"):
+        await api.invoke(None)  # type: ignore[arg-type]
+
+    client.request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generated_session_rpc_checks_active_callback_before_request():
+    client = AsyncMock()
+    api = CommandsApi(
+        client,
+        "sess-1",
+        lambda: (_ for _ in ()).throw(RuntimeError("session inactive")),
+    )
+
+    with pytest.raises(RuntimeError, match="session inactive"):
+        await api.invoke(CommandsInvokeRequest(name="help"))
+
+    client.request.assert_not_called()

--- a/python/test_rpc_generated.py
+++ b/python/test_rpc_generated.py
@@ -7,6 +7,8 @@ import pytest
 from copilot.generated.rpc import (
     CommandsApi,
     CommandsInvokeRequest,
+    ServerModelsApi,
+    ServerToolsApi,
     SlashCommandInvocationResultKind,
 )
 
@@ -33,6 +35,18 @@ async def test_generated_rpc_rejects_missing_required_params():
         await api.invoke(None)  # type: ignore[arg-type]
 
     client.request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generated_rpc_allows_missing_optional_only_params():
+    client = AsyncMock()
+    client.request = AsyncMock(side_effect=[{"models": []}, {"tools": []}])
+
+    await ServerModelsApi(client).list()
+    await ServerToolsApi(client).list()
+
+    assert client.request.call_args_list[0].args[:2] == ("models.list", {})
+    assert client.request.call_args_list[1].args[:2] == ("tools.list", {})
 
 
 @pytest.mark.asyncio

--- a/scripts/codegen/go.ts
+++ b/scripts/codegen/go.ts
@@ -3720,7 +3720,10 @@ function emitRpcWrapper(lines: string[], node: Record<string, unknown>, isSessio
     // Emit the common service struct (unexported, shared by all API groups via type cast)
     lines.push(`type ${serviceName} struct {`);
     lines.push(`\tclient *jsonrpc2.Client`);
-    if (isSession) lines.push(`\tsessionID string`);
+    if (isSession) {
+        lines.push(`\tsessionID string`);
+        lines.push(`\tassertActive func() error`);
+    }
     lines.push(`}`);
     lines.push(``);
 
@@ -3764,11 +3767,15 @@ function emitRpcWrapper(lines: string[], node: Record<string, unknown>, isSessio
     }
 
     // Constructor
-    const ctorParams = isSession ? "client *jsonrpc2.Client, sessionID string" : "client *jsonrpc2.Client";
+    const ctorParams = isSession ? "client *jsonrpc2.Client, sessionID string, assertActive ...func() error" : "client *jsonrpc2.Client";
     lines.push(`func New${wrapperName}(${ctorParams}) *${wrapperName} {`);
     lines.push(`\tr := &${wrapperName}{}`);
     if (isSession) {
-        lines.push(`\tr.common = ${serviceName}{client: client, sessionID: sessionID}`);
+        lines.push(`\tvar assertActiveFn func() error`);
+        lines.push(`\tif len(assertActive) > 0 {`);
+        lines.push(`\t\tassertActiveFn = assertActive[0]`);
+        lines.push(`\t}`);
+        lines.push(`\tr.common = ${serviceName}{client: client, sessionID: sessionID, assertActive: assertActiveFn}`);
     } else {
         lines.push(`\tr.common = ${serviceName}{client: client}`);
     }
@@ -3805,6 +3812,7 @@ function emitMethod(lines: string[], receiver: string, name: string, method: Rpc
     // For wrapper-level methods, access fields through a.common; for service type aliases, use a directly
     const clientRef = isWrapper ? "a.common.client" : "a.client";
     const sessionIDRef = isWrapper ? "a.common.sessionID" : "a.sessionID";
+    const assertActiveRef = isWrapper ? "a.common.assertActive" : "a.assertActive";
 
     pushGoRpcMethodComment(
         lines,
@@ -3832,6 +3840,18 @@ function emitMethod(lines: string[], receiver: string, name: string, method: Rpc
         lines.push(`\tvar requestParams *${paramsType}`);
         lines.push(`\tif len(params) > 0 {`);
         lines.push(`\t\trequestParams = params[0]`);
+        lines.push(`\t}`);
+    }
+    if (isSession) {
+        lines.push(`\tif ${assertActiveRef} != nil {`);
+        lines.push(`\t\tif err := ${assertActiveRef}(); err != nil {`);
+        lines.push(`\t\t\treturn nil, err`);
+        lines.push(`\t\t}`);
+        lines.push(`\t}`);
+    }
+    if (hasParams && !paramsAreOptional && hasRequiredNonSessionParams) {
+        lines.push(`\tif ${paramsRef} == nil {`);
+        lines.push(`\t\treturn nil, errors.New("params is required")`);
         lines.push(`\t}`);
     }
 

--- a/scripts/codegen/python.ts
+++ b/scripts/codegen/python.ts
@@ -2610,9 +2610,11 @@ function emitMethod(lines: string[], name: string, method: RpcMethod, isSession:
     const effectiveParams = getMethodParamsSchema(method);
     const paramProps = effectiveParams?.properties || {};
     const nonSessionParams = Object.keys(paramProps).filter((k) => k !== "sessionId");
+    const requiredParams = new Set(effectiveParams?.required || []);
     const hasParams = isSession ? nonSessionParams.length > 0 : hasSchemaPayload(effectiveParams);
     const paramsType = resolveType(pythonParamsTypeName(method));
-    const paramsOptional = isParamsOptional(method);
+    const hasRequiredNonSessionParams = nonSessionParams.some((name) => requiredParams.has(name));
+    const paramsOptional = isParamsOptional(method) || !hasRequiredNonSessionParams;
 
     // Build signature with typed params + optional timeout
     const sig = hasParams

--- a/scripts/codegen/python.ts
+++ b/scripts/codegen/python.ts
@@ -2514,12 +2514,13 @@ function emitPyApiGroup(
     }
     lines.push(`class ${apiName}:`);
     if (isSession) {
-        lines.push(`    def __init__(self, client: "JsonRpcClient", session_id: str):`);
+        lines.push(`    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):`);
         lines.push(`        self._client = client`);
         lines.push(`        self._session_id = session_id`);
+        lines.push(`        self._assert_active = assert_active`);
         for (const [subGroupName] of subGroups) {
             const subApiName = apiName.replace(/Api$/, "") + toPascalCase(subGroupName) + "Api";
-            lines.push(`        self.${toSnakeCase(subGroupName)} = ${subApiName}(client, session_id)`);
+            lines.push(`        self.${toSnakeCase(subGroupName)} = ${subApiName}(client, session_id, assert_active)`);
         }
     } else {
         lines.push(`    def __init__(self, client: "JsonRpcClient"):`);
@@ -2559,11 +2560,12 @@ function emitRpcWrapper(lines: string[], node: Record<string, unknown>, isSessio
         lines.push(classPrefix === "_Internal"
             ? `    """Internal SDK session-scoped RPC methods. Not part of the public API."""`
             : `    """Typed session-scoped RPC methods."""`);
-        lines.push(`    def __init__(self, client: "JsonRpcClient", session_id: str):`);
+        lines.push(`    def __init__(self, client: "JsonRpcClient", session_id: str, assert_active: Callable[[], None] | None = None):`);
         lines.push(`        self._client = client`);
         lines.push(`        self._session_id = session_id`);
+        lines.push(`        self._assert_active = assert_active`);
         for (const [groupName] of groups) {
-            lines.push(`        self.${toSnakeCase(groupName)} = ${classPrefix}${toPascalCase(groupName)}Api(client, session_id)`);
+            lines.push(`        self.${toSnakeCase(groupName)} = ${classPrefix}${toPascalCase(groupName)}Api(client, session_id, assert_active)`);
         }
     } else {
         lines.push(`class ${wrapperName}:`);
@@ -2629,6 +2631,18 @@ function emitMethod(lines: string[], name: string, method: RpcMethod, isSession:
         experimental: method.stability === "experimental" && !groupExperimental,
         internal: method.visibility === "internal",
     });
+
+    if (isSession) {
+        lines.push(`        if self._assert_active is not None:`);
+        lines.push(`            self._assert_active()`);
+    }
+    if (hasParams && !paramsOptional) {
+        lines.push(`        if params is None:`);
+        lines.push(`            raise TypeError("params is required")`);
+    }
+    if (isSession || (hasParams && !paramsOptional)) {
+        lines.push(``);
+    }
 
     // Deserialize helper
     const innerTypeName = hasNullableResult ? resolveType(pythonResultTypeName(method, nullableInner)) : resultType;

--- a/scripts/codegen/typescript.ts
+++ b/scripts/codegen/typescript.ts
@@ -709,9 +709,11 @@ function emitGroup(
             const paramEntries = effectiveParams?.properties
                 ? Object.entries(effectiveParams.properties).filter(([k]) => k !== "sessionId")
                 : [];
+            const requiredParams = new Set(effectiveParams?.required ?? []);
             const hasParams = hasSchemaPayload(effectiveParams);
             const hasNonSessionParams = paramEntries.length > 0;
-            const paramsOptional = isParamsOptional(value);
+            const hasRequiredNonSessionParams = paramEntries.some(([name]) => requiredParams.has(name));
+            const paramsOptional = isParamsOptional(value) || !hasRequiredNonSessionParams;
 
             const sigParams: string[] = [];
             let bodyArg: string;
@@ -730,7 +732,7 @@ function emitGroup(
                 if (hasParams) {
                     const optMark = paramsOptional ? "?" : "";
                     sigParams.push(`params${optMark}: ${paramsType}`);
-                    bodyArg = "params";
+                    bodyArg = paramsOptional ? "(params ?? {})" : "params";
                 } else {
                     bodyArg = "{}";
                 }

--- a/scripts/codegen/typescript.ts
+++ b/scripts/codegen/typescript.ts
@@ -656,7 +656,7 @@ function hasInternalMethods(node: Record<string, unknown>): boolean {
 
     if (schema.session) {
         lines.push(`/** Create typed session-scoped RPC methods. */`);
-        lines.push(`export function createSessionRpc(connection: MessageConnection, sessionId: string) {`);
+        lines.push(`export function createSessionRpc(connection: MessageConnection, sessionId: string, assertActive?: () => void) {`);
         lines.push(`    return {`);
         lines.push(...emitGroup(schema.session, "        ", true, false, false, "public"));
         lines.push(`    };`);
@@ -669,7 +669,7 @@ function hasInternalMethods(node: Record<string, unknown>): boolean {
             lines.push(` * surface. Not exported on the public client API.`);
             lines.push(` * @internal`);
             lines.push(` */`);
-            lines.push(`export function createInternalSessionRpc(connection: MessageConnection, sessionId: string) {`);
+            lines.push(`export function createInternalSessionRpc(connection: MessageConnection, sessionId: string, assertActive?: () => void) {`);
             lines.push(`    return {`);
             lines.push(...emitGroup(schema.session, "        ", true, false, false, "internal"));
             lines.push(`    };`);
@@ -711,13 +711,14 @@ function emitGroup(
                 : [];
             const hasParams = hasSchemaPayload(effectiveParams);
             const hasNonSessionParams = paramEntries.length > 0;
+            const paramsOptional = isParamsOptional(value);
 
             const sigParams: string[] = [];
             let bodyArg: string;
 
             if (isSession) {
                 if (hasNonSessionParams) {
-                    const optMark = isParamsOptional(value) ? "?" : "";
+                    const optMark = paramsOptional ? "?" : "";
                     // sessionId is already stripped from the generated type definition,
                     // so no need for Omit<..., "sessionId">
                     sigParams.push(`params${optMark}: ${paramsType}`);
@@ -727,7 +728,7 @@ function emitGroup(
                 }
             } else {
                 if (hasParams) {
-                    const optMark = isParamsOptional(value) ? "?" : "";
+                    const optMark = paramsOptional ? "?" : "";
                     sigParams.push(`params${optMark}: ${paramsType}`);
                     bodyArg = "params";
                 } else {
@@ -741,8 +742,17 @@ function emitGroup(
                 includeDeprecated: (value as RpcMethod).deprecated && !parentDeprecated,
                 includeExperimental: (value as RpcMethod).stability === "experimental" && !parentExperimental,
             });
-            lines.push(`${indent}${key}: async (${sigParams.join(", ")}): Promise<${resultType}> =>`);
-            lines.push(`${indent}    connection.sendRequest("${rpcMethod}", ${bodyArg}),`);
+            lines.push(`${indent}${key}: async (${sigParams.join(", ")}): Promise<${resultType}> => {`);
+            if (isSession) {
+                lines.push(`${indent}    assertActive?.();`);
+            }
+            if (sigParams.length > 0 && !paramsOptional) {
+                lines.push(`${indent}    if (params == null) {`);
+                lines.push(`${indent}        throw new TypeError("params is required");`);
+                lines.push(`${indent}    }`);
+            }
+            lines.push(`${indent}    return connection.sendRequest("${rpcMethod}", ${bodyArg});`);
+            lines.push(`${indent}},`);
         } else if (typeof value === "object" && value !== null) {
             const groupExperimental = isNodeFullyExperimental(value as Record<string, unknown>);
             const groupDeprecated = isNodeFullyDeprecated(value as Record<string, unknown>);


### PR DESCRIPTION
C# recently tightened generated RPC argument validation and session lifecycle cleanup. This ports the commensurate behavior to the SDKs that had matching gaps so clients fail earlier, do not keep stale active sessions around, and reject duplicate active local sessions consistently.

## Summary

- Updates the TypeScript, Python, and Go RPC generators so generated session APIs validate required params before sending and reject session-scoped RPC calls after disconnect.
- Cleans up Node, Python, and Go session/client lifecycle handling: direct disconnect unregisters from the parent client, stop/force-stop/delete paths clear active session maps safely, and duplicate active session IDs are rejected.
- Adds focused lifecycle and generated-RPC regression coverage, plus adjusts Go e2e resume coverage for the new duplicate-active-session contract.

Rust was reviewed but left unchanged because its existing ownership/lifecycle model already covers the comparable behavior.

## Validation

- `cd nodejs && npm run typecheck`
- `cd nodejs && npm test -- client.test.ts --testNamePattern "directly disconnected|reports stop errors|replacement session|duplicate active|validates required"`
- `cd python && python -m pytest -q test_client.py test_rpc_generated.py`
- `cd python && python -m ruff check test_client.py test_rpc_generated.py copilot\client.py copilot\session.py`
- `cd go && go test -timeout 20m ./...`
- `git diff --check`