### PR TITLE
Publish .snupkg symbols package to NuGet.org

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -129,7 +129,9 @@ jobs:
         uses: actions/upload-artifact@v7.0.0
         with:
           name: dotnet-package
-          path: dotnet/artifacts/*.nupkg
+          path: |
+            dotnet/artifacts/*.nupkg
+            dotnet/artifacts/*.snupkg
       - name: NuGet login (OIDC)
         if: github.ref == 'refs/heads/main'
         uses: NuGet/login@v1
@@ -142,7 +144,9 @@ jobs:
           user: stevesanderson
       - name: Publish to NuGet
         if: github.ref == 'refs/heads/main'
-        run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: |
+          dotnet nuget push ./artifacts/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols
+          dotnet nuget push ./artifacts/*.snupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
   publish-rust:
     name: Publish Rust SDK


### PR DESCRIPTION
The .NET SDK csproj already produces a portable-PDB `.snupkg` alongside the main `.nupkg` (`IncludeSymbols` + `SymbolPackageFormat=snupkg`, with `Microsoft.SourceLink.GitHub` and deterministic CI builds), but the `publish-dotnet` workflow job only uploaded and pushed the `.nupkg`. As a result, symbols were built every release but never reached NuGet.org's symbol server, so consumers couldn't step into the SDK with a debugger via `https://symbols.nuget.org/download/symbols`.

This updates the workflow to:

- Include `dotnet/artifacts/*.snupkg` in the `dotnet-package` workflow artifact alongside `*.nupkg`.
- Push the main `.nupkg` with `--no-symbols` (the symbol push is now explicit, so there's no value in letting the main push try to auto-discover and re-push the symbols package).
- Then explicitly push `*.snupkg` to `https://api.nuget.org/v3/index.json`, which `dotnet nuget push` dispatches to NuGet.org's symbol endpoint.

This matches the publishing pattern recommended in NuGet's own docs and used by mature .NET OSS libraries (the .NET runtime, ASP.NET Core, Microsoft.Extensions.*, etc.).

I verified locally that `dotnet pack -c Release` already produces both files, that the PDBs inside the `.snupkg` are portable (BSJB header) for all three target frameworks, and that an explicit `.snupkg` push hits NuGet.org's `api/v2/symbolpackage` endpoint as expected.

Closes #1213

This pull request was generated by Copilot.