### PR TITLE
docs: clarify BYOK reasoning content

### DIFF
--- a/docs/auth/byok.md
+++ b/docs/auth/byok.md
@@ -490,6 +490,16 @@ Some Copilot features may behave differently with BYOK:
 * **Usage tracking** - Usage is tracked by your provider, not GitHub Copilot
 * **Premium requests** - Do not count against Copilot premium request quotas
 
+### Reasoning content
+
+Reasoning content is provider-specific:
+
+| Provider | Behavior |
+|----------|----------|
+| OpenAI / Azure OpenAI | Readable reasoning text is not returned for Responses API calls; `assistant.reasoning` events may have empty `content`, and encrypted reasoning is available on `assistant.message.encryptedContent` for the same session |
+| Anthropic | Readable reasoning text may be exposed through `assistant.reasoning` events and `assistant.message.reasoningText`; encrypted reasoning may be available as `reasoningOpaque` |
+| OpenAI-compatible providers such as vLLM | Plaintext reasoning depends on the model and server response format |
+
 ### Provider-specific limitations
 
 | Provider | Limitations |

--- a/docs/features/streaming-events.md
+++ b/docs/features/streaming-events.md
@@ -254,6 +254,8 @@ Ephemeral. Incremental chunk of the model's extended thinking, streamed in real 
 | `reasoningId` | `string` | ✅ | Matches the corresponding `assistant.reasoning` event |
 | `deltaContent` | `string` | ✅ | Text chunk to append to reasoning content |
 
+For OpenAI BYOK providers, these events may be emitted with empty `content` or `deltaContent` because readable reasoning text is not returned. Encrypted reasoning is available on the `assistant.message` event as `encryptedContent` for the same session.
+
 ### `assistant.message`
 
 The assistant's complete response for this LLM call. May include tool invocation requests.


### PR DESCRIPTION
## Summary
- note that OpenAI BYOK reasoning events can carry empty readable content
- add BYOK provider notes for reasoning content

Fixes #1230

## Checks
- git diff --check