### PR TITLE
C# SDK: re-land x-opaque-json → JsonElement mapping with object boundary at RPC params

### DIFF
--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -1629,6 +1629,20 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
     private static JsonSerializerOptions SerializerOptionsForMessageFormatter { get; } = CreateSerializerOptions();
 
+    /// <summary>
+    /// Converts an arbitrary value into the <see cref="JsonElement"/> representation that wire
+    /// DTOs use for opaque-JSON fields. Pass-through for <see cref="JsonElement"/>, otherwise
+    /// serializes the runtime type using the shared JSON-RPC serializer options so that any
+    /// type registered in the SDK's source-generated contexts (e.g. primitives,
+    /// <c>Dictionary&lt;string, object&gt;</c>, generated DTOs) is supported.
+    /// </summary>
+    public static JsonElement? ToJsonElementForWire(object? value) => value switch
+    {
+        null => null,
+        JsonElement je => je,
+        _ => JsonSerializer.SerializeToElement(value, SerializerOptionsForMessageFormatter.GetTypeInfo(value.GetType()))
+    };
+
     private static JsonSerializerOptions CreateSerializerOptions()
     {
         var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)

--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -247,7 +247,7 @@ public sealed class Tool
 
     /// <summary>JSON Schema for the tool's input parameters.</summary>
     [JsonPropertyName("parameters")]
-    public IDictionary<string, object>? Parameters { get; set; }
+    public IDictionary<string, JsonElement>? Parameters { get; set; }
 }
 
 /// <summary>Built-in tools available for the requested model, with their parameters and instructions.</summary>
@@ -378,7 +378,7 @@ public sealed class McpConfigList
 {
     /// <summary>All MCP servers from user config, keyed by name.</summary>
     [JsonPropertyName("servers")]
-    public IDictionary<string, object> Servers { get => field ??= new Dictionary<string, object>(); set; }
+    public IDictionary<string, JsonElement> Servers { get => field ??= new Dictionary<string, JsonElement>(); set; }
 }
 
 /// <summary>MCP server name and configuration to add to user configuration.</summary>
@@ -386,7 +386,7 @@ internal sealed class McpConfigAddRequest
 {
     /// <summary>MCP server configuration (stdio process or remote HTTP/SSE).</summary>
     [JsonPropertyName("config")]
-    public object Config { get; set; } = null!;
+    public JsonElement Config { get; set; }
 
     /// <summary>Unique name for the MCP server.</summary>
     [RegularExpression("^[^\\x00-\\x1f/\\x7f-\\x9f}]+(?:\\/[^\\x00-\\x1f/\\x7f-\\x9f}]+)*$")]
@@ -401,7 +401,7 @@ internal sealed class McpConfigUpdateRequest
 {
     /// <summary>MCP server configuration (stdio process or remote HTTP/SSE).</summary>
     [JsonPropertyName("config")]
-    public object Config { get; set; } = null!;
+    public JsonElement Config { get; set; }
 
     /// <summary>Name of the MCP server to update.</summary>
     [RegularExpression("^[^\\x00-\\x1f/\\x7f-\\x9f}]+(?:\\/[^\\x00-\\x1f/\\x7f-\\x9f}]+)*$")]
@@ -1074,7 +1074,7 @@ public sealed class InstalledPlugin
 
     /// <summary>Source for direct repo installs (when marketplace is empty).</summary>
     [JsonPropertyName("source")]
-    public object? Source { get; set; }
+    public JsonElement? Source { get; set; }
 
     /// <summary>Version installed (if available).</summary>
     [JsonPropertyName("version")]
@@ -1345,8 +1345,9 @@ internal sealed class SendRequest
     public string SessionId { get; set; } = string.Empty;
 
     /// <summary>Optional provenance tag copied to the resulting user.message event. Supported values are `system`, `command-*`, and `schedule-*`.</summary>
+    [JsonInclude]
     [JsonPropertyName("source")]
-    public object? Source { get; set; }
+    internal JsonElement? Source { get; set; }
 
     /// <summary>W3C Trace Context traceparent header for distributed tracing of this agent turn.</summary>
     [JsonPropertyName("traceparent")]
@@ -2617,8 +2618,9 @@ public sealed class AgentInfo
     public string Id { get; set; } = string.Empty;
 
     /// <summary>MCP server configurations attached to this agent, keyed by server name. Server config shape mirrors the MCP `mcpServers` schema.</summary>
+    [Experimental(Diagnostics.Experimental)]
     [JsonPropertyName("mcpServers")]
-    public IDictionary<string, object>? McpServers { get; set; }
+    public IDictionary<string, JsonElement>? McpServers { get; set; }
 
     /// <summary>Preferred model id for this agent. When omitted, inherits the outer agent's model.</summary>
     [JsonPropertyName("model")]
@@ -3474,7 +3476,7 @@ internal sealed class McpExecuteSamplingParams
 {
     /// <summary>The original MCP JSON-RPC request ID (string or number). Used by the runtime to correlate the inference with the originating MCP request for telemetry; this is distinct from `requestId` (which is the schema-level cancellation handle).</summary>
     [JsonPropertyName("mcpRequestId")]
-    public object McpRequestId { get; set; } = null!;
+    public JsonElement McpRequestId { get; set; }
 
     /// <summary>Raw MCP CreateMessageRequest params, as received in the `sampling.requested` event. Treated as opaque at the schema layer; the runtime converts the embedded MCP messages into the OpenAI chat-completion shape internally.</summary>
     [JsonPropertyName("request")]
@@ -3668,7 +3670,7 @@ public sealed class SessionInstalledPlugin
 
     /// <summary>Source descriptor for direct repo installs (when marketplace is empty).</summary>
     [JsonPropertyName("source")]
-    public object? Source { get; set; }
+    public JsonElement? Source { get; set; }
 
     /// <summary>Installed version, if known.</summary>
     [JsonPropertyName("version")]
@@ -3680,8 +3682,9 @@ public sealed class SessionInstalledPlugin
 internal sealed class SessionUpdateOptionsParams
 {
     /// <summary>Additional content-exclusion policies to merge into the session's policy set. Opaque shape; see `ContentExclusionApiResponse` in the runtime.</summary>
+    [Experimental(Diagnostics.Experimental)]
     [JsonPropertyName("additionalContentExclusionPolicies")]
-    public IList<object>? AdditionalContentExclusionPolicies { get; set; }
+    public IList<JsonElement>? AdditionalContentExclusionPolicies { get; set; }
 
     /// <summary>Runtime context discriminator (e.g., `cli`, `actions`).</summary>
     [JsonPropertyName("agentContext")]
@@ -3784,8 +3787,9 @@ internal sealed class SessionUpdateOptionsParams
     public string? Model { get; set; }
 
     /// <summary>Custom model-provider configuration (BYOK). Opaque shape; see `ProviderConfig` in the runtime.</summary>
+    [Experimental(Diagnostics.Experimental)]
     [JsonPropertyName("provider")]
-    public object? Provider { get; set; }
+    public JsonElement? Provider { get; set; }
 
     /// <summary>Reasoning effort for the selected model (model-defined enum).</summary>
     [JsonPropertyName("reasoningEffort")]
@@ -3796,8 +3800,9 @@ internal sealed class SessionUpdateOptionsParams
     public bool? RunningInInteractiveMode { get; set; }
 
     /// <summary>Sandbox configuration shape; opaque to SDK consumers. See `SandboxConfig` in the runtime.</summary>
+    [Experimental(Diagnostics.Experimental)]
     [JsonPropertyName("sandboxConfig")]
-    public object? SandboxConfig { get; set; }
+    public JsonElement? SandboxConfig { get; set; }
 
     /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
@@ -3950,7 +3955,7 @@ internal sealed class HandlePendingToolCallRequest
 
     /// <summary>Tool call result (string or expanded result object).</summary>
     [JsonPropertyName("result")]
-    public object? Result { get; set; }
+    public JsonElement? Result { get; set; }
 
     /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
@@ -4367,7 +4372,7 @@ public sealed class UIElicitationResponse
 
     /// <summary>The form values submitted by the user (present when action is 'accept').</summary>
     [JsonPropertyName("content")]
-    public IDictionary<string, object>? Content { get; set; }
+    public IDictionary<string, JsonElement>? Content { get; set; }
 }
 
 /// <summary>JSON Schema describing the form fields to present to the user.</summary>
@@ -4376,7 +4381,7 @@ public sealed class UIElicitationSchema
 {
     /// <summary>Form field definitions, keyed by field name.</summary>
     [JsonPropertyName("properties")]
-    public IDictionary<string, object> Properties { get => field ??= new Dictionary<string, object>(); set; }
+    public IDictionary<string, JsonElement> Properties { get => field ??= new Dictionary<string, JsonElement>(); set; }
 
     /// <summary>List of required field names.</summary>
     [JsonPropertyName("required")]
@@ -4636,7 +4641,7 @@ public sealed class PermissionsConfigureAdditionalContentExclusionPolicy
 {
     /// <summary>Gets or sets the <c>last_updated_at</c> value.</summary>
     [JsonPropertyName("last_updated_at")]
-    public object LastUpdatedAt { get; set; } = null!;
+    public JsonElement LastUpdatedAt { get; set; }
 
     /// <summary>Gets or sets the <c>rules</c> value.</summary>
     [JsonPropertyName("rules")]
@@ -6517,7 +6522,7 @@ internal sealed class EventLogReadRequest
 
     /// <summary>Either '*' to receive all event types, or a non-empty list of event types to receive.</summary>
     [JsonPropertyName("types")]
-    public object? Types { get; set; }
+    public JsonElement? Types { get; set; }
 
     /// <summary>Milliseconds to wait for new events when the cursor is at the tail of history. 0 (default) returns immediately even if no events are available. Capped at 30000ms. Ephemeral events that arrive during the wait are delivered in this batch but are NOT replayable on a subsequent read (use a non-zero waitMs in your next call to capture future ephemerals as they happen).</summary>
     [JsonConverter(typeof(MillisecondsTimeSpanConverter))]
@@ -7139,7 +7144,7 @@ public sealed class SessionFsSqliteQueryResult
 
     /// <summary>For SELECT: array of row objects. For others: empty array.</summary>
     [JsonPropertyName("rows")]
-    public IList<IDictionary<string, object>> Rows { get => field ??= []; set; }
+    public IList<IDictionary<string, JsonElement>> Rows { get => field ??= []; set; }
 
     /// <summary>Number of rows affected (for INSERT/UPDATE/DELETE).</summary>
     [JsonPropertyName("rowsAffected")]
@@ -7151,7 +7156,7 @@ public sealed class SessionFsSqliteQueryRequest
 {
     /// <summary>Optional named bind parameters.</summary>
     [JsonPropertyName("params")]
-    public IDictionary<string, object>? Params { get; set; }
+    public IDictionary<string, JsonElement>? Params { get; set; }
 
     /// <summary>SQL query to execute.</summary>
     [JsonPropertyName("query")]
@@ -10354,7 +10359,7 @@ public sealed class ServerMcpConfigApi
         ArgumentNullException.ThrowIfNull(name);
         ArgumentNullException.ThrowIfNull(config);
 
-        var request = new McpConfigAddRequest { Name = name, Config = config };
+        var request = new McpConfigAddRequest { Name = name, Config = CopilotClient.ToJsonElementForWire(config)!.Value };
         await CopilotClient.InvokeRpcAsync(_rpc, "mcp.config.add", [request], cancellationToken);
     }
 
@@ -10367,7 +10372,7 @@ public sealed class ServerMcpConfigApi
         ArgumentNullException.ThrowIfNull(name);
         ArgumentNullException.ThrowIfNull(config);
 
-        var request = new McpConfigUpdateRequest { Name = name, Config = config };
+        var request = new McpConfigUpdateRequest { Name = name, Config = CopilotClient.ToJsonElementForWire(config)!.Value };
         await CopilotClient.InvokeRpcAsync(_rpc, "mcp.config.update", [request], cancellationToken);
     }
 
@@ -10938,7 +10943,7 @@ public sealed class SessionRpc
         ArgumentNullException.ThrowIfNull(prompt);
         _session.ThrowIfDisposed();
 
-        var request = new SendRequest { SessionId = _session.SessionId, Prompt = prompt, DisplayPrompt = displayPrompt, Attachments = attachments, Mode = mode, Prepend = prepend, Billable = billable, RequiredTool = requiredTool, Source = source, AgentMode = agentMode, RequestHeaders = requestHeaders, Traceparent = traceparent, Tracestate = tracestate, Wait = wait };
+        var request = new SendRequest { SessionId = _session.SessionId, Prompt = prompt, DisplayPrompt = displayPrompt, Attachments = attachments, Mode = mode, Prepend = prepend, Billable = billable, RequiredTool = requiredTool, Source = CopilotClient.ToJsonElementForWire(source), AgentMode = agentMode, RequestHeaders = requestHeaders, Traceparent = traceparent, Tracestate = tracestate, Wait = wait };
         return await CopilotClient.InvokeRpcAsync<SendResult>(_session.Rpc, "session.send", [request], cancellationToken);
     }
 
@@ -11718,7 +11723,7 @@ public sealed class McpApi
         ArgumentNullException.ThrowIfNull(request);
         _session.ThrowIfDisposed();
 
-        var rpcRequest = new McpExecuteSamplingParams { SessionId = _session.SessionId, RequestId = requestId, ServerName = serverName, McpRequestId = mcpRequestId, Request = request };
+        var rpcRequest = new McpExecuteSamplingParams { SessionId = _session.SessionId, RequestId = requestId, ServerName = serverName, McpRequestId = CopilotClient.ToJsonElementForWire(mcpRequestId)!.Value, Request = request };
         return await CopilotClient.InvokeRpcAsync<McpSamplingExecutionResult>(_session.Rpc, "session.mcp.executeSampling", [rpcRequest], cancellationToken);
     }
 
@@ -11866,11 +11871,11 @@ public sealed class OptionsApi
     /// <param name="manageScheduleEnabled">Whether to expose the `manage_schedule` tool to the agent. The runtime always owns the per-session schedule registry; this flag only controls tool exposure (typically gated to staff users).</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Indicates whether the session options patch was applied successfully.</returns>
-    public async Task<SessionUpdateOptionsResult> UpdateAsync(string? model = null, string? reasoningEffort = null, string? clientName = null, string? lspClientName = null, string? integrationId = null, IDictionary<string, bool>? featureFlags = null, bool? isExperimentalMode = null, object? provider = null, string? workingDirectory = null, IList<string>? availableTools = null, IList<string>? excludedTools = null, bool? enableScriptSafety = null, string? shellInitProfile = null, IList<string>? shellProcessFlags = null, object? sandboxConfig = null, bool? logInteractiveShells = null, OptionsUpdateEnvValueMode? envValueMode = null, IList<string>? skillDirectories = null, IList<string>? disabledSkills = null, bool? enableOnDemandInstructionDiscovery = null, IList<SessionInstalledPlugin>? installedPlugins = null, bool? customAgentsLocalOnly = null, bool? skipCustomInstructions = null, IList<string>? disabledInstructionSources = null, bool? coauthorEnabled = null, string? trajectoryFile = null, bool? enableStreaming = null, string? copilotUrl = null, bool? askUserDisabled = null, bool? continueOnAutoMode = null, bool? runningInInteractiveMode = null, bool? enableReasoningSummaries = null, string? agentContext = null, string? eventsLogDirectory = null, IList<object>? additionalContentExclusionPolicies = null, bool? manageScheduleEnabled = null, CancellationToken cancellationToken = default)
+    public async Task<SessionUpdateOptionsResult> UpdateAsync(string? model = null, string? reasoningEffort = null, string? clientName = null, string? lspClientName = null, string? integrationId = null, IDictionary<string, bool>? featureFlags = null, bool? isExperimentalMode = null, object? provider = null, string? workingDirectory = null, IList<string>? availableTools = null, IList<string>? excludedTools = null, bool? enableScriptSafety = null, string? shellInitProfile = null, IList<string>? shellProcessFlags = null, object? sandboxConfig = null, bool? logInteractiveShells = null, OptionsUpdateEnvValueMode? envValueMode = null, IList<string>? skillDirectories = null, IList<string>? disabledSkills = null, bool? enableOnDemandInstructionDiscovery = null, IList<SessionInstalledPlugin>? installedPlugins = null, bool? customAgentsLocalOnly = null, bool? skipCustomInstructions = null, IList<string>? disabledInstructionSources = null, bool? coauthorEnabled = null, string? trajectoryFile = null, bool? enableStreaming = null, string? copilotUrl = null, bool? askUserDisabled = null, bool? continueOnAutoMode = null, bool? runningInInteractiveMode = null, bool? enableReasoningSummaries = null, string? agentContext = null, string? eventsLogDirectory = null, IList<object?>? additionalContentExclusionPolicies = null, bool? manageScheduleEnabled = null, CancellationToken cancellationToken = default)
     {
         _session.ThrowIfDisposed();
 
-        var request = new SessionUpdateOptionsParams { SessionId = _session.SessionId, Model = model, ReasoningEffort = reasoningEffort, ClientName = clientName, LspClientName = lspClientName, IntegrationId = integrationId, FeatureFlags = featureFlags, IsExperimentalMode = isExperimentalMode, Provider = provider, WorkingDirectory = workingDirectory, AvailableTools = availableTools, ExcludedTools = excludedTools, EnableScriptSafety = enableScriptSafety, ShellInitProfile = shellInitProfile, ShellProcessFlags = shellProcessFlags, SandboxConfig = sandboxConfig, LogInteractiveShells = logInteractiveShells, EnvValueMode = envValueMode, SkillDirectories = skillDirectories, DisabledSkills = disabledSkills, EnableOnDemandInstructionDiscovery = enableOnDemandInstructionDiscovery, InstalledPlugins = installedPlugins, CustomAgentsLocalOnly = customAgentsLocalOnly, SkipCustomInstructions = skipCustomInstructions, DisabledInstructionSources = disabledInstructionSources, CoauthorEnabled = coauthorEnabled, TrajectoryFile = trajectoryFile, EnableStreaming = enableStreaming, CopilotUrl = copilotUrl, AskUserDisabled = askUserDisabled, ContinueOnAutoMode = continueOnAutoMode, RunningInInteractiveMode = runningInInteractiveMode, EnableReasoningSummaries = enableReasoningSummaries, AgentContext = agentContext, EventsLogDirectory = eventsLogDirectory, AdditionalContentExclusionPolicies = additionalContentExclusionPolicies, ManageScheduleEnabled = manageScheduleEnabled };
+        var request = new SessionUpdateOptionsParams { SessionId = _session.SessionId, Model = model, ReasoningEffort = reasoningEffort, ClientName = clientName, LspClientName = lspClientName, IntegrationId = integrationId, FeatureFlags = featureFlags, IsExperimentalMode = isExperimentalMode, Provider = CopilotClient.ToJsonElementForWire(provider), WorkingDirectory = workingDirectory, AvailableTools = availableTools, ExcludedTools = excludedTools, EnableScriptSafety = enableScriptSafety, ShellInitProfile = shellInitProfile, ShellProcessFlags = shellProcessFlags, SandboxConfig = CopilotClient.ToJsonElementForWire(sandboxConfig), LogInteractiveShells = logInteractiveShells, EnvValueMode = envValueMode, SkillDirectories = skillDirectories, DisabledSkills = disabledSkills, EnableOnDemandInstructionDiscovery = enableOnDemandInstructionDiscovery, InstalledPlugins = installedPlugins, CustomAgentsLocalOnly = customAgentsLocalOnly, SkipCustomInstructions = skipCustomInstructions, DisabledInstructionSources = disabledInstructionSources, CoauthorEnabled = coauthorEnabled, TrajectoryFile = trajectoryFile, EnableStreaming = enableStreaming, CopilotUrl = copilotUrl, AskUserDisabled = askUserDisabled, ContinueOnAutoMode = continueOnAutoMode, RunningInInteractiveMode = runningInInteractiveMode, EnableReasoningSummaries = enableReasoningSummaries, AgentContext = agentContext, EventsLogDirectory = eventsLogDirectory, AdditionalContentExclusionPolicies = additionalContentExclusionPolicies?.Select(static v => CopilotClient.ToJsonElementForWire(v)!.Value).ToList(), ManageScheduleEnabled = manageScheduleEnabled };
         return await CopilotClient.InvokeRpcAsync<SessionUpdateOptionsResult>(_session.Rpc, "session.options.update", [request], cancellationToken);
     }
 }
@@ -11979,7 +11984,7 @@ public sealed class ToolsApi
         ArgumentNullException.ThrowIfNull(requestId);
         _session.ThrowIfDisposed();
 
-        var request = new HandlePendingToolCallRequest { SessionId = _session.SessionId, RequestId = requestId, Result = result, Error = error };
+        var request = new HandlePendingToolCallRequest { SessionId = _session.SessionId, RequestId = requestId, Result = CopilotClient.ToJsonElementForWire(result), Error = error };
         return await CopilotClient.InvokeRpcAsync<HandlePendingToolCallResult>(_session.Rpc, "session.tools.handlePendingToolCall", [request], cancellationToken);
     }
 
@@ -12836,7 +12841,7 @@ public sealed class EventLogApi
     {
         _session.ThrowIfDisposed();
 
-        var request = new EventLogReadRequest { SessionId = _session.SessionId, Cursor = cursor, Max = max, Wait = waitMs, Types = types, AgentScope = agentScope };
+        var request = new EventLogReadRequest { SessionId = _session.SessionId, Cursor = cursor, Max = max, Wait = waitMs, Types = CopilotClient.ToJsonElementForWire(types), AgentScope = agentScope };
         return await CopilotClient.InvokeRpcAsync<EventsReadResult>(_session.Rpc, "session.eventLog.read", [request], cancellationToken);
     }
 
@@ -13172,11 +13177,9 @@ internal static class ClientSessionApiRegistration
 [JsonSerializable(typeof(GitHub.Copilot.AssistantTurnStartData), TypeInfoPropertyName = "SessionEventsAssistantTurnStartData")]
 [JsonSerializable(typeof(GitHub.Copilot.AssistantTurnStartEvent), TypeInfoPropertyName = "SessionEventsAssistantTurnStartEvent")]
 [JsonSerializable(typeof(GitHub.Copilot.AssistantUsageApiEndpoint), TypeInfoPropertyName = "SessionEventsAssistantUsageApiEndpoint")]
-[JsonSerializable(typeof(GitHub.Copilot.AssistantUsageCopilotUsage), TypeInfoPropertyName = "SessionEventsAssistantUsageCopilotUsage")]
 [JsonSerializable(typeof(GitHub.Copilot.AssistantUsageCopilotUsageTokenDetail), TypeInfoPropertyName = "SessionEventsAssistantUsageCopilotUsageTokenDetail")]
 [JsonSerializable(typeof(GitHub.Copilot.AssistantUsageData), TypeInfoPropertyName = "SessionEventsAssistantUsageData")]
 [JsonSerializable(typeof(GitHub.Copilot.AssistantUsageEvent), TypeInfoPropertyName = "SessionEventsAssistantUsageEvent")]
-[JsonSerializable(typeof(GitHub.Copilot.AssistantUsageQuotaSnapshot), TypeInfoPropertyName = "SessionEventsAssistantUsageQuotaSnapshot")]
 [JsonSerializable(typeof(GitHub.Copilot.AutoModeSwitchCompletedData), TypeInfoPropertyName = "SessionEventsAutoModeSwitchCompletedData")]
 [JsonSerializable(typeof(GitHub.Copilot.AutoModeSwitchCompletedEvent), TypeInfoPropertyName = "SessionEventsAutoModeSwitchCompletedEvent")]
 [JsonSerializable(typeof(GitHub.Copilot.AutoModeSwitchRequestedData), TypeInfoPropertyName = "SessionEventsAutoModeSwitchRequestedData")]
@@ -13195,7 +13198,6 @@ internal static class ClientSessionApiRegistration
 [JsonSerializable(typeof(GitHub.Copilot.CommandsChangedData), TypeInfoPropertyName = "SessionEventsCommandsChangedData")]
 [JsonSerializable(typeof(GitHub.Copilot.CommandsChangedEvent), TypeInfoPropertyName = "SessionEventsCommandsChangedEvent")]
 [JsonSerializable(typeof(GitHub.Copilot.CompactionCompleteCompactionTokensUsed), TypeInfoPropertyName = "SessionEventsCompactionCompleteCompactionTokensUsed")]
-[JsonSerializable(typeof(GitHub.Copilot.CompactionCompleteCompactionTokensUsedCopilotUsage), TypeInfoPropertyName = "SessionEventsCompactionCompleteCompactionTokensUsedCopilotUsage")]
 [JsonSerializable(typeof(GitHub.Copilot.CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail), TypeInfoPropertyName = "SessionEventsCompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail")]
 [JsonSerializable(typeof(GitHub.Copilot.CustomAgentsUpdatedAgent), TypeInfoPropertyName = "SessionEventsCustomAgentsUpdatedAgent")]
 [JsonSerializable(typeof(GitHub.Copilot.ElicitationCompletedAction), TypeInfoPropertyName = "SessionEventsElicitationCompletedAction")]

--- a/dotnet/src/Generated/SessionEvents.cs
+++ b/dotnet/src/Generated/SessionEvents.cs
@@ -1667,14 +1667,16 @@ public sealed partial class SessionShutdownData
     public required TimeSpan TotalApiDuration { get; set; }
 
     /// <summary>Session-wide accumulated nano-AI units cost.</summary>
+    [Experimental(Diagnostics.Experimental)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("totalNanoAiu")]
     public double? TotalNanoAiu { get; set; }
 
     /// <summary>Total number of premium API requests used during the session.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonInclude]
     [JsonPropertyName("totalPremiumRequests")]
-    public double? TotalPremiumRequests { get; set; }
+    internal double? TotalPremiumRequests { get; set; }
 }
 
 /// <summary>Working directory and git context at session start.</summary>
@@ -1987,11 +1989,13 @@ public sealed partial class AssistantStreamingDeltaData
 public sealed partial class AssistantMessageData
 {
     /// <summary>Raw Anthropic content array with advisor blocks (server_tool_use, advisor_tool_result) for verbatim round-tripping.</summary>
+    [Experimental(Diagnostics.Experimental)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("anthropicAdvisorBlocks")]
-    public object[]? AnthropicAdvisorBlocks { get; set; }
+    public JsonElement[]? AnthropicAdvisorBlocks { get; set; }
 
     /// <summary>Anthropic advisor model ID used for this response, for timeline display on replay.</summary>
+    [Experimental(Diagnostics.Experimental)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("anthropicAdvisorModel")]
     public string? AnthropicAdvisorModel { get; set; }
@@ -2127,10 +2131,12 @@ public sealed partial class AssistantUsageData
 
     /// <summary>Per-request cost and usage data from the CAPI copilot_usage response field.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonInclude]
     [JsonPropertyName("copilotUsage")]
-    public AssistantUsageCopilotUsage? CopilotUsage { get; set; }
+    internal AssistantUsageCopilotUsage? CopilotUsage { get; set; }
 
     /// <summary>Model multiplier cost for billing purposes.</summary>
+    [Experimental(Diagnostics.Experimental)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("cost")]
     public double? Cost { get; set; }
@@ -2180,8 +2186,9 @@ public sealed partial class AssistantUsageData
 
     /// <summary>Per-quota resource usage snapshots, keyed by quota identifier.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonInclude]
     [JsonPropertyName("quotaSnapshots")]
-    public IDictionary<string, AssistantUsageQuotaSnapshot>? QuotaSnapshots { get; set; }
+    internal IDictionary<string, AssistantUsageQuotaSnapshot>? QuotaSnapshots { get; set; }
 
     /// <summary>Reasoning effort level used for model calls, if applicable (e.g. "none", "low", "medium", "high", "xhigh", "max").</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -2258,7 +2265,7 @@ public sealed partial class ToolUserRequestedData
     /// <summary>Arguments for the tool invocation.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("arguments")]
-    public object? Arguments { get; set; }
+    public JsonElement? Arguments { get; set; }
 
     /// <summary>Unique identifier for this tool call.</summary>
     [JsonPropertyName("toolCallId")]
@@ -2275,7 +2282,7 @@ public sealed partial class ToolExecutionStartData
     /// <summary>Arguments passed to the tool.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("arguments")]
-    public object? Arguments { get; set; }
+    public JsonElement? Arguments { get; set; }
 
     /// <summary>Name of the MCP server hosting this tool, when the tool is an MCP tool.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -2383,7 +2390,7 @@ public sealed partial class ToolExecutionCompleteData
     /// <summary>Tool-specific telemetry data (e.g., CodeQL check counts, grep match counts).</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("toolTelemetry")]
-    public IDictionary<string, object>? ToolTelemetry { get; set; }
+    public IDictionary<string, JsonElement>? ToolTelemetry { get; set; }
 
     /// <summary>Identifier for the agent loop turn this tool was invoked in, matching the corresponding assistant.turn_start event.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -2565,7 +2572,7 @@ public sealed partial class HookStartData
     /// <summary>Input data passed to the hook.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("input")]
-    public object? Input { get; set; }
+    public JsonElement? Input { get; set; }
 }
 
 /// <summary>Hook invocation completion details including output, success status, and error information.</summary>
@@ -2587,7 +2594,7 @@ public sealed partial class HookEndData
     /// <summary>Output data produced by the hook.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("output")]
-    public object? Output { get; set; }
+    public JsonElement? Output { get; set; }
 
     /// <summary>Whether the hook completed successfully.</summary>
     [JsonPropertyName("success")]
@@ -2760,7 +2767,7 @@ public sealed partial class ElicitationCompletedData
     /// <summary>The submitted form data when action is 'accept'; keys match the requested schema fields.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("content")]
-    public IDictionary<string, object>? Content { get; set; }
+    public IDictionary<string, JsonElement>? Content { get; set; }
 
     /// <summary>Request ID of the resolved elicitation request; clients should dismiss any UI for this request.</summary>
     [JsonPropertyName("requestId")]
@@ -2772,7 +2779,7 @@ public sealed partial class SamplingRequestedData
 {
     /// <summary>The JSON-RPC request ID from the MCP protocol.</summary>
     [JsonPropertyName("mcpRequestId")]
-    public required object McpRequestId { get; set; }
+    public required JsonElement McpRequestId { get; set; }
 
     /// <summary>Unique identifier for this sampling request; used to respond via session.respondToSampling().</summary>
     [JsonPropertyName("requestId")]
@@ -2831,7 +2838,7 @@ public sealed partial class SessionCustomNotificationData
 
     /// <summary>Source-defined JSON payload for the custom notification.</summary>
     [JsonPropertyName("payload")]
-    public required object Payload { get; set; }
+    public required JsonElement Payload { get; set; }
 
     /// <summary>Namespace for the custom notification producer.</summary>
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Safe for generated string properties: JSON Schema minLength/maxLength map to string length validation, not reflection over trimmed Count members")]
@@ -2856,7 +2863,7 @@ public sealed partial class ExternalToolRequestedData
     /// <summary>Arguments to pass to the external tool.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("arguments")]
-    public object? Arguments { get; set; }
+    public JsonElement? Arguments { get; set; }
 
     /// <summary>Unique identifier for this request; used to respond via session.respondToExternalTool().</summary>
     [JsonPropertyName("requestId")]
@@ -3181,11 +3188,13 @@ public sealed partial class ShutdownCodeChanges
 public sealed partial class ShutdownModelMetricRequests
 {
     /// <summary>Cumulative cost multiplier for requests to this model.</summary>
+    [Experimental(Diagnostics.Experimental)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("cost")]
     public double? Cost { get; set; }
 
     /// <summary>Total number of API requests made to this model.</summary>
+    [Experimental(Diagnostics.Experimental)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("count")]
     public long? Count { get; set; }
@@ -3240,6 +3249,7 @@ public sealed partial class ShutdownModelMetric
     public IDictionary<string, ShutdownModelMetricTokenDetail>? TokenDetails { get; set; }
 
     /// <summary>Accumulated nano-AI units cost for this model.</summary>
+    [Experimental(Diagnostics.Experimental)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("totalNanoAiu")]
     public double? TotalNanoAiu { get; set; }
@@ -3281,7 +3291,7 @@ public sealed partial class CompactionCompleteCompactionTokensUsedCopilotUsageTo
 
 /// <summary>Per-request cost and usage data from the CAPI copilot_usage response field.</summary>
 /// <remarks>Nested data type for <c>CompactionCompleteCompactionTokensUsedCopilotUsage</c>.</remarks>
-public sealed partial class CompactionCompleteCompactionTokensUsedCopilotUsage
+internal sealed partial class CompactionCompleteCompactionTokensUsedCopilotUsage
 {
     /// <summary>Itemized token usage breakdown.</summary>
     [JsonPropertyName("tokenDetails")]
@@ -3308,8 +3318,9 @@ public sealed partial class CompactionCompleteCompactionTokensUsed
 
     /// <summary>Per-request cost and usage data from the CAPI copilot_usage response field.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonInclude]
     [JsonPropertyName("copilotUsage")]
-    public CompactionCompleteCompactionTokensUsedCopilotUsage? CopilotUsage { get; set; }
+    internal CompactionCompleteCompactionTokensUsedCopilotUsage? CopilotUsage { get; set; }
 
     /// <summary>Duration of the compaction LLM call in milliseconds.</summary>
     [JsonConverter(typeof(MillisecondsTimeSpanConverter))]
@@ -3526,7 +3537,7 @@ public sealed partial class AssistantMessageToolRequest
     /// <summary>Arguments to pass to the tool, format depends on the tool.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("arguments")]
-    public object? Arguments { get; set; }
+    public JsonElement? Arguments { get; set; }
 
     /// <summary>Resolved intention summary describing what this specific call does.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -3585,7 +3596,7 @@ public sealed partial class AssistantUsageCopilotUsageTokenDetail
 
 /// <summary>Per-request cost and usage data from the CAPI copilot_usage response field.</summary>
 /// <remarks>Nested data type for <c>AssistantUsageCopilotUsage</c>.</remarks>
-public sealed partial class AssistantUsageCopilotUsage
+internal sealed partial class AssistantUsageCopilotUsage
 {
     /// <summary>Itemized token usage breakdown.</summary>
     [JsonPropertyName("tokenDetails")]
@@ -3598,40 +3609,48 @@ public sealed partial class AssistantUsageCopilotUsage
 
 /// <summary>Schema for the `AssistantUsageQuotaSnapshot` type.</summary>
 /// <remarks>Nested data type for <c>AssistantUsageQuotaSnapshot</c>.</remarks>
-public sealed partial class AssistantUsageQuotaSnapshot
+internal sealed partial class AssistantUsageQuotaSnapshot
 {
     /// <summary>Total requests allowed by the entitlement.</summary>
+    [JsonInclude]
     [JsonPropertyName("entitlementRequests")]
-    public required long EntitlementRequests { get; set; }
+    internal required long EntitlementRequests { get; set; }
 
     /// <summary>Whether the user has an unlimited usage entitlement.</summary>
+    [JsonInclude]
     [JsonPropertyName("isUnlimitedEntitlement")]
-    public required bool IsUnlimitedEntitlement { get; set; }
+    internal required bool IsUnlimitedEntitlement { get; set; }
 
     /// <summary>Number of additional usage requests made this period.</summary>
+    [JsonInclude]
     [JsonPropertyName("overage")]
-    public required double Overage { get; set; }
+    internal required double Overage { get; set; }
 
     /// <summary>Whether additional usage is allowed when quota is exhausted.</summary>
+    [JsonInclude]
     [JsonPropertyName("overageAllowedWithExhaustedQuota")]
-    public required bool OverageAllowedWithExhaustedQuota { get; set; }
+    internal required bool OverageAllowedWithExhaustedQuota { get; set; }
 
     /// <summary>Percentage of quota remaining (0 to 100).</summary>
+    [JsonInclude]
     [JsonPropertyName("remainingPercentage")]
-    public required double RemainingPercentage { get; set; }
+    internal required double RemainingPercentage { get; set; }
 
     /// <summary>Date when the quota resets.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonInclude]
     [JsonPropertyName("resetDate")]
-    public DateTimeOffset? ResetDate { get; set; }
+    internal DateTimeOffset? ResetDate { get; set; }
 
     /// <summary>Whether usage is still permitted after quota exhaustion.</summary>
+    [JsonInclude]
     [JsonPropertyName("usageAllowedWithExhaustedQuota")]
-    public required bool UsageAllowedWithExhaustedQuota { get; set; }
+    internal required bool UsageAllowedWithExhaustedQuota { get; set; }
 
     /// <summary>Number of requests already consumed.</summary>
+    [JsonInclude]
     [JsonPropertyName("usedRequests")]
-    public required long UsedRequests { get; set; }
+    internal required long UsedRequests { get; set; }
 }
 
 /// <summary>Error details when the tool execution failed.</summary>
@@ -3978,7 +3997,7 @@ public sealed partial class SystemMessageMetadata
     /// <summary>Template variables used when constructing the prompt.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("variables")]
-    public IDictionary<string, object>? Variables { get; set; }
+    public IDictionary<string, JsonElement>? Variables { get; set; }
 }
 
 /// <summary>Schema for the `SystemNotificationAgentCompleted` type.</summary>
@@ -4282,7 +4301,7 @@ public sealed partial class PermissionRequestMcp : PermissionRequest
     /// <summary>Arguments to pass to the MCP tool.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("args")]
-    public object? Args { get; set; }
+    public JsonElement? Args { get; set; }
 
     /// <summary>Whether this MCP tool is read-only (no side effects).</summary>
     [JsonPropertyName("readOnly")]
@@ -4382,7 +4401,7 @@ public sealed partial class PermissionRequestCustomTool : PermissionRequest
     /// <summary>Arguments to pass to the custom tool.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("args")]
-    public object? Args { get; set; }
+    public JsonElement? Args { get; set; }
 
     /// <summary>Tool call ID that triggered this permission request.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -4414,7 +4433,7 @@ public sealed partial class PermissionRequestHook : PermissionRequest
     /// <summary>Arguments of the tool call being gated.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("toolArgs")]
-    public object? ToolArgs { get; set; }
+    public JsonElement? ToolArgs { get; set; }
 
     /// <summary>Tool call ID that triggered this permission request.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -4597,7 +4616,7 @@ public sealed partial class PermissionPromptRequestMcp : PermissionPromptRequest
     /// <summary>Arguments to pass to the MCP tool.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("args")]
-    public object? Args { get; set; }
+    public JsonElement? Args { get; set; }
 
     /// <summary>Name of the MCP server providing the tool.</summary>
     [JsonPropertyName("serverName")]
@@ -4693,7 +4712,7 @@ public sealed partial class PermissionPromptRequestCustomTool : PermissionPrompt
     /// <summary>Arguments to pass to the custom tool.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("args")]
-    public object? Args { get; set; }
+    public JsonElement? Args { get; set; }
 
     /// <summary>Tool call ID that triggered this permission request.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -4747,7 +4766,7 @@ public sealed partial class PermissionPromptRequestHook : PermissionPromptReques
     /// <summary>Arguments of the tool call being gated.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("toolArgs")]
-    public object? ToolArgs { get; set; }
+    public JsonElement? ToolArgs { get; set; }
 
     /// <summary>Tool call ID that triggered this permission request.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -5117,7 +5136,7 @@ public sealed partial class ElicitationRequestedSchema
 {
     /// <summary>Form field definitions, keyed by field name.</summary>
     [JsonPropertyName("properties")]
-    public required IDictionary<string, object> Properties { get; set; }
+    public required IDictionary<string, JsonElement> Properties { get; set; }
 
     /// <summary>List of required field names.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -637,7 +637,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
                                 ? new ElicitationSchema
                                 {
                                     Type = data.RequestedSchema.Type,
-                                    Properties = data.RequestedSchema.Properties,
+                                    Properties = data.RequestedSchema.Properties.ToDictionary(kvp => kvp.Key, kvp => (object)kvp.Value),
                                     Required = data.RequestedSchema.Required?.ToList()
                                 }
                                 : null;
@@ -687,7 +687,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
     /// <summary>
     /// Executes a tool handler and sends the result back via the HandlePendingToolCall RPC.
     /// </summary>
-    private async Task ExecuteToolAndRespondAsync(string requestId, string toolName, string toolCallId, object? arguments, AIFunction tool)
+    private async Task ExecuteToolAndRespondAsync(string requestId, string toolName, string toolCallId, JsonElement? arguments, AIFunction tool)
     {
         try
         {
@@ -707,13 +707,8 @@ public sealed partial class CopilotSession : IAsyncDisposable
                 }
             };
 
-            if (arguments is not null)
+            if (arguments is JsonElement incomingJsonArgs)
             {
-                if (arguments is not JsonElement incomingJsonArgs)
-                {
-                    throw new InvalidOperationException($"Incoming arguments must be a {nameof(JsonElement)}; received {arguments.GetType().Name}");
-                }
-
                 foreach (var prop in incomingJsonArgs.EnumerateObject())
                 {
                     aiFunctionArgs[prop.Name] = prop.Value;
@@ -948,7 +943,9 @@ public sealed partial class CopilotSession : IAsyncDisposable
             await Rpc.Ui.HandlePendingElicitationAsync(requestId, new UIElicitationResponse
             {
                 Action = result.Action,
-                Content = result.Content
+                Content = result.Content?.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => CopilotClient.ToJsonElementForWire(kvp.Value)!.Value)
             });
             LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotSession.HandleElicitationRequestAsync response sent successfully. Elapsed={Elapsed}, SessionId={SessionId}, RequestId={RequestId}",
@@ -991,6 +988,15 @@ public sealed partial class CopilotSession : IAsyncDisposable
     /// </summary>
     private sealed class SessionUiApiImpl(CopilotSession session) : ISessionUiApi
     {
+        // Parses a JSON string and returns a detached JsonElement. Using `using`
+        // ensures the pooled buffers backing the JsonDocument are released
+        // promptly; the cloned RootElement is independent of the document.
+        private static JsonElement ParseJsonElement(string json)
+        {
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.Clone();
+        }
+
         public async Task<ElicitationResult> ElicitAsync(ElicitationParams elicitationParams, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(elicitationParams);
@@ -1000,12 +1006,18 @@ public sealed partial class CopilotSession : IAsyncDisposable
             var schema = new UIElicitationSchema
             {
                 Type = elicitationParams.RequestedSchema.Type,
-                Properties = elicitationParams.RequestedSchema.Properties,
+                Properties = elicitationParams.RequestedSchema.Properties.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => CopilotClient.ToJsonElementForWire(kvp.Value)!.Value),
                 Required = elicitationParams.RequestedSchema.Required
             };
 
             var result = await session.Rpc.Ui.ElicitationAsync(elicitationParams.Message, schema, cancellationToken);
-            return new ElicitationResult { Action = result.Action, Content = result.Content };
+            return new ElicitationResult
+            {
+                Action = result.Action,
+                Content = result.Content?.ToDictionary(kvp => kvp.Key, kvp => (object)kvp.Value)
+            };
         }
 
         public async Task<bool> ConfirmAsync(string message, CancellationToken cancellationToken)
@@ -1017,9 +1029,9 @@ public sealed partial class CopilotSession : IAsyncDisposable
             var schema = new UIElicitationSchema
             {
                 Type = "object",
-                Properties = new Dictionary<string, object>
+                Properties = new Dictionary<string, JsonElement>
                 {
-                    ["confirmed"] = new Dictionary<string, object> { ["type"] = "boolean", ["default"] = true }
+                    ["confirmed"] = ParseJsonElement("""{"type":"boolean","default":true}""")
                 },
                 Required = ["confirmed"]
             };
@@ -1029,11 +1041,10 @@ public sealed partial class CopilotSession : IAsyncDisposable
                 && result.Content != null
                 && result.Content.TryGetValue("confirmed", out var val))
             {
-                return val switch
+                return val.ValueKind switch
                 {
-                    bool b => b,
-                    JsonElement { ValueKind: JsonValueKind.True } => true,
-                    JsonElement { ValueKind: JsonValueKind.False } => false,
+                    JsonValueKind.True => true,
+                    JsonValueKind.False => false,
                     _ => false
                 };
             }
@@ -1048,12 +1059,13 @@ public sealed partial class CopilotSession : IAsyncDisposable
             session.ThrowIfDisposed();
             session.AssertElicitation();
 
+            var enumJson = JsonSerializer.Serialize(options, TypesJsonContext.Default.StringArray);
             var schema = new UIElicitationSchema
             {
                 Type = "object",
-                Properties = new Dictionary<string, object>
+                Properties = new Dictionary<string, JsonElement>
                 {
-                    ["selection"] = new Dictionary<string, object> { ["type"] = "string", ["enum"] = options }
+                    ["selection"] = ParseJsonElement($$"""{"type":"string","enum":{{enumJson}}}""")
                 },
                 Required = ["selection"]
             };
@@ -1063,12 +1075,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
                 && result.Content != null
                 && result.Content.TryGetValue("selection", out var val))
             {
-                return val switch
-                {
-                    string s => s,
-                    JsonElement { ValueKind: JsonValueKind.String } je => je.GetString(),
-                    _ => val.ToString()
-                };
+                return val.ValueKind == JsonValueKind.String ? val.GetString() : val.ToString();
             }
 
             return null;
@@ -1080,18 +1087,21 @@ public sealed partial class CopilotSession : IAsyncDisposable
             session.ThrowIfDisposed();
             session.AssertElicitation();
 
-            var field = new Dictionary<string, object> { ["type"] = "string" };
-            if (options?.Title != null) field["title"] = options.Title;
-            if (options?.Description != null) field["description"] = options.Description;
-            if (options?.MinLength != null) field["minLength"] = options.MinLength;
-            if (options?.MaxLength != null) field["maxLength"] = options.MaxLength;
-            if (options?.Format != null) field["format"] = options.Format;
-            if (options?.Default != null) field["default"] = options.Default;
+            var fieldNode = new System.Text.Json.Nodes.JsonObject { ["type"] = "string" };
+            if (options?.Title != null) fieldNode["title"] = options.Title;
+            if (options?.Description != null) fieldNode["description"] = options.Description;
+            if (options?.MinLength != null) fieldNode["minLength"] = options.MinLength;
+            if (options?.MaxLength != null) fieldNode["maxLength"] = options.MaxLength;
+            if (options?.Format != null) fieldNode["format"] = options.Format;
+            if (options?.Default != null) fieldNode["default"] = options.Default;
 
             var schema = new UIElicitationSchema
             {
                 Type = "object",
-                Properties = new Dictionary<string, object> { ["value"] = field },
+                Properties = new Dictionary<string, JsonElement>
+                {
+                    ["value"] = ParseJsonElement(fieldNode.ToJsonString())
+                },
                 Required = ["value"]
             };
 
@@ -1100,12 +1110,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
                 && result.Content != null
                 && result.Content.TryGetValue("value", out var val))
             {
-                return val switch
-                {
-                    string s => s,
-                    JsonElement { ValueKind: JsonValueKind.String } je => je.GetString(),
-                    _ => val.ToString()
-                };
+                return val.ValueKind == JsonValueKind.String ? val.GetString() : val.ToString();
             }
 
             return null;

--- a/dotnet/src/SessionFsProvider.cs
+++ b/dotnet/src/SessionFsProvider.cs
@@ -3,6 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using GitHub.Copilot.Rpc;
+using System.Text.Json;
 
 namespace GitHub.Copilot;
 
@@ -44,7 +45,7 @@ public interface ISessionFsSqliteProvider
     Task<SessionFsSqliteResult?> QueryAsync(
         SessionFsSqliteQueryType queryType,
         string query,
-        IDictionary<string, object>? bindParams,
+        IDictionary<string, object?>? bindParams,
         CancellationToken cancellationToken);
 
     /// <summary>
@@ -287,11 +288,16 @@ public abstract class SessionFsProvider : ISessionFsHandler
 
         try
         {
-            var result = await sqliteProvider.QueryAsync(request.QueryType, request.Query, request.Params, cancellationToken).ConfigureAwait(false);
+            var bindParams = request.Params?.ToDictionary(
+                kvp => kvp.Key,
+                kvp => JsonElementToValue(kvp.Value));
+            var result = await sqliteProvider.QueryAsync(request.QueryType, request.Query, bindParams, cancellationToken).ConfigureAwait(false);
 
             return new SessionFsSqliteQueryResult
             {
-                Rows = result?.Rows ?? [],
+                Rows = result?.Rows?.Select(row => (IDictionary<string, JsonElement>)row.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => CopilotClient.ToJsonElementForWire(kvp.Value)!.Value)).ToList() ?? [],
                 Columns = result?.Columns ?? [],
                 RowsAffected = result?.RowsAffected ?? 0,
                 LastInsertRowid = result?.LastInsertRowid,
@@ -329,4 +335,14 @@ public abstract class SessionFsProvider : ISessionFsHandler
             : SessionFsErrorCode.UNKNOWN;
         return new SessionFsError { Code = code, Message = ex.Message };
     }
+
+    private static object? JsonElementToValue(JsonElement element) => element.ValueKind switch
+    {
+        JsonValueKind.Null => null,
+        JsonValueKind.True => true,
+        JsonValueKind.False => false,
+        JsonValueKind.String => element.GetString(),
+        JsonValueKind.Number => element.TryGetInt64(out var l) ? l : element.GetDouble(),
+        _ => element.GetRawText(),
+    };
 }

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -672,7 +672,7 @@ public sealed class ToolInvocation
     /// <summary>
     /// Arguments passed to the tool by the language model.
     /// </summary>
-    public object? Arguments { get; set; }
+    public JsonElement? Arguments { get; set; }
 }
 
 /// <summary>
@@ -1123,7 +1123,7 @@ public sealed class PreToolUseHookInput
     /// Arguments that will be passed to the tool.
     /// </summary>
     [JsonPropertyName("toolArgs")]
-    public object? ToolArgs { get; set; }
+    public JsonElement? ToolArgs { get; set; }
 }
 
 /// <summary>
@@ -1278,13 +1278,13 @@ public sealed class PostToolUseHookInput
     /// Arguments that were passed to the tool.
     /// </summary>
     [JsonPropertyName("toolArgs")]
-    public object? ToolArgs { get; set; }
+    public JsonElement? ToolArgs { get; set; }
 
     /// <summary>
     /// Result returned by the tool execution.
     /// </summary>
     [JsonPropertyName("toolResult")]
-    public object? ToolResult { get; set; }
+    public JsonElement? ToolResult { get; set; }
 }
 
 /// <summary>

--- a/dotnet/test/E2E/InMemorySessionFsSqliteHandler.cs
+++ b/dotnet/test/E2E/InMemorySessionFsSqliteHandler.cs
@@ -43,7 +43,7 @@ internal sealed class InMemorySessionFsSqliteHandler(string sessionId, List<Sqli
     public Task<SessionFsSqliteResult?> QueryAsync(
         SessionFsSqliteQueryType queryType,
         string query,
-        IDictionary<string, object>? bindParams,
+        IDictionary<string, object?>? bindParams,
         CancellationToken cancellationToken)
     {
         sqliteCalls.Add(new SqliteCall(sessionId, queryType.Value, query));
@@ -125,7 +125,7 @@ internal sealed class InMemorySessionFsSqliteHandler(string sessionId, List<Sqli
         return Task.FromResult(_db is not null);
     }
 
-    private static void AddParams(SqliteCommand cmd, IDictionary<string, object>? bindParams)
+    private static void AddParams(SqliteCommand cmd, IDictionary<string, object?>? bindParams)
     {
         if (bindParams is null) return;
         foreach (var (key, value) in bindParams)

--- a/dotnet/test/E2E/PendingWorkResumeE2ETests.cs
+++ b/dotnet/test/E2E/PendingWorkResumeE2ETests.cs
@@ -6,6 +6,7 @@ using GitHub.Copilot.Rpc;
 using GitHub.Copilot.Test.Harness;
 using Microsoft.Extensions.AI;
 using System.ComponentModel;
+using System.Text.Json;
 using Xunit;
 using Xunit.Abstractions;
 using RpcPermissionDecisionApproveOnce = GitHub.Copilot.Rpc.PermissionDecisionApproveOnce;
@@ -136,7 +137,7 @@ public class PendingWorkResumeE2ETests(E2ETestFixture fixture, ITestOutputHelper
 
             var toolResult = await session2.Rpc.Tools.HandlePendingToolCallAsync(
                 toolEvent.Data.RequestId,
-                result: "EXTERNAL_RESUMED_BETA");
+                result: JsonDocument.Parse("\"EXTERNAL_RESUMED_BETA\"").RootElement.Clone());
             Assert.True(toolResult.Success);
 
             var answer = await TestHelper.GetFinalAssistantMessageAsync(session2, PendingWorkTimeout);
@@ -205,7 +206,7 @@ public class PendingWorkResumeE2ETests(E2ETestFixture fixture, ITestOutputHelper
 
             var resumedResult = await session2.Rpc.Tools.HandlePendingToolCallAsync(
                 toolEvent.Data.RequestId,
-                result: "EXTERNAL_RESUMED_BETA");
+                result: JsonDocument.Parse("\"EXTERNAL_RESUMED_BETA\"").RootElement.Clone());
             Assert.True(resumedResult.Success);
 
             // continuePendingWork=false may interrupt agent continuation before this response,
@@ -282,11 +283,11 @@ public class PendingWorkResumeE2ETests(E2ETestFixture fixture, ITestOutputHelper
             var toolB = toolEvents["pending_lookup_b"];
             var resultB = await session2.Rpc.Tools.HandlePendingToolCallAsync(
                 toolB.Data.RequestId,
-                result: "PARALLEL_B_BETA");
+                result: JsonDocument.Parse("\"PARALLEL_B_BETA\"").RootElement.Clone());
             Assert.True(resultB.Success);
             var resultA = await session2.Rpc.Tools.HandlePendingToolCallAsync(
                 toolA.Data.RequestId,
-                result: "PARALLEL_A_ALPHA");
+                result: JsonDocument.Parse("\"PARALLEL_A_ALPHA\"").RootElement.Clone());
             Assert.True(resultA.Success);
 
             await session2.DisposeAsync();

--- a/dotnet/test/E2E/RpcTasksAndHandlersE2ETests.cs
+++ b/dotnet/test/E2E/RpcTasksAndHandlersE2ETests.cs
@@ -4,6 +4,7 @@
 
 using GitHub.Copilot.Rpc;
 using GitHub.Copilot.Test.Harness;
+using System.Text.Json;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -143,7 +144,7 @@ public class RpcTasksAndHandlersE2ETests(E2ETestFixture fixture, ITestOutputHelp
 
         var tool = await session.Rpc.Tools.HandlePendingToolCallAsync(
             requestId: "missing-tool-request",
-            result: "tool result");
+            result: JsonDocument.Parse("\"tool result\"").RootElement.Clone());
         Assert.False(tool.Success);
 
         var command = await session.Rpc.Commands.HandlePendingCommandAsync(

--- a/dotnet/test/E2E/SessionFsE2ETests.cs
+++ b/dotnet/test/E2E/SessionFsE2ETests.cs
@@ -609,7 +609,7 @@ public class SessionFsE2ETests(E2ETestFixture fixture, ITestOutputHelper output)
         protected override Task RenameAsync(string src, string dest, CancellationToken cancellationToken) =>
             Task.FromException(exception);
 
-        Task<SessionFsSqliteResult?> ISessionFsSqliteProvider.QueryAsync(SessionFsSqliteQueryType queryType, string query, IDictionary<string, object>? bindParams, CancellationToken cancellationToken) =>
+        Task<SessionFsSqliteResult?> ISessionFsSqliteProvider.QueryAsync(SessionFsSqliteQueryType queryType, string query, IDictionary<string, object?>? bindParams, CancellationToken cancellationToken) =>
             Task.FromException<SessionFsSqliteResult?>(exception);
 
         Task<bool> ISessionFsSqliteProvider.ExistsAsync(CancellationToken cancellationToken) =>

--- a/dotnet/test/E2E/ToolResultsE2ETests.cs
+++ b/dotnet/test/E2E/ToolResultsE2ETests.cs
@@ -113,8 +113,8 @@ public partial class ToolResultsE2ETests(E2ETestFixture fixture, ITestOutputHelp
                 ResultType = "success",
                 ToolTelemetry = new Dictionary<string, object>
                 {
-                    ["metrics"] = new Dictionary<string, object> { ["analysisTimeMs"] = 150 },
-                    ["properties"] = new Dictionary<string, object> { ["analyzer"] = "eslint" },
+                    ["metrics"] = JsonDocument.Parse("""{"analysisTimeMs":150}""").RootElement.Clone(),
+                    ["properties"] = JsonDocument.Parse("""{"analyzer":"eslint"}""").RootElement.Clone(),
                 },
             });
     }

--- a/dotnet/test/Unit/SessionEventSerializationTests.cs
+++ b/dotnet/test/Unit/SessionEventSerializationTests.cs
@@ -66,7 +66,7 @@ public class SessionEventSerializationTests
                         Content = "ok",
                         DetailedContent = "ok",
                     },
-                    ToolTelemetry = new Dictionary<string, object>
+                    ToolTelemetry = new Dictionary<string, JsonElement>
                     {
                         ["properties"] = ParseJsonElement("""{"command":"view"}"""),
                         ["metrics"] = ParseJsonElement("""{"resultLength":2}"""),
@@ -84,7 +84,6 @@ public class SessionEventSerializationTests
                 Data = new SessionShutdownData
                 {
                     ShutdownType = ShutdownType.Routine,
-                    TotalPremiumRequests = 1,
                     TotalApiDuration = TimeSpan.FromMilliseconds(100),
                     SessionStartTime = 1773609948932,
                     CodeChanges = new ShutdownCodeChanges

--- a/go/rpc/zrpc.go
+++ b/go/rpc/zrpc.go
@@ -81,6 +81,7 @@ type AgentInfo struct {
 	ID string `json:"id"`
 	// MCP server configurations attached to this agent, keyed by server name. Server config
 	// shape mirrors the MCP `mcpServers` schema.
+	// Experimental: McpServers is part of an experimental API and may change or be removed.
 	McpServers map[string]any `json:"mcpServers,omitempty"`
 	// Preferred model id for this agent. When omitted, inherits the outer agent's model.
 	Model *string `json:"model,omitempty"`
@@ -3403,6 +3404,8 @@ type SendRequest struct {
 	RequiredTool *string `json:"requiredTool,omitempty"`
 	// Optional provenance tag copied to the resulting user.message event. Supported values are
 	// `system`, `command-*`, and `schedule-*`.
+	// Internal: Source is part of the SDK's internal API surface and is not intended for
+	// external use.
 	Source any `json:"source,omitempty"`
 	// W3C Trace Context traceparent header for distributed tracing of this agent turn
 	Traceparent *string `json:"traceparent,omitempty"`
@@ -4322,6 +4325,8 @@ type SessionTelemetrySetFeatureOverridesResult struct {
 type SessionUpdateOptionsParams struct {
 	// Additional content-exclusion policies to merge into the session's policy set. Opaque
 	// shape; see `ContentExclusionApiResponse` in the runtime.
+	// Experimental: AdditionalContentExclusionPolicies is part of an experimental API and may
+	// change or be removed.
 	AdditionalContentExclusionPolicies []any `json:"additionalContentExclusionPolicies,omitempty"`
 	// Runtime context discriminator (e.g., `cli`, `actions`).
 	AgentContext *string `json:"agentContext,omitempty"`
@@ -4382,12 +4387,14 @@ type SessionUpdateOptionsParams struct {
 	Model *string `json:"model,omitempty"`
 	// Custom model-provider configuration (BYOK). Opaque shape; see `ProviderConfig` in the
 	// runtime.
+	// Experimental: Provider is part of an experimental API and may change or be removed.
 	Provider any `json:"provider,omitempty"`
 	// Reasoning effort for the selected model (model-defined enum).
 	ReasoningEffort *string `json:"reasoningEffort,omitempty"`
 	// Whether the session is running in an interactive UI.
 	RunningInInteractiveMode *bool `json:"runningInInteractiveMode,omitempty"`
 	// Sandbox configuration shape; opaque to SDK consumers. See `SandboxConfig` in the runtime.
+	// Experimental: SandboxConfig is part of an experimental API and may change or be removed.
 	SandboxConfig any `json:"sandboxConfig,omitempty"`
 	// Shell init profile (`None` or `NonInteractive`).
 	ShellInitProfile *string `json:"shellInitProfile,omitempty"`

--- a/go/rpc/zsession_events.go
+++ b/go/rpc/zsession_events.go
@@ -170,8 +170,10 @@ func (*AssistantReasoningData) Type() SessionEventType { return SessionEventType
 // Assistant response containing text content, optional tool requests, and interaction metadata
 type AssistantMessageData struct {
 	// Raw Anthropic content array with advisor blocks (server_tool_use, advisor_tool_result) for verbatim round-tripping
+	// Experimental: AnthropicAdvisorBlocks is part of an experimental API and may change or be removed.
 	AnthropicAdvisorBlocks []any `json:"anthropicAdvisorBlocks,omitempty"`
 	// Anthropic advisor model ID used for this response, for timeline display on replay
+	// Experimental: AnthropicAdvisorModel is part of an experimental API and may change or be removed.
 	AnthropicAdvisorModel *string `json:"anthropicAdvisorModel,omitempty"`
 	// The assistant's text response content
 	Content string `json:"content"`
@@ -532,8 +534,10 @@ type AssistantUsageData struct {
 	// Number of tokens written to prompt cache
 	CacheWriteTokens *int64 `json:"cacheWriteTokens,omitempty"`
 	// Per-request cost and usage data from the CAPI copilot_usage response field
+	// Internal: CopilotUsage is part of the SDK's internal API surface and is not intended for external use.
 	CopilotUsage *AssistantUsageCopilotUsage `json:"copilotUsage,omitempty"`
 	// Model multiplier cost for billing purposes
+	// Experimental: Cost is part of an experimental API and may change or be removed.
 	Cost *float64 `json:"cost,omitempty"`
 	// Duration of the API call in milliseconds
 	Duration *int64 `json:"duration,omitempty"`
@@ -553,6 +557,7 @@ type AssistantUsageData struct {
 	// GitHub request tracing ID (x-github-request-id header) for server-side log correlation
 	ProviderCallID *string `json:"providerCallId,omitempty"`
 	// Per-quota resource usage snapshots, keyed by quota identifier
+	// Internal: QuotaSnapshots is part of the SDK's internal API surface and is not intended for external use.
 	QuotaSnapshots map[string]AssistantUsageQuotaSnapshot `json:"quotaSnapshots,omitempty"`
 	// Reasoning effort level used for model calls, if applicable (e.g. "none", "low", "medium", "high", "xhigh", "max")
 	ReasoningEffort *string `json:"reasoningEffort,omitempty"`
@@ -1052,8 +1057,10 @@ type SessionShutdownData struct {
 	// Cumulative time spent in API calls during the session, in milliseconds
 	TotalAPIDurationMs int64 `json:"totalApiDurationMs"`
 	// Session-wide accumulated nano-AI units cost
+	// Experimental: TotalNanoAiu is part of an experimental API and may change or be removed.
 	TotalNanoAiu *float64 `json:"totalNanoAiu,omitempty"`
 	// Total number of premium API requests used during the session
+	// Internal: TotalPremiumRequests is part of the SDK's internal API surface and is not intended for external use.
 	TotalPremiumRequests *float64 `json:"totalPremiumRequests,omitempty"`
 }
 
@@ -1465,6 +1472,7 @@ type AssistantMessageToolRequest struct {
 }
 
 // Per-request cost and usage data from the CAPI copilot_usage response field
+// Internal: AssistantUsageCopilotUsage is an internal SDK API and is not part of the public surface.
 type AssistantUsageCopilotUsage struct {
 	// Itemized token usage breakdown
 	TokenDetails []AssistantUsageCopilotUsageTokenDetail `json:"tokenDetails"`
@@ -1485,22 +1493,31 @@ type AssistantUsageCopilotUsageTokenDetail struct {
 }
 
 // Schema for the `AssistantUsageQuotaSnapshot` type.
+// Internal: AssistantUsageQuotaSnapshot is an internal SDK API and is not part of the public surface.
 type AssistantUsageQuotaSnapshot struct {
 	// Total requests allowed by the entitlement
+	// Internal: EntitlementRequests is part of the SDK's internal API surface and is not intended for external use.
 	EntitlementRequests int64 `json:"entitlementRequests"`
 	// Whether the user has an unlimited usage entitlement
+	// Internal: IsUnlimitedEntitlement is part of the SDK's internal API surface and is not intended for external use.
 	IsUnlimitedEntitlement bool `json:"isUnlimitedEntitlement"`
 	// Number of additional usage requests made this period
+	// Internal: Overage is part of the SDK's internal API surface and is not intended for external use.
 	Overage float64 `json:"overage"`
 	// Whether additional usage is allowed when quota is exhausted
+	// Internal: OverageAllowedWithExhaustedQuota is part of the SDK's internal API surface and is not intended for external use.
 	OverageAllowedWithExhaustedQuota bool `json:"overageAllowedWithExhaustedQuota"`
 	// Percentage of quota remaining (0 to 100)
+	// Internal: RemainingPercentage is part of the SDK's internal API surface and is not intended for external use.
 	RemainingPercentage float64 `json:"remainingPercentage"`
 	// Date when the quota resets
+	// Internal: ResetDate is part of the SDK's internal API surface and is not intended for external use.
 	ResetDate *time.Time `json:"resetDate,omitempty"`
 	// Whether usage is still permitted after quota exhaustion
+	// Internal: UsageAllowedWithExhaustedQuota is part of the SDK's internal API surface and is not intended for external use.
 	UsageAllowedWithExhaustedQuota bool `json:"usageAllowedWithExhaustedQuota"`
 	// Number of requests already consumed
+	// Internal: UsedRequests is part of the SDK's internal API surface and is not intended for external use.
 	UsedRequests int64 `json:"usedRequests"`
 }
 
@@ -1525,6 +1542,7 @@ type CompactionCompleteCompactionTokensUsed struct {
 	// Tokens written to prompt cache in the compaction LLM call
 	CacheWriteTokens *int64 `json:"cacheWriteTokens,omitempty"`
 	// Per-request cost and usage data from the CAPI copilot_usage response field
+	// Internal: CopilotUsage is part of the SDK's internal API surface and is not intended for external use.
 	CopilotUsage *CompactionCompleteCompactionTokensUsedCopilotUsage `json:"copilotUsage,omitempty"`
 	// Duration of the compaction LLM call in milliseconds
 	Duration *int64 `json:"duration,omitempty"`
@@ -1537,6 +1555,7 @@ type CompactionCompleteCompactionTokensUsed struct {
 }
 
 // Per-request cost and usage data from the CAPI copilot_usage response field
+// Internal: CompactionCompleteCompactionTokensUsedCopilotUsage is an internal SDK API and is not part of the public surface.
 type CompactionCompleteCompactionTokensUsedCopilotUsage struct {
 	// Itemized token usage breakdown
 	TokenDetails []CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail `json:"tokenDetails"`
@@ -2229,6 +2248,7 @@ type ShutdownModelMetric struct {
 	// Token count details per type
 	TokenDetails map[string]ShutdownModelMetricTokenDetail `json:"tokenDetails,omitempty"`
 	// Accumulated nano-AI units cost for this model
+	// Experimental: TotalNanoAiu is part of an experimental API and may change or be removed.
 	TotalNanoAiu *float64 `json:"totalNanoAiu,omitempty"`
 	// Token usage breakdown
 	Usage ShutdownModelMetricUsage `json:"usage"`
@@ -2237,8 +2257,10 @@ type ShutdownModelMetric struct {
 // Request count and cost metrics
 type ShutdownModelMetricRequests struct {
 	// Cumulative cost multiplier for requests to this model
+	// Experimental: Cost is part of an experimental API and may change or be removed.
 	Cost *float64 `json:"cost,omitempty"`
 	// Total number of API requests made to this model
+	// Experimental: Count is part of an experimental API and may change or be removed.
 	Count *int64 `json:"count,omitempty"`
 }
 

--- a/go/zsession_events.go
+++ b/go/zsession_events.go
@@ -21,10 +21,8 @@ type (
 	AssistantTurnEndData                                          = rpc.AssistantTurnEndData
 	AssistantTurnStartData                                        = rpc.AssistantTurnStartData
 	AssistantUsageAPIEndpoint                                     = rpc.AssistantUsageAPIEndpoint
-	AssistantUsageCopilotUsage                                    = rpc.AssistantUsageCopilotUsage
 	AssistantUsageCopilotUsageTokenDetail                         = rpc.AssistantUsageCopilotUsageTokenDetail
 	AssistantUsageData                                            = rpc.AssistantUsageData
-	AssistantUsageQuotaSnapshot                                   = rpc.AssistantUsageQuotaSnapshot
 	Attachment                                                    = rpc.Attachment
 	AttachmentType                                                = rpc.AttachmentType
 	AutoModeSwitchCompletedData                                   = rpc.AutoModeSwitchCompletedData
@@ -38,7 +36,6 @@ type (
 	CommandsChangedCommand                                        = rpc.CommandsChangedCommand
 	CommandsChangedData                                           = rpc.CommandsChangedData
 	CompactionCompleteCompactionTokensUsed                        = rpc.CompactionCompleteCompactionTokensUsed
-	CompactionCompleteCompactionTokensUsedCopilotUsage            = rpc.CompactionCompleteCompactionTokensUsedCopilotUsage
 	CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail = rpc.CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail
 	CustomAgentsUpdatedAgent                                      = rpc.CustomAgentsUpdatedAgent
 	CustomNotificationPayload                                     = rpc.CustomNotificationPayload

--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -1186,13 +1186,11 @@ export interface AgentInfo {
   model?: string;
   /**
    * MCP server configurations attached to this agent, keyed by server name. Server config shape mirrors the MCP `mcpServers` schema.
+   *
+   * @experimental
    */
   mcpServers?: {
-    [k: string]:
-      | {
-          [k: string]: unknown | undefined;
-        }
-      | undefined;
+    [k: string]: unknown | undefined;
   };
   /**
    * Skill names preloaded into this agent's context. Omitted means none.
@@ -2146,11 +2144,7 @@ export interface ExternalToolTextResultForLlm {
    * Optional tool-specific telemetry
    */
   toolTelemetry?: {
-    [k: string]:
-      | {
-          [k: string]: unknown | undefined;
-        }
-      | undefined;
+    [k: string]: unknown | undefined;
   };
   /**
    * Base64-encoded binary results returned to the model
@@ -5580,6 +5574,8 @@ export interface SendRequest {
   requiredTool?: string;
   /**
    * Optional provenance tag copied to the resulting user.message event. Supported values are `system`, `command-*`, and `schedule-*`.
+   *
+   * @internal
    */
   source?: {
     [k: string]: unknown | undefined;
@@ -6105,11 +6101,7 @@ export interface SessionFsSqliteQueryResult {
    * For SELECT: array of row objects. For others: empty array.
    */
   rows: {
-    [k: string]:
-      | {
-          [k: string]: unknown | undefined;
-        }
-      | undefined;
+    [k: string]: unknown | undefined;
   }[];
   /**
    * Column names from the result set
@@ -6869,6 +6861,8 @@ export interface SessionUpdateOptionsParams {
   isExperimentalMode?: boolean;
   /**
    * Custom model-provider configuration (BYOK). Opaque shape; see `ProviderConfig` in the runtime.
+   *
+   * @experimental
    */
   provider?: {
     [k: string]: unknown | undefined;
@@ -6899,6 +6893,8 @@ export interface SessionUpdateOptionsParams {
   shellProcessFlags?: string[];
   /**
    * Sandbox configuration shape; opaque to SDK consumers. See `SandboxConfig` in the runtime.
+   *
+   * @experimental
    */
   sandboxConfig?: {
     [k: string]: unknown | undefined;
@@ -6978,10 +6974,10 @@ export interface SessionUpdateOptionsParams {
   eventsLogDirectory?: string;
   /**
    * Additional content-exclusion policies to merge into the session's policy set. Opaque shape; see `ContentExclusionApiResponse` in the runtime.
+   *
+   * @experimental
    */
-  additionalContentExclusionPolicies?: {
-    [k: string]: unknown | undefined;
-  }[];
+  additionalContentExclusionPolicies?: unknown[];
   /**
    * Whether to expose the `manage_schedule` tool to the agent. The runtime always owns the per-session schedule registry; this flag only controls tool exposure (typically gated to staff users).
    */
@@ -7814,11 +7810,7 @@ export interface Tool {
    * JSON Schema for the tool's input parameters
    */
   parameters?: {
-    [k: string]:
-      | {
-          [k: string]: unknown | undefined;
-        }
-      | undefined;
+    [k: string]: unknown | undefined;
   };
   /**
    * Optional instructions for how to use this tool effectively

--- a/nodejs/src/generated/session-events.ts
+++ b/nodejs/src/generated/session-events.ts
@@ -1464,10 +1464,14 @@ export interface ShutdownData {
   totalApiDurationMs: number;
   /**
    * Session-wide accumulated nano-AI units cost
+   *
+   * @experimental
    */
   totalNanoAiu?: number;
   /**
    * Total number of premium API requests used during the session
+   *
+   * @internal
    */
   totalPremiumRequests?: number;
 }
@@ -1501,6 +1505,8 @@ export interface ShutdownModelMetric {
   };
   /**
    * Accumulated nano-AI units cost for this model
+   *
+   * @experimental
    */
   totalNanoAiu?: number;
   usage: ShutdownModelMetricUsage;
@@ -1511,10 +1517,14 @@ export interface ShutdownModelMetric {
 export interface ShutdownModelMetricRequests {
   /**
    * Cumulative cost multiplier for requests to this model
+   *
+   * @experimental
    */
   cost?: number;
   /**
    * Total number of API requests made to this model
+   *
+   * @experimental
    */
   count?: number;
 }
@@ -1809,6 +1819,11 @@ export interface CompactionCompleteCompactionTokensUsed {
    * Tokens written to prompt cache in the compaction LLM call
    */
   cacheWriteTokens?: number;
+  /**
+   * Per-request cost and usage data from the CAPI copilot_usage response field
+   *
+   * @internal
+   */
   copilotUsage?: CompactionCompleteCompactionTokensUsedCopilotUsage;
   /**
    * Duration of the compaction LLM call in milliseconds
@@ -1830,6 +1845,7 @@ export interface CompactionCompleteCompactionTokensUsed {
 /**
  * Per-request cost and usage data from the CAPI copilot_usage response field
  */
+/** @internal */
 export interface CompactionCompleteCompactionTokensUsedCopilotUsage {
   /**
    * Itemized token usage breakdown
@@ -2403,12 +2419,14 @@ export interface AssistantMessageEvent {
 export interface AssistantMessageData {
   /**
    * Raw Anthropic content array with advisor blocks (server_tool_use, advisor_tool_result) for verbatim round-tripping
+   *
+   * @experimental
    */
-  anthropicAdvisorBlocks?: {
-    [k: string]: unknown | undefined;
-  }[];
+  anthropicAdvisorBlocks?: unknown[];
   /**
    * Anthropic advisor model ID used for this response, for timeline display on replay
+   *
+   * @experimental
    */
   anthropicAdvisorModel?: string;
   /**
@@ -2678,9 +2696,16 @@ export interface AssistantUsageData {
    * Number of tokens written to prompt cache
    */
   cacheWriteTokens?: number;
+  /**
+   * Per-request cost and usage data from the CAPI copilot_usage response field
+   *
+   * @internal
+   */
   copilotUsage?: AssistantUsageCopilotUsage;
   /**
    * Model multiplier cost for billing purposes
+   *
+   * @experimental
    */
   cost?: number;
   /**
@@ -2718,6 +2743,8 @@ export interface AssistantUsageData {
   providerCallId?: string;
   /**
    * Per-quota resource usage snapshots, keyed by quota identifier
+   *
+   * @internal
    */
   quotaSnapshots?: {
     [k: string]: AssistantUsageQuotaSnapshot | undefined;
@@ -2738,6 +2765,7 @@ export interface AssistantUsageData {
 /**
  * Per-request cost and usage data from the CAPI copilot_usage response field
  */
+/** @internal */
 export interface AssistantUsageCopilotUsage {
   /**
    * Itemized token usage breakdown
@@ -2772,37 +2800,54 @@ export interface AssistantUsageCopilotUsageTokenDetail {
 /**
  * Schema for the `AssistantUsageQuotaSnapshot` type.
  */
+/** @internal */
 export interface AssistantUsageQuotaSnapshot {
   /**
    * Total requests allowed by the entitlement
+   *
+   * @internal
    */
   entitlementRequests: number;
   /**
    * Whether the user has an unlimited usage entitlement
+   *
+   * @internal
    */
   isUnlimitedEntitlement: boolean;
   /**
    * Number of additional usage requests made this period
+   *
+   * @internal
    */
   overage: number;
   /**
    * Whether additional usage is allowed when quota is exhausted
+   *
+   * @internal
    */
   overageAllowedWithExhaustedQuota: boolean;
   /**
    * Percentage of quota remaining (0 to 100)
+   *
+   * @internal
    */
   remainingPercentage: number;
   /**
    * Date when the quota resets
+   *
+   * @internal
    */
   resetDate?: string;
   /**
    * Whether usage is still permitted after quota exhaustion
+   *
+   * @internal
    */
   usageAllowedWithExhaustedQuota: boolean;
   /**
    * Number of requests already consumed
+   *
+   * @internal
    */
   usedRequests: number;
 }
@@ -3176,11 +3221,7 @@ export interface ToolExecutionCompleteData {
    * Tool-specific telemetry data (e.g., CodeQL check counts, grep match counts)
    */
   toolTelemetry?: {
-    [k: string]:
-      | {
-          [k: string]: unknown | undefined;
-        }
-      | undefined;
+    [k: string]: unknown | undefined;
   };
   /**
    * Identifier for the agent loop turn this tool was invoked in, matching the corresponding assistant.turn_start event
@@ -3886,11 +3927,7 @@ export interface SystemMessageMetadata {
    * Template variables used when constructing the prompt
    */
   variables?: {
-    [k: string]:
-      | {
-          [k: string]: unknown | undefined;
-        }
-      | undefined;
+    [k: string]: unknown | undefined;
   };
 }
 /**
@@ -5136,11 +5173,7 @@ export interface ElicitationRequestedSchema {
    * Form field definitions, keyed by field name
    */
   properties: {
-    [k: string]:
-      | {
-          [k: string]: unknown | undefined;
-        }
-      | undefined;
+    [k: string]: unknown | undefined;
   };
   /**
    * List of required field names

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -38,9 +38,9 @@ from ._sdk_protocol_version import get_sdk_protocol_version
 from ._telemetry import get_trace_context
 from .generated.rpc import (
     ClientSessionApiHandlers,
-    ConnectRequest,
     RemoteSessionMode,
     ServerRpc,
+    _ConnectRequest,
     _InternalServerRpc,
     from_datetime,
     register_client_session_api_handlers,
@@ -2628,8 +2628,8 @@ class CopilotClient:
 
         server_version: int | None
         try:
-            connect_result = await _InternalServerRpc(self._client).connect(
-                ConnectRequest(token=self._effective_connection_token)
+            connect_result = await _InternalServerRpc(self._client)._connect(
+                _ConnectRequest(token=self._effective_connection_token)
             )
             server_version = connect_result.protocol_version
         except JsonRpcError as err:

--- a/python/copilot/generated/rpc.py
+++ b/python/copilot/generated/rpc.py
@@ -452,17 +452,17 @@ class ConnectRemoteSessionParams:
 
 # Internal: this type is an internal SDK API and is not part of the public surface.
 @dataclass
-class ConnectRequest:
+class _ConnectRequest:
     """Optional connection token presented by the SDK client during the handshake."""
 
     token: str | None = None
     """Connection token; required when the server was started with COPILOT_CONNECTION_TOKEN"""
 
     @staticmethod
-    def from_dict(obj: Any) -> 'ConnectRequest':
+    def from_dict(obj: Any) -> '_ConnectRequest':
         assert isinstance(obj, dict)
         token = from_union([from_str, from_none], obj.get("token"))
-        return ConnectRequest(token)
+        return _ConnectRequest(token)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -472,7 +472,7 @@ class ConnectRequest:
 
 # Internal: this type is an internal SDK API and is not part of the public surface.
 @dataclass
-class ConnectResult:
+class _ConnectResult:
     """Handshake result reporting the server's protocol version and package version on success."""
 
     ok: bool
@@ -485,12 +485,12 @@ class ConnectResult:
     """Server package version"""
 
     @staticmethod
-    def from_dict(obj: Any) -> 'ConnectResult':
+    def from_dict(obj: Any) -> '_ConnectResult':
         assert isinstance(obj, dict)
         ok = from_bool(obj.get("ok"))
         protocol_version = from_int(obj.get("protocolVersion"))
         version = from_str(obj.get("version"))
-        return ConnectResult(ok, protocol_version, version)
+        return _ConnectResult(ok, protocol_version, version)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -9420,6 +9420,7 @@ class SendRequest:
     """If set, the request will fail if the named tool is not available when this message is
     among the user messages at the start of the current exchange
     """
+    # Internal: this field is an internal SDK API and is not part of the public surface.
     source: Any = None
     """Optional provenance tag copied to the resulting user.message event. Supported values are
     `system`, `command-*`, and `schedule-*`.
@@ -13706,8 +13707,8 @@ class RPC:
     connected_remote_session_metadata_kind: ConnectedRemoteSessionMetadataKind
     connected_remote_session_metadata_repository: ConnectedRemoteSessionMetadataRepository
     connect_remote_session_params: ConnectRemoteSessionParams
-    connect_request: ConnectRequest
-    connect_result: ConnectResult
+    connect_request: _ConnectRequest
+    connect_result: _ConnectResult
     content_filter_mode: ContentFilterMode
     copilot_api_token_auth_info: CopilotAPITokenAuthInfo
     copilot_user_response: CopilotUserResponse
@@ -14217,8 +14218,8 @@ class RPC:
         connected_remote_session_metadata_kind = ConnectedRemoteSessionMetadataKind(obj.get("ConnectedRemoteSessionMetadataKind"))
         connected_remote_session_metadata_repository = ConnectedRemoteSessionMetadataRepository.from_dict(obj.get("ConnectedRemoteSessionMetadataRepository"))
         connect_remote_session_params = ConnectRemoteSessionParams.from_dict(obj.get("ConnectRemoteSessionParams"))
-        connect_request = ConnectRequest.from_dict(obj.get("ConnectRequest"))
-        connect_result = ConnectResult.from_dict(obj.get("ConnectResult"))
+        connect_request = _ConnectRequest.from_dict(obj.get("ConnectRequest"))
+        connect_result = _ConnectResult.from_dict(obj.get("ConnectResult"))
         content_filter_mode = ContentFilterMode(obj.get("ContentFilterMode"))
         copilot_api_token_auth_info = CopilotAPITokenAuthInfo.from_dict(obj.get("CopilotApiTokenAuthInfo"))
         copilot_user_response = CopilotUserResponse.from_dict(obj.get("CopilotUserResponse"))
@@ -14728,8 +14729,8 @@ class RPC:
         result["ConnectedRemoteSessionMetadataKind"] = to_enum(ConnectedRemoteSessionMetadataKind, self.connected_remote_session_metadata_kind)
         result["ConnectedRemoteSessionMetadataRepository"] = to_class(ConnectedRemoteSessionMetadataRepository, self.connected_remote_session_metadata_repository)
         result["ConnectRemoteSessionParams"] = to_class(ConnectRemoteSessionParams, self.connect_remote_session_params)
-        result["ConnectRequest"] = to_class(ConnectRequest, self.connect_request)
-        result["ConnectResult"] = to_class(ConnectResult, self.connect_result)
+        result["ConnectRequest"] = to_class(_ConnectRequest, self.connect_request)
+        result["ConnectResult"] = to_class(_ConnectResult, self.connect_result)
         result["ContentFilterMode"] = to_enum(ContentFilterMode, self.content_filter_mode)
         result["CopilotApiTokenAuthInfo"] = to_class(CopilotAPITokenAuthInfo, self.copilot_api_token_auth_info)
         result["CopilotUserResponse"] = to_class(CopilotUserResponse, self.copilot_user_response)
@@ -15656,10 +15657,10 @@ class _InternalServerRpc:
     def __init__(self, client: "JsonRpcClient"):
         self._client = client
 
-    async def connect(self, params: ConnectRequest, *, timeout: float | None = None) -> ConnectResult:
+    async def _connect(self, params: _ConnectRequest, *, timeout: float | None = None) -> _ConnectResult:
         "Performs the SDK server connection handshake and validates the optional connection token.\n\nArgs:\n    params: Optional connection token presented by the SDK client during the handshake.\n\nReturns:\n    Handshake result reporting the server's protocol version and package version on success.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
-        return ConnectResult.from_dict(await self._client.request("connect", params_dict, **_timeout_kwargs(timeout)))
+        return _ConnectResult.from_dict(await self._client.request("connect", params_dict, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.

--- a/python/copilot/generated/session_events.py
+++ b/python/copilot/generated/session_events.py
@@ -320,7 +320,9 @@ class AssistantMessageData:
     "Assistant response containing text content, optional tool requests, and interaction metadata"
     content: str
     message_id: str
+    # Experimental: this field is part of an experimental API and may change or be removed.
     anthropic_advisor_blocks: list[Any] | None = None
+    # Experimental: this field is part of an experimental API and may change or be removed.
     anthropic_advisor_model: str | None = None
     encrypted_content: str | None = None
     interaction_id: str | None = None
@@ -619,17 +621,17 @@ class AssistantTurnStartData:
 
 
 @dataclass
-class AssistantUsageCopilotUsage:
+class _AssistantUsageCopilotUsage:
     "Per-request cost and usage data from the CAPI copilot_usage response field"
     token_details: list[AssistantUsageCopilotUsageTokenDetail]
     total_nano_aiu: float
 
     @staticmethod
-    def from_dict(obj: Any) -> "AssistantUsageCopilotUsage":
+    def from_dict(obj: Any) -> "_AssistantUsageCopilotUsage":
         assert isinstance(obj, dict)
         token_details = from_list(AssistantUsageCopilotUsageTokenDetail.from_dict, obj.get("tokenDetails"))
         total_nano_aiu = from_float(obj.get("totalNanoAiu"))
-        return AssistantUsageCopilotUsage(
+        return _AssistantUsageCopilotUsage(
             token_details=token_details,
             total_nano_aiu=total_nano_aiu,
         )
@@ -680,7 +682,9 @@ class AssistantUsageData:
     api_endpoint: AssistantUsageApiEndpoint | None = None
     cache_read_tokens: int | None = None
     cache_write_tokens: int | None = None
-    copilot_usage: AssistantUsageCopilotUsage | None = None
+    # Internal: this field is an internal SDK API and is not part of the public surface.
+    _copilot_usage: _AssistantUsageCopilotUsage | None = None
+    # Experimental: this field is part of an experimental API and may change or be removed.
     cost: float | None = None
     duration: timedelta | None = None
     initiator: str | None = None
@@ -690,7 +694,8 @@ class AssistantUsageData:
     # Deprecated: this field is deprecated.
     parent_tool_call_id: str | None = None
     provider_call_id: str | None = None
-    quota_snapshots: dict[str, AssistantUsageQuotaSnapshot] | None = None
+    # Internal: this field is an internal SDK API and is not part of the public surface.
+    _quota_snapshots: dict[str, _AssistantUsageQuotaSnapshot] | None = None
     reasoning_effort: str | None = None
     reasoning_tokens: int | None = None
     time_to_first_token: timedelta | None = None
@@ -703,7 +708,7 @@ class AssistantUsageData:
         api_endpoint = from_union([from_none, lambda x: parse_enum(AssistantUsageApiEndpoint, x)], obj.get("apiEndpoint"))
         cache_read_tokens = from_union([from_none, from_int], obj.get("cacheReadTokens"))
         cache_write_tokens = from_union([from_none, from_int], obj.get("cacheWriteTokens"))
-        copilot_usage = from_union([from_none, AssistantUsageCopilotUsage.from_dict], obj.get("copilotUsage"))
+        _copilot_usage = from_union([from_none, _AssistantUsageCopilotUsage.from_dict], obj.get("copilotUsage"))
         cost = from_union([from_none, from_float], obj.get("cost"))
         duration = from_union([from_none, from_timedelta], obj.get("duration"))
         initiator = from_union([from_none, from_str], obj.get("initiator"))
@@ -712,7 +717,7 @@ class AssistantUsageData:
         output_tokens = from_union([from_none, from_int], obj.get("outputTokens"))
         parent_tool_call_id = from_union([from_none, from_str], obj.get("parentToolCallId"))
         provider_call_id = from_union([from_none, from_str], obj.get("providerCallId"))
-        quota_snapshots = from_union([from_none, lambda x: from_dict(AssistantUsageQuotaSnapshot.from_dict, x)], obj.get("quotaSnapshots"))
+        _quota_snapshots = from_union([from_none, lambda x: from_dict(_AssistantUsageQuotaSnapshot.from_dict, x)], obj.get("quotaSnapshots"))
         reasoning_effort = from_union([from_none, from_str], obj.get("reasoningEffort"))
         reasoning_tokens = from_union([from_none, from_int], obj.get("reasoningTokens"))
         time_to_first_token = from_union([from_none, from_timedelta], obj.get("timeToFirstTokenMs"))
@@ -722,7 +727,7 @@ class AssistantUsageData:
             api_endpoint=api_endpoint,
             cache_read_tokens=cache_read_tokens,
             cache_write_tokens=cache_write_tokens,
-            copilot_usage=copilot_usage,
+            _copilot_usage=_copilot_usage,
             cost=cost,
             duration=duration,
             initiator=initiator,
@@ -731,7 +736,7 @@ class AssistantUsageData:
             output_tokens=output_tokens,
             parent_tool_call_id=parent_tool_call_id,
             provider_call_id=provider_call_id,
-            quota_snapshots=quota_snapshots,
+            _quota_snapshots=_quota_snapshots,
             reasoning_effort=reasoning_effort,
             reasoning_tokens=reasoning_tokens,
             time_to_first_token=time_to_first_token,
@@ -748,8 +753,8 @@ class AssistantUsageData:
             result["cacheReadTokens"] = from_union([from_none, to_int], self.cache_read_tokens)
         if self.cache_write_tokens is not None:
             result["cacheWriteTokens"] = from_union([from_none, to_int], self.cache_write_tokens)
-        if self.copilot_usage is not None:
-            result["copilotUsage"] = from_union([from_none, lambda x: to_class(AssistantUsageCopilotUsage, x)], self.copilot_usage)
+        if self._copilot_usage is not None:
+            result["copilotUsage"] = from_union([from_none, lambda x: to_class(_AssistantUsageCopilotUsage, x)], self._copilot_usage)
         if self.cost is not None:
             result["cost"] = from_union([from_none, to_float], self.cost)
         if self.duration is not None:
@@ -766,8 +771,8 @@ class AssistantUsageData:
             result["parentToolCallId"] = from_union([from_none, from_str], self.parent_tool_call_id)
         if self.provider_call_id is not None:
             result["providerCallId"] = from_union([from_none, from_str], self.provider_call_id)
-        if self.quota_snapshots is not None:
-            result["quotaSnapshots"] = from_union([from_none, lambda x: from_dict(lambda x: to_class(AssistantUsageQuotaSnapshot, x), x)], self.quota_snapshots)
+        if self._quota_snapshots is not None:
+            result["quotaSnapshots"] = from_union([from_none, lambda x: from_dict(lambda x: to_class(_AssistantUsageQuotaSnapshot, x), x)], self._quota_snapshots)
         if self.reasoning_effort is not None:
             result["reasoningEffort"] = from_union([from_none, from_str], self.reasoning_effort)
         if self.reasoning_tokens is not None:
@@ -778,50 +783,58 @@ class AssistantUsageData:
 
 
 @dataclass
-class AssistantUsageQuotaSnapshot:
-    "Schema for the `AssistantUsageQuotaSnapshot` type."
-    entitlement_requests: int
-    is_unlimited_entitlement: bool
-    overage: float
-    overage_allowed_with_exhausted_quota: bool
-    remaining_percentage: float
-    usage_allowed_with_exhausted_quota: bool
-    used_requests: int
-    reset_date: datetime | None = None
+class _AssistantUsageQuotaSnapshot:
+    "Schema for the `_AssistantUsageQuotaSnapshot` type."
+    # Internal: this field is an internal SDK API and is not part of the public surface.
+    _entitlement_requests: int
+    # Internal: this field is an internal SDK API and is not part of the public surface.
+    _is_unlimited_entitlement: bool
+    # Internal: this field is an internal SDK API and is not part of the public surface.
+    _overage: float
+    # Internal: this field is an internal SDK API and is not part of the public surface.
+    _overage_allowed_with_exhausted_quota: bool
+    # Internal: this field is an internal SDK API and is not part of the public surface.
+    _remaining_percentage: float
+    # Internal: this field is an internal SDK API and is not part of the public surface.
+    _usage_allowed_with_exhausted_quota: bool
+    # Internal: this field is an internal SDK API and is not part of the public surface.
+    _used_requests: int
+    # Internal: this field is an internal SDK API and is not part of the public surface.
+    _reset_date: datetime | None = None
 
     @staticmethod
-    def from_dict(obj: Any) -> "AssistantUsageQuotaSnapshot":
+    def from_dict(obj: Any) -> "_AssistantUsageQuotaSnapshot":
         assert isinstance(obj, dict)
-        entitlement_requests = from_int(obj.get("entitlementRequests"))
-        is_unlimited_entitlement = from_bool(obj.get("isUnlimitedEntitlement"))
-        overage = from_float(obj.get("overage"))
-        overage_allowed_with_exhausted_quota = from_bool(obj.get("overageAllowedWithExhaustedQuota"))
-        remaining_percentage = from_float(obj.get("remainingPercentage"))
-        usage_allowed_with_exhausted_quota = from_bool(obj.get("usageAllowedWithExhaustedQuota"))
-        used_requests = from_int(obj.get("usedRequests"))
-        reset_date = from_union([from_none, from_datetime], obj.get("resetDate"))
-        return AssistantUsageQuotaSnapshot(
-            entitlement_requests=entitlement_requests,
-            is_unlimited_entitlement=is_unlimited_entitlement,
-            overage=overage,
-            overage_allowed_with_exhausted_quota=overage_allowed_with_exhausted_quota,
-            remaining_percentage=remaining_percentage,
-            usage_allowed_with_exhausted_quota=usage_allowed_with_exhausted_quota,
-            used_requests=used_requests,
-            reset_date=reset_date,
+        _entitlement_requests = from_int(obj.get("entitlementRequests"))
+        _is_unlimited_entitlement = from_bool(obj.get("isUnlimitedEntitlement"))
+        _overage = from_float(obj.get("overage"))
+        _overage_allowed_with_exhausted_quota = from_bool(obj.get("overageAllowedWithExhaustedQuota"))
+        _remaining_percentage = from_float(obj.get("remainingPercentage"))
+        _usage_allowed_with_exhausted_quota = from_bool(obj.get("usageAllowedWithExhaustedQuota"))
+        _used_requests = from_int(obj.get("usedRequests"))
+        _reset_date = from_union([from_none, from_datetime], obj.get("resetDate"))
+        return _AssistantUsageQuotaSnapshot(
+            _entitlement_requests=_entitlement_requests,
+            _is_unlimited_entitlement=_is_unlimited_entitlement,
+            _overage=_overage,
+            _overage_allowed_with_exhausted_quota=_overage_allowed_with_exhausted_quota,
+            _remaining_percentage=_remaining_percentage,
+            _usage_allowed_with_exhausted_quota=_usage_allowed_with_exhausted_quota,
+            _used_requests=_used_requests,
+            _reset_date=_reset_date,
         )
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["entitlementRequests"] = to_int(self.entitlement_requests)
-        result["isUnlimitedEntitlement"] = from_bool(self.is_unlimited_entitlement)
-        result["overage"] = to_float(self.overage)
-        result["overageAllowedWithExhaustedQuota"] = from_bool(self.overage_allowed_with_exhausted_quota)
-        result["remainingPercentage"] = to_float(self.remaining_percentage)
-        result["usageAllowedWithExhaustedQuota"] = from_bool(self.usage_allowed_with_exhausted_quota)
-        result["usedRequests"] = to_int(self.used_requests)
-        if self.reset_date is not None:
-            result["resetDate"] = from_union([from_none, to_datetime], self.reset_date)
+        result["entitlementRequests"] = to_int(self._entitlement_requests)
+        result["isUnlimitedEntitlement"] = from_bool(self._is_unlimited_entitlement)
+        result["overage"] = to_float(self._overage)
+        result["overageAllowedWithExhaustedQuota"] = from_bool(self._overage_allowed_with_exhausted_quota)
+        result["remainingPercentage"] = to_float(self._remaining_percentage)
+        result["usageAllowedWithExhaustedQuota"] = from_bool(self._usage_allowed_with_exhausted_quota)
+        result["usedRequests"] = to_int(self._used_requests)
+        if self._reset_date is not None:
+            result["resetDate"] = from_union([from_none, to_datetime], self._reset_date)
         return result
 
 
@@ -1038,7 +1051,8 @@ class CompactionCompleteCompactionTokensUsed:
     "Token usage breakdown for the compaction LLM call (aligned with assistant.usage format)"
     cache_read_tokens: int | None = None
     cache_write_tokens: int | None = None
-    copilot_usage: CompactionCompleteCompactionTokensUsedCopilotUsage | None = None
+    # Internal: this field is an internal SDK API and is not part of the public surface.
+    _copilot_usage: _CompactionCompleteCompactionTokensUsedCopilotUsage | None = None
     duration: timedelta | None = None
     input_tokens: int | None = None
     model: str | None = None
@@ -1049,7 +1063,7 @@ class CompactionCompleteCompactionTokensUsed:
         assert isinstance(obj, dict)
         cache_read_tokens = from_union([from_none, from_int], obj.get("cacheReadTokens"))
         cache_write_tokens = from_union([from_none, from_int], obj.get("cacheWriteTokens"))
-        copilot_usage = from_union([from_none, CompactionCompleteCompactionTokensUsedCopilotUsage.from_dict], obj.get("copilotUsage"))
+        _copilot_usage = from_union([from_none, _CompactionCompleteCompactionTokensUsedCopilotUsage.from_dict], obj.get("copilotUsage"))
         duration = from_union([from_none, from_timedelta], obj.get("duration"))
         input_tokens = from_union([from_none, from_int], obj.get("inputTokens"))
         model = from_union([from_none, from_str], obj.get("model"))
@@ -1057,7 +1071,7 @@ class CompactionCompleteCompactionTokensUsed:
         return CompactionCompleteCompactionTokensUsed(
             cache_read_tokens=cache_read_tokens,
             cache_write_tokens=cache_write_tokens,
-            copilot_usage=copilot_usage,
+            _copilot_usage=_copilot_usage,
             duration=duration,
             input_tokens=input_tokens,
             model=model,
@@ -1070,8 +1084,8 @@ class CompactionCompleteCompactionTokensUsed:
             result["cacheReadTokens"] = from_union([from_none, to_int], self.cache_read_tokens)
         if self.cache_write_tokens is not None:
             result["cacheWriteTokens"] = from_union([from_none, to_int], self.cache_write_tokens)
-        if self.copilot_usage is not None:
-            result["copilotUsage"] = from_union([from_none, lambda x: to_class(CompactionCompleteCompactionTokensUsedCopilotUsage, x)], self.copilot_usage)
+        if self._copilot_usage is not None:
+            result["copilotUsage"] = from_union([from_none, lambda x: to_class(_CompactionCompleteCompactionTokensUsedCopilotUsage, x)], self._copilot_usage)
         if self.duration is not None:
             result["duration"] = from_union([from_none, to_timedelta_int], self.duration)
         if self.input_tokens is not None:
@@ -1084,17 +1098,17 @@ class CompactionCompleteCompactionTokensUsed:
 
 
 @dataclass
-class CompactionCompleteCompactionTokensUsedCopilotUsage:
+class _CompactionCompleteCompactionTokensUsedCopilotUsage:
     "Per-request cost and usage data from the CAPI copilot_usage response field"
     token_details: list[CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail]
     total_nano_aiu: float
 
     @staticmethod
-    def from_dict(obj: Any) -> "CompactionCompleteCompactionTokensUsedCopilotUsage":
+    def from_dict(obj: Any) -> "_CompactionCompleteCompactionTokensUsedCopilotUsage":
         assert isinstance(obj, dict)
         token_details = from_list(CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail.from_dict, obj.get("tokenDetails"))
         total_nano_aiu = from_float(obj.get("totalNanoAiu"))
-        return CompactionCompleteCompactionTokensUsedCopilotUsage(
+        return _CompactionCompleteCompactionTokensUsedCopilotUsage(
             token_details=token_details,
             total_nano_aiu=total_nano_aiu,
         )
@@ -3681,8 +3695,10 @@ class SessionShutdownData:
     system_tokens: int | None = None
     token_details: dict[str, ShutdownTokenDetail] | None = None
     tool_definitions_tokens: int | None = None
+    # Experimental: this field is part of an experimental API and may change or be removed.
     total_nano_aiu: float | None = None
-    total_premium_requests: float | None = None
+    # Internal: this field is an internal SDK API and is not part of the public surface.
+    _total_premium_requests: float | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "SessionShutdownData":
@@ -3700,7 +3716,7 @@ class SessionShutdownData:
         token_details = from_union([from_none, lambda x: from_dict(ShutdownTokenDetail.from_dict, x)], obj.get("tokenDetails"))
         tool_definitions_tokens = from_union([from_none, from_int], obj.get("toolDefinitionsTokens"))
         total_nano_aiu = from_union([from_none, from_float], obj.get("totalNanoAiu"))
-        total_premium_requests = from_union([from_none, from_float], obj.get("totalPremiumRequests"))
+        _total_premium_requests = from_union([from_none, from_float], obj.get("totalPremiumRequests"))
         return SessionShutdownData(
             code_changes=code_changes,
             model_metrics=model_metrics,
@@ -3715,7 +3731,7 @@ class SessionShutdownData:
             token_details=token_details,
             tool_definitions_tokens=tool_definitions_tokens,
             total_nano_aiu=total_nano_aiu,
-            total_premium_requests=total_premium_requests,
+            _total_premium_requests=_total_premium_requests,
         )
 
     def to_dict(self) -> dict:
@@ -3741,8 +3757,8 @@ class SessionShutdownData:
             result["toolDefinitionsTokens"] = from_union([from_none, to_int], self.tool_definitions_tokens)
         if self.total_nano_aiu is not None:
             result["totalNanoAiu"] = from_union([from_none, to_float], self.total_nano_aiu)
-        if self.total_premium_requests is not None:
-            result["totalPremiumRequests"] = from_union([from_none, to_float], self.total_premium_requests)
+        if self._total_premium_requests is not None:
+            result["totalPremiumRequests"] = from_union([from_none, to_float], self._total_premium_requests)
         return result
 
 
@@ -4099,6 +4115,7 @@ class ShutdownModelMetric:
     requests: ShutdownModelMetricRequests
     usage: ShutdownModelMetricUsage
     token_details: dict[str, ShutdownModelMetricTokenDetail] | None = None
+    # Experimental: this field is part of an experimental API and may change or be removed.
     total_nano_aiu: float | None = None
 
     @staticmethod
@@ -4129,7 +4146,9 @@ class ShutdownModelMetric:
 @dataclass
 class ShutdownModelMetricRequests:
     "Request count and cost metrics"
+    # Experimental: this field is part of an experimental API and may change or be removed.
     cost: float | None = None
+    # Experimental: this field is part of an experimental API and may change or be removed.
     count: int | None = None
 
     @staticmethod

--- a/rust/src/generated/api_types.rs
+++ b/rust/src/generated/api_types.rs
@@ -472,6 +472,13 @@ pub struct AgentInfo {
     /// Stable identifier for selection. For most agents this is the same as `name`; for plugin/builtin agents it may differ. Always populated; defaults to `name` when no distinct id was assigned.
     pub id: String,
     /// MCP server configurations attached to this agent, keyed by server name. Server config shape mirrors the MCP `mcpServers` schema.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This type is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases.
+    ///
+    /// </div>
     #[serde(default)]
     pub mcp_servers: HashMap<String, serde_json::Value>,
     /// Preferred model id for this agent. When omitted, inherits the outer agent's model.
@@ -1102,7 +1109,7 @@ pub struct ConnectRemoteSessionParams {
 /// Optional connection token presented by the SDK client during the handshake.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ConnectRequest {
+pub(crate) struct ConnectRequest {
     /// Connection token; required when the server was started with COPILOT_CONNECTION_TOKEN
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
@@ -1111,7 +1118,7 @@ pub struct ConnectRequest {
 /// Handshake result reporting the server's protocol version and package version on success.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ConnectResult {
+pub(crate) struct ConnectResult {
     /// Always true on success
     pub ok: bool,
     /// Server protocol version number
@@ -5160,8 +5167,9 @@ pub struct SendRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub required_tool: Option<String>,
     /// Optional provenance tag copied to the resulting user.message event. Supported values are `system`, `command-*`, and `schedule-*`.
+    #[doc(hidden)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub source: Option<serde_json::Value>,
+    pub(crate) source: Option<serde_json::Value>,
     /// W3C Trace Context traceparent header for distributed tracing of this agent turn
     #[serde(skip_serializing_if = "Option::is_none")]
     pub traceparent: Option<String>,
@@ -6397,6 +6405,13 @@ pub struct SessionsSetAdditionalPluginsResult {}
 #[serde(rename_all = "camelCase")]
 pub struct SessionUpdateOptionsParams {
     /// Additional content-exclusion policies to merge into the session's policy set. Opaque shape; see `ContentExclusionApiResponse` in the runtime.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This type is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases.
+    ///
+    /// </div>
     #[serde(default)]
     pub additional_content_exclusion_policies: Vec<serde_json::Value>,
     /// Runtime context discriminator (e.g., `cli`, `actions`).
@@ -6475,6 +6490,13 @@ pub struct SessionUpdateOptionsParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     /// Custom model-provider configuration (BYOK). Opaque shape; see `ProviderConfig` in the runtime.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This type is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases.
+    ///
+    /// </div>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<serde_json::Value>,
     /// Reasoning effort for the selected model (model-defined enum).
@@ -6484,6 +6506,13 @@ pub struct SessionUpdateOptionsParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub running_in_interactive_mode: Option<bool>,
     /// Sandbox configuration shape; opaque to SDK consumers. See `SandboxConfig` in the runtime.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This type is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases.
+    ///
+    /// </div>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sandbox_config: Option<serde_json::Value>,
     /// Shell init profile (`None` or `NonInteractive`).

--- a/rust/src/generated/rpc.rs
+++ b/rust/src/generated/rpc.rs
@@ -107,7 +107,7 @@ impl<'a> ClientRpc<'a> {
     /// # Returns
     ///
     /// Handshake result reporting the server's protocol version and package version on success.
-    pub async fn connect(&self, params: ConnectRequest) -> Result<ConnectResult, Error> {
+    pub(crate) async fn connect(&self, params: ConnectRequest) -> Result<ConnectResult, Error> {
         let wire_params = serde_json::to_value(params)?;
         let _value = self
             .client

--- a/rust/src/generated/session_events.rs
+++ b/rust/src/generated/session_events.rs
@@ -723,9 +723,23 @@ pub struct ShutdownCodeChanges {
 #[serde(rename_all = "camelCase")]
 pub struct ShutdownModelMetricRequests {
     /// Cumulative cost multiplier for requests to this model
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This type is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases.
+    ///
+    /// </div>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<f64>,
     /// Total number of API requests made to this model
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This type is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases.
+    ///
+    /// </div>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub count: Option<i64>,
 }
@@ -765,6 +779,13 @@ pub struct ShutdownModelMetric {
     #[serde(default)]
     pub token_details: HashMap<String, ShutdownModelMetricTokenDetail>,
     /// Accumulated nano-AI units cost for this model
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This type is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases.
+    ///
+    /// </div>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_nano_aiu: Option<f64>,
     /// Token usage breakdown
@@ -815,11 +836,19 @@ pub struct SessionShutdownData {
     /// Cumulative time spent in API calls during the session, in milliseconds
     pub total_api_duration_ms: i64,
     /// Session-wide accumulated nano-AI units cost
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This type is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases.
+    ///
+    /// </div>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_nano_aiu: Option<f64>,
     /// Total number of premium API requests used during the session
+    #[doc(hidden)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub total_premium_requests: Option<f64>,
+    pub(crate) total_premium_requests: Option<f64>,
 }
 
 /// Session event "session.context_changed". Updated working directory and git context after the change
@@ -907,7 +936,7 @@ pub struct CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail {
 /// Per-request cost and usage data from the CAPI copilot_usage response field
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CompactionCompleteCompactionTokensUsedCopilotUsage {
+pub(crate) struct CompactionCompleteCompactionTokensUsedCopilotUsage {
     /// Itemized token usage breakdown
     pub token_details: Vec<CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail>,
     /// Total cost in nano-AI units for this request
@@ -925,8 +954,9 @@ pub struct CompactionCompleteCompactionTokensUsed {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_write_tokens: Option<i64>,
     /// Per-request cost and usage data from the CAPI copilot_usage response field
+    #[doc(hidden)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub copilot_usage: Option<CompactionCompleteCompactionTokensUsedCopilotUsage>,
+    pub(crate) copilot_usage: Option<CompactionCompleteCompactionTokensUsedCopilotUsage>,
     /// Duration of the compaction LLM call in milliseconds
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<i64>,
@@ -1126,9 +1156,23 @@ pub struct AssistantMessageToolRequest {
 #[serde(rename_all = "camelCase")]
 pub struct AssistantMessageData {
     /// Raw Anthropic content array with advisor blocks (server_tool_use, advisor_tool_result) for verbatim round-tripping
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This type is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases.
+    ///
+    /// </div>
     #[serde(default)]
     pub anthropic_advisor_blocks: Vec<serde_json::Value>,
     /// Anthropic advisor model ID used for this response, for timeline display on replay
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This type is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases.
+    ///
+    /// </div>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub anthropic_advisor_model: Option<String>,
     /// The assistant's text response content
@@ -1223,7 +1267,7 @@ pub struct AssistantUsageCopilotUsageTokenDetail {
 /// Per-request cost and usage data from the CAPI copilot_usage response field
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct AssistantUsageCopilotUsage {
+pub(crate) struct AssistantUsageCopilotUsage {
     /// Itemized token usage breakdown
     pub token_details: Vec<AssistantUsageCopilotUsageTokenDetail>,
     /// Total cost in nano-AI units for this request
@@ -1233,24 +1277,32 @@ pub struct AssistantUsageCopilotUsage {
 /// Schema for the `AssistantUsageQuotaSnapshot` type.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct AssistantUsageQuotaSnapshot {
+pub(crate) struct AssistantUsageQuotaSnapshot {
     /// Total requests allowed by the entitlement
-    pub entitlement_requests: i64,
+    #[doc(hidden)]
+    pub(crate) entitlement_requests: i64,
     /// Whether the user has an unlimited usage entitlement
-    pub is_unlimited_entitlement: bool,
+    #[doc(hidden)]
+    pub(crate) is_unlimited_entitlement: bool,
     /// Number of additional usage requests made this period
-    pub overage: f64,
+    #[doc(hidden)]
+    pub(crate) overage: f64,
     /// Whether additional usage is allowed when quota is exhausted
-    pub overage_allowed_with_exhausted_quota: bool,
+    #[doc(hidden)]
+    pub(crate) overage_allowed_with_exhausted_quota: bool,
     /// Percentage of quota remaining (0 to 100)
-    pub remaining_percentage: f64,
+    #[doc(hidden)]
+    pub(crate) remaining_percentage: f64,
     /// Date when the quota resets
+    #[doc(hidden)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reset_date: Option<String>,
+    pub(crate) reset_date: Option<String>,
     /// Whether usage is still permitted after quota exhaustion
-    pub usage_allowed_with_exhausted_quota: bool,
+    #[doc(hidden)]
+    pub(crate) usage_allowed_with_exhausted_quota: bool,
     /// Number of requests already consumed
-    pub used_requests: i64,
+    #[doc(hidden)]
+    pub(crate) used_requests: i64,
 }
 
 /// Session event "assistant.usage". LLM API call usage metrics including tokens, costs, quotas, and billing information
@@ -1270,9 +1322,17 @@ pub struct AssistantUsageData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_write_tokens: Option<i64>,
     /// Per-request cost and usage data from the CAPI copilot_usage response field
+    #[doc(hidden)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub copilot_usage: Option<AssistantUsageCopilotUsage>,
+    pub(crate) copilot_usage: Option<AssistantUsageCopilotUsage>,
     /// Model multiplier cost for billing purposes
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This type is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases.
+    ///
+    /// </div>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<f64>,
     /// Duration of the API call in milliseconds
@@ -1301,8 +1361,9 @@ pub struct AssistantUsageData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider_call_id: Option<String>,
     /// Per-quota resource usage snapshots, keyed by quota identifier
+    #[doc(hidden)]
     #[serde(default)]
-    pub quota_snapshots: HashMap<String, AssistantUsageQuotaSnapshot>,
+    pub(crate) quota_snapshots: HashMap<String, AssistantUsageQuotaSnapshot>,
     /// Reasoning effort level used for model calls, if applicable (e.g. "none", "low", "medium", "high", "xhigh", "max")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<String>,

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -26,6 +26,7 @@ import {
     collectRpcMethodReferencedDefinitionNames,
     findSharedSchemaDefinitions,
     postProcessSchema,
+    propagateInternalVisibility,
     resolveRef,
     resolveObjectSchema,
     resolveSchema,
@@ -36,6 +37,8 @@ import {
     isNodeFullyDeprecated,
     isSchemaDeprecated,
     isSchemaExperimental,
+    isSchemaInternal,
+    isOpaqueJson,
     isObjectSchema,
     isVoidSchema,
     getNullableInner,
@@ -275,7 +278,28 @@ function isNonNullableCSharpValueType(typeName: string): boolean {
         "long",
         "DateTimeOffset",
         "TimeSpan",
+        "JsonElement",
     ].includes(typeName) || generatedEnums.has(typeName) || emittedRpcEnumResultTypes.has(typeName) || externalRpcValueTypes.has(typeName);
+}
+
+/**
+ * Schemas marked `.asOpaqueJson()` on the runtime side carry
+ * `x-opaque-json: true`. These are the only shapes that legitimately surface
+ * as opaque JSON in the SDK (mapped to `JsonElement` in C#). Anything else
+ * that lacks an idiomatic mapping (untyped fields, non-discriminated unions,
+ * etc.) is rejected by the runtime's schema-shape lint, so the codegen
+ * treats reaching an unmappable schema here as a bug.
+ *
+ * The predicate itself lives in {@link "./utils".isOpaqueJson} for reuse.
+ */
+function failUnmappable(context: string, schema: JSONSchema7): never {
+    const summary = JSON.stringify(schema, (key, value) => (key === "description" ? undefined : value)).slice(0, 200);
+    throw new Error(
+        `C# codegen: cannot map schema to an idiomatic C# type (${context}). ` +
+            `On the runtime side, either tighten the Zod schema to a typed shape, or — if it is genuinely free-form JSON — ` +
+            `mark it \`.asOpaqueJson()\` so the schema emits \`x-opaque-json: true\` and the codegen maps it to JsonElement. ` +
+            `Offending schema (truncated): ${summary}`,
+    );
 }
 
 function requiresArgumentNullCheck(typeName: string, isRequired: boolean): boolean {
@@ -309,6 +333,9 @@ function localRequestVariableName(paramEntries: [string, JSONSchema7Definition][
 }
 
 function schemaTypeToCSharp(schema: JSONSchema7, required: boolean, knownTypes: Map<string, string>, propName?: string): string {
+    if (isOpaqueJson(schema)) {
+        return required ? "JsonElement" : "JsonElement?";
+    }
     const nullableInner = getNullableInner(schema);
     if (nullableInner) {
         // Pass required=true to get the base type, then add "?" for nullable
@@ -361,7 +388,8 @@ function schemaTypeToCSharp(schema: JSONSchema7, required: boolean, knownTypes: 
     if (type === "boolean") return required ? "bool" : "bool?";
     if (type === "array") {
         const items = schema.items as JSONSchema7 | undefined;
-        const itemType = items ? schemaTypeToCSharp(items, true, knownTypes) : "object";
+        if (!items) failUnmappable(`array without items (propName=${propName ?? "?"})`, schema);
+        const itemType = schemaTypeToCSharp(items, true, knownTypes);
         return required ? `${itemType}[]` : `${itemType}[]?`;
     }
     if (type === "object") {
@@ -369,9 +397,9 @@ function schemaTypeToCSharp(schema: JSONSchema7, required: boolean, knownTypes: 
             const valueType = schemaTypeToCSharp(schema.additionalProperties as JSONSchema7, true, knownTypes);
             return required ? `IDictionary<string, ${valueType}>` : `IDictionary<string, ${valueType}>?`;
         }
-        return required ? "object" : "object?";
+        failUnmappable(`object without properties or typed additionalProperties (propName=${propName ?? "?"})`, schema);
     }
-    return required ? "object" : "object?";
+    failUnmappable(`unknown/missing type (propName=${propName ?? "?"})`, schema);
 }
 
 /** Tracks whether any TimeSpan property was emitted so the converter can be generated. */
@@ -487,6 +515,20 @@ function obsoleteAttributeBlock(indent = ""): string {
 
 function pushObsoleteAttributes(lines: string[], indent = ""): void {
     lines.push(...obsoleteAttributes(indent));
+}
+
+/**
+ * Emit the `[JsonInclude]` attribute for an internally-marked property and
+ * return the C# access modifier to use for the property declaration.
+ *
+ * `[JsonInclude]` is required because System.Text.Json only auto-(de)serialises
+ * public members by default; without it, the `internal` setter would silently
+ * be skipped.
+ */
+function pushCSharpInternalAttribute(lines: string[], schema: JSONSchema7, indent = "    "): "public" | "internal" {
+    const propInternal = isSchemaInternal(schema);
+    if (propInternal) lines.push(`${indent}[JsonInclude]`);
+    return propInternal ? "internal" : "public";
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
@@ -747,11 +789,13 @@ function generateFlattenedBooleanDiscriminatedClass(
         lines.push(...xmlDocPropertyComment(info.schema.description, propName, "    "));
         lines.push(...emitDataAnnotations(info.schema, "    ", csharpType));
         if (isSchemaDeprecated(info.schema)) pushObsoleteAttributes(lines, "    ");
+        if (isSchemaExperimental(info.schema)) pushExperimentalAttribute(lines, "    ");
         if (isMillisecondsDurationProperty(propName, info.schema)) lines.push(`    [JsonConverter(typeof(MillisecondsTimeSpanConverter))]`);
         if (!isReq) lines.push(`    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`);
+        const propVisibility = pushCSharpInternalAttribute(lines, info.schema);
         lines.push(`    [JsonPropertyName("${propName}")]`);
         const reqMod = isReq && !csharpType.endsWith("?") ? "required " : "";
-        lines.push(`    public ${reqMod}${csharpType} ${csharpName} { get; set; }`);
+        lines.push(`    ${propVisibility} ${reqMod}${csharpType} ${csharpName} { get; set; }`);
     }
 
     lines.push(`}`);
@@ -850,11 +894,13 @@ function generateDerivedClass(
             lines.push(...xmlDocPropertyComment(prop.description, propName, "    "));
             lines.push(...emitDataAnnotations(prop, "    ", csharpType));
             if (isSchemaDeprecated(prop)) pushObsoleteAttributes(lines, "    ");
+            if (isSchemaExperimental(prop)) pushExperimentalAttribute(lines, "    ");
             if (isMillisecondsDurationProperty(propName, prop)) lines.push(`    [JsonConverter(typeof(MillisecondsTimeSpanConverter))]`);
             if (!isReq) lines.push(`    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`);
+            const propVisibility = pushCSharpInternalAttribute(lines, prop);
             lines.push(`    [JsonPropertyName("${propName}")]`);
             const reqMod = isReq && !csharpType.endsWith("?") ? "required " : "";
-            lines.push(`    public ${reqMod}${csharpType} ${csharpName} { get; set; }`, "");
+            lines.push(`    ${propVisibility} ${reqMod}${csharpType} ${csharpName} { get; set; }`, "");
         }
     }
 
@@ -917,11 +963,11 @@ function getJsonUnionMatchExpression(variant: JsonUnionVariant, variants: JsonUn
     ].join(" && ");
 }
 
-function generateJsonUnionClass(className: string, variants: JsonUnionVariant[], description: string | undefined, jsonContextType: string): string {
+function generateJsonUnionClass(className: string, variants: JsonUnionVariant[], description: string | undefined, jsonContextType: string, isInternal: boolean): string {
     const lines: string[] = [];
     lines.push(...xmlDocCommentWithFallback(description, `JSON union data type for <c>${escapeXml(className)}</c>.`, ""));
     lines.push(`[JsonConverter(typeof(Converter))]`);
-    lines.push(`public sealed partial class ${className}`);
+    lines.push(`${isInternal ? "internal" : "public"} sealed partial class ${className}`);
     lines.push(`{`);
 
     for (const variant of variants) {
@@ -1047,7 +1093,7 @@ function tryGenerateSessionJsonUnionType(
         });
     }
 
-    nestedClasses.set(className, generateJsonUnionClass(className, variants, schema.description, "SessionEventsJsonContext"));
+    nestedClasses.set(className, generateJsonUnionClass(className, variants, schema.description, "SessionEventsJsonContext", isSchemaInternal(schema)));
     return className;
 }
 
@@ -1063,7 +1109,7 @@ function generateNestedClass(
     lines.push(...xmlDocCommentWithFallback(schema.description, `Nested data type for <c>${className}</c>.`, ""));
     if (isSchemaExperimental(schema)) pushExperimentalAttribute(lines);
     if (isSchemaDeprecated(schema)) pushObsoleteAttributes(lines);
-    lines.push(`public sealed partial class ${className}`, `{`);
+    lines.push(`${isSchemaInternal(schema) ? "internal" : "public"} sealed partial class ${className}`, `{`);
 
     for (const [propName, propSchema] of Object.entries(schema.properties || {}).sort(([a], [b]) => a.localeCompare(b))) {
         if (typeof propSchema !== "object") continue;
@@ -1075,11 +1121,13 @@ function generateNestedClass(
         lines.push(...xmlDocPropertyComment(prop.description, propName, "    "));
         lines.push(...emitDataAnnotations(prop, "    ", csharpType));
         if (isSchemaDeprecated(prop)) pushObsoleteAttributes(lines, "    ");
+        if (isSchemaExperimental(prop)) pushExperimentalAttribute(lines, "    ");
         if (isMillisecondsDurationProperty(propName, prop)) lines.push(`    [JsonConverter(typeof(MillisecondsTimeSpanConverter))]`);
         if (!isReq) lines.push(`    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`);
+        const propVisibility = pushCSharpInternalAttribute(lines, prop);
         lines.push(`    [JsonPropertyName("${propName}")]`);
         const reqMod = isReq && !csharpType.endsWith("?") ? "required " : "";
-        lines.push(`    public ${reqMod}${csharpType} ${csharpName} { get; set; }`, "");
+        lines.push(`    ${propVisibility} ${reqMod}${csharpType} ${csharpName} { get; set; }`, "");
     }
     if (lines[lines.length - 1] === "") lines.pop();
     lines.push(`}`);
@@ -1095,6 +1143,9 @@ function resolveSessionPropertyType(
     nestedClasses: Map<string, string>,
     enumOutput: string[]
 ): string {
+    if (isOpaqueJson(propSchema)) {
+        return isRequired ? "JsonElement" : "JsonElement?";
+    }
     // Handle $ref by resolving against schema definitions
     if (propSchema.$ref) {
         const className = typeToClassName(refTypeName(propSchema.$ref, sessionDefinitions));
@@ -1145,12 +1196,12 @@ function resolveSessionPropertyType(
         }
         const unionType = tryGenerateSessionJsonUnionType(propSchema, parentClassName, propName, knownTypes, nestedClasses, enumOutput);
         if (unionType) return isRequired ? unionType : `${unionType}?`;
-        return !isRequired ? "object?" : "object";
+        failUnmappable(`anyOf without discriminator (${parentClassName}.${propName})`, propSchema);
     }
     if (propSchema.oneOf) {
         const unionType = tryGenerateSessionJsonUnionType(propSchema, parentClassName, propName, knownTypes, nestedClasses, enumOutput);
         if (unionType) return isRequired ? unionType : `${unionType}?`;
-        return !isRequired ? "object?" : "object";
+        failUnmappable(`oneOf without discriminator (${parentClassName}.${propName})`, propSchema);
     }
     if (propSchema.enum && Array.isArray(propSchema.enum)) {
         const enumName = getOrCreateEnum(parentClassName, propName, propSchema.enum as string[], enumOutput, propSchema.description, getEnumValueDescriptions(propSchema), propSchema.title as string | undefined, isSchemaDeprecated(propSchema), isSchemaExperimental(propSchema));
@@ -1191,7 +1242,8 @@ function resolveSessionPropertyType(
 }
 
 function generateDataClass(variant: EventVariant, knownTypes: Map<string, string>, nestedClasses: Map<string, string>, enumOutput: string[]): string {
-    if (!variant.dataSchema?.properties) return `public sealed partial class ${variant.dataClassName} { }`;
+    const dataVisibility = isSchemaInternal(variant.dataSchema) ? "internal" : "public";
+    if (!variant.dataSchema?.properties) return `${dataVisibility} sealed partial class ${variant.dataClassName} { }`;
 
     const required = new Set(variant.dataSchema.required || []);
     const lines: string[] = [];
@@ -1206,7 +1258,7 @@ function generateDataClass(variant: EventVariant, knownTypes: Map<string, string
     if (isSchemaDeprecated(variant.dataSchema)) {
         pushObsoleteAttributes(lines);
     }
-    lines.push(`public sealed partial class ${variant.dataClassName}`, `{`);
+    lines.push(`${dataVisibility} sealed partial class ${variant.dataClassName}`, `{`);
 
     for (const [propName, propSchema] of Object.entries(variant.dataSchema.properties).sort(([a], [b]) => a.localeCompare(b))) {
         if (typeof propSchema !== "object") continue;
@@ -1218,11 +1270,13 @@ function generateDataClass(variant: EventVariant, knownTypes: Map<string, string
         lines.push(...xmlDocPropertyComment(prop.description, propName, "    "));
         lines.push(...emitDataAnnotations(prop, "    ", csharpType));
         if (isSchemaDeprecated(prop)) pushObsoleteAttributes(lines, "    ");
+        if (isSchemaExperimental(prop)) pushExperimentalAttribute(lines, "    ");
         if (isMillisecondsDurationProperty(propName, prop)) lines.push(`    [JsonConverter(typeof(MillisecondsTimeSpanConverter))]`);
         if (!isReq) lines.push(`    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`);
+        const propVisibility = pushCSharpInternalAttribute(lines, prop);
         lines.push(`    [JsonPropertyName("${propName}")]`);
         const reqMod = isReq && !csharpType.endsWith("?") ? "required " : "";
-        lines.push(`    public ${reqMod}${csharpType} ${csharpName} { get; set; }`, "");
+        lines.push(`    ${propVisibility} ${reqMod}${csharpType} ${csharpName} { get; set; }`, "");
     }
     if (lines[lines.length - 1] === "") lines.pop();
     lines.push(`}`);
@@ -1250,10 +1304,12 @@ function emitSessionEventEnvelopeProperty(
     lines.push(...xmlDocPropertyComment(property.schema.description, property.name, "    "));
     lines.push(...emitDataAnnotations(property.schema, "    ", csharpType));
     if (isSchemaDeprecated(property.schema)) pushObsoleteAttributes(lines, "    ");
+    if (isSchemaExperimental(property.schema)) pushExperimentalAttribute(lines, "    ");
     if (isMillisecondsDurationProperty(property.name, property.schema)) lines.push(`    [JsonConverter(typeof(MillisecondsTimeSpanConverter))]`);
     if (!property.required) lines.push(`    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`);
+    const propVisibility = pushCSharpInternalAttribute(lines, property.schema);
     lines.push(`    [JsonPropertyName("${property.name}")]`);
-    lines.push(`    public ${csharpType} ${csharpName} { get; set; }`, "");
+    lines.push(`    ${propVisibility} ${csharpType} ${csharpName} { get; set; }`, "");
 
     return lines;
 }
@@ -1320,11 +1376,12 @@ namespace GitHub.Copilot;
         if (variant.eventExperimental) {
             pushExperimentalAttribute(lines);
         }
-        lines.push(`public sealed partial class ${variant.className} : SessionEvent`, `{`);
+        const variantVisibility = isSchemaInternal(variant.dataSchema) ? "internal" : "public";
+        lines.push(`${variantVisibility} sealed partial class ${variant.className} : SessionEvent`, `{`);
         lines.push(`    /// <inheritdoc />`);
         lines.push(`    [JsonIgnore]`, `    public override string Type => "${variant.typeName}";`, "");
         lines.push(`    /// <summary>The <c>${escapeXml(variant.typeName)}</c> event payload.</summary>`);
-        lines.push(`    [JsonPropertyName("data")]`, `    public required ${variant.dataClassName} Data { get; set; }`, `}`, "");
+        lines.push(`    [JsonPropertyName("data")]`, `    ${variantVisibility} required ${variant.dataClassName} Data { get; set; }`, `}`, "");
     }
 
     // Data classes
@@ -1352,7 +1409,7 @@ export async function generateSessionEvents(schemaPath?: string): Promise<void> 
     console.log("C#: generating session-events...");
     const resolvedPath = schemaPath ?? (await getSessionEventsSchemaPath());
     const schema = cloneSchemaForCodegen(JSON.parse(await fs.readFile(resolvedPath, "utf-8")) as JSONSchema7);
-    const processed = postProcessSchema(schema);
+    const processed = propagateInternalVisibility(postProcessSchema(schema));
     const code = generateSessionEventsCode(processed);
     const outPath = await writeGeneratedFile("dotnet/src/Generated/SessionEvents.cs", code);
     console.log(`  ✓ ${outPath}`);
@@ -1603,14 +1660,15 @@ function emitRpcClass(
         lines.push(...xmlDocPropertyComment(prop.description, propName, "    "));
         lines.push(...emitDataAnnotations(prop, "    ", csharpType));
         if (isSchemaDeprecated(prop)) pushObsoleteAttributes(lines, "    ");
+        if (isSchemaExperimental(prop)) pushExperimentalAttribute(lines, "    ");
         if (isMillisecondsDurationProperty(propName, prop)) lines.push(`    [JsonConverter(typeof(MillisecondsTimeSpanConverter))]`);
+        const propVisibility = pushCSharpInternalAttribute(lines, prop);
         lines.push(`    [JsonPropertyName("${propName}")]`);
 
         let defaultVal = "";
         let propAccessors = "{ get; set; }";
         if (isReq && !csharpType.endsWith("?")) {
             if (csharpType === "string") defaultVal = " = string.Empty;";
-            else if (csharpType === "object") defaultVal = " = null!;";
             else if (csharpType.startsWith("IList<")) {
                 propAccessors = "{ get => field ??= []; set; }";
             } else if (csharpType.startsWith("IDictionary<")) {
@@ -1622,7 +1680,7 @@ function emitRpcClass(
                 defaultVal = " = null!;";
             }
         }
-        lines.push(`    public ${csharpType} ${csharpName} ${propAccessors}${defaultVal}`);
+        lines.push(`    ${propVisibility} ${csharpType} ${csharpName} ${propAccessors}${defaultVal}`);
         if (i < props.length - 1) lines.push("");
     }
     lines.push(`}`);
@@ -1799,12 +1857,40 @@ function emitServerInstanceMethod(
         const csharpName = requestClassName
             ? toCSharpPropertyName(pName, jsonSchema)
             : toPascalCase(pName);
-        const csType = requestClassName
+        const naturalType = requestClassName
             ? resolveRpcType(jsonSchema, isReq, requestClassName, csharpName, classes)
             : schemaTypeToCSharp(jsonSchema, isReq, rpcKnownTypes, csharpName);
+        // Boundary special-case: if the natural type is JsonElement/JsonElement?
+        // or a list of JsonElement (i.e. the schema is opaque-JSON, possibly
+        // wrapped in an array), accept object/IList<object?> at the public
+        // surface for ergonomics and convert at the call site. DTO fields
+        // keep the JsonElement form.
+        const opaqueRequired = naturalType === "JsonElement";
+        const opaqueOptional = naturalType === "JsonElement?";
+        const opaqueListRequired = naturalType === "IList<JsonElement>";
+        const opaqueListOptional = naturalType === "IList<JsonElement>?";
+        const opaque = opaqueRequired || opaqueOptional || opaqueListRequired || opaqueListOptional;
+        const csType = opaqueRequired
+            ? "object"
+            : opaqueOptional
+                ? "object?"
+                : opaqueListRequired
+                    ? "IList<object?>"
+                    : opaqueListOptional
+                        ? "IList<object?>?"
+                        : naturalType;
         sigParams.push(`${csType} ${pName}${isReq ? "" : " = null"}`);
-        bodyAssignments.push(`${csharpName} = ${pName}`);
-        if (requiresArgumentNullCheck(csType, isReq)) {
+        const assignedValue = opaqueRequired
+            ? `CopilotClient.ToJsonElementForWire(${pName})!.Value`
+            : opaqueOptional
+                ? `CopilotClient.ToJsonElementForWire(${pName})`
+                : opaqueListRequired
+                    ? `${pName}.Select(static v => CopilotClient.ToJsonElementForWire(v)!.Value).ToList()`
+                    : opaqueListOptional
+                        ? `${pName}?.Select(static v => CopilotClient.ToJsonElementForWire(v)!.Value).ToList()`
+                        : pName;
+        bodyAssignments.push(`${csharpName} = ${assignedValue}`);
+        if (opaqueRequired || opaqueListRequired || (!opaque && requiresArgumentNullCheck(csType, isReq))) {
             argumentNullChecks.push(`${indent}    ArgumentNullException.ThrowIfNull(${pName});`);
         }
         parameterDescriptions.push({ name: pName, description: jsonSchema.description });
@@ -1956,14 +2042,38 @@ function emitSessionMethod(key: string, method: RpcMethod, lines: string[], clas
         for (const [pName, pSchema] of paramEntries) {
             if (typeof pSchema !== "object") continue;
             const isReq = requiredSet.has(pName);
-            const csharpName = toCSharpPropertyName(pName, pSchema as JSONSchema7);
-            const csType = resolveRpcType(pSchema as JSONSchema7, isReq, requestClassName, csharpName, classes);
+            const jsonSchema = pSchema as JSONSchema7;
+            const csharpName = toCSharpPropertyName(pName, jsonSchema);
+            const naturalType = resolveRpcType(jsonSchema, isReq, requestClassName, csharpName, classes);
+            const opaqueRequired = naturalType === "JsonElement";
+            const opaqueOptional = naturalType === "JsonElement?";
+            const opaqueListRequired = naturalType === "IList<JsonElement>";
+            const opaqueListOptional = naturalType === "IList<JsonElement>?";
+            const opaque = opaqueRequired || opaqueOptional || opaqueListRequired || opaqueListOptional;
+            const csType = opaqueRequired
+                ? "object"
+                : opaqueOptional
+                    ? "object?"
+                    : opaqueListRequired
+                        ? "IList<object?>"
+                        : opaqueListOptional
+                            ? "IList<object?>?"
+                            : naturalType;
             sigParams.push(`${csType} ${pName}${isReq ? "" : " = null"}`);
-            bodyAssignments.push(`${csharpName} = ${pName}`);
-            if (requiresArgumentNullCheck(csType, isReq)) {
+            const assignedValue = opaqueRequired
+                ? `CopilotClient.ToJsonElementForWire(${pName})!.Value`
+                : opaqueOptional
+                    ? `CopilotClient.ToJsonElementForWire(${pName})`
+                    : opaqueListRequired
+                        ? `${pName}.Select(static v => CopilotClient.ToJsonElementForWire(v)!.Value).ToList()`
+                        : opaqueListOptional
+                            ? `${pName}?.Select(static v => CopilotClient.ToJsonElementForWire(v)!.Value).ToList()`
+                            : pName;
+            bodyAssignments.push(`${csharpName} = ${assignedValue}`);
+            if (opaqueRequired || opaqueListRequired || (!opaque && requiresArgumentNullCheck(csType, isReq))) {
                 argumentNullChecks.push(`${indent}    ArgumentNullException.ThrowIfNull(${pName});`);
             }
-            parameterDescriptions.push({ name: pName, description: (pSchema as JSONSchema7).description });
+            parameterDescriptions.push({ name: pName, description: jsonSchema.description });
         }
     }
     sigParams.push("CancellationToken cancellationToken = default");
@@ -2334,7 +2444,7 @@ async function generate(sessionSchemaPath?: string, apiSchemaPath?: string): Pro
     await generateSessionEvents(sessionSchemaPath);
     try {
         const resolvedSessionPath = sessionSchemaPath ?? (await getSessionEventsSchemaPath());
-        const sessionSchema = postProcessSchema(cloneSchemaForCodegen(JSON.parse(await fs.readFile(resolvedSessionPath, "utf-8")) as JSONSchema7));
+        const sessionSchema = propagateInternalVisibility(postProcessSchema(cloneSchemaForCodegen(JSON.parse(await fs.readFile(resolvedSessionPath, "utf-8")) as JSONSchema7)));
         await generateRpc(apiSchemaPath, sessionSchema);
     } catch (err) {
         if ((err as NodeJS.ErrnoException).code === "ENOENT" && !apiSchemaPath) {

--- a/scripts/codegen/go.ts
+++ b/scripts/codegen/go.ts
@@ -37,9 +37,11 @@ import {
     isRpcMethod,
     isSchemaDeprecated,
     isSchemaExperimental,
+    isSchemaInternal,
     isVoidSchema,
     parseExternalSchemaRef,
     postProcessSchema,
+    propagateInternalVisibility,
     refTypeName,
     resolveObjectSchema,
     resolveRef,
@@ -199,6 +201,31 @@ function pushGoExperimentalSubApiComment(lines: string[], name: string, indent =
 
 function pushGoExperimentalMethodComment(lines: string[], methodName: string, indent = ""): void {
     pushGoComment(lines, `Experimental: ${methodName} is an experimental API and may change or be removed in future versions.`, indent);
+}
+
+function pushGoInternalPropertyComment(lines: string[], goName: string, ctx: GoCodegenCtx, indent = "\t"): void {
+    pushGoCommentForContext(lines, `Internal: ${goName} is part of the SDK's internal API surface and is not intended for external use.`, ctx, indent);
+}
+
+function pushGoExperimentalPropertyComment(lines: string[], goName: string, ctx: GoCodegenCtx, indent = "\t"): void {
+    pushGoCommentForContext(lines, `Experimental: ${goName} is part of an experimental API and may change or be removed.`, ctx, indent);
+}
+
+/**
+ * Emit `Deprecated:` / `Experimental:` / `Internal:` doc comments above a Go
+ * struct field. Centralises the per-field marker logic shared between the
+ * regular struct emitter and the discriminated-union variant emitters.
+ */
+function pushGoFieldMarkers(lines: string[], prop: JSONSchema7, goName: string, ctx: GoCodegenCtx, indent = "\t"): void {
+    if (isSchemaDeprecated(prop)) {
+        pushGoCommentForContext(lines, `Deprecated: ${goName} is deprecated.`, ctx, indent);
+    }
+    if (isSchemaExperimental(prop)) {
+        pushGoExperimentalPropertyComment(lines, goName, ctx, indent);
+    }
+    if (isSchemaInternal(prop)) {
+        pushGoInternalPropertyComment(lines, goName, ctx, indent);
+    }
 }
 
 function lowerFirst(value: string): string {
@@ -1111,9 +1138,7 @@ function emitGoStruct(
         if (prop.description) {
             pushGoCommentForContext(lines, prop.description, ctx, "\t");
         }
-        if (isSchemaDeprecated(prop)) {
-            pushGoCommentForContext(lines, `Deprecated: ${goName} is deprecated.`, ctx, "\t");
-        }
+        pushGoFieldMarkers(lines, prop, goName, ctx);
         const jsonTag = `json:"${propName}${omit}"`;
         lines.push(`\t${goName} ${goType} \`${jsonTag}\``);
         fields.push({ propName, goName, goType, jsonTag });
@@ -1802,9 +1827,7 @@ function emitGoFlatDiscriminatedUnion(
                 if (prop.description) {
                     pushGoCommentForContext(lines, prop.description, ctx, "\t");
                 }
-                if (isSchemaDeprecated(prop)) {
-                    pushGoCommentForContext(lines, `Deprecated: ${goName} is deprecated.`, ctx, "\t");
-                }
+                pushGoFieldMarkers(lines, prop, goName, ctx);
                 const jsonTag = `json:"${propName}${omit}"`;
                 lines.push(`\t${goName} ${goType} \`${jsonTag}\``);
                 fields.push({ propName, goName, goType, jsonTag });
@@ -1931,9 +1954,7 @@ function emitGoRequiredFieldDiscriminatedUnion(
                 if (prop.description) {
                     pushGoCommentForContext(lines, prop.description, ctx, "\t");
                 }
-                if (isSchemaDeprecated(prop)) {
-                    pushGoCommentForContext(lines, `Deprecated: ${goName} is deprecated.`, ctx, "\t");
-                }
+                pushGoFieldMarkers(lines, prop, goName, ctx);
                 const jsonTag = `json:"${propName}${omit}"`;
                 lines.push(`\t${goName} ${goType} \`${jsonTag}\``);
                 fields.push({ propName, goName, goType, jsonTag });
@@ -3043,9 +3064,7 @@ export function generateGoSessionEventsCode(schema: JSONSchema7, packageName: st
             if (prop.description) {
                 pushGoCommentForContext(lines, prop.description, ctx, "\t");
             }
-            if (isSchemaDeprecated(prop)) {
-                pushGoCommentForContext(lines, `Deprecated: ${goName} is deprecated.`, ctx, "\t");
-            }
+            pushGoFieldMarkers(lines, prop, goName, ctx);
             const jsonTag = `json:"${propName}${omit}"`;
             lines.push(`\t${goName} ${goType} \`${jsonTag}\``);
             fields.push({ propName, goName, goType, jsonTag });
@@ -3337,11 +3356,15 @@ function collectGoTopLevelNames(code: string, keyword: "type" | "const"): string
 function generateGoSessionEventAliasFile(
     generatedSessionTypeCode: string,
     additionalTypeNames: Iterable<string> = [],
-    additionalConstNames: Iterable<string> = []
+    additionalConstNames: Iterable<string> = [],
+    excludeTypeNames: Iterable<string> = []
 ): string {
+    const excluded = new Set(excludeTypeNames);
     const typeNames = [...new Set([...collectGoTopLevelNames(generatedSessionTypeCode, "type"), ...additionalTypeNames])]
+        .filter((name) => !excluded.has(name))
         .sort(compareGoTypeNames);
     const constNames = [...new Set([...collectGoTopLevelNames(generatedSessionTypeCode, "const"), ...additionalConstNames])]
+        .filter((name) => !excluded.has(name))
         .sort(compareGoTypeNames);
     const lines: string[] = [];
 
@@ -3428,7 +3451,7 @@ async function generateSessionEvents(schemaPath?: string, apiSchema?: ApiSchema)
 
     const resolvedPath = schemaPath ?? (await getSessionEventsSchemaPath());
     const schema = cloneSchemaForCodegen(JSON.parse(await fs.readFile(resolvedPath, "utf-8")) as JSONSchema7);
-    const processed = postProcessSchema(schema);
+    const processed = propagateInternalVisibility(postProcessSchema(schema));
     const sharedDefinitions = apiSchema
         ? findSharedSchemaDefinitions(
             processed as unknown as Record<string, unknown>,
@@ -3440,7 +3463,26 @@ async function generateSessionEvents(schemaPath?: string, apiSchema?: ApiSchema)
     const sessionSchema = rewriteSharedDefinitionReferences(processed, sharedDefinitions, "api.schema.json", true);
 
     const generatedSessionCode = generateGoSessionEventsCode(sessionSchema, "rpc");
-    const generatedTypeCode = stripTrailingGoWhitespace(generatedSessionCode.typeCode);
+    let generatedTypeCode = stripTrailingGoWhitespace(generatedSessionCode.typeCode);
+    // Annotate internal session-event types (driven by the JSON Schema definition's
+    // `visibility: "internal"` flag). Matches what the RPC generator does below;
+    // the session-events emit path doesn't pass through that code so we apply it here.
+    {
+        const sessionDefs = collectDefinitionCollections(sessionSchema as Record<string, unknown>);
+        const allSessionDefs = { ...sessionDefs.$defs, ...sessionDefs.definitions };
+        const internalSessionTypeNames = new Set<string>();
+        for (const [name, def] of Object.entries(allSessionDefs)) {
+            if (def && typeof def === "object" && (def as Record<string, unknown>).visibility === "internal") {
+                internalSessionTypeNames.add(name);
+            }
+        }
+        for (const typeName of internalSessionTypeNames) {
+            generatedTypeCode = generatedTypeCode.replace(
+                new RegExp(`^(type ${typeName} struct)`, "m"),
+                `// Internal: ${typeName} is an internal SDK API and is not part of the public surface.\n$1`
+            );
+        }
+    }
     const generatedEncodingCode = stripTrailingGoWhitespace(generatedSessionCode.encodingCode);
     rpcSessionEventTopLevelNames = {
         types: new Set(collectGoTopLevelNames(generatedTypeCode, "type")),
@@ -3460,9 +3502,24 @@ async function generateSessionEvents(schemaPath?: string, apiSchema?: ApiSchema)
     const sharedAliasNames = apiSchema
         ? collectGoSharedSessionEventAliasNames(sharedSessionEventDefinitions, apiSchema)
         : { typeNames: [], constNames: [] };
+    // Exclude internal types from the public `copilot` package re-exports. They
+    // remain accessible in the lower-level `rpc` package (where they're tagged
+    // with `// Internal:` doc comments), but consumers using only the canonical
+    // `copilot.*` namespace never see them. This is the strongest practical
+    // signal Go offers without requiring runtime refactoring to enable full
+    // lowercase/unexported types.
+    const internalTypesInSession = new Set<string>();
+    {
+        const { definitions, $defs } = collectDefinitionCollections(sessionSchema as Record<string, unknown>);
+        for (const [name, def] of Object.entries({ ...definitions, ...$defs })) {
+            if (def && typeof def === "object" && (def as Record<string, unknown>).visibility === "internal") {
+                internalTypesInSession.add(name);
+            }
+        }
+    }
     const aliasOutPath = await writeGeneratedFile(
         "go/zsession_events.go",
-        generateGoSessionEventAliasFile(generatedTypeCode, sharedAliasNames.typeNames, sharedAliasNames.constNames)
+        generateGoSessionEventAliasFile(generatedTypeCode, sharedAliasNames.typeNames, sharedAliasNames.constNames, internalTypesInSession)
     );
     console.log(`  ✓ ${aliasOutPath}`);
 
@@ -3476,7 +3533,7 @@ async function generateRpc(schemaPath?: string): Promise<void> {
     console.log("Go: generating RPC types...");
 
     const resolvedPath = schemaPath ?? (await getApiSchemaPath());
-    const schema = fixNullableRequiredRefsInApiSchema(cloneSchemaForCodegen(JSON.parse(await fs.readFile(resolvedPath, "utf-8")) as ApiSchema));
+    const schema = propagateInternalVisibility(fixNullableRequiredRefsInApiSchema(cloneSchemaForCodegen(JSON.parse(await fs.readFile(resolvedPath, "utf-8")) as ApiSchema)) as JSONSchema7) as unknown as ApiSchema;
 
     const allMethods = [
         ...collectRpcMethods(schema.server || {}),

--- a/scripts/codegen/package-lock.json
+++ b/scripts/codegen/package-lock.json
@@ -795,7 +795,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/scripts/codegen/python.ts
+++ b/scripts/codegen/python.ts
@@ -8,7 +8,7 @@
 
 import fs from "fs/promises";
 import path from "path";
-import type { JSONSchema7 } from "json-schema";
+import type { JSONSchema7, JSONSchema7Definition } from "json-schema";
 import { fileURLToPath } from "url";
 import {
     cloneSchemaForCodegen,
@@ -25,7 +25,13 @@ import {
     isNodeFullyDeprecated,
     isSchemaDeprecated,
     isSchemaExperimental,
+    isSchemaInternal,
     postProcessSchema,
+    propagateInternalVisibility,
+    collectInternalSymbols,
+    collectInternalFieldsOnPublicTypes,
+    annotateInternalPythonFields,
+    renameInternalPythonSymbols,
     stripBooleanLiterals,
     writeGeneratedFile,
     collectDefinitionCollections,
@@ -675,6 +681,24 @@ function pushPyExperimentalComment(lines: string[], subject: PyExperimentalSubje
 
 function pushPyExperimentalApiGroupComment(lines: string[]): void {
     lines.push("# Experimental: this API group is experimental and may change or be removed.");
+}
+
+/**
+ * Emit `# Deprecated:` / `# Experimental:` / `# Internal:` comments above a
+ * dataclass field. Order matches our other codegens (deprecated, experimental,
+ * internal) and keeps the comments out of the field declaration itself.
+ */
+function pushPyFieldMarkers(lines: string[], propSchema: JSONSchema7 | null | undefined): void {
+    if (!propSchema) return;
+    if (isSchemaDeprecated(propSchema)) {
+        lines.push(`    # Deprecated: this field is deprecated.`);
+    }
+    if (isSchemaExperimental(propSchema)) {
+        lines.push(`    # Experimental: this field is part of an experimental API and may change or be removed.`);
+    }
+    if (isSchemaInternal(propSchema)) {
+        lines.push(`    # Internal: this field is an internal SDK API and is not part of the public surface.`);
+    }
 }
 
 /**
@@ -2057,9 +2081,11 @@ function emitPyClass(
     const fieldInfos = orderedFieldEntries.map(([propName, propSchema]) => {
         const isRequired = required.has(propName);
         const resolved = resolvePyPropertyType(propSchema, typeName, propName, isRequired, ctx);
+        const baseFieldName = toPyFieldName(propName, propSchema, ctx);
+        const fieldName = isSchemaInternal(propSchema) ? `_${baseFieldName}` : baseFieldName;
         return {
             jsonName: propName,
-            fieldName: toPyFieldName(propName, propSchema, ctx),
+            fieldName,
             isRequired,
             resolved,
         };
@@ -2092,9 +2118,8 @@ function emitPyClass(
 
     for (const field of fieldInfos) {
         const suffix = field.isRequired ? "" : " = None";
-        if (isSchemaDeprecated(orderedFieldEntries.find(([n]) => n === field.jsonName)?.[1] as JSONSchema7)) {
-            lines.push(`    # Deprecated: this field is deprecated.`);
-        }
+        const propSchema = orderedFieldEntries.find(([n]) => n === field.jsonName)?.[1] as JSONSchema7 | undefined;
+        pushPyFieldMarkers(lines, propSchema);
         lines.push(`    ${field.fieldName}: ${field.resolved.annotation}${suffix}`);
     }
 
@@ -2217,7 +2242,7 @@ function emitPyFlatDiscriminatedUnion(
 
         return {
             jsonName: propName,
-            fieldName: toPyFieldName(propName, propSchema, ctx),
+            fieldName: isSchemaInternal(propSchema) ? `_${toPyFieldName(propName, propSchema, ctx)}` : toPyFieldName(propName, propSchema, ctx),
             isRequired: requiredInAll,
             resolved,
         };
@@ -2234,10 +2259,8 @@ function emitPyFlatDiscriminatedUnion(
     }
     for (const field of fieldInfos) {
         const suffix = field.isRequired ? "" : " = None";
-        const fieldSchema = orderedFieldEntries.find(([n]) => n === field.jsonName)?.[1];
-        if (fieldSchema && isSchemaDeprecated(fieldSchema)) {
-            lines.push(`    # Deprecated: this field is deprecated.`);
-        }
+        const fieldSchema = orderedFieldEntries.find(([n]) => n === field.jsonName)?.[1] as JSONSchema7 | undefined;
+        pushPyFieldMarkers(lines, fieldSchema);
         lines.push(`    ${field.fieldName}: ${field.resolved.annotation}${suffix}`);
     }
     lines.push(``);
@@ -2624,8 +2647,10 @@ async function generateSessionEvents(schemaPath?: string): Promise<void> {
 
     const resolvedPath = schemaPath ?? (await getSessionEventsSchemaPath());
     const schema = JSON.parse(await fs.readFile(resolvedPath, "utf-8")) as JSONSchema7;
-    const processed = postProcessSchema(schema);
-    const code = generatePythonSessionEventsCode(processed);
+    const processed = propagateInternalVisibility(postProcessSchema(schema));
+    let code = generatePythonSessionEventsCode(processed);
+    const { typeNames } = collectInternalSymbols(processed);
+    code = renameInternalPythonSymbols(code, typeNames);
 
     const outPath = await writeGeneratedFile("python/copilot/generated/session_events.py", code);
     console.log(`  ✓ ${outPath}`);
@@ -3017,6 +3042,44 @@ def _patch_model_capabilities(data: dict) -> dict:
     finalCode = postProcessDiscriminatorDefaultsForPython(finalCode, refBasedUnions);
     finalCode = unwrapRedundantPythonLambdas(finalCode);
 
+    // Apply `_`-prefix to type names of internal RPC types so the leading-underscore
+    // Python convention signals "internal, no stability guarantees" to consumers.
+    {
+        const internalDefs = new Set<string>();
+        for (const [name, def] of Object.entries(rpcDefinitions.definitions)) {
+            if (def && typeof def === "object" && (def as Record<string, unknown>).visibility === "internal") {
+                internalDefs.add(name);
+            }
+        }
+        for (const [name, def] of Object.entries(rpcDefinitions.$defs)) {
+            if (def && typeof def === "object" && (def as Record<string, unknown>).visibility === "internal") {
+                internalDefs.add(name);
+            }
+        }
+        if (internalDefs.size > 0) {
+            finalCode = renameInternalPythonSymbols(finalCode, internalDefs);
+        }
+    }
+
+    // Annotate internal fields on otherwise-public RPC types with a `# Internal:`
+    // comment immediately above the field declaration. Quicktype's generated
+    // from_dict/to_dict reference field names in patterns that are brittle to
+    // regex-based identifier rewriting, so we annotate rather than rename. The
+    // marker is visible in IDE hovers and signals "internal, no stability
+    // guarantee" without breaking the wire-protocol round-trip.
+    {
+        const combinedSchema: JSONSchema7 = {
+            definitions: {
+                ...(rpcDefinitions.definitions as Record<string, JSONSchema7Definition>),
+                ...(rpcDefinitions.$defs as Record<string, JSONSchema7Definition>),
+            },
+        };
+        const fieldsByType = collectInternalFieldsOnPublicTypes(combinedSchema);
+        if (fieldsByType.size > 0) {
+            finalCode = annotateInternalPythonFields(finalCode, fieldsByType, toSnakeCase);
+        }
+    }
+
     const outPath = await writeGeneratedFile("python/copilot/generated/rpc.py", finalCode);
     console.log(`  ✓ ${outPath}`);
 }
@@ -3141,7 +3204,8 @@ function emitRpcWrapper(lines: string[], node: Record<string, unknown>, isSessio
 }
 
 function emitMethod(lines: string[], name: string, method: RpcMethod, isSession: boolean, resolveType: (name: string) => string, groupExperimental = false, groupDeprecated = false): void {
-    const methodName = toSnakeCase(name);
+    const isInternal = method.visibility === "internal";
+    const methodName = (isInternal ? "_" : "") + toSnakeCase(name);
     const resultSchema = getMethodResultSchema(method);
     const nullableInner = resultSchema ? getNullableInner(resultSchema) : undefined;
     const effectiveResultSchema = nullableInner ?? resultSchema;

--- a/scripts/codegen/rust.ts
+++ b/scripts/codegen/rust.ts
@@ -38,9 +38,11 @@ import {
 	isRpcMethod,
 	isSchemaDeprecated,
 	isSchemaExperimental,
+	isSchemaInternal,
 	isVoidSchema,
 	parseExternalSchemaRef,
 	postProcessSchema,
+	propagateInternalVisibility,
 	refTypeName,
 	resolveObjectSchema,
 	resolveRef,
@@ -776,6 +778,7 @@ function emitRustStruct(
 	if (isSchemaDeprecated(schema)) {
 		lines.push(...rustDeprecatedAttributes());
 	}
+	const structVis = isSchemaInternal(schema) ? "pub(crate)" : "pub";
 
 	// Resolve field types up-front so we can decide whether `Default` can be
 	// derived. A required field whose bare type is non-default-able (e.g. an
@@ -810,13 +813,18 @@ function emitRustStruct(
 		lines.push("#[derive(Debug, Clone, Default, Serialize, Deserialize)]");
 	}
 	lines.push(`#[serde(rename_all = "camelCase")]`);
-	lines.push(`pub struct ${typeName} {`);
+	lines.push(`${structVis} struct ${typeName} {`);
 
 	for (const { propName, prop, isReq, rustField, rustType } of fields) {
 		if (prop.description) {
 			for (const line of prop.description.split(/\r?\n/)) {
 				lines.push(`    /// ${line}`);
 			}
+		}
+		pushRustExperimentalDocs(lines, isSchemaExperimental(prop), "    ");
+		const propIsInternal = isSchemaInternal(prop);
+		if (propIsInternal) {
+			lines.push(`    #[doc(hidden)]`);
 		}
 		if (isSchemaDeprecated(prop)) {
 			lines.push(...rustDeprecatedAttributes("    "));
@@ -846,7 +854,7 @@ function emitRustStruct(
 			lines.push(`    #[serde(rename = "${propName}")]`);
 		}
 
-		lines.push(`    pub ${rustField}: ${rustType},`);
+		lines.push(`    ${propIsInternal ? "pub(crate)" : "pub"} ${rustField}: ${rustType},`);
 	}
 
 	lines.push("}");
@@ -1781,17 +1789,18 @@ function emitNamespaceMethod(
 	};
 
 	const paramArg = hasParams ? `, params: ${paramsTypeName}` : "";
+	const fnVis = method.visibility === "internal" ? "pub(crate)" : "pub";
 
 	if (hasParams && paramsInfo.optional) {
 		out.push(...buildDocs(false));
 		out.push(
-			`    pub async fn ${fnName}(&self) -> Result<${returnType}, Error> {`,
+			`    ${fnVis} async fn ${fnName}(&self) -> Result<${returnType}, Error> {`,
 		);
 		pushNamespaceMethodBody(out, constName, isSession, false, resultIsVoid);
 		out.push("");
 		out.push(...buildDocs(true));
 		out.push(
-			`    pub async fn ${fnName}_with_params(&self, params: ${paramsTypeName}) -> Result<${returnType}, Error> {`,
+			`    ${fnVis} async fn ${fnName}_with_params(&self, params: ${paramsTypeName}) -> Result<${returnType}, Error> {`,
 		);
 		pushNamespaceMethodBody(out, constName, isSession, true, resultIsVoid);
 		out.push("");
@@ -1800,7 +1809,7 @@ function emitNamespaceMethod(
 
 	out.push(...buildDocs(hasParams));
 	out.push(
-		`    pub async fn ${fnName}(&self${paramArg}) -> Result<${returnType}, Error> {`,
+		`    ${fnVis} async fn ${fnName}(&self${paramArg}) -> Result<${returnType}, Error> {`,
 	);
 	pushNamespaceMethodBody(out, constName, isSession, hasParams, resultIsVoid);
 	out.push("");
@@ -1988,11 +1997,15 @@ async function generate(): Promise<void> {
 		await fs.readFile(apiSchemaPath, "utf-8"),
 	) as ApiSchema;
 
-	const sessionEventsSchema = postProcessSchema(
-		stripBooleanLiterals(sessionEventsRaw) as JSONSchema7,
+	const sessionEventsSchema = propagateInternalVisibility(
+		postProcessSchema(
+			stripBooleanLiterals(sessionEventsRaw) as JSONSchema7,
+		),
 	);
-	const apiSchema = postProcessSchema(
-		stripBooleanLiterals(apiRaw) as JSONSchema7,
+	const apiSchema = propagateInternalVisibility(
+		postProcessSchema(
+			stripBooleanLiterals(apiRaw) as JSONSchema7,
+		),
 	) as unknown as ApiSchema;
 
 	// Ensure output directory exists

--- a/scripts/codegen/typescript.ts
+++ b/scripts/codegen/typescript.ts
@@ -18,6 +18,7 @@ import {
     getRpcSchemaTypeName,
     getSessionEventsSchemaPath,
     postProcessSchema,
+    propagateInternalVisibility,
     writeGeneratedFile,
     collectExternalSchemaRefNames,
     collectDefinitionCollections,
@@ -36,7 +37,9 @@ import {
     isNodeFullyDeprecated,
     isVoidSchema,
     isSchemaExperimental,
+    appendPropertyMarkerTagsToDescriptions,
     getEnumValueDescriptions,
+    stripOpaqueJsonMarker,
     type ApiSchema,
     type DefinitionCollections,
     type RpcMethod,
@@ -280,6 +283,13 @@ export function normalizeSchemaForTypeScript(schema: JSONSchema7): JSONSchema7 {
             Object.entries(value as Record<string, unknown>).map(([key, child]) => [key, rewrite(child)])
         ) as Record<string, unknown>;
 
+        // The TypeScript codegen doesn't distinguish opaque JSON from any
+        // other unconstrained value, so drop the marker before feeding the
+        // schema to json-schema-to-typescript. C# codegen reads the marker
+        // from its own (un-normalized) view of the schema and emits
+        // `JsonElement` instead.
+        stripOpaqueJsonMarker(rewritten);
+
         const enumValueDescriptions = getEnumValueDescriptions(rewritten as JSONSchema7);
         if (enumValueDescriptions && Array.isArray(rewritten.enum) && rewritten.enum.every((entry) => typeof entry === "string")) {
             rewritten.tsType = (rewritten.enum as string[])
@@ -330,13 +340,14 @@ async function generateSessionEvents(schemaPath?: string): Promise<void> {
 
     const resolvedPath = schemaPath ?? (await getSessionEventsSchemaPath());
     const schema = JSON.parse(await fs.readFile(resolvedPath, "utf-8")) as JSONSchema7;
-    const processed = postProcessSchema(schema);
+    const processed = propagateInternalVisibility(postProcessSchema(schema));
     const definitionCollections = collectDefinitionCollections(processed as Record<string, unknown>);
     const sessionEvent =
         resolveSchema({ $ref: "#/definitions/SessionEvent" }, definitionCollections) ??
         resolveSchema({ $ref: "#/$defs/SessionEvent" }, definitionCollections) ??
         processed;
     const schemaForCompile = withSharedDefinitions(sessionEvent, definitionCollections);
+    appendPropertyMarkerTagsToDescriptions(schemaForCompile);
 
     const ts = await compile(normalizeSchemaForTypeScript(schemaForCompile), "SessionEvent", {
         bannerComment: `/**
@@ -348,7 +359,27 @@ async function generateSessionEvents(schemaPath?: string): Promise<void> {
         strictIndexSignatures: true,
     });
 
-    const annotatedTs = annotateTypeScriptTypes(ts, experimentalDefinitionNames(definitionCollections), TS_EXPERIMENTAL_JSDOC);
+    let annotatedTs = annotateTypeScriptTypes(ts, experimentalDefinitionNames(definitionCollections), TS_EXPERIMENTAL_JSDOC);
+    // Add @internal JSDoc annotations for session-event types marked
+    // `visibility: "internal"` in the schema. The tag drives `stripInternal`
+    // so the whole type is dropped from the published .d.ts.
+    const sessionInternalTypes = new Set<string>();
+    for (const [name, def] of Object.entries(definitionCollections.definitions ?? {})) {
+        if (def && typeof def === "object" && (def as Record<string, unknown>).visibility === "internal") {
+            sessionInternalTypes.add(name);
+        }
+    }
+    for (const [name, def] of Object.entries(definitionCollections.$defs ?? {})) {
+        if (def && typeof def === "object" && (def as Record<string, unknown>).visibility === "internal") {
+            sessionInternalTypes.add(name);
+        }
+    }
+    for (const intType of sessionInternalTypes) {
+        annotatedTs = annotatedTs.replace(
+            new RegExp(`(^|\\n)(export (?:interface|type) ${intType}\\b)`, "m"),
+            `$1/** @internal */\n$2`
+        );
+    }
     const outPath = await writeGeneratedFile("nodejs/src/generated/session-events.ts", annotatedTs);
     console.log(`  ✓ ${outPath}`);
 }
@@ -579,6 +610,7 @@ import type { MessageConnection } from "vscode-jsonrpc/node.js";
     }
 
     const schemaForCompile = combinedSchema;
+    appendPropertyMarkerTagsToDescriptions(schemaForCompile);
 
     const compiled = await compile(normalizeSchemaForTypeScript(schemaForCompile), "_RpcSchemaRoot", {
         bannerComment: "",
@@ -895,7 +927,7 @@ async function generate(sessionSchemaPath?: string, apiSchemaPath?: string): Pro
     await generateSessionEvents(sessionSchemaPath);
     try {
         const resolvedSessionPath = sessionSchemaPath ?? (await getSessionEventsSchemaPath());
-        const sessionSchema = postProcessSchema(JSON.parse(await fs.readFile(resolvedSessionPath, "utf-8")) as JSONSchema7);
+        const sessionSchema = propagateInternalVisibility(postProcessSchema(JSON.parse(await fs.readFile(resolvedSessionPath, "utf-8")) as JSONSchema7));
         await generateRpc(apiSchemaPath, sessionSchema);
     } catch (err) {
         if ((err as NodeJS.ErrnoException).code === "ENOENT" && !apiSchemaPath) {

--- a/scripts/codegen/utils.ts
+++ b/scripts/codegen/utils.ts
@@ -501,6 +501,346 @@ export function isSchemaExperimental(schema: JSONSchema7 | null | undefined): bo
     return typeof schema === "object" && schema !== null && (schema as Record<string, unknown>).stability === "experimental";
 }
 
+/** Returns true when a JSON Schema node is marked as visibility:"internal" (set via `.asInternal()` on the Zod source). */
+export function isSchemaInternal(schema: JSONSchema7 | null | undefined): boolean {
+    return typeof schema === "object" && schema !== null && (schema as Record<string, unknown>).visibility === "internal";
+}
+
+/**
+ * Collects the set of definition names marked `visibility: "internal"` and a
+ * per-definition set of internal property names. Used by code generators that
+ * need to apply `_`-prefix or similar renames consistently across both type
+ * declarations and references.
+ *
+ * Call after `propagateInternalVisibility` so transitively-internal fields are
+ * also picked up.
+ */
+export function collectInternalSymbols(schema: JSONSchema7): {
+    typeNames: Set<string>;
+    fieldsByType: Map<string, Set<string>>;
+} {
+    const typeNames = new Set<string>();
+    const fieldsByType = new Map<string, Set<string>>();
+    const { definitions, $defs } = collectDefinitionCollections(schema as Record<string, unknown>);
+    const allDefs: Record<string, JSONSchema7Definition> = { ...definitions, ...$defs };
+    for (const [name, def] of Object.entries(allDefs)) {
+        if (!def || typeof def !== "object") continue;
+        const d = def as Record<string, unknown>;
+        if (d.visibility === "internal") typeNames.add(name);
+        const props = d.properties;
+        if (props && typeof props === "object" && !Array.isArray(props)) {
+            for (const [propName, propSchema] of Object.entries(props as Record<string, unknown>)) {
+                if (propSchema && typeof propSchema === "object" && (propSchema as Record<string, unknown>).visibility === "internal") {
+                    if (!fieldsByType.has(name)) fieldsByType.set(name, new Set());
+                    fieldsByType.get(name)!.add(propName);
+                }
+            }
+        }
+    }
+    return { typeNames, fieldsByType };
+}
+
+/**
+ * Post-process a Python module so that types marked `visibility: "internal"`
+ * carry an underscore prefix on their class identifier.
+ *
+ * Why: Python has no compiler-enforced visibility, but the leading-underscore
+ * convention is universally recognized as "no stability guarantee". Combined
+ * with `__all__` exclusion at the module level (handled separately), this is
+ * the strongest "internal" signal Python idioms provide and matches the
+ * cross-language bar of "we can do breaking changes on these without
+ * having to apologize".
+ *
+ * Field-level visibility is expected to be handled at emission time by each
+ * Python emitter (because field names depend on the emitter's PEP 8 normalization
+ * and the emitter's class-name conventions may diverge from the schema's
+ * definition names, breaking any single-class regex). Type-level renaming is
+ * safe to do globally because schema definition names match the emitted class
+ * identifiers for the types that carry `visibility: "internal"`.
+ */
+export function renameInternalPythonSymbols(
+    code: string,
+    typeNames: Iterable<string>
+): string {
+    const escapeRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    let result = code;
+    const sortedTypes = [...typeNames].sort((a, b) => b.length - a.length);
+    // Phase 1: rename each identifier globally at word boundaries.
+    for (const t of sortedTypes) {
+        result = result.replace(
+            new RegExp(`(?<![A-Za-z0-9_])${escapeRegex(t)}(?![A-Za-z0-9_])`, "g"),
+            `_${t}`
+        );
+    }
+    // Phase 2: restore JSON-key strings that match the rename target. Those
+    // strings carry the wire-protocol definition name and must remain untouched
+    // regardless of the Python-side rename. Patterns: `obj.get("Foo")` and
+    // `result["Foo"] = ...` in quicktype's serialization helpers.
+    for (const t of sortedTypes) {
+        const escaped = escapeRegex(t);
+        result = result.replace(
+            new RegExp(`(obj\\.get\\(")_${escaped}("\\))`, "g"),
+            `$1${t}$2`
+        );
+        result = result.replace(
+            new RegExp(`(result\\[")_${escaped}("\\])`, "g"),
+            `$1${t}$2`
+        );
+    }
+    return result;
+}
+
+/**
+ * Collects the set of (publicTypeName, internalFieldName[]) pairs from a
+ * processed schema. Used by code generators that need to annotate or rename
+ * properties whose type carries `visibility: "internal"` but whose containing
+ * definition is itself public — e.g. so IDEs/code completion can hint that a
+ * field is internal even when the type isn't renamed.
+ *
+ * Only definitions that are NOT themselves `visibility: "internal"` are included
+ * (those are already covered by type-level rename/visibility). The returned map
+ * is keyed by JSON Schema definition name; field names are the JSON property
+ * names (un-cased).
+ */
+export function collectInternalFieldsOnPublicTypes(
+    schema: JSONSchema7
+): Map<string, Set<string>> {
+    const out = new Map<string, Set<string>>();
+    const { definitions, $defs } = collectDefinitionCollections(schema as Record<string, unknown>);
+    const allDefs: Record<string, JSONSchema7Definition> = { ...definitions, ...$defs };
+    for (const [name, def] of Object.entries(allDefs)) {
+        if (!def || typeof def !== "object") continue;
+        const d = def as Record<string, unknown>;
+        if (d.visibility === "internal") continue;
+        const props = d.properties;
+        if (!props || typeof props !== "object" || Array.isArray(props)) continue;
+        for (const [propName, propSchema] of Object.entries(props as Record<string, unknown>)) {
+            if (propSchema && typeof propSchema === "object" && (propSchema as Record<string, unknown>).visibility === "internal") {
+                if (!out.has(name)) out.set(name, new Set());
+                out.get(name)!.add(propName);
+            }
+        }
+    }
+    return out;
+}
+
+/**
+ * Annotate quicktype-generated Python field declarations whose schema is marked
+ * `visibility: "internal"` with a `# Internal:` comment immediately above the
+ * declaration. The comment is visible in IDE hovers/code completion, so
+ * consumers see the marker even though the identifier itself is unchanged.
+ *
+ * This is the field-level fallback for code paths that can't rename the field
+ * identifier (quicktype's generated `from_dict`/`to_dict` reference field names
+ * in patterns brittle to regex rewriting). For session-events and other
+ * hand-rolled emitters, prefer renaming.
+ *
+ * The `toFieldName` callback maps a JSON property name to its Python attribute
+ * name (typically snake_case).
+ */
+export function annotateInternalPythonFields(
+    code: string,
+    fieldsByType: Map<string, Set<string>>,
+    toFieldName: (jsonName: string) => string
+): string {
+    const escapeRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    let result = code;
+    for (const [typeName, fields] of fieldsByType) {
+        // Match the class body up to the next top-level statement. quicktype's
+        // generated classes are separated by blank-line boundaries.
+        const classRe = new RegExp(
+            `(@dataclass\\nclass ${escapeRegex(typeName)}[:(][^]*?)(?=\\n(?:@dataclass\\n)?class \\w|\\n\\nclass |\\n[A-Za-z_]\\w* =|$)`,
+            "g"
+        );
+        result = result.replace(classRe, (block) => {
+            for (const jsonField of fields) {
+                const pyField = toFieldName(jsonField);
+                const escaped = escapeRegex(pyField);
+                // Match `    fieldName: type` style declarations (PEP 526). Avoid
+                // double-annotating if the comment is already present immediately above.
+                block = block.replace(
+                    new RegExp(`(^(?!    # Internal:.*$)(?:.*\\n)?)(    )${escaped}(?=\\s*:)`, "gm"),
+                    (_match, prefix, indent) => {
+                        // Avoid duplicate annotation if the previous line is already an Internal: marker.
+                        if (/    # Internal:/.test(prefix)) return `${prefix}${indent}${pyField}`;
+                        return `${prefix}${indent}# Internal: this field is an internal SDK API and is not part of the public surface.\n${indent}${pyField}`;
+                    }
+                );
+            }
+            return block;
+        });
+    }
+    return result;
+}
+
+/**
+ * Walks a top-level JSON Schema and marks any property whose referenced type
+ * resolves to an internal definition as `visibility: "internal"` itself.
+ *
+ * Schemas can be authored with an internal-typed reference on a property that
+ * isn't itself explicitly marked internal (e.g. `copilotUsage` referencing
+ * `AssistantUsageCopilotUsage`). Code generators that map `visibility:
+ * "internal"` to hard language-level visibility (C# `internal`, Rust
+ * `pub(crate)`) would otherwise produce inconsistent-accessibility errors
+ * (CS0053 in C#, E0446 in Rust). This pass closes that gap by promoting
+ * referencing properties to internal — matching the language compilers'
+ * own transitivity rule.
+ *
+ * Only references that resolve directly, through arrays, or through dictionary
+ * `additionalProperties` are considered. References that flow only through a
+ * `oneOf`/`anyOf` of public+internal variants are left alone (the union itself
+ * is the carrier of visibility there).
+ *
+ * Mutates `schema` in place and returns it. Idempotent.
+ */
+export function propagateInternalVisibility(schema: JSONSchema7): JSONSchema7 {
+    if (typeof schema !== "object" || schema === null) return schema;
+
+    const { definitions, $defs } = collectDefinitionCollections(schema as Record<string, unknown>);
+    const allDefs: Record<string, JSONSchema7Definition> = { ...definitions, ...$defs };
+    const internalTypeNames = new Set<string>();
+    for (const [name, def] of Object.entries(allDefs)) {
+        if (def && typeof def === "object" && isSchemaInternal(def as JSONSchema7)) {
+            internalTypeNames.add(name);
+        }
+    }
+    if (internalTypeNames.size === 0) return schema;
+
+    const refToName = (ref: unknown): string | undefined => {
+        if (typeof ref !== "string") return undefined;
+        const m = ref.match(/^#\/(?:definitions|\$defs)\/([^/]+)$/);
+        return m ? m[1] : undefined;
+    };
+
+    /** Returns true when a property's *direct* type carrier is an internal definition. */
+    const propertyReferencesInternal = (propSchema: JSONSchema7): boolean => {
+        const direct = refToName((propSchema as Record<string, unknown>).$ref);
+        if (direct && internalTypeNames.has(direct)) return true;
+        const items = (propSchema as Record<string, unknown>).items;
+        if (items && typeof items === "object" && !Array.isArray(items)) {
+            const itemsRef = refToName((items as Record<string, unknown>).$ref);
+            if (itemsRef && internalTypeNames.has(itemsRef)) return true;
+        }
+        const addl = (propSchema as Record<string, unknown>).additionalProperties;
+        if (addl && typeof addl === "object") {
+            const addlRef = refToName((addl as Record<string, unknown>).$ref);
+            if (addlRef && internalTypeNames.has(addlRef)) return true;
+        }
+        return false;
+    };
+
+    const visit = (node: unknown): void => {
+        if (!node || typeof node !== "object") return;
+        if (Array.isArray(node)) {
+            for (const item of node) visit(item);
+            return;
+        }
+        const record = node as Record<string, unknown>;
+        const props = record.properties;
+        if (props && typeof props === "object" && !Array.isArray(props)) {
+            for (const propSchema of Object.values(props as Record<string, unknown>)) {
+                if (!propSchema || typeof propSchema !== "object") continue;
+                if (!isSchemaInternal(propSchema as JSONSchema7) && propertyReferencesInternal(propSchema as JSONSchema7)) {
+                    (propSchema as Record<string, unknown>).visibility = "internal";
+                }
+                visit(propSchema);
+            }
+        }
+        for (const key of ["items", "additionalProperties", "anyOf", "allOf", "oneOf"]) {
+            if (record[key]) visit(record[key]);
+        }
+        for (const collectionKey of ["definitions", "$defs"]) {
+            const collection = record[collectionKey];
+            if (collection && typeof collection === "object" && !Array.isArray(collection)) {
+                for (const def of Object.values(collection as Record<string, unknown>)) {
+                    if (def && typeof def === "object") visit(def);
+                }
+            }
+        }
+    };
+
+    visit(schema);
+    return schema;
+}
+
+/**
+ * Returns true when a JSON Schema node is marked `x-opaque-json: true` (set via
+ * `.asOpaqueJson()` on the Zod source). These are the only shapes that legitimately
+ * surface as opaque JSON in the SDK; everything else with an underspecified type
+ * is rejected by the runtime's schema lint pass.
+ */
+export function isOpaqueJson(schema: JSONSchema7 | null | undefined): boolean {
+    return typeof schema === "object" && schema !== null && (schema as Record<string, unknown>)["x-opaque-json"] === true;
+}
+
+/**
+ * Removes the `x-opaque-json` marker from a schema node in place. Useful for
+ * codegens (e.g. TypeScript) that don't distinguish opaque JSON from any other
+ * unconstrained value and would otherwise have the marker confuse downstream
+ * tooling. Codegens that *do* care (e.g. C#, which maps opaque JSON to
+ * `JsonElement`) should call `isOpaqueJson` *before* this point.
+ */
+export function stripOpaqueJsonMarker(schema: Record<string, unknown>): void {
+    delete schema["x-opaque-json"];
+}
+
+/**
+ * Append `@internal` and/or `@experimental` JSDoc-style tags to the `description`
+ * of every property that carries `visibility: "internal"` or `stability: "experimental"`
+ * inline. Used by codegens whose output mechanism (e.g. `json-schema-to-typescript`)
+ * renders `description` verbatim as JSDoc; downstream tooling then picks the tags
+ * up automatically.
+ *
+ * Mutates `schema` in place and returns it. Callers that don't want their input
+ * mutated should clone first.
+ */
+export function appendPropertyMarkerTagsToDescriptions(schema: JSONSchema7): JSONSchema7 {
+    const seen = new WeakSet<object>();
+    const visit = (node: unknown): void => {
+        if (!node || typeof node !== "object") return;
+        if (seen.has(node)) return;
+        seen.add(node);
+
+        if (Array.isArray(node)) {
+            for (const item of node) visit(item);
+            return;
+        }
+
+        const record = node as Record<string, unknown>;
+        const props = record.properties;
+        if (props && typeof props === "object" && !Array.isArray(props)) {
+            for (const propSchema of Object.values(props as Record<string, unknown>)) {
+                if (!propSchema || typeof propSchema !== "object") continue;
+                const tags: string[] = [];
+                if (isSchemaInternal(propSchema as JSONSchema7)) tags.push("@internal");
+                if (isSchemaExperimental(propSchema as JSONSchema7)) tags.push("@experimental");
+                if (tags.length === 0) continue;
+                const propRecord = propSchema as Record<string, unknown>;
+                const existing = typeof propRecord.description === "string" ? propRecord.description : "";
+                const suffix = tags.join("\n");
+                propRecord.description = existing.length > 0 ? `${existing}\n\n${suffix}` : suffix;
+
+                // json-schema-to-typescript drops the description on properties whose
+                // schema is a bare `$ref`. Rewriting to `allOf: [{$ref}]` keeps the
+                // referenced type while preserving the description (and our appended
+                // JSDoc tags) on the property declaration. Other generators don't see
+                // this wrapper because they consume the schema before this pass.
+                if (typeof propRecord.$ref === "string" && !propRecord.allOf) {
+                    const refValue = propRecord.$ref;
+                    delete propRecord.$ref;
+                    propRecord.allOf = [{ $ref: refValue } as JSONSchema7Definition];
+                }
+            }
+        }
+
+        for (const value of Object.values(record)) {
+            if (value && typeof value === "object") visit(value);
+        }
+    };
+    visit(schema);
+    return schema;
+}
+
 // ── $ref resolution ─────────────────────────────────────────────────────────
 
 /** Extract the generated type name from a `$ref` path (e.g. "#/definitions/Model" → "Model"). */


### PR DESCRIPTION
## What this PR does

### 1. Codegen: `x-opaque-json` → `JsonElement` (`scripts/codegen/csharp.ts`)

The runtime schema generator now stamps `x-opaque-json: true` on every field/type that legitimately holds free-form JSON (tool args, hook payloads, telemetry, form schemas, etc.) and rejects everything else at build time. The codegen consumes that marker:

- DTO fields with `x-opaque-json: true` → `JsonElement` / `JsonElement?` (was `object?`).
- All bare-`object` fallbacks removed from the codegen; reaching an unmappable shape is now a hard error.
- Hand-written types that round-trip opaque JSON (`ToolInvocation.Arguments`, hook in/out, related serialization plumbing in `Session.cs`, `SessionFsProvider.cs`, `Client.cs`) switched to `JsonElement` on the wire. New `TestJsonContext` for tests.

### 2. RPC-boundary special-case (the bit that made #1343 painful)

The reverted PR forced consumers to pass `JsonElement` for **outbound** RPC method parameters (e.g. `Rpc.Tools.HandlePendingToolCallAsync(... JsonElement result, ...)`). That's worse UX than the old `object?` surface: callers naturally hold a typed CLR value (string, dictionary, generated DTO) and don't want to serialize before each call.

Fixed by introducing an asymmetric boundary:

- **Inbound** opaque-JSON (events, hook inputs, tool args, generated event DTOs, DTO fields) stays `JsonElement(?)` — consumers can introspect the wire payload directly.
- **Outbound** opaque-JSON at top-level RPC method parameters now accepts `object`/`object?`. The codegen generates a call to a new helper:

  ```csharp
  public static JsonElement? ToJsonElementForWire(object? value)
  ```

  which short-circuits if `value` is already a `JsonElement`, otherwise serializes the runtime type using `SerializerOptionsForMessageFormatter` (the chained source-gen `JsonSerializerContexts` the SDK uses for all JSON-RPC traffic). This matches pre-revert serialization exactly.

  DTO field types stay `JsonElement(?)` — the `object` only appears at the public RPC surface. A generated call site looks like:

  ```csharp
  public async Task<HandlePendingToolCallResult> HandlePendingToolCallAsync(
      string requestId, object? result = null, string? error = null, ...)
  {
      var request = new HandlePendingToolCallRequest {
          ..., Result = CopilotClient.ToJsonElementForWire(result), ...
      };
      ...
  }
  ```

- `ToolResultObject.ToolTelemetry` reverted to `IDictionary<string, object>?` for the same reason (it's a consumer-constructed outbound type). Tests updated.

## Validation

- `dotnet build` clean across net472 / net8.0 / net10.0.
- 98 (net8.0) + 91 (net472) unit tests pass; failures match baseline (4 `ConnectionTokenTests` rely on the test-harness proxy subprocess and aren't relevant to this change).
- TS / Python / Go / Rust codegens regenerate cleanly against the updated runtime schema.

## Dependencies

This PR requires runtime changes to be merged first (or for the runtime's regenerated `generated/*.schema.json` to ship a copy). The branch already contains regenerated artifacts from the runtime PR's schema; once the runtime merges and re-emits, no codegen changes will be needed here.