### PR TITLE
Add runtime_instructions system message section to all SDKs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1909,7 +1909,7 @@ const session = await client.createSession({
 });
 ```
 
-Available section IDs: `identity`, `tone`, `tool_efficiency`, `environment_context`, `code_change_rules`, `guidelines`, `safety`, `tool_instructions`, `custom_instructions`, `last_instructions`.
+Available section IDs: `identity`, `tone`, `tool_efficiency`, `environment_context`, `code_change_rules`, `guidelines`, `safety`, `tool_instructions`, `custom_instructions`, `runtime_instructions`, `last_instructions`.
 
 Each override supports four actions: `replace`, `remove`, `append`, and `prepend`. Unknown section IDs are handled gracefully—content is appended to additional instructions and a warning is emitted; `remove` on unknown sections is silently ignored.
 

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1,4 +1,4 @@
-﻿# Copilot SDK
+# Copilot SDK
 
 SDK for programmatic control of GitHub Copilot CLI.
 
@@ -627,18 +627,18 @@ var session = await client.CreateSessionAsync(new SessionConfig
     SystemMessage = new SystemMessageConfig
     {
         Mode = SystemMessageMode.Customize,
-        Sections = new Dictionary<string, SectionOverride>
+        Sections = new Dictionary<SystemMessageSection, SectionOverride>
         {
-            [SystemPromptSections.Tone] = new() { Action = SectionOverrideAction.Replace, Content = "Respond in a warm, professional tone. Be thorough in explanations." },
-            [SystemPromptSections.CodeChangeRules] = new() { Action = SectionOverrideAction.Remove },
-            [SystemPromptSections.Guidelines] = new() { Action = SectionOverrideAction.Append, Content = "\n* Always cite data sources" },
+            [SystemMessageSection.Tone] = new() { Action = SectionOverrideAction.Replace, Content = "Respond in a warm, professional tone. Be thorough in explanations." },
+            [SystemMessageSection.CodeChangeRules] = new() { Action = SectionOverrideAction.Remove },
+            [SystemMessageSection.Guidelines] = new() { Action = SectionOverrideAction.Append, Content = "\n* Always cite data sources" },
         },
         Content = "Focus on financial analysis and reporting."
     }
 });
 ```
 
-Available section IDs are defined as constants on `SystemPromptSections`: `Identity`, `Tone`, `ToolEfficiency`, `EnvironmentContext`, `CodeChangeRules`, `Guidelines`, `Safety`, `ToolInstructions`, `CustomInstructions`, `LastInstructions`.
+Available section IDs are defined as members of the `SystemMessageSection` enum: `Identity`, `Tone`, `ToolEfficiency`, `EnvironmentContext`, `CodeChangeRules`, `Guidelines`, `Safety`, `ToolInstructions`, `CustomInstructions`, `RuntimeInstructions`, `LastInstructions`.
 
 Each section override supports four actions: `Replace`, `Remove`, `Append`, and `Prepend`. Unknown section IDs are handled gracefully: content is appended to additional instructions, and `Remove` overrides are silently ignored.
 

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -638,7 +638,7 @@ var session = await client.CreateSessionAsync(new SessionConfig
 });
 ```
 
-Available section IDs are defined as members of the `SystemMessageSection` enum: `Identity`, `Tone`, `ToolEfficiency`, `EnvironmentContext`, `CodeChangeRules`, `Guidelines`, `Safety`, `ToolInstructions`, `CustomInstructions`, `RuntimeInstructions`, `LastInstructions`.
+Available section IDs are defined as static properties on the `SystemMessageSection` struct: `Identity`, `Tone`, `ToolEfficiency`, `EnvironmentContext`, `CodeChangeRules`, `Guidelines`, `Safety`, `ToolInstructions`, `CustomInstructions`, `RuntimeInstructions`, `LastInstructions`.
 
 Each section override supports four actions: `Replace`, `Remove`, `Append`, and `Prepend`. Unknown section IDs are handled gracefully: content is appended to additional instructions, and `Remove` overrides are silently ignored.
 

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -1,4 +1,4 @@
-﻿/*---------------------------------------------------------------------------------------------
+/*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
@@ -464,13 +464,13 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         }
 
         var callbacks = new Dictionary<string, Func<string, Task<string>>>();
-        var wireSections = new Dictionary<string, SectionOverride>();
+        var wireSections = new Dictionary<SystemMessageSection, SectionOverride>();
 
         foreach (var (sectionId, sectionOverride) in systemMessage.Sections)
         {
             if (sectionOverride.Transform != null)
             {
-                callbacks[sectionId] = sectionOverride.Transform;
+                callbacks[sectionId.Value] = sectionOverride.Transform;
                 wireSections[sectionId] = new SectionOverride { Action = SectionOverrideAction.Transform };
             }
             else

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -1748,7 +1748,7 @@ public enum SystemMessageMode
 }
 
 /// <summary>
-/// Specifies the operation to perform on a system prompt section.
+/// Specifies the operation to perform on a system message section.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter<SectionOverrideAction>))]
 public enum SectionOverrideAction
@@ -1771,7 +1771,7 @@ public enum SectionOverrideAction
 }
 
 /// <summary>
-/// Override operation for a single system prompt section.
+/// Override operation for a single system message section.
 /// </summary>
 public sealed class SectionOverride
 {
@@ -1797,30 +1797,95 @@ public sealed class SectionOverride
 }
 
 /// <summary>
-/// Known system prompt section identifiers for the "customize" mode.
+/// Identifies a system message section for the "customize" mode.
 /// </summary>
-public static class SystemPromptSections
+[JsonConverter(typeof(SystemMessageSection.Converter))]
+public readonly struct SystemMessageSection : IEquatable<SystemMessageSection>
 {
     /// <summary>Agent identity preamble and mode statement.</summary>
-    public const string Identity = "identity";
+    public static SystemMessageSection Identity { get; } = new("identity");
     /// <summary>Response style, conciseness rules, output formatting preferences.</summary>
-    public const string Tone = "tone";
+    public static SystemMessageSection Tone { get; } = new("tone");
     /// <summary>Tool usage patterns, parallel calling, batching guidelines.</summary>
-    public const string ToolEfficiency = "tool_efficiency";
+    public static SystemMessageSection ToolEfficiency { get; } = new("tool_efficiency");
     /// <summary>CWD, OS, git root, directory listing, available tools.</summary>
-    public const string EnvironmentContext = "environment_context";
+    public static SystemMessageSection EnvironmentContext { get; } = new("environment_context");
     /// <summary>Coding rules, linting/testing, ecosystem tools, style.</summary>
-    public const string CodeChangeRules = "code_change_rules";
+    public static SystemMessageSection CodeChangeRules { get; } = new("code_change_rules");
     /// <summary>Tips, behavioral best practices, behavioral guidelines.</summary>
-    public const string Guidelines = "guidelines";
+    public static SystemMessageSection Guidelines { get; } = new("guidelines");
     /// <summary>Environment limitations, prohibited actions, security policies.</summary>
-    public const string Safety = "safety";
+    public static SystemMessageSection Safety { get; } = new("safety");
     /// <summary>Per-tool usage instructions.</summary>
-    public const string ToolInstructions = "tool_instructions";
+    public static SystemMessageSection ToolInstructions { get; } = new("tool_instructions");
     /// <summary>Repository and organization custom instructions.</summary>
-    public const string CustomInstructions = "custom_instructions";
+    public static SystemMessageSection CustomInstructions { get; } = new("custom_instructions");
+    /// <summary>Runtime-provided context and instructions (e.g. system notifications, memories, workspace context, mode-specific instructions, content-exclusion policy).</summary>
+    public static SystemMessageSection RuntimeInstructions { get; } = new("runtime_instructions");
     /// <summary>End-of-prompt instructions: parallel tool calling, persistence, task completion.</summary>
-    public const string LastInstructions = "last_instructions";
+    public static SystemMessageSection LastInstructions { get; } = new("last_instructions");
+
+    /// <summary>Gets the underlying string value of this <see cref="SystemMessageSection"/>.</summary>
+    public string Value => _value ?? string.Empty;
+
+    private readonly string? _value;
+
+    /// <summary>Initializes a new instance of the <see cref="SystemMessageSection"/> struct.</summary>
+    /// <param name="value">The string value for this section identifier.</param>
+    [JsonConstructor]
+    public SystemMessageSection(string value) => _value = value;
+
+    /// <inheritdoc/>
+    public static bool operator ==(SystemMessageSection left, SystemMessageSection right) => left.Equals(right);
+
+    /// <inheritdoc/>
+    public static bool operator !=(SystemMessageSection left, SystemMessageSection right) => !left.Equals(right);
+
+    /// <inheritdoc/>
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is SystemMessageSection other && Equals(other);
+
+    /// <inheritdoc/>
+    public bool Equals(SystemMessageSection other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
+
+    /// <inheritdoc/>
+    public override string ToString() => Value;
+
+    /// <summary>Provides a <see cref="JsonConverter{SystemMessageSection}"/> for serializing <see cref="SystemMessageSection"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<SystemMessageSection>
+    {
+        /// <inheritdoc/>
+        public override SystemMessageSection Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.String)
+            {
+                throw new JsonException("Expected string for SystemMessageSection.");
+            }
+
+            var value = reader.GetString();
+            if (value is null)
+            {
+                throw new JsonException("SystemMessageSection value cannot be null.");
+            }
+
+            return new SystemMessageSection(value);
+        }
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, SystemMessageSection value, JsonSerializerOptions options) =>
+            writer.WriteStringValue(value.Value);
+
+        /// <inheritdoc/>
+        public override SystemMessageSection ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            new(reader.GetString()!);
+
+        /// <inheritdoc/>
+        public override void WriteAsPropertyName(Utf8JsonWriter writer, SystemMessageSection value, JsonSerializerOptions options) =>
+            writer.WritePropertyName(value.Value);
+    }
 }
 
 /// <summary>
@@ -1841,9 +1906,9 @@ public sealed class SystemMessageConfig
 
     /// <summary>
     /// Section-level overrides for customize mode.
-    /// Keys are section identifiers (see <see cref="SystemPromptSections"/>).
+    /// Keys are section identifiers (see <see cref="SystemMessageSection"/>).
     /// </summary>
-    public IDictionary<string, SectionOverride>? Sections { get; set; }
+    public IDictionary<SystemMessageSection, SectionOverride>? Sections { get; set; }
 }
 
 /// <summary>
@@ -3001,7 +3066,7 @@ public sealed class SetForegroundSessionResponse
 }
 
 /// <summary>
-/// Content data for a single system prompt section in a transform RPC call.
+/// Content data for a single system message section in a transform RPC call.
 /// </summary>
 public sealed class SystemMessageTransformSection
 {

--- a/dotnet/test/E2E/SessionE2ETests.cs
+++ b/dotnet/test/E2E/SessionE2ETests.cs
@@ -1,4 +1,4 @@
-﻿/*---------------------------------------------------------------------------------------------
+/*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
@@ -101,10 +101,10 @@ public class SessionE2ETests(E2ETestFixture fixture, ITestOutputHelper output) :
             SystemMessage = new SystemMessageConfig
             {
                 Mode = SystemMessageMode.Customize,
-                Sections = new Dictionary<string, SectionOverride>
+                Sections = new Dictionary<SystemMessageSection, SectionOverride>
                 {
-                    [SystemPromptSections.Tone] = new() { Action = SectionOverrideAction.Replace, Content = customTone },
-                    [SystemPromptSections.CodeChangeRules] = new() { Action = SectionOverrideAction.Remove },
+                    [SystemMessageSection.Tone] = new() { Action = SectionOverrideAction.Replace, Content = customTone },
+                    [SystemMessageSection.CodeChangeRules] = new() { Action = SectionOverrideAction.Remove },
                 },
                 Content = appendedContent
             }

--- a/dotnet/test/E2E/SystemMessageTransformE2ETests.cs
+++ b/dotnet/test/E2E/SystemMessageTransformE2ETests.cs
@@ -22,9 +22,9 @@ public class SystemMessageTransformE2ETests(E2ETestFixture fixture, ITestOutputH
             SystemMessage = new SystemMessageConfig
             {
                 Mode = SystemMessageMode.Customize,
-                Sections = new Dictionary<string, SectionOverride>
+                Sections = new Dictionary<SystemMessageSection, SectionOverride>
                 {
-                    ["identity"] = new SectionOverride
+                    [SystemMessageSection.Identity] = new SectionOverride
                     {
                         Transform = async (content) =>
                         {
@@ -33,7 +33,7 @@ public class SystemMessageTransformE2ETests(E2ETestFixture fixture, ITestOutputH
                             return content;
                         }
                     },
-                    ["tone"] = new SectionOverride
+                    [SystemMessageSection.Tone] = new SectionOverride
                     {
                         Transform = async (content) =>
                         {
@@ -68,9 +68,9 @@ public class SystemMessageTransformE2ETests(E2ETestFixture fixture, ITestOutputH
             SystemMessage = new SystemMessageConfig
             {
                 Mode = SystemMessageMode.Customize,
-                Sections = new Dictionary<string, SectionOverride>
+                Sections = new Dictionary<SystemMessageSection, SectionOverride>
                 {
-                    ["identity"] = new SectionOverride
+                    [SystemMessageSection.Identity] = new SectionOverride
                     {
                         Transform = async (content) =>
                         {
@@ -108,13 +108,13 @@ public class SystemMessageTransformE2ETests(E2ETestFixture fixture, ITestOutputH
             SystemMessage = new SystemMessageConfig
             {
                 Mode = SystemMessageMode.Customize,
-                Sections = new Dictionary<string, SectionOverride>
+                Sections = new Dictionary<SystemMessageSection, SectionOverride>
                 {
-                    ["safety"] = new SectionOverride
+                    [SystemMessageSection.Safety] = new SectionOverride
                     {
                         Action = SectionOverrideAction.Remove
                     },
-                    ["identity"] = new SectionOverride
+                    [SystemMessageSection.Identity] = new SectionOverride
                     {
                         Transform = async (content) =>
                         {

--- a/dotnet/test/Unit/PublicDtoTests.cs
+++ b/dotnet/test/Unit/PublicDtoTests.cs
@@ -174,15 +174,17 @@ public class PublicDtoTests
             .FirstOrDefault(candidate =>
                 candidate.IsGenericType &&
                 (candidate.GetGenericTypeDefinition() == typeof(IDictionary<,>) ||
-                 candidate.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>)) &&
-                candidate.GetGenericArguments()[0] == typeof(string));
+                 candidate.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>)));
 
         if (dictionaryInterface is not null)
         {
+            var keyType = dictionaryInterface.GetGenericArguments()[0];
             var valueType = dictionaryInterface.GetGenericArguments()[1];
+            TryCreateSampleValue(keyType, visited, out var sampleKey);
             TryCreateSampleValue(valueType, visited, out var sampleValue);
-            var dictionary = (IDictionary)Activator.CreateInstance(typeof(Dictionary<,>).MakeGenericType(typeof(string), valueType))!;
-            dictionary["key"] = sampleValue;
+            var dictionaryType = typeof(Dictionary<,>).MakeGenericType(keyType, valueType);
+            var dictionary = (IDictionary)Activator.CreateInstance(dictionaryType)!;
+            dictionary[sampleKey!] = sampleValue;
             value = dictionary;
             return true;
         }

--- a/go/README.md
+++ b/go/README.md
@@ -160,7 +160,7 @@ Event types: `SessionLifecycleCreated`, `SessionLifecycleDeleted`, `SessionLifec
 - `SystemMessage` (\*SystemMessageConfig): System message configuration. Supports three modes:
   - **append** (default): Appends `Content` after the SDK-managed prompt
   - **replace**: Replaces the entire prompt with `Content`
-  - **customize**: Selectively override individual sections via `Sections` map (keys: `SectionIdentity`, `SectionTone`, `SectionToolEfficiency`, `SectionEnvironmentContext`, `SectionCodeChangeRules`, `SectionGuidelines`, `SectionSafety`, `SectionToolInstructions`, `SectionCustomInstructions`, `SectionLastInstructions`; values: `SectionOverride` with `Action` and optional `Content`)
+  - **customize**: Selectively override individual sections via `Sections` map (keys: `SectionIdentity`, `SectionTone`, `SectionToolEfficiency`, `SectionEnvironmentContext`, `SectionCodeChangeRules`, `SectionGuidelines`, `SectionSafety`, `SectionToolInstructions`, `SectionCustomInstructions`, `SectionRuntimeInstructions`, `SectionLastInstructions`; values: `SectionOverride` with `Action` and optional `Content`)
 - `Provider` (\*ProviderConfig): Custom API provider configuration (BYOK). See [Custom Providers](#custom-providers) section.
 - `Streaming` (*bool): Enable streaming delta events (nil = runtime default)
 - `InfiniteSessions` (\*InfiniteSessionConfig): Automatic context compaction configuration
@@ -233,7 +233,7 @@ session, err := client.CreateSession(ctx, &copilot.SessionConfig{
 })
 ```
 
-Available section constants: `SectionIdentity`, `SectionTone`, `SectionToolEfficiency`, `SectionEnvironmentContext`, `SectionCodeChangeRules`, `SectionGuidelines`, `SectionSafety`, `SectionToolInstructions`, `SectionCustomInstructions`, `SectionLastInstructions`.
+Available section constants: `SectionIdentity`, `SectionTone`, `SectionToolEfficiency`, `SectionEnvironmentContext`, `SectionCodeChangeRules`, `SectionGuidelines`, `SectionSafety`, `SectionToolInstructions`, `SectionCustomInstructions`, `SectionRuntimeInstructions`, `SectionLastInstructions`.
 
 Each section override supports four actions:
 

--- a/go/types.go
+++ b/go/types.go
@@ -194,21 +194,36 @@ func Int(v int) *int {
 	return &v
 }
 
-// Known system prompt section identifiers for the "customize" mode.
+// Known system message section identifiers for the "customize" mode.
 const (
-	SectionIdentity           = "identity"
-	SectionTone               = "tone"
-	SectionToolEfficiency     = "tool_efficiency"
+	// SectionIdentity is the agent identity preamble and mode statement.
+	SectionIdentity = "identity"
+	// SectionTone covers response style, conciseness rules, and output formatting preferences.
+	SectionTone = "tone"
+	// SectionToolEfficiency covers tool usage patterns, parallel calling, and batching guidelines.
+	SectionToolEfficiency = "tool_efficiency"
+	// SectionEnvironmentContext covers CWD, OS, git root, directory listing, and available tools.
 	SectionEnvironmentContext = "environment_context"
-	SectionCodeChangeRules    = "code_change_rules"
-	SectionGuidelines         = "guidelines"
-	SectionSafety             = "safety"
-	SectionToolInstructions   = "tool_instructions"
+	// SectionCodeChangeRules covers coding rules, linting/testing, ecosystem tools, and style.
+	SectionCodeChangeRules = "code_change_rules"
+	// SectionGuidelines covers tips, behavioral best practices, and behavioral guidelines.
+	SectionGuidelines = "guidelines"
+	// SectionSafety covers environment limitations, prohibited actions, and security policies.
+	SectionSafety = "safety"
+	// SectionToolInstructions covers per-tool usage instructions.
+	SectionToolInstructions = "tool_instructions"
+	// SectionCustomInstructions covers repository and organization custom instructions.
 	SectionCustomInstructions = "custom_instructions"
-	SectionLastInstructions   = "last_instructions"
+	// SectionRuntimeInstructions targets runtime-provided context and instructions
+	// (e.g. system notifications, memories, workspace context, mode-specific instructions,
+	// content-exclusion policy).
+	SectionRuntimeInstructions = "runtime_instructions"
+	// SectionLastInstructions covers end-of-prompt instructions: parallel tool calling,
+	// persistence, and task completion.
+	SectionLastInstructions = "last_instructions"
 )
 
-// SectionOverrideAction represents the action to perform on a system prompt section.
+// SectionOverrideAction represents the action to perform on a system message section.
 type SectionOverrideAction string
 
 const (
@@ -222,12 +237,12 @@ const (
 	SectionActionPrepend SectionOverrideAction = "prepend"
 )
 
-// SectionTransformFn is a callback that receives the current content of a system prompt section
+// SectionTransformFn is a callback that receives the current content of a system message section
 // and returns the transformed content. Used with the "transform" action to read-then-write
 // modify sections at runtime.
 type SectionTransformFn func(currentContent string) (string, error)
 
-// SectionOverride defines an override operation for a single system prompt section.
+// SectionOverride defines an override operation for a single system message section.
 type SectionOverride struct {
 	// Action is the operation to perform: "replace", "remove", "append", "prepend", or "transform".
 	Action SectionOverrideAction `json:"action,omitempty"`

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -573,8 +573,8 @@ The SDK auto-injects environment context, tool instructions, and security guardr
 Use `mode: "customize"` to selectively override individual sections of the prompt while preserving the rest:
 
 ```typescript
-import { SYSTEM_PROMPT_SECTIONS } from "@github/copilot-sdk";
-import type { SectionOverride, SystemPromptSection } from "@github/copilot-sdk";
+import { SYSTEM_MESSAGE_SECTIONS } from "@github/copilot-sdk";
+import type { SectionOverride, SystemMessageSection } from "@github/copilot-sdk";
 
 const session = await client.createSession({
     model: "gpt-5",
@@ -597,7 +597,7 @@ const session = await client.createSession({
 });
 ```
 
-Available section IDs: `identity`, `tone`, `tool_efficiency`, `environment_context`, `code_change_rules`, `guidelines`, `safety`, `tool_instructions`, `custom_instructions`, `last_instructions`. Use the `SYSTEM_PROMPT_SECTIONS` constant for descriptions of each section.
+Available section IDs: `identity`, `tone`, `tool_efficiency`, `environment_context`, `code_change_rules`, `guidelines`, `safety`, `tool_instructions`, `custom_instructions`, `runtime_instructions`, `last_instructions`. Use the `SYSTEM_MESSAGE_SECTIONS` constant for descriptions of each section.
 
 Each section override supports four actions:
 

--- a/nodejs/src/index.ts
+++ b/nodejs/src/index.ts
@@ -16,7 +16,7 @@ export {
     approveAll,
     convertMcpCallToolResult,
     createSessionFsAdapter,
-    SYSTEM_PROMPT_SECTIONS,
+    SYSTEM_MESSAGE_SECTIONS,
 } from "./types.js";
 // Re-export the generated session-event types (every *Event interface and
 // its corresponding *Data payload type, plus supporting unions/aliases) so
@@ -110,7 +110,7 @@ export type {
     SystemMessageConfig,
     SystemMessageCustomizeConfig,
     SystemMessageReplaceConfig,
-    SystemPromptSection,
+    SystemMessageSection,
     TelemetryConfig,
     TraceContext,
     TraceContextProvider,

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -733,10 +733,10 @@ export interface ToolCallResponsePayload {
 }
 
 /**
- * Known system prompt section identifiers for the "customize" mode.
+ * Known system message section identifiers for the "customize" mode.
  * Each section corresponds to a distinct part of the system prompt.
  */
-export type SystemPromptSection =
+export type SystemMessageSection =
     | "identity"
     | "tone"
     | "tool_efficiency"
@@ -746,10 +746,11 @@ export type SystemPromptSection =
     | "safety"
     | "tool_instructions"
     | "custom_instructions"
+    | "runtime_instructions"
     | "last_instructions";
 
 /** Section metadata for documentation and tooling. */
-export const SYSTEM_PROMPT_SECTIONS: Record<SystemPromptSection, { description: string }> = {
+export const SYSTEM_MESSAGE_SECTIONS: Record<SystemMessageSection, { description: string }> = {
     identity: { description: "Agent identity preamble and mode statement" },
     tone: { description: "Response style, conciseness rules, output formatting preferences" },
     tool_efficiency: { description: "Tool usage patterns, parallel calling, batching guidelines" },
@@ -759,6 +760,10 @@ export const SYSTEM_PROMPT_SECTIONS: Record<SystemPromptSection, { description: 
     safety: { description: "Environment limitations, prohibited actions, security policies" },
     tool_instructions: { description: "Per-tool usage instructions" },
     custom_instructions: { description: "Repository and organization custom instructions" },
+    runtime_instructions: {
+        description:
+            "Runtime-provided context and instructions (e.g. system notifications, memories, workspace context, mode-specific instructions, content-exclusion policy)",
+    },
     last_instructions: {
         description:
             "End-of-prompt instructions: parallel tool calling, persistence, task completion",
@@ -787,7 +792,7 @@ export type SectionOverrideAction =
     | SectionTransformFn;
 
 /**
- * Override operation for a single system prompt section.
+ * Override operation for a single system message section.
  */
 export interface SectionOverride {
     /**
@@ -843,7 +848,7 @@ export interface SystemMessageCustomizeConfig {
      * Unknown section IDs gracefully fall back: content-bearing overrides are appended
      * to additional instructions, and "remove" on unknown sections is a silent no-op.
      */
-    sections?: Partial<Record<SystemPromptSection, SectionOverride>>;
+    sections?: Partial<Record<SystemMessageSection, SectionOverride>>;
 
     /**
      * Additional content appended after all sections.

--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -168,7 +168,7 @@ class SystemMessageReplaceConfig(TypedDict):
     content: str
 
 
-# Known system prompt section identifiers for the "customize" mode.
+# Known system message section identifiers for the "customize" mode.
 
 SectionTransformFn = Callable[[str], str | Awaitable[str]]
 """Transform callback: receives current section content, returns new content."""
@@ -176,7 +176,7 @@ SectionTransformFn = Callable[[str], str | Awaitable[str]]
 SectionOverrideAction = Literal["replace", "remove", "append", "prepend"] | SectionTransformFn
 """Override action: a string literal for static overrides, or a callback for transforms."""
 
-SystemPromptSection = Literal[
+SystemMessageSection = Literal[
     "identity",
     "tone",
     "tool_efficiency",
@@ -186,10 +186,11 @@ SystemPromptSection = Literal[
     "safety",
     "tool_instructions",
     "custom_instructions",
+    "runtime_instructions",
     "last_instructions",
 ]
 
-SYSTEM_PROMPT_SECTIONS: dict[SystemPromptSection, str] = {
+SYSTEM_MESSAGE_SECTIONS: dict[SystemMessageSection, str] = {
     "identity": "Agent identity preamble and mode statement",
     "tone": "Response style, conciseness rules, output formatting preferences",
     "tool_efficiency": "Tool usage patterns, parallel calling, batching guidelines",
@@ -199,6 +200,11 @@ SYSTEM_PROMPT_SECTIONS: dict[SystemPromptSection, str] = {
     "safety": "Environment limitations, prohibited actions, security policies",
     "tool_instructions": "Per-tool usage instructions",
     "custom_instructions": "Repository and organization custom instructions",
+    "runtime_instructions": (
+        "Runtime-provided context and instructions"
+        " (e.g. system notifications, memories, workspace context,"
+        " mode-specific instructions, content-exclusion policy)"
+    ),
     "last_instructions": (
         "End-of-prompt instructions: parallel tool calling, persistence, task completion"
     ),
@@ -206,7 +212,7 @@ SYSTEM_PROMPT_SECTIONS: dict[SystemPromptSection, str] = {
 
 
 class SectionOverride(TypedDict, total=False):
-    """Override operation for a single system prompt section."""
+    """Override operation for a single system message section."""
 
     action: Required[SectionOverrideAction]
     content: NotRequired[str]
@@ -219,7 +225,7 @@ class SystemMessageCustomizeConfig(TypedDict, total=False):
     """
 
     mode: Required[Literal["customize"]]
-    sections: NotRequired[dict[SystemPromptSection, SectionOverride]]
+    sections: NotRequired[dict[SystemMessageSection, SectionOverride]]
     content: NotRequired[str]
 
 

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -2377,7 +2377,7 @@ impl SystemMessageConfig {
     }
 }
 
-/// An override operation for a single system prompt section.
+/// An override operation for a single system message section.
 ///
 /// Used within [`SystemMessageConfig::sections`] when `mode` is `"customize"`.
 /// The `action` field determines the operation: `"replace"`, `"remove"`,


### PR DESCRIPTION
## Motivation

The latest copilot-agent-runtime introduced a new `runtime_instructions` system message section that targets runtime-provided context assembled from multiple sources (systemMessage.content, system notifications, memories, workspace context, mode-specific instructions, and content-exclusion policy). The SDKs need to expose this new section so consumers can customize or transform it.

## Approach

Added the `runtime_instructions` section identifier to all SDKs (except Java, which was excluded from this work):

- **Node.js**: Added to the `SystemMessageSection` type union and `SYSTEM_MESSAGE_SECTIONS` constant with a descriptive comment
- **Python**: Added to the `SystemMessageSection` Literal type and `SYSTEM_MESSAGE_SECTIONS` dictionary
- **Go**: Added `SectionRuntimeInstructions` constant; also added doc comments to all existing section constants (previously undocumented)
- **.NET**: Added `SystemMessageSection.RuntimeInstructions`; refactored the type from a static class with string constants to a string-backed struct pattern (matching `ToolBinaryResultType`, `CopilotLogLevel`, etc.) for better type safety when used as dictionary keys in `SystemMessageConfig.Sections`
- **Rust**: Comment-only update (Rust SDK uses raw strings for section IDs with no predefined constants)

## Additional cleanup

Renamed `SystemPromptSection`/`SYSTEM_PROMPT_SECTIONS` to `SystemMessageSection`/`SYSTEM_MESSAGE_SECTIONS` across all SDKs for consistency -- these are sections of `SystemMessageConfig`, not "prompt" sections.

All SDK builds verified passing (Go, .NET, Node.js TypeScript check).