### PR TITLE
Change title from 'GitHub Copilot SDK documentation' to 'Copilot SDK'

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# GitHub Copilot SDK documentation
+# Copilot SDK 
 
 Welcome to the GitHub Copilot SDK docs. Whether you're building your first Copilot-powered app or deploying to production, you'll find what you need here.
 


### PR DESCRIPTION
Updated the title of the documentation. GitHub docs is pulling this header from the index file to populate the nav bar.