### PR TITLE
Fix .NET package version props generation

### DIFF
--- a/dotnet/src/GitHub.Copilot.SDK.csproj
+++ b/dotnet/src/GitHub.Copilot.SDK.csproj
@@ -68,7 +68,7 @@
         <Error Condition="'$(CopilotCliVersion)' == ''" Text="CopilotCliVersion could not be read from nodejs/package-lock.json" />
     </Target>
 
-    <Target Name="_GenerateVersionProps" DependsOnTargets="_GetCopilotCliVersion" BeforeTargets="Pack">
+    <Target Name="_GenerateVersionProps" DependsOnTargets="_GetCopilotCliVersion" BeforeTargets="_GetPackageFiles">
         <PropertyGroup>
             <_VersionPropsContent>
                 <![CDATA[<Project>


### PR DESCRIPTION
The .NET package should include `GitHub.Copilot.SDK.props` so consumers get `CopilotCliVersion` from the NuGet build assets. After the multi-targeting change, `_GenerateVersionProps` ran before `Pack`, which is too late for NuGet's `_GetPackageFiles` collection, causing the props file to be omitted.

This changes the generation hook to run before `_GetPackageFiles` so the generated props item is visible when NuGet builds the package.

Validated by packing with an isolated NuGet cache and checking the `.nupkg` contains `build/GitHub.Copilot.SDK.props` with the expected version.