### PR TITLE
SDK: add includeCurrentDatetime flag to suppress datetime injection

### DIFF
--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -618,7 +618,8 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 GitHubToken: config.GitHubToken,
                 RemoteSession: config.RemoteSession,
                 Cloud: config.Cloud,
-                InstructionDirectories: config.InstructionDirectories);
+                InstructionDirectories: config.InstructionDirectories,
+                IncludeCurrentDatetime: config.IncludeCurrentDatetime);
 
             var rpcTimestamp = Stopwatch.GetTimestamp();
             var response = await InvokeRpcAsync<CreateSessionResponse>(
@@ -778,7 +779,8 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 GitHubToken: config.GitHubToken,
                 RemoteSession: config.RemoteSession,
                 ContinuePendingWork: config.ContinuePendingWork,
-                InstructionDirectories: config.InstructionDirectories);
+                InstructionDirectories: config.InstructionDirectories,
+                IncludeCurrentDatetime: config.IncludeCurrentDatetime);
 
             var rpcTimestamp = Stopwatch.GetTimestamp();
             var response = await InvokeRpcAsync<ResumeSessionResponse>(
@@ -1866,7 +1868,8 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         string? GitHubToken = null,
         RemoteSessionMode? RemoteSession = null,
         CloudSessionOptions? Cloud = null,
-        IList<string>? InstructionDirectories = null);
+        IList<string>? InstructionDirectories = null,
+        bool? IncludeCurrentDatetime = null);
 
     internal record ToolDefinition(
         string Name,
@@ -1928,7 +1931,8 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         string? GitHubToken = null,
         RemoteSessionMode? RemoteSession = null,
         bool? ContinuePendingWork = null,
-        IList<string>? InstructionDirectories = null);
+        IList<string>? InstructionDirectories = null,
+        bool? IncludeCurrentDatetime = null);
 
     internal record ResumeSessionResponse(
         string SessionId,

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -2214,6 +2214,7 @@ public abstract class SessionConfigBase
         OnUserInputRequest = other.OnUserInputRequest;
         Provider = other.Provider;
         EnableSessionTelemetry = other.EnableSessionTelemetry;
+        IncludeCurrentDatetime = other.IncludeCurrentDatetime;
         ReasoningEffort = other.ReasoningEffort;
         CreateSessionFsProvider = other.CreateSessionFsProvider;
         GitHubToken = other.GitHubToken;
@@ -2291,6 +2292,12 @@ public abstract class SessionConfigBase
     /// OpenTelemetry export for observability.
     /// </summary>
     public bool? EnableSessionTelemetry { get; set; }
+
+    /// <summary>
+    /// When false, suppresses current_datetime injection in the model-facing user message.
+    /// Defaults to true (datetime is included) when null.
+    /// </summary>
+    public bool? IncludeCurrentDatetime { get; set; }
 
     /// <summary>Handler for permission requests from the server.</summary>
     public Func<PermissionRequest, PermissionInvocation, Task<PermissionDecision>>? OnPermissionRequest { get; set; }

--- a/go/client.go
+++ b/go/client.go
@@ -612,6 +612,7 @@ func (c *Client) CreateSession(ctx context.Context, config *SessionConfig) (*Ses
 	req.ExcludedTools = config.ExcludedTools
 	req.Provider = config.Provider
 	req.EnableSessionTelemetry = config.EnableSessionTelemetry
+	req.IncludeCurrentDatetime = config.IncludeCurrentDatetime
 	req.ModelCapabilities = config.ModelCapabilities
 	req.WorkingDirectory = config.WorkingDirectory
 	req.MCPServers = config.MCPServers
@@ -796,6 +797,7 @@ func (c *Client) ResumeSessionWithOptions(ctx context.Context, sessionID string,
 	req.Tools = config.Tools
 	req.Provider = config.Provider
 	req.EnableSessionTelemetry = config.EnableSessionTelemetry
+	req.IncludeCurrentDatetime = config.IncludeCurrentDatetime
 	req.ModelCapabilities = config.ModelCapabilities
 	req.AvailableTools = config.AvailableTools
 	req.ExcludedTools = config.ExcludedTools

--- a/go/types.go
+++ b/go/types.go
@@ -870,6 +870,10 @@ type SessionConfig struct {
 	// regardless of this setting. This is independent of the OpenTelemetry
 	// configuration in ClientOptions.Telemetry.
 	EnableSessionTelemetry *bool
+	// IncludeCurrentDatetime includes the current local datetime in model-facing user messages.
+	// When false, suppresses the injected <current_datetime> tag. When nil, defaults
+	// to true for backwards compatibility.
+	IncludeCurrentDatetime *bool
 	// ModelCapabilities overrides individual model capabilities resolved by the runtime.
 	// Only non-nil fields are applied over the runtime-resolved capabilities.
 	ModelCapabilities *rpc.ModelCapabilitiesOverride
@@ -1084,6 +1088,10 @@ type ResumeSessionConfig struct {
 	// regardless of this setting. This is independent of the OpenTelemetry
 	// configuration in ClientOptions.Telemetry.
 	EnableSessionTelemetry *bool
+	// IncludeCurrentDatetime includes the current local datetime in model-facing user messages.
+	// When false, suppresses the injected <current_datetime> tag. When nil, defaults
+	// to true for backwards compatibility.
+	IncludeCurrentDatetime *bool
 	// ModelCapabilities overrides individual model capabilities resolved by the runtime.
 	// Only non-nil fields are applied over the runtime-resolved capabilities.
 	ModelCapabilities *rpc.ModelCapabilitiesOverride
@@ -1374,6 +1382,7 @@ type createSessionRequest struct {
 	ExcludedTools                  []string                       `json:"excludedTools,omitempty"`
 	Provider                       *ProviderConfig                `json:"provider,omitempty"`
 	EnableSessionTelemetry         *bool                          `json:"enableSessionTelemetry,omitempty"`
+	IncludeCurrentDatetime         *bool                          `json:"includeCurrentDatetime,omitempty"`
 	ModelCapabilities              *rpc.ModelCapabilitiesOverride `json:"modelCapabilities,omitempty"`
 	RequestPermission              *bool                          `json:"requestPermission,omitempty"`
 	RequestUserInput               *bool                          `json:"requestUserInput,omitempty"`
@@ -1428,6 +1437,7 @@ type resumeSessionRequest struct {
 	ExcludedTools                  []string                       `json:"excludedTools,omitempty"`
 	Provider                       *ProviderConfig                `json:"provider,omitempty"`
 	EnableSessionTelemetry         *bool                          `json:"enableSessionTelemetry,omitempty"`
+	IncludeCurrentDatetime         *bool                          `json:"includeCurrentDatetime,omitempty"`
 	ModelCapabilities              *rpc.ModelCapabilitiesOverride `json:"modelCapabilities,omitempty"`
 	RequestPermission              *bool                          `json:"requestPermission,omitempty"`
 	RequestUserInput               *bool                          `json:"requestUserInput,omitempty"`

--- a/java/src/main/java/com/github/copilot/sdk/SessionRequestBuilder.java
+++ b/java/src/main/java/com/github/copilot/sdk/SessionRequestBuilder.java
@@ -112,6 +112,7 @@ final class SessionRequestBuilder {
         request.setExcludedTools(config.getExcludedTools());
         request.setProvider(config.getProvider());
         config.getEnableSessionTelemetry().ifPresent(request::setEnableSessionTelemetry);
+        config.getIncludeCurrentDatetime().ifPresent(request::setIncludeCurrentDatetime);
         if (config.getOnUserInputRequest() != null) {
             request.setRequestUserInput(true);
         }
@@ -203,6 +204,7 @@ final class SessionRequestBuilder {
         request.setExcludedTools(config.getExcludedTools());
         request.setProvider(config.getProvider());
         config.getEnableSessionTelemetry().ifPresent(request::setEnableSessionTelemetry);
+        config.getIncludeCurrentDatetime().ifPresent(request::setIncludeCurrentDatetime);
         if (config.getOnUserInputRequest() != null) {
             request.setRequestUserInput(true);
         }

--- a/java/src/main/java/com/github/copilot/sdk/json/CreateSessionRequest.java
+++ b/java/src/main/java/com/github/copilot/sdk/json/CreateSessionRequest.java
@@ -55,6 +55,9 @@ public final class CreateSessionRequest {
     @JsonProperty("enableSessionTelemetry")
     private Boolean enableSessionTelemetry;
 
+    @JsonProperty("includeCurrentDatetime")
+    private Boolean includeCurrentDatetime;
+
     @JsonProperty("requestPermission")
     private Boolean requestPermission;
 
@@ -239,6 +242,25 @@ public final class CreateSessionRequest {
      */
     public void clearEnableSessionTelemetry() {
         this.enableSessionTelemetry = null;
+    }
+
+    /** Gets include current datetime flag. @return the flag */
+    public Boolean getIncludeCurrentDatetime() {
+        return includeCurrentDatetime;
+    }
+
+    /**
+     * Sets include current datetime flag. @param includeCurrentDatetime the flag
+     */
+    public void setIncludeCurrentDatetime(Boolean includeCurrentDatetime) {
+        this.includeCurrentDatetime = includeCurrentDatetime;
+    }
+
+    /**
+     * Clears the includeCurrentDatetime setting, reverting to the default behavior.
+     */
+    public void clearIncludeCurrentDatetime() {
+        this.includeCurrentDatetime = null;
     }
 
     /** Gets request permission flag. @return the flag */

--- a/java/src/main/java/com/github/copilot/sdk/json/ResumeSessionConfig.java
+++ b/java/src/main/java/com/github/copilot/sdk/json/ResumeSessionConfig.java
@@ -46,6 +46,7 @@ public class ResumeSessionConfig {
     private List<String> excludedTools;
     private ProviderConfig provider;
     private Boolean enableSessionTelemetry;
+    private Boolean includeCurrentDatetime;
     private String reasoningEffort;
     private ModelCapabilitiesOverride modelCapabilities;
     private PermissionHandler onPermissionRequest;
@@ -276,6 +277,46 @@ public class ResumeSessionConfig {
      */
     public ResumeSessionConfig clearEnableSessionTelemetry() {
         this.enableSessionTelemetry = null;
+        return this;
+    }
+
+    /**
+     * Gets whether the current local datetime is included in model-facing user
+     * messages.
+     *
+     * @return an {@link java.util.Optional} containing {@code true} to include the
+     *         current datetime or {@code false} to suppress it, or
+     *         {@link java.util.Optional#empty()} to use the runtime default
+     */
+    @JsonIgnore
+    public Optional<Boolean> getIncludeCurrentDatetime() {
+        return Optional.ofNullable(includeCurrentDatetime);
+    }
+
+    /**
+     * Sets whether to include the current local datetime in model-facing user
+     * messages.
+     * <p>
+     * When {@code false}, suppresses the injected {@code <current_datetime>} tag.
+     * Default: {@code true}.
+     *
+     * @param includeCurrentDatetime
+     *            {@code true} to include the current datetime, {@code false} to
+     *            suppress it, or {@code null} to use the runtime default
+     * @return this config for method chaining
+     */
+    public ResumeSessionConfig setIncludeCurrentDatetime(Boolean includeCurrentDatetime) {
+        this.includeCurrentDatetime = includeCurrentDatetime;
+        return this;
+    }
+
+    /**
+     * Clears the includeCurrentDatetime setting, reverting to the default behavior.
+     *
+     * @return this instance for method chaining
+     */
+    public ResumeSessionConfig clearIncludeCurrentDatetime() {
+        this.includeCurrentDatetime = null;
         return this;
     }
 
@@ -937,6 +978,7 @@ public class ResumeSessionConfig {
         copy.excludedTools = this.excludedTools != null ? new ArrayList<>(this.excludedTools) : null;
         copy.provider = this.provider;
         copy.enableSessionTelemetry = this.enableSessionTelemetry;
+        copy.includeCurrentDatetime = this.includeCurrentDatetime;
         copy.reasoningEffort = this.reasoningEffort;
         copy.modelCapabilities = this.modelCapabilities;
         copy.onPermissionRequest = this.onPermissionRequest;

--- a/java/src/main/java/com/github/copilot/sdk/json/ResumeSessionRequest.java
+++ b/java/src/main/java/com/github/copilot/sdk/json/ResumeSessionRequest.java
@@ -56,6 +56,9 @@ public final class ResumeSessionRequest {
     @JsonProperty("enableSessionTelemetry")
     private Boolean enableSessionTelemetry;
 
+    @JsonProperty("includeCurrentDatetime")
+    private Boolean includeCurrentDatetime;
+
     @JsonProperty("requestPermission")
     private Boolean requestPermission;
 
@@ -243,6 +246,25 @@ public final class ResumeSessionRequest {
      */
     public void clearEnableSessionTelemetry() {
         this.enableSessionTelemetry = null;
+    }
+
+    /** Gets include current datetime flag. @return the flag */
+    public Boolean getIncludeCurrentDatetime() {
+        return includeCurrentDatetime;
+    }
+
+    /**
+     * Sets include current datetime flag. @param includeCurrentDatetime the flag
+     */
+    public void setIncludeCurrentDatetime(Boolean includeCurrentDatetime) {
+        this.includeCurrentDatetime = includeCurrentDatetime;
+    }
+
+    /**
+     * Clears the includeCurrentDatetime setting, reverting to the default behavior.
+     */
+    public void clearIncludeCurrentDatetime() {
+        this.includeCurrentDatetime = null;
     }
 
     /** Gets request permission flag. @return the flag */

--- a/java/src/main/java/com/github/copilot/sdk/json/SessionConfig.java
+++ b/java/src/main/java/com/github/copilot/sdk/json/SessionConfig.java
@@ -48,6 +48,7 @@ public class SessionConfig {
     private List<String> excludedTools;
     private ProviderConfig provider;
     private Boolean enableSessionTelemetry;
+    private Boolean includeCurrentDatetime;
     private PermissionHandler onPermissionRequest;
     private UserInputHandler onUserInputRequest;
     private SessionHooks hooks;
@@ -331,6 +332,46 @@ public class SessionConfig {
      */
     public SessionConfig clearEnableSessionTelemetry() {
         this.enableSessionTelemetry = null;
+        return this;
+    }
+
+    /**
+     * Gets whether the current local datetime is included in model-facing user
+     * messages.
+     *
+     * @return an {@link java.util.Optional} containing {@code true} to include the
+     *         current datetime or {@code false} to suppress it, or
+     *         {@link java.util.Optional#empty()} to use the runtime default
+     */
+    @JsonIgnore
+    public Optional<Boolean> getIncludeCurrentDatetime() {
+        return Optional.ofNullable(includeCurrentDatetime);
+    }
+
+    /**
+     * Sets whether to include the current local datetime in model-facing user
+     * messages.
+     * <p>
+     * When {@code false}, suppresses the injected {@code <current_datetime>} tag.
+     * Default: {@code true}.
+     *
+     * @param includeCurrentDatetime
+     *            {@code true} to include the current datetime, {@code false} to
+     *            suppress it, or {@code null} to use the runtime default
+     * @return this config instance for method chaining
+     */
+    public SessionConfig setIncludeCurrentDatetime(Boolean includeCurrentDatetime) {
+        this.includeCurrentDatetime = includeCurrentDatetime;
+        return this;
+    }
+
+    /**
+     * Clears the includeCurrentDatetime setting, reverting to the default behavior.
+     *
+     * @return this instance for method chaining
+     */
+    public SessionConfig clearIncludeCurrentDatetime() {
+        this.includeCurrentDatetime = null;
         return this;
     }
 
@@ -1033,6 +1074,7 @@ public class SessionConfig {
         copy.excludedTools = this.excludedTools != null ? new ArrayList<>(this.excludedTools) : null;
         copy.provider = this.provider;
         copy.enableSessionTelemetry = this.enableSessionTelemetry;
+        copy.includeCurrentDatetime = this.includeCurrentDatetime;
         copy.onPermissionRequest = this.onPermissionRequest;
         copy.onUserInputRequest = this.onUserInputRequest;
         copy.hooks = this.hooks;

--- a/java/src/test/java/com/github/copilot/sdk/ConfigCloneTest.java
+++ b/java/src/test/java/com/github/copilot/sdk/ConfigCloneTest.java
@@ -216,6 +216,25 @@ class ConfigCloneTest {
     }
 
     @Test
+    void sessionConfigIncludeCurrentDatetimeCopied() {
+        SessionConfig original = new SessionConfig();
+        original.setIncludeCurrentDatetime(false);
+
+        SessionConfig cloned = original.clone();
+
+        assertFalse(cloned.getIncludeCurrentDatetime().orElse(true));
+    }
+
+    @Test
+    void sessionConfigIncludeCurrentDatetimeDefaultIsNull() {
+        SessionConfig original = new SessionConfig();
+
+        SessionConfig cloned = original.clone();
+
+        assertTrue(cloned.getIncludeCurrentDatetime().isEmpty());
+    }
+
+    @Test
     void resumeSessionConfigEnableSessionTelemetryCopied() {
         ResumeSessionConfig original = new ResumeSessionConfig();
         original.setEnableSessionTelemetry(false);
@@ -232,6 +251,25 @@ class ConfigCloneTest {
         ResumeSessionConfig cloned = original.clone();
 
         assertTrue(cloned.getEnableSessionTelemetry().isEmpty());
+    }
+
+    @Test
+    void resumeSessionConfigIncludeCurrentDatetimeCopied() {
+        ResumeSessionConfig original = new ResumeSessionConfig();
+        original.setIncludeCurrentDatetime(false);
+
+        ResumeSessionConfig cloned = original.clone();
+
+        assertFalse(cloned.getIncludeCurrentDatetime().orElse(true));
+    }
+
+    @Test
+    void resumeSessionConfigIncludeCurrentDatetimeDefaultIsNull() {
+        ResumeSessionConfig original = new ResumeSessionConfig();
+
+        ResumeSessionConfig cloned = original.clone();
+
+        assertTrue(cloned.getIncludeCurrentDatetime().isEmpty());
     }
 
     @Test

--- a/java/src/test/java/com/github/copilot/sdk/OptionalApiAndJacksonTest.java
+++ b/java/src/test/java/com/github/copilot/sdk/OptionalApiAndJacksonTest.java
@@ -64,6 +64,16 @@ class OptionalApiAndJacksonTest {
     }
 
     @Test
+    void sessionConfig_clearIncludeCurrentDatetime() {
+        var cfg = new SessionConfig();
+        cfg.setIncludeCurrentDatetime(false);
+        assertTrue(cfg.getIncludeCurrentDatetime().isPresent());
+
+        cfg.clearIncludeCurrentDatetime();
+        assertTrue(cfg.getIncludeCurrentDatetime().isEmpty());
+    }
+
+    @Test
     void sessionConfig_clearEnableConfigDiscovery() {
         var cfg = new SessionConfig();
         cfg.setEnableConfigDiscovery(false);
@@ -93,6 +103,16 @@ class OptionalApiAndJacksonTest {
 
         cfg.clearEnableSessionTelemetry();
         assertTrue(cfg.getEnableSessionTelemetry().isEmpty());
+    }
+
+    @Test
+    void resumeSessionConfig_clearIncludeCurrentDatetime() {
+        var cfg = new ResumeSessionConfig();
+        cfg.setIncludeCurrentDatetime(false);
+        assertTrue(cfg.getIncludeCurrentDatetime().isPresent());
+
+        cfg.clearIncludeCurrentDatetime();
+        assertTrue(cfg.getIncludeCurrentDatetime().isEmpty());
     }
 
     @Test
@@ -333,6 +353,18 @@ class OptionalApiAndJacksonTest {
     }
 
     @Test
+    void sessionConfig_includeCurrentDatetimeValue() {
+        var cfg = new SessionConfig();
+        assertTrue(cfg.getIncludeCurrentDatetime().isEmpty());
+
+        cfg.setIncludeCurrentDatetime(true);
+        assertTrue(cfg.getIncludeCurrentDatetime().get());
+
+        cfg.setIncludeCurrentDatetime(false);
+        assertFalse(cfg.getIncludeCurrentDatetime().get());
+    }
+
+    @Test
     void sessionConfig_enableConfigDiscoveryValue() {
         var cfg = new SessionConfig();
         assertTrue(cfg.getEnableConfigDiscovery().isEmpty());
@@ -363,6 +395,18 @@ class OptionalApiAndJacksonTest {
 
         cfg.setEnableSessionTelemetry(false);
         assertFalse(cfg.getEnableSessionTelemetry().get());
+    }
+
+    @Test
+    void resumeSessionConfig_includeCurrentDatetimeValue() {
+        var cfg = new ResumeSessionConfig();
+        assertTrue(cfg.getIncludeCurrentDatetime().isEmpty());
+
+        cfg.setIncludeCurrentDatetime(true);
+        assertTrue(cfg.getIncludeCurrentDatetime().get());
+
+        cfg.setIncludeCurrentDatetime(false);
+        assertFalse(cfg.getIncludeCurrentDatetime().get());
     }
 
     @Test

--- a/java/src/test/java/com/github/copilot/sdk/SessionRequestBuilderTest.java
+++ b/java/src/test/java/com/github/copilot/sdk/SessionRequestBuilderTest.java
@@ -104,6 +104,20 @@ public class SessionRequestBuilderTest {
         assertNull(request.getEnableSessionTelemetry());
     }
 
+    @Test
+    void testBuildCreateRequestForwardsIncludeCurrentDatetimeWhenFalse() {
+        var config = new SessionConfig().setIncludeCurrentDatetime(false);
+        CreateSessionRequest request = SessionRequestBuilder.buildCreateRequest(config);
+        assertFalse(request.getIncludeCurrentDatetime());
+    }
+
+    @Test
+    void testBuildCreateRequestOmitsIncludeCurrentDatetimeWhenNotSet() {
+        var config = new SessionConfig();
+        CreateSessionRequest request = SessionRequestBuilder.buildCreateRequest(config);
+        assertNull(request.getIncludeCurrentDatetime());
+    }
+
     // =========================================================================
     // buildResumeRequest
     // =========================================================================
@@ -129,6 +143,20 @@ public class SessionRequestBuilderTest {
         var config = new ResumeSessionConfig();
         ResumeSessionRequest request = SessionRequestBuilder.buildResumeRequest("sid-1", config);
         assertNull(request.getEnableSessionTelemetry());
+    }
+
+    @Test
+    void testBuildResumeRequestForwardsIncludeCurrentDatetimeWhenFalse() {
+        var config = new ResumeSessionConfig().setIncludeCurrentDatetime(false);
+        ResumeSessionRequest request = SessionRequestBuilder.buildResumeRequest("sid-1", config);
+        assertFalse(request.getIncludeCurrentDatetime());
+    }
+
+    @Test
+    void testBuildResumeRequestOmitsIncludeCurrentDatetimeWhenNotSet() {
+        var config = new ResumeSessionConfig();
+        ResumeSessionRequest request = SessionRequestBuilder.buildResumeRequest("sid-1", config);
+        assertNull(request.getIncludeCurrentDatetime());
     }
 
     @Test
@@ -538,6 +566,48 @@ public class SessionRequestBuilderTest {
         var mapper = JsonRpcClient.getObjectMapper();
         var json = mapper.writeValueAsString(request);
         assertFalse(json.contains("enableSessionTelemetry"), "enableSessionTelemetry should be omitted when null");
+    }
+
+    // =========================================================================
+    // includeCurrentDatetime serialization
+    // =========================================================================
+
+    @Test
+    void testCreateRequestSerializesIncludeCurrentDatetimeWhenFalse() throws Exception {
+        var config = new SessionConfig().setIncludeCurrentDatetime(false);
+        CreateSessionRequest request = SessionRequestBuilder.buildCreateRequest(config);
+        var mapper = JsonRpcClient.getObjectMapper();
+        var json = mapper.writeValueAsString(request);
+        assertTrue(json.contains("\"includeCurrentDatetime\":false"),
+                "includeCurrentDatetime should be serialized when set to false");
+    }
+
+    @Test
+    void testCreateRequestOmitsIncludeCurrentDatetimeWhenNull() throws Exception {
+        var config = new SessionConfig();
+        CreateSessionRequest request = SessionRequestBuilder.buildCreateRequest(config);
+        var mapper = JsonRpcClient.getObjectMapper();
+        var json = mapper.writeValueAsString(request);
+        assertFalse(json.contains("includeCurrentDatetime"), "includeCurrentDatetime should be omitted when null");
+    }
+
+    @Test
+    void testResumeRequestSerializesIncludeCurrentDatetimeWhenFalse() throws Exception {
+        var config = new ResumeSessionConfig().setIncludeCurrentDatetime(false);
+        ResumeSessionRequest request = SessionRequestBuilder.buildResumeRequest("sid-dt", config);
+        var mapper = JsonRpcClient.getObjectMapper();
+        var json = mapper.writeValueAsString(request);
+        assertTrue(json.contains("\"includeCurrentDatetime\":false"),
+                "includeCurrentDatetime should be serialized when set to false");
+    }
+
+    @Test
+    void testResumeRequestOmitsIncludeCurrentDatetimeWhenNull() throws Exception {
+        var config = new ResumeSessionConfig();
+        ResumeSessionRequest request = SessionRequestBuilder.buildResumeRequest("sid-dt", config);
+        var mapper = JsonRpcClient.getObjectMapper();
+        var json = mapper.writeValueAsString(request);
+        assertFalse(json.contains("includeCurrentDatetime"), "includeCurrentDatetime should be omitted when null");
     }
 
     // =========================================================================

--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -858,6 +858,7 @@ export class CopilotClient {
                 excludedTools: config.excludedTools,
                 provider: config.provider,
                 enableSessionTelemetry: config.enableSessionTelemetry,
+                includeCurrentDatetime: config.includeCurrentDatetime,
                 modelCapabilities: config.modelCapabilities,
                 requestPermission: !!config.onPermissionRequest,
                 requestUserInput: !!config.onUserInputRequest,
@@ -980,6 +981,7 @@ export class CopilotClient {
                 availableTools: config.availableTools,
                 excludedTools: config.excludedTools,
                 enableSessionTelemetry: config.enableSessionTelemetry,
+                includeCurrentDatetime: config.includeCurrentDatetime,
                 tools: config.tools?.map((tool) => ({
                     name: tool.name,
                     description: tool.description,

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -1504,6 +1504,13 @@ export interface SessionConfigBase {
     enableSessionTelemetry?: boolean;
 
     /**
+     * Include the current local datetime in model-facing user messages.
+     * When `false`, suppresses the injected `<current_datetime>` tag.
+     * Defaults to `true` for backwards compatibility.
+     */
+    includeCurrentDatetime?: boolean;
+
+    /**
      * Optional handler for permission requests from the server.
      * When omitted, permission requests are surfaced as events and left pending for
      * the consumer to resolve via the pending permission RPC.

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -1544,6 +1544,7 @@ class CopilotClient:
         github_token: str | None = None,
         remote_session: RemoteSessionMode | None = None,
         cloud: CloudSessionOptions | None = None,
+        include_current_datetime: bool | None = None,
     ) -> CopilotSession:
         """
         Create a new conversation session with the Copilot CLI.
@@ -1610,6 +1611,9 @@ class CopilotClient:
                 session. Optionally associates repository metadata with the
                 cloud session.
             on_event: Callback for session events.
+            include_current_datetime: When False, suppresses the injected
+                ``<current_datetime>`` tag in model-facing user messages.
+                Defaults to True when omitted (datetime is injected).
 
         Returns:
             A :class:`CopilotSession` instance for the new session.
@@ -1723,6 +1727,9 @@ class CopilotClient:
 
         if enable_session_telemetry is not None:
             payload["enableSessionTelemetry"] = enable_session_telemetry
+
+        if include_current_datetime is not None:
+            payload["includeCurrentDatetime"] = include_current_datetime
 
         # Add model capabilities override if provided
         if model_capabilities:
@@ -1919,6 +1926,7 @@ class CopilotClient:
         github_token: str | None = None,
         remote_session: RemoteSessionMode | None = None,
         continue_pending_work: bool | None = None,
+        include_current_datetime: bool | None = None,
     ) -> CopilotSession:
         """
         Resume an existing conversation session by its ID.
@@ -1986,6 +1994,9 @@ class CopilotClient:
                 tool calls or permission prompts that were still pending when the
                 session was last suspended. When False (the default), the runtime
                 treats pending work as interrupted on resume.
+            include_current_datetime: When False, suppresses the injected
+                ``<current_datetime>`` tag in model-facing user messages.
+                Defaults to True when omitted (datetime is injected).
 
         Returns:
             A :class:`CopilotSession` instance for the resumed session.
@@ -2048,6 +2059,8 @@ class CopilotClient:
             payload["provider"] = self._convert_provider_to_wire_format(provider)
         if enable_session_telemetry is not None:
             payload["enableSessionTelemetry"] = enable_session_telemetry
+        if include_current_datetime is not None:
+            payload["includeCurrentDatetime"] = include_current_datetime
         if model_capabilities:
             payload["modelCapabilities"] = _capabilities_to_dict(model_capabilities)
         if streaming is not None:

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1160,6 +1160,10 @@ pub struct SessionConfig {
     /// only non-streaming sub-agent events and `subagent.*` lifecycle events
     /// are delivered. Defaults to true on the CLI.
     pub include_sub_agent_streaming_events: Option<bool>,
+    /// Include the current local datetime in model-facing user messages.
+    /// When false, suppresses the injected `<current_datetime>` tag.
+    /// Defaults to true on the CLI when unset.
+    pub include_current_datetime: Option<bool>,
     /// Slash commands registered for this session. When the CLI has a TUI,
     /// each command appears as `/name` for the user to invoke and the
     /// associated [`CommandHandler`] is called when executed.
@@ -1238,6 +1242,7 @@ impl std::fmt::Debug for SessionConfig {
                 "include_sub_agent_streaming_events",
                 &self.include_sub_agent_streaming_events,
             )
+            .field("include_current_datetime", &self.include_current_datetime)
             .field("commands", &self.commands)
             .field(
                 "session_fs_provider",
@@ -1311,6 +1316,7 @@ impl Default for SessionConfig {
             remote_session: None,
             cloud: None,
             include_sub_agent_streaming_events: None,
+            include_current_datetime: None,
             commands: None,
             session_fs_provider: None,
             permission_handler: None,
@@ -1426,6 +1432,7 @@ impl SessionConfig {
             remote_session: self.remote_session,
             cloud: self.cloud,
             include_sub_agent_streaming_events: self.include_sub_agent_streaming_events,
+            include_current_datetime: self.include_current_datetime,
             commands: wire_commands,
         };
 
@@ -1734,6 +1741,13 @@ impl SessionConfig {
         self
     }
 
+    /// Include the current local datetime in model-facing user messages.
+    /// Defaults to true on the CLI when unset.
+    pub fn with_include_current_datetime(mut self, include: bool) -> Self {
+        self.include_current_datetime = Some(include);
+        self
+    }
+
     /// Set per-session remote behavior.
     pub fn with_remote_session(
         mut self,
@@ -1822,6 +1836,9 @@ pub struct ResumeSessionConfig {
     pub remote_session: Option<crate::generated::api_types::RemoteSessionMode>,
     /// Forward sub-agent streaming events to this connection on resume.
     pub include_sub_agent_streaming_events: Option<bool>,
+    /// Include the current local datetime in model-facing user messages on resume.
+    /// Defaults to true on the CLI when unset.
+    pub include_current_datetime: Option<bool>,
     /// Slash commands registered for this session on resume. See
     /// [`SessionConfig::commands`] — commands are not persisted server-side,
     /// so the resume payload re-supplies the registration.
@@ -1900,6 +1917,7 @@ impl std::fmt::Debug for ResumeSessionConfig {
                 "include_sub_agent_streaming_events",
                 &self.include_sub_agent_streaming_events,
             )
+            .field("include_current_datetime", &self.include_current_datetime)
             .field("commands", &self.commands)
             .field(
                 "session_fs_provider",
@@ -2014,6 +2032,7 @@ impl ResumeSessionConfig {
             github_token: self.github_token,
             remote_session: self.remote_session,
             include_sub_agent_streaming_events: self.include_sub_agent_streaming_events,
+            include_current_datetime: self.include_current_datetime,
             commands: wire_commands,
             suppress_resume_event: self.suppress_resume_event,
             continue_pending_work: self.continue_pending_work,
@@ -2068,6 +2087,7 @@ impl ResumeSessionConfig {
             github_token: None,
             remote_session: None,
             include_sub_agent_streaming_events: None,
+            include_current_datetime: None,
             commands: None,
             session_fs_provider: None,
             suppress_resume_event: None,
@@ -2339,6 +2359,13 @@ impl ResumeSessionConfig {
     /// Forward sub-agent streaming events to this connection on resume.
     pub fn with_include_sub_agent_streaming_events(mut self, include: bool) -> Self {
         self.include_sub_agent_streaming_events = Some(include);
+        self
+    }
+
+    /// Include the current local datetime in model-facing user messages on resume.
+    /// Defaults to true on the CLI when unset.
+    pub fn with_include_current_datetime(mut self, include: bool) -> Self {
+        self.include_current_datetime = Some(include);
         self
     }
 
@@ -3593,6 +3620,7 @@ mod tests {
         cfg.working_directory = Some(PathBuf::from("/tmp/work"));
         cfg.github_token = Some("ghs_secret".to_string());
         cfg.include_sub_agent_streaming_events = Some(false);
+        cfg.include_current_datetime = Some(false);
         cfg.enable_session_telemetry = Some(false);
         cfg.remote_session = Some(crate::generated::api_types::RemoteSessionMode::Export);
         cfg.cloud = Some(CloudSessionOptions::with_repository(
@@ -3608,6 +3636,7 @@ mod tests {
         assert_eq!(wire_json["workingDirectory"], "/tmp/work");
         assert_eq!(wire_json["gitHubToken"], "ghs_secret");
         assert_eq!(wire_json["includeSubAgentStreamingEvents"], false);
+        assert_eq!(wire_json["includeCurrentDatetime"], false);
         assert_eq!(wire_json["enableSessionTelemetry"], false);
         assert_eq!(wire_json["remoteSession"], "export");
         assert_eq!(wire_json["cloud"]["repository"]["owner"], "github");
@@ -3620,6 +3649,7 @@ mod tests {
             .expect("default has no duplicate handlers");
         let empty_json = serde_json::to_value(&empty_wire).unwrap();
         assert!(empty_json.get("gitHubToken").is_none());
+        assert!(empty_json.get("includeCurrentDatetime").is_none());
         assert!(empty_json.get("enableSessionTelemetry").is_none());
         assert!(empty_json.get("remoteSession").is_none());
         assert!(empty_json.get("cloud").is_none());
@@ -3634,6 +3664,7 @@ mod tests {
         cfg.config_dir = Some(PathBuf::from("/tmp/cfg"));
         cfg.github_token = Some("ghs_secret".to_string());
         cfg.include_sub_agent_streaming_events = Some(true);
+        cfg.include_current_datetime = Some(true);
         cfg.enable_session_telemetry = Some(false);
         cfg.remote_session = Some(crate::generated::api_types::RemoteSessionMode::On);
 
@@ -3644,6 +3675,7 @@ mod tests {
         assert_eq!(wire_json["configDir"], "/tmp/cfg");
         assert_eq!(wire_json["gitHubToken"], "ghs_secret");
         assert_eq!(wire_json["includeSubAgentStreamingEvents"], true);
+        assert_eq!(wire_json["includeCurrentDatetime"], true);
         assert_eq!(wire_json["enableSessionTelemetry"], false);
         assert_eq!(wire_json["remoteSession"], "on");
 
@@ -3653,6 +3685,7 @@ mod tests {
             .expect("default resume has no duplicate handlers");
         let empty_json = serde_json::to_value(&empty_wire).unwrap();
         assert!(empty_json.get("remoteSession").is_none());
+        assert!(empty_json.get("includeCurrentDatetime").is_none());
     }
 
     #[test]
@@ -3677,7 +3710,8 @@ mod tests {
             .with_working_directory(PathBuf::from("/tmp/work"))
             .with_github_token("ghp_test")
             .with_enable_session_telemetry(false)
-            .with_include_sub_agent_streaming_events(false);
+            .with_include_sub_agent_streaming_events(false)
+            .with_include_current_datetime(false);
 
         assert_eq!(cfg.session_id.as_ref().map(|s| s.as_str()), Some("sess-1"));
         assert_eq!(cfg.model.as_deref(), Some("claude-sonnet-4"));
@@ -3709,6 +3743,7 @@ mod tests {
         assert_eq!(cfg.github_token.as_deref(), Some("ghp_test"));
         assert_eq!(cfg.enable_session_telemetry, Some(false));
         assert_eq!(cfg.include_sub_agent_streaming_events, Some(false));
+        assert_eq!(cfg.include_current_datetime, Some(false));
     }
 
     #[test]
@@ -3731,6 +3766,7 @@ mod tests {
             .with_github_token("ghp_test")
             .with_enable_session_telemetry(false)
             .with_include_sub_agent_streaming_events(true)
+            .with_include_current_datetime(true)
             .with_suppress_resume_event(true)
             .with_continue_pending_work(true);
 
@@ -3762,6 +3798,7 @@ mod tests {
         assert_eq!(cfg.github_token.as_deref(), Some("ghp_test"));
         assert_eq!(cfg.enable_session_telemetry, Some(false));
         assert_eq!(cfg.include_sub_agent_streaming_events, Some(true));
+        assert_eq!(cfg.include_current_datetime, Some(true));
         assert_eq!(cfg.suppress_resume_event, Some(true));
         assert_eq!(cfg.continue_pending_work, Some(true));
     }

--- a/rust/src/wire.rs
+++ b/rust/src/wire.rs
@@ -100,6 +100,8 @@ pub(crate) struct SessionCreateWire {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub include_sub_agent_streaming_events: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_current_datetime: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub commands: Option<Vec<CommandWireDefinition>>,
 }
 
@@ -163,6 +165,8 @@ pub(crate) struct SessionResumeWire {
     pub remote_session: Option<RemoteSessionMode>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub include_sub_agent_streaming_events: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_current_datetime: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub commands: Option<Vec<CommandWireDefinition>>,
     /// Maps to wire field `disableResume`.


### PR DESCRIPTION
## Why

Surfaces a new opt-in **`includeCurrentDatetime`** session option across every
SDK language so callers can suppress the runtime's injected
`<current_datetime>` tag on model-facing user messages. This is the SDK-side
counterpart to runtime PR
[github/copilot-agent-runtime#8130](https://github.com/github/copilot-agent-runtime/pull/8130),
which performs the actual suppression on the runtime side.

Two real-world failure modes motivated the flag:

1. **Short-prompt summarisation pollution.** When a host application makes
   a short SDK call to summarise a user prompt (e.g. to name a chat
   session), the model frequently latches onto the injected
   `<current_datetime>` block and produces a summary about the date/time
   rather than the user's actual prompt.
2. **User-supplied date/time confusion.** When the user's prompt itself
   contains a date or time and the task depends on that user-provided
   value, the model often conflates it with the SDK-injected
   `<current_datetime>` tag.

Hosts that need either case can now opt out by passing
`includeCurrentDatetime: false`; existing callers that rely on the tag are
unaffected because the default remains `true`.

## What changes

A single opt-in option on `SessionConfig` / `ResumeSessionConfig` (or the
language-equivalent) that serialises to the JSON wire field
`includeCurrentDatetime`. The runtime contract is defined in
[github/copilot-agent-runtime#8130](https://github.com/github/copilot-agent-runtime/pull/8130).

| Language | Surface added |
|---|---|
| Node.js | `SessionConfigBase.includeCurrentDatetime?: boolean` |
| Python | `create_session(..., include_current_datetime=...)` + `resume_session(..., include_current_datetime=...)` |
| Go | `SessionConfig.IncludeCurrentDatetime` / `ResumeSessionConfig.IncludeCurrentDatetime` (`*bool`) |
| .NET | `SessionConfigBase.IncludeCurrentDatetime` (`bool?`) |
| Rust | `SessionConfig.include_current_datetime` / `ResumeSessionConfig.include_current_datetime` + `with_include_current_datetime` builder |
| Java | `SessionConfig.includeCurrentDatetime` / `ResumeSessionConfig.includeCurrentDatetime` + `SessionRequestBuilder.includeCurrentDatetime` + clone/Jackson/builder unit tests |

Behaviour:

- **Default** (unset / `null` / `None` / `nil`): no `includeCurrentDatetime`
  field is sent over the wire. The runtime preserves today's behaviour and
  injects `<current_datetime>` — backwards compatible for every existing
  caller.
- **`true`**: explicit opt-in, equivalent to default.
- **`false`**: SDK sends `includeCurrentDatetime: false`. A runtime that
  supports the flag (PR #8130 and later) suppresses injection. A
  down-level runtime ignores the unknown field and continues to inject —
  see graceful-degradation note below.

## Graceful degradation against down-level runtimes

The flag is purely additive on the wire. Down-level CLIs that don't
implement PR #8130 silently ignore the unknown `includeCurrentDatetime`
field and continue to inject `<current_datetime>` as before; no parse
errors are raised. This was verified in the runtime PR by pointing the
patched SDK at a down-level CLI bundled on the host. Callers therefore
need an updated CLI (`@github/copilot` containing PR #8130) to actually
observe the suppression, but the API surface itself remains safe.

## Verification

CONTRIBUTING.md test commands run against this branch (macOS, against
runtime PR #8130 with the flag honoured end-to-end):

| Language | Suite | Result |
|---|---|---|
| Node | `npm test` | ✅ 416 passed / 7 skipped |
| Node | `npm run lint` | ✅ 0 errors (3 pre-existing `any` warnings) |
| Python | `pytest --ignore=e2e` | ✅ 145 passed |
| Python | `ruff check .` | ✅ Clean |
| Python | `pytest e2e` | ⚠ 283 passed / 7 failed¹ / 6 skipped (+1 file skipped²) |
| Go | `go test ./...` | ✅ All packages pass |
| Go | `golangci-lint run` | ⚠ 1 pre-existing govet³ (not in patched files) |
| .NET | `dotnet test` | ✅ 463 passed / 2 skipped |
| Rust | `cargo test --features test-support` | ✅ All unit + 18 doctests |
| Java | Custom E2E driver against `gpt-5.2` | ✅ Wire field appears with `false`, absent when default |

¹ All 7 e2e failures are the same pre-existing macOS auth issue
(`Failed to get token for auth info`) in tests that spawn child processes
/ new clients; none of the failing tests touch `includeCurrentDatetime`.
² `e2e/test_pending_work_resume_e2e.py` excluded due to a pre-existing
indefinite hang on macOS (asyncio/timeout interaction), unrelated to this
change.
³ `go/definetool.go:210` — pre-existing on `main`, not in the patched
files.

End-to-end verification with the matching runtime PR also covers the
GitHub provider against every SDK language using OTEL trace inspection
to confirm the `<current_datetime>` tag's presence/absence on the wire,
plus the down-level CLI graceful-degradation path. See the runtime PR
body for the full provider × language matrix:
https://github.com/github/copilot-agent-runtime/pull/8130

## Linked PR

- Runtime contract & wire-field handler:
  github/copilot-agent-runtime#8130
