### PR TITLE
C# codegen: add isOpaqueJson guard to resolveRpcType

### DIFF
--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -1504,6 +1504,9 @@ function stableStringify(value: unknown): string {
 }
 
 function resolveRpcType(schema: JSONSchema7, isRequired: boolean, parentClassName: string, propName: string, classes: string[]): string {
+    if (isOpaqueJson(schema)) {
+        return isRequired ? "JsonElement" : "JsonElement?";
+    }
     // Handle $ref by resolving against schema definitions and generating the referenced class
     if (schema.$ref) {
         const typeName = typeToClassName(refTypeName(schema.$ref, rpcDefinitions));


### PR DESCRIPTION
## Problem

The C# codegen's `resolveRpcType` function lacked an early `isOpaqueJson` check. When a schema had both `x-opaque-json: true` and `additionalProperties: {}`, the `additionalProperties` branch fired first and tried to resolve the empty `{}` value schema, causing:

\\\
Error: C# codegen: cannot map schema to an idiomatic C# type
(unknown/missing type (propName=InputSchemaValue))
\\\

This was the root cause of the **1.0.53-0 SDK update failure** ([run 26350573462](https://github.com/github/copilot-sdk/actions/runs/26350573462)). The runtime-side schema-shape lint (copilot-agent-runtime#8452) correctly classified the schema as opaque, but the SDK codegen didn't respect the marker in the RPC code path.

## Fix

Add an early `isOpaqueJson` guard at the top of `resolveRpcType`, mirroring the existing check in `schemaTypeToCSharp` (session-events path, line 336) and `resolveSessionPropertyType` (line 1146).

## Notes

- The other language codegens (Go, Rust, Python, Java) have the same missing check but don't crash because they fall back to generic types (`any`, `serde_json::Value`, `Any`, `Object`). Only C# is strict enough to throw.
- The runtime worked around this at the time via copilot-agent-runtime#8669 (Canvas schema cleanup), but this fix closes the gap on the SDK side so future opaque schemas in the RPC path won't hit this.