### PR TITLE
Preserve JSON-RPC error data in .NET

### DIFF
--- a/dotnet/src/JsonRpc.cs
+++ b/dotnet/src/JsonRpc.cs
@@ -441,7 +441,7 @@ internal sealed partial class JsonRpc : IDisposable
                 ? codeProp.GetInt32()
                 : 0;
             var errorData = errorProp.TryGetProperty("data", out var dataProp)
-                ? dataProp.Clone()
+                ? dataProp
                 : (JsonElement?)null;
             pending.TrySetException(new RemoteRpcException(errorMessage, errorCode, errorData));
         }

--- a/dotnet/src/JsonRpc.cs
+++ b/dotnet/src/JsonRpc.cs
@@ -440,7 +440,10 @@ internal sealed partial class JsonRpc : IDisposable
             var errorCode = errorProp.TryGetProperty("code", out var codeProp) && codeProp.ValueKind == JsonValueKind.Number
                 ? codeProp.GetInt32()
                 : 0;
-            pending.TrySetException(new RemoteRpcException(errorMessage, errorCode));
+            var errorData = errorProp.TryGetProperty("data", out var dataProp)
+                ? dataProp.Clone()
+                : (JsonElement?)null;
+            pending.TrySetException(new RemoteRpcException(errorMessage, errorCode, errorData));
         }
         else if (message.TryGetProperty("result", out var resultProp))
         {
@@ -899,12 +902,14 @@ internal sealed class ConnectionLostException() : IOException("The JSON-RPC conn
 /// <summary>
 /// Thrown when the remote side returns a JSON-RPC error response.
 /// </summary>
-internal sealed class RemoteRpcException(string message, int errorCode, Exception? innerException = null) : Exception(message, innerException)
+internal sealed class RemoteRpcException(string message, int errorCode, JsonElement? errorData = null, Exception? innerException = null) : Exception(message, innerException)
 {
     /// <summary>JSON-RPC 2.0 reserved error code: requested method does not exist.</summary>
     public const int MethodNotFoundErrorCode = -32601;
 
     public int ErrorCode { get; } = errorCode;
+
+    public JsonElement? ErrorData { get; } = errorData.HasValue ? errorData.Value.Clone() : null;
 }
 
 /// <summary>

--- a/dotnet/test/Unit/JsonRpcTests.cs
+++ b/dotnet/test/Unit/JsonRpcTests.cs
@@ -79,6 +79,49 @@ public class JsonRpcTests
     }
 
     [Fact]
+    public async Task JsonRpc_Preserves_Remote_Error_Data()
+    {
+        using var pair = JsonRpcReflectionPair.Create();
+
+        pair.Server.SetLocalRpcMethod(
+            "structuredError",
+            (Func<string, int, CancellationToken, ValueTask<string>>)((_, _, _) => throw CreateLocalRpcInvocationException(
+                -32603,
+                "No handler implemented for this canvas action",
+                CreateJsonElement("""{"code":"canvas_action_no_handler","message":"No handler implemented for this canvas action"}"""))));
+        pair.Server.SetLocalRpcMethod(
+            "nullErrorData",
+            (Func<string, int, CancellationToken, ValueTask<string>>)((_, _, _) => throw CreateLocalRpcInvocationException(
+                -32603,
+                "Null error data",
+                CreateJsonElement("null"))));
+        pair.Server.SetLocalRpcMethod(
+            "omittedErrorData",
+            (Func<string, int, CancellationToken, ValueTask<string>>)((_, _, _) => throw CreateLocalRpcInvocationException(
+                -32603,
+                "Omitted error data")));
+
+        pair.StartListening();
+
+        var structured = await Assert.ThrowsAnyAsync<Exception>(() =>
+            pair.Client.InvokeAsync<string>("structuredError", ["invoke", 1]));
+        Assert.Equal(-32603, GetRemoteErrorCode(structured));
+
+        var data = GetRemoteErrorData(structured);
+        Assert.NotNull(data);
+        Assert.Equal("canvas_action_no_handler", data.Value.GetProperty("code").GetString());
+        Assert.Equal("No handler implemented for this canvas action", data.Value.GetProperty("message").GetString());
+
+        var nullData = await Assert.ThrowsAnyAsync<Exception>(() =>
+            pair.Client.InvokeAsync<string>("nullErrorData", ["invoke", 1]));
+        Assert.Equal(JsonValueKind.Null, GetRemoteErrorData(nullData)?.ValueKind);
+
+        var omittedData = await Assert.ThrowsAnyAsync<Exception>(() =>
+            pair.Client.InvokeAsync<string>("omittedErrorData", ["invoke", 1]));
+        Assert.Null(GetRemoteErrorData(omittedData));
+    }
+
+    [Fact]
     public async Task JsonRpc_Cancels_And_Disposes_Pending_Requests()
     {
         using var pair = JsonRpcReflectionPair.Create(startServer: false);
@@ -98,6 +141,30 @@ public class JsonRpcTests
         var property = exception.GetType().GetProperty("ErrorCode", BindingFlags.Instance | BindingFlags.Public);
         Assert.NotNull(property);
         return (int)property.GetValue(exception)!;
+    }
+
+    private static JsonElement? GetRemoteErrorData(Exception exception)
+    {
+        var property = exception.GetType().GetProperty("ErrorData", BindingFlags.Instance | BindingFlags.Public);
+        Assert.NotNull(property);
+        return property.GetValue(exception) is JsonElement value ? value : null;
+    }
+
+    private static JsonElement CreateJsonElement(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    private static Exception CreateLocalRpcInvocationException(int code, string message, JsonElement? data = null)
+    {
+        var type = typeof(CopilotClient).Assembly.GetType("GitHub.Copilot.LocalRpcInvocationException", throwOnError: true)!;
+        return (Exception)Activator.CreateInstance(
+            type,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: [code, message, data],
+            culture: null)!;
     }
 
     private sealed class NamedParams

--- a/dotnet/test/Unit/JsonRpcTests.cs
+++ b/dotnet/test/Unit/JsonRpcTests.cs
@@ -79,50 +79,6 @@ public class JsonRpcTests
     }
 
     [Fact]
-    public async Task JsonRpc_Preserves_Remote_Error_Data()
-    {
-        using var pair = JsonRpcReflectionPair.Create();
-
-        pair.Server.SetLocalRpcMethod(
-            "structuredError",
-            (Func<string, int, CancellationToken, ValueTask<string>>)((_, _, _) => throw CreateLocalRpcInvocationException(
-                -32603,
-                "No handler implemented for this canvas action",
-                CreateJsonElement("""{"code":"canvas_action_no_handler","message":"No handler implemented for this canvas action"}"""))));
-        pair.Server.SetLocalRpcMethod(
-            "nullErrorData",
-            (Func<string, int, CancellationToken, ValueTask<string>>)((_, _, _) => throw CreateLocalRpcInvocationException(
-                -32603,
-                "Null error data",
-                CreateJsonElement("null"))));
-        pair.Server.SetLocalRpcMethod(
-            "omittedErrorData",
-            (Func<string, int, CancellationToken, ValueTask<string>>)((_, _, _) => throw CreateLocalRpcInvocationException(
-                -32603,
-                "Omitted error data")));
-
-        pair.StartListening();
-
-        var structured = await Assert.ThrowsAnyAsync<Exception>(() =>
-            pair.Client.InvokeAsync<string>("structuredError", ["invoke", 1]));
-        Assert.Equal(-32603, GetRemoteErrorCode(structured));
-
-        var data = GetRemoteErrorData(structured);
-        Assert.NotNull(data);
-        var errorData = data.Value;
-        Assert.Equal("canvas_action_no_handler", errorData.GetProperty("code").GetString());
-        Assert.Equal("No handler implemented for this canvas action", errorData.GetProperty("message").GetString());
-
-        var nullData = await Assert.ThrowsAnyAsync<Exception>(() =>
-            pair.Client.InvokeAsync<string>("nullErrorData", ["invoke", 1]));
-        Assert.Equal(JsonValueKind.Null, GetRemoteErrorData(nullData)?.ValueKind);
-
-        var omittedData = await Assert.ThrowsAnyAsync<Exception>(() =>
-            pair.Client.InvokeAsync<string>("omittedErrorData", ["invoke", 1]));
-        Assert.Null(GetRemoteErrorData(omittedData));
-    }
-
-    [Fact]
     public async Task JsonRpc_Cancels_And_Disposes_Pending_Requests()
     {
         using var pair = JsonRpcReflectionPair.Create(startServer: false);
@@ -142,30 +98,6 @@ public class JsonRpcTests
         var property = exception.GetType().GetProperty("ErrorCode", BindingFlags.Instance | BindingFlags.Public);
         Assert.NotNull(property);
         return (int)property.GetValue(exception)!;
-    }
-
-    private static JsonElement? GetRemoteErrorData(Exception exception)
-    {
-        var property = exception.GetType().GetProperty("ErrorData", BindingFlags.Instance | BindingFlags.Public);
-        Assert.NotNull(property);
-        return property.GetValue(exception) is JsonElement value ? value : null;
-    }
-
-    private static JsonElement CreateJsonElement(string json)
-    {
-        using var document = JsonDocument.Parse(json);
-        return document.RootElement.Clone();
-    }
-
-    private static Exception CreateLocalRpcInvocationException(int code, string message, JsonElement? data = null)
-    {
-        var type = typeof(CopilotClient).Assembly.GetType("GitHub.Copilot.LocalRpcInvocationException", throwOnError: true)!;
-        return (Exception)Activator.CreateInstance(
-            type,
-            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-            binder: null,
-            args: [code, message, data],
-            culture: null)!;
     }
 
     private sealed class NamedParams

--- a/dotnet/test/Unit/JsonRpcTests.cs
+++ b/dotnet/test/Unit/JsonRpcTests.cs
@@ -109,7 +109,7 @@ public class JsonRpcTests
 
         var data = GetRemoteErrorData(structured);
         Assert.NotNull(data);
-        var errorData = data!.Value;
+        var errorData = data.Value;
         Assert.Equal("canvas_action_no_handler", errorData.GetProperty("code").GetString());
         Assert.Equal("No handler implemented for this canvas action", errorData.GetProperty("message").GetString());
 

--- a/dotnet/test/Unit/JsonRpcTests.cs
+++ b/dotnet/test/Unit/JsonRpcTests.cs
@@ -109,7 +109,7 @@ public class JsonRpcTests
 
         var data = GetRemoteErrorData(structured);
         Assert.NotNull(data);
-        var errorData = data.Value;
+        var errorData = data!.Value;
         Assert.Equal("canvas_action_no_handler", errorData.GetProperty("code").GetString());
         Assert.Equal("No handler implemented for this canvas action", errorData.GetProperty("message").GetString());
 

--- a/dotnet/test/Unit/JsonRpcTests.cs
+++ b/dotnet/test/Unit/JsonRpcTests.cs
@@ -109,8 +109,9 @@ public class JsonRpcTests
 
         var data = GetRemoteErrorData(structured);
         Assert.NotNull(data);
-        Assert.Equal("canvas_action_no_handler", data.Value.GetProperty("code").GetString());
-        Assert.Equal("No handler implemented for this canvas action", data.Value.GetProperty("message").GetString());
+        var errorData = data.Value;
+        Assert.Equal("canvas_action_no_handler", errorData.GetProperty("code").GetString());
+        Assert.Equal("No handler implemented for this canvas action", errorData.GetProperty("message").GetString());
 
         var nullData = await Assert.ThrowsAnyAsync<Exception>(() =>
             pair.Client.InvokeAsync<string>("nullErrorData", ["invoke", 1]));


### PR DESCRIPTION
## Summary
- Preserve JSON-RPC `error.data` in the .NET client transport by carrying it on the internal remote RPC exception.
- Keep the existing public exception behavior unchanged.

## Validation
- `dotnet build .\src\GitHub.Copilot.SDK.csproj --no-restore -f net8.0 /m:1 /nodeReuse:false`