### PR TITLE
Fix C# canvas action RPC compatibility

### DIFF
--- a/dotnet/src/Canvas.cs
+++ b/dotnet/src/Canvas.cs
@@ -129,12 +129,12 @@ internal partial class CanvasJsonContext : JsonSerializerContext;
 /// </summary>
 /// <remarks>
 /// A session installs a single <see cref="ICanvasHandler"/> via
-/// <c>SessionConfigBase.CanvasHandler</c>. The handler receives every
+/// <c>SessionConfigBase.CanvasHandler</c>. The handler receives all
 /// inbound <c>canvas.open</c> / <c>canvas.close</c> / <c>canvas.invokeAction</c>
 /// (or legacy <c>canvas.action.invoke</c>)
-/// JSON-RPC request the runtime issues for this session and decides — typically
+/// JSON-RPC requests the runtime issues for this session and decides — typically
 /// by inspecting <see cref="CanvasProviderOpenRequest.CanvasId"/> — which
-/// application-side canvas should handle the call.
+/// application-side canvas should handle each call.
 /// <para>
 /// The SDK does not maintain a per-canvas registry; multiplexing across
 /// declared canvases is the implementor's responsibility.

--- a/dotnet/src/Canvas.cs
+++ b/dotnet/src/Canvas.cs
@@ -131,6 +131,7 @@ internal partial class CanvasJsonContext : JsonSerializerContext;
 /// A session installs a single <see cref="ICanvasHandler"/> via
 /// <c>SessionConfigBase.CanvasHandler</c>. The handler receives every
 /// inbound <c>canvas.open</c> / <c>canvas.close</c> / <c>canvas.invokeAction</c>
+/// (or legacy <c>canvas.action.invoke</c>)
 /// JSON-RPC request the runtime issues for this session and decides — typically
 /// by inspecting <see cref="CanvasProviderOpenRequest.CanvasId"/> — which
 /// application-side canvas should handle the call.

--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -14803,6 +14803,12 @@ internal static class ClientSessionApiRegistration
             if (handler is null) throw new InvalidOperationException($"No canvas handler registered for session: {request.SessionId}");
             return await handler.InvokeActionAsync(request, cancellationToken);
         }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("canvas.action.invoke", (Func<CanvasProviderInvokeActionRequest, CancellationToken, ValueTask<object>>)(async (request, cancellationToken) =>
+        {
+            var handler = getHandlers(request.SessionId).Canvas;
+            if (handler is null) throw new InvalidOperationException($"No canvas handler registered for session: {request.SessionId}");
+            return await handler.InvokeActionAsync(request, cancellationToken);
+        }), singleObjectParam: true);
     }
 }
 

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -2511,7 +2511,7 @@ public abstract class SessionConfigBase
     /// <summary>
     /// Provider-side canvas lifecycle handler. The SDK routes inbound
     /// <c>canvas.open</c> / <c>canvas.close</c> / <c>canvas.invokeAction</c>
-    /// requests to this handler.
+    /// (or legacy <c>canvas.action.invoke</c>) requests to this handler.
     /// </summary>
     [Experimental(Diagnostics.Experimental)]
     [JsonIgnore]

--- a/dotnet/test/Unit/JsonRpcTests.cs
+++ b/dotnet/test/Unit/JsonRpcTests.cs
@@ -5,6 +5,7 @@
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Rpc = GitHub.Copilot.Rpc;
 using Xunit;
 
 namespace GitHub.Copilot.Test.Unit;
@@ -93,6 +94,64 @@ public class JsonRpcTests
         await Assert.ThrowsAnyAsync<ObjectDisposedException>(() => pending);
     }
 
+    [Fact]
+    public async Task JsonRpc_Routes_CanvasInvokeAction_LegacyAlias_To_Same_Handler()
+    {
+        using var pair = JsonRpcReflectionPair.Create(startServer: false);
+        var handler = new RecordingRpcCanvasHandler();
+        RegisterClientSessionApiHandlers(pair.Server, sessionId =>
+        {
+            Assert.Equal("session-1", sessionId);
+            return new Rpc.ClientSessionApiHandlers { Canvas = handler };
+        });
+
+        pair.Server.StartListening();
+        pair.StartListening();
+
+        var canonical = await InvokeCanvasActionAsync(pair.Client, "canvas.invokeAction");
+        var legacy = await InvokeCanvasActionAsync(pair.Client, "canvas.action.invoke");
+
+        Assert.Equal(1, canonical.Count);
+        Assert.Equal("increment", canonical.ActionName);
+        Assert.Equal(2, legacy.Count);
+        Assert.Equal("increment", legacy.ActionName);
+        Assert.Collection(handler.ActionRequests, AssertIncrementActionRequest, AssertIncrementActionRequest);
+    }
+
+    private static Task<CanvasActionAliasResponse> InvokeCanvasActionAsync(JsonRpcReflection rpc, string methodName) =>
+        rpc.InvokeAsync<CanvasActionAliasResponse>(
+            methodName,
+            [new Rpc.CanvasProviderInvokeActionRequest
+            {
+                SessionId = "session-1",
+                InstanceId = "canvas-1",
+                CanvasId = "canvas",
+                ExtensionId = "provider",
+                ActionName = "increment"
+            }]);
+
+    private static void AssertIncrementActionRequest(Rpc.CanvasProviderInvokeActionRequest request)
+    {
+        Assert.Equal("session-1", request.SessionId);
+        Assert.Equal("canvas-1", request.InstanceId);
+        Assert.Equal("canvas", request.CanvasId);
+        Assert.Equal("provider", request.ExtensionId);
+        Assert.Equal("increment", request.ActionName);
+    }
+
+    private static void RegisterClientSessionApiHandlers(
+        JsonRpcReflection rpc,
+        Func<string, Rpc.ClientSessionApiHandlers> getHandlers)
+    {
+        var registrationType = typeof(Rpc.ClientSessionApiHandlers).Assembly.GetType(
+            "GitHub.Copilot.Rpc.ClientSessionApiRegistration",
+            throwOnError: true)!;
+
+        registrationType
+            .GetMethod("RegisterClientSessionApiHandlers", BindingFlags.Public | BindingFlags.Static)!
+            .Invoke(null, [rpc.Instance, getHandlers]);
+    }
+
     private static int GetRemoteErrorCode(Exception exception)
     {
         var property = exception.GetType().GetProperty("ErrorCode", BindingFlags.Instance | BindingFlags.Public);
@@ -115,6 +174,38 @@ public class JsonRpcTests
     private sealed class SingleObjectResponse
     {
         public string Value { get; set; } = string.Empty;
+    }
+
+    private sealed class CanvasActionAliasResponse
+    {
+        public string ActionName { get; set; } = string.Empty;
+
+        public int Count { get; set; }
+    }
+
+    private sealed class RecordingRpcCanvasHandler : Rpc.ICanvasHandler
+    {
+        public List<Rpc.CanvasProviderInvokeActionRequest> ActionRequests { get; } = [];
+
+        public Task<Rpc.CanvasProviderOpenResult> OpenAsync(
+            Rpc.CanvasProviderOpenRequest request,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task CloseAsync(Rpc.CanvasProviderCloseRequest request, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<object> InvokeActionAsync(
+            Rpc.CanvasProviderInvokeActionRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            ActionRequests.Add(request);
+            return Task.FromResult<object>(new CanvasActionAliasResponse
+            {
+                ActionName = request.ActionName,
+                Count = ActionRequests.Count
+            });
+        }
     }
 
     private sealed class JsonRpcReflectionPair : IDisposable
@@ -178,6 +269,8 @@ public class JsonRpcTests
                 args: [stream, stream, SerializerOptions, null],
                 culture: null)!;
         }
+
+        public object Instance => _instance;
 
         public void StartListening() => JsonRpcType.GetMethod(nameof(StartListening))!.Invoke(_instance, null);
 

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -2176,6 +2176,15 @@ function clientHandlerMethodName(rpcMethod: string): string {
     return `${toPascalCase(parts[parts.length - 1])}Async`;
 }
 
+function clientSessionApiRegistrationRpcMethods(rpcMethod: string): string[] {
+    if (rpcMethod === "canvas.invokeAction") {
+        // Older runtimes dispatch canvas actions with this method name.
+        return [rpcMethod, "canvas.action.invoke"];
+    }
+
+    return [rpcMethod];
+}
+
 function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>, classes: string[]): string[] {
     const lines: string[] = [];
     const groups = collectClientGroups(clientSchema);
@@ -2272,20 +2281,22 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>,
             const paramsClass = paramsTypeName(method);
             const taskType = handlerTaskType(method);
 
-            if (hasParams) {
-                lines.push(`        rpc.SetLocalRpcMethod("${method.rpcMethod}", (Func<${paramsClass}, CancellationToken, ${taskType}>)(async (request, cancellationToken) =>`);
-                lines.push(`        {`);
-                lines.push(`            var handler = getHandlers(request.SessionId).${handlerProperty};`);
-                lines.push(`            if (handler is null) throw new InvalidOperationException($"No ${groupName} handler registered for session: {request.SessionId}");`);
-                if (!isVoidSchema(resultSchema)) {
-                    lines.push(`            return await handler.${handlerMethod}(request, cancellationToken);`);
+            for (const rpcMethod of clientSessionApiRegistrationRpcMethods(method.rpcMethod)) {
+                if (hasParams) {
+                    lines.push(`        rpc.SetLocalRpcMethod("${rpcMethod}", (Func<${paramsClass}, CancellationToken, ${taskType}>)(async (request, cancellationToken) =>`);
+                    lines.push(`        {`);
+                    lines.push(`            var handler = getHandlers(request.SessionId).${handlerProperty};`);
+                    lines.push(`            if (handler is null) throw new InvalidOperationException($"No ${groupName} handler registered for session: {request.SessionId}");`);
+                    if (!isVoidSchema(resultSchema)) {
+                        lines.push(`            return await handler.${handlerMethod}(request, cancellationToken);`);
+                    } else {
+                        lines.push(`            await handler.${handlerMethod}(request, cancellationToken);`);
+                    }
+                    lines.push(`        }), singleObjectParam: true);`);
                 } else {
-                    lines.push(`            await handler.${handlerMethod}(request, cancellationToken);`);
+                    lines.push(`        rpc.SetLocalRpcMethod("${rpcMethod}", (Func<CancellationToken, ${taskType}>)(_ =>`);
+                    lines.push(`            throw new InvalidOperationException("No params provided for ${rpcMethod}")));`);
                 }
-                lines.push(`        }), singleObjectParam: true);`);
-            } else {
-                lines.push(`        rpc.SetLocalRpcMethod("${method.rpcMethod}", (Func<CancellationToken, ${taskType}>)(_ =>`);
-                lines.push(`            throw new InvalidOperationException("No params provided for ${method.rpcMethod}")));`);
             }
         }
     }


### PR DESCRIPTION
The copilot-agent-runtime CI leg runs the latest C# SDK tests against the live runtime, and the canvas action test was failing because that runtime still dispatches the legacy `canvas.action.invoke` client-session method.

This keeps the canonical `canvas.invokeAction` registration and also registers `canvas.action.invoke` to the same C# canvas handler path. The C# code generator now emits that compatibility alias so regenerated RPC sources preserve the fix.

Tests:
- `dotnet build dotnet\src\GitHub.Copilot.SDK.csproj --no-restore`
- `dotnet test dotnet\test\GitHub.Copilot.SDK.Test.csproj --filter "FullyQualifiedName~GitHub.Copilot.Test.Unit.CanvasTests" --no-restore`