### PR TITLE
Add MessageOptions.agentMode and fix per-message mode misuse

### DIFF
--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -276,6 +276,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
             Prompt = options.Prompt,
             Attachments = options.Attachments,
             Mode = options.Mode,
+            AgentMode = options.AgentMode,
             Traceparent = traceparent,
             Tracestate = tracestate,
             RequestHeaders = options.RequestHeaders,
@@ -1665,6 +1666,8 @@ public sealed partial class CopilotSession : IAsyncDisposable
         public string Prompt { get; init; } = string.Empty;
         public IList<UserMessageAttachment>? Attachments { get; init; }
         public string? Mode { get; init; }
+        [JsonPropertyName("agentMode")]
+        public AgentMode? AgentMode { get; init; }
         public string? Traceparent { get; init; }
         public string? Tracestate { get; init; }
         public IDictionary<string, string>? RequestHeaders { get; init; }

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -1712,6 +1712,29 @@ public enum SystemMessageMode
 }
 
 /// <summary>
+/// The UI mode the agent is in for a given turn.
+/// </summary>
+/// <remarks>
+/// Set on <see cref="MessageOptions.AgentMode"/> to send a message in a specific mode; defaults to the session's current mode.
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter<AgentMode>))]
+public enum AgentMode
+{
+    /// <summary>The agent is responding interactively to the user.</summary>
+    [JsonStringEnumMemberName("interactive")]
+    Interactive,
+    /// <summary>The agent is preparing a plan before making changes.</summary>
+    [JsonStringEnumMemberName("plan")]
+    Plan,
+    /// <summary>The agent is working autonomously toward task completion.</summary>
+    [JsonStringEnumMemberName("autopilot")]
+    Autopilot,
+    /// <summary>The agent is in shell-focused UI mode.</summary>
+    [JsonStringEnumMemberName("shell")]
+    Shell
+}
+
+/// <summary>
 /// Specifies the operation to perform on a system message section.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter<SectionOverrideAction>))]
@@ -2645,6 +2668,7 @@ public sealed class MessageOptions
 
         Attachments = other.Attachments is not null ? [.. other.Attachments] : null;
         Mode = other.Mode;
+        AgentMode = other.AgentMode;
         Prompt = other.Prompt;
         RequestHeaders = other.RequestHeaders is not null
             ? new Dictionary<string, string>(other.RequestHeaders)
@@ -2660,9 +2684,15 @@ public sealed class MessageOptions
     /// </summary>
     public IList<UserMessageAttachment>? Attachments { get; set; }
     /// <summary>
-    /// Interaction mode for the message (e.g., "plan", "edit").
+    /// How to deliver the message. <c>"enqueue"</c> (default) appends to the message queue;
+    /// <c>"immediate"</c> interjects during an in-progress turn.
     /// </summary>
     public string? Mode { get; set; }
+    /// <summary>
+    /// The UI mode the agent was in when this message was sent (for example "plan", "autopilot").
+    /// Defaults to the session's current mode when unset.
+    /// </summary>
+    public AgentMode? AgentMode { get; set; }
     /// <summary>
     /// Custom per-turn HTTP headers for outbound model requests.
     /// </summary>

--- a/dotnet/test/E2E/ModeHandlersE2ETests.cs
+++ b/dotnet/test/E2E/ModeHandlersE2ETests.cs
@@ -53,7 +53,7 @@ public class ModeHandlersE2ETests(E2ETestFixture fixture, ITestOutputHelper outp
 
         var response = await session.SendAndWaitAsync(new MessageOptions
         {
-            Mode = "plan",
+            AgentMode = AgentMode.Plan,
             Prompt = "Create a brief implementation plan for adding a greeting.txt file, then request approval with exit_plan_mode.",
         }, timeout: TimeSpan.FromSeconds(120));
 

--- a/dotnet/test/E2E/SessionE2ETests.cs
+++ b/dotnet/test/E2E/SessionE2ETests.cs
@@ -858,13 +858,12 @@ public class SessionE2ETests(E2ETestFixture fixture, ITestOutputHelper output) :
         await session.SendAndWaitAsync(new MessageOptions
         {
             Prompt = "Say mode ok.",
-            Mode = "plan",
+            AgentMode = AgentMode.Plan,
         });
 
         var userMessage = (await session.GetEventsAsync()).OfType<UserMessageEvent>().Last();
         Assert.Equal("Say mode ok.", userMessage.Data.Content);
-        // The current runtime accepts the per-message mode option but does not echo it on user.message.
-        Assert.Null(userMessage.Data.AgentMode);
+        Assert.Equal(UserMessageAgentMode.Plan, userMessage.Data.AgentMode);
     }
 
     [Fact]

--- a/dotnet/test/Unit/SerializationTests.cs
+++ b/dotnet/test/Unit/SerializationTests.cs
@@ -57,7 +57,7 @@ public class SerializationTests
         var original = new MessageOptions
         {
             Prompt = "real prompt",
-            Mode = "plan",
+            Mode = "enqueue",
             RequestHeaders = new Dictionary<string, string> { ["X-Trace"] = "trace-value" }
         };
 
@@ -65,13 +65,13 @@ public class SerializationTests
         using var document = JsonDocument.Parse(json);
         var root = document.RootElement;
         Assert.Equal("real prompt", root.GetProperty("prompt").GetString());
-        Assert.Equal("plan", root.GetProperty("mode").GetString());
+        Assert.Equal("enqueue", root.GetProperty("mode").GetString());
         Assert.Equal("trace-value", root.GetProperty("requestHeaders").GetProperty("X-Trace").GetString());
 
         var deserialized = JsonSerializer.Deserialize<MessageOptions>(json, options);
         Assert.NotNull(deserialized);
         Assert.Equal("real prompt", deserialized.Prompt);
-        Assert.Equal("plan", deserialized.Mode);
+        Assert.Equal("enqueue", deserialized.Mode);
         Assert.Equal("trace-value", deserialized.RequestHeaders!["X-Trace"]);
     }
 
@@ -84,7 +84,7 @@ public class SerializationTests
             requestType,
             ("SessionId", "session-id"),
             ("Prompt", "real prompt"),
-            ("Mode", "plan"),
+            ("Mode", "enqueue"),
             ("RequestHeaders", new Dictionary<string, string> { ["X-Trace"] = "trace-value" }));
 
         var json = JsonSerializer.Serialize(request, requestType, options);
@@ -92,7 +92,7 @@ public class SerializationTests
         var root = document.RootElement;
         Assert.Equal("session-id", root.GetProperty("sessionId").GetString());
         Assert.Equal("real prompt", root.GetProperty("prompt").GetString());
-        Assert.Equal("plan", root.GetProperty("mode").GetString());
+        Assert.Equal("enqueue", root.GetProperty("mode").GetString());
         Assert.Equal("trace-value", root.GetProperty("requestHeaders").GetProperty("X-Trace").GetString());
     }
 

--- a/go/internal/e2e/mode_handlers_e2e_test.go
+++ b/go/internal/e2e/mode_handlers_e2e_test.go
@@ -84,8 +84,8 @@ func TestModeHandlersE2E(t *testing.T) {
 		)
 
 		response, err := session.SendAndWait(t.Context(), copilot.MessageOptions{
-			Prompt: planPrompt,
-			Mode:   "plan",
+			Prompt:    planPrompt,
+			AgentMode: copilot.AgentModePlan,
 		})
 		if err != nil {
 			t.Fatalf("Failed to send message: %v", err)

--- a/go/internal/e2e/session_e2e_test.go
+++ b/go/internal/e2e/session_e2e_test.go
@@ -1510,8 +1510,8 @@ func TestSessionMessageOptionsE2E(t *testing.T) {
 		}
 
 		_, err = session.SendAndWait(t.Context(), copilot.MessageOptions{
-			Prompt: "Say mode ok.",
-			Mode:   "plan",
+			Prompt:    "Say mode ok.",
+			AgentMode: copilot.AgentModePlan,
 		})
 		if err != nil {
 			t.Fatalf("SendAndWait failed: %v", err)
@@ -1535,10 +1535,8 @@ func TestSessionMessageOptionsE2E(t *testing.T) {
 		if userMsg.Content != "Say mode ok." {
 			t.Errorf("Expected Content 'Say mode ok.', got %q", userMsg.Content)
 		}
-		// The current runtime accepts the per-message mode option but does not
-		// echo it back on the user.message event.
-		if userMsg.AgentMode != nil {
-			t.Errorf("Expected AgentMode=nil, got %v", *userMsg.AgentMode)
+		if userMsg.AgentMode == nil || *userMsg.AgentMode != copilot.UserMessageAgentModePlan {
+			t.Errorf("Expected AgentMode=plan, got %v", userMsg.AgentMode)
 		}
 	})
 

--- a/go/session.go
+++ b/go/session.go
@@ -289,6 +289,7 @@ func (s *Session) Send(ctx context.Context, options MessageOptions) (string, err
 		Prompt:         options.Prompt,
 		Attachments:    options.Attachments,
 		Mode:           options.Mode,
+		AgentMode:      options.AgentMode,
 		Traceparent:    traceparent,
 		Tracestate:     tracestate,
 		RequestHeaders: options.RequestHeaders,

--- a/go/types.go
+++ b/go/types.go
@@ -1316,9 +1316,25 @@ type MessageOptions struct {
 	Attachments []Attachment
 	// Mode is the message delivery mode (default: "enqueue")
 	Mode string
+	// AgentMode is the UI mode the agent was in when this message was sent
+	// (for example "plan" or "autopilot"). Defaults to the session's current
+	// mode when empty.
+	AgentMode AgentMode
 	// RequestHeaders are custom per-turn HTTP headers for outbound model requests.
 	RequestHeaders map[string]string
 }
+
+// AgentMode is the UI mode the agent is in for a given turn. See
+// [MessageOptions.AgentMode].
+type AgentMode = rpc.SendAgentMode
+
+// AgentMode values supported by the runtime.
+const (
+	AgentModeInteractive = rpc.SendAgentModeInteractive
+	AgentModePlan        = rpc.SendAgentModePlan
+	AgentModeAutopilot   = rpc.SendAgentModeAutopilot
+	AgentModeShell       = rpc.SendAgentModeShell
+)
 
 // SessionEventHandler is a callback for session events
 type SessionEventHandler func(event SessionEvent)
@@ -1685,6 +1701,7 @@ type sessionSendRequest struct {
 	Prompt         string            `json:"prompt"`
 	Attachments    []Attachment      `json:"attachments,omitempty"`
 	Mode           string            `json:"mode,omitempty"`
+	AgentMode      AgentMode         `json:"agentMode,omitempty"`
 	Traceparent    string            `json:"traceparent,omitempty"`
 	Tracestate     string            `json:"tracestate,omitempty"`
 	RequestHeaders map[string]string `json:"requestHeaders,omitempty"`

--- a/java/src/main/java/com/github/copilot/CopilotSession.java
+++ b/java/src/main/java/com/github/copilot/CopilotSession.java
@@ -475,6 +475,7 @@ public final class CopilotSession implements AutoCloseable {
         request.setPrompt(options.getPrompt());
         request.setAttachments(options.getAttachments());
         request.setMode(options.getMode());
+        request.setAgentMode(options.getAgentMode());
         request.setRequestHeaders(options.getRequestHeaders());
 
         return rpc.invoke("session.send", request, SendMessageResponse.class).thenApply(SendMessageResponse::messageId);

--- a/java/src/main/java/com/github/copilot/rpc/AgentMode.java
+++ b/java/src/main/java/com/github/copilot/rpc/AgentMode.java
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+package com.github.copilot.rpc;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * The UI mode the agent is in for a given turn.
+ * <p>
+ * Set on {@link MessageOptions#setAgentMode(AgentMode)} to send a message in a
+ * specific mode; defaults to the session's current mode when unset.
+ *
+ * @see MessageOptions
+ * @since 1.0.0
+ */
+public enum AgentMode {
+
+    /** The agent is responding interactively to the user. */
+    INTERACTIVE("interactive"),
+
+    /** The agent is preparing a plan before making changes. */
+    PLAN("plan"),
+
+    /** The agent is working autonomously toward task completion. */
+    AUTOPILOT("autopilot"),
+
+    /** The agent is in shell-focused UI mode. */
+    SHELL("shell");
+
+    private final String value;
+
+    AgentMode(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the JSON value for this agent mode.
+     *
+     * @return the string value used in JSON serialization
+     */
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/java/src/main/java/com/github/copilot/rpc/MessageOptions.java
+++ b/java/src/main/java/com/github/copilot/rpc/MessageOptions.java
@@ -45,6 +45,7 @@ public class MessageOptions {
     private String prompt;
     private List<MessageAttachment> attachments;
     private String mode;
+    private AgentMode agentMode;
     private Map<String, String> requestHeaders;
 
     /**
@@ -127,6 +128,30 @@ public class MessageOptions {
     }
 
     /**
+     * Sets the per-message agent UI mode.
+     * <p>
+     * Defaults to the session's current mode when unset.
+     *
+     * @param agentMode
+     *            the agent mode (for example {@link AgentMode#PLAN} or
+     *            {@link AgentMode#AUTOPILOT})
+     * @return this options instance for method chaining
+     */
+    public MessageOptions setAgentMode(AgentMode agentMode) {
+        this.agentMode = agentMode;
+        return this;
+    }
+
+    /**
+     * Gets the per-message agent UI mode.
+     *
+     * @return the agent mode, or {@code null} if not set
+     */
+    public AgentMode getAgentMode() {
+        return agentMode;
+    }
+
+    /**
      * Gets the custom per-turn HTTP headers for outbound model requests.
      *
      * @return the headers map, or {@code null} if not set
@@ -167,6 +192,7 @@ public class MessageOptions {
         copy.prompt = this.prompt;
         copy.attachments = this.attachments != null ? new ArrayList<>(this.attachments) : null;
         copy.mode = this.mode;
+        copy.agentMode = this.agentMode;
         copy.requestHeaders = this.requestHeaders != null ? new HashMap<>(this.requestHeaders) : null;
         return copy;
     }

--- a/java/src/main/java/com/github/copilot/rpc/SendMessageRequest.java
+++ b/java/src/main/java/com/github/copilot/rpc/SendMessageRequest.java
@@ -37,6 +37,9 @@ public final class SendMessageRequest {
     @JsonProperty("mode")
     private String mode;
 
+    @JsonProperty("agentMode")
+    private AgentMode agentMode;
+
     @JsonProperty("requestHeaders")
     private Map<String, String> requestHeaders;
 
@@ -78,6 +81,16 @@ public final class SendMessageRequest {
     /** Sets the mode. @param mode the message mode */
     public void setMode(String mode) {
         this.mode = mode;
+    }
+
+    /** Gets the per-message agent UI mode. @return the agent mode */
+    public AgentMode getAgentMode() {
+        return agentMode;
+    }
+
+    /** Sets the per-message agent UI mode. @param agentMode the agent mode */
+    public void setAgentMode(AgentMode agentMode) {
+        this.agentMode = agentMode;
     }
 
     /** Gets the per-turn request headers. @return the headers map */

--- a/nodejs/src/session.ts
+++ b/nodejs/src/session.ts
@@ -214,6 +214,7 @@ export class CopilotSession {
             prompt: options.prompt,
             attachments: options.attachments,
             mode: options.mode,
+            agentMode: options.agentMode,
             requestHeaders: options.requestHeaders,
         });
 

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -1929,6 +1929,12 @@ export interface MessageOptions {
     mode?: "enqueue" | "immediate";
 
     /**
+     * The UI mode the agent was in when this message was sent (for example "plan" or "autopilot").
+     * Defaults to the session's current mode when unset.
+     */
+    agentMode?: "interactive" | "plan" | "autopilot" | "shell";
+
+    /**
      * Custom HTTP headers to include in outbound model requests for this turn.
      */
     requestHeaders?: Record<string, string>;

--- a/nodejs/test/e2e/mode_handlers.e2e.test.ts
+++ b/nodejs/test/e2e/mode_handlers.e2e.test.ts
@@ -104,7 +104,7 @@ describe("Mode handlers", async () => {
 
             const response = await session.sendAndWait({
                 prompt: PLAN_PROMPT,
-                mode: "plan" as unknown as NonNullable<Parameters<typeof session.send>[0]["mode"]>,
+                agentMode: "plan",
             });
 
             expect(exitPlanModeRequests).toHaveLength(1);

--- a/nodejs/test/e2e/session.e2e.test.ts
+++ b/nodejs/test/e2e/session.e2e.test.ts
@@ -840,9 +840,7 @@ describe("Sessions", async () => {
 
         await session.sendAndWait({
             prompt: "Say mode ok.",
-            // The runtime accepts arbitrary agent mode strings (e.g. "plan", "interactive")
-            // but the public TS type currently constrains mode to send-time values.
-            mode: "plan" as unknown as NonNullable<Parameters<typeof session.send>[0]["mode"]>,
+            agentMode: "plan",
         });
 
         const messages = await session.getEvents();
@@ -851,9 +849,7 @@ describe("Sessions", async () => {
             | undefined;
         expect(userMessage).toBeDefined();
         expect(userMessage!.data.content).toBe("Say mode ok.");
-        // The current runtime accepts the per-message mode option but does not echo it
-        // on the user.message event.
-        expect(userMessage!.data.agentMode ?? null).toBeNull();
+        expect(userMessage!.data.agentMode).toBe("plan");
 
         await session.disconnect();
     });

--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -1157,6 +1157,7 @@ class CopilotSession:
         *,
         attachments: list[Attachment] | None = None,
         mode: Literal["enqueue", "immediate"] | None = None,
+        agent_mode: Literal["interactive", "plan", "autopilot", "shell"] | None = None,
         request_headers: dict[str, str] | None = None,
     ) -> str:
         """
@@ -1170,6 +1171,9 @@ class CopilotSession:
             prompt: The message text to send.
             attachments: Optional file, directory, or selection attachments.
             mode: Message delivery mode (``"enqueue"`` or ``"immediate"``).
+            agent_mode: The UI mode the agent was in when this message was sent
+                (for example ``"plan"`` or ``"autopilot"``). Defaults to the
+                session's current mode when unset.
             request_headers: Optional per-turn HTTP headers for outbound model requests.
 
         Returns:
@@ -1192,6 +1196,8 @@ class CopilotSession:
             params["attachments"] = attachments
         if mode is not None:
             params["mode"] = mode
+        if agent_mode is not None:
+            params["agentMode"] = agent_mode
         if request_headers is not None:
             params["requestHeaders"] = request_headers
         params.update(get_trace_context())
@@ -1215,6 +1221,7 @@ class CopilotSession:
         *,
         attachments: list[Attachment] | None = None,
         mode: Literal["enqueue", "immediate"] | None = None,
+        agent_mode: Literal["interactive", "plan", "autopilot", "shell"] | None = None,
         request_headers: dict[str, str] | None = None,
         timeout: float = 60.0,
     ) -> SessionEvent | None:
@@ -1231,6 +1238,9 @@ class CopilotSession:
             prompt: The message text to send.
             attachments: Optional file, directory, or selection attachments.
             mode: Message delivery mode (``"enqueue"`` or ``"immediate"``).
+            agent_mode: The UI mode the agent was in when this message was sent
+                (for example ``"plan"`` or ``"autopilot"``). Defaults to the
+                session's current mode when unset.
             request_headers: Optional per-turn HTTP headers for outbound model requests.
             timeout: Timeout in seconds (default: 60). Controls how long to wait;
                 does not abort in-flight agent work.
@@ -1289,6 +1299,7 @@ class CopilotSession:
                 prompt,
                 attachments=attachments,
                 mode=mode,
+                agent_mode=agent_mode,
                 request_headers=request_headers,
             )
             await asyncio.wait_for(idle_event.wait(), timeout=timeout)

--- a/python/e2e/test_mode_handlers_e2e.py
+++ b/python/e2e/test_mode_handlers_e2e.py
@@ -113,7 +113,7 @@ class TestModeHandlers:
 
             response = await session.send_and_wait(
                 PLAN_PROMPT,
-                mode="plan",  # type: ignore[arg-type]
+                agent_mode="plan",
             )
 
             assert len(exit_plan_mode_requests) == 1

--- a/python/e2e/test_session_e2e.py
+++ b/python/e2e/test_session_e2e.py
@@ -1077,8 +1077,8 @@ class TestSessions:
             pytest.fail("disconnect from within handler appears to have deadlocked")
 
     async def test_should_send_with_mode_property(self, ctx: E2ETestContext):
-        """Per-message `mode` is accepted but not echoed back on user.message."""
-        from copilot.generated.session_events import UserMessageData
+        """Per-message `agent_mode` is forwarded and echoed back on user.message."""
+        from copilot.generated.session_events import UserMessageAgentMode, UserMessageData
 
         session = await ctx.client.create_session(
             on_permission_request=PermissionHandler.approve_all,
@@ -1086,7 +1086,7 @@ class TestSessions:
 
         await session.send_and_wait(
             "Say mode ok.",
-            mode="plan",  # type: ignore[arg-type]
+            agent_mode="plan",
         )
 
         messages = await session.get_events()
@@ -1094,8 +1094,7 @@ class TestSessions:
         assert user_messages
         last = user_messages[-1].data
         assert last.content == "Say mode ok."
-        # The runtime accepts the per-message mode but does not echo it back.
-        assert last.agent_mode is None
+        assert last.agent_mode == UserMessageAgentMode.PLAN
 
         await session.disconnect()
 

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -356,6 +356,9 @@ impl Session {
         if let Some(m) = opts.mode {
             params["mode"] = serde_json::to_value(m)?;
         }
+        if let Some(am) = opts.agent_mode {
+            params["agentMode"] = serde_json::to_value(am)?;
+        }
         if let Some(mut a) = opts.attachments {
             ensure_attachment_display_names(&mut a);
             params["attachments"] = serde_json::to_value(a)?;

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -2944,6 +2944,24 @@ pub enum DeliveryMode {
     Immediate,
 }
 
+/// The UI mode the agent is in for a given turn, used by
+/// [`MessageOptions::agent_mode`].
+///
+/// Wire values: `"interactive"`, `"plan"`, `"autopilot"`, `"shell"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum AgentMode {
+    /// The agent is responding interactively to the user.
+    Interactive,
+    /// The agent is preparing a plan before making changes.
+    Plan,
+    /// The agent is working autonomously toward task completion.
+    Autopilot,
+    /// The agent is in shell-focused UI mode.
+    Shell,
+}
+
 /// Options for sending a user message to the agent.
 ///
 /// Used by both [`Session::send`](crate::session::Session::send) and
@@ -2983,6 +3001,10 @@ pub struct MessageOptions {
     /// ([`DeliveryMode::Enqueue`], default) or interrupts the session and
     /// runs immediately ([`DeliveryMode::Immediate`]).
     pub mode: Option<DeliveryMode>,
+    /// Optional UI mode the agent was in when this message was sent
+    /// (for example [`AgentMode::Plan`] or [`AgentMode::Autopilot`]).
+    /// Defaults to the session's current mode when `None`.
+    pub agent_mode: Option<AgentMode>,
     /// Optional attachments to include with the message.
     pub attachments: Option<Vec<Attachment>>,
     /// Maximum time to wait for the session to go idle. Honored only by
@@ -3011,6 +3033,7 @@ impl MessageOptions {
         Self {
             prompt: prompt.into(),
             mode: None,
+            agent_mode: None,
             attachments: None,
             wait_timeout: None,
             request_headers: None,
@@ -3026,6 +3049,14 @@ impl MessageOptions {
     /// prompt behind in-flight work.
     pub fn with_mode(mut self, mode: DeliveryMode) -> Self {
         self.mode = Some(mode);
+        self
+    }
+
+    /// Set the per-message agent UI mode for this turn.
+    ///
+    /// When `None`, the session's current mode is used.
+    pub fn with_agent_mode(mut self, agent_mode: AgentMode) -> Self {
+        self.agent_mode = Some(agent_mode);
         self
     }
 
@@ -3623,11 +3654,11 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        Attachment, AttachmentLineRange, AttachmentSelectionPosition, AttachmentSelectionRange,
-        ConnectionState, CustomAgentConfig, DeliveryMode, ExtensionInfo, GitHubReferenceType,
-        InfiniteSessionConfig, ProviderConfig, ResumeSessionConfig, SessionConfig, SessionEvent,
-        SessionId, SystemMessageConfig, Tool, ToolBinaryResult, ToolResult, ToolResultExpanded,
-        ToolResultResponse, ensure_attachment_display_names,
+        AgentMode, Attachment, AttachmentLineRange, AttachmentSelectionPosition,
+        AttachmentSelectionRange, ConnectionState, CustomAgentConfig, DeliveryMode, ExtensionInfo,
+        GitHubReferenceType, InfiniteSessionConfig, ProviderConfig, ResumeSessionConfig,
+        SessionConfig, SessionEvent, SessionId, SystemMessageConfig, Tool, ToolBinaryResult,
+        ToolResult, ToolResultExpanded, ToolResultResponse, ensure_attachment_display_names,
     };
     use crate::generated::session_events::TypedSessionEvent;
 
@@ -4162,6 +4193,25 @@ mod tests {
         );
         let parsed: DeliveryMode = serde_json::from_str("\"immediate\"").unwrap();
         assert_eq!(parsed, DeliveryMode::Immediate);
+    }
+
+    #[test]
+    fn agent_mode_serializes_to_kebab_case_strings() {
+        assert_eq!(
+            serde_json::to_string(&AgentMode::Interactive).unwrap(),
+            "\"interactive\""
+        );
+        assert_eq!(serde_json::to_string(&AgentMode::Plan).unwrap(), "\"plan\"");
+        assert_eq!(
+            serde_json::to_string(&AgentMode::Autopilot).unwrap(),
+            "\"autopilot\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AgentMode::Shell).unwrap(),
+            "\"shell\""
+        );
+        let parsed: AgentMode = serde_json::from_str("\"plan\"").unwrap();
+        assert_eq!(parsed, AgentMode::Plan);
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds a public `agentMode` field to `MessageOptions` across all six SDKs (.NET, Node, Python, Go, Java, Rust) so callers can set the per-message UI mode (`interactive` / `plan` / `autopilot` / `shell`) without abusing the queue-delivery `mode` field. The new field is plumbed through `session.send` to the JSON-RPC `agentMode` parameter, matching the runtime's existing wire schema. The misleading XML doc on the .NET `MessageOptions.Mode` property is corrected. Four pre-existing E2E/unit tests in .NET, Node, Python, and Go that were setting `mode = "plan"` (variously via `as unknown as` casts, `# type: ignore`, or silently as a `string?` in .NET) are migrated to use the new `agentMode` field and updated to assert the runtime echoes the value back on the `user.message` event.

## Why

Every SDK exposed a per-message `mode` field but none exposed `agentMode` — so callers who wanted to start a turn in plan/autopilot/etc. had no correct way to do it from the SDKs, and four tests across .NET/Node/Python/Go reached for `mode` instead. The runtime's `mode` only accepts `enqueue` / `immediate`, so those calls had no effect on agent mode and were only "working" because a runtime regression exposed `exit_plan_mode` in every session mode. Once that runtime regression was fixed (in copilot-agent-runtime#8809), the `Should_Invoke_Exit_Plan_Mode_Handler_When_Model_Uses_Tool` test in the .NET SDK began failing because the session was still effectively `interactive` and the model was no longer offered the `exit_plan_mode` tool. Exposing `agentMode` on every SDK's surface gives callers (and the failing test) the correct API to express that intent, closes the same gap in Java and Rust before anyone else trips on it, and the corrected docs prevent the next caller from making the same mistake.
