### PR TITLE
Add workflow to trigger docs-internal SDK sync on docs changes

### DIFF
--- a/.github/workflows/trigger-docs-sync.yml
+++ b/.github/workflows/trigger-docs-sync.yml
@@ -1,0 +1,31 @@
+name: Trigger docs sync
+
+# Automatically triggers the docs-internal SDK sync workflow
+# whenever documentation source files change on main.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+
+jobs:
+  notify-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch sync to docs-internal
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          # TODO: Create a repository secret named DOCS_INTERNAL_PAT
+          # with a PAT that has contents:write access to github/docs-internal.
+          # Alternatively, use a GitHub App token for better security
+          # (see: actions/create-github-app-token@v1).
+          token: ${{ secrets.DOCS_INTERNAL_PAT }}
+          repository: github/docs-internal
+          event-type: sync-sdk-docs
+          client-payload: >-
+            {
+              "ref": "${{ github.sha }}",
+              "sender": "${{ github.actor }}"
+            }
+


### PR DESCRIPTION
_GitHub Copilot generated this pull request._

## Summary

Adds a GitHub Actions workflow that automatically triggers the [docs-internal SDK sync pipeline](https://github.com/github/docs-internal/pull/61226) whenever files in `docs/` change on `main`.

### How it works

1. A push to `main` that touches `docs/**` triggers this workflow
2. The workflow sends a `repository_dispatch` event (type: `sync-sdk-docs`) to `github/docs-internal`
3. The docs-internal sync workflow picks up the event, clones this repo, normalizes the docs, and opens a PR

### Setup needed

> **TODO:** Create a repository secret named `DOCS_INTERNAL_PAT` with a PAT that has `contents:write` access to `github/docs-internal`. Alternatively, switch to a GitHub App token for better security (no long-lived credentials to rotate).

### Related

- docs-internal sync pipeline: https://github.com/github/docs-internal/pull/61226
- docs-internal codetabs: https://github.com/github/docs-internal/pull/61324