### PR TITLE
Add displayPrompt support to session.send across all SDKs

### DIFF
--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -274,6 +274,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
         {
             SessionId = SessionId,
             Prompt = options.Prompt,
+            DisplayPrompt = options.DisplayPrompt,
             Attachments = options.Attachments,
             Mode = options.Mode,
             AgentMode = options.AgentMode,
@@ -1664,6 +1665,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
     {
         public string SessionId { get; init; } = string.Empty;
         public string Prompt { get; init; } = string.Empty;
+        public string? DisplayPrompt { get; init; }
         public IList<UserMessageAttachment>? Attachments { get; init; }
         public string? Mode { get; init; }
         [JsonPropertyName("agentMode")]

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -2767,6 +2767,7 @@ public sealed class MessageOptions
         Mode = other.Mode;
         AgentMode = other.AgentMode;
         Prompt = other.Prompt;
+        DisplayPrompt = other.DisplayPrompt;
         RequestHeaders = other.RequestHeaders is not null
             ? new Dictionary<string, string>(other.RequestHeaders)
             : null;
@@ -2794,6 +2795,10 @@ public sealed class MessageOptions
     /// Custom per-turn HTTP headers for outbound model requests.
     /// </summary>
     public IDictionary<string, string>? RequestHeaders { get; set; }
+    /// <summary>
+    /// If provided, this is shown in the timeline instead of <see cref="Prompt"/>.
+    /// </summary>
+    public string? DisplayPrompt { get; set; }
 
     /// <summary>
     /// Creates a shallow clone of this <see cref="MessageOptions"/> instance.

--- a/go/session.go
+++ b/go/session.go
@@ -287,6 +287,7 @@ func (s *Session) Send(ctx context.Context, options MessageOptions) (string, err
 	req := sessionSendRequest{
 		SessionID:      s.SessionID,
 		Prompt:         options.Prompt,
+		DisplayPrompt:  options.DisplayPrompt,
 		Attachments:    options.Attachments,
 		Mode:           options.Mode,
 		AgentMode:      options.AgentMode,

--- a/go/types.go
+++ b/go/types.go
@@ -1357,6 +1357,8 @@ type MessageOptions struct {
 	AgentMode AgentMode
 	// RequestHeaders are custom per-turn HTTP headers for outbound model requests.
 	RequestHeaders map[string]string
+	// DisplayPrompt, if provided, is shown in the timeline instead of Prompt.
+	DisplayPrompt string
 }
 
 // AgentMode is the UI mode the agent is in for a given turn. See
@@ -1744,6 +1746,7 @@ type sessionAbortRequest struct {
 type sessionSendRequest struct {
 	SessionID      string            `json:"sessionId"`
 	Prompt         string            `json:"prompt"`
+	DisplayPrompt  string            `json:"displayPrompt,omitempty"`
 	Attachments    []Attachment      `json:"attachments,omitempty"`
 	Mode           string            `json:"mode,omitempty"`
 	AgentMode      AgentMode         `json:"agentMode,omitempty"`

--- a/java/src/main/java/com/github/copilot/CopilotSession.java
+++ b/java/src/main/java/com/github/copilot/CopilotSession.java
@@ -477,6 +477,7 @@ public final class CopilotSession implements AutoCloseable {
         request.setMode(options.getMode());
         request.setAgentMode(options.getAgentMode());
         request.setRequestHeaders(options.getRequestHeaders());
+        request.setDisplayPrompt(options.getDisplayPrompt());
 
         return rpc.invoke("session.send", request, SendMessageResponse.class).thenApply(SendMessageResponse::messageId);
     }

--- a/java/src/main/java/com/github/copilot/rpc/MessageOptions.java
+++ b/java/src/main/java/com/github/copilot/rpc/MessageOptions.java
@@ -189,8 +189,8 @@ public class MessageOptions {
     /**
      * Sets the display prompt shown in the timeline instead of the prompt.
      * <p>
-     * If provided, this text is displayed in the conversation timeline UI
-     * instead of the actual prompt text.
+     * If provided, this text is displayed in the conversation timeline UI instead
+     * of the actual prompt text.
      *
      * @param displayPrompt
      *            the display prompt text

--- a/java/src/main/java/com/github/copilot/rpc/MessageOptions.java
+++ b/java/src/main/java/com/github/copilot/rpc/MessageOptions.java
@@ -47,6 +47,7 @@ public class MessageOptions {
     private String mode;
     private AgentMode agentMode;
     private Map<String, String> requestHeaders;
+    private String displayPrompt;
 
     /**
      * Gets the message prompt.
@@ -177,6 +178,30 @@ public class MessageOptions {
     }
 
     /**
+     * Gets the display prompt shown in the timeline instead of the prompt.
+     *
+     * @return the display prompt, or {@code null} if not set
+     */
+    public String getDisplayPrompt() {
+        return displayPrompt;
+    }
+
+    /**
+     * Sets the display prompt shown in the timeline instead of the prompt.
+     * <p>
+     * If provided, this text is displayed in the conversation timeline UI
+     * instead of the actual prompt text.
+     *
+     * @param displayPrompt
+     *            the display prompt text
+     * @return this options instance for method chaining
+     */
+    public MessageOptions setDisplayPrompt(String displayPrompt) {
+        this.displayPrompt = displayPrompt;
+        return this;
+    }
+
+    /**
      * Creates a shallow clone of this {@code MessageOptions} instance.
      * <p>
      * Mutable collection properties are copied into new collection instances so
@@ -194,6 +219,7 @@ public class MessageOptions {
         copy.mode = this.mode;
         copy.agentMode = this.agentMode;
         copy.requestHeaders = this.requestHeaders != null ? new HashMap<>(this.requestHeaders) : null;
+        copy.displayPrompt = this.displayPrompt;
         return copy;
     }
 

--- a/java/src/main/java/com/github/copilot/rpc/SendMessageRequest.java
+++ b/java/src/main/java/com/github/copilot/rpc/SendMessageRequest.java
@@ -43,6 +43,9 @@ public final class SendMessageRequest {
     @JsonProperty("requestHeaders")
     private Map<String, String> requestHeaders;
 
+    @JsonProperty("displayPrompt")
+    private String displayPrompt;
+
     /** Gets the session ID. @return the session ID */
     public String getSessionId() {
         return sessionId;
@@ -101,5 +104,15 @@ public final class SendMessageRequest {
     /** Sets the per-turn request headers. @param requestHeaders the headers map */
     public void setRequestHeaders(Map<String, String> requestHeaders) {
         this.requestHeaders = requestHeaders;
+    }
+
+    /** Gets the display prompt. @return the display prompt */
+    public String getDisplayPrompt() {
+        return displayPrompt;
+    }
+
+    /** Sets the display prompt shown in the timeline instead of the prompt. @param displayPrompt the display prompt */
+    public void setDisplayPrompt(String displayPrompt) {
+        this.displayPrompt = displayPrompt;
     }
 }

--- a/java/src/main/java/com/github/copilot/rpc/SendMessageRequest.java
+++ b/java/src/main/java/com/github/copilot/rpc/SendMessageRequest.java
@@ -111,7 +111,12 @@ public final class SendMessageRequest {
         return displayPrompt;
     }
 
-    /** Sets the display prompt shown in the timeline instead of the prompt. @param displayPrompt the display prompt */
+    /**
+     * Sets the display prompt shown in the timeline instead of the prompt.
+     *
+     * @param displayPrompt
+     *            the display prompt
+     */
     public void setDisplayPrompt(String displayPrompt) {
         this.displayPrompt = displayPrompt;
     }

--- a/nodejs/src/session.ts
+++ b/nodejs/src/session.ts
@@ -212,6 +212,7 @@ export class CopilotSession {
             ...(await getTraceContext(this.traceContextProvider)),
             sessionId: this.sessionId,
             prompt: options.prompt,
+            displayPrompt: options.displayPrompt,
             attachments: options.attachments,
             mode: options.mode,
             agentMode: options.agentMode,

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -2015,6 +2015,11 @@ export interface MessageOptions {
      * Custom HTTP headers to include in outbound model requests for this turn.
      */
     requestHeaders?: Record<string, string>;
+
+    /**
+     * If provided, this is shown in the timeline instead of `prompt`.
+     */
+    displayPrompt?: string;
 }
 
 /**

--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -1159,6 +1159,7 @@ class CopilotSession:
         mode: Literal["enqueue", "immediate"] | None = None,
         agent_mode: Literal["interactive", "plan", "autopilot", "shell"] | None = None,
         request_headers: dict[str, str] | None = None,
+        display_prompt: str | None = None,
     ) -> str:
         """
         Send a message to this session.
@@ -1175,6 +1176,8 @@ class CopilotSession:
                 (for example ``"plan"`` or ``"autopilot"``). Defaults to the
                 session's current mode when unset.
             request_headers: Optional per-turn HTTP headers for outbound model requests.
+            display_prompt: If provided, this is shown in the timeline instead of
+                ``prompt``.
 
         Returns:
             The message ID assigned by the server, which can be used to correlate events.
@@ -1200,6 +1203,8 @@ class CopilotSession:
             params["agentMode"] = agent_mode
         if request_headers is not None:
             params["requestHeaders"] = request_headers
+        if display_prompt is not None:
+            params["displayPrompt"] = display_prompt
         params.update(get_trace_context())
 
         rpc_start = time.perf_counter()
@@ -1223,6 +1228,7 @@ class CopilotSession:
         mode: Literal["enqueue", "immediate"] | None = None,
         agent_mode: Literal["interactive", "plan", "autopilot", "shell"] | None = None,
         request_headers: dict[str, str] | None = None,
+        display_prompt: str | None = None,
         timeout: float = 60.0,
     ) -> SessionEvent | None:
         """
@@ -1242,6 +1248,8 @@ class CopilotSession:
                 (for example ``"plan"`` or ``"autopilot"``). Defaults to the
                 session's current mode when unset.
             request_headers: Optional per-turn HTTP headers for outbound model requests.
+            display_prompt: If provided, this is shown in the timeline instead of
+                ``prompt``.
             timeout: Timeout in seconds (default: 60). Controls how long to wait;
                 does not abort in-flight agent work.
 
@@ -1301,6 +1309,7 @@ class CopilotSession:
                 mode=mode,
                 agent_mode=agent_mode,
                 request_headers=request_headers,
+                display_prompt=display_prompt,
             )
             await asyncio.wait_for(idle_event.wait(), timeout=timeout)
             if error_event:

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -371,6 +371,9 @@ impl Session {
         {
             params["requestHeaders"] = serde_json::to_value(headers)?;
         }
+        if let Some(display_prompt) = opts.display_prompt {
+            params["displayPrompt"] = serde_json::to_value(display_prompt)?;
+        }
         let trace_ctx = if opts.traceparent.is_some() || opts.tracestate.is_some() {
             TraceContext {
                 traceparent: opts.traceparent,

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -3107,6 +3107,8 @@ pub struct MessageOptions {
     ///
     /// Per-turn override paired with [`traceparent`](Self::traceparent).
     pub tracestate: Option<String>,
+    /// If provided, this is shown in the timeline instead of `prompt`.
+    pub display_prompt: Option<String>,
 }
 
 impl MessageOptions {
@@ -3121,6 +3123,7 @@ impl MessageOptions {
             request_headers: None,
             traceparent: None,
             tracestate: None,
+            display_prompt: None,
         }
     }
 
@@ -3179,6 +3182,12 @@ impl MessageOptions {
     /// Set the W3C `tracestate` header for this turn.
     pub fn with_tracestate(mut self, tracestate: impl Into<String>) -> Self {
         self.tracestate = Some(tracestate.into());
+        self
+    }
+
+    /// Set the display prompt shown in the timeline instead of `prompt`.
+    pub fn with_display_prompt(mut self, display_prompt: impl Into<String>) -> Self {
+        self.display_prompt = Some(display_prompt.into());
         self
     }
 }

--- a/rust/tests/session_test.rs
+++ b/rust/tests/session_test.rs
@@ -497,6 +497,48 @@ async fn send_omits_request_headers_when_unset_or_empty() {
 }
 
 #[tokio::test]
+async fn send_serializes_display_prompt() {
+    let (session, mut server) = create_session_pair().await;
+    let session = Arc::new(session);
+
+    let handle = tokio::spawn({
+        let session = session.clone();
+        async move {
+            session
+                .send(MessageOptions::new("hi").with_display_prompt("Show this to user"))
+                .await
+        }
+    });
+
+    let request = server.read_request().await;
+    assert_eq!(request["method"], "session.send");
+    assert_eq!(request["params"]["prompt"], "hi");
+    assert_eq!(request["params"]["displayPrompt"], "Show this to user");
+
+    server.respond(&request, serde_json::json!({})).await;
+    timeout(TIMEOUT, handle).await.unwrap().unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn send_omits_display_prompt_when_unset() {
+    let (session, mut server) = create_session_pair().await;
+    let session = Arc::new(session);
+
+    let handle = tokio::spawn({
+        let session = session.clone();
+        async move { session.send(MessageOptions::new("plain")).await }
+    });
+    let request = server.read_request().await;
+    assert!(
+        request["params"].get("displayPrompt").is_none(),
+        "displayPrompt should be omitted when unset, got: {}",
+        request["params"]
+    );
+    server.respond(&request, serde_json::json!({})).await;
+    timeout(TIMEOUT, handle).await.unwrap().unwrap().unwrap();
+}
+
+#[tokio::test]
 async fn session_rpc_methods_send_correct_method_names() {
     let (session, mut server) = create_session_pair().await;
     let session = Arc::new(session);


### PR DESCRIPTION
## Summary

Add a `displayPrompt` field to the `session.send` RPC params across all language SDKs. When provided, this value is shown in the conversation timeline instead of the actual prompt text.

## Changes

- **Rust** (`rust/src/types.rs`, `rust/src/session.rs`): Added `display_prompt: Option<String>` field to `MessageOptions` with a `with_display_prompt()` builder method, serialized as `displayPrompt` in params.
- **Node.js** (`nodejs/src/types.ts`, `nodejs/src/session.ts`): Added optional `displayPrompt` to `MessageOptions` interface and pass it through in `send()`.
- **Python** (`python/copilot/session.py`): Added `display_prompt` keyword argument to `send()` and `send_and_wait()`.
- **Go** (`go/types.go`, `go/session.go`): Added `DisplayPrompt` field to `MessageOptions` and `sessionSendRequest`.
- **Java** (`java/src/main/java/.../rpc/MessageOptions.java`, `SendMessageRequest.java`, `CopilotSession.java`): Added `displayPrompt` field with getter/setter and pass it in `send()`.
- **.NET** (`dotnet/src/Types.cs`, `dotnet/src/Session.cs`): Added `DisplayPrompt` property to `MessageOptions` and `SendMessageRequest`, passed in `SendAsync()`.

## Motivation

The GitHub app sends prompts that may contain additional context (e.g., canvas context, system instructions) prepended to the user's message. The `displayPrompt` field lets the app tell the runtime what to show in the timeline as the user's message, rather than showing the full enriched prompt.