### PR TITLE
Defer sessionId to server for cloud sessions

### DIFF
--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -70,17 +70,17 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     private readonly CopilotClientOptions _options;
     private readonly RuntimeConnection _connection;
     private readonly ILogger _logger;
-    private Task<Connection>? _connectionTask;
-    private bool _disposed;
     private readonly int? _optionsPort;
     private readonly string? _optionsHost;
-    private int? _actualPort;
-    private int? _negotiatedProtocolVersion;
-    private List<ModelInfo>? _modelsCache;
-    private readonly SemaphoreSlim _modelsCacheLock = new(1, 1);
     private readonly Func<CancellationToken, Task<IList<ModelInfo>>>? _onListModels;
     private readonly List<LifecycleSubscription> _lifecycleHandlers = [];
-    private readonly object _lifecycleHandlersLock = new();
+
+    private Task<Connection>? _connectionTask;
+    private bool _disposed;
+    private int? _actualPort;
+    private int? _negotiatedProtocolVersion;
+    private SemaphoreSlim? _modelsCacheLock;
+    private List<ModelInfo>? _modelsCache;
     private ServerRpc? _serverRpc;
 
     private sealed record LifecycleSubscription(Type EventType, Action<SessionLifecycleEvent> Handler);
@@ -482,23 +482,28 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             return (systemMessage, null);
         }
 
-        var callbacks = new Dictionary<string, Func<string, Task<string>>>();
-        var wireSections = new Dictionary<SystemMessageSection, SectionOverride>();
+        Dictionary<string, Func<string, Task<string>>>? callbacks = null;
+        Dictionary<SystemMessageSection, SectionOverride>? wireSections = null;
 
-        foreach (var (sectionId, sectionOverride) in systemMessage.Sections)
+        if (systemMessage.Sections is { Count: > 0 })
         {
-            if (sectionOverride.Transform != null)
+            wireSections ??= [];
+
+            foreach (var (sectionId, sectionOverride) in systemMessage.Sections)
             {
-                callbacks[sectionId.Value] = sectionOverride.Transform;
-                wireSections[sectionId] = new SectionOverride { Action = SectionOverrideAction.Transform };
-            }
-            else
-            {
-                wireSections[sectionId] = sectionOverride;
+                if (sectionOverride.Transform != null)
+                {
+                    (callbacks ??= [])[sectionId.Value] = sectionOverride.Transform;
+                    wireSections[sectionId] = new SectionOverride { Action = SectionOverrideAction.Transform };
+                }
+                else
+                {
+                    wireSections[sectionId] = sectionOverride;
+                }
             }
         }
 
-        if (callbacks.Count == 0)
+        if (callbacks is null)
         {
             return (systemMessage, null);
         }
@@ -511,6 +516,66 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         };
 
         return (wireConfig, callbacks);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="CopilotSession"/>, wires up handlers from the
+    /// session config, registers it with the client, and starts its event
+    /// processing loop. Used by both <see cref="CreateSessionAsync"/> (invoked
+    /// from the JSON-RPC read loop the instant the response arrives, so that
+    /// session events delivered between the response and the awaiter
+    /// resuming are not dropped) and <see cref="ResumeSessionAsync"/>
+    /// (invoked before the RPC is issued, since the session id is known up
+    /// front).
+    /// </summary>
+    private CopilotSession InitializeSession(
+        string sessionId,
+        JsonRpc rpc,
+        SessionConfigBase config,
+        Dictionary<string, Func<string, Task<string>>>? transformCallbacks,
+        bool hasHooks,
+        string callerName)
+    {
+        var setupTimestamp = Stopwatch.GetTimestamp();
+        var session = new CopilotSession(
+            sessionId,
+            rpc,
+            _logger,
+            this);
+        session.RegisterTools(config.Tools ?? []);
+        session.RegisterPermissionHandler(config.OnPermissionRequest);
+        session.RegisterCommands(config.Commands);
+        session.RegisterElicitationHandler(config.OnElicitationRequest);
+        session.RegisterExitPlanModeHandler(config.OnExitPlanModeRequest);
+        session.RegisterAutoModeSwitchHandler(config.OnAutoModeSwitchRequest);
+        if (config.OnUserInputRequest != null)
+        {
+            session.RegisterUserInputHandler(config.OnUserInputRequest);
+        }
+        if (config.Hooks != null)
+        {
+            session.RegisterHooks(config.Hooks);
+        }
+        if (transformCallbacks != null)
+        {
+            session.RegisterTransformCallbacks(transformCallbacks);
+        }
+        if (config.OnEvent != null)
+        {
+            session.On<SessionEvent>(config.OnEvent);
+        }
+        ConfigureSessionFsHandlers(session, config.CreateSessionFsProvider);
+        session.SetCanvasHandler(config.CanvasHandler);
+        RegisterSession(session);
+        session.StartProcessingEvents();
+        LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
+            callerName + " local setup complete. Elapsed={Elapsed}, SessionId={SessionId}, Tools={ToolsCount}, Commands={CommandsCount}, Hooks={HasHooks}",
+            setupTimestamp,
+            sessionId,
+            config.Tools?.Count ?? 0,
+            config.Commands?.Count ?? 0,
+            hasHooks);
+        return session;
     }
 
     /// <summary>
@@ -613,7 +678,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                     return supplied;
                 }
                 var mergedSections = supplied.Sections is null
-                    ? new Dictionary<SystemMessageSection, SectionOverride>()
+                    ? []
                     : new Dictionary<SystemMessageSection, SectionOverride>(supplied.Sections);
                 mergedSections[SystemMessageSection.EnvironmentContext] = new() { Action = SectionOverrideAction.Remove };
                 return new SystemMessageConfig
@@ -664,7 +729,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             customAgentsLocalOnly = config.CustomAgentsLocalOnly ?? true;
             coauthorEnabled = config.CoauthorEnabled ?? false;
             manageScheduleEnabled = config.ManageScheduleEnabled ?? false;
-            installedPlugins = new List<SessionInstalledPlugin>();
+            installedPlugins = [];
             hasAnyPatch = true;
         }
         else
@@ -755,57 +820,36 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
         var (wireSystemMessage, transformCallbacks) = ExtractTransformCallbacks(config.SystemMessage);
 
-        var sessionId = config.SessionId ?? Guid.NewGuid().ToString();
+        // For cloud sessions, let the CLI/server assign the session id and
+        // register the session lazily once the response arrives. For non-cloud
+        // sessions we generate the id client-side (when the caller didn't
+        // supply one) so the session can be registered BEFORE the RPC — the
+        // CLI may issue session-scoped requests (e.g. sessionFs.WriteFile
+        // for workspace metadata) during session.create processing, before
+        // it has sent the response.
+        var useServerGeneratedId = config.Cloud != null && string.IsNullOrEmpty(config.SessionId);
+        var localSessionId = useServerGeneratedId
+            ? null
+            : (string.IsNullOrEmpty(config.SessionId) ? Guid.NewGuid().ToString() : config.SessionId);
 
-        // Create and register the session before issuing the RPC so that
-        // events emitted by the CLI (e.g. session.start) are not dropped.
-        var setupTimestamp = Stopwatch.GetTimestamp();
-        var session = new CopilotSession(
-            sessionId,
-            connection.Rpc,
-            _logger,
-            this);
-        session.RegisterTools(config.Tools ?? []);
-        session.RegisterPermissionHandler(config.OnPermissionRequest);
-        session.RegisterCommands(config.Commands);
-        session.RegisterElicitationHandler(config.OnElicitationRequest);
-        session.RegisterExitPlanModeHandler(config.OnExitPlanModeRequest);
-        session.RegisterAutoModeSwitchHandler(config.OnAutoModeSwitchRequest);
-        if (config.OnUserInputRequest != null)
+        CopilotSession? session = null;
+        if (localSessionId != null)
         {
-            session.RegisterUserInputHandler(config.OnUserInputRequest);
+            session = InitializeSession(
+                localSessionId,
+                connection.Rpc,
+                config,
+                transformCallbacks,
+                hasHooks,
+                "CopilotClient.CreateSessionAsync");
         }
-        if (config.Hooks != null)
-        {
-            session.RegisterHooks(config.Hooks);
-        }
-        if (transformCallbacks != null)
-        {
-            session.RegisterTransformCallbacks(transformCallbacks);
-        }
-        if (config.OnEvent != null)
-        {
-            session.On<SessionEvent>(config.OnEvent);
-        }
-        ConfigureSessionFsHandlers(session, config.CreateSessionFsProvider);
-        session.SetCanvasHandler(config.CanvasHandler);
-        RegisterSession(session);
-        session.StartProcessingEvents();
-        LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
-            "CopilotClient.CreateSessionAsync local setup complete. Elapsed={Elapsed}, SessionId={SessionId}, Tools={ToolsCount}, Commands={CommandsCount}, Hooks={HasHooks}",
-            setupTimestamp,
-            sessionId,
-            config.Tools?.Count ?? 0,
-            config.Commands?.Count ?? 0,
-            hasHooks);
-
         try
         {
             var (traceparent, tracestate) = TelemetryHelpers.GetTraceContext();
 
             var request = new CreateSessionRequest(
                 config.Model,
-                sessionId,
+                localSessionId,
                 config.ClientName,
                 config.ReasoningEffort,
                 config.Tools?.Select(ToolDefinition.FromAIFunction).ToList(),
@@ -848,12 +892,49 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 ToolFilterPrecedence: toolFilter.ToolFilterPrecedence);
 
             var rpcTimestamp = Stopwatch.GetTimestamp();
+
+            // For the server-assigned (cloud) path, register the session
+            // synchronously from the read loop the instant the response
+            // arrives. This closes the small window where a session.event
+            // notification could arrive after the response but before the
+            // awaiter resumes — without this hook the dispatcher would
+            // silently drop those events. Non-cloud sessions are already
+            // registered above (before the RPC).
+            Action<JsonElement>? onResponseInline = session != null ? null : raw =>
+            {
+                if (raw.ValueKind is JsonValueKind.Object
+                    && raw.TryGetProperty("sessionId", out var sessionIdProp)
+                    && sessionIdProp.ValueKind is JsonValueKind.String
+                    && sessionIdProp.GetString() is string sessionId
+                    && !string.IsNullOrEmpty(sessionId))
+                {
+                    session = InitializeSession(
+                        sessionId,
+                        connection.Rpc,
+                        config,
+                        transformCallbacks,
+                        hasHooks,
+                        "CopilotClient.CreateSessionAsync");
+                }
+            };
+
             var response = await InvokeRpcAsync<CreateSessionResponse>(
-                connection.Rpc, "session.create", [request], cancellationToken);
+                connection.Rpc, "session.create", [request], null, cancellationToken, onResponseInline);
             LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
                 "CopilotClient.CreateSessionAsync session creation request completed successfully. Elapsed={Elapsed}, SessionId={SessionId}",
                 rpcTimestamp,
-                sessionId);
+                response.SessionId);
+
+            if (session is null)
+            {
+                throw new InvalidOperationException("session.create response did not include a sessionId.");
+            }
+
+            if (localSessionId != null && !string.Equals(localSessionId, response.SessionId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"session.create returned sessionId {response.SessionId} but the caller requested {localSessionId}.");
+            }
 
             session.WorkspacePath = response.WorkspacePath;
             session.SetCapabilities(response.Capabilities);
@@ -863,21 +944,23 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         }
         catch (Exception ex)
         {
-            session.RemoveFromClient();
+            session?.RemoveFromClient();
+
             if (ex is not OperationCanceledException)
             {
                 LoggingHelpers.LogTiming(_logger, LogLevel.Warning, ex,
                     "CopilotClient.CreateSessionAsync failed. Elapsed={Elapsed}, SessionId={SessionId}",
                     totalTimestamp,
-                    sessionId);
+                    session?.SessionId);
             }
+
             throw;
         }
 
         LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
             "CopilotClient.CreateSessionAsync complete. Elapsed={Elapsed}, SessionId={SessionId}",
             totalTimestamp,
-            sessionId);
+            session.SessionId);
         return session;
     }
 
@@ -932,45 +1015,13 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
         // Create and register the session before issuing the RPC so that
         // events emitted by the CLI (e.g. session.start) are not dropped.
-        var setupTimestamp = Stopwatch.GetTimestamp();
-        var session = new CopilotSession(
+        var session = InitializeSession(
             sessionId,
             connection.Rpc,
-            _logger,
-            client: this);
-        session.RegisterTools(config.Tools ?? []);
-        session.RegisterPermissionHandler(config.OnPermissionRequest);
-        session.RegisterCommands(config.Commands);
-        session.RegisterElicitationHandler(config.OnElicitationRequest);
-        session.RegisterExitPlanModeHandler(config.OnExitPlanModeRequest);
-        session.RegisterAutoModeSwitchHandler(config.OnAutoModeSwitchRequest);
-        if (config.OnUserInputRequest != null)
-        {
-            session.RegisterUserInputHandler(config.OnUserInputRequest);
-        }
-        if (config.Hooks != null)
-        {
-            session.RegisterHooks(config.Hooks);
-        }
-        if (transformCallbacks != null)
-        {
-            session.RegisterTransformCallbacks(transformCallbacks);
-        }
-        if (config.OnEvent != null)
-        {
-            session.On<SessionEvent>(config.OnEvent);
-        }
-        ConfigureSessionFsHandlers(session, config.CreateSessionFsProvider);
-        session.SetCanvasHandler(config.CanvasHandler);
-        RegisterSession(session);
-        session.StartProcessingEvents();
-        LoggingHelpers.LogTiming(_logger, LogLevel.Debug, null,
-            "CopilotClient.ResumeSessionAsync local setup complete. Elapsed={Elapsed}, SessionId={SessionId}, Tools={ToolsCount}, Commands={CommandsCount}, Hooks={HasHooks}",
-            setupTimestamp,
-            sessionId,
-            config.Tools?.Count ?? 0,
-            config.Commands?.Count ?? 0,
-            hasHooks);
+            config,
+            transformCallbacks,
+            hasHooks,
+            "CopilotClient.ResumeSessionAsync");
 
         try
         {
@@ -1117,6 +1168,11 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     /// <exception cref="InvalidOperationException">Thrown when the client is not connected or not authenticated.</exception>
     public async Task<IList<ModelInfo>> ListModelsAsync(CancellationToken cancellationToken = default)
     {
+        if (_modelsCacheLock is null)
+        {
+            Interlocked.CompareExchange(ref _modelsCacheLock, new(1, 1), null);
+        }
+
         await _modelsCacheLock.WaitAsync(cancellationToken);
         try
         {
@@ -1351,14 +1407,14 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
         var subscription = new LifecycleSubscription(typeof(T), evt => handler((T)evt));
 
-        lock (_lifecycleHandlersLock)
+        lock (_lifecycleHandlers)
         {
             _lifecycleHandlers.Add(subscription);
         }
 
         return new ActionDisposable(() =>
         {
-            lock (_lifecycleHandlersLock)
+            lock (_lifecycleHandlers)
             {
                 _lifecycleHandlers.Remove(subscription);
             }
@@ -1367,20 +1423,19 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
     private void DispatchLifecycleEvent(SessionLifecycleEvent evt)
     {
-        List<LifecycleSubscription> snapshot;
-        lock (_lifecycleHandlersLock)
+        LifecycleSubscription[] snapshot;
+        lock (_lifecycleHandlers)
         {
-            snapshot = [.. _lifecycleHandlers];
+            snapshot = _lifecycleHandlers.ToArray();
         }
 
         var eventType = evt.GetType();
         foreach (var subscription in snapshot)
         {
-            if (!subscription.EventType.IsAssignableFrom(eventType))
+            if (subscription.EventType.IsAssignableFrom(eventType))
             {
-                continue;
+                try { subscription.Handler(evt); } catch { /* Ignore handler errors */ }
             }
-            try { subscription.Handler(evt); } catch { /* Ignore handler errors */ }
         }
     }
 
@@ -1404,11 +1459,11 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         return InvokeRpcAsync<object>(rpc, method, args, cancellationToken);
     }
 
-    internal static async Task<T> InvokeRpcAsync<T>(JsonRpc rpc, string method, object?[]? args, StringBuilder? stderrBuffer, CancellationToken cancellationToken)
+    internal static async Task<T> InvokeRpcAsync<T>(JsonRpc rpc, string method, object?[]? args, StringBuilder? stderrBuffer, CancellationToken cancellationToken, Action<JsonElement>? onResponseInline = null)
     {
         try
         {
-            return await rpc.InvokeAsync<T>(method, args, cancellationToken);
+            return await rpc.InvokeAsync<T>(method, args, cancellationToken, onResponseInline);
         }
         catch (ConnectionLostException ex)
         {
@@ -1425,6 +1480,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             {
                 throw new IOException(FormatCliExitedMessage("CLI process exited unexpectedly.", stderrOutput!), ex);
             }
+
             throw new IOException($"Communication error with Copilot CLI: {ex.Message}", ex);
         }
         catch (RemoteRpcException ex)

--- a/dotnet/src/JsonRpc.cs
+++ b/dotnet/src/JsonRpc.cs
@@ -73,11 +73,22 @@ internal sealed partial class JsonRpc : IDisposable
     /// <summary>
     /// Sends a JSON-RPC request and waits for the response.
     /// </summary>
-    public async Task<T> InvokeAsync<T>(string method, object?[]? args, CancellationToken cancellationToken)
+    /// <param name="method">The JSON-RPC method name.</param>
+    /// <param name="args">Positional arguments for the call.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="onResponseInline">
+    /// Optional callback invoked synchronously from the read loop after the
+    /// response is parsed but before the awaiter resumes. Use this when you
+    /// need to mutate client-side state (for example, register a server-assigned
+    /// session id) before any subsequent notification on the same connection is
+    /// dispatched. The callback receives the raw JSON-RPC <c>result</c> element.
+    /// If the callback throws, the exception is propagated to the awaiter.
+    /// </param>
+    public async Task<T> InvokeAsync<T>(string method, object?[]? args, CancellationToken cancellationToken, Action<JsonElement>? onResponseInline = null)
     {
         var timingTimestamp = Stopwatch.GetTimestamp();
         var id = Interlocked.Increment(ref _nextId);
-        var pending = new PendingRequest();
+        var pending = new PendingRequest(onResponseInline);
         _pendingRequests[id] = pending;
 
         CancellationTokenRegistration cancelRegistration = default;
@@ -166,7 +177,7 @@ internal sealed partial class JsonRpc : IDisposable
     /// </summary>
     public void SetLocalRpcMethod(string methodName, Delegate handler, bool singleObjectParam = false)
     {
-        _methods[methodName] = new MethodRegistration(handler, singleObjectParam);
+        _methods[methodName] = new(handler, singleObjectParam);
     }
 
     /// <inheritdoc />
@@ -447,7 +458,24 @@ internal sealed partial class JsonRpc : IDisposable
         }
         else if (message.TryGetProperty("result", out var resultProp))
         {
-            pending.TrySetResult(resultProp.Clone());
+            var cloned = resultProp.Clone();
+            if (pending.OnResultInline is { } inline)
+            {
+                // Run the inline callback synchronously in the read loop so any
+                // state it mutates (e.g. session registration) is visible before
+                // the read loop dispatches the next message.
+                try
+                {
+                    inline(cloned);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Inline response callback for request {RequestId} threw", id);
+                    pending.TrySetException(ex);
+                    return;
+                }
+            }
+            pending.TrySetResult(cloned);
         }
         else
         {
@@ -765,7 +793,17 @@ internal sealed partial class JsonRpc : IDisposable
         }
     }
 
-    private sealed class PendingRequest() : TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously);
+    private sealed class PendingRequest(Action<JsonElement>? onResultInline = null) : TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously)
+    {
+        /// <summary>
+        /// Optional callback invoked synchronously from the read loop after the
+        /// response is parsed but before the awaiter resumes. Used to perform
+        /// state changes that must happen before any subsequent notification on
+        /// the same connection is dispatched (e.g. registering a session whose
+        /// id was assigned by the server in the response).
+        /// </summary>
+        public Action<JsonElement>? OnResultInline { get; } = onResultInline;
+    }
 
     private static readonly MethodInfo s_taskGetResult = typeof(Task<>).GetProperty(nameof(Task<int>.Result), BindingFlags.Instance | BindingFlags.Public)!.GetMethod!;
     private static readonly MethodInfo s_valueTaskAsTask = typeof(ValueTask<>).GetMethod(nameof(ValueTask<int>.AsTask), BindingFlags.Instance | BindingFlags.Public)!;

--- a/dotnet/test/Unit/ClientSessionLifetimeTests.cs
+++ b/dotnet/test/Unit/ClientSessionLifetimeTests.cs
@@ -307,10 +307,19 @@ public sealed class ClientSessionLifetimeTests
 
         private Dictionary<string, object?> CreateSessionResult(JsonElement request)
         {
-            _lastSessionId = request
-                .GetProperty("params")
-                .GetProperty("sessionId")
-                .GetString();
+            string? sessionId = null;
+            if (request.TryGetProperty("params", out var paramsProp)
+                && paramsProp.ValueKind == JsonValueKind.Object
+                && paramsProp.TryGetProperty("sessionId", out var sidProp)
+                && sidProp.ValueKind == JsonValueKind.String)
+            {
+                sessionId = sidProp.GetString();
+            }
+            if (string.IsNullOrEmpty(sessionId))
+            {
+                sessionId = Guid.NewGuid().ToString();
+            }
+            _lastSessionId = sessionId;
 
             return new Dictionary<string, object?>
             {

--- a/dotnet/test/Unit/JsonRpcTests.cs
+++ b/dotnet/test/Unit/JsonRpcTests.cs
@@ -190,7 +190,8 @@ public class JsonRpcTests
                 .GetMethod("InvokeAsync")!
                 .MakeGenericMethod(typeof(T));
 
-            var task = (Task<T>)method.Invoke(_instance, [methodName, args, cancellationToken])!;
+            // Pass null for the optional onResponseInline parameter.
+            var task = (Task<T>)method.Invoke(_instance, [methodName, args, cancellationToken, null])!;
             return await task.ConfigureAwait(false);
         }
 

--- a/go/client.go
+++ b/go/client.go
@@ -689,83 +689,161 @@ func (c *Client) CreateSession(ctx context.Context, config *SessionConfig) (*Ses
 	req.Traceparent = traceparent
 	req.Tracestate = tracestate
 
-	sessionID := config.SessionID
-	if sessionID == "" {
-		sessionID = uuid.New().String()
+	// For cloud sessions, let the CLI/server assign the session id and
+	// register the session lazily once the response arrives. For non-cloud
+	// sessions we generate the id client-side (when the caller didn't
+	// supply one) so the session can be registered BEFORE the RPC — the
+	// CLI may issue session-scoped requests (e.g. sessionFs.writeFile for
+	// workspace metadata) during session.create processing, before it has
+	// sent the response.
+	useServerGeneratedID := config.Cloud != nil && config.SessionID == ""
+	var localSessionID string
+	if useServerGeneratedID {
+		localSessionID = ""
+	} else if config.SessionID != "" {
+		localSessionID = config.SessionID
+	} else {
+		localSessionID = uuid.NewString()
 	}
-	req.SessionID = sessionID
+	req.SessionID = localSessionID
 
-	// Create and register the session before issuing the RPC so that
-	// events emitted by the CLI (e.g. session.start) are not dropped.
-	session := newSession(sessionID, c.client, "")
+	// initializeSession creates the session, wires up handlers, and registers
+	// it in the sessions map. Invoked from the read loop the instant the
+	// session.create response arrives (synchronously, before the next
+	// message is dispatched) so notifications for the new session id are
+	// routed to a registered session.
+	initializeSession := func(sessionID string) (*Session, error) {
+		s := newSession(sessionID, c.client, "")
 
-	session.registerTools(config.Tools)
-	session.registerPermissionHandler(config.OnPermissionRequest)
-	if config.OnUserInputRequest != nil {
-		session.registerUserInputHandler(config.OnUserInputRequest)
-	}
-	if config.Hooks != nil {
-		session.registerHooks(config.Hooks)
-	}
-	if transformCallbacks != nil {
-		session.registerTransformCallbacks(transformCallbacks)
-	}
-	if config.OnEvent != nil {
-		session.On(config.OnEvent)
-	}
-	if len(config.Commands) > 0 {
-		session.registerCommands(config.Commands)
-	}
-	if config.OnElicitationRequest != nil {
-		session.registerElicitationHandler(config.OnElicitationRequest)
-	}
-	if config.OnExitPlanModeRequest != nil {
-		session.registerExitPlanModeHandler(config.OnExitPlanModeRequest)
-	}
-	if config.OnAutoModeSwitchRequest != nil {
-		session.registerAutoModeSwitchHandler(config.OnAutoModeSwitchRequest)
-	}
-	if config.CanvasHandler != nil {
-		session.registerCanvasHandler(config.CanvasHandler)
-	}
-
-	c.sessionsMux.Lock()
-	c.sessions[sessionID] = session
-	c.sessionsMux.Unlock()
-
-	if c.options.SessionFs != nil {
-		if config.CreateSessionFsProvider == nil {
-			c.sessionsMux.Lock()
-			delete(c.sessions, sessionID)
-			c.sessionsMux.Unlock()
-			return nil, fmt.Errorf("CreateSessionFsProvider is required in session config when SessionFs is enabled in client options")
+		s.registerTools(config.Tools)
+		s.registerPermissionHandler(config.OnPermissionRequest)
+		if config.OnUserInputRequest != nil {
+			s.registerUserInputHandler(config.OnUserInputRequest)
 		}
-		provider := config.CreateSessionFsProvider(session)
-		if c.options.SessionFs.Capabilities != nil && c.options.SessionFs.Capabilities.Sqlite {
-			if _, ok := provider.(SessionFsSqliteProvider); !ok {
+		if config.Hooks != nil {
+			s.registerHooks(config.Hooks)
+		}
+		if transformCallbacks != nil {
+			s.registerTransformCallbacks(transformCallbacks)
+		}
+		if config.OnEvent != nil {
+			s.On(config.OnEvent)
+		}
+		if len(config.Commands) > 0 {
+			s.registerCommands(config.Commands)
+		}
+		if config.OnElicitationRequest != nil {
+			s.registerElicitationHandler(config.OnElicitationRequest)
+		}
+		if config.OnExitPlanModeRequest != nil {
+			s.registerExitPlanModeHandler(config.OnExitPlanModeRequest)
+		}
+		if config.OnAutoModeSwitchRequest != nil {
+			s.registerAutoModeSwitchHandler(config.OnAutoModeSwitchRequest)
+		}
+		if config.CanvasHandler != nil {
+			s.registerCanvasHandler(config.CanvasHandler)
+		}
+
+		c.sessionsMux.Lock()
+		c.sessions[sessionID] = s
+		c.sessionsMux.Unlock()
+
+		if c.options.SessionFs != nil {
+			if config.CreateSessionFsProvider == nil {
 				c.sessionsMux.Lock()
 				delete(c.sessions, sessionID)
 				c.sessionsMux.Unlock()
-				return nil, fmt.Errorf("SessionFs capabilities declare SQLite support but the provider does not implement SessionFsSqliteProvider")
+				return nil, fmt.Errorf("CreateSessionFsProvider is required in session config when SessionFs is enabled in client options")
 			}
+			provider := config.CreateSessionFsProvider(s)
+			if c.options.SessionFs.Capabilities != nil && c.options.SessionFs.Capabilities.Sqlite {
+				if _, ok := provider.(SessionFsSqliteProvider); !ok {
+					c.sessionsMux.Lock()
+					delete(c.sessions, sessionID)
+					c.sessionsMux.Unlock()
+					return nil, fmt.Errorf("SessionFs capabilities declare SQLite support but the provider does not implement SessionFsSqliteProvider")
+				}
+			}
+			s.clientSessionApis.SessionFs = newSessionFsAdapter(provider)
 		}
-		session.clientSessionApis.SessionFs = newSessionFsAdapter(provider)
+		return s, nil
 	}
 
-	result, err := c.client.Request("session.create", req)
+	var session *Session
+	var registeredSessionID string
+
+	// Pre-register non-cloud sessions BEFORE issuing the RPC so any
+	// session-scoped requests the CLI emits during session.create processing
+	// (e.g. sessionFs.writeFile for workspace metadata) can be routed to the
+	// correct handlers.
+	if localSessionID != "" {
+		s, err := initializeSession(localSessionID)
+		if err != nil {
+			return nil, err
+		}
+		session = s
+		registeredSessionID = localSessionID
+	}
+
+	// For the server-assigned (cloud) path, register the session
+	// synchronously from the read loop the instant the response arrives,
+	// before the read loop dispatches the next message. Without this hook
+	// the awaiter goroutine may not run until after the read loop has
+	// dispatched the first session.event notification, which would be
+	// silently dropped because the session id isn't yet in the lookup
+	// table. Non-cloud sessions are already registered above.
+	var inlineCb func(raw json.RawMessage) error
+	if session == nil {
+		inlineCb = func(raw json.RawMessage) error {
+			var early struct {
+				SessionID string `json:"sessionId"`
+			}
+			if err := json.Unmarshal(raw, &early); err != nil {
+				return fmt.Errorf("failed to parse sessionId from response: %w", err)
+			}
+			if early.SessionID == "" {
+				return fmt.Errorf("session.create response did not include a sessionId")
+			}
+			s, err := initializeSession(early.SessionID)
+			if err != nil {
+				return err
+			}
+			session = s
+			registeredSessionID = early.SessionID
+			return nil
+		}
+	}
+
+	result, err := c.client.RequestWithInlineResponse("session.create", req, inlineCb)
 	if err != nil {
-		c.sessionsMux.Lock()
-		delete(c.sessions, sessionID)
-		c.sessionsMux.Unlock()
+		if registeredSessionID != "" {
+			c.sessionsMux.Lock()
+			delete(c.sessions, registeredSessionID)
+			c.sessionsMux.Unlock()
+		}
 		return nil, fmt.Errorf("failed to create session: %w", err)
 	}
 
 	var response createSessionResponse
 	if err := json.Unmarshal(result, &response); err != nil {
-		c.sessionsMux.Lock()
-		delete(c.sessions, sessionID)
-		c.sessionsMux.Unlock()
+		if registeredSessionID != "" {
+			c.sessionsMux.Lock()
+			delete(c.sessions, registeredSessionID)
+			c.sessionsMux.Unlock()
+		}
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	if session == nil {
+		return nil, fmt.Errorf("session.create response did not include a sessionId")
+	}
+
+	if localSessionID != "" && response.SessionID != "" && response.SessionID != localSessionID {
+		c.sessionsMux.Lock()
+		delete(c.sessions, registeredSessionID)
+		c.sessionsMux.Unlock()
+		return nil, fmt.Errorf("session.create returned sessionId %s but the caller requested %s", response.SessionID, localSessionID)
 	}
 
 	session.workspacePath = response.WorkspacePath

--- a/go/internal/jsonrpc2/jsonrpc2.go
+++ b/go/internal/jsonrpc2/jsonrpc2.go
@@ -62,30 +62,32 @@ type RequestHandler func(params json.RawMessage) (json.RawMessage, *Error)
 
 // Client is a minimal JSON-RPC 2.0 client for stdio transport.
 type Client struct {
-	reader          *headerReader // reads frames from the remote side
-	stdout          io.ReadCloser
-	writer          chan *headerWriter // 1-buffered; holds the writer when not in use
-	mu              sync.Mutex
-	pendingRequests map[string]chan *Response
-	requestHandlers map[string]RequestHandler
-	running         atomic.Bool
-	stopChan        chan struct{}
-	wg              sync.WaitGroup
-	processDone     chan struct{} // closed when the underlying process exits
-	processErrorPtr *error        // points to the process error
-	processErrorMu  sync.RWMutex  // protects processErrorPtr
-	onClose         func()        // called when the read loop exits unexpectedly
+	reader                 *headerReader // reads frames from the remote side
+	stdout                 io.ReadCloser
+	writer                 chan *headerWriter // 1-buffered; holds the writer when not in use
+	mu                     sync.Mutex
+	pendingRequests        map[string]chan *Response
+	pendingInlineCallbacks map[string]func(json.RawMessage) error
+	requestHandlers        map[string]RequestHandler
+	running                atomic.Bool
+	stopChan               chan struct{}
+	wg                     sync.WaitGroup
+	processDone            chan struct{} // closed when the underlying process exits
+	processErrorPtr        *error        // points to the process error
+	processErrorMu         sync.RWMutex  // protects processErrorPtr
+	onClose                func()        // called when the read loop exits unexpectedly
 }
 
 // NewClient creates a new JSON-RPC client.
 func NewClient(stdin io.WriteCloser, stdout io.ReadCloser) *Client {
 	c := &Client{
-		reader:          newHeaderReader(stdout),
-		stdout:          stdout,
-		writer:          make(chan *headerWriter, 1),
-		pendingRequests: make(map[string]chan *Response),
-		requestHandlers: make(map[string]RequestHandler),
-		stopChan:        make(chan struct{}),
+		reader:                 newHeaderReader(stdout),
+		stdout:                 stdout,
+		writer:                 make(chan *headerWriter, 1),
+		pendingRequests:        make(map[string]chan *Response),
+		pendingInlineCallbacks: make(map[string]func(json.RawMessage) error),
+		requestHandlers:        make(map[string]RequestHandler),
+		stopChan:               make(chan struct{}),
 	}
 	c.writer <- newHeaderWriter(stdin)
 	return c
@@ -201,18 +203,34 @@ func (c *Client) SetRequestHandler(method string, handler RequestHandler) {
 
 // Request sends a JSON-RPC request and waits for the response
 func (c *Client) Request(method string, params any) (json.RawMessage, error) {
+	return c.RequestWithInlineResponse(method, params, nil)
+}
+
+// RequestWithInlineResponse sends a JSON-RPC request and waits for the response,
+// invoking an optional callback synchronously from the read loop the instant a
+// successful response is parsed — before the response is delivered to the
+// awaiter and before the read loop dispatches the next message. Use this when
+// client-side state must be visible (for example, a session id assigned by the
+// server in the response) before any subsequent notification on the same
+// connection is dispatched. If the callback returns an error, that error is
+// returned to the awaiter in place of the response.
+func (c *Client) RequestWithInlineResponse(method string, params any, onResponseInline func(json.RawMessage) error) (json.RawMessage, error) {
 	requestID := generateUUID()
 
 	// Create response channel
 	responseChan := make(chan *Response, 1)
 	c.mu.Lock()
 	c.pendingRequests[requestID] = responseChan
+	if onResponseInline != nil {
+		c.pendingInlineCallbacks[requestID] = onResponseInline
+	}
 	c.mu.Unlock()
 
 	// Clean up on exit
 	defer func() {
 		c.mu.Lock()
 		delete(c.pendingRequests, requestID)
+		delete(c.pendingInlineCallbacks, requestID)
 		c.mu.Unlock()
 	}()
 
@@ -347,13 +365,39 @@ func (c *Client) handleResponse(response *Response) {
 	}
 	c.mu.Lock()
 	responseChan, ok := c.pendingRequests[id]
+	inlineCb := c.pendingInlineCallbacks[id]
+	delete(c.pendingInlineCallbacks, id)
 	c.mu.Unlock()
 
-	if ok {
-		select {
-		case responseChan <- response:
-		default:
-		}
+	if !ok {
+		return
+	}
+
+	// Run the inline callback synchronously in the read loop so any state it
+	// mutates is visible before the read loop dispatches the next message.
+	// Wrap in a recover so a misbehaving callback can't take down the loop.
+	if inlineCb != nil && response.Error == nil {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					response.Error = &Error{
+						Code:    ErrInternal.Code,
+						Message: fmt.Sprintf("inline response callback panicked: %v", r),
+					}
+				}
+			}()
+			if err := inlineCb(response.Result); err != nil {
+				response.Error = &Error{
+					Code:    ErrInternal.Code,
+					Message: err.Error(),
+				}
+			}
+		}()
+	}
+
+	select {
+	case responseChan <- response:
+	default:
 	}
 }
 

--- a/java/src/main/java/com/github/copilot/CopilotClient.java
+++ b/java/src/main/java/com/github/copilot/CopilotClient.java
@@ -443,33 +443,59 @@ public final class CopilotClient implements AutoCloseable {
         }
         return ensureConnected().thenCompose(connection -> {
             long totalNanos = System.nanoTime();
-            // Pre-generate session ID so the session can be registered before the RPC call,
-            // ensuring no events emitted by the CLI during creation are lost.
-            String sessionId = config.getSessionId() != null
-                    ? config.getSessionId()
-                    : java.util.UUID.randomUUID().toString();
+            // For cloud sessions, let the CLI/server assign the session id
+            // and register the session lazily once the response arrives. For
+            // non-cloud sessions we generate the id client-side (when the
+            // caller didn't supply one) so the session can be registered
+            // BEFORE the RPC — the CLI may issue session-scoped requests
+            // (e.g. sessionFs.writeFile for workspace metadata) during
+            // session.create processing, before it has sent the response.
+            String callerSessionId = config.getSessionId();
+            boolean useServerGeneratedId = config.getCloud() != null
+                    && (callerSessionId == null || callerSessionId.isEmpty());
+            String localSessionId = useServerGeneratedId
+                    ? null
+                    : (callerSessionId != null && !callerSessionId.isEmpty()
+                            ? callerSessionId
+                            : java.util.UUID.randomUUID().toString());
 
-            long setupNanos = System.nanoTime();
-            var session = new CopilotSession(sessionId, connection.rpc);
-            if (options.getExecutor() != null) {
-                session.setExecutor(options.getExecutor());
-            }
-            SessionRequestBuilder.configureSession(session, config);
-            sessions.put(sessionId, session);
-            LoggingHelpers.logTiming(LOG, Level.FINE,
-                    "CopilotClient.createSession local setup complete. Elapsed={Elapsed}, SessionId=" + sessionId,
-                    setupNanos);
-
-            // Extract transform callbacks from the system message config.
-            // Callbacks are registered with the session; a wire-safe copy of the
-            // system message (with transform sections replaced by action="transform")
-            // is used in the RPC request.
+            // Extract transform callbacks from the system message config. Callbacks
+            // are registered with the session; a wire-safe copy of the system
+            // message (with transform sections replaced by action="transform") is
+            // used in the RPC request.
             var extracted = SessionRequestBuilder.extractTransformCallbacks(config.getSystemMessage());
-            if (extracted.transformCallbacks() != null) {
-                session.registerTransformCallbacks(extracted.transformCallbacks());
+
+            // Creates the session, wires up handlers, and registers it in the
+            // sessions map.
+            java.util.function.Function<String, CopilotSession> initializeSession = sid -> {
+                long setupNanos = System.nanoTime();
+                var s = new CopilotSession(sid, connection.rpc);
+                if (options.getExecutor() != null) {
+                    s.setExecutor(options.getExecutor());
+                }
+                SessionRequestBuilder.configureSession(s, config);
+                if (extracted.transformCallbacks() != null) {
+                    s.registerTransformCallbacks(extracted.transformCallbacks());
+                }
+                sessions.put(sid, s);
+                LoggingHelpers.logTiming(LOG, Level.FINE,
+                        "CopilotClient.createSession local setup complete. Elapsed={Elapsed}, SessionId=" + sid,
+                        setupNanos);
+                return s;
+            };
+
+            String[] registeredIdHolder = new String[1];
+            CopilotSession[] preRegisteredSessionHolder = new CopilotSession[1];
+
+            // Pre-register non-cloud sessions BEFORE issuing the RPC so any
+            // session-scoped requests the CLI emits during session.create
+            // processing can be routed to the correct handlers.
+            if (localSessionId != null) {
+                preRegisteredSessionHolder[0] = initializeSession.apply(localSessionId);
+                registeredIdHolder[0] = localSessionId;
             }
 
-            var request = SessionRequestBuilder.buildCreateRequest(config, sessionId);
+            var request = SessionRequestBuilder.buildCreateRequest(config, localSessionId);
             if (extracted.wireSystemMessage() != config.getSystemMessage()) {
                 request.setSystemMessage(extracted.wireSystemMessage());
             }
@@ -477,6 +503,9 @@ public final class CopilotClient implements AutoCloseable {
             // Empty mode: validate availableTools and set toolFilterPrecedence
             if (options.getMode() == CopilotClientMode.EMPTY) {
                 if (config.getAvailableTools() == null) {
+                    if (registeredIdHolder[0] != null) {
+                        sessions.remove(registeredIdHolder[0]);
+                    }
                     throw new IllegalArgumentException(
                             "CopilotClient is in Mode = EMPTY but the session config did not specify "
                                     + "availableTools. Empty mode requires every session to explicitly opt into "
@@ -488,20 +517,24 @@ public final class CopilotClient implements AutoCloseable {
             long rpcNanos = System.nanoTime();
             return connection.rpc.invoke("session.create", request, CreateSessionResponse.class)
                     .thenCompose(response -> {
+                        String returnedId = response.sessionId();
                         LoggingHelpers.logTiming(LOG, Level.FINE,
                                 "CopilotClient.createSession session creation request completed. Elapsed={Elapsed}, SessionId="
-                                        + sessionId,
+                                        + (returnedId != null ? returnedId : localSessionId),
                                 rpcNanos);
+                        if (returnedId == null || returnedId.isEmpty()) {
+                            throw new RuntimeException("session.create response did not include a sessionId");
+                        }
+                        if (localSessionId != null && !localSessionId.equals(returnedId)) {
+                            throw new RuntimeException("session.create returned sessionId " + returnedId
+                                    + " but the caller requested " + localSessionId);
+                        }
+                        CopilotSession session = preRegisteredSessionHolder[0] != null
+                                ? preRegisteredSessionHolder[0]
+                                : initializeSession.apply(returnedId);
+                        registeredIdHolder[0] = returnedId;
                         session.setWorkspacePath(response.workspacePath());
                         session.setCapabilities(response.capabilities());
-                        // If the server returned a different sessionId (e.g. a v2 CLI that ignores
-                        // the client-supplied ID), re-key the sessions map.
-                        String returnedId = response.sessionId();
-                        if (returnedId != null && !returnedId.equals(sessionId)) {
-                            sessions.remove(sessionId);
-                            session.setActiveSessionId(returnedId);
-                            sessions.put(returnedId, session);
-                        }
 
                         return updateSessionOptionsForMode(session, config.getSkipCustomInstructions().orElse(null),
                                 config.getCustomAgentsLocalOnly().orElse(null),
@@ -509,19 +542,17 @@ public final class CopilotClient implements AutoCloseable {
                                 config.getManageScheduleEnabled().orElse(null)).thenApply(v -> {
                                     LoggingHelpers.logTiming(LOG, Level.FINE,
                                             "CopilotClient.createSession complete. Elapsed={Elapsed}, SessionId="
-                                                    + sessionId,
+                                                    + session.getSessionId(),
                                             totalNanos);
                                     return session;
                                 });
                     }).exceptionally(ex -> {
-                        sessions.remove(sessionId);
-                        // Also remove the re-keyed entry if the server returned a different ID
-                        String activeId = session.getSessionId();
-                        if (!sessionId.equals(activeId)) {
-                            sessions.remove(activeId);
+                        if (registeredIdHolder[0] != null) {
+                            sessions.remove(registeredIdHolder[0]);
                         }
                         LoggingHelpers.logTiming(LOG, Level.WARNING, ex,
-                                "CopilotClient.createSession failed. Elapsed={Elapsed}, SessionId=" + sessionId,
+                                "CopilotClient.createSession failed. Elapsed={Elapsed}, SessionId="
+                                        + (registeredIdHolder[0] != null ? registeredIdHolder[0] : "<unassigned>"),
                                 totalNanos);
                         throw ex instanceof RuntimeException re ? re : new RuntimeException(ex);
                     });

--- a/java/src/test/java/com/github/copilot/CreateSessionReKeyEntryTest.java
+++ b/java/src/test/java/com/github/copilot/CreateSessionReKeyEntryTest.java
@@ -25,8 +25,10 @@ import com.github.copilot.rpc.PermissionHandler;
 import com.github.copilot.rpc.SessionConfig;
 
 /**
- * Tests for the session-map re-key cleanup paths in CopilotClient when the
- * server returns a different session ID than the client-supplied one.
+ * Tests that CopilotClient rejects session.create responses whose sessionId
+ * differs from the client-supplied one. Re-keying the sessions map at runtime
+ * is intentionally not supported — the server must honor the client-supplied
+ * sessionId (or generate one when none is supplied).
  */
 class CreateSessionReKeyEntryTest {
 
@@ -177,7 +179,7 @@ class CreateSessionReKeyEntryTest {
     }
 
     @Test
-    void createSessionReKeyEntry_successfulReKey_removesOldKeyAndAddsNewKey() throws Exception {
+    void createSession_serverReturnsDifferentSessionId_throwsAndRemovesPreRegisteredEntry() throws Exception {
         String clientSessionId = "client-supplied-id";
         String serverSessionId = "server-returned-id";
 
@@ -188,26 +190,26 @@ class CreateSessionReKeyEntryTest {
             var config = new SessionConfig().setSessionId(clientSessionId)
                     .setOnPermissionRequest(PermissionHandler.APPROVE_ALL);
 
-            CopilotSession session = client.createSession(config).get();
+            ExecutionException ex = assertThrows(ExecutionException.class, () -> client.createSession(config).get());
+            assertNotNull(ex.getCause());
+            assertTrue(ex.getCause().getMessage().contains(serverSessionId),
+                    "Error message should mention the server-returned sessionId");
+            assertTrue(ex.getCause().getMessage().contains(clientSessionId),
+                    "Error message should mention the client-requested sessionId");
 
             Map<String, CopilotSession> sessions = getSessionsMap(client);
-
-            // The old client-supplied key should be removed
             assertNull(sessions.get(clientSessionId),
-                    "Old client-supplied sessionId should be removed from sessions map after re-key");
-            // The new server-returned key should be present
-            assertSame(session, sessions.get(serverSessionId),
-                    "Server-returned sessionId should be the key in sessions map");
-            // The session object should report the server-returned ID
-            assertEquals(serverSessionId, session.getSessionId(),
-                    "Session should report the server-returned sessionId");
+                    "Pre-registered client-supplied sessionId should be removed after rejection");
+            assertNull(sessions.get(serverSessionId),
+                    "Server-returned sessionId should never be registered after rejection");
+            assertTrue(sessions.isEmpty(), "Sessions map should be empty after rejected create");
 
             client.close();
         }
     }
 
     @Test
-    void createSessionReKeyEntry_failureAfterReKey_removesBothKeys() throws Exception {
+    void createSession_serverReturnsDifferentSessionIdWithSkipCustomInstructions_throwsAndCleansUp() throws Exception {
         String clientSessionId = "client-supplied-id";
         String serverSessionId = "server-returned-id";
 
@@ -215,29 +217,27 @@ class CreateSessionReKeyEntryTest {
             var client = new CopilotClient(new CopilotClientOptions().setAutoStart(false));
             injectConnection(client, server.rpcClient);
 
-            // Set skipCustomInstructions so that session.options.update is actually invoked
+            // Even when skipCustomInstructions would trigger session.options.update,
+            // the sessionId-mismatch error fires first and short-circuits the flow.
             var config = new SessionConfig().setSessionId(clientSessionId)
                     .setOnPermissionRequest(PermissionHandler.APPROVE_ALL).setSkipCustomInstructions(true);
 
-            // The session.options.update will fail, triggering the exceptionally handler
             ExecutionException ex = assertThrows(ExecutionException.class, () -> client.createSession(config).get());
             assertNotNull(ex.getCause());
 
             Map<String, CopilotSession> sessions = getSessionsMap(client);
-
-            // Both the original and re-keyed entries should be cleaned up
             assertNull(sessions.get(clientSessionId),
-                    "Original client-supplied sessionId should be removed on failure");
+                    "Pre-registered client-supplied sessionId should be removed on failure");
             assertNull(sessions.get(serverSessionId),
-                    "Re-keyed server-returned sessionId should be removed on failure");
-            assertTrue(sessions.isEmpty(), "Sessions map should be empty after failed create with re-key");
+                    "Server-returned sessionId should never be registered on failure");
+            assertTrue(sessions.isEmpty(), "Sessions map should be empty after failed create");
 
             client.close();
         }
     }
 
     @Test
-    void createSessionReKeyEntry_noReKey_sameIdKept() throws Exception {
+    void createSession_serverReturnsSameSessionId_sessionKeptUnderClientId() throws Exception {
         String sessionId = "same-id-for-both";
 
         try (var server = new ReKeyServer(sessionId, false)) {

--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -996,49 +996,72 @@ export class CopilotClient {
         config = { ...this.configDefaultsForMode(), ...config };
         config.systemMessage = this.getSystemMessageConfigForMode(config.systemMessage);
 
-        const sessionId = config.sessionId ?? randomUUID();
-
-        // Create and register the session before issuing the RPC so that
-        // events emitted by the CLI (e.g. session.start) are not dropped.
-        const session = new CopilotSession(
-            sessionId,
-            this.connection!,
-            undefined,
-            this.onGetTraceContext
-        );
-        session.registerTools(config.tools);
-        session.registerCanvases(config.canvases);
-        session.registerCommands(config.commands);
-        session.registerPermissionHandler(config.onPermissionRequest);
-        if (config.onUserInputRequest) {
-            session.registerUserInputHandler(config.onUserInputRequest);
-        }
-        if (config.onElicitationRequest) {
-            session.registerElicitationHandler(config.onElicitationRequest);
-        }
-        if (config.onExitPlanModeRequest) {
-            session.registerExitPlanModeHandler(config.onExitPlanModeRequest);
-        }
-        if (config.onAutoModeSwitchRequest) {
-            session.registerAutoModeSwitchHandler(config.onAutoModeSwitchRequest);
-        }
-        if (config.hooks) {
-            session.registerHooks(config.hooks);
-        }
+        // For cloud sessions, let the CLI/server assign the session id and
+        // register the session lazily once the response arrives. For non-cloud
+        // sessions we generate the id client-side (when the caller didn't
+        // supply one) so the session can be registered BEFORE the RPC — the
+        // CLI may issue session-scoped requests (e.g. `sessionFs.writeFile`
+        // for workspace metadata) during `session.create` processing, before
+        // it has sent the response.
+        const callerSessionId = config.sessionId;
+        const useServerGeneratedId = config.cloud != null && callerSessionId == null;
+        const localSessionId = useServerGeneratedId ? undefined : (callerSessionId ?? randomUUID());
 
         // Extract transform callbacks from system message config before serialization.
         const { wirePayload: wireSystemMessage, transformCallbacks } = extractTransformCallbacks(
             config.systemMessage
         );
-        if (transformCallbacks) {
-            session.registerTransformCallbacks(transformCallbacks);
-        }
 
-        if (config.onEvent) {
-            session.on(config.onEvent);
+        // Creates the session object, wires up handlers, and registers it in
+        // the sessions map.
+        const initializeSession = (sessionId: string): CopilotSession => {
+            const s = new CopilotSession(
+                sessionId,
+                this.connection!,
+                undefined,
+                this.onGetTraceContext
+            );
+            s.registerTools(config.tools);
+            s.registerCanvases(config.canvases);
+            s.registerCommands(config.commands);
+            s.registerPermissionHandler(config.onPermissionRequest);
+            if (config.onUserInputRequest) {
+                s.registerUserInputHandler(config.onUserInputRequest);
+            }
+            if (config.onElicitationRequest) {
+                s.registerElicitationHandler(config.onElicitationRequest);
+            }
+            if (config.onExitPlanModeRequest) {
+                s.registerExitPlanModeHandler(config.onExitPlanModeRequest);
+            }
+            if (config.onAutoModeSwitchRequest) {
+                s.registerAutoModeSwitchHandler(config.onAutoModeSwitchRequest);
+            }
+            if (config.hooks) {
+                s.registerHooks(config.hooks);
+            }
+            if (transformCallbacks) {
+                s.registerTransformCallbacks(transformCallbacks);
+            }
+            if (config.onEvent) {
+                s.on(config.onEvent);
+            }
+            this.sessions.set(sessionId, s);
+            this.setupSessionFs(s, config);
+            return s;
+        };
+
+        let session: CopilotSession | undefined;
+        let registeredId: string | undefined;
+
+        // Pre-register non-cloud sessions BEFORE issuing the RPC so any
+        // session-scoped requests the CLI emits during `session.create`
+        // processing (e.g. sessionFs.writeFile for workspace metadata) can be
+        // routed to the correct handlers.
+        if (localSessionId !== undefined) {
+            session = initializeSession(localSessionId);
+            registeredId = localSessionId;
         }
-        this.sessions.set(sessionId, session);
-        this.setupSessionFs(session, config);
 
         const toolFilterOptions = this.resolveToolFilterOptions(config);
 
@@ -1046,7 +1069,7 @@ export class CopilotClient {
             const response = await this.connection!.sendRequest("session.create", {
                 ...(await getTraceContext(this.onGetTraceContext)),
                 model: config.model,
-                sessionId,
+                sessionId: localSessionId,
                 clientName: config.clientName,
                 reasoningEffort: config.reasoningEffort,
                 tools: config.tools?.map((tool) => ({
@@ -1096,17 +1119,37 @@ export class CopilotClient {
                 cloud: config.cloud,
             });
 
-            const { workspacePath, capabilities } = response as {
+            const {
+                sessionId: returnedSessionId,
+                workspacePath,
+                capabilities,
+            } = response as {
                 sessionId: string;
                 workspacePath?: string;
                 capabilities?: SessionCapabilities;
             };
+            if (!returnedSessionId) {
+                throw new Error("session.create response did not include a sessionId");
+            }
+            if (localSessionId !== undefined && localSessionId !== returnedSessionId) {
+                throw new Error(
+                    `session.create returned sessionId ${returnedSessionId} but the caller requested ${localSessionId}`
+                );
+            }
+            if (session === undefined) {
+                // Cloud / server-assigned path: register the session now that
+                // the CLI has told us which id it chose.
+                session = initializeSession(returnedSessionId);
+                registeredId = returnedSessionId;
+            }
             session["_workspacePath"] = workspacePath;
             session.setCapabilities(capabilities);
 
             await this.updateSessionOptionsForMode(session, config);
         } catch (e) {
-            this.sessions.delete(sessionId);
+            if (registeredId !== undefined) {
+                this.sessions.delete(registeredId);
+            }
             throw e;
         }
 

--- a/nodejs/test/client.test.ts
+++ b/nodejs/test/client.test.ts
@@ -38,7 +38,8 @@ describe("CopilotClient", () => {
         const spy = vi
             .spyOn((client as any).connection!, "sendRequest")
             .mockImplementation(async (method: string, params: any) => {
-                if (method === "session.create") return { sessionId: params.sessionId };
+                if (method === "session.create")
+                    return { sessionId: params.sessionId ?? "session-id" };
                 throw new Error(`Unexpected method: ${method}`);
             });
 
@@ -398,7 +399,8 @@ describe("CopilotClient", () => {
         const spy = vi
             .spyOn((client as any).connection!, "sendRequest")
             .mockImplementation(async (method: string, params: any) => {
-                if (method === "session.create") return { sessionId: params.sessionId };
+                if (method === "session.create")
+                    return { sessionId: params.sessionId ?? "session-id" };
                 throw new Error(`Unexpected method: ${method}`);
             });
 

--- a/nodejs/test/toolSet.test.ts
+++ b/nodejs/test/toolSet.test.ts
@@ -127,7 +127,7 @@ describe("Tool filter wiring", () => {
             .spyOn((client as any).connection!, "sendRequest")
             .mockImplementation(async (method: string, params: any) => {
                 if (method === "session.create" || method === "session.resume") {
-                    return { sessionId: params.sessionId };
+                    return { sessionId: params.sessionId ?? "session-id" };
                 }
                 if (method === "session.options.update") {
                     return { success: true };
@@ -225,7 +225,7 @@ describe("Empty-mode safe defaults", () => {
             .spyOn((client as any).connection!, "sendRequest")
             .mockImplementation(async (method: string, params: any) => {
                 if (method === "session.create" || method === "session.resume") {
-                    return { sessionId: params.sessionId };
+                    return { sessionId: params.sessionId ?? "session-id" };
                 }
                 if (method === "session.options.update") {
                     return { success: true };
@@ -401,7 +401,8 @@ describe("Empty-mode safe defaults", () => {
         onTestFinished(() => client.forceStop());
         vi.spyOn((client as any).connection!, "sendRequest").mockImplementation(
             async (method: string, params: any) => {
-                if (method === "session.create") return { sessionId: params.sessionId };
+                if (method === "session.create")
+                    return { sessionId: params.sessionId ?? "session-id" };
                 if (method === "session.options.update") {
                     throw new Error("update rejected");
                 }

--- a/python/copilot/_jsonrpc.py
+++ b/python/copilot/_jsonrpc.py
@@ -78,6 +78,7 @@ class JsonRpcClient:
         """
         self.process = process
         self.pending_requests: dict[str, asyncio.Future] = {}
+        self._pending_inline_callbacks: dict[str, Callable[[Any], None]] = {}
         self.notification_handler: Callable[[str, dict], None] | None = None
         self.request_handlers: dict[str, RequestHandler] = {}
         self._running = False
@@ -134,7 +135,12 @@ class JsonRpcClient:
             self._stderr_thread.join(timeout=1.0)
 
     async def request(
-        self, method: str, params: dict | None = None, timeout: float | None = None
+        self,
+        method: str,
+        params: dict | None = None,
+        timeout: float | None = None,
+        *,
+        on_response_inline: Callable[[Any], None] | None = None,
     ) -> Any:
         """
         Send a JSON-RPC request and wait for the response.
@@ -144,6 +150,14 @@ class JsonRpcClient:
             params: Optional parameters
             timeout: Optional request timeout in seconds. If None (default),
                 waits indefinitely for the server to respond.
+            on_response_inline: Optional synchronous callback invoked from the
+                reader thread the instant a successful response is parsed,
+                before the awaiter's future is scheduled on the event loop.
+                Use this to perform state mutations (for example, registering
+                a server-assigned session id) that must be visible before any
+                subsequent notification on the same connection is dispatched.
+                The callback receives the parsed JSON result. If the callback
+                raises, the exception is propagated to the awaiter.
 
         Returns:
             The result from the response
@@ -162,6 +176,8 @@ class JsonRpcClient:
         future = self._loop.create_future()
         with self._pending_lock:
             self.pending_requests[request_id] = future
+            if on_response_inline is not None:
+                self._pending_inline_callbacks[request_id] = on_response_inline
 
         message = {
             "jsonrpc": "2.0",
@@ -195,6 +211,7 @@ class JsonRpcClient:
         finally:
             with self._pending_lock:
                 self.pending_requests.pop(request_id, None)
+                self._pending_inline_callbacks.pop(request_id, None)
 
     async def notify(self, method: str, params: dict | None = None):
         """
@@ -343,6 +360,7 @@ class JsonRpcClient:
         if "id" in message:
             with self._pending_lock:
                 future = self.pending_requests.get(message["id"])
+                inline_cb = self._pending_inline_callbacks.pop(message["id"], None)
 
             if future is not None:
                 loop = future.get_loop()
@@ -356,7 +374,22 @@ class JsonRpcClient:
                     )
                     loop.call_soon_threadsafe(future.set_exception, exc)
                 elif "result" in message:
-                    loop.call_soon_threadsafe(future.set_result, message["result"])
+                    result = message["result"]
+                    # Invoke the inline callback synchronously in the reader
+                    # thread so any state it mutates is visible before the next
+                    # message (e.g. a session.event notification) is dispatched.
+                    if inline_cb is not None:
+                        try:
+                            inline_cb(result)
+                        except Exception as exc:  # pylint: disable=broad-except
+                            logger.warning(
+                                "Inline response callback for request %s raised",
+                                message["id"],
+                                exc_info=True,
+                            )
+                            loop.call_soon_threadsafe(future.set_exception, exc)
+                            return
+                    loop.call_soon_threadsafe(future.set_result, result)
                 else:
                     exc = ValueError("Invalid JSON-RPC response")
                     loop.call_soon_threadsafe(future.set_exception, exc)

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -1845,82 +1845,140 @@ class CopilotClient:
             raise RuntimeError("Client not connected")
 
         total_start = time.perf_counter()
-        actual_session_id = session_id or str(uuid.uuid4())
-        payload["sessionId"] = actual_session_id
+        # For cloud sessions, let the CLI/server assign the session id and
+        # register the session lazily once the response arrives. For non-cloud
+        # sessions we generate the id client-side (when the caller didn't
+        # supply one) so the session can be registered BEFORE the RPC — the
+        # CLI may issue session-scoped requests (e.g. ``sessionFs.writeFile``
+        # for workspace metadata) during ``session.create`` processing, before
+        # it has sent the response.
+        use_server_generated_id = cloud is not None and session_id is None
+        local_session_id: str | None = (
+            None if use_server_generated_id else (session_id or str(uuid.uuid4()))
+        )
+        if local_session_id is not None:
+            payload["sessionId"] = local_session_id
 
         # Propagate W3C Trace Context to CLI if OpenTelemetry is active
         trace_ctx = get_trace_context()
         payload.update(trace_ctx)
 
-        # Create and register the session before issuing the RPC so that
-        # events emitted by the CLI (e.g. session.start) are not dropped.
-        setup_start = time.perf_counter()
-        session = CopilotSession(actual_session_id, self._client, workspace_path=None)
-        if self._session_fs_config:
-            if create_session_fs_handler is None:
-                raise ValueError(
-                    "create_session_fs_handler is required in session config when "
-                    "session_fs is enabled in client options."
-                )
-            fs_provider: SessionFsProvider = create_session_fs_handler(session)
-            caps = self._session_fs_config.get("capabilities")
-            if caps and caps.get("sqlite"):
-                from .session_fs_provider import SessionFsSqliteProvider
+        def _initialize_session(sid: str) -> CopilotSession:
+            """Create the session, wire up handlers, and register it.
 
-                if not isinstance(fs_provider, SessionFsSqliteProvider):
+            Invoked from the reader thread the instant the session.create
+            response arrives (synchronously, before the next message is
+            dispatched) so notifications for the new session id are routed
+            to a registered session.
+            """
+            setup_start = time.perf_counter()
+            s = CopilotSession(sid, self._client, workspace_path=None)
+            if self._session_fs_config:
+                if create_session_fs_handler is None:
                     raise ValueError(
-                        "SessionFs capabilities declare SQLite support but the provider "
-                        "does not implement SessionFsSqliteProvider"
+                        "create_session_fs_handler is required in session config when "
+                        "session_fs is enabled in client options."
                     )
-            session._client_session_apis.session_fs = create_session_fs_adapter(fs_provider)
-        session._register_tools(tools)
-        session._register_commands(commands)
-        session._register_permission_handler(on_permission_request)
-        if on_user_input_request:
-            session._register_user_input_handler(on_user_input_request)
-        if on_elicitation_request:
-            session._register_elicitation_handler(on_elicitation_request)
-        if on_exit_plan_mode_request:
-            session._register_exit_plan_mode_handler(on_exit_plan_mode_request)
-        if on_auto_mode_switch_request:
-            session._register_auto_mode_switch_handler(on_auto_mode_switch_request)
-        if canvas_handler is not None:
-            session._register_canvas_handler(canvas_handler)
-        if hooks:
-            session._register_hooks(hooks)
-        if transform_callbacks:
-            session._register_transform_callbacks(transform_callbacks)
-        if on_event:
-            session.on(on_event)
-        with self._sessions_lock:
-            self._sessions[actual_session_id] = session
-        log_timing(
-            logger,
-            logging.DEBUG,
-            "CopilotClient.create_session local setup complete",
-            setup_start,
-            session_id=actual_session_id,
-            tools_count=len(tools or []),
-            commands_count=len(commands or []),
-            has_hooks=hooks is not None,
-        )
+                fs_provider: SessionFsProvider = create_session_fs_handler(s)
+                caps = self._session_fs_config.get("capabilities")
+                if caps and caps.get("sqlite"):
+                    from .session_fs_provider import SessionFsSqliteProvider
+
+                    if not isinstance(fs_provider, SessionFsSqliteProvider):
+                        raise ValueError(
+                            "SessionFs capabilities declare SQLite support but the provider "
+                            "does not implement SessionFsSqliteProvider"
+                        )
+                s._client_session_apis.session_fs = create_session_fs_adapter(fs_provider)
+            s._register_tools(tools)
+            s._register_commands(commands)
+            s._register_permission_handler(on_permission_request)
+            if on_user_input_request:
+                s._register_user_input_handler(on_user_input_request)
+            if on_elicitation_request:
+                s._register_elicitation_handler(on_elicitation_request)
+            if on_exit_plan_mode_request:
+                s._register_exit_plan_mode_handler(on_exit_plan_mode_request)
+            if on_auto_mode_switch_request:
+                s._register_auto_mode_switch_handler(on_auto_mode_switch_request)
+            if canvas_handler is not None:
+                s._register_canvas_handler(canvas_handler)
+            if hooks:
+                s._register_hooks(hooks)
+            if transform_callbacks:
+                s._register_transform_callbacks(transform_callbacks)
+            if on_event:
+                s.on(on_event)
+            with self._sessions_lock:
+                self._sessions[sid] = s
+            log_timing(
+                logger,
+                logging.DEBUG,
+                "CopilotClient.create_session local setup complete",
+                setup_start,
+                session_id=sid,
+                tools_count=len(tools or []),
+                commands_count=len(commands or []),
+                has_hooks=hooks is not None,
+            )
+            return s
+
+        session: CopilotSession | None = None
+        registered_session_id: str | None = None
+
+        # Pre-register non-cloud sessions BEFORE issuing the RPC so any
+        # session-scoped requests the CLI emits during session.create
+        # processing (e.g. sessionFs.writeFile for workspace metadata) can be
+        # routed to the correct handlers.
+        if local_session_id is not None:
+            session = _initialize_session(local_session_id)
+            registered_session_id = local_session_id
 
         try:
             rpc_start = time.perf_counter()
-            response = await self._client.request("session.create", payload)
+
+            # For the server-assigned (cloud) path, register the session
+            # synchronously from the reader thread the instant the response
+            # arrives, before the next message can be dispatched. The
+            # awaiter's continuation otherwise runs after the event loop has
+            # already processed the first session.event notification, which
+            # would silently drop because the session id isn't yet
+            # registered. Non-cloud sessions are already registered above.
+            def _register_inline(raw_response: Any) -> None:
+                nonlocal session, registered_session_id
+                if session is not None:
+                    return
+                if not isinstance(raw_response, dict):
+                    return
+                sid = raw_response.get("sessionId")
+                if isinstance(sid, str) and sid:
+                    session = _initialize_session(sid)
+                    registered_session_id = sid
+
+            response = await self._client.request(
+                "session.create", payload, on_response_inline=_register_inline
+            )
             log_timing(
                 logger,
                 logging.DEBUG,
                 "CopilotClient.create_session session creation request completed successfully",
                 rpc_start,
-                session_id=actual_session_id,
+                session_id=registered_session_id,
             )
+            if session is None:
+                raise RuntimeError("session.create response did not include a sessionId")
+            if local_session_id is not None and response.get("sessionId") != local_session_id:
+                raise RuntimeError(
+                    f"session.create returned sessionId {response.get('sessionId')} "
+                    f"but the caller requested {local_session_id}"
+                )
             session._workspace_path = response.get("workspacePath")
             capabilities = response.get("capabilities")
             session._set_capabilities(capabilities)
         except BaseException as exc:
-            with self._sessions_lock:
-                self._sessions.pop(actual_session_id, None)
+            if registered_session_id is not None:
+                with self._sessions_lock:
+                    self._sessions.pop(registered_session_id, None)
             if not isinstance(exc, asyncio.CancelledError):
                 log_timing(
                     logger,
@@ -1928,7 +1986,7 @@ class CopilotClient:
                     "CopilotClient.create_session failed",
                     total_start,
                     exc_info=True,
-                    session_id=actual_session_id,
+                    session_id=registered_session_id,
                 )
             raise
 
@@ -1946,7 +2004,7 @@ class CopilotClient:
             logging.DEBUG,
             "CopilotClient.create_session complete",
             total_start,
-            session_id=actual_session_id,
+            session_id=registered_session_id,
         )
         return session
 

--- a/python/e2e/test_client_options_e2e.py
+++ b/python/e2e/test_client_options_e2e.py
@@ -142,7 +142,7 @@ function handleMessage(message) {
     return;
   }
   if (message.method === "session.create") {
-    const sessionId = message.params?.session_id ?? "fake-session";
+    const sessionId = message.params?.sessionId ?? message.params?.session_id ?? "fake-session";
     writeResponse(message.id, { sessionId, workspacePath: null, capabilities: null });
     return;
   }

--- a/python/test_client.py
+++ b/python/test_client.py
@@ -70,10 +70,16 @@ class TestCreateSessionConfig:
         try:
             captured = {}
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 if method == "session.create":
-                    return {"sessionId": params["sessionId"], "workspacePath": None}
+                    # Cloud sessions: server assigns the id if the client didn't.
+                    sid = params.get("sessionId") or "server-assigned-session"
+                    result = {"sessionId": sid, "workspacePath": None}
+                    callback = kwargs.get("on_response_inline")
+                    if callback is not None:
+                        callback(result)
+                    return result
                 return {}
 
             client._client.request = mock_request
@@ -263,9 +269,9 @@ class TestOverridesBuiltInTool:
             captured = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
-                return await original_request(method, params)
+                return await original_request(method, params, **kwargs)
 
             client._client.request = mock_request
 
@@ -295,7 +301,7 @@ class TestOverridesBuiltInTool:
 
             captured = {}
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 # Return a fake response instead of calling the real CLI,
                 # which would fail without auth credentials.
@@ -328,10 +334,15 @@ class TestInstructionDirectories:
         try:
             captured = {}
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 if method == "session.create":
-                    return {"sessionId": params["sessionId"], "workspacePath": None}
+                    sid = params.get("sessionId") or "session-id"
+                    result = {"sessionId": sid, "workspacePath": None}
+                    callback = kwargs.get("on_response_inline")
+                    if callback is not None:
+                        callback(result)
+                    return result
                 return {}
 
             client._client.request = mock_request
@@ -356,7 +367,7 @@ class TestInstructionDirectories:
         try:
             captured = {}
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 if method == "session.resume":
                     return {"sessionId": params["sessionId"], "workspacePath": None}
@@ -509,9 +520,9 @@ class TestSessionConfigForwarding:
             captured = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
-                return await original_request(method, params)
+                return await original_request(method, params, **kwargs)
 
             client._client.request = mock_request
             await client.create_session(
@@ -534,12 +545,12 @@ class TestSessionConfigForwarding:
             captured = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 if method == "session.resume":
                     # Return a fake response to avoid needing real auth
                     return {"sessionId": session.session_id}
-                return await original_request(method, params)
+                return await original_request(method, params, **kwargs)
 
             client._client.request = mock_request
             await client.resume_session(
@@ -560,9 +571,9 @@ class TestSessionConfigForwarding:
             captured = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
-                return await original_request(method, params)
+                return await original_request(method, params, **kwargs)
 
             client._client.request = mock_request
             await client.create_session(
@@ -586,11 +597,11 @@ class TestSessionConfigForwarding:
             captured = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 if method == "session.resume":
                     return {"sessionId": session.session_id}
-                return await original_request(method, params)
+                return await original_request(method, params, **kwargs)
 
             client._client.request = mock_request
             await client.resume_session(
@@ -611,11 +622,16 @@ class TestSessionConfigForwarding:
             captured = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 if method == "session.create":
-                    return {"sessionId": params["sessionId"]}
-                return await original_request(method, params)
+                    sid = params.get("sessionId") or "session-id"
+                    result = {"sessionId": sid}
+                    callback = kwargs.get("on_response_inline")
+                    if callback is not None:
+                        callback(result)
+                    return result
+                return await original_request(method, params, **kwargs)
 
             client._client.request = mock_request
             await client.create_session(
@@ -653,11 +669,11 @@ class TestSessionConfigForwarding:
             captured = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 if method == "session.resume":
                     return {"sessionId": session.session_id}
-                return await original_request(method, params)
+                return await original_request(method, params, **kwargs)
 
             client._client.request = mock_request
             await client.resume_session(
@@ -696,11 +712,11 @@ class TestSessionConfigForwarding:
             captured = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 if method == "session.send":
                     return {"messageId": "msg-1"}
-                return await original_request(method, params)
+                return await original_request(method, params, **kwargs)
 
             client._client.request = mock_request
             await session.send(
@@ -724,9 +740,9 @@ class TestSessionConfigForwarding:
             captured = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
-                return await original_request(method, params)
+                return await original_request(method, params, **kwargs)
 
             client._client.request = mock_request
             await client.create_session(
@@ -751,11 +767,11 @@ class TestSessionConfigForwarding:
             captured = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 if method == "session.resume":
                     return {"sessionId": session.session_id}
-                return await original_request(method, params)
+                return await original_request(method, params, **kwargs)
 
             client._client.request = mock_request
             await client.resume_session(
@@ -777,9 +793,9 @@ class TestSessionConfigForwarding:
             captured = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
-                return await original_request(method, params)
+                return await original_request(method, params, **kwargs)
 
             client._client.request = mock_request
             await client.create_session(
@@ -800,9 +816,9 @@ class TestSessionConfigForwarding:
             captured = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
-                return await original_request(method, params)
+                return await original_request(method, params, **kwargs)
 
             client._client.request = mock_request
             await client.create_session(
@@ -826,11 +842,11 @@ class TestSessionConfigForwarding:
             captured = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 if method == "session.resume":
                     return {"sessionId": session.session_id}
-                return await original_request(method, params)
+                return await original_request(method, params, **kwargs)
 
             client._client.request = mock_request
             await client.resume_session(
@@ -856,11 +872,11 @@ class TestSessionConfigForwarding:
             captured = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 if method == "session.resume":
                     return {"sessionId": session.session_id}
-                return await original_request(method, params)
+                return await original_request(method, params, **kwargs)
 
             client._client.request = mock_request
             await client.resume_session(
@@ -885,11 +901,11 @@ class TestSessionConfigForwarding:
             captured: dict = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 if method == "session.resume":
                     return {"sessionId": session.session_id}
-                return await original_request(method, params)
+                return await original_request(method, params, **kwargs)
 
             client._client.request = mock_request
             await client.resume_session(
@@ -914,11 +930,11 @@ class TestSessionConfigForwarding:
             captured: dict = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 if method == "session.resume":
                     return {"sessionId": session.session_id}
-                return await original_request(method, params)
+                return await original_request(method, params, **kwargs)
 
             client._client.request = mock_request
             await client.resume_session(
@@ -942,11 +958,11 @@ class TestSessionConfigForwarding:
             captured = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 if method == "session.model.switchTo":
                     return {}
-                return await original_request(method, params)
+                return await original_request(method, params, **kwargs)
 
             client._client.request = mock_request
             await session.set_model("gpt-4.1")

--- a/python/test_commands_and_elicitation.py
+++ b/python/test_commands_and_elicitation.py
@@ -56,7 +56,7 @@ class TestCommands:
             captured: dict = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 return await original_request(method, params)
 
@@ -98,7 +98,7 @@ class TestCommands:
 
             captured: dict = {}
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 if method == "session.resume":
                     return {"sessionId": params["sessionId"]}
@@ -146,7 +146,7 @@ class TestCommands:
             rpc_calls: list[tuple] = []
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 if method == "session.commands.handlePendingCommand":
                     rpc_calls.append((method, params))
                     return {"success": True}
@@ -215,7 +215,7 @@ class TestCommands:
             rpc_calls: list[tuple] = []
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 if method == "session.commands.handlePendingCommand":
                     rpc_calls.append((method, params))
                     return {"success": True}
@@ -269,7 +269,7 @@ class TestCommands:
             rpc_calls: list[tuple] = []
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 if method == "session.commands.handlePendingCommand":
                     rpc_calls.append((method, params))
                     return {"success": True}
@@ -322,7 +322,7 @@ class TestUiElicitation:
         try:
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 if method == "session.create":
                     result = await original_request(method, params)
                     return {**result, "capabilities": {"ui": {"elicitation": True}}}
@@ -415,7 +415,7 @@ class TestOnElicitationContext:
             captured: dict = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 return await original_request(method, params)
 
@@ -447,7 +447,7 @@ class TestOnElicitationContext:
             captured: dict = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 return await original_request(method, params)
 
@@ -475,7 +475,7 @@ class TestOnElicitationContext:
             captured: dict = {}
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 return await original_request(method, params)
 
@@ -516,7 +516,7 @@ class TestOnElicitationContext:
             )
             captured: dict = {}
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 captured[method] = params
                 if method == "session.resume":
                     return {"sessionId": params["sessionId"]}
@@ -620,7 +620,7 @@ class TestOnElicitationContext:
             rpc_calls: list[tuple] = []
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 if method == "session.ui.handlePendingElicitation":
                     rpc_calls.append((method, params))
                     return {"success": True}
@@ -667,7 +667,7 @@ class TestOnElicitationContext:
             rpc_calls: list[tuple] = []
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 if method == "session.ui.handlePendingElicitation":
                     rpc_calls.append((method, params))
                     return {"success": True}
@@ -727,7 +727,7 @@ class TestOnElicitationContext:
 
             original_request = client._client.request
 
-            async def mock_request(method, params):
+            async def mock_request(method, params, **kwargs):
                 if method == "session.ui.handlePendingElicitation":
                     return {"success": True}
                 return await original_request(method, params)

--- a/rust/src/jsonrpc.rs
+++ b/rust/src/jsonrpc.rs
@@ -13,6 +13,25 @@ use tracing::{Instrument, debug, error, warn};
 
 use crate::{Error, ErrorKind, ProtocolErrorKind};
 
+/// Callback invoked synchronously by the JSON-RPC read loop the instant a
+/// successful response is parsed, before the response is delivered to the
+/// awaiter and before the read loop dispatches the next message. Use this
+/// when client-side state (for example, registering a server-assigned
+/// session id with the router) must be visible to any subsequent
+/// notification on the same connection.
+///
+/// If the callback returns an error, that error is delivered to the
+/// awaiter in place of the response.
+pub(crate) type InlineResponseCallback =
+    Box<dyn FnOnce(&JsonRpcResponse) -> Result<(), Error> + Send + Sync>;
+
+/// Internal pairing of the response delivery channel with an optional
+/// inline callback that the read loop runs synchronously before delivery.
+struct PendingRequest {
+    sender: oneshot::Sender<JsonRpcResponse>,
+    inline_callback: Option<InlineResponseCallback>,
+}
+
 /// A JSON-RPC 2.0 request message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -182,7 +201,7 @@ pub struct JsonRpcClient {
     /// for cancel-safety, and JSON-RPC frames are small relative to the
     /// natural request/response back-pressure of the wire.
     write_tx: mpsc::UnboundedSender<WriteCommand>,
-    pending_requests: Arc<RwLock<HashMap<u64, oneshot::Sender<JsonRpcResponse>>>>,
+    pending_requests: Arc<RwLock<HashMap<u64, PendingRequest>>>,
     notification_tx: broadcast::Sender<JsonRpcNotification>,
     request_tx: mpsc::UnboundedSender<JsonRpcRequest>,
     read_task: Mutex<Option<JoinHandle<()>>>,
@@ -282,7 +301,7 @@ impl JsonRpcClient {
 
     async fn read_loop(
         reader: impl AsyncRead + Unpin + Send,
-        pending_requests: Arc<RwLock<HashMap<u64, oneshot::Sender<JsonRpcResponse>>>>,
+        pending_requests: Arc<RwLock<HashMap<u64, PendingRequest>>>,
         notification_tx: broadcast::Sender<JsonRpcNotification>,
         request_tx: mpsc::UnboundedSender<JsonRpcRequest>,
     ) {
@@ -291,11 +310,54 @@ impl JsonRpcClient {
         loop {
             match Self::read_message(&mut reader).await {
                 Ok(Some(message)) => match message {
-                    JsonRpcMessage::Response(response) => {
+                    JsonRpcMessage::Response(mut response) => {
                         let id = response.id;
-                        let tx = pending_requests.write().remove(&id);
-                        if let Some(tx) = tx {
-                            if tx.send(response).is_err() {
+                        let pending = pending_requests.write().remove(&id);
+                        if let Some(PendingRequest {
+                            sender,
+                            inline_callback,
+                        }) = pending
+                        {
+                            // Run the inline callback synchronously on the
+                            // read loop so any state it mutates (e.g.
+                            // registering a server-assigned session id with
+                            // the router) is visible before the loop reads
+                            // and dispatches the next message.
+                            if let Some(cb) = inline_callback
+                                && response.error.is_none()
+                            {
+                                let cb_outcome =
+                                    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                        cb(&response)
+                                    }));
+                                match cb_outcome {
+                                    Ok(Ok(())) => {}
+                                    Ok(Err(error)) => {
+                                        response.result = None;
+                                        response.error = Some(JsonRpcError {
+                                            code: -32603,
+                                            message: error.to_string(),
+                                            data: None,
+                                        });
+                                    }
+                                    Err(panic) => {
+                                        let message = panic
+                                            .downcast_ref::<&'static str>()
+                                            .map(|s| (*s).to_string())
+                                            .or_else(|| panic.downcast_ref::<String>().cloned())
+                                            .unwrap_or_else(|| {
+                                                "inline response callback panicked".to_string()
+                                            });
+                                        response.result = None;
+                                        response.error = Some(JsonRpcError {
+                                            code: -32603,
+                                            message,
+                                            data: None,
+                                        });
+                                    }
+                                }
+                            }
+                            if sender.send(response).is_err() {
                                 warn!(request_id = %id, "failed to send response for request");
                             }
                         } else {
@@ -380,17 +442,50 @@ impl JsonRpcClient {
     /// requests map is cleaned up automatically (the `PendingGuard` drop
     /// removes the entry, and the read loop's response handling tolerates
     /// a missing entry).
+    #[allow(dead_code, reason = "public API exported via crate::JsonRpcClient")]
     pub async fn send_request(
         &self,
         method: &str,
         params: Option<serde_json::Value>,
+    ) -> Result<JsonRpcResponse, Error> {
+        self.send_request_with_inline_callback(method, params, None)
+            .await
+    }
+
+    /// Send a JSON-RPC request whose response is observed synchronously
+    /// by the read loop *before* it is delivered to the awaiter.
+    ///
+    /// The optional `inline_callback` runs on the JSON-RPC read task the
+    /// instant a successful response is parsed, and before the read loop
+    /// dispatches the next message. This is the only way to perform
+    /// client-side bookkeeping (for example, registering a server-
+    /// assigned session id with the router) that must be visible to any
+    /// notification or request that the server may emit on the same
+    /// connection immediately after the response.
+    ///
+    /// If the callback returns an error or panics, that error is
+    /// surfaced to the awaiter in place of the original response (the
+    /// response payload is discarded and an internal-error JSON-RPC
+    /// error is delivered instead). The error is never propagated back
+    /// to the server and does not crash the read loop.
+    pub(crate) async fn send_request_with_inline_callback(
+        &self,
+        method: &str,
+        params: Option<serde_json::Value>,
+        inline_callback: Option<InlineResponseCallback>,
     ) -> Result<JsonRpcResponse, Error> {
         let request_start = Instant::now();
         let id = self.request_id.fetch_add(1, Ordering::SeqCst);
         let request = JsonRpcRequest::new(id, method, params);
 
         let (tx, rx) = oneshot::channel();
-        self.pending_requests.write().insert(id, tx);
+        self.pending_requests.write().insert(
+            id,
+            PendingRequest {
+                sender: tx,
+                inline_callback,
+            },
+        );
 
         // RAII guard that removes the pending entry if this future is
         // dropped before the response arrives. Disarmed below before the
@@ -496,7 +591,7 @@ impl JsonRpcClient {
 /// owning future is dropped before the response arrives. Disarmed on the
 /// happy path so the read loop's response handling owns the cleanup.
 struct PendingGuard<'a> {
-    map: &'a RwLock<HashMap<u64, oneshot::Sender<JsonRpcResponse>>>,
+    map: &'a RwLock<HashMap<u64, PendingRequest>>,
     id: u64,
     armed: bool,
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1380,6 +1380,7 @@ impl Client {
     }
 
     /// Send a JSON-RPC request and wait for the response.
+    #[allow(dead_code, reason = "convenience for future internal use")]
     pub(crate) async fn send_request(
         &self,
         method: &str,
@@ -1412,12 +1413,39 @@ impl Client {
         method: &str,
         params: Option<serde_json::Value>,
     ) -> Result<serde_json::Value> {
+        self.call_with_inline_callback(method, params, None).await
+    }
+
+    /// Same as [`call`](Self::call), but installs an `inline_callback`
+    /// that runs synchronously on the JSON-RPC read task the instant the
+    /// successful response is parsed, before it is delivered to this
+    /// awaiter and before the read loop dispatches the next message.
+    ///
+    /// This is the only way to perform client-side bookkeeping (for
+    /// example, registering a server-assigned session id with the
+    /// router) that must be visible to any notification or request the
+    /// server may emit on the same connection immediately after the
+    /// response.
+    ///
+    /// If the callback returns an error, that error is propagated to
+    /// this awaiter in place of the response. The callback never causes
+    /// the read loop to crash.
+    pub(crate) async fn call_with_inline_callback(
+        &self,
+        method: &str,
+        params: Option<serde_json::Value>,
+        inline_callback: Option<crate::jsonrpc::InlineResponseCallback>,
+    ) -> Result<serde_json::Value> {
         let session_id: Option<SessionId> = params
             .as_ref()
             .and_then(|p| p.get("sessionId"))
             .and_then(|v| v.as_str())
             .map(SessionId::from);
-        let response = self.send_request(method, params).await?;
+        let response = self
+            .inner
+            .rpc
+            .send_request_with_inline_callback(method, params, inline_callback)
+            .await?;
         if let Some(err) = response.error {
             if err.message.contains("Session not found") {
                 return Err(ErrorKind::Session(SessionErrorKind::NotFound(
@@ -2423,24 +2451,6 @@ mod tests {
         assert_eq!(first.unwrap()[0].id, "single-flight-model");
         assert_eq!(second.unwrap()[0].id, "single-flight-model");
         assert_eq!(calls.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test]
-    async fn cancelled_create_session_unregisters_pending_session() {
-        let (client_write, _server_read) = tokio::io::duplex(8192);
-        let (_server_write, client_read) = tokio::io::duplex(8192);
-        let client = Client::from_streams(client_read, client_write, std::env::temp_dir()).unwrap();
-        let handle = tokio::spawn({
-            let client = client.clone();
-            async move { client.create_session(SessionConfig::default()).await }
-        });
-
-        wait_for_pending_session_registration(&client).await;
-        handle.abort();
-        let _ = handle.await;
-
-        assert!(client.inner.router.session_ids().is_empty());
-        client.force_stop();
     }
 
     #[tokio::test]

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -796,11 +796,24 @@ impl Client {
     /// broadcast (and silently skips dispatch if one arrives anyway).
     pub async fn create_session(&self, mut config: SessionConfig) -> Result<Session, Error> {
         let total_start = Instant::now();
-        let session_id = config
-            .session_id
-            .clone()
-            .unwrap_or_else(|| SessionId::from(uuid::Uuid::new_v4().to_string()));
-        config.session_id = Some(session_id.clone());
+        // For cloud sessions, let the CLI/server assign the session id and
+        // register the session lazily once the response arrives. For non-cloud
+        // sessions we generate the id client-side (when the caller didn't
+        // supply one) so the session can be registered BEFORE the RPC — the
+        // CLI may issue session-scoped requests (e.g. sessionFs.writeFile for
+        // workspace metadata) during session.create processing, before it has
+        // sent the response.
+        let caller_session_id = config.session_id.clone();
+        let use_server_generated_id = config.cloud.is_some() && caller_session_id.is_none();
+        let local_session_id: Option<SessionId> = if use_server_generated_id {
+            None
+        } else {
+            Some(
+                caller_session_id
+                    .clone()
+                    .unwrap_or_else(|| SessionId::new(uuid::Uuid::new_v4().to_string())),
+            )
+        };
         if config.hooks_handler.is_some() && config.hooks.is_none() {
             config.hooks = Some(true);
         }
@@ -830,7 +843,7 @@ impl Client {
         let opt_custom_agents_local_only = config.custom_agents_local_only;
         let opt_coauthor_enabled = config.coauthor_enabled;
         let opt_manage_schedule_enabled = config.manage_schedule_enabled;
-        let (wire, mut runtime) = config.into_wire(session_id.clone())?;
+        let (wire, mut runtime) = config.into_wire(local_session_id.clone())?;
 
         let permission_handler = crate::permission::resolve_handler(
             runtime.permission_handler.take(),
@@ -872,10 +885,94 @@ impl Client {
 
         let setup_start = Instant::now();
         let capabilities = Arc::new(parking_lot::RwLock::new(SessionCapabilities::default()));
-        let channels = self.register_session(&session_id);
         let idle_waiter = Arc::new(ParkingLotMutex::new(None));
         let shutdown = CancellationToken::new();
         let (event_tx, _) = tokio::sync::broadcast::channel(512);
+
+        // For cloud sessions (use_server_generated_id), defer session
+        // registration to the inline callback so the read task registers
+        // the session synchronously the instant the response arrives.
+        // For non-cloud sessions, register up-front so the CLI can issue
+        // session-scoped requests during session.create processing.
+        let inline_stash: Arc<
+            ParkingLotMutex<Option<(SessionId, crate::router::SessionChannels)>>,
+        > = Arc::new(ParkingLotMutex::new(None));
+
+        let inline_callback: Option<crate::jsonrpc::InlineResponseCallback> = if let Some(ref sid) =
+            local_session_id
+        {
+            let channels = self.register_session(sid);
+            *inline_stash.lock() = Some((sid.clone(), channels));
+            None
+        } else {
+            let client = self.clone();
+            let stash = inline_stash.clone();
+            let expected = caller_session_id.clone();
+            Some(Box::new(move |response| {
+                let result = response.result.as_ref().ok_or_else(|| {
+                    Error::with_message(ErrorKind::Json, "session.create response had no result")
+                })?;
+                let parsed: CreateSessionResult =
+                    serde_json::from_value(result.clone()).map_err(Error::from)?;
+                if let Some(requested) = expected.as_ref()
+                    && parsed.session_id != *requested
+                {
+                    return Err(ErrorKind::Session(SessionErrorKind::SessionIdMismatch {
+                        requested: requested.clone(),
+                        returned: parsed.session_id,
+                    })
+                    .into());
+                }
+                let channels = client.register_session(&parsed.session_id);
+                *stash.lock() = Some((parsed.session_id, channels));
+                Ok(())
+            }))
+        };
+
+        let rpc_start = Instant::now();
+        let result = match self
+            .call_with_inline_callback("session.create", Some(params), inline_callback)
+            .await
+        {
+            Ok(result) => result,
+            Err(error) => {
+                if let Some((id, _channels)) = inline_stash.lock().take() {
+                    self.unregister_session(&id);
+                }
+                return Err(error);
+            }
+        };
+        tracing::debug!(
+            elapsed_ms = rpc_start.elapsed().as_millis(),
+            "Client::create_session session creation request completed successfully"
+        );
+        let create_result: CreateSessionResult = match serde_json::from_value(result) {
+            Ok(result) => result,
+            Err(error) => {
+                if let Some((id, _channels)) = inline_stash.lock().take() {
+                    self.unregister_session(&id);
+                }
+                return Err(error.into());
+            }
+        };
+
+        if let Some(ref requested) = local_session_id
+            && create_result.session_id != *requested
+        {
+            if let Some((id, _channels)) = inline_stash.lock().take() {
+                self.unregister_session(&id);
+            }
+            return Err(ErrorKind::Session(SessionErrorKind::SessionIdMismatch {
+                requested: requested.clone(),
+                returned: create_result.session_id.clone(),
+            })
+            .into());
+        }
+
+        let (session_id, channels) = inline_stash
+            .lock()
+            .take()
+            .expect("session registration must have populated stash on success");
         let event_loop = spawn_event_loop(
             session_id.clone(),
             self.clone(),
@@ -891,8 +988,6 @@ impl Client {
             event_tx.clone(),
             shutdown.clone(),
         );
-        let mut registration =
-            PendingSessionRegistration::new(self.clone(), session_id.clone(), shutdown.clone());
         tracing::debug!(
             elapsed_ms = setup_start.elapsed().as_millis(),
             session_id = %session_id,
@@ -901,34 +996,6 @@ impl Client {
             has_hooks,
             "Client::create_session local setup complete"
         );
-
-        let rpc_start = Instant::now();
-        let result = match self.call("session.create", Some(params)).await {
-            Ok(result) => result,
-            Err(error) => {
-                registration.cleanup(event_loop).await;
-                return Err(error);
-            }
-        };
-        tracing::debug!(
-            elapsed_ms = rpc_start.elapsed().as_millis(),
-            "Client::create_session session creation request completed successfully"
-        );
-        let create_result: CreateSessionResult = match serde_json::from_value(result) {
-            Ok(result) => result,
-            Err(error) => {
-                registration.cleanup(event_loop).await;
-                return Err(error.into());
-            }
-        };
-        if create_result.session_id != session_id {
-            registration.cleanup(event_loop).await;
-            return Err(ErrorKind::Session(SessionErrorKind::SessionIdMismatch {
-                requested: session_id,
-                returned: create_result.session_id,
-            })
-            .into());
-        }
         *capabilities.write() = create_result.capabilities.unwrap_or_default();
 
         tracing::debug!(
@@ -936,7 +1003,6 @@ impl Client {
             session_id = %session_id,
             "Client::create_session complete"
         );
-        registration.disarm();
         let session = Session {
             id: session_id,
             cwd: self.cwd().clone(),

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1427,7 +1427,7 @@ impl SessionConfig {
     /// [`SessionCreateWire`]: crate::wire::SessionCreateWire
     pub(crate) fn into_wire(
         mut self,
-        session_id: SessionId,
+        session_id: Option<SessionId>,
     ) -> Result<(crate::wire::SessionCreateWire, SessionConfigRuntime), crate::Error> {
         let permission_active =
             self.permission_handler.is_some() || self.permission_policy.is_some();
@@ -3871,7 +3871,7 @@ mod tests {
         // time, not stored on the config. With no handlers installed, every
         // request_* flag should serialize as false.
         let (wire, _runtime) = cfg
-            .into_wire(SessionId::from("default-flags"))
+            .into_wire(Some(SessionId::from("default-flags")))
             .expect("default config has no duplicate handlers");
         assert!(!wire.request_user_input);
         assert!(!wire.request_permission);
@@ -3914,7 +3914,7 @@ mod tests {
         ));
 
         let (wire, _runtime) = cfg
-            .into_wire(SessionId::from("custom-id"))
+            .into_wire(Some(SessionId::from("custom-id")))
             .expect("no duplicate handlers");
         let wire_json = serde_json::to_value(&wire).unwrap();
         assert_eq!(wire_json["sessionId"], "custom-id");
@@ -3930,7 +3930,7 @@ mod tests {
 
         // Unset fields are omitted on the wire.
         let (empty_wire, _) = SessionConfig::default()
-            .into_wire(SessionId::from("empty"))
+            .into_wire(Some(SessionId::from("empty")))
             .expect("default has no duplicate handlers");
         let empty_json = serde_json::to_value(&empty_wire).unwrap();
         assert!(empty_json.get("gitHubToken").is_none());
@@ -4129,7 +4129,7 @@ mod tests {
         let cfg =
             SessionConfig::default().with_instruction_directories([PathBuf::from("/tmp/instr")]);
         let (wire, _) = cfg
-            .into_wire(SessionId::from("instr-on"))
+            .into_wire(Some(SessionId::from("instr-on")))
             .expect("no duplicate handlers");
         let json = serde_json::to_value(&wire).unwrap();
         assert_eq!(
@@ -4139,7 +4139,7 @@ mod tests {
 
         // Unset case — skip_serializing_if must omit the field.
         let (wire, _) = SessionConfig::default()
-            .into_wire(SessionId::from("instr-off"))
+            .into_wire(Some(SessionId::from("instr-off")))
             .expect("no duplicate handlers");
         let json = serde_json::to_value(&wire).unwrap();
         assert!(json.get("instructionDirectories").is_none());

--- a/rust/src/wire.rs
+++ b/rust/src/wire.rs
@@ -42,7 +42,8 @@ pub(crate) struct CommandWireDefinition {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SessionCreateWire {
-    pub session_id: SessionId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<SessionId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary

When a caller creates a session with `cloud` set **and** does not supply a `sessionId`, the SDK now omits `sessionId` from the `session.create` request and lets the CLI/server assign one. The returned id is captured synchronously when the response is parsed (via an inline response callback) so any subsequent `session.event` notification routes to the registered session without race.

For all other cases (no `cloud`, or caller-supplied `sessionId`), the SDK continues to generate a UUID client-side (when none is supplied) and **pre-register** the session BEFORE issuing the RPC. Pre-registration is required because the CLI may issue session-scoped requests (e.g. `sessionFs.writeFile` for workspace metadata) DURING `session.create` processing, before it has sent the response — without pre-registration those requests would have no handler.

A caller-supplied `sessionId` is always forwarded to the server (even with `cloud`), so the server can validate it. A mismatched returned id fails the call with a clear error.

In addition, the .NET implementation extracts the session-init local function from `CreateSessionAsync` into a private `InitializeSession` helper now shared by both `CreateSessionAsync` and `ResumeSessionAsync`, eliminating duplicated handler-wiring code.

## Decision matrix

| `cloud`  | caller `sessionId` | Behavior                                                                                |
| -------- | ------------------ | --------------------------------------------------------------------------------------- |
| set      | not supplied       | **Server-assigned.** Omit `sessionId` from RPC; register lazily from inline callback.   |
| set      | supplied           | Pre-register with caller id; send to server; server validates.                          |
| not set  | not supplied       | Client-generated UUID; pre-register; send to server.                                    |
| not set  | supplied           | Pre-register with caller id; send to server.                                            |

## What changed per SDK

The same conditional (`useServerGeneratedId = cloud != null && callerSessionId == null`) is applied uniformly across all 6 SDKs:

- **.NET** (`dotnet/src/Client.cs`): New private `InitializeSession` helper shared by `CreateSessionAsync` and `ResumeSessionAsync`. `CreateSessionAsync` either pre-registers (default) or installs an `onResponseInline` callback (cloud + no id).
- **Python** (`python/copilot/client.py`): `create_session` either pre-registers via `uuid.uuid4()` or installs an `on_response_inline` callback that registers when the response is parsed.
- **Go** (`go/client.go`): `CreateSession` either pre-registers via `uuid.NewString()` or installs an inline callback that registers from the read loop the instant the response arrives.
- **Rust** (`rust/src/session.rs`): `create_session` either pre-registers via `uuid::Uuid::new_v4()` or installs an `InlineResponseCallback` that validates the returned id and registers in the router. `SessionConfig::into_wire` now takes the resolved local session id (or `None` when the server is generating one).
- **Java** (`java/src/main/java/com/github/copilot/CopilotClient.java`): `createSession` either pre-registers via `UUID.randomUUID()` or registers in the `.thenCompose` continuation (race-free — CompletableFuture sync continuations run on the JSON-RPC reader thread).
- **Node.js** (`nodejs/src/client.ts`): `createSession` either pre-registers via `randomUUID()` or lazy-initializes after the response (race-free — vscode-jsonrpc dispatches each message via `setImmediate`, so microtasks flush before the next message is read).

## Why hybrid instead of always-lazy?

An earlier iteration of this PR took the "always lazy-init" path. CI surfaced that the CLI emits `sessionFs.writeFile` for workspace metadata DURING `session.create` processing (before the response). For non-cloud sessions the SDK must have a registered handler at that moment, which is only possible if it pre-registers before sending the RPC. Cloud sessions don't have a workspace and so don't hit that path, which is why deferring to the server is safe there.

## Testing

All SDK unit tests and lints pass locally. The .NET `CreateSessionReKeyEntryTest` (Java) was rewritten to assert that mismatched ids are rejected (the previous "re-key on mismatch" behavior is intentionally gone).

E2E suites are validated in CI on the PR.