### PR TITLE
Re-invalidate build.rs when extracted CLI cache is removed

### DIFF
--- a/rust/build.rs
+++ b/rust/build.rs
@@ -124,6 +124,8 @@ fn main() {
             extract_to_cache(&archive, &install_dir, platform);
         }
 
+        // Re-check after potential download+extract above; not an `else`
+        // because we need to verify the extraction actually produced the file.
         if final_path.is_file() {
             println!("cargo:rustc-cfg=has_extracted_cli");
         }

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -106,6 +106,13 @@ fn main() {
         let install_dir = extracted_install_dir(&version);
         let final_path = install_dir.join(platform.binary_name);
 
+        // Invalidate build.rs whenever the cached binary disappears (cache GC,
+        // manual rm, OS reset, switching extract dir). Without this, cargo
+        // replays the saved `has_extracted_cli` cfg from its build-script
+        // output cache even when the file is gone, and runtime resolution
+        // fails with BinaryNotFound.
+        println!("cargo:rerun-if-changed={}", final_path.display());
+
         if !final_path.is_file() {
             let archive = cached_download(
                 &format!("{base_url}/{}", platform.asset_name),
@@ -117,7 +124,9 @@ fn main() {
             extract_to_cache(&archive, &install_dir, platform);
         }
 
-        println!("cargo:rustc-cfg=has_extracted_cli");
+        if final_path.is_file() {
+            println!("cargo:rustc-cfg=has_extracted_cli");
+        }
     }
 }
 


### PR DESCRIPTION
When `bundled-cli` is OFF, `build.rs` downloads and extracts the Copilot CLI binary to a platform cache directory at build time, then emits `cargo:rustc-cfg=has_extracted_cli` so the runtime resolver knows where to look.

**Problem:** no `rerun-if-changed` directive watches the extracted binary itself. If the file disappears between builds (cache GC, `rm -rf ~/Library/Caches`, switching `COPILOT_CLI_EXTRACT_DIR`) and no other watched input changes, cargo treats the build script as up-to-date, replays the cached `has_extracted_cli` cfg, and the runtime resolver hits `BinaryNotFound` despite a "successful" build.

**Fix:**

1. Add `rerun-if-changed=<final_path>` pointing at the extracted binary. Cargo's semantics for a missing path are "always rerun" — exactly the right behavior here.
2. Only emit `rustc-cfg=has_extracted_cli` when `final_path.is_file()` holds after extraction, making the cfg honest about ground truth.

The `bundled-cli` ON path (embed mode) is unchanged.

<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;">&nbsp;&nbsp;Generated via Copilot (Claude Opus 4.6) <a href="https://adaptivepatchwork.com/ai-attribution/">on behalf</a> of @tclem</em></sub>