### PR TITLE
Plumb Extension SDK Path Through Session Create And Resume

### DIFF
--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -937,6 +937,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 Canvases: config.Canvases,
                 RequestCanvasRenderer: config.RequestCanvasRenderer,
                 RequestExtensions: config.RequestExtensions,
+                ExtensionSdkPath: config.ExtensionSdkPath,
                 ExtensionInfo: config.ExtensionInfo,
                 ToolFilterPrecedence: toolFilter.ToolFilterPrecedence);
 
@@ -1131,6 +1132,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 Canvases: config.Canvases,
                 RequestCanvasRenderer: config.RequestCanvasRenderer,
                 RequestExtensions: config.RequestExtensions,
+                ExtensionSdkPath: config.ExtensionSdkPath,
                 ExtensionInfo: config.ExtensionInfo,
                 OpenCanvases: config.OpenCanvases,
                 ToolFilterPrecedence: toolFilter.ToolFilterPrecedence);
@@ -2321,6 +2323,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         IList<CanvasDeclaration>? Canvases = null,
         bool? RequestCanvasRenderer = null,
         bool? RequestExtensions = null,
+        string? ExtensionSdkPath = null,
         ExtensionInfo? ExtensionInfo = null,
         OptionsUpdateToolFilterPrecedence? ToolFilterPrecedence = null);
 #pragma warning restore GHCP001
@@ -2406,6 +2409,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         IList<CanvasDeclaration>? Canvases = null,
         bool? RequestCanvasRenderer = null,
         bool? RequestExtensions = null,
+        string? ExtensionSdkPath = null,
         ExtensionInfo? ExtensionInfo = null,
         IList<OpenCanvasInstance>? OpenCanvases = null,
         OptionsUpdateToolFilterPrecedence? ToolFilterPrecedence = null);

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -2459,6 +2459,7 @@ public abstract class SessionConfigBase
         Canvases = other.Canvases is not null ? [.. other.Canvases] : null;
         RequestCanvasRenderer = other.RequestCanvasRenderer;
         RequestExtensions = other.RequestExtensions;
+        ExtensionSdkPath = other.ExtensionSdkPath;
         ExtensionInfo = other.ExtensionInfo;
         CanvasHandler = other.CanvasHandler;
 #pragma warning restore GHCP001
@@ -2819,6 +2820,16 @@ public abstract class SessionConfigBase
     /// </summary>
     [Experimental(Diagnostics.Experimental)]
     public bool? RequestExtensions { get; set; }
+
+    /// <summary>
+    /// Optional override path to a <c>copilot-sdk/</c> folder to inject into
+    /// extension subprocesses for this session in place of the bundled SDK.
+    /// When unset or invalid (missing folder, or missing <c>index.js</c> /
+    /// <c>extension.js</c>), the runtime falls back to the bundled SDK
+    /// without throwing. Takes precedence over any server-level default.
+    /// </summary>
+    [Experimental(Diagnostics.Experimental)]
+    public string? ExtensionSdkPath { get; set; }
 
     /// <summary>
     /// Stable extension identity for canvas/tool providers on this connection.

--- a/go/client.go
+++ b/go/client.go
@@ -654,6 +654,7 @@ func (c *Client) CreateSession(ctx context.Context, config *SessionConfig) (*Ses
 	req.Canvases = config.Canvases
 	req.RequestCanvasRenderer = config.RequestCanvasRenderer
 	req.RequestExtensions = config.RequestExtensions
+	req.ExtensionSdkPath = config.ExtensionSdkPath
 
 	if len(config.Commands) > 0 {
 		cmds := make([]wireCommand, 0, len(config.Commands))
@@ -992,6 +993,7 @@ func (c *Client) ResumeSessionWithOptions(ctx context.Context, sessionID string,
 	req.OpenCanvases = config.OpenCanvases
 	req.RequestCanvasRenderer = config.RequestCanvasRenderer
 	req.RequestExtensions = config.RequestExtensions
+	req.ExtensionSdkPath = config.ExtensionSdkPath
 	if config.OnPermissionRequest != nil {
 		req.RequestPermission = Bool(true)
 	}

--- a/go/types.go
+++ b/go/types.go
@@ -1094,6 +1094,12 @@ type SessionConfig struct {
 	RequestCanvasRenderer *bool
 	// RequestExtensions asks the host to surface declared canvases as agent-visible extensions.
 	RequestExtensions *bool
+	// ExtensionSdkPath optionally overrides the bundled `@github/copilot-sdk` drop
+	// injected into extension subprocesses. When set to an absolute path containing
+	// a valid `copilot-sdk/` folder (with `index.js` and `extension.js` at the
+	// root), the host injects the override into every forked extension; invalid or
+	// missing paths fall back to the bundled SDK silently.
+	ExtensionSdkPath *string
 	// CanvasHandler receives inbound canvas.open / canvas.close / canvas.action.invoke
 	// requests for this session. The SDK does not maintain a per-canvas registry;
 	// the handler must dispatch on CanvasProviderOpenRequest.CanvasID itself.
@@ -1429,6 +1435,9 @@ type ResumeSessionConfig struct {
 	RequestCanvasRenderer *bool
 	// RequestExtensions asks the host to surface declared canvases as agent-visible extensions.
 	RequestExtensions *bool
+	// ExtensionSdkPath optionally overrides the bundled `@github/copilot-sdk` drop
+	// injected into extension subprocesses. See SessionConfig.ExtensionSdkPath.
+	ExtensionSdkPath *string
 	// CanvasHandler receives inbound canvas.* requests for this session. See SessionConfig.CanvasHandler.
 	CanvasHandler CanvasHandler `json:"-"`
 	// ExtensionInfo identifies the stable extension providing this session's canvases.
@@ -1696,6 +1705,7 @@ type createSessionRequest struct {
 	Canvases                           []CanvasDeclaration                    `json:"canvases,omitempty"`
 	RequestCanvasRenderer              *bool                                  `json:"requestCanvasRenderer,omitempty"`
 	RequestExtensions                  *bool                                  `json:"requestExtensions,omitempty"`
+	ExtensionSdkPath                   *string                                `json:"extensionSdkPath,omitempty"`
 	ExtensionInfo                      *ExtensionInfo                         `json:"extensionInfo,omitempty"`
 	Traceparent                        string                                 `json:"traceparent,omitempty"`
 	Tracestate                         string                                 `json:"tracestate,omitempty"`
@@ -1774,6 +1784,7 @@ type resumeSessionRequest struct {
 	OpenCanvases                       []rpc.OpenCanvasInstance               `json:"openCanvases,omitempty"`
 	RequestCanvasRenderer              *bool                                  `json:"requestCanvasRenderer,omitempty"`
 	RequestExtensions                  *bool                                  `json:"requestExtensions,omitempty"`
+	ExtensionSdkPath                   *string                                `json:"extensionSdkPath,omitempty"`
 	ExtensionInfo                      *ExtensionInfo                         `json:"extensionInfo,omitempty"`
 	Traceparent                        string                                 `json:"traceparent,omitempty"`
 	Tracestate                         string                                 `json:"tracestate,omitempty"`

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.8",
             "license": "MIT",
             "dependencies": {
-                "@github/copilot": "^1.0.56-1",
+                "@github/copilot": "^1.0.56-2",
                 "vscode-jsonrpc": "^8.2.1",
                 "zod": "^4.3.6"
             },
@@ -663,9 +663,9 @@
             }
         },
         "node_modules/@github/copilot": {
-            "version": "1.0.56-1",
-            "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.56-1.tgz",
-            "integrity": "sha512-9VGwX6kcUfm8NHTQaUEtmR6qA73jyDXwtBSmd8ia3OpadEpqc5V65isv37zEtGDv33PPA4ntvoEG0CK4j2oXEg==",
+            "version": "1.0.56-2",
+            "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.56-2.tgz",
+            "integrity": "sha512-Dpue7utF6PzGS4tPrG3pRXL3d1lMJHFFT8PJegljn7vg64LAbjhk5yNgBXbMg/XbObu755SJTNtbEL/aSdrGNg==",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "detect-libc": "^2.1.2"
@@ -674,20 +674,20 @@
                 "copilot": "npm-loader.js"
             },
             "optionalDependencies": {
-                "@github/copilot-darwin-arm64": "1.0.56-1",
-                "@github/copilot-darwin-x64": "1.0.56-1",
-                "@github/copilot-linux-arm64": "1.0.56-1",
-                "@github/copilot-linux-x64": "1.0.56-1",
-                "@github/copilot-linuxmusl-arm64": "1.0.56-1",
-                "@github/copilot-linuxmusl-x64": "1.0.56-1",
-                "@github/copilot-win32-arm64": "1.0.56-1",
-                "@github/copilot-win32-x64": "1.0.56-1"
+                "@github/copilot-darwin-arm64": "1.0.56-2",
+                "@github/copilot-darwin-x64": "1.0.56-2",
+                "@github/copilot-linux-arm64": "1.0.56-2",
+                "@github/copilot-linux-x64": "1.0.56-2",
+                "@github/copilot-linuxmusl-arm64": "1.0.56-2",
+                "@github/copilot-linuxmusl-x64": "1.0.56-2",
+                "@github/copilot-win32-arm64": "1.0.56-2",
+                "@github/copilot-win32-x64": "1.0.56-2"
             }
         },
         "node_modules/@github/copilot-darwin-arm64": {
-            "version": "1.0.56-1",
-            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.56-1.tgz",
-            "integrity": "sha512-GmdinjTXPKe7CBGC6pfFEOcqE3cN7craTo4muMPIRzDWnnkPwkIT05z74fgLc+r0/+MtllCysXkQVLixHEmyQw==",
+            "version": "1.0.56-2",
+            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.56-2.tgz",
+            "integrity": "sha512-RHJNhdPSkdPc/nabWVess7BfEda7xfwBQ2X5vq9nq4VjqTbvUHBFwTt792q00TE4DZR/UsWr0sJKJkLcRvTltQ==",
             "cpu": [
                 "arm64"
             ],
@@ -701,9 +701,9 @@
             }
         },
         "node_modules/@github/copilot-darwin-x64": {
-            "version": "1.0.56-1",
-            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.56-1.tgz",
-            "integrity": "sha512-WfkSnB0MxmMxV58yqF8O0GkBzXCCKy3H6s13Xrqfvotmk9KNriVzCHmUnnMTve4XeOGCGrOqU2Hy2VNUu8Cj1A==",
+            "version": "1.0.56-2",
+            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.56-2.tgz",
+            "integrity": "sha512-EqBtGH1I2rX5TzSJ+L9O22SQ8jlSsn1YJeFS6RTtYU+NhC6xLajjfTutkA5DZOr3eQgmeceit/4NDqEdjwANEA==",
             "cpu": [
                 "x64"
             ],
@@ -717,11 +717,14 @@
             }
         },
         "node_modules/@github/copilot-linux-arm64": {
-            "version": "1.0.56-1",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.56-1.tgz",
-            "integrity": "sha512-fNwcdnPG8N01n9MFl4xKswFsO4ZjkckM5D7UqgtO4aiJYGQYmw+Viq0MFzKD4G8Nzl5k6qR1pDnvWciVAcYDag==",
+            "version": "1.0.56-2",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.56-2.tgz",
+            "integrity": "sha512-FmjODKft2tmY5B0B94RDek/TR3QtdDTT7W/+lqkiosnUyLhsNtmzKaDYpiQsCBee68YUuB1umecqiTL1qMo3cw==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "SEE LICENSE IN LICENSE.md",
             "optional": true,
@@ -733,11 +736,14 @@
             }
         },
         "node_modules/@github/copilot-linux-x64": {
-            "version": "1.0.56-1",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.56-1.tgz",
-            "integrity": "sha512-Ow2dQSpuJXHmnw4RBitt/RiAMxsG9Mu5x0MX7ueNzhK1xfuGp7m8yUikbJNZQbBq2KZB2OlwGDKx2KtEBxtbig==",
+            "version": "1.0.56-2",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.56-2.tgz",
+            "integrity": "sha512-aqF4k6mDLU1OXdaAb3gBIRCgdrlXX+1FBtcoLKPMjzVfkA2abEZ/vuYfZWS7ZaxG/aCOScp8D+/E+RaYHsGYOw==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "SEE LICENSE IN LICENSE.md",
             "optional": true,
@@ -749,11 +755,14 @@
             }
         },
         "node_modules/@github/copilot-linuxmusl-arm64": {
-            "version": "1.0.56-1",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.56-1.tgz",
-            "integrity": "sha512-vZQAF+QCa+UVND6NNo/lexc3bLWLYMP63aY5peh5BIYrPLv0Ylf5+VSJoaxBC1qFrjLmFaKo4KRWtmh8Mqx6Lw==",
+            "version": "1.0.56-2",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.56-2.tgz",
+            "integrity": "sha512-+CztOiU7/nlNLX50jcpOMreMrDr7+DFnq3OV59doDd9UgqTdpjEnZKjkgHpxid117rYF/95cN5EYWD7ermOcjA==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "SEE LICENSE IN LICENSE.md",
             "optional": true,
@@ -765,11 +774,14 @@
             }
         },
         "node_modules/@github/copilot-linuxmusl-x64": {
-            "version": "1.0.56-1",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.56-1.tgz",
-            "integrity": "sha512-EEubP5DRWX/w2CPuZr7aQdfd57mGQ8gDNXOLNds+94Qp2UQD0/wJxF+FrU9YZSWPhcjG/BmXxnw/D7xwby53Nw==",
+            "version": "1.0.56-2",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.56-2.tgz",
+            "integrity": "sha512-FuBYfN2dX2a5fSEzPImtX6hjtjwiL0kutrq4RuvHYxUu0FR0JRB4vfN2mQ/KN4X5DZgaGkPQk19hkoEgd1tmdg==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "SEE LICENSE IN LICENSE.md",
             "optional": true,
@@ -781,9 +793,9 @@
             }
         },
         "node_modules/@github/copilot-win32-arm64": {
-            "version": "1.0.56-1",
-            "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.56-1.tgz",
-            "integrity": "sha512-PHr9xxlbh/UMYP0XL7UnPhgPdQyGbA6lJ7yqxoy0JO017c9o62Bhcd39gCuVPlkYurxeFzAdPnlbDVxSKBfNKQ==",
+            "version": "1.0.56-2",
+            "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.56-2.tgz",
+            "integrity": "sha512-mKTzS9HrH+wvOmIgIaRUs+l89o51P7ACVk4P/o1UEWGxDblTxwRZGL+cRBhqNltIxY+8XVIAEwg6CzE+sTH5Hw==",
             "cpu": [
                 "arm64"
             ],
@@ -797,9 +809,9 @@
             }
         },
         "node_modules/@github/copilot-win32-x64": {
-            "version": "1.0.56-1",
-            "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.56-1.tgz",
-            "integrity": "sha512-EWMfn0EQhUYOpwG+VaLif9ZLBt3D9mZ0DFmxVSM2DSnIMRlpC23hAnwY9n1R6zAvwQY20XMLIJ4d0LW4mUX9Ag==",
+            "version": "1.0.56-2",
+            "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.56-2.tgz",
+            "integrity": "sha512-tacHeeqNiLawmlUpturke10I9d6kkREqTcHGkGRy/MEwrio7A77L45j/IegRcQNjLwHP62R2+5GmNFx6BRwx9w==",
             "cpu": [
                 "x64"
             ],

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -56,7 +56,7 @@
     "author": "GitHub",
     "license": "MIT",
     "dependencies": {
-        "@github/copilot": "^1.0.56-1",
+        "@github/copilot": "^1.0.56-2",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
     },

--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -1110,6 +1110,7 @@ export class CopilotClient {
                 canvases: config.canvases?.map((canvas) => canvas.declaration),
                 requestCanvasRenderer: config.requestCanvasRenderer,
                 requestExtensions: config.requestExtensions,
+                extensionSdkPath: config.extensionSdkPath,
                 extensionInfo: config.extensionInfo,
                 commands: config.commands?.map((cmd) => ({
                     name: cmd.name,
@@ -1294,6 +1295,7 @@ export class CopilotClient {
                 canvases: config.canvases?.map((canvas) => canvas.declaration),
                 requestCanvasRenderer: config.requestCanvasRenderer,
                 requestExtensions: config.requestExtensions,
+                extensionSdkPath: config.extensionSdkPath,
                 extensionInfo: config.extensionInfo,
                 commands: config.commands?.map((cmd) => ({
                     name: cmd.name,

--- a/nodejs/src/extension.ts
+++ b/nodejs/src/extension.ts
@@ -22,7 +22,7 @@ export {
     type CanvasOptions,
 } from "./canvas.js";
 
-export type JoinSessionConfig = Omit<ResumeSessionConfig, "onPermissionRequest"> & {
+export type JoinSessionConfig = Omit<ResumeSessionConfig, "onPermissionRequest" | "extensionSdkPath"> & {
     onPermissionRequest?: PermissionHandler;
 };
 

--- a/nodejs/src/extension.ts
+++ b/nodejs/src/extension.ts
@@ -53,8 +53,18 @@ export async function joinSession(config: JoinSessionConfig = {}): Promise<Copil
     }
 
     const client = new CopilotClient({ _internalConnection: { kind: "parent-process" } });
+
+    // Strip `extensionSdkPath` at runtime even though `JoinSessionConfig` omits it
+    // at the type level — untyped (JS) callers can still slip it through, and
+    // honoring it here would be misleading since the extension subprocess has
+    // already been forked by the host with the SDK the host chose.
+    const { extensionSdkPath: _stripped, ...rest } = config as JoinSessionConfig & {
+        extensionSdkPath?: string;
+    };
+    void _stripped;
+
     return client.resumeSession(sessionId, {
-        ...config,
+        ...rest,
         onPermissionRequest: config.onPermissionRequest ?? defaultJoinSessionPermissionHandler,
         suppressResumeEvent: config.suppressResumeEvent ?? true,
     });

--- a/nodejs/src/extension.ts
+++ b/nodejs/src/extension.ts
@@ -22,7 +22,10 @@ export {
     type CanvasOptions,
 } from "./canvas.js";
 
-export type JoinSessionConfig = Omit<ResumeSessionConfig, "onPermissionRequest" | "extensionSdkPath"> & {
+export type JoinSessionConfig = Omit<
+    ResumeSessionConfig,
+    "onPermissionRequest" | "extensionSdkPath"
+> & {
     onPermissionRequest?: PermissionHandler;
 };
 

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -1643,6 +1643,20 @@ export interface SessionConfigBase {
     requestExtensions?: boolean;
 
     /**
+     * Optional override path to a `copilot-sdk/` folder to inject into
+     * extension subprocesses for this session in place of the bundled SDK.
+     * When unset or invalid (missing folder or missing `index.js` /
+     * `extension.js`), the runtime falls back to the bundled SDK without
+     * throwing. Takes precedence over any server-level default.
+     *
+     * Only honored on session create and resume — extensions joining via
+     * `joinSession` cannot override the SDK path, because the extension
+     * subprocess has already been forked by the host with the SDK the host
+     * chose. `JoinSessionConfig` omits this field for that reason.
+     */
+    extensionSdkPath?: string;
+
+    /**
      * Stable extension identity for canvas providers on this connection. When
      * set, the runtime uses `${source}:${name}` as the agent-facing extension
      * id instead of a reconnect-specific connection id.

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -1612,6 +1612,7 @@ class CopilotClient:
         canvases: list[CanvasDeclaration] | None = None,
         request_canvas_renderer: bool | None = None,
         request_extensions: bool | None = None,
+        extension_sdk_path: str | None = None,
         extension_info: ExtensionInfo | None = None,
         canvas_handler: CanvasHandler | None = None,
     ) -> CopilotSession:
@@ -2173,6 +2174,7 @@ class CopilotClient:
         canvases: list[CanvasDeclaration] | None = None,
         request_canvas_renderer: bool | None = None,
         request_extensions: bool | None = None,
+        extension_sdk_path: str | None = None,
         extension_info: ExtensionInfo | None = None,
         canvas_handler: CanvasHandler | None = None,
         open_canvases: list[OpenCanvasInstance] | None = None,
@@ -2479,6 +2481,8 @@ class CopilotClient:
             payload["requestCanvasRenderer"] = request_canvas_renderer
         if request_extensions is not None:
             payload["requestExtensions"] = request_extensions
+        if extension_sdk_path is not None:
+            payload["extensionSdkPath"] = extension_sdk_path
         if extension_info is not None:
             payload["extensionInfo"] = extension_info.to_dict()
 

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -1945,6 +1945,8 @@ class CopilotClient:
             payload["requestCanvasRenderer"] = request_canvas_renderer
         if request_extensions is not None:
             payload["requestExtensions"] = request_extensions
+        if extension_sdk_path is not None:
+            payload["extensionSdkPath"] = extension_sdk_path
         if extension_info is not None:
             payload["extensionInfo"] = extension_info.to_dict()
 

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1174,6 +1174,10 @@ pub struct SessionConfig {
     pub request_canvas_renderer: Option<bool>,
     /// Request extension tools and dispatch for this connection.
     pub request_extensions: Option<bool>,
+    /// Optional override path to a `copilot-sdk/` folder to inject into
+    /// extension subprocesses for this session. Invalid paths fall back
+    /// to the bundled SDK; takes precedence over the host's default.
+    pub extension_sdk_path: Option<String>,
     /// Stable extension identity for canvas/tool providers on this connection.
     pub extension_info: Option<ExtensionInfo>,
     /// Allowlist of built-in tool names the agent may use.
@@ -1380,6 +1384,7 @@ impl std::fmt::Debug for SessionConfig {
             )
             .field("request_canvas_renderer", &self.request_canvas_renderer)
             .field("request_extensions", &self.request_extensions)
+            .field("extension_sdk_path", &self.extension_sdk_path)
             .field("extension_info", &self.extension_info)
             .field("available_tools", &self.available_tools)
             .field("excluded_tools", &self.excluded_tools)
@@ -1489,6 +1494,7 @@ impl Default for SessionConfig {
             canvas_handler: None,
             request_canvas_renderer: None,
             request_extensions: None,
+            extension_sdk_path: None,
             extension_info: None,
             available_tools: None,
             excluded_tools: None,
@@ -1622,6 +1628,7 @@ impl SessionConfig {
             canvases: wire_canvases,
             request_canvas_renderer: self.request_canvas_renderer,
             request_extensions: self.request_extensions,
+            extension_sdk_path: self.extension_sdk_path,
             extension_info: self.extension_info,
             available_tools: self.available_tools,
             excluded_tools: self.excluded_tools,
@@ -1857,6 +1864,14 @@ impl SessionConfig {
     /// Request extension tools and dispatch for this connection.
     pub fn with_request_extensions(mut self, request: bool) -> Self {
         self.request_extensions = Some(request);
+        self
+    }
+
+    /// Override the bundled `@github/copilot-sdk` drop injected into extension
+    /// subprocesses for this session. Invalid paths fall back to the bundled
+    /// SDK silently.
+    pub fn with_extension_sdk_path(mut self, path: impl Into<String>) -> Self {
+        self.extension_sdk_path = Some(path.into());
         self
     }
 
@@ -2181,6 +2196,10 @@ pub struct ResumeSessionConfig {
     pub request_canvas_renderer: Option<bool>,
     /// Request extension tools and dispatch for this connection.
     pub request_extensions: Option<bool>,
+    /// Optional override path to a `copilot-sdk/` folder to inject into
+    /// extension subprocesses for this session on resume. See
+    /// `SessionConfig::extension_sdk_path`.
+    pub extension_sdk_path: Option<String>,
     /// Stable extension identity for canvas/tool providers on this connection.
     pub extension_info: Option<ExtensionInfo>,
     /// Allowlist of tool names the agent may use.
@@ -2330,6 +2349,7 @@ impl std::fmt::Debug for ResumeSessionConfig {
             .field("open_canvases", &self.open_canvases)
             .field("request_canvas_renderer", &self.request_canvas_renderer)
             .field("request_extensions", &self.request_extensions)
+            .field("extension_sdk_path", &self.extension_sdk_path)
             .field("extension_info", &self.extension_info)
             .field("available_tools", &self.available_tools)
             .field("excluded_tools", &self.excluded_tools)
@@ -2476,6 +2496,7 @@ impl ResumeSessionConfig {
             open_canvases: self.open_canvases,
             request_canvas_renderer: self.request_canvas_renderer,
             request_extensions: self.request_extensions,
+            extension_sdk_path: self.extension_sdk_path,
             extension_info: self.extension_info,
             available_tools: self.available_tools,
             excluded_tools: self.excluded_tools,
@@ -2557,6 +2578,7 @@ impl ResumeSessionConfig {
             open_canvases: None,
             request_canvas_renderer: None,
             request_extensions: None,
+            extension_sdk_path: None,
             extension_info: None,
             available_tools: None,
             excluded_tools: None,
@@ -2764,6 +2786,14 @@ impl ResumeSessionConfig {
     /// Request extension tools and dispatch for this connection on resume.
     pub fn with_request_extensions(mut self, request: bool) -> Self {
         self.request_extensions = Some(request);
+        self
+    }
+
+    /// Override the bundled `@github/copilot-sdk` drop injected into extension
+    /// subprocesses for this resumed session. Invalid paths fall back to the
+    /// bundled SDK silently.
+    pub fn with_extension_sdk_path(mut self, path: impl Into<String>) -> Self {
+        self.extension_sdk_path = Some(path.into());
         self
     }
 

--- a/rust/src/wire.rs
+++ b/rust/src/wire.rs
@@ -67,6 +67,8 @@ pub(crate) struct SessionCreateWire {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_extensions: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub extension_sdk_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub extension_info: Option<ExtensionInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub available_tools: Option<Vec<String>>,
@@ -170,6 +172,8 @@ pub(crate) struct SessionResumeWire {
     pub request_canvas_renderer: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_extensions: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extension_sdk_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extension_info: Option<ExtensionInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## What

Adds an `extensionSdkPath` option to the session-creation and session-resume surfaces of the Node.js, Go, Python, Rust, and .NET SDKs. Callers can now point the host at a local `copilot-sdk/` folder that should be injected into extension subprocesses for that session, in place of whatever `@github/copilot-sdk` was bundled with the CLI that the SDK depends on.

The field is intentionally absent from implementations of `joinSession`, because by the time an extension joins, its subprocess has already been forked with whatever SDK the host chose.

Java is unchanged because it does not yet expose the broader extension surface (`requestExtensions`, canvases, etc.) — when that lands, this field should be added alongside it using the same pattern.

## Why

[A corresponding runtime PR](https://github.com/github/copilot-agent-runtime/pull/9095) added `extensionSdkPath` to the JSON-RPC `session.create` and `session.resume` payloads, but each language SDK only forwards explicitly-named fields. Without this passthrough, SDK consumers had no first-class way to test or pin a custom `@github/copilot-sdk` build end-to-end short of dropping down to raw JSON-RPC or rebuilding the entire host CLI. Adding the field across all currently-supported SDKs keeps the per-language surface in sync with the runtime and lets extension authors and SDK integrators iterate on SDK changes with a single typed option.
