### PR TITLE
Fix Go session event attachment aliases

### DIFF
--- a/scripts/codegen/go.ts
+++ b/scripts/codegen/go.ts
@@ -3295,20 +3295,33 @@ export function generateGoSessionEventsCode(schema: JSONSchema7, packageName: st
         AttachmentTypeGithubReference: "UserMessageAttachmentTypeGithubReference",
         AttachmentTypeBlob: "UserMessageAttachmentTypeBlob",
     };
-    out.push(`// Type aliases for convenience.`);
-    out.push(`type (`);
-    for (const [alias, target] of Object.entries(TYPE_ALIASES).sort(([left], [right]) => left.localeCompare(right))) {
-        out.push(`\t${alias} = ${target}`);
+    const generatedTypeNames = new Set(collectGoTopLevelNames(joinGoCode(out), "type"));
+    const generatedConstNames = new Set(collectGoTopLevelNames(joinGoCode(out), "const"));
+    const typeAliases = Object.entries(TYPE_ALIASES)
+        .filter(([alias, target]) => generatedTypeNames.has(target) && !generatedTypeNames.has(alias))
+        .sort(([left], [right]) => left.localeCompare(right));
+    const constAliases = Object.entries(CONST_ALIASES)
+        .filter(([alias, target]) => generatedConstNames.has(target) && !generatedConstNames.has(alias))
+        .sort(([left], [right]) => left.localeCompare(right));
+    if (typeAliases.length > 0) {
+        out.push(`// Type aliases for convenience.`);
+        out.push(`type (`);
+        for (const [alias, target] of typeAliases) {
+            out.push(`\t${alias} = ${target}`);
+        }
+        out.push(`)`);
+        out.push(``);
     }
-    out.push(`)`);
-    out.push(``);
-    out.push(`// Constant aliases for convenience.`);
-    out.push(`const (`);
-    for (const [alias, target] of Object.entries(CONST_ALIASES).sort(([left], [right]) => left.localeCompare(right))) {
-        out.push(`\t${alias} = ${target}`);
+
+    if (constAliases.length > 0) {
+        out.push(`// Constant aliases for convenience.`);
+        out.push(`const (`);
+        for (const [alias, target] of constAliases) {
+            out.push(`\t${alias} = ${target}`);
+        }
+        out.push(`)`);
+        out.push(``);
     }
-    out.push(`)`);
-    out.push(``);
 
     const encodingOut: string[] = [...sessionEncoding];
     if (encodingOut.length > 0) encodingOut.push("");


### PR DESCRIPTION
## Summary

- Make Go session-event compatibility aliases conditional so stale aliases are not emitted when the runtime schema promotes a name into shared generated RPC types.
- Keep this PR scoped to the `Attachment` / `AttachmentType` failure from the runtime bump workflow.

## Root Cause

Runtime `1.0.57-2` promotes `Attachment` and related attachment definitions into shared API/session-event schema definitions. Go session-event codegen still always emitted legacy compatibility aliases like `Attachment = UserMessageAttachment`, but those old `UserMessageAttachment*` generated names no longer exist once the shared `rpc.Attachment*` definitions are generated.

That made the runtime bump workflow fail during Go generation with duplicate/stale `Attachment` and `AttachmentType` declarations.

## Fix

The session-event generator now validates compatibility aliases before emitting them:

- the target generated name must exist
- the alias name must not already be generated

With the new runtime schema, `Attachment` is emitted through the normal shared alias path as `Attachment = rpc.Attachment`, and the stale `UserMessageAttachment*` aliases are skipped.

## Out of Scope

This PR intentionally does not change `ContextTier`. If the runtime bump exposes a separate `ContextTier` duplicate after the `Attachment` issue is fixed, that should be handled separately from this narrow generator fix.

## Validation

- `npm run generate:go`
- `npx tsx go.ts <@github/copilot@1.0.57-2 session-events.schema.json> <@github/copilot@1.0.57-2 api.schema.json>`
- `git diff --check`