### PR TITLE
Java: Make it so slash command responses are accessible via RPC

### DIFF
--- a/.github/skills/java-coding-skill/SKILL.md
+++ b/.github/skills/java-coding-skill/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: java-coding-skill
-description: "Use this skill whenever editing `*.java` files in the `java/` SDK in order to write idiomatic, well-structured Java code for the Copilot SDK"
+description: "Use this skill whenever editing `*.java` files in the `java/` directore of the SDK in order to write idiomatic, well-structured Java code for the Copilot SDK"
 ---
 
 # Java Coding Skill
 
 ## Core Principles
 
-- The SDK is in public preview and may have breaking changes
-- Requires Java 17 or later
-- Requires GitHub Copilot CLI installed and in PATH
-- Uses `CompletableFuture` for all async operations
-- Implements `AutoCloseable` for resource cleanup (try-with-resources)
+- Requires Java 25 or later for building the jar artifact for Copilot SDK for java.
+- Uses the Multi-Relase jar feature JEP 238 https://openjdk.org/jeps/238 with `maven.compiler.release` 17 so that uses running JDK 17 can use the jar.
+- Requires GitHub Copilot CLI installed and in PATH.
+- Uses `CompletableFuture` for all async operations.
+- Implements `AutoCloseable` for resource cleanup (try-with-resources).
 
 ## Installation
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -165,6 +165,26 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>3.4.1</version>
+                <configuration>
+                    <!--
+                        The E2E test harness spawns Node.js child processes
+                        (npx tsx server.ts) whose CWD is inside
+                        target/copilot-sdk/test/harness/. On macOS, orphaned
+                        node processes can briefly hold file descriptors on
+                        the directory tree after the test JVM exits, causing
+                        the first 'mvn clean' to fail with
+                        "Failed to delete target/copilot-sdk".
+
+                        retryOnError + retryCount give the OS time to reap
+                        those processes before the clean phase gives up.
+                    -->
+                    <retryOnError>true</retryOnError>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.15.0</version>
             </plugin>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -364,6 +364,14 @@
                         <project.build.finalName>${project.build.finalName}</project.build.finalName>
                         <project.build.testOutputDirectory>${project.build.testOutputDirectory}</project.build.testOutputDirectory>
                     </systemPropertyVariables>
+                    <!--
+                        Keep the integration-test JVM aligned with Surefire so
+                        tests like SlashCommandsIT resolve the pinned CLI from
+                        the cloned harness in target/copilot-sdk/nodejs.
+                    -->
+                    <environmentVariables>
+                        <COPILOT_CLI_PATH>${copilot.cli.path}</COPILOT_CLI_PATH>
+                    </environmentVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/java/scripts/codegen/java.ts
+++ b/java/scripts/codegen/java.ts
@@ -141,6 +141,273 @@ function resolveRef(schema: JSONSchema7 | undefined): JSONSchema7 | undefined {
     return schema;
 }
 
+/** Extract the definition name from a $ref string (e.g., "#/definitions/Foo" → "Foo") */
+function extractRefName(schema: JSONSchema7 | null | undefined): string | null {
+    if (!schema?.$ref) return null;
+    // Handle cross-schema refs
+    const crossMatch = schema.$ref.match(/^[^#]+#\/definitions\/(.+)$/);
+    if (crossMatch) return crossMatch[1];
+    return schema.$ref.replace(/^#\/definitions\//, "");
+}
+
+// ── Discriminated union support ─────────────────────────────────────────────
+
+interface DiscriminatorInfo {
+    property: string;
+    mapping: Map<string, { value: unknown; schema: JSONSchema7 }>;
+}
+
+/**
+ * Find a discriminator property shared by all variants in an anyOf.
+ * A discriminator is a property with a `const` value that uniquely identifies each variant.
+ */
+function findDiscriminator(variants: JSONSchema7[]): DiscriminatorInfo | null {
+    if (variants.length === 0) return null;
+    const firstVariant = variants[0];
+    if (!firstVariant.properties) return null;
+
+    for (const [propName, propSchema] of Object.entries(firstVariant.properties).sort(([a], [b]) => a.localeCompare(b))) {
+        if (typeof propSchema !== "object") continue;
+        const schema = propSchema as JSONSchema7;
+        if (schema.const === undefined) continue;
+
+        const mapping = new Map<string, { value: unknown; schema: JSONSchema7 }>();
+        let isValidDiscriminator = true;
+
+        for (const variant of variants) {
+            if (!variant.properties) { isValidDiscriminator = false; break; }
+            const variantProp = variant.properties[propName];
+            if (typeof variantProp !== "object") { isValidDiscriminator = false; break; }
+            const variantSchema = variantProp as JSONSchema7;
+            if (variantSchema.const === undefined) { isValidDiscriminator = false; break; }
+            const key = String(variantSchema.const);
+            if (mapping.has(key)) { isValidDiscriminator = false; break; }
+            mapping.set(key, { value: variantSchema.const, schema: variant });
+        }
+
+        if (isValidDiscriminator && mapping.size === variants.length) {
+            return { property: propName, mapping };
+        }
+    }
+    return null;
+}
+
+/**
+ * Resolve anyOf variants, handling $ref to definitions.
+ */
+function resolveAnyOfVariants(anyOf: JSONSchema7[]): JSONSchema7[] {
+    return anyOf
+        .map((v) => {
+            if (v.$ref) {
+                const name = v.$ref.replace(/^#\/definitions\//, "");
+                return currentDefinitions[name] ?? v;
+            }
+            return v;
+        })
+        .filter((v) => v.type !== "null");
+}
+
+/**
+ * Generate a polymorphic base class and variant subclasses for a discriminated union result type.
+ */
+async function generatePolymorphicResultClass(
+    className: string,
+    schema: JSONSchema7,
+    packageName: string,
+    packageDir: string
+): Promise<void> {
+    const anyOf = schema.anyOf as JSONSchema7[];
+    const variants = resolveAnyOfVariants(anyOf);
+    const discriminator = findDiscriminator(variants);
+
+    if (!discriminator) {
+        console.warn(`[codegen] Cannot find discriminator for ${className} — skipping polymorphic generation`);
+        return;
+    }
+
+    // Collect variant info
+    interface VariantInfo {
+        discriminatorValue: string;
+        variantClassName: string;
+        schema: JSONSchema7;
+    }
+
+    const variantInfos: VariantInfo[] = [];
+    for (const [discValue, { schema: variantSchema }] of discriminator.mapping) {
+        const variantClassName = (variantSchema as JSONSchema7 & { title?: string }).title ?? `${className}${toPascalCase(discValue)}`;
+        variantInfos.push({ discriminatorValue: discValue, variantClassName, schema: variantSchema });
+    }
+
+    // Generate the abstract base class
+    const baseLines: string[] = [];
+    baseLines.push(COPYRIGHT);
+    baseLines.push("");
+    baseLines.push(AUTO_GENERATED_HEADER);
+    baseLines.push(GENERATED_FROM_API);
+    baseLines.push("");
+    baseLines.push(`package ${packageName};`);
+    baseLines.push("");
+    baseLines.push(`import com.fasterxml.jackson.annotation.JsonIgnoreProperties;`);
+    baseLines.push(`import com.fasterxml.jackson.annotation.JsonSubTypes;`);
+    baseLines.push(`import com.fasterxml.jackson.annotation.JsonTypeInfo;`);
+    baseLines.push(`import javax.annotation.processing.Generated;`);
+    baseLines.push("");
+    if (schema.description) {
+        baseLines.push(`/**`);
+        baseLines.push(` * ${schema.description}`);
+        baseLines.push(` *`);
+        baseLines.push(` * @since 1.0.0`);
+        baseLines.push(` */`);
+    }
+    baseLines.push(`@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "${discriminator.property}", visible = true)`);
+    baseLines.push(`@JsonSubTypes({`);
+    for (let i = 0; i < variantInfos.length; i++) {
+        const v = variantInfos[i];
+        const comma = i < variantInfos.length - 1 ? "," : "";
+        baseLines.push(`    @JsonSubTypes.Type(value = ${v.variantClassName}.class, name = "${v.discriminatorValue}")${comma}`);
+    }
+    baseLines.push(`})`);
+    baseLines.push(`@JsonIgnoreProperties(ignoreUnknown = true)`);
+    baseLines.push(GENERATED_ANNOTATION);
+    baseLines.push(`public abstract class ${className} {`);
+    baseLines.push("");
+    baseLines.push(`    /**`);
+    baseLines.push(`     * Returns the discriminator value for this variant.`);
+    baseLines.push(`     *`);
+    baseLines.push(`     * @return the ${discriminator.property} discriminator`);
+    baseLines.push(`     */`);
+    baseLines.push(`    public abstract String get${toPascalCase(discriminator.property)}();`);
+    baseLines.push(`}`);
+    baseLines.push("");
+
+    await writeGeneratedFile(`${packageDir}/${className}.java`, baseLines.join("\n"));
+
+    // Generate each variant subclass
+    for (const variant of variantInfos) {
+        await generatePolymorphicVariantClass(variant.variantClassName, variant.schema, variant.discriminatorValue, discriminator.property, className, packageName, packageDir);
+    }
+}
+
+/**
+ * Generate a single variant subclass of a polymorphic result type.
+ */
+async function generatePolymorphicVariantClass(
+    className: string,
+    schema: JSONSchema7,
+    discriminatorValue: string,
+    discriminatorProperty: string,
+    baseClassName: string,
+    packageName: string,
+    packageDir: string
+): Promise<void> {
+    const allImports = new Set<string>([
+        "com.fasterxml.jackson.annotation.JsonIgnoreProperties",
+        "com.fasterxml.jackson.annotation.JsonInclude",
+        "com.fasterxml.jackson.annotation.JsonProperty",
+        "javax.annotation.processing.Generated",
+    ]);
+    const nestedTypes = new Map<string, JavaClassDef>();
+
+    // Collect fields (excluding the discriminator property)
+    interface FieldInfo {
+        jsonName: string;
+        javaName: string;
+        javaType: string;
+        description?: string;
+    }
+
+    const fields: FieldInfo[] = [];
+    if (schema.properties) {
+        for (const [propName, propSchema] of Object.entries(schema.properties)) {
+            if (propName === discriminatorProperty) continue;
+            if (typeof propSchema !== "object") continue;
+            const prop = propSchema as JSONSchema7;
+            const result = schemaTypeToJava(prop, false, className, propName, nestedTypes);
+            for (const imp of result.imports) allImports.add(imp);
+            fields.push({
+                jsonName: propName,
+                javaName: toCamelCase(propName),
+                javaType: result.javaType,
+                description: prop.description,
+            });
+        }
+    }
+
+    const lines: string[] = [];
+    lines.push(COPYRIGHT);
+    lines.push("");
+    lines.push(AUTO_GENERATED_HEADER);
+    lines.push(GENERATED_FROM_API);
+    lines.push("");
+    lines.push(`package ${packageName};`);
+    lines.push("");
+
+    // Placeholder for imports
+    const importPlaceholderIdx = lines.length;
+    lines.push("__IMPORTS__");
+    lines.push("");
+
+    if (schema.description) {
+        lines.push(`/**`);
+        lines.push(` * ${schema.description}`);
+        lines.push(` *`);
+        lines.push(` * @since 1.0.0`);
+        lines.push(` */`);
+    } else {
+        lines.push(`/**`);
+        lines.push(` * Variant {@code ${discriminatorValue}} of {@link ${baseClassName}}.`);
+        lines.push(` *`);
+        lines.push(` * @since 1.0.0`);
+        lines.push(` */`);
+    }
+    lines.push(`@JsonIgnoreProperties(ignoreUnknown = true)`);
+    lines.push(`@JsonInclude(JsonInclude.Include.NON_NULL)`);
+    lines.push(GENERATED_ANNOTATION);
+    lines.push(`public final class ${className} extends ${baseClassName} {`);
+    lines.push("");
+
+    // Discriminator field
+    lines.push(`    @JsonProperty("${discriminatorProperty}")`);
+    lines.push(`    private final String ${toCamelCase(discriminatorProperty)} = "${discriminatorValue}";`);
+    lines.push("");
+    lines.push(`    @Override`);
+    lines.push(`    public String get${toPascalCase(discriminatorProperty)}() { return ${toCamelCase(discriminatorProperty)}; }`);
+    lines.push("");
+
+    // Other fields
+    for (const field of fields) {
+        if (field.description) {
+            lines.push(`    /** ${field.description} */`);
+        }
+        lines.push(`    @JsonProperty("${field.jsonName}")`);
+        lines.push(`    private ${field.javaType} ${field.javaName};`);
+        lines.push("");
+    }
+
+    // Getters and setters
+    for (const field of fields) {
+        lines.push(`    public ${field.javaType} get${field.javaName.charAt(0).toUpperCase() + field.javaName.slice(1)}() { return ${field.javaName}; }`);
+        lines.push(`    public void set${field.javaName.charAt(0).toUpperCase() + field.javaName.slice(1)}(${field.javaType} ${field.javaName}) { this.${field.javaName} = ${field.javaName}; }`);
+        lines.push("");
+    }
+
+    // Render nested types
+    for (const [, nested] of nestedTypes) {
+        lines.push(...renderNestedType(nested, 1, new Map(), allImports));
+    }
+
+    if (lines[lines.length - 1] === "") lines.pop();
+    lines.push(`}`);
+    lines.push("");
+
+    // Replace import placeholder
+    const sortedImports = [...allImports].sort();
+    const importLines = sortedImports.map((i) => `import ${i};`).join("\n");
+    lines[importPlaceholderIdx] = importLines;
+
+    await writeGeneratedFile(`${packageDir}/${className}.java`, lines.join("\n"));
+}
+
 function schemaTypeToJava(
     schema: JSONSchema7,
     required: boolean,
@@ -727,6 +994,13 @@ async function generatePendingStandaloneTypes(
                 await generateStandaloneEnum(name, schema, packageName, packageDir, headerComment);
             } else if (schema.type === "object" && schema.properties) {
                 await generateStandaloneRecord(name, schema, packageName, packageDir, headerComment);
+            } else if (schema.anyOf && Array.isArray(schema.anyOf)) {
+                const variants = resolveAnyOfVariants(schema.anyOf as JSONSchema7[]);
+                if (variants.length > 1 && findDiscriminator(variants)) {
+                    await generatePolymorphicResultClass(name, schema, packageName, packageDir);
+                } else {
+                    console.warn(`[codegen] Cannot generate standalone type for ${name}: anyOf without discriminator`);
+                }
             } else {
                 console.warn(`[codegen] Cannot generate standalone type for ${name}: type=${schema.type}`);
             }
@@ -970,12 +1244,34 @@ async function generateRpcTypes(schemaPath: string): Promise<void> {
 
             // Generate result class — resolve $ref if result is a reference
             let resultSchema = method.result as JSONSchema7 | null;
+            const resultRefName = extractRefName(resultSchema);
             if (resultSchema?.$ref) resultSchema = resolveRef(resultSchema) as JSONSchema7;
-            if (resultSchema && typeof resultSchema === "object" && resultSchema.properties) {
-                const resultClassName = `${className}Result`;
-                if (!generatedClasses.has(resultClassName)) {
-                    generatedClasses.set(resultClassName, true);
-                    allFiles.push(await generateRpcDataClass(resultClassName, resultSchema, packageName, packageDir, method.rpcMethod, "result"));
+            if (resultSchema && typeof resultSchema === "object") {
+                if (resultSchema.properties && Object.keys(resultSchema.properties).length > 0) {
+                    // Object with properties → generate a record class
+                    const resultClassName = `${className}Result`;
+                    if (!generatedClasses.has(resultClassName)) {
+                        generatedClasses.set(resultClassName, true);
+                        allFiles.push(await generateRpcDataClass(resultClassName, resultSchema, packageName, packageDir, method.rpcMethod, "result"));
+                    }
+                } else if (resultRefName && resultSchema.type === "string" && resultSchema.enum) {
+                    // String enum → register for standalone generation
+                    pendingStandaloneTypes.set(resultRefName, resultSchema);
+                } else if (resultRefName && resultSchema.anyOf && Array.isArray(resultSchema.anyOf)) {
+                    // anyOf discriminated union → generate polymorphic hierarchy
+                    const variants = resolveAnyOfVariants(resultSchema.anyOf as JSONSchema7[]);
+                    if (variants.length > 1 && findDiscriminator(variants)) {
+                        if (!generatedClasses.has(resultRefName)) {
+                            generatedClasses.set(resultRefName, true);
+                            await generatePolymorphicResultClass(resultRefName, resultSchema, packageName, packageDir);
+                        }
+                    }
+                } else if (resultRefName && resultSchema.type === "object" && !resultSchema.properties) {
+                    // Empty named object → generate empty record
+                    if (!generatedClasses.has(resultRefName)) {
+                        generatedClasses.set(resultRefName, true);
+                        allFiles.push(await generateRpcDataClass(resultRefName, resultSchema, packageName, packageDir, method.rpcMethod, "result"));
+                    }
                 }
             }
         }
@@ -1092,11 +1388,43 @@ function apiClassName(prefix: string, path: string[]): string {
 
 /**
  * Derive the result class name for an RPC method.
- * If the result schema has no properties we use Void; if no result schema we also use Void.
+ * Handles $ref to named definitions (enums, anyOf unions, objects with properties).
+ * Falls back to Void for null results or schemas with no meaningful type.
  */
 function wrapperResultClassName(method: RpcMethodNode): string {
-    let result = method.result;
-    if (result?.$ref) result = resolveRef(result) as JSONSchema7;
+    const originalResult = method.result;
+    if (!originalResult) return "Void";
+
+    // If result is a $ref, use the definition name directly
+    const refName = extractRefName(originalResult);
+    if (refName) {
+        const resolved = currentDefinitions[refName];
+        if (resolved) {
+            // String enum → use the definition name
+            if (resolved.type === "string" && resolved.enum) {
+                return refName;
+            }
+            // anyOf discriminated union → use the definition name
+            if (resolved.anyOf && Array.isArray(resolved.anyOf)) {
+                const variants = resolveAnyOfVariants(resolved.anyOf as JSONSchema7[]);
+                if (variants.length > 1 && findDiscriminator(variants)) {
+                    return refName;
+                }
+            }
+            // Object with properties → use MethodNameResult
+            if (resolved.type === "object" && resolved.properties && Object.keys(resolved.properties).length > 0) {
+                return rpcMethodToClassName(method.rpcMethod) + "Result";
+            }
+            // Empty object (no properties) that is a named definition → use definition name
+            if (resolved.type === "object" && !resolved.properties) {
+                return refName;
+            }
+        }
+    }
+
+    // Inline result schema with properties
+    let result = originalResult;
+    if (result.$ref) result = resolveRef(result) as JSONSchema7;
     if (
         result &&
         typeof result === "object" &&

--- a/java/src/generated/java/com/github/copilot/generated/PermissionApproved.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionApproved.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionApproved` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionApproved extends PermissionResult {
+
+    @JsonProperty("kind")
+    private final String kind = "approved";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionApprovedForLocation.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionApprovedForLocation.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionApprovedForLocation` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionApprovedForLocation extends PermissionResult {
+
+    @JsonProperty("kind")
+    private final String kind = "approved-for-location";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** The approval to persist for this location */
+    @JsonProperty("approval")
+    private UserToolSessionApproval approval;
+
+    /** The location key (git root or cwd) to persist the approval to */
+    @JsonProperty("locationKey")
+    private String locationKey;
+
+    public UserToolSessionApproval getApproval() { return approval; }
+    public void setApproval(UserToolSessionApproval approval) { this.approval = approval; }
+
+    public String getLocationKey() { return locationKey; }
+    public void setLocationKey(String locationKey) { this.locationKey = locationKey; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionApprovedForSession.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionApprovedForSession.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionApprovedForSession` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionApprovedForSession extends PermissionResult {
+
+    @JsonProperty("kind")
+    private final String kind = "approved-for-session";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** The approval to add as a session-scoped rule */
+    @JsonProperty("approval")
+    private UserToolSessionApproval approval;
+
+    public UserToolSessionApproval getApproval() { return approval; }
+    public void setApproval(UserToolSessionApproval approval) { this.approval = approval; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionCancelled.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionCancelled.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionCancelled` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionCancelled extends PermissionResult {
+
+    @JsonProperty("kind")
+    private final String kind = "cancelled";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Optional explanation of why the request was cancelled */
+    @JsonProperty("reason")
+    private String reason;
+
+    public String getReason() { return reason; }
+    public void setReason(String reason) { this.reason = reason; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionDeniedByContentExclusionPolicy.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionDeniedByContentExclusionPolicy.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDeniedByContentExclusionPolicy` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDeniedByContentExclusionPolicy extends PermissionResult {
+
+    @JsonProperty("kind")
+    private final String kind = "denied-by-content-exclusion-policy";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** File path that triggered the exclusion */
+    @JsonProperty("path")
+    private String path;
+
+    /** Human-readable explanation of why the path was excluded */
+    @JsonProperty("message")
+    private String message;
+
+    public String getPath() { return path; }
+    public void setPath(String path) { this.path = path; }
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionDeniedByPermissionRequestHook.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionDeniedByPermissionRequestHook.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDeniedByPermissionRequestHook` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDeniedByPermissionRequestHook extends PermissionResult {
+
+    @JsonProperty("kind")
+    private final String kind = "denied-by-permission-request-hook";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Optional message from the hook explaining the denial */
+    @JsonProperty("message")
+    private String message;
+
+    /** Whether to interrupt the current agent turn */
+    @JsonProperty("interrupt")
+    private Boolean interrupt;
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+
+    public Boolean getInterrupt() { return interrupt; }
+    public void setInterrupt(Boolean interrupt) { this.interrupt = interrupt; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionDeniedByRules.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionDeniedByRules.java
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDeniedByRules` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDeniedByRules extends PermissionResult {
+
+    @JsonProperty("kind")
+    private final String kind = "denied-by-rules";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Rules that denied the request */
+    @JsonProperty("rules")
+    private List<PermissionRule> rules;
+
+    public List<PermissionRule> getRules() { return rules; }
+    public void setRules(List<PermissionRule> rules) { this.rules = rules; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionDeniedInteractivelyByUser.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionDeniedInteractivelyByUser.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDeniedInteractivelyByUser` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDeniedInteractivelyByUser extends PermissionResult {
+
+    @JsonProperty("kind")
+    private final String kind = "denied-interactively-by-user";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Optional feedback from the user explaining the denial */
+    @JsonProperty("feedback")
+    private String feedback;
+
+    /** Whether to force-reject the current agent turn */
+    @JsonProperty("forceReject")
+    private Boolean forceReject;
+
+    public String getFeedback() { return feedback; }
+    public void setFeedback(String feedback) { this.feedback = feedback; }
+
+    public Boolean getForceReject() { return forceReject; }
+    public void setForceReject(Boolean forceReject) { this.forceReject = forceReject; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionDeniedNoApprovalRuleAndCouldNotRequestFromUser.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionDeniedNoApprovalRuleAndCouldNotRequestFromUser.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDeniedNoApprovalRuleAndCouldNotRequestFromUser` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDeniedNoApprovalRuleAndCouldNotRequestFromUser extends PermissionResult {
+
+    @JsonProperty("kind")
+    private final String kind = "denied-no-approval-rule-and-could-not-request-from-user";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequest.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequest.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import javax.annotation.processing.Generated;
+
+/**
+ * Derived user-facing permission prompt details for UI consumers
+ *
+ * @since 1.0.0
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = PermissionPromptRequestCommands.class, name = "commands"),
+    @JsonSubTypes.Type(value = PermissionPromptRequestWrite.class, name = "write"),
+    @JsonSubTypes.Type(value = PermissionPromptRequestRead.class, name = "read"),
+    @JsonSubTypes.Type(value = PermissionPromptRequestMcp.class, name = "mcp"),
+    @JsonSubTypes.Type(value = PermissionPromptRequestUrl.class, name = "url"),
+    @JsonSubTypes.Type(value = PermissionPromptRequestMemory.class, name = "memory"),
+    @JsonSubTypes.Type(value = PermissionPromptRequestCustomTool.class, name = "custom-tool"),
+    @JsonSubTypes.Type(value = PermissionPromptRequestPath.class, name = "path"),
+    @JsonSubTypes.Type(value = PermissionPromptRequestHook.class, name = "hook"),
+    @JsonSubTypes.Type(value = PermissionPromptRequestExtensionManagement.class, name = "extension-management"),
+    @JsonSubTypes.Type(value = PermissionPromptRequestExtensionPermissionAccess.class, name = "extension-permission-access")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public abstract class PermissionPromptRequest {
+
+    /**
+     * Returns the discriminator value for this variant.
+     *
+     * @return the kind discriminator
+     */
+    public abstract String getKind();
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestCommands.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestCommands.java
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+/**
+ * Shell command permission prompt
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionPromptRequestCommands extends PermissionPromptRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "commands";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** The complete shell command text to be executed */
+    @JsonProperty("fullCommandText")
+    private String fullCommandText;
+
+    /** Human-readable description of what the command intends to do */
+    @JsonProperty("intention")
+    private String intention;
+
+    /** Command identifiers covered by this approval prompt */
+    @JsonProperty("commandIdentifiers")
+    private List<String> commandIdentifiers;
+
+    /** Whether the UI can offer session-wide approval for this command pattern */
+    @JsonProperty("canOfferSessionApproval")
+    private Boolean canOfferSessionApproval;
+
+    /** Optional warning message about risks of running this command */
+    @JsonProperty("warning")
+    private String warning;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public String getFullCommandText() { return fullCommandText; }
+    public void setFullCommandText(String fullCommandText) { this.fullCommandText = fullCommandText; }
+
+    public String getIntention() { return intention; }
+    public void setIntention(String intention) { this.intention = intention; }
+
+    public List<String> getCommandIdentifiers() { return commandIdentifiers; }
+    public void setCommandIdentifiers(List<String> commandIdentifiers) { this.commandIdentifiers = commandIdentifiers; }
+
+    public Boolean getCanOfferSessionApproval() { return canOfferSessionApproval; }
+    public void setCanOfferSessionApproval(Boolean canOfferSessionApproval) { this.canOfferSessionApproval = canOfferSessionApproval; }
+
+    public String getWarning() { return warning; }
+    public void setWarning(String warning) { this.warning = warning; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestCustomTool.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestCustomTool.java
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Custom tool invocation permission prompt
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionPromptRequestCustomTool extends PermissionPromptRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "custom-tool";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** Name of the custom tool */
+    @JsonProperty("toolName")
+    private String toolName;
+
+    /** Description of what the custom tool does */
+    @JsonProperty("toolDescription")
+    private String toolDescription;
+
+    /** Arguments to pass to the custom tool */
+    @JsonProperty("args")
+    private Object args;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public String getToolName() { return toolName; }
+    public void setToolName(String toolName) { this.toolName = toolName; }
+
+    public String getToolDescription() { return toolDescription; }
+    public void setToolDescription(String toolDescription) { this.toolDescription = toolDescription; }
+
+    public Object getArgs() { return args; }
+    public void setArgs(Object args) { this.args = args; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestExtensionManagement.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestExtensionManagement.java
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Extension management permission prompt
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionPromptRequestExtensionManagement extends PermissionPromptRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "extension-management";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** The extension management operation (scaffold, reload) */
+    @JsonProperty("operation")
+    private String operation;
+
+    /** Name of the extension being managed */
+    @JsonProperty("extensionName")
+    private String extensionName;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public String getOperation() { return operation; }
+    public void setOperation(String operation) { this.operation = operation; }
+
+    public String getExtensionName() { return extensionName; }
+    public void setExtensionName(String extensionName) { this.extensionName = extensionName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestExtensionPermissionAccess.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestExtensionPermissionAccess.java
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+/**
+ * Extension permission access prompt
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionPromptRequestExtensionPermissionAccess extends PermissionPromptRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "extension-permission-access";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** Name of the extension requesting permission access */
+    @JsonProperty("extensionName")
+    private String extensionName;
+
+    /** Capabilities the extension is requesting */
+    @JsonProperty("capabilities")
+    private List<String> capabilities;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public String getExtensionName() { return extensionName; }
+    public void setExtensionName(String extensionName) { this.extensionName = extensionName; }
+
+    public List<String> getCapabilities() { return capabilities; }
+    public void setCapabilities(List<String> capabilities) { this.capabilities = capabilities; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestHook.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestHook.java
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Hook confirmation permission prompt
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionPromptRequestHook extends PermissionPromptRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "hook";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** Name of the tool the hook is gating */
+    @JsonProperty("toolName")
+    private String toolName;
+
+    /** Arguments of the tool call being gated */
+    @JsonProperty("toolArgs")
+    private Object toolArgs;
+
+    /** Optional message from the hook explaining why confirmation is needed */
+    @JsonProperty("hookMessage")
+    private String hookMessage;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public String getToolName() { return toolName; }
+    public void setToolName(String toolName) { this.toolName = toolName; }
+
+    public Object getToolArgs() { return toolArgs; }
+    public void setToolArgs(Object toolArgs) { this.toolArgs = toolArgs; }
+
+    public String getHookMessage() { return hookMessage; }
+    public void setHookMessage(String hookMessage) { this.hookMessage = hookMessage; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestMcp.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestMcp.java
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * MCP tool invocation permission prompt
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionPromptRequestMcp extends PermissionPromptRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "mcp";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** Name of the MCP server providing the tool */
+    @JsonProperty("serverName")
+    private String serverName;
+
+    /** Internal name of the MCP tool */
+    @JsonProperty("toolName")
+    private String toolName;
+
+    /** Human-readable title of the MCP tool */
+    @JsonProperty("toolTitle")
+    private String toolTitle;
+
+    /** Arguments to pass to the MCP tool */
+    @JsonProperty("args")
+    private Object args;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public String getServerName() { return serverName; }
+    public void setServerName(String serverName) { this.serverName = serverName; }
+
+    public String getToolName() { return toolName; }
+    public void setToolName(String toolName) { this.toolName = toolName; }
+
+    public String getToolTitle() { return toolTitle; }
+    public void setToolTitle(String toolTitle) { this.toolTitle = toolTitle; }
+
+    public Object getArgs() { return args; }
+    public void setArgs(Object args) { this.args = args; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestMemory.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestMemory.java
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Memory operation permission prompt
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionPromptRequestMemory extends PermissionPromptRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "memory";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** Whether this is a store or vote memory operation */
+    @JsonProperty("action")
+    private PermissionRequestMemoryAction action;
+
+    /** Topic or subject of the memory (store only) */
+    @JsonProperty("subject")
+    private String subject;
+
+    /** The fact being stored or voted on */
+    @JsonProperty("fact")
+    private String fact;
+
+    /** Source references for the stored fact (store only) */
+    @JsonProperty("citations")
+    private String citations;
+
+    /** Vote direction (vote only) */
+    @JsonProperty("direction")
+    private PermissionRequestMemoryDirection direction;
+
+    /** Reason for the vote (vote only) */
+    @JsonProperty("reason")
+    private String reason;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public PermissionRequestMemoryAction getAction() { return action; }
+    public void setAction(PermissionRequestMemoryAction action) { this.action = action; }
+
+    public String getSubject() { return subject; }
+    public void setSubject(String subject) { this.subject = subject; }
+
+    public String getFact() { return fact; }
+    public void setFact(String fact) { this.fact = fact; }
+
+    public String getCitations() { return citations; }
+    public void setCitations(String citations) { this.citations = citations; }
+
+    public PermissionRequestMemoryDirection getDirection() { return direction; }
+    public void setDirection(PermissionRequestMemoryDirection direction) { this.direction = direction; }
+
+    public String getReason() { return reason; }
+    public void setReason(String reason) { this.reason = reason; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestPath.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestPath.java
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+/**
+ * Path access permission prompt
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionPromptRequestPath extends PermissionPromptRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "path";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** Underlying permission kind that needs path approval */
+    @JsonProperty("accessKind")
+    private PermissionPromptRequestPathAccessKind accessKind;
+
+    /** File paths that require explicit approval */
+    @JsonProperty("paths")
+    private List<String> paths;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public PermissionPromptRequestPathAccessKind getAccessKind() { return accessKind; }
+    public void setAccessKind(PermissionPromptRequestPathAccessKind accessKind) { this.accessKind = accessKind; }
+
+    public List<String> getPaths() { return paths; }
+    public void setPaths(List<String> paths) { this.paths = paths; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestPathAccessKind.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestPathAccessKind.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: session-events.schema.json
+
+package com.github.copilot.generated;
+
+import javax.annotation.processing.Generated;
+
+/**
+ * Underlying permission kind that needs path approval
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public enum PermissionPromptRequestPathAccessKind {
+    /** The {@code read} variant. */
+    READ("read"),
+    /** The {@code shell} variant. */
+    SHELL("shell"),
+    /** The {@code write} variant. */
+    WRITE("write");
+
+    private final String value;
+    PermissionPromptRequestPathAccessKind(String value) { this.value = value; }
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() { return value; }
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static PermissionPromptRequestPathAccessKind fromValue(String value) {
+        for (PermissionPromptRequestPathAccessKind v : values()) {
+            if (v.value.equals(value)) return v;
+        }
+        throw new IllegalArgumentException("Unknown PermissionPromptRequestPathAccessKind value: " + value);
+    }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestRead.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestRead.java
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * File read permission prompt
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionPromptRequestRead extends PermissionPromptRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "read";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** Human-readable description of why the file is being read */
+    @JsonProperty("intention")
+    private String intention;
+
+    /** Path of the file or directory being read */
+    @JsonProperty("path")
+    private String path;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public String getIntention() { return intention; }
+    public void setIntention(String intention) { this.intention = intention; }
+
+    public String getPath() { return path; }
+    public void setPath(String path) { this.path = path; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestUrl.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestUrl.java
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * URL access permission prompt
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionPromptRequestUrl extends PermissionPromptRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "url";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** Human-readable description of why the URL is being accessed */
+    @JsonProperty("intention")
+    private String intention;
+
+    /** URL to be fetched */
+    @JsonProperty("url")
+    private String url;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public String getIntention() { return intention; }
+    public void setIntention(String intention) { this.intention = intention; }
+
+    public String getUrl() { return url; }
+    public void setUrl(String url) { this.url = url; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestWrite.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionPromptRequestWrite.java
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * File write permission prompt
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionPromptRequestWrite extends PermissionPromptRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "write";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** Human-readable description of the intended file change */
+    @JsonProperty("intention")
+    private String intention;
+
+    /** Path of the file being written to */
+    @JsonProperty("fileName")
+    private String fileName;
+
+    /** Unified diff showing the proposed changes */
+    @JsonProperty("diff")
+    private String diff;
+
+    /** Complete new file contents for newly created files */
+    @JsonProperty("newFileContents")
+    private String newFileContents;
+
+    /** Whether the UI can offer session-wide approval for file write operations */
+    @JsonProperty("canOfferSessionApproval")
+    private Boolean canOfferSessionApproval;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public String getIntention() { return intention; }
+    public void setIntention(String intention) { this.intention = intention; }
+
+    public String getFileName() { return fileName; }
+    public void setFileName(String fileName) { this.fileName = fileName; }
+
+    public String getDiff() { return diff; }
+    public void setDiff(String diff) { this.diff = diff; }
+
+    public String getNewFileContents() { return newFileContents; }
+    public void setNewFileContents(String newFileContents) { this.newFileContents = newFileContents; }
+
+    public Boolean getCanOfferSessionApproval() { return canOfferSessionApproval; }
+    public void setCanOfferSessionApproval(Boolean canOfferSessionApproval) { this.canOfferSessionApproval = canOfferSessionApproval; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionRequest.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionRequest.java
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import javax.annotation.processing.Generated;
+
+/**
+ * Details of the permission being requested
+ *
+ * @since 1.0.0
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = PermissionRequestShell.class, name = "shell"),
+    @JsonSubTypes.Type(value = PermissionRequestWrite.class, name = "write"),
+    @JsonSubTypes.Type(value = PermissionRequestRead.class, name = "read"),
+    @JsonSubTypes.Type(value = PermissionRequestMcp.class, name = "mcp"),
+    @JsonSubTypes.Type(value = PermissionRequestUrl.class, name = "url"),
+    @JsonSubTypes.Type(value = PermissionRequestMemory.class, name = "memory"),
+    @JsonSubTypes.Type(value = PermissionRequestCustomTool.class, name = "custom-tool"),
+    @JsonSubTypes.Type(value = PermissionRequestHook.class, name = "hook"),
+    @JsonSubTypes.Type(value = PermissionRequestExtensionManagement.class, name = "extension-management"),
+    @JsonSubTypes.Type(value = PermissionRequestExtensionPermissionAccess.class, name = "extension-permission-access")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public abstract class PermissionRequest {
+
+    /**
+     * Returns the discriminator value for this variant.
+     *
+     * @return the kind discriminator
+     */
+    public abstract String getKind();
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionRequestCustomTool.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionRequestCustomTool.java
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Custom tool invocation permission request
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionRequestCustomTool extends PermissionRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "custom-tool";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** Name of the custom tool */
+    @JsonProperty("toolName")
+    private String toolName;
+
+    /** Description of what the custom tool does */
+    @JsonProperty("toolDescription")
+    private String toolDescription;
+
+    /** Arguments to pass to the custom tool */
+    @JsonProperty("args")
+    private Object args;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public String getToolName() { return toolName; }
+    public void setToolName(String toolName) { this.toolName = toolName; }
+
+    public String getToolDescription() { return toolDescription; }
+    public void setToolDescription(String toolDescription) { this.toolDescription = toolDescription; }
+
+    public Object getArgs() { return args; }
+    public void setArgs(Object args) { this.args = args; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionRequestExtensionManagement.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionRequestExtensionManagement.java
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Extension management permission request
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionRequestExtensionManagement extends PermissionRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "extension-management";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** The extension management operation (scaffold, reload) */
+    @JsonProperty("operation")
+    private String operation;
+
+    /** Name of the extension being managed */
+    @JsonProperty("extensionName")
+    private String extensionName;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public String getOperation() { return operation; }
+    public void setOperation(String operation) { this.operation = operation; }
+
+    public String getExtensionName() { return extensionName; }
+    public void setExtensionName(String extensionName) { this.extensionName = extensionName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionRequestExtensionPermissionAccess.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionRequestExtensionPermissionAccess.java
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+/**
+ * Extension permission access request
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionRequestExtensionPermissionAccess extends PermissionRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "extension-permission-access";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** Name of the extension requesting permission access */
+    @JsonProperty("extensionName")
+    private String extensionName;
+
+    /** Capabilities the extension is requesting */
+    @JsonProperty("capabilities")
+    private List<String> capabilities;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public String getExtensionName() { return extensionName; }
+    public void setExtensionName(String extensionName) { this.extensionName = extensionName; }
+
+    public List<String> getCapabilities() { return capabilities; }
+    public void setCapabilities(List<String> capabilities) { this.capabilities = capabilities; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionRequestHook.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionRequestHook.java
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Hook confirmation permission request
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionRequestHook extends PermissionRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "hook";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** Name of the tool the hook is gating */
+    @JsonProperty("toolName")
+    private String toolName;
+
+    /** Arguments of the tool call being gated */
+    @JsonProperty("toolArgs")
+    private Object toolArgs;
+
+    /** Optional message from the hook explaining why confirmation is needed */
+    @JsonProperty("hookMessage")
+    private String hookMessage;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public String getToolName() { return toolName; }
+    public void setToolName(String toolName) { this.toolName = toolName; }
+
+    public Object getToolArgs() { return toolArgs; }
+    public void setToolArgs(Object toolArgs) { this.toolArgs = toolArgs; }
+
+    public String getHookMessage() { return hookMessage; }
+    public void setHookMessage(String hookMessage) { this.hookMessage = hookMessage; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionRequestMcp.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionRequestMcp.java
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * MCP tool invocation permission request
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionRequestMcp extends PermissionRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "mcp";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** Name of the MCP server providing the tool */
+    @JsonProperty("serverName")
+    private String serverName;
+
+    /** Internal name of the MCP tool */
+    @JsonProperty("toolName")
+    private String toolName;
+
+    /** Human-readable title of the MCP tool */
+    @JsonProperty("toolTitle")
+    private String toolTitle;
+
+    /** Arguments to pass to the MCP tool */
+    @JsonProperty("args")
+    private Object args;
+
+    /** Whether this MCP tool is read-only (no side effects) */
+    @JsonProperty("readOnly")
+    private Boolean readOnly;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public String getServerName() { return serverName; }
+    public void setServerName(String serverName) { this.serverName = serverName; }
+
+    public String getToolName() { return toolName; }
+    public void setToolName(String toolName) { this.toolName = toolName; }
+
+    public String getToolTitle() { return toolTitle; }
+    public void setToolTitle(String toolTitle) { this.toolTitle = toolTitle; }
+
+    public Object getArgs() { return args; }
+    public void setArgs(Object args) { this.args = args; }
+
+    public Boolean getReadOnly() { return readOnly; }
+    public void setReadOnly(Boolean readOnly) { this.readOnly = readOnly; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionRequestMemory.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionRequestMemory.java
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Memory operation permission request
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionRequestMemory extends PermissionRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "memory";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** Whether this is a store or vote memory operation */
+    @JsonProperty("action")
+    private PermissionRequestMemoryAction action;
+
+    /** Topic or subject of the memory (store only) */
+    @JsonProperty("subject")
+    private String subject;
+
+    /** The fact being stored or voted on */
+    @JsonProperty("fact")
+    private String fact;
+
+    /** Source references for the stored fact (store only) */
+    @JsonProperty("citations")
+    private String citations;
+
+    /** Vote direction (vote only) */
+    @JsonProperty("direction")
+    private PermissionRequestMemoryDirection direction;
+
+    /** Reason for the vote (vote only) */
+    @JsonProperty("reason")
+    private String reason;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public PermissionRequestMemoryAction getAction() { return action; }
+    public void setAction(PermissionRequestMemoryAction action) { this.action = action; }
+
+    public String getSubject() { return subject; }
+    public void setSubject(String subject) { this.subject = subject; }
+
+    public String getFact() { return fact; }
+    public void setFact(String fact) { this.fact = fact; }
+
+    public String getCitations() { return citations; }
+    public void setCitations(String citations) { this.citations = citations; }
+
+    public PermissionRequestMemoryDirection getDirection() { return direction; }
+    public void setDirection(PermissionRequestMemoryDirection direction) { this.direction = direction; }
+
+    public String getReason() { return reason; }
+    public void setReason(String reason) { this.reason = reason; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionRequestMemoryAction.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionRequestMemoryAction.java
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: session-events.schema.json
+
+package com.github.copilot.generated;
+
+import javax.annotation.processing.Generated;
+
+/**
+ * Whether this is a store or vote memory operation
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public enum PermissionRequestMemoryAction {
+    /** The {@code store} variant. */
+    STORE("store"),
+    /** The {@code vote} variant. */
+    VOTE("vote");
+
+    private final String value;
+    PermissionRequestMemoryAction(String value) { this.value = value; }
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() { return value; }
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static PermissionRequestMemoryAction fromValue(String value) {
+        for (PermissionRequestMemoryAction v : values()) {
+            if (v.value.equals(value)) return v;
+        }
+        throw new IllegalArgumentException("Unknown PermissionRequestMemoryAction value: " + value);
+    }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionRequestMemoryDirection.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionRequestMemoryDirection.java
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: session-events.schema.json
+
+package com.github.copilot.generated;
+
+import javax.annotation.processing.Generated;
+
+/**
+ * Vote direction (vote only)
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public enum PermissionRequestMemoryDirection {
+    /** The {@code upvote} variant. */
+    UPVOTE("upvote"),
+    /** The {@code downvote} variant. */
+    DOWNVOTE("downvote");
+
+    private final String value;
+    PermissionRequestMemoryDirection(String value) { this.value = value; }
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() { return value; }
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static PermissionRequestMemoryDirection fromValue(String value) {
+        for (PermissionRequestMemoryDirection v : values()) {
+            if (v.value.equals(value)) return v;
+        }
+        throw new IllegalArgumentException("Unknown PermissionRequestMemoryDirection value: " + value);
+    }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionRequestRead.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionRequestRead.java
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * File or directory read permission request
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionRequestRead extends PermissionRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "read";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** Human-readable description of why the file is being read */
+    @JsonProperty("intention")
+    private String intention;
+
+    /** Path of the file or directory being read */
+    @JsonProperty("path")
+    private String path;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public String getIntention() { return intention; }
+    public void setIntention(String intention) { this.intention = intention; }
+
+    public String getPath() { return path; }
+    public void setPath(String path) { this.path = path; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionRequestShell.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionRequestShell.java
@@ -1,0 +1,94 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+/**
+ * Shell command permission request
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionRequestShell extends PermissionRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "shell";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** The complete shell command text to be executed */
+    @JsonProperty("fullCommandText")
+    private String fullCommandText;
+
+    /** Human-readable description of what the command intends to do */
+    @JsonProperty("intention")
+    private String intention;
+
+    /** Parsed command identifiers found in the command text */
+    @JsonProperty("commands")
+    private List<PermissionRequestShellCommand> commands;
+
+    /** File paths that may be read or written by the command */
+    @JsonProperty("possiblePaths")
+    private List<String> possiblePaths;
+
+    /** URLs that may be accessed by the command */
+    @JsonProperty("possibleUrls")
+    private List<PermissionRequestShellPossibleUrl> possibleUrls;
+
+    /** Whether the command includes a file write redirection (e.g., > or >>) */
+    @JsonProperty("hasWriteFileRedirection")
+    private Boolean hasWriteFileRedirection;
+
+    /** Whether the UI can offer session-wide approval for this command pattern */
+    @JsonProperty("canOfferSessionApproval")
+    private Boolean canOfferSessionApproval;
+
+    /** Optional warning message about risks of running this command */
+    @JsonProperty("warning")
+    private String warning;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public String getFullCommandText() { return fullCommandText; }
+    public void setFullCommandText(String fullCommandText) { this.fullCommandText = fullCommandText; }
+
+    public String getIntention() { return intention; }
+    public void setIntention(String intention) { this.intention = intention; }
+
+    public List<PermissionRequestShellCommand> getCommands() { return commands; }
+    public void setCommands(List<PermissionRequestShellCommand> commands) { this.commands = commands; }
+
+    public List<String> getPossiblePaths() { return possiblePaths; }
+    public void setPossiblePaths(List<String> possiblePaths) { this.possiblePaths = possiblePaths; }
+
+    public List<PermissionRequestShellPossibleUrl> getPossibleUrls() { return possibleUrls; }
+    public void setPossibleUrls(List<PermissionRequestShellPossibleUrl> possibleUrls) { this.possibleUrls = possibleUrls; }
+
+    public Boolean getHasWriteFileRedirection() { return hasWriteFileRedirection; }
+    public void setHasWriteFileRedirection(Boolean hasWriteFileRedirection) { this.hasWriteFileRedirection = hasWriteFileRedirection; }
+
+    public Boolean getCanOfferSessionApproval() { return canOfferSessionApproval; }
+    public void setCanOfferSessionApproval(Boolean canOfferSessionApproval) { this.canOfferSessionApproval = canOfferSessionApproval; }
+
+    public String getWarning() { return warning; }
+    public void setWarning(String warning) { this.warning = warning; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionRequestShellCommand.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionRequestShellCommand.java
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: session-events.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionRequestShellCommand` type.
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PermissionRequestShellCommand(
+    /** Command identifier (e.g., executable name) */
+    @JsonProperty("identifier") String identifier,
+    /** Whether this command is read-only (no side effects) */
+    @JsonProperty("readOnly") Boolean readOnly
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionRequestShellPossibleUrl.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionRequestShellPossibleUrl.java
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: session-events.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionRequestShellPossibleUrl` type.
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PermissionRequestShellPossibleUrl(
+    /** URL that may be accessed by the command */
+    @JsonProperty("url") String url
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionRequestUrl.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionRequestUrl.java
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * URL access permission request
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionRequestUrl extends PermissionRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "url";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** Human-readable description of why the URL is being accessed */
+    @JsonProperty("intention")
+    private String intention;
+
+    /** URL to be fetched */
+    @JsonProperty("url")
+    private String url;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public String getIntention() { return intention; }
+    public void setIntention(String intention) { this.intention = intention; }
+
+    public String getUrl() { return url; }
+    public void setUrl(String url) { this.url = url; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionRequestWrite.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionRequestWrite.java
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * File write permission request
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionRequestWrite extends PermissionRequest {
+
+    @JsonProperty("kind")
+    private final String kind = "write";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Tool call ID that triggered this permission request */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** Human-readable description of the intended file change */
+    @JsonProperty("intention")
+    private String intention;
+
+    /** Path of the file being written to */
+    @JsonProperty("fileName")
+    private String fileName;
+
+    /** Unified diff showing the proposed changes */
+    @JsonProperty("diff")
+    private String diff;
+
+    /** Complete new file contents for newly created files */
+    @JsonProperty("newFileContents")
+    private String newFileContents;
+
+    /** Whether the UI can offer session-wide approval for file write operations */
+    @JsonProperty("canOfferSessionApproval")
+    private Boolean canOfferSessionApproval;
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public String getIntention() { return intention; }
+    public void setIntention(String intention) { this.intention = intention; }
+
+    public String getFileName() { return fileName; }
+    public void setFileName(String fileName) { this.fileName = fileName; }
+
+    public String getDiff() { return diff; }
+    public void setDiff(String diff) { this.diff = diff; }
+
+    public String getNewFileContents() { return newFileContents; }
+    public void setNewFileContents(String newFileContents) { this.newFileContents = newFileContents; }
+
+    public Boolean getCanOfferSessionApproval() { return canOfferSessionApproval; }
+    public void setCanOfferSessionApproval(Boolean canOfferSessionApproval) { this.canOfferSessionApproval = canOfferSessionApproval; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionResult.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionResult.java
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import javax.annotation.processing.Generated;
+
+/**
+ * The result of the permission request
+ *
+ * @since 1.0.0
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = PermissionApproved.class, name = "approved"),
+    @JsonSubTypes.Type(value = PermissionApprovedForSession.class, name = "approved-for-session"),
+    @JsonSubTypes.Type(value = PermissionApprovedForLocation.class, name = "approved-for-location"),
+    @JsonSubTypes.Type(value = PermissionCancelled.class, name = "cancelled"),
+    @JsonSubTypes.Type(value = PermissionDeniedByRules.class, name = "denied-by-rules"),
+    @JsonSubTypes.Type(value = PermissionDeniedNoApprovalRuleAndCouldNotRequestFromUser.class, name = "denied-no-approval-rule-and-could-not-request-from-user"),
+    @JsonSubTypes.Type(value = PermissionDeniedInteractivelyByUser.class, name = "denied-interactively-by-user"),
+    @JsonSubTypes.Type(value = PermissionDeniedByContentExclusionPolicy.class, name = "denied-by-content-exclusion-policy"),
+    @JsonSubTypes.Type(value = PermissionDeniedByPermissionRequestHook.class, name = "denied-by-permission-request-hook")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public abstract class PermissionResult {
+
+    /**
+     * Returns the discriminator value for this variant.
+     *
+     * @return the kind discriminator
+     */
+    public abstract String getKind();
+}

--- a/java/src/generated/java/com/github/copilot/generated/PermissionRule.java
+++ b/java/src/generated/java/com/github/copilot/generated/PermissionRule.java
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: session-events.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionRule` type.
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PermissionRule(
+    /** The rule kind, such as Shell or GitHubMCP */
+    @JsonProperty("kind") String kind,
+    /** Argument value matched against the request, or null when the rule kind has no argument (e.g. 'read', 'write', 'memory'). */
+    @JsonProperty("argument") String argument
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/SystemNotification.java
+++ b/java/src/generated/java/com/github/copilot/generated/SystemNotification.java
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import javax.annotation.processing.Generated;
+
+/**
+ * Structured metadata identifying what triggered this notification
+ *
+ * @since 1.0.0
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = SystemNotificationAgentCompleted.class, name = "agent_completed"),
+    @JsonSubTypes.Type(value = SystemNotificationAgentIdle.class, name = "agent_idle"),
+    @JsonSubTypes.Type(value = SystemNotificationNewInboxMessage.class, name = "new_inbox_message"),
+    @JsonSubTypes.Type(value = SystemNotificationShellCompleted.class, name = "shell_completed"),
+    @JsonSubTypes.Type(value = SystemNotificationShellDetachedCompleted.class, name = "shell_detached_completed"),
+    @JsonSubTypes.Type(value = SystemNotificationInstructionDiscovered.class, name = "instruction_discovered")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public abstract class SystemNotification {
+
+    /**
+     * Returns the discriminator value for this variant.
+     *
+     * @return the type discriminator
+     */
+    public abstract String getType();
+}

--- a/java/src/generated/java/com/github/copilot/generated/SystemNotificationAgentCompleted.java
+++ b/java/src/generated/java/com/github/copilot/generated/SystemNotificationAgentCompleted.java
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `SystemNotificationAgentCompleted` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class SystemNotificationAgentCompleted extends SystemNotification {
+
+    @JsonProperty("type")
+    private final String type = "agent_completed";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Unique identifier of the background agent */
+    @JsonProperty("agentId")
+    private String agentId;
+
+    /** Type of the agent (e.g., explore, task, general-purpose) */
+    @JsonProperty("agentType")
+    private String agentType;
+
+    /** Whether the agent completed successfully or failed */
+    @JsonProperty("status")
+    private SystemNotificationAgentCompletedStatus status;
+
+    /** Human-readable description of the agent task */
+    @JsonProperty("description")
+    private String description;
+
+    /** The full prompt given to the background agent */
+    @JsonProperty("prompt")
+    private String prompt;
+
+    public String getAgentId() { return agentId; }
+    public void setAgentId(String agentId) { this.agentId = agentId; }
+
+    public String getAgentType() { return agentType; }
+    public void setAgentType(String agentType) { this.agentType = agentType; }
+
+    public SystemNotificationAgentCompletedStatus getStatus() { return status; }
+    public void setStatus(SystemNotificationAgentCompletedStatus status) { this.status = status; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getPrompt() { return prompt; }
+    public void setPrompt(String prompt) { this.prompt = prompt; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/SystemNotificationAgentCompletedStatus.java
+++ b/java/src/generated/java/com/github/copilot/generated/SystemNotificationAgentCompletedStatus.java
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: session-events.schema.json
+
+package com.github.copilot.generated;
+
+import javax.annotation.processing.Generated;
+
+/**
+ * Whether the agent completed successfully or failed
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public enum SystemNotificationAgentCompletedStatus {
+    /** The {@code completed} variant. */
+    COMPLETED("completed"),
+    /** The {@code failed} variant. */
+    FAILED("failed");
+
+    private final String value;
+    SystemNotificationAgentCompletedStatus(String value) { this.value = value; }
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() { return value; }
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static SystemNotificationAgentCompletedStatus fromValue(String value) {
+        for (SystemNotificationAgentCompletedStatus v : values()) {
+            if (v.value.equals(value)) return v;
+        }
+        throw new IllegalArgumentException("Unknown SystemNotificationAgentCompletedStatus value: " + value);
+    }
+}

--- a/java/src/generated/java/com/github/copilot/generated/SystemNotificationAgentIdle.java
+++ b/java/src/generated/java/com/github/copilot/generated/SystemNotificationAgentIdle.java
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `SystemNotificationAgentIdle` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class SystemNotificationAgentIdle extends SystemNotification {
+
+    @JsonProperty("type")
+    private final String type = "agent_idle";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Unique identifier of the background agent */
+    @JsonProperty("agentId")
+    private String agentId;
+
+    /** Type of the agent (e.g., explore, task, general-purpose) */
+    @JsonProperty("agentType")
+    private String agentType;
+
+    /** Human-readable description of the agent task */
+    @JsonProperty("description")
+    private String description;
+
+    public String getAgentId() { return agentId; }
+    public void setAgentId(String agentId) { this.agentId = agentId; }
+
+    public String getAgentType() { return agentType; }
+    public void setAgentType(String agentType) { this.agentType = agentType; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/SystemNotificationInstructionDiscovered.java
+++ b/java/src/generated/java/com/github/copilot/generated/SystemNotificationInstructionDiscovered.java
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `SystemNotificationInstructionDiscovered` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class SystemNotificationInstructionDiscovered extends SystemNotification {
+
+    @JsonProperty("type")
+    private final String type = "instruction_discovered";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Relative path to the discovered instruction file */
+    @JsonProperty("sourcePath")
+    private String sourcePath;
+
+    /** Path of the file access that triggered discovery */
+    @JsonProperty("triggerFile")
+    private String triggerFile;
+
+    /** Tool command that triggered discovery (currently always 'view') */
+    @JsonProperty("triggerTool")
+    private String triggerTool;
+
+    /** Human-readable label for the timeline (e.g., 'AGENTS.md from packages/billing/') */
+    @JsonProperty("description")
+    private String description;
+
+    public String getSourcePath() { return sourcePath; }
+    public void setSourcePath(String sourcePath) { this.sourcePath = sourcePath; }
+
+    public String getTriggerFile() { return triggerFile; }
+    public void setTriggerFile(String triggerFile) { this.triggerFile = triggerFile; }
+
+    public String getTriggerTool() { return triggerTool; }
+    public void setTriggerTool(String triggerTool) { this.triggerTool = triggerTool; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/SystemNotificationNewInboxMessage.java
+++ b/java/src/generated/java/com/github/copilot/generated/SystemNotificationNewInboxMessage.java
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `SystemNotificationNewInboxMessage` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class SystemNotificationNewInboxMessage extends SystemNotification {
+
+    @JsonProperty("type")
+    private final String type = "new_inbox_message";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Unique identifier of the inbox entry */
+    @JsonProperty("entryId")
+    private String entryId;
+
+    /** Human-readable name of the sender */
+    @JsonProperty("senderName")
+    private String senderName;
+
+    /** Category of the sender (e.g., sidekick-agent, plugin, hook) */
+    @JsonProperty("senderType")
+    private String senderType;
+
+    /** Short summary shown before the agent decides whether to read the inbox */
+    @JsonProperty("summary")
+    private String summary;
+
+    public String getEntryId() { return entryId; }
+    public void setEntryId(String entryId) { this.entryId = entryId; }
+
+    public String getSenderName() { return senderName; }
+    public void setSenderName(String senderName) { this.senderName = senderName; }
+
+    public String getSenderType() { return senderType; }
+    public void setSenderType(String senderType) { this.senderType = senderType; }
+
+    public String getSummary() { return summary; }
+    public void setSummary(String summary) { this.summary = summary; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/SystemNotificationShellCompleted.java
+++ b/java/src/generated/java/com/github/copilot/generated/SystemNotificationShellCompleted.java
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `SystemNotificationShellCompleted` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class SystemNotificationShellCompleted extends SystemNotification {
+
+    @JsonProperty("type")
+    private final String type = "shell_completed";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Unique identifier of the shell session */
+    @JsonProperty("shellId")
+    private String shellId;
+
+    /** Exit code of the shell command, if available */
+    @JsonProperty("exitCode")
+    private Long exitCode;
+
+    /** Human-readable description of the command */
+    @JsonProperty("description")
+    private String description;
+
+    public String getShellId() { return shellId; }
+    public void setShellId(String shellId) { this.shellId = shellId; }
+
+    public Long getExitCode() { return exitCode; }
+    public void setExitCode(Long exitCode) { this.exitCode = exitCode; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/SystemNotificationShellDetachedCompleted.java
+++ b/java/src/generated/java/com/github/copilot/generated/SystemNotificationShellDetachedCompleted.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `SystemNotificationShellDetachedCompleted` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class SystemNotificationShellDetachedCompleted extends SystemNotification {
+
+    @JsonProperty("type")
+    private final String type = "shell_detached_completed";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Unique identifier of the detached shell session */
+    @JsonProperty("shellId")
+    private String shellId;
+
+    /** Human-readable description of the command */
+    @JsonProperty("description")
+    private String description;
+
+    public String getShellId() { return shellId; }
+    public void setShellId(String shellId) { this.shellId = shellId; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/ToolExecutionCompleteContent.java
+++ b/java/src/generated/java/com/github/copilot/generated/ToolExecutionCompleteContent.java
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import javax.annotation.processing.Generated;
+
+/**
+ * A content block within a tool result, which may be text, terminal output, image, audio, or a resource
+ *
+ * @since 1.0.0
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = ToolExecutionCompleteContentText.class, name = "text"),
+    @JsonSubTypes.Type(value = ToolExecutionCompleteContentTerminal.class, name = "terminal"),
+    @JsonSubTypes.Type(value = ToolExecutionCompleteContentImage.class, name = "image"),
+    @JsonSubTypes.Type(value = ToolExecutionCompleteContentAudio.class, name = "audio"),
+    @JsonSubTypes.Type(value = ToolExecutionCompleteContentResourceLink.class, name = "resource_link"),
+    @JsonSubTypes.Type(value = ToolExecutionCompleteContentResource.class, name = "resource")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public abstract class ToolExecutionCompleteContent {
+
+    /**
+     * Returns the discriminator value for this variant.
+     *
+     * @return the type discriminator
+     */
+    public abstract String getType();
+}

--- a/java/src/generated/java/com/github/copilot/generated/ToolExecutionCompleteContentAudio.java
+++ b/java/src/generated/java/com/github/copilot/generated/ToolExecutionCompleteContentAudio.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Audio content block with base64-encoded data
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class ToolExecutionCompleteContentAudio extends ToolExecutionCompleteContent {
+
+    @JsonProperty("type")
+    private final String type = "audio";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Base64-encoded audio data */
+    @JsonProperty("data")
+    private String data;
+
+    /** MIME type of the audio (e.g., audio/wav, audio/mpeg) */
+    @JsonProperty("mimeType")
+    private String mimeType;
+
+    public String getData() { return data; }
+    public void setData(String data) { this.data = data; }
+
+    public String getMimeType() { return mimeType; }
+    public void setMimeType(String mimeType) { this.mimeType = mimeType; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/ToolExecutionCompleteContentImage.java
+++ b/java/src/generated/java/com/github/copilot/generated/ToolExecutionCompleteContentImage.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Image content block with base64-encoded data
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class ToolExecutionCompleteContentImage extends ToolExecutionCompleteContent {
+
+    @JsonProperty("type")
+    private final String type = "image";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Base64-encoded image data */
+    @JsonProperty("data")
+    private String data;
+
+    /** MIME type of the image (e.g., image/png, image/jpeg) */
+    @JsonProperty("mimeType")
+    private String mimeType;
+
+    public String getData() { return data; }
+    public void setData(String data) { this.data = data; }
+
+    public String getMimeType() { return mimeType; }
+    public void setMimeType(String mimeType) { this.mimeType = mimeType; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/ToolExecutionCompleteContentResource.java
+++ b/java/src/generated/java/com/github/copilot/generated/ToolExecutionCompleteContentResource.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Embedded resource content block with inline text or binary data
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class ToolExecutionCompleteContentResource extends ToolExecutionCompleteContent {
+
+    @JsonProperty("type")
+    private final String type = "resource";
+
+    @Override
+    public String getType() { return type; }
+
+    /** The embedded resource contents, either text or base64-encoded binary */
+    @JsonProperty("resource")
+    private Object resource;
+
+    public Object getResource() { return resource; }
+    public void setResource(Object resource) { this.resource = resource; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/ToolExecutionCompleteContentResourceLink.java
+++ b/java/src/generated/java/com/github/copilot/generated/ToolExecutionCompleteContentResourceLink.java
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+/**
+ * Resource link content block referencing an external resource
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class ToolExecutionCompleteContentResourceLink extends ToolExecutionCompleteContent {
+
+    @JsonProperty("type")
+    private final String type = "resource_link";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Icons associated with this resource */
+    @JsonProperty("icons")
+    private List<ToolExecutionCompleteContentResourceLinkIcon> icons;
+
+    /** Resource name identifier */
+    @JsonProperty("name")
+    private String name;
+
+    /** Human-readable display title for the resource */
+    @JsonProperty("title")
+    private String title;
+
+    /** URI identifying the resource */
+    @JsonProperty("uri")
+    private String uri;
+
+    /** Human-readable description of the resource */
+    @JsonProperty("description")
+    private String description;
+
+    /** MIME type of the resource content */
+    @JsonProperty("mimeType")
+    private String mimeType;
+
+    /** Size of the resource in bytes */
+    @JsonProperty("size")
+    private Long size;
+
+    public List<ToolExecutionCompleteContentResourceLinkIcon> getIcons() { return icons; }
+    public void setIcons(List<ToolExecutionCompleteContentResourceLinkIcon> icons) { this.icons = icons; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public String getUri() { return uri; }
+    public void setUri(String uri) { this.uri = uri; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getMimeType() { return mimeType; }
+    public void setMimeType(String mimeType) { this.mimeType = mimeType; }
+
+    public Long getSize() { return size; }
+    public void setSize(Long size) { this.size = size; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/ToolExecutionCompleteContentResourceLinkIcon.java
+++ b/java/src/generated/java/com/github/copilot/generated/ToolExecutionCompleteContentResourceLinkIcon.java
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: session-events.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+/**
+ * Icon image for a resource
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ToolExecutionCompleteContentResourceLinkIcon(
+    /** URL or path to the icon image */
+    @JsonProperty("src") String src,
+    /** MIME type of the icon image */
+    @JsonProperty("mimeType") String mimeType,
+    /** Available icon sizes (e.g., ['16x16', '32x32']) */
+    @JsonProperty("sizes") List<String> sizes,
+    /** Theme variant this icon is intended for */
+    @JsonProperty("theme") ToolExecutionCompleteContentResourceLinkIconTheme theme
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/ToolExecutionCompleteContentResourceLinkIconTheme.java
+++ b/java/src/generated/java/com/github/copilot/generated/ToolExecutionCompleteContentResourceLinkIconTheme.java
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: session-events.schema.json
+
+package com.github.copilot.generated;
+
+import javax.annotation.processing.Generated;
+
+/**
+ * Theme variant this icon is intended for
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public enum ToolExecutionCompleteContentResourceLinkIconTheme {
+    /** The {@code light} variant. */
+    LIGHT("light"),
+    /** The {@code dark} variant. */
+    DARK("dark");
+
+    private final String value;
+    ToolExecutionCompleteContentResourceLinkIconTheme(String value) { this.value = value; }
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() { return value; }
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static ToolExecutionCompleteContentResourceLinkIconTheme fromValue(String value) {
+        for (ToolExecutionCompleteContentResourceLinkIconTheme v : values()) {
+            if (v.value.equals(value)) return v;
+        }
+        throw new IllegalArgumentException("Unknown ToolExecutionCompleteContentResourceLinkIconTheme value: " + value);
+    }
+}

--- a/java/src/generated/java/com/github/copilot/generated/ToolExecutionCompleteContentTerminal.java
+++ b/java/src/generated/java/com/github/copilot/generated/ToolExecutionCompleteContentTerminal.java
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Terminal/shell output content block with optional exit code and working directory
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class ToolExecutionCompleteContentTerminal extends ToolExecutionCompleteContent {
+
+    @JsonProperty("type")
+    private final String type = "terminal";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Terminal/shell output text */
+    @JsonProperty("text")
+    private String text;
+
+    /** Process exit code, if the command has completed */
+    @JsonProperty("exitCode")
+    private Long exitCode;
+
+    /** Working directory where the command was executed */
+    @JsonProperty("cwd")
+    private String cwd;
+
+    public String getText() { return text; }
+    public void setText(String text) { this.text = text; }
+
+    public Long getExitCode() { return exitCode; }
+    public void setExitCode(Long exitCode) { this.exitCode = exitCode; }
+
+    public String getCwd() { return cwd; }
+    public void setCwd(String cwd) { this.cwd = cwd; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/ToolExecutionCompleteContentText.java
+++ b/java/src/generated/java/com/github/copilot/generated/ToolExecutionCompleteContentText.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Plain text content block
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class ToolExecutionCompleteContentText extends ToolExecutionCompleteContent {
+
+    @JsonProperty("type")
+    private final String type = "text";
+
+    @Override
+    public String getType() { return type; }
+
+    /** The text content */
+    @JsonProperty("text")
+    private String text;
+
+    public String getText() { return text; }
+    public void setText(String text) { this.text = text; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserMessageAttachment.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserMessageAttachment.java
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import javax.annotation.processing.Generated;
+
+/**
+ * A user message attachment — a file, directory, code selection, blob, or GitHub reference
+ *
+ * @since 1.0.0
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = UserMessageAttachmentFile.class, name = "file"),
+    @JsonSubTypes.Type(value = UserMessageAttachmentDirectory.class, name = "directory"),
+    @JsonSubTypes.Type(value = UserMessageAttachmentSelection.class, name = "selection"),
+    @JsonSubTypes.Type(value = UserMessageAttachmentGithubReference.class, name = "github_reference"),
+    @JsonSubTypes.Type(value = UserMessageAttachmentBlob.class, name = "blob")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public abstract class UserMessageAttachment {
+
+    /**
+     * Returns the discriminator value for this variant.
+     *
+     * @return the type discriminator
+     */
+    public abstract String getType();
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentBlob.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentBlob.java
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Blob attachment with inline base64-encoded data
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserMessageAttachmentBlob extends UserMessageAttachment {
+
+    @JsonProperty("type")
+    private final String type = "blob";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Base64-encoded content */
+    @JsonProperty("data")
+    private String data;
+
+    /** MIME type of the inline data */
+    @JsonProperty("mimeType")
+    private String mimeType;
+
+    /** User-facing display name for the attachment */
+    @JsonProperty("displayName")
+    private String displayName;
+
+    public String getData() { return data; }
+    public void setData(String data) { this.data = data; }
+
+    public String getMimeType() { return mimeType; }
+    public void setMimeType(String mimeType) { this.mimeType = mimeType; }
+
+    public String getDisplayName() { return displayName; }
+    public void setDisplayName(String displayName) { this.displayName = displayName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentDirectory.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentDirectory.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Directory attachment
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserMessageAttachmentDirectory extends UserMessageAttachment {
+
+    @JsonProperty("type")
+    private final String type = "directory";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Absolute directory path */
+    @JsonProperty("path")
+    private String path;
+
+    /** User-facing display name for the attachment */
+    @JsonProperty("displayName")
+    private String displayName;
+
+    public String getPath() { return path; }
+    public void setPath(String path) { this.path = path; }
+
+    public String getDisplayName() { return displayName; }
+    public void setDisplayName(String displayName) { this.displayName = displayName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentFile.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentFile.java
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * File attachment
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserMessageAttachmentFile extends UserMessageAttachment {
+
+    @JsonProperty("type")
+    private final String type = "file";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Absolute file path */
+    @JsonProperty("path")
+    private String path;
+
+    /** User-facing display name for the attachment */
+    @JsonProperty("displayName")
+    private String displayName;
+
+    /** Optional line range to scope the attachment to a specific section of the file */
+    @JsonProperty("lineRange")
+    private UserMessageAttachmentFileLineRange lineRange;
+
+    public String getPath() { return path; }
+    public void setPath(String path) { this.path = path; }
+
+    public String getDisplayName() { return displayName; }
+    public void setDisplayName(String displayName) { this.displayName = displayName; }
+
+    public UserMessageAttachmentFileLineRange getLineRange() { return lineRange; }
+    public void setLineRange(UserMessageAttachmentFileLineRange lineRange) { this.lineRange = lineRange; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentFileLineRange.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentFileLineRange.java
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: session-events.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Optional line range to scope the attachment to a specific section of the file
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record UserMessageAttachmentFileLineRange(
+    /** Start line number (1-based) */
+    @JsonProperty("start") Long start,
+    /** End line number (1-based, inclusive) */
+    @JsonProperty("end") Long end
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentGithubReference.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentGithubReference.java
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * GitHub issue, pull request, or discussion reference
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserMessageAttachmentGithubReference extends UserMessageAttachment {
+
+    @JsonProperty("type")
+    private final String type = "github_reference";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Issue, pull request, or discussion number */
+    @JsonProperty("number")
+    private Long number;
+
+    /** Title of the referenced item */
+    @JsonProperty("title")
+    private String title;
+
+    /** Type of GitHub reference */
+    @JsonProperty("referenceType")
+    private UserMessageAttachmentGithubReferenceType referenceType;
+
+    /** Current state of the referenced item (e.g., open, closed, merged) */
+    @JsonProperty("state")
+    private String state;
+
+    /** URL to the referenced item on GitHub */
+    @JsonProperty("url")
+    private String url;
+
+    public Long getNumber() { return number; }
+    public void setNumber(Long number) { this.number = number; }
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public UserMessageAttachmentGithubReferenceType getReferenceType() { return referenceType; }
+    public void setReferenceType(UserMessageAttachmentGithubReferenceType referenceType) { this.referenceType = referenceType; }
+
+    public String getState() { return state; }
+    public void setState(String state) { this.state = state; }
+
+    public String getUrl() { return url; }
+    public void setUrl(String url) { this.url = url; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentGithubReferenceType.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentGithubReferenceType.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: session-events.schema.json
+
+package com.github.copilot.generated;
+
+import javax.annotation.processing.Generated;
+
+/**
+ * Type of GitHub reference
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public enum UserMessageAttachmentGithubReferenceType {
+    /** The {@code issue} variant. */
+    ISSUE("issue"),
+    /** The {@code pr} variant. */
+    PR("pr"),
+    /** The {@code discussion} variant. */
+    DISCUSSION("discussion");
+
+    private final String value;
+    UserMessageAttachmentGithubReferenceType(String value) { this.value = value; }
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() { return value; }
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static UserMessageAttachmentGithubReferenceType fromValue(String value) {
+        for (UserMessageAttachmentGithubReferenceType v : values()) {
+            if (v.value.equals(value)) return v;
+        }
+        throw new IllegalArgumentException("Unknown UserMessageAttachmentGithubReferenceType value: " + value);
+    }
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentSelection.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentSelection.java
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Code selection attachment from an editor
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserMessageAttachmentSelection extends UserMessageAttachment {
+
+    @JsonProperty("type")
+    private final String type = "selection";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Absolute path to the file containing the selection */
+    @JsonProperty("filePath")
+    private String filePath;
+
+    /** User-facing display name for the selection */
+    @JsonProperty("displayName")
+    private String displayName;
+
+    /** The selected text content */
+    @JsonProperty("text")
+    private String text;
+
+    /** Position range of the selection within the file */
+    @JsonProperty("selection")
+    private UserMessageAttachmentSelectionDetails selection;
+
+    public String getFilePath() { return filePath; }
+    public void setFilePath(String filePath) { this.filePath = filePath; }
+
+    public String getDisplayName() { return displayName; }
+    public void setDisplayName(String displayName) { this.displayName = displayName; }
+
+    public String getText() { return text; }
+    public void setText(String text) { this.text = text; }
+
+    public UserMessageAttachmentSelectionDetails getSelection() { return selection; }
+    public void setSelection(UserMessageAttachmentSelectionDetails selection) { this.selection = selection; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentSelectionDetails.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentSelectionDetails.java
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: session-events.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Position range of the selection within the file
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record UserMessageAttachmentSelectionDetails(
+    /** Start position of the selection */
+    @JsonProperty("start") UserMessageAttachmentSelectionDetailsStart start,
+    /** End position of the selection */
+    @JsonProperty("end") UserMessageAttachmentSelectionDetailsEnd end
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentSelectionDetailsEnd.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentSelectionDetailsEnd.java
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: session-events.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * End position of the selection
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record UserMessageAttachmentSelectionDetailsEnd(
+    /** End line number (0-based) */
+    @JsonProperty("line") Long line,
+    /** End character offset within the line (0-based) */
+    @JsonProperty("character") Long character
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentSelectionDetailsStart.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserMessageAttachmentSelectionDetailsStart.java
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: session-events.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Start position of the selection
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record UserMessageAttachmentSelectionDetailsStart(
+    /** Start line number (0-based) */
+    @JsonProperty("line") Long line,
+    /** Start character offset within the line (0-based) */
+    @JsonProperty("character") Long character
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserToolSessionApproval.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserToolSessionApproval.java
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import javax.annotation.processing.Generated;
+
+/**
+ * The approval to add as a session-scoped rule
+ *
+ * @since 1.0.0
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = UserToolSessionApprovalCommands.class, name = "commands"),
+    @JsonSubTypes.Type(value = UserToolSessionApprovalRead.class, name = "read"),
+    @JsonSubTypes.Type(value = UserToolSessionApprovalWrite.class, name = "write"),
+    @JsonSubTypes.Type(value = UserToolSessionApprovalMcp.class, name = "mcp"),
+    @JsonSubTypes.Type(value = UserToolSessionApprovalMemory.class, name = "memory"),
+    @JsonSubTypes.Type(value = UserToolSessionApprovalCustomTool.class, name = "custom-tool"),
+    @JsonSubTypes.Type(value = UserToolSessionApprovalExtensionManagement.class, name = "extension-management"),
+    @JsonSubTypes.Type(value = UserToolSessionApprovalExtensionPermissionAccess.class, name = "extension-permission-access")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public abstract class UserToolSessionApproval {
+
+    /**
+     * Returns the discriminator value for this variant.
+     *
+     * @return the kind discriminator
+     */
+    public abstract String getKind();
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserToolSessionApprovalCommands.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserToolSessionApprovalCommands.java
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `UserToolSessionApprovalCommands` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserToolSessionApprovalCommands extends UserToolSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "commands";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Command identifiers approved by the user */
+    @JsonProperty("commandIdentifiers")
+    private List<String> commandIdentifiers;
+
+    public List<String> getCommandIdentifiers() { return commandIdentifiers; }
+    public void setCommandIdentifiers(List<String> commandIdentifiers) { this.commandIdentifiers = commandIdentifiers; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserToolSessionApprovalCustomTool.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserToolSessionApprovalCustomTool.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `UserToolSessionApprovalCustomTool` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserToolSessionApprovalCustomTool extends UserToolSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "custom-tool";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Custom tool name */
+    @JsonProperty("toolName")
+    private String toolName;
+
+    public String getToolName() { return toolName; }
+    public void setToolName(String toolName) { this.toolName = toolName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserToolSessionApprovalExtensionManagement.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserToolSessionApprovalExtensionManagement.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `UserToolSessionApprovalExtensionManagement` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserToolSessionApprovalExtensionManagement extends UserToolSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "extension-management";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Optional operation identifier */
+    @JsonProperty("operation")
+    private String operation;
+
+    public String getOperation() { return operation; }
+    public void setOperation(String operation) { this.operation = operation; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserToolSessionApprovalExtensionPermissionAccess.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserToolSessionApprovalExtensionPermissionAccess.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `UserToolSessionApprovalExtensionPermissionAccess` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserToolSessionApprovalExtensionPermissionAccess extends UserToolSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "extension-permission-access";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Extension name */
+    @JsonProperty("extensionName")
+    private String extensionName;
+
+    public String getExtensionName() { return extensionName; }
+    public void setExtensionName(String extensionName) { this.extensionName = extensionName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserToolSessionApprovalMcp.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserToolSessionApprovalMcp.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `UserToolSessionApprovalMcp` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserToolSessionApprovalMcp extends UserToolSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "mcp";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** MCP server name */
+    @JsonProperty("serverName")
+    private String serverName;
+
+    /** Optional MCP tool name, or null for all tools on the server */
+    @JsonProperty("toolName")
+    private String toolName;
+
+    public String getServerName() { return serverName; }
+    public void setServerName(String serverName) { this.serverName = serverName; }
+
+    public String getToolName() { return toolName; }
+    public void setToolName(String toolName) { this.toolName = toolName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserToolSessionApprovalMemory.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserToolSessionApprovalMemory.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `UserToolSessionApprovalMemory` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserToolSessionApprovalMemory extends UserToolSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "memory";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserToolSessionApprovalRead.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserToolSessionApprovalRead.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `UserToolSessionApprovalRead` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserToolSessionApprovalRead extends UserToolSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "read";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/UserToolSessionApprovalWrite.java
+++ b/java/src/generated/java/com/github/copilot/generated/UserToolSessionApprovalWrite.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `UserToolSessionApprovalWrite` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserToolSessionApprovalWrite extends UserToolSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "write";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistryLiveTargetEntry.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistryLiveTargetEntry.java
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Full registry entry for the spawned child. Lets the controller call `handleLiveTargetSelected(entry)` directly without re-reading the registry (avoids a TOCTOU window).
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AgentRegistryLiveTargetEntry(
+    /** Registry entry schema version (1 = ui-server, 2 = managed-server) */
+    @JsonProperty("schemaVersion") Long schemaVersion,
+    /** Process kind tag for the registry entry */
+    @JsonProperty("kind") AgentRegistryLiveTargetEntryKind kind,
+    /** Operating-system pid of the process owning this entry */
+    @JsonProperty("pid") Long pid,
+    /** Bind host for the entry's JSON-RPC server */
+    @JsonProperty("host") String host,
+    /** TCP port the entry's JSON-RPC server is listening on */
+    @JsonProperty("port") Long port,
+    /** Connection token (null when the target is unauthenticated) */
+    @JsonProperty("token") String token,
+    /** Session ID of the foreground session for this entry */
+    @JsonProperty("sessionId") String sessionId,
+    /** Friendly session name (when set) */
+    @JsonProperty("sessionName") String sessionName,
+    /** Working directory of the session (when known) */
+    @JsonProperty("cwd") String cwd,
+    /** Git branch of the session (when known) */
+    @JsonProperty("branch") String branch,
+    /** Model identifier currently selected for the session */
+    @JsonProperty("model") String model,
+    /** Coarse lifecycle status of the foreground session */
+    @JsonProperty("status") AgentRegistryLiveTargetEntryStatus status,
+    /** Kind of attention required when status === "attention". Meaningful only when status === "attention". */
+    @JsonProperty("attentionKind") AgentRegistryLiveTargetEntryAttentionKind attentionKind,
+    /** Monotonic per-publisher revision counter incremented on every status update. Lets watchers detect transient flips. */
+    @JsonProperty("statusRevision") Long statusRevision,
+    /** How the most recent turn ended (clean vs aborted). Lets the renderer distinguish done from done_cancelled. */
+    @JsonProperty("lastTerminalEvent") AgentRegistryLiveTargetEntryLastTerminalEvent lastTerminalEvent,
+    /** ISO 8601 timestamp captured at registration */
+    @JsonProperty("startedAt") String startedAt,
+    /** Copilot CLI version that wrote the entry */
+    @JsonProperty("copilotVersion") String copilotVersion,
+    /** Wall-clock milliseconds since the watcher last observed this entry (heartbeat freshness) */
+    @JsonProperty("lastSeenMs") Long lastSeenMs
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistryLiveTargetEntryAttentionKind.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistryLiveTargetEntryAttentionKind.java
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import javax.annotation.processing.Generated;
+
+/**
+ * Kind of attention required when status === "attention". Meaningful only when status === "attention".
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public enum AgentRegistryLiveTargetEntryAttentionKind {
+    /** The {@code error} variant. */
+    ERROR("error"),
+    /** The {@code permission} variant. */
+    PERMISSION("permission"),
+    /** The {@code exit_plan} variant. */
+    EXIT_PLAN("exit_plan"),
+    /** The {@code elicitation} variant. */
+    ELICITATION("elicitation"),
+    /** The {@code user_input} variant. */
+    USER_INPUT("user_input");
+
+    private final String value;
+    AgentRegistryLiveTargetEntryAttentionKind(String value) { this.value = value; }
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() { return value; }
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static AgentRegistryLiveTargetEntryAttentionKind fromValue(String value) {
+        for (AgentRegistryLiveTargetEntryAttentionKind v : values()) {
+            if (v.value.equals(value)) return v;
+        }
+        throw new IllegalArgumentException("Unknown AgentRegistryLiveTargetEntryAttentionKind value: " + value);
+    }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistryLiveTargetEntryKind.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistryLiveTargetEntryKind.java
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import javax.annotation.processing.Generated;
+
+/**
+ * Process kind tag for the registry entry
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public enum AgentRegistryLiveTargetEntryKind {
+    /** The {@code ui-server} variant. */
+    UI_SERVER("ui-server"),
+    /** The {@code managed-server} variant. */
+    MANAGED_SERVER("managed-server");
+
+    private final String value;
+    AgentRegistryLiveTargetEntryKind(String value) { this.value = value; }
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() { return value; }
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static AgentRegistryLiveTargetEntryKind fromValue(String value) {
+        for (AgentRegistryLiveTargetEntryKind v : values()) {
+            if (v.value.equals(value)) return v;
+        }
+        throw new IllegalArgumentException("Unknown AgentRegistryLiveTargetEntryKind value: " + value);
+    }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistryLiveTargetEntryLastTerminalEvent.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistryLiveTargetEntryLastTerminalEvent.java
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import javax.annotation.processing.Generated;
+
+/**
+ * How the most recent turn ended (clean vs aborted). Lets the renderer distinguish done from done_cancelled.
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public enum AgentRegistryLiveTargetEntryLastTerminalEvent {
+    /** The {@code turn_end} variant. */
+    TURN_END("turn_end"),
+    /** The {@code abort} variant. */
+    ABORT("abort");
+
+    private final String value;
+    AgentRegistryLiveTargetEntryLastTerminalEvent(String value) { this.value = value; }
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() { return value; }
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static AgentRegistryLiveTargetEntryLastTerminalEvent fromValue(String value) {
+        for (AgentRegistryLiveTargetEntryLastTerminalEvent v : values()) {
+            if (v.value.equals(value)) return v;
+        }
+        throw new IllegalArgumentException("Unknown AgentRegistryLiveTargetEntryLastTerminalEvent value: " + value);
+    }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistryLiveTargetEntryStatus.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistryLiveTargetEntryStatus.java
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import javax.annotation.processing.Generated;
+
+/**
+ * Coarse lifecycle status of the foreground session
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public enum AgentRegistryLiveTargetEntryStatus {
+    /** The {@code working} variant. */
+    WORKING("working"),
+    /** The {@code waiting} variant. */
+    WAITING("waiting"),
+    /** The {@code done} variant. */
+    DONE("done"),
+    /** The {@code attention} variant. */
+    ATTENTION("attention");
+
+    private final String value;
+    AgentRegistryLiveTargetEntryStatus(String value) { this.value = value; }
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() { return value; }
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static AgentRegistryLiveTargetEntryStatus fromValue(String value) {
+        for (AgentRegistryLiveTargetEntryStatus v : values()) {
+            if (v.value.equals(value)) return v;
+        }
+        throw new IllegalArgumentException("Unknown AgentRegistryLiveTargetEntryStatus value: " + value);
+    }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistryLogCapture.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistryLogCapture.java
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Per-spawn log-capture outcome; populated from spawnLiveTarget.
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AgentRegistryLogCapture(
+    /** Whether per-spawn log capture is on (false when env-disabled or open failed) */
+    @JsonProperty("enabled") Boolean enabled,
+    /** Absolute path to the per-spawn log file (only set when enabled) */
+    @JsonProperty("path") String path,
+    /** Human-readable open failure message (only set when enabled === false AND the env-disable opt-out was NOT used) */
+    @JsonProperty("openError") String openError,
+    /** Categorized reason for log-open failure */
+    @JsonProperty("openErrorReason") AgentRegistryLogCaptureOpenErrorReason openErrorReason
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistryLogCaptureOpenErrorReason.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistryLogCaptureOpenErrorReason.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import javax.annotation.processing.Generated;
+
+/**
+ * Categorized reason for log-open failure
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public enum AgentRegistryLogCaptureOpenErrorReason {
+    /** The {@code permission} variant. */
+    PERMISSION("permission"),
+    /** The {@code disk_full} variant. */
+    DISK_FULL("disk_full"),
+    /** The {@code other} variant. */
+    OTHER("other");
+
+    private final String value;
+    AgentRegistryLogCaptureOpenErrorReason(String value) { this.value = value; }
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() { return value; }
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static AgentRegistryLogCaptureOpenErrorReason fromValue(String value) {
+        for (AgentRegistryLogCaptureOpenErrorReason v : values()) {
+            if (v.value.equals(value)) return v;
+        }
+        throw new IllegalArgumentException("Unknown AgentRegistryLogCaptureOpenErrorReason value: " + value);
+    }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistrySpawnError.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistrySpawnError.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * `child_process.spawn` itself failed before the child entered the registry.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class AgentRegistrySpawnError extends AgentRegistrySpawnResult {
+
+    @JsonProperty("kind")
+    private final String kind = "spawn-error";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Human-readable error message */
+    @JsonProperty("message")
+    private String message;
+
+    /** Underlying errno code (e.g. ENOENT, EACCES) when available */
+    @JsonProperty("code")
+    private String code;
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistrySpawnRegistryTimeout.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistrySpawnRegistryTimeout.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Spawn succeeded but the child did not publish a matching managed-server entry within the timeout.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class AgentRegistrySpawnRegistryTimeout extends AgentRegistrySpawnResult {
+
+    @JsonProperty("kind")
+    private final String kind = "registry-timeout";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Process ID of the orphaned child (so the caller can offer 'kill the pid' guidance) */
+    @JsonProperty("childPid")
+    private Long childPid;
+
+    /** Per-spawn log-capture outcome; populated from spawnLiveTarget. */
+    @JsonProperty("logCapture")
+    private AgentRegistryLogCapture logCapture;
+
+    public Long getChildPid() { return childPid; }
+    public void setChildPid(Long childPid) { this.childPid = childPid; }
+
+    public AgentRegistryLogCapture getLogCapture() { return logCapture; }
+    public void setLogCapture(AgentRegistryLogCapture logCapture) { this.logCapture = logCapture; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistrySpawnResult.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistrySpawnResult.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import javax.annotation.processing.Generated;
+
+/**
+ * Outcome of an agentRegistry.spawn call.
+ *
+ * @since 1.0.0
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = AgentRegistrySpawnSpawned.class, name = "spawned"),
+    @JsonSubTypes.Type(value = AgentRegistrySpawnError.class, name = "spawn-error"),
+    @JsonSubTypes.Type(value = AgentRegistrySpawnRegistryTimeout.class, name = "registry-timeout"),
+    @JsonSubTypes.Type(value = AgentRegistrySpawnValidationError.class, name = "validation-error")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public abstract class AgentRegistrySpawnResult {
+
+    /**
+     * Returns the discriminator value for this variant.
+     *
+     * @return the kind discriminator
+     */
+    public abstract String getKind();
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistrySpawnSpawned.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistrySpawnSpawned.java
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Managed-server child was spawned and registered successfully.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class AgentRegistrySpawnSpawned extends AgentRegistrySpawnResult {
+
+    @JsonProperty("kind")
+    private final String kind = "spawned";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Full registry entry for the spawned child. Lets the controller call `handleLiveTargetSelected(entry)` directly without re-reading the registry (avoids a TOCTOU window). */
+    @JsonProperty("entry")
+    private AgentRegistryLiveTargetEntry entry;
+
+    /** Whether the delegate already sent the initial prompt. Always omitted in the current wiring: the controller sends the prompt post-attach via the standard LocalRpcSession.send path. */
+    @JsonProperty("initialPromptSent")
+    private Boolean initialPromptSent;
+
+    /** If the delegate attempted to send the initial prompt and failed, the categorized error message. */
+    @JsonProperty("initialPromptError")
+    private String initialPromptError;
+
+    /** Per-spawn log-capture outcome; populated from spawnLiveTarget. */
+    @JsonProperty("logCapture")
+    private AgentRegistryLogCapture logCapture;
+
+    public AgentRegistryLiveTargetEntry getEntry() { return entry; }
+    public void setEntry(AgentRegistryLiveTargetEntry entry) { this.entry = entry; }
+
+    public Boolean getInitialPromptSent() { return initialPromptSent; }
+    public void setInitialPromptSent(Boolean initialPromptSent) { this.initialPromptSent = initialPromptSent; }
+
+    public String getInitialPromptError() { return initialPromptError; }
+    public void setInitialPromptError(String initialPromptError) { this.initialPromptError = initialPromptError; }
+
+    public AgentRegistryLogCapture getLogCapture() { return logCapture; }
+    public void setLogCapture(AgentRegistryLogCapture logCapture) { this.logCapture = logCapture; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistrySpawnValidationError.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistrySpawnValidationError.java
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Synchronous pre-validation rejected the spawn request.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class AgentRegistrySpawnValidationError extends AgentRegistrySpawnResult {
+
+    @JsonProperty("kind")
+    private final String kind = "validation-error";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Categorized reason for the rejection. Low-cardinality enum so telemetry can aggregate by reason without leaking raw paths or agent/model names. */
+    @JsonProperty("reason")
+    private AgentRegistrySpawnValidationErrorReason reason;
+
+    /** Which parameter field was invalid. Omitted when the rejection is not field-specific. */
+    @JsonProperty("field")
+    private AgentRegistrySpawnValidationErrorField field;
+
+    /** Human-readable explanation; safe to surface in the UI banner. Never logged to unrestricted telemetry. */
+    @JsonProperty("message")
+    private String message;
+
+    public AgentRegistrySpawnValidationErrorReason getReason() { return reason; }
+    public void setReason(AgentRegistrySpawnValidationErrorReason reason) { this.reason = reason; }
+
+    public AgentRegistrySpawnValidationErrorField getField() { return field; }
+    public void setField(AgentRegistrySpawnValidationErrorField field) { this.field = field; }
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistrySpawnValidationErrorField.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistrySpawnValidationErrorField.java
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import javax.annotation.processing.Generated;
+
+/**
+ * Which parameter field was invalid. Omitted when the rejection is not field-specific.
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public enum AgentRegistrySpawnValidationErrorField {
+    /** The {@code cwd} variant. */
+    CWD("cwd"),
+    /** The {@code name} variant. */
+    NAME("name"),
+    /** The {@code agentName} variant. */
+    AGENTNAME("agentName"),
+    /** The {@code model} variant. */
+    MODEL("model"),
+    /** The {@code permissionMode} variant. */
+    PERMISSIONMODE("permissionMode");
+
+    private final String value;
+    AgentRegistrySpawnValidationErrorField(String value) { this.value = value; }
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() { return value; }
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static AgentRegistrySpawnValidationErrorField fromValue(String value) {
+        for (AgentRegistrySpawnValidationErrorField v : values()) {
+            if (v.value.equals(value)) return v;
+        }
+        throw new IllegalArgumentException("Unknown AgentRegistrySpawnValidationErrorField value: " + value);
+    }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistrySpawnValidationErrorReason.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/AgentRegistrySpawnValidationErrorReason.java
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import javax.annotation.processing.Generated;
+
+/**
+ * Categorized reason for the rejection. Low-cardinality enum so telemetry can aggregate by reason without leaking raw paths or agent/model names.
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public enum AgentRegistrySpawnValidationErrorReason {
+    /** The {@code cwd-not-found} variant. */
+    CWD_NOT_FOUND("cwd-not-found"),
+    /** The {@code cwd-not-directory} variant. */
+    CWD_NOT_DIRECTORY("cwd-not-directory"),
+    /** The {@code invalid-name} variant. */
+    INVALID_NAME("invalid-name"),
+    /** The {@code unknown-agent} variant. */
+    UNKNOWN_AGENT("unknown-agent"),
+    /** The {@code unknown-model} variant. */
+    UNKNOWN_MODEL("unknown-model"),
+    /** The {@code yolo-not-allowed} variant. */
+    YOLO_NOT_ALLOWED("yolo-not-allowed");
+
+    private final String value;
+    AgentRegistrySpawnValidationErrorReason(String value) { this.value = value; }
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() { return value; }
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static AgentRegistrySpawnValidationErrorReason fromValue(String value) {
+        for (AgentRegistrySpawnValidationErrorReason v : values()) {
+            if (v.value.equals(value)) return v;
+        }
+        throw new IllegalArgumentException("Unknown AgentRegistrySpawnValidationErrorReason value: " + value);
+    }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/ApiKeyAuthInfo.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/ApiKeyAuthInfo.java
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `ApiKeyAuthInfo` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class ApiKeyAuthInfo extends AuthInfo {
+
+    @JsonProperty("type")
+    private final String type = "api-key";
+
+    @Override
+    public String getType() { return type; }
+
+    /** The API key. Treat as a secret. */
+    @JsonProperty("apiKey")
+    private String apiKey;
+
+    /** Authentication host. */
+    @JsonProperty("host")
+    private String host;
+
+    /** Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this verbatim and does not re-fetch when set. */
+    @JsonProperty("copilotUser")
+    private CopilotUserResponse copilotUser;
+
+    public String getApiKey() { return apiKey; }
+    public void setApiKey(String apiKey) { this.apiKey = apiKey; }
+
+    public String getHost() { return host; }
+    public void setHost(String host) { this.host = host; }
+
+    public CopilotUserResponse getCopilotUser() { return copilotUser; }
+    public void setCopilotUser(CopilotUserResponse copilotUser) { this.copilotUser = copilotUser; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/AuthInfo.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/AuthInfo.java
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import javax.annotation.processing.Generated;
+
+/**
+ * The new auth credentials to install on the session. When omitted or `undefined`, the call is a no-op and the session's existing credentials are preserved. The runtime stores the value verbatim and uses it for outbound model/API requests; it does NOT re-validate or re-fetch the associated Copilot user response. Several variants carry secret material; treat this method's params as containing secrets at rest and in transit.
+ *
+ * @since 1.0.0
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = HMACAuthInfo.class, name = "hmac"),
+    @JsonSubTypes.Type(value = EnvAuthInfo.class, name = "env"),
+    @JsonSubTypes.Type(value = TokenAuthInfo.class, name = "token"),
+    @JsonSubTypes.Type(value = CopilotApiTokenAuthInfo.class, name = "copilot-api-token"),
+    @JsonSubTypes.Type(value = UserAuthInfo.class, name = "user"),
+    @JsonSubTypes.Type(value = GhCliAuthInfo.class, name = "gh-cli"),
+    @JsonSubTypes.Type(value = ApiKeyAuthInfo.class, name = "api-key")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public abstract class AuthInfo {
+
+    /**
+     * Returns the discriminator value for this variant.
+     *
+     * @return the type discriminator
+     */
+    public abstract String getType();
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/CopilotApiTokenAuthInfo.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/CopilotApiTokenAuthInfo.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `CopilotApiTokenAuthInfo` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class CopilotApiTokenAuthInfo extends AuthInfo {
+
+    @JsonProperty("type")
+    private final String type = "copilot-api-token";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Authentication host (always the public GitHub host). */
+    @JsonProperty("host")
+    private String host;
+
+    /** Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this verbatim and does not re-fetch when set. */
+    @JsonProperty("copilotUser")
+    private CopilotUserResponse copilotUser;
+
+    public String getHost() { return host; }
+    public void setHost(String host) { this.host = host; }
+
+    public CopilotUserResponse getCopilotUser() { return copilotUser; }
+    public void setCopilotUser(CopilotUserResponse copilotUser) { this.copilotUser = copilotUser; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/CopilotUserResponse.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/CopilotUserResponse.java
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.processing.Generated;
+
+/**
+ * Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this verbatim and does not re-fetch when set.
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CopilotUserResponse(
+    @JsonProperty("login") String login,
+    @JsonProperty("access_type_sku") String accessTypeSku,
+    @JsonProperty("analytics_tracking_id") String analyticsTrackingId,
+    @JsonProperty("assigned_date") Object assignedDate,
+    @JsonProperty("can_signup_for_limited") Boolean canSignupForLimited,
+    @JsonProperty("chat_enabled") Boolean chatEnabled,
+    @JsonProperty("copilot_plan") String copilotPlan,
+    @JsonProperty("copilotignore_enabled") Boolean copilotignoreEnabled,
+    /** Schema for the `CopilotUserResponseEndpoints` type. */
+    @JsonProperty("endpoints") CopilotUserResponseEndpoints endpoints,
+    @JsonProperty("organization_login_list") List<String> organizationLoginList,
+    @JsonProperty("organization_list") Object organizationList,
+    @JsonProperty("codex_agent_enabled") Boolean codexAgentEnabled,
+    @JsonProperty("is_mcp_enabled") Object isMcpEnabled,
+    @JsonProperty("quota_reset_date") String quotaResetDate,
+    /** Schema for the `CopilotUserResponseQuotaSnapshots` type. */
+    @JsonProperty("quota_snapshots") CopilotUserResponseQuotaSnapshots quotaSnapshots,
+    @JsonProperty("restricted_telemetry") Boolean restrictedTelemetry,
+    @JsonProperty("token_based_billing") Boolean tokenBasedBilling,
+    @JsonProperty("quota_reset_date_utc") String quotaResetDateUtc,
+    @JsonProperty("limited_user_quotas") Map<String, Double> limitedUserQuotas,
+    @JsonProperty("limited_user_reset_date") String limitedUserResetDate,
+    @JsonProperty("monthly_quotas") Map<String, Double> monthlyQuotas,
+    @JsonProperty("cloud_session_storage_enabled") Boolean cloudSessionStorageEnabled,
+    @JsonProperty("cli_remote_control_enabled") Boolean cliRemoteControlEnabled
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/CopilotUserResponseEndpoints.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/CopilotUserResponseEndpoints.java
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `CopilotUserResponseEndpoints` type.
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CopilotUserResponseEndpoints(
+    @JsonProperty("api") String api,
+    @JsonProperty("origin-tracker") String originTracker,
+    @JsonProperty("proxy") String proxy,
+    @JsonProperty("telemetry") String telemetry
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/CopilotUserResponseQuotaSnapshots.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/CopilotUserResponseQuotaSnapshots.java
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `CopilotUserResponseQuotaSnapshots` type.
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CopilotUserResponseQuotaSnapshots(
+    /** Schema for the `CopilotUserResponseQuotaSnapshotsChat` type. */
+    @JsonProperty("chat") CopilotUserResponseQuotaSnapshotsChat chat,
+    /** Schema for the `CopilotUserResponseQuotaSnapshotsCompletions` type. */
+    @JsonProperty("completions") CopilotUserResponseQuotaSnapshotsCompletions completions,
+    /** Schema for the `CopilotUserResponseQuotaSnapshotsPremiumInteractions` type. */
+    @JsonProperty("premium_interactions") CopilotUserResponseQuotaSnapshotsPremiumInteractions premiumInteractions
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/CopilotUserResponseQuotaSnapshotsChat.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/CopilotUserResponseQuotaSnapshotsChat.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `CopilotUserResponseQuotaSnapshotsChat` type.
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CopilotUserResponseQuotaSnapshotsChat(
+    @JsonProperty("entitlement") Double entitlement,
+    @JsonProperty("overage_count") Double overageCount,
+    @JsonProperty("overage_permitted") Boolean overagePermitted,
+    @JsonProperty("percent_remaining") Double percentRemaining,
+    @JsonProperty("quota_id") String quotaId,
+    @JsonProperty("quota_remaining") Double quotaRemaining,
+    @JsonProperty("remaining") Double remaining,
+    @JsonProperty("unlimited") Boolean unlimited,
+    @JsonProperty("timestamp_utc") String timestampUtc,
+    @JsonProperty("has_quota") Boolean hasQuota,
+    @JsonProperty("quota_reset_at") Double quotaResetAt,
+    @JsonProperty("token_based_billing") Boolean tokenBasedBilling
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/CopilotUserResponseQuotaSnapshotsCompletions.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/CopilotUserResponseQuotaSnapshotsCompletions.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `CopilotUserResponseQuotaSnapshotsCompletions` type.
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CopilotUserResponseQuotaSnapshotsCompletions(
+    @JsonProperty("entitlement") Double entitlement,
+    @JsonProperty("overage_count") Double overageCount,
+    @JsonProperty("overage_permitted") Boolean overagePermitted,
+    @JsonProperty("percent_remaining") Double percentRemaining,
+    @JsonProperty("quota_id") String quotaId,
+    @JsonProperty("quota_remaining") Double quotaRemaining,
+    @JsonProperty("remaining") Double remaining,
+    @JsonProperty("unlimited") Boolean unlimited,
+    @JsonProperty("timestamp_utc") String timestampUtc,
+    @JsonProperty("has_quota") Boolean hasQuota,
+    @JsonProperty("quota_reset_at") Double quotaResetAt,
+    @JsonProperty("token_based_billing") Boolean tokenBasedBilling
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/CopilotUserResponseQuotaSnapshotsPremiumInteractions.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/CopilotUserResponseQuotaSnapshotsPremiumInteractions.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `CopilotUserResponseQuotaSnapshotsPremiumInteractions` type.
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CopilotUserResponseQuotaSnapshotsPremiumInteractions(
+    @JsonProperty("entitlement") Double entitlement,
+    @JsonProperty("overage_count") Double overageCount,
+    @JsonProperty("overage_permitted") Boolean overagePermitted,
+    @JsonProperty("percent_remaining") Double percentRemaining,
+    @JsonProperty("quota_id") String quotaId,
+    @JsonProperty("quota_remaining") Double quotaRemaining,
+    @JsonProperty("remaining") Double remaining,
+    @JsonProperty("unlimited") Boolean unlimited,
+    @JsonProperty("timestamp_utc") String timestampUtc,
+    @JsonProperty("has_quota") Boolean hasQuota,
+    @JsonProperty("quota_reset_at") Double quotaResetAt,
+    @JsonProperty("token_based_billing") Boolean tokenBasedBilling
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/EnvAuthInfo.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/EnvAuthInfo.java
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `EnvAuthInfo` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class EnvAuthInfo extends AuthInfo {
+
+    @JsonProperty("type")
+    private final String type = "env";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Authentication host (e.g. https://github.com or a GHES host). */
+    @JsonProperty("host")
+    private String host;
+
+    /** User login associated with the token. Undefined for server-to-server tokens (those starting with `ghs_`). */
+    @JsonProperty("login")
+    private String login;
+
+    /** The token value itself. Treat as a secret. */
+    @JsonProperty("token")
+    private String token;
+
+    /** Name of the environment variable the token was sourced from. */
+    @JsonProperty("envVar")
+    private String envVar;
+
+    /** Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this verbatim and does not re-fetch when set. */
+    @JsonProperty("copilotUser")
+    private CopilotUserResponse copilotUser;
+
+    public String getHost() { return host; }
+    public void setHost(String host) { this.host = host; }
+
+    public String getLogin() { return login; }
+    public void setLogin(String login) { this.login = login; }
+
+    public String getToken() { return token; }
+    public void setToken(String token) { this.token = token; }
+
+    public String getEnvVar() { return envVar; }
+    public void setEnvVar(String envVar) { this.envVar = envVar; }
+
+    public CopilotUserResponse getCopilotUser() { return copilotUser; }
+    public void setCopilotUser(CopilotUserResponse copilotUser) { this.copilotUser = copilotUser; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/GhCliAuthInfo.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/GhCliAuthInfo.java
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `GhCliAuthInfo` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class GhCliAuthInfo extends AuthInfo {
+
+    @JsonProperty("type")
+    private final String type = "gh-cli";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Authentication host. */
+    @JsonProperty("host")
+    private String host;
+
+    /** User login as reported by `gh auth status`. */
+    @JsonProperty("login")
+    private String login;
+
+    /** The token returned by `gh auth token`. Treat as a secret. */
+    @JsonProperty("token")
+    private String token;
+
+    /** Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this verbatim and does not re-fetch when set. */
+    @JsonProperty("copilotUser")
+    private CopilotUserResponse copilotUser;
+
+    public String getHost() { return host; }
+    public void setHost(String host) { this.host = host; }
+
+    public String getLogin() { return login; }
+    public void setLogin(String login) { this.login = login; }
+
+    public String getToken() { return token; }
+    public void setToken(String token) { this.token = token; }
+
+    public CopilotUserResponse getCopilotUser() { return copilotUser; }
+    public void setCopilotUser(CopilotUserResponse copilotUser) { this.copilotUser = copilotUser; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/HMACAuthInfo.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/HMACAuthInfo.java
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `HMACAuthInfo` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class HMACAuthInfo extends AuthInfo {
+
+    @JsonProperty("type")
+    private final String type = "hmac";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Authentication host. HMAC auth always targets the public GitHub host. */
+    @JsonProperty("host")
+    private String host;
+
+    /** HMAC secret used to sign requests. */
+    @JsonProperty("hmac")
+    private String hmac;
+
+    /** Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this verbatim and does not re-fetch when set. */
+    @JsonProperty("copilotUser")
+    private CopilotUserResponse copilotUser;
+
+    public String getHost() { return host; }
+    public void setHost(String host) { this.host = host; }
+
+    public String getHmac() { return hmac; }
+    public void setHmac(String hmac) { this.hmac = hmac; }
+
+    public CopilotUserResponse getCopilotUser() { return copilotUser; }
+    public void setCopilotUser(CopilotUserResponse copilotUser) { this.copilotUser = copilotUser; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecision.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecision.java
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import javax.annotation.processing.Generated;
+
+/**
+ * The client's response to the pending permission prompt
+ *
+ * @since 1.0.0
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = PermissionDecisionApproveOnce.class, name = "approve-once"),
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForSession.class, name = "approve-for-session"),
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForLocation.class, name = "approve-for-location"),
+    @JsonSubTypes.Type(value = PermissionDecisionApprovePermanently.class, name = "approve-permanently"),
+    @JsonSubTypes.Type(value = PermissionDecisionReject.class, name = "reject"),
+    @JsonSubTypes.Type(value = PermissionDecisionUserNotAvailable.class, name = "user-not-available"),
+    @JsonSubTypes.Type(value = PermissionDecisionApproved.class, name = "approved"),
+    @JsonSubTypes.Type(value = PermissionDecisionApprovedForSession.class, name = "approved-for-session"),
+    @JsonSubTypes.Type(value = PermissionDecisionApprovedForLocation.class, name = "approved-for-location"),
+    @JsonSubTypes.Type(value = PermissionDecisionCancelled.class, name = "cancelled"),
+    @JsonSubTypes.Type(value = PermissionDecisionDeniedByRules.class, name = "denied-by-rules"),
+    @JsonSubTypes.Type(value = PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser.class, name = "denied-no-approval-rule-and-could-not-request-from-user"),
+    @JsonSubTypes.Type(value = PermissionDecisionDeniedInteractivelyByUser.class, name = "denied-interactively-by-user"),
+    @JsonSubTypes.Type(value = PermissionDecisionDeniedByContentExclusionPolicy.class, name = "denied-by-content-exclusion-policy"),
+    @JsonSubTypes.Type(value = PermissionDecisionDeniedByPermissionRequestHook.class, name = "denied-by-permission-request-hook")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public abstract class PermissionDecision {
+
+    /**
+     * Returns the discriminator value for this variant.
+     *
+     * @return the kind discriminator
+     */
+    public abstract String getKind();
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocation.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocation.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForLocation` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForLocation extends PermissionDecision {
+
+    @JsonProperty("kind")
+    private final String kind = "approve-for-location";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Approval to persist for this location */
+    @JsonProperty("approval")
+    private PermissionDecisionApproveForLocationApproval approval;
+
+    /** Location key (git root or cwd) to persist the approval to */
+    @JsonProperty("locationKey")
+    private String locationKey;
+
+    public PermissionDecisionApproveForLocationApproval getApproval() { return approval; }
+    public void setApproval(PermissionDecisionApproveForLocationApproval approval) { this.approval = approval; }
+
+    public String getLocationKey() { return locationKey; }
+    public void setLocationKey(String locationKey) { this.locationKey = locationKey; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApproval.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApproval.java
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import javax.annotation.processing.Generated;
+
+/**
+ * Approval to persist for this location
+ *
+ * @since 1.0.0
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForLocationApprovalCommands.class, name = "commands"),
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForLocationApprovalRead.class, name = "read"),
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForLocationApprovalWrite.class, name = "write"),
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForLocationApprovalMcp.class, name = "mcp"),
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForLocationApprovalMcpSampling.class, name = "mcp-sampling"),
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForLocationApprovalMemory.class, name = "memory"),
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForLocationApprovalCustomTool.class, name = "custom-tool"),
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForLocationApprovalExtensionManagement.class, name = "extension-management"),
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForLocationApprovalExtensionPermissionAccess.class, name = "extension-permission-access")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public abstract class PermissionDecisionApproveForLocationApproval {
+
+    /**
+     * Returns the discriminator value for this variant.
+     *
+     * @return the kind discriminator
+     */
+    public abstract String getKind();
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApprovalCommands.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApprovalCommands.java
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForLocationApprovalCommands` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForLocationApprovalCommands extends PermissionDecisionApproveForLocationApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "commands";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Command identifiers covered by this approval. */
+    @JsonProperty("commandIdentifiers")
+    private List<String> commandIdentifiers;
+
+    public List<String> getCommandIdentifiers() { return commandIdentifiers; }
+    public void setCommandIdentifiers(List<String> commandIdentifiers) { this.commandIdentifiers = commandIdentifiers; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApprovalCustomTool.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApprovalCustomTool.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForLocationApprovalCustomTool` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForLocationApprovalCustomTool extends PermissionDecisionApproveForLocationApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "custom-tool";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Custom tool name. */
+    @JsonProperty("toolName")
+    private String toolName;
+
+    public String getToolName() { return toolName; }
+    public void setToolName(String toolName) { this.toolName = toolName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApprovalExtensionManagement.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApprovalExtensionManagement.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForLocationApprovalExtensionManagement` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForLocationApprovalExtensionManagement extends PermissionDecisionApproveForLocationApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "extension-management";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Optional operation identifier; when omitted, the approval covers all extension management operations. */
+    @JsonProperty("operation")
+    private String operation;
+
+    public String getOperation() { return operation; }
+    public void setOperation(String operation) { this.operation = operation; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApprovalExtensionPermissionAccess.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApprovalExtensionPermissionAccess.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForLocationApprovalExtensionPermissionAccess` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForLocationApprovalExtensionPermissionAccess extends PermissionDecisionApproveForLocationApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "extension-permission-access";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Extension name. */
+    @JsonProperty("extensionName")
+    private String extensionName;
+
+    public String getExtensionName() { return extensionName; }
+    public void setExtensionName(String extensionName) { this.extensionName = extensionName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApprovalMcp.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApprovalMcp.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForLocationApprovalMcp` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForLocationApprovalMcp extends PermissionDecisionApproveForLocationApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "mcp";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** MCP server name. */
+    @JsonProperty("serverName")
+    private String serverName;
+
+    /** MCP tool name, or null to cover every tool on the server. */
+    @JsonProperty("toolName")
+    private String toolName;
+
+    public String getServerName() { return serverName; }
+    public void setServerName(String serverName) { this.serverName = serverName; }
+
+    public String getToolName() { return toolName; }
+    public void setToolName(String toolName) { this.toolName = toolName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApprovalMcpSampling.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApprovalMcpSampling.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForLocationApprovalMcpSampling` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForLocationApprovalMcpSampling extends PermissionDecisionApproveForLocationApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "mcp-sampling";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** MCP server name. */
+    @JsonProperty("serverName")
+    private String serverName;
+
+    public String getServerName() { return serverName; }
+    public void setServerName(String serverName) { this.serverName = serverName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApprovalMemory.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApprovalMemory.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForLocationApprovalMemory` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForLocationApprovalMemory extends PermissionDecisionApproveForLocationApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "memory";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApprovalRead.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApprovalRead.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForLocationApprovalRead` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForLocationApprovalRead extends PermissionDecisionApproveForLocationApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "read";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApprovalWrite.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForLocationApprovalWrite.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForLocationApprovalWrite` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForLocationApprovalWrite extends PermissionDecisionApproveForLocationApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "write";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSession.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSession.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForSession` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForSession extends PermissionDecision {
+
+    @JsonProperty("kind")
+    private final String kind = "approve-for-session";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Session-scoped approval to remember (tool prompts only; omitted for path/url prompts) */
+    @JsonProperty("approval")
+    private PermissionDecisionApproveForSessionApproval approval;
+
+    /** URL domain to approve for the rest of the session (URL prompts only) */
+    @JsonProperty("domain")
+    private String domain;
+
+    public PermissionDecisionApproveForSessionApproval getApproval() { return approval; }
+    public void setApproval(PermissionDecisionApproveForSessionApproval approval) { this.approval = approval; }
+
+    public String getDomain() { return domain; }
+    public void setDomain(String domain) { this.domain = domain; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApproval.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApproval.java
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import javax.annotation.processing.Generated;
+
+/**
+ * Session-scoped approval to remember (tool prompts only; omitted for path/url prompts)
+ *
+ * @since 1.0.0
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForSessionApprovalCommands.class, name = "commands"),
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForSessionApprovalRead.class, name = "read"),
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForSessionApprovalWrite.class, name = "write"),
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForSessionApprovalMcp.class, name = "mcp"),
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForSessionApprovalMcpSampling.class, name = "mcp-sampling"),
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForSessionApprovalMemory.class, name = "memory"),
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForSessionApprovalCustomTool.class, name = "custom-tool"),
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForSessionApprovalExtensionManagement.class, name = "extension-management"),
+    @JsonSubTypes.Type(value = PermissionDecisionApproveForSessionApprovalExtensionPermissionAccess.class, name = "extension-permission-access")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public abstract class PermissionDecisionApproveForSessionApproval {
+
+    /**
+     * Returns the discriminator value for this variant.
+     *
+     * @return the kind discriminator
+     */
+    public abstract String getKind();
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApprovalCommands.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApprovalCommands.java
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForSessionApprovalCommands` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForSessionApprovalCommands extends PermissionDecisionApproveForSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "commands";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Command identifiers covered by this approval. */
+    @JsonProperty("commandIdentifiers")
+    private List<String> commandIdentifiers;
+
+    public List<String> getCommandIdentifiers() { return commandIdentifiers; }
+    public void setCommandIdentifiers(List<String> commandIdentifiers) { this.commandIdentifiers = commandIdentifiers; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApprovalCustomTool.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApprovalCustomTool.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForSessionApprovalCustomTool` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForSessionApprovalCustomTool extends PermissionDecisionApproveForSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "custom-tool";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Custom tool name. */
+    @JsonProperty("toolName")
+    private String toolName;
+
+    public String getToolName() { return toolName; }
+    public void setToolName(String toolName) { this.toolName = toolName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApprovalExtensionManagement.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApprovalExtensionManagement.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForSessionApprovalExtensionManagement` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForSessionApprovalExtensionManagement extends PermissionDecisionApproveForSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "extension-management";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Optional operation identifier; when omitted, the approval covers all extension management operations. */
+    @JsonProperty("operation")
+    private String operation;
+
+    public String getOperation() { return operation; }
+    public void setOperation(String operation) { this.operation = operation; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApprovalExtensionPermissionAccess.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApprovalExtensionPermissionAccess.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForSessionApprovalExtensionPermissionAccess` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForSessionApprovalExtensionPermissionAccess extends PermissionDecisionApproveForSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "extension-permission-access";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Extension name. */
+    @JsonProperty("extensionName")
+    private String extensionName;
+
+    public String getExtensionName() { return extensionName; }
+    public void setExtensionName(String extensionName) { this.extensionName = extensionName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApprovalMcp.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApprovalMcp.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForSessionApprovalMcp` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForSessionApprovalMcp extends PermissionDecisionApproveForSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "mcp";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** MCP server name. */
+    @JsonProperty("serverName")
+    private String serverName;
+
+    /** MCP tool name, or null to cover every tool on the server. */
+    @JsonProperty("toolName")
+    private String toolName;
+
+    public String getServerName() { return serverName; }
+    public void setServerName(String serverName) { this.serverName = serverName; }
+
+    public String getToolName() { return toolName; }
+    public void setToolName(String toolName) { this.toolName = toolName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApprovalMcpSampling.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApprovalMcpSampling.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForSessionApprovalMcpSampling` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForSessionApprovalMcpSampling extends PermissionDecisionApproveForSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "mcp-sampling";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** MCP server name. */
+    @JsonProperty("serverName")
+    private String serverName;
+
+    public String getServerName() { return serverName; }
+    public void setServerName(String serverName) { this.serverName = serverName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApprovalMemory.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApprovalMemory.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForSessionApprovalMemory` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForSessionApprovalMemory extends PermissionDecisionApproveForSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "memory";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApprovalRead.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApprovalRead.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForSessionApprovalRead` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForSessionApprovalRead extends PermissionDecisionApproveForSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "read";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApprovalWrite.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveForSessionApprovalWrite.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveForSessionApprovalWrite` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveForSessionApprovalWrite extends PermissionDecisionApproveForSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "write";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveOnce.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproveOnce.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproveOnce` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproveOnce extends PermissionDecision {
+
+    @JsonProperty("kind")
+    private final String kind = "approve-once";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApprovePermanently.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApprovePermanently.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApprovePermanently` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApprovePermanently extends PermissionDecision {
+
+    @JsonProperty("kind")
+    private final String kind = "approve-permanently";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** URL domain to approve permanently */
+    @JsonProperty("domain")
+    private String domain;
+
+    public String getDomain() { return domain; }
+    public void setDomain(String domain) { this.domain = domain; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproved.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApproved.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApproved` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApproved extends PermissionDecision {
+
+    @JsonProperty("kind")
+    private final String kind = "approved";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApprovedForLocation.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApprovedForLocation.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApprovedForLocation` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApprovedForLocation extends PermissionDecision {
+
+    @JsonProperty("kind")
+    private final String kind = "approved-for-location";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** The approval to persist for this location */
+    @JsonProperty("approval")
+    private UserToolSessionApproval approval;
+
+    /** The location key (git root or cwd) to persist the approval to */
+    @JsonProperty("locationKey")
+    private String locationKey;
+
+    public UserToolSessionApproval getApproval() { return approval; }
+    public void setApproval(UserToolSessionApproval approval) { this.approval = approval; }
+
+    public String getLocationKey() { return locationKey; }
+    public void setLocationKey(String locationKey) { this.locationKey = locationKey; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApprovedForSession.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionApprovedForSession.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionApprovedForSession` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionApprovedForSession extends PermissionDecision {
+
+    @JsonProperty("kind")
+    private final String kind = "approved-for-session";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** The approval to add as a session-scoped rule */
+    @JsonProperty("approval")
+    private UserToolSessionApproval approval;
+
+    public UserToolSessionApproval getApproval() { return approval; }
+    public void setApproval(UserToolSessionApproval approval) { this.approval = approval; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionCancelled.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionCancelled.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionCancelled` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionCancelled extends PermissionDecision {
+
+    @JsonProperty("kind")
+    private final String kind = "cancelled";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Optional explanation of why the request was cancelled */
+    @JsonProperty("reason")
+    private String reason;
+
+    public String getReason() { return reason; }
+    public void setReason(String reason) { this.reason = reason; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionDeniedByContentExclusionPolicy.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionDeniedByContentExclusionPolicy.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionDeniedByContentExclusionPolicy` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionDeniedByContentExclusionPolicy extends PermissionDecision {
+
+    @JsonProperty("kind")
+    private final String kind = "denied-by-content-exclusion-policy";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** File path that triggered the exclusion */
+    @JsonProperty("path")
+    private String path;
+
+    /** Human-readable explanation of why the path was excluded */
+    @JsonProperty("message")
+    private String message;
+
+    public String getPath() { return path; }
+    public void setPath(String path) { this.path = path; }
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionDeniedByPermissionRequestHook.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionDeniedByPermissionRequestHook.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionDeniedByPermissionRequestHook` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionDeniedByPermissionRequestHook extends PermissionDecision {
+
+    @JsonProperty("kind")
+    private final String kind = "denied-by-permission-request-hook";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Optional message from the hook explaining the denial */
+    @JsonProperty("message")
+    private String message;
+
+    /** Whether to interrupt the current agent turn */
+    @JsonProperty("interrupt")
+    private Boolean interrupt;
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+
+    public Boolean getInterrupt() { return interrupt; }
+    public void setInterrupt(Boolean interrupt) { this.interrupt = interrupt; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionDeniedByRules.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionDeniedByRules.java
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionDeniedByRules` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionDeniedByRules extends PermissionDecision {
+
+    @JsonProperty("kind")
+    private final String kind = "denied-by-rules";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Rules that denied the request */
+    @JsonProperty("rules")
+    private List<PermissionRule> rules;
+
+    public List<PermissionRule> getRules() { return rules; }
+    public void setRules(List<PermissionRule> rules) { this.rules = rules; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionDeniedInteractivelyByUser.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionDeniedInteractivelyByUser.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionDeniedInteractivelyByUser` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionDeniedInteractivelyByUser extends PermissionDecision {
+
+    @JsonProperty("kind")
+    private final String kind = "denied-interactively-by-user";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Optional feedback from the user explaining the denial */
+    @JsonProperty("feedback")
+    private String feedback;
+
+    /** Whether to force-reject the current agent turn */
+    @JsonProperty("forceReject")
+    private Boolean forceReject;
+
+    public String getFeedback() { return feedback; }
+    public void setFeedback(String feedback) { this.feedback = feedback; }
+
+    public Boolean getForceReject() { return forceReject; }
+    public void setForceReject(Boolean forceReject) { this.forceReject = forceReject; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionDeniedNoApprovalRuleAndCouldNotRequestFromUser extends PermissionDecision {
+
+    @JsonProperty("kind")
+    private final String kind = "denied-no-approval-rule-and-could-not-request-from-user";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionReject.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionReject.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionReject` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionReject extends PermissionDecision {
+
+    @JsonProperty("kind")
+    private final String kind = "reject";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Optional feedback explaining the rejection */
+    @JsonProperty("feedback")
+    private String feedback;
+
+    public String getFeedback() { return feedback; }
+    public void setFeedback(String feedback) { this.feedback = feedback; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionUserNotAvailable.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionDecisionUserNotAvailable.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionDecisionUserNotAvailable` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionDecisionUserNotAvailable extends PermissionDecision {
+
+    @JsonProperty("kind")
+    private final String kind = "user-not-available";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetails.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetails.java
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import javax.annotation.processing.Generated;
+
+/**
+ * Tool approval to persist and apply
+ *
+ * @since 1.0.0
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = PermissionsLocationsAddToolApprovalDetailsCommands.class, name = "commands"),
+    @JsonSubTypes.Type(value = PermissionsLocationsAddToolApprovalDetailsRead.class, name = "read"),
+    @JsonSubTypes.Type(value = PermissionsLocationsAddToolApprovalDetailsWrite.class, name = "write"),
+    @JsonSubTypes.Type(value = PermissionsLocationsAddToolApprovalDetailsMcp.class, name = "mcp"),
+    @JsonSubTypes.Type(value = PermissionsLocationsAddToolApprovalDetailsMcpSampling.class, name = "mcp-sampling"),
+    @JsonSubTypes.Type(value = PermissionsLocationsAddToolApprovalDetailsMemory.class, name = "memory"),
+    @JsonSubTypes.Type(value = PermissionsLocationsAddToolApprovalDetailsCustomTool.class, name = "custom-tool"),
+    @JsonSubTypes.Type(value = PermissionsLocationsAddToolApprovalDetailsExtensionManagement.class, name = "extension-management"),
+    @JsonSubTypes.Type(value = PermissionsLocationsAddToolApprovalDetailsExtensionPermissionAccess.class, name = "extension-permission-access")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public abstract class PermissionsLocationsAddToolApprovalDetails {
+
+    /**
+     * Returns the discriminator value for this variant.
+     *
+     * @return the kind discriminator
+     */
+    public abstract String getKind();
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetailsCommands.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetailsCommands.java
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionsLocationsAddToolApprovalDetailsCommands` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionsLocationsAddToolApprovalDetailsCommands extends PermissionsLocationsAddToolApprovalDetails {
+
+    @JsonProperty("kind")
+    private final String kind = "commands";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Command identifiers covered by this approval. */
+    @JsonProperty("commandIdentifiers")
+    private List<String> commandIdentifiers;
+
+    public List<String> getCommandIdentifiers() { return commandIdentifiers; }
+    public void setCommandIdentifiers(List<String> commandIdentifiers) { this.commandIdentifiers = commandIdentifiers; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetailsCustomTool.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetailsCustomTool.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionsLocationsAddToolApprovalDetailsCustomTool` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionsLocationsAddToolApprovalDetailsCustomTool extends PermissionsLocationsAddToolApprovalDetails {
+
+    @JsonProperty("kind")
+    private final String kind = "custom-tool";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Custom tool name. */
+    @JsonProperty("toolName")
+    private String toolName;
+
+    public String getToolName() { return toolName; }
+    public void setToolName(String toolName) { this.toolName = toolName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetailsExtensionManagement.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetailsExtensionManagement.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionsLocationsAddToolApprovalDetailsExtensionManagement` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionsLocationsAddToolApprovalDetailsExtensionManagement extends PermissionsLocationsAddToolApprovalDetails {
+
+    @JsonProperty("kind")
+    private final String kind = "extension-management";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Optional operation identifier; when omitted, the approval covers all extension management operations. */
+    @JsonProperty("operation")
+    private String operation;
+
+    public String getOperation() { return operation; }
+    public void setOperation(String operation) { this.operation = operation; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetailsExtensionPermissionAccess.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetailsExtensionPermissionAccess.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionsLocationsAddToolApprovalDetailsExtensionPermissionAccess` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionsLocationsAddToolApprovalDetailsExtensionPermissionAccess extends PermissionsLocationsAddToolApprovalDetails {
+
+    @JsonProperty("kind")
+    private final String kind = "extension-permission-access";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Extension name. */
+    @JsonProperty("extensionName")
+    private String extensionName;
+
+    public String getExtensionName() { return extensionName; }
+    public void setExtensionName(String extensionName) { this.extensionName = extensionName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetailsMcp.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetailsMcp.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionsLocationsAddToolApprovalDetailsMcp` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionsLocationsAddToolApprovalDetailsMcp extends PermissionsLocationsAddToolApprovalDetails {
+
+    @JsonProperty("kind")
+    private final String kind = "mcp";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** MCP server name. */
+    @JsonProperty("serverName")
+    private String serverName;
+
+    /** MCP tool name, or null to cover every tool on the server. */
+    @JsonProperty("toolName")
+    private String toolName;
+
+    public String getServerName() { return serverName; }
+    public void setServerName(String serverName) { this.serverName = serverName; }
+
+    public String getToolName() { return toolName; }
+    public void setToolName(String toolName) { this.toolName = toolName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetailsMcpSampling.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetailsMcpSampling.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionsLocationsAddToolApprovalDetailsMcpSampling` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionsLocationsAddToolApprovalDetailsMcpSampling extends PermissionsLocationsAddToolApprovalDetails {
+
+    @JsonProperty("kind")
+    private final String kind = "mcp-sampling";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** MCP server name. */
+    @JsonProperty("serverName")
+    private String serverName;
+
+    public String getServerName() { return serverName; }
+    public void setServerName(String serverName) { this.serverName = serverName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetailsMemory.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetailsMemory.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionsLocationsAddToolApprovalDetailsMemory` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionsLocationsAddToolApprovalDetailsMemory extends PermissionsLocationsAddToolApprovalDetails {
+
+    @JsonProperty("kind")
+    private final String kind = "memory";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetailsRead.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetailsRead.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionsLocationsAddToolApprovalDetailsRead` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionsLocationsAddToolApprovalDetailsRead extends PermissionsLocationsAddToolApprovalDetails {
+
+    @JsonProperty("kind")
+    private final String kind = "read";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetailsWrite.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/PermissionsLocationsAddToolApprovalDetailsWrite.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `PermissionsLocationsAddToolApprovalDetailsWrite` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class PermissionsLocationsAddToolApprovalDetailsWrite extends PermissionsLocationsAddToolApprovalDetails {
+
+    @JsonProperty("kind")
+    private final String kind = "write";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/QueuedCommandHandled.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/QueuedCommandHandled.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `QueuedCommandHandled` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class QueuedCommandHandled extends QueuedCommandResult {
+
+    @JsonProperty("handled")
+    private final String handled = "true";
+
+    @Override
+    public String getHandled() { return handled; }
+
+    /** When true, the runtime will not process subsequent queued commands until a new request comes in. */
+    @JsonProperty("stopProcessingQueue")
+    private Boolean stopProcessingQueue;
+
+    public Boolean getStopProcessingQueue() { return stopProcessingQueue; }
+    public void setStopProcessingQueue(Boolean stopProcessingQueue) { this.stopProcessingQueue = stopProcessingQueue; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/QueuedCommandNotHandled.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/QueuedCommandNotHandled.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `QueuedCommandNotHandled` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class QueuedCommandNotHandled extends QueuedCommandResult {
+
+    @JsonProperty("handled")
+    private final String handled = "false";
+
+    @Override
+    public String getHandled() { return handled; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/QueuedCommandResult.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/QueuedCommandResult.java
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import javax.annotation.processing.Generated;
+
+/**
+ * Result of the queued command execution.
+ *
+ * @since 1.0.0
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "handled", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = QueuedCommandHandled.class, name = "true"),
+    @JsonSubTypes.Type(value = QueuedCommandNotHandled.class, name = "false")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public abstract class QueuedCommandResult {
+
+    /**
+     * Returns the discriminator value for this variant.
+     *
+     * @return the handled discriminator
+     */
+    public abstract String getHandled();
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachment.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachment.java
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import javax.annotation.processing.Generated;
+
+/**
+ * A user message attachment — a file, directory, code selection, blob, or GitHub reference
+ *
+ * @since 1.0.0
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = SendAttachmentFile.class, name = "file"),
+    @JsonSubTypes.Type(value = SendAttachmentDirectory.class, name = "directory"),
+    @JsonSubTypes.Type(value = SendAttachmentSelection.class, name = "selection"),
+    @JsonSubTypes.Type(value = SendAttachmentGithubReference.class, name = "github_reference"),
+    @JsonSubTypes.Type(value = SendAttachmentBlob.class, name = "blob")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public abstract class SendAttachment {
+
+    /**
+     * Returns the discriminator value for this variant.
+     *
+     * @return the type discriminator
+     */
+    public abstract String getType();
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentBlob.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentBlob.java
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Blob attachment with inline base64-encoded data
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class SendAttachmentBlob extends SendAttachment {
+
+    @JsonProperty("type")
+    private final String type = "blob";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Base64-encoded content */
+    @JsonProperty("data")
+    private String data;
+
+    /** MIME type of the inline data */
+    @JsonProperty("mimeType")
+    private String mimeType;
+
+    /** User-facing display name for the attachment */
+    @JsonProperty("displayName")
+    private String displayName;
+
+    public String getData() { return data; }
+    public void setData(String data) { this.data = data; }
+
+    public String getMimeType() { return mimeType; }
+    public void setMimeType(String mimeType) { this.mimeType = mimeType; }
+
+    public String getDisplayName() { return displayName; }
+    public void setDisplayName(String displayName) { this.displayName = displayName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentDirectory.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentDirectory.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Directory attachment
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class SendAttachmentDirectory extends SendAttachment {
+
+    @JsonProperty("type")
+    private final String type = "directory";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Absolute directory path */
+    @JsonProperty("path")
+    private String path;
+
+    /** User-facing display name for the attachment */
+    @JsonProperty("displayName")
+    private String displayName;
+
+    public String getPath() { return path; }
+    public void setPath(String path) { this.path = path; }
+
+    public String getDisplayName() { return displayName; }
+    public void setDisplayName(String displayName) { this.displayName = displayName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentFile.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentFile.java
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * File attachment
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class SendAttachmentFile extends SendAttachment {
+
+    @JsonProperty("type")
+    private final String type = "file";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Absolute file path */
+    @JsonProperty("path")
+    private String path;
+
+    /** User-facing display name for the attachment */
+    @JsonProperty("displayName")
+    private String displayName;
+
+    /** Optional line range to scope the attachment to a specific section of the file */
+    @JsonProperty("lineRange")
+    private SendAttachmentFileLineRange lineRange;
+
+    public String getPath() { return path; }
+    public void setPath(String path) { this.path = path; }
+
+    public String getDisplayName() { return displayName; }
+    public void setDisplayName(String displayName) { this.displayName = displayName; }
+
+    public SendAttachmentFileLineRange getLineRange() { return lineRange; }
+    public void setLineRange(SendAttachmentFileLineRange lineRange) { this.lineRange = lineRange; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentFileLineRange.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentFileLineRange.java
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Optional line range to scope the attachment to a specific section of the file
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SendAttachmentFileLineRange(
+    /** Start line number (1-based) */
+    @JsonProperty("start") Long start,
+    /** End line number (1-based, inclusive) */
+    @JsonProperty("end") Long end
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentGithubReference.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentGithubReference.java
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * GitHub issue, pull request, or discussion reference
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class SendAttachmentGithubReference extends SendAttachment {
+
+    @JsonProperty("type")
+    private final String type = "github_reference";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Issue, pull request, or discussion number */
+    @JsonProperty("number")
+    private Long number;
+
+    /** Title of the referenced item */
+    @JsonProperty("title")
+    private String title;
+
+    /** Type of GitHub reference */
+    @JsonProperty("referenceType")
+    private SendAttachmentGithubReferenceType referenceType;
+
+    /** Current state of the referenced item (e.g., open, closed, merged) */
+    @JsonProperty("state")
+    private String state;
+
+    /** URL to the referenced item on GitHub */
+    @JsonProperty("url")
+    private String url;
+
+    public Long getNumber() { return number; }
+    public void setNumber(Long number) { this.number = number; }
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public SendAttachmentGithubReferenceType getReferenceType() { return referenceType; }
+    public void setReferenceType(SendAttachmentGithubReferenceType referenceType) { this.referenceType = referenceType; }
+
+    public String getState() { return state; }
+    public void setState(String state) { this.state = state; }
+
+    public String getUrl() { return url; }
+    public void setUrl(String url) { this.url = url; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentGithubReferenceType.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentGithubReferenceType.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import javax.annotation.processing.Generated;
+
+/**
+ * Type of GitHub reference
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public enum SendAttachmentGithubReferenceType {
+    /** The {@code issue} variant. */
+    ISSUE("issue"),
+    /** The {@code pr} variant. */
+    PR("pr"),
+    /** The {@code discussion} variant. */
+    DISCUSSION("discussion");
+
+    private final String value;
+    SendAttachmentGithubReferenceType(String value) { this.value = value; }
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() { return value; }
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static SendAttachmentGithubReferenceType fromValue(String value) {
+        for (SendAttachmentGithubReferenceType v : values()) {
+            if (v.value.equals(value)) return v;
+        }
+        throw new IllegalArgumentException("Unknown SendAttachmentGithubReferenceType value: " + value);
+    }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentSelection.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentSelection.java
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Code selection attachment from an editor
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class SendAttachmentSelection extends SendAttachment {
+
+    @JsonProperty("type")
+    private final String type = "selection";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Absolute path to the file containing the selection */
+    @JsonProperty("filePath")
+    private String filePath;
+
+    /** User-facing display name for the selection */
+    @JsonProperty("displayName")
+    private String displayName;
+
+    /** The selected text content */
+    @JsonProperty("text")
+    private String text;
+
+    /** Position range of the selection within the file */
+    @JsonProperty("selection")
+    private SendAttachmentSelectionDetails selection;
+
+    public String getFilePath() { return filePath; }
+    public void setFilePath(String filePath) { this.filePath = filePath; }
+
+    public String getDisplayName() { return displayName; }
+    public void setDisplayName(String displayName) { this.displayName = displayName; }
+
+    public String getText() { return text; }
+    public void setText(String text) { this.text = text; }
+
+    public SendAttachmentSelectionDetails getSelection() { return selection; }
+    public void setSelection(SendAttachmentSelectionDetails selection) { this.selection = selection; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentSelectionDetails.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentSelectionDetails.java
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Position range of the selection within the file
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SendAttachmentSelectionDetails(
+    /** Start position of the selection */
+    @JsonProperty("start") SendAttachmentSelectionDetailsStart start,
+    /** End position of the selection */
+    @JsonProperty("end") SendAttachmentSelectionDetailsEnd end
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentSelectionDetailsEnd.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentSelectionDetailsEnd.java
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * End position of the selection
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SendAttachmentSelectionDetailsEnd(
+    /** End line number (0-based) */
+    @JsonProperty("line") Long line,
+    /** End character offset within the line (0-based) */
+    @JsonProperty("character") Long character
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentSelectionDetailsStart.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SendAttachmentSelectionDetailsStart.java
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Start position of the selection
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SendAttachmentSelectionDetailsStart(
+    /** Start line number (0-based) */
+    @JsonProperty("line") Long line,
+    /** Start character offset within the line (0-based) */
+    @JsonProperty("character") Long character
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/ServerAgentRegistryApi.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/ServerAgentRegistryApi.java
@@ -31,8 +31,8 @@ public final class ServerAgentRegistryApi {
      * @apiNote This method is experimental and may change in a future version.
      * @since 1.0.0
      */
-    public CompletableFuture<Void> spawn(AgentRegistrySpawnParams params) {
-        return caller.invoke("agentRegistry.spawn", params, Void.class);
+    public CompletableFuture<AgentRegistrySpawnResult> spawn(AgentRegistrySpawnParams params) {
+        return caller.invoke("agentRegistry.spawn", params, AgentRegistrySpawnResult.class);
     }
 
 }

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SessionCommandsApi.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SessionCommandsApi.java
@@ -48,10 +48,10 @@ public final class SessionCommandsApi {
      * @apiNote This method is experimental and may change in a future version.
      * @since 1.0.0
      */
-    public CompletableFuture<Void> invoke(SessionCommandsInvokeParams params) {
+    public CompletableFuture<SlashCommandInvocationResult> invoke(SessionCommandsInvokeParams params) {
         com.fasterxml.jackson.databind.node.ObjectNode _p = MAPPER.valueToTree(params);
         _p.put("sessionId", this.sessionId);
-        return caller.invoke("session.commands.invoke", _p, Void.class);
+        return caller.invoke("session.commands.invoke", _p, SlashCommandInvocationResult.class);
     }
 
     /**

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SessionModeApi.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SessionModeApi.java
@@ -35,8 +35,8 @@ public final class SessionModeApi {
      * @apiNote This method is experimental and may change in a future version.
      * @since 1.0.0
      */
-    public CompletableFuture<Void> get() {
-        return caller.invoke("session.mode.get", java.util.Map.of("sessionId", this.sessionId), Void.class);
+    public CompletableFuture<SessionMode> get() {
+        return caller.invoke("session.mode.get", java.util.Map.of("sessionId", this.sessionId), SessionMode.class);
     }
 
     /**

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SlashCommandAgentPromptResult.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SlashCommandAgentPromptResult.java
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `SlashCommandAgentPromptResult` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class SlashCommandAgentPromptResult extends SlashCommandInvocationResult {
+
+    @JsonProperty("kind")
+    private final String kind = "agent-prompt";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Prompt to submit to the agent */
+    @JsonProperty("prompt")
+    private String prompt;
+
+    /** Prompt text to display to the user */
+    @JsonProperty("displayPrompt")
+    private String displayPrompt;
+
+    /** Optional target session mode for the agent prompt */
+    @JsonProperty("mode")
+    private SessionMode mode;
+
+    /** True when the invocation mutated user runtime settings; consumers caching settings should refresh */
+    @JsonProperty("runtimeSettingsChanged")
+    private Boolean runtimeSettingsChanged;
+
+    public String getPrompt() { return prompt; }
+    public void setPrompt(String prompt) { this.prompt = prompt; }
+
+    public String getDisplayPrompt() { return displayPrompt; }
+    public void setDisplayPrompt(String displayPrompt) { this.displayPrompt = displayPrompt; }
+
+    public SessionMode getMode() { return mode; }
+    public void setMode(SessionMode mode) { this.mode = mode; }
+
+    public Boolean getRuntimeSettingsChanged() { return runtimeSettingsChanged; }
+    public void setRuntimeSettingsChanged(Boolean runtimeSettingsChanged) { this.runtimeSettingsChanged = runtimeSettingsChanged; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SlashCommandCompletedResult.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SlashCommandCompletedResult.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `SlashCommandCompletedResult` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class SlashCommandCompletedResult extends SlashCommandInvocationResult {
+
+    @JsonProperty("kind")
+    private final String kind = "completed";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Optional user-facing message describing the completed command */
+    @JsonProperty("message")
+    private String message;
+
+    /** True when the invocation mutated user runtime settings; consumers caching settings should refresh */
+    @JsonProperty("runtimeSettingsChanged")
+    private Boolean runtimeSettingsChanged;
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+
+    public Boolean getRuntimeSettingsChanged() { return runtimeSettingsChanged; }
+    public void setRuntimeSettingsChanged(Boolean runtimeSettingsChanged) { this.runtimeSettingsChanged = runtimeSettingsChanged; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SlashCommandInvocationResult.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SlashCommandInvocationResult.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import javax.annotation.processing.Generated;
+
+/**
+ * Result of invoking the slash command (text output, prompt to send to the agent, or completion).
+ *
+ * @since 1.0.0
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = SlashCommandTextResult.class, name = "text"),
+    @JsonSubTypes.Type(value = SlashCommandAgentPromptResult.class, name = "agent-prompt"),
+    @JsonSubTypes.Type(value = SlashCommandCompletedResult.class, name = "completed"),
+    @JsonSubTypes.Type(value = SlashCommandSelectSubcommandResult.class, name = "select-subcommand")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public abstract class SlashCommandInvocationResult {
+
+    /**
+     * Returns the discriminator value for this variant.
+     *
+     * @return the kind discriminator
+     */
+    public abstract String getKind();
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SlashCommandSelectSubcommandOption.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SlashCommandSelectSubcommandOption.java
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `SlashCommandSelectSubcommandOption` type.
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SlashCommandSelectSubcommandOption(
+    /** Subcommand name to invoke */
+    @JsonProperty("name") String name,
+    /** Human-readable description of the subcommand */
+    @JsonProperty("description") String description,
+    /** Optional group label for organizing options */
+    @JsonProperty("group") String group
+) {
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SlashCommandSelectSubcommandResult.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SlashCommandSelectSubcommandResult.java
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `SlashCommandSelectSubcommandResult` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class SlashCommandSelectSubcommandResult extends SlashCommandInvocationResult {
+
+    @JsonProperty("kind")
+    private final String kind = "select-subcommand";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Parent command name that requires subcommand selection */
+    @JsonProperty("command")
+    private String command;
+
+    /** Human-readable title for the selection UI */
+    @JsonProperty("title")
+    private String title;
+
+    /** Available subcommand options for the client to present */
+    @JsonProperty("options")
+    private List<SlashCommandSelectSubcommandOption> options;
+
+    /** True when the invocation mutated user runtime settings; consumers caching settings should refresh */
+    @JsonProperty("runtimeSettingsChanged")
+    private Boolean runtimeSettingsChanged;
+
+    public String getCommand() { return command; }
+    public void setCommand(String command) { this.command = command; }
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public List<SlashCommandSelectSubcommandOption> getOptions() { return options; }
+    public void setOptions(List<SlashCommandSelectSubcommandOption> options) { this.options = options; }
+
+    public Boolean getRuntimeSettingsChanged() { return runtimeSettingsChanged; }
+    public void setRuntimeSettingsChanged(Boolean runtimeSettingsChanged) { this.runtimeSettingsChanged = runtimeSettingsChanged; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SlashCommandTextResult.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SlashCommandTextResult.java
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `SlashCommandTextResult` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class SlashCommandTextResult extends SlashCommandInvocationResult {
+
+    @JsonProperty("kind")
+    private final String kind = "text";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Text output for the client to render */
+    @JsonProperty("text")
+    private String text;
+
+    /** Whether text contains Markdown */
+    @JsonProperty("markdown")
+    private Boolean markdown;
+
+    /** Whether ANSI sequences should be preserved */
+    @JsonProperty("preserveAnsi")
+    private Boolean preserveAnsi;
+
+    /** True when the invocation mutated user runtime settings; consumers caching settings should refresh */
+    @JsonProperty("runtimeSettingsChanged")
+    private Boolean runtimeSettingsChanged;
+
+    public String getText() { return text; }
+    public void setText(String text) { this.text = text; }
+
+    public Boolean getMarkdown() { return markdown; }
+    public void setMarkdown(Boolean markdown) { this.markdown = markdown; }
+
+    public Boolean getPreserveAnsi() { return preserveAnsi; }
+    public void setPreserveAnsi(Boolean preserveAnsi) { this.preserveAnsi = preserveAnsi; }
+
+    public Boolean getRuntimeSettingsChanged() { return runtimeSettingsChanged; }
+    public void setRuntimeSettingsChanged(Boolean runtimeSettingsChanged) { this.runtimeSettingsChanged = runtimeSettingsChanged; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/TaskAgentInfo.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/TaskAgentInfo.java
@@ -1,0 +1,150 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.OffsetDateTime;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `TaskAgentInfo` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class TaskAgentInfo extends TaskInfo {
+
+    @JsonProperty("type")
+    private final String type = "agent";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Unique task identifier */
+    @JsonProperty("id")
+    private String id;
+
+    /** Tool call ID associated with this agent task */
+    @JsonProperty("toolCallId")
+    private String toolCallId;
+
+    /** Short description of the task */
+    @JsonProperty("description")
+    private String description;
+
+    /** Current lifecycle status of the task */
+    @JsonProperty("status")
+    private TaskStatus status;
+
+    /** ISO 8601 timestamp when the task was started */
+    @JsonProperty("startedAt")
+    private OffsetDateTime startedAt;
+
+    /** ISO 8601 timestamp when the task finished */
+    @JsonProperty("completedAt")
+    private OffsetDateTime completedAt;
+
+    /** Accumulated active execution time in milliseconds */
+    @JsonProperty("activeTimeMs")
+    private Long activeTimeMs;
+
+    /** ISO 8601 timestamp when the current active period began */
+    @JsonProperty("activeStartedAt")
+    private OffsetDateTime activeStartedAt;
+
+    /** Error message when the task failed */
+    @JsonProperty("error")
+    private String error;
+
+    /** Type of agent running this task */
+    @JsonProperty("agentType")
+    private String agentType;
+
+    /** Prompt passed to the agent */
+    @JsonProperty("prompt")
+    private String prompt;
+
+    /** Result text from the task when available */
+    @JsonProperty("result")
+    private String result;
+
+    /** Model used for the task when specified */
+    @JsonProperty("model")
+    private String model;
+
+    /** Whether task execution is synchronously awaited or managed in the background */
+    @JsonProperty("executionMode")
+    private TaskExecutionMode executionMode;
+
+    /** Whether the task is currently in the original sync wait and can be moved to background mode. False once it is already backgrounded, idle, finished, or no longer has a promotable sync waiter. */
+    @JsonProperty("canPromoteToBackground")
+    private Boolean canPromoteToBackground;
+
+    /** Most recent response text from the agent */
+    @JsonProperty("latestResponse")
+    private String latestResponse;
+
+    /** ISO 8601 timestamp when the agent entered idle state */
+    @JsonProperty("idleSince")
+    private OffsetDateTime idleSince;
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getToolCallId() { return toolCallId; }
+    public void setToolCallId(String toolCallId) { this.toolCallId = toolCallId; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public TaskStatus getStatus() { return status; }
+    public void setStatus(TaskStatus status) { this.status = status; }
+
+    public OffsetDateTime getStartedAt() { return startedAt; }
+    public void setStartedAt(OffsetDateTime startedAt) { this.startedAt = startedAt; }
+
+    public OffsetDateTime getCompletedAt() { return completedAt; }
+    public void setCompletedAt(OffsetDateTime completedAt) { this.completedAt = completedAt; }
+
+    public Long getActiveTimeMs() { return activeTimeMs; }
+    public void setActiveTimeMs(Long activeTimeMs) { this.activeTimeMs = activeTimeMs; }
+
+    public OffsetDateTime getActiveStartedAt() { return activeStartedAt; }
+    public void setActiveStartedAt(OffsetDateTime activeStartedAt) { this.activeStartedAt = activeStartedAt; }
+
+    public String getError() { return error; }
+    public void setError(String error) { this.error = error; }
+
+    public String getAgentType() { return agentType; }
+    public void setAgentType(String agentType) { this.agentType = agentType; }
+
+    public String getPrompt() { return prompt; }
+    public void setPrompt(String prompt) { this.prompt = prompt; }
+
+    public String getResult() { return result; }
+    public void setResult(String result) { this.result = result; }
+
+    public String getModel() { return model; }
+    public void setModel(String model) { this.model = model; }
+
+    public TaskExecutionMode getExecutionMode() { return executionMode; }
+    public void setExecutionMode(TaskExecutionMode executionMode) { this.executionMode = executionMode; }
+
+    public Boolean getCanPromoteToBackground() { return canPromoteToBackground; }
+    public void setCanPromoteToBackground(Boolean canPromoteToBackground) { this.canPromoteToBackground = canPromoteToBackground; }
+
+    public String getLatestResponse() { return latestResponse; }
+    public void setLatestResponse(String latestResponse) { this.latestResponse = latestResponse; }
+
+    public OffsetDateTime getIdleSince() { return idleSince; }
+    public void setIdleSince(OffsetDateTime idleSince) { this.idleSince = idleSince; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/TaskExecutionMode.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/TaskExecutionMode.java
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import javax.annotation.processing.Generated;
+
+/**
+ * Whether task execution is synchronously awaited or managed in the background
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public enum TaskExecutionMode {
+    /** The {@code sync} variant. */
+    SYNC("sync"),
+    /** The {@code background} variant. */
+    BACKGROUND("background");
+
+    private final String value;
+    TaskExecutionMode(String value) { this.value = value; }
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() { return value; }
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static TaskExecutionMode fromValue(String value) {
+        for (TaskExecutionMode v : values()) {
+            if (v.value.equals(value)) return v;
+        }
+        throw new IllegalArgumentException("Unknown TaskExecutionMode value: " + value);
+    }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/TaskInfo.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/TaskInfo.java
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `TaskInfo` type.
+ *
+ * @since 1.0.0
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = TaskAgentInfo.class, name = "agent"),
+    @JsonSubTypes.Type(value = TaskShellInfo.class, name = "shell")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public abstract class TaskInfo {
+
+    /**
+     * Returns the discriminator value for this variant.
+     *
+     * @return the type discriminator
+     */
+    public abstract String getType();
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/TaskShellInfo.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/TaskShellInfo.java
@@ -1,0 +1,108 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.OffsetDateTime;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `TaskShellInfo` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class TaskShellInfo extends TaskInfo {
+
+    @JsonProperty("type")
+    private final String type = "shell";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Unique task identifier */
+    @JsonProperty("id")
+    private String id;
+
+    /** Short description of the task */
+    @JsonProperty("description")
+    private String description;
+
+    /** Current lifecycle status of the task */
+    @JsonProperty("status")
+    private TaskStatus status;
+
+    /** ISO 8601 timestamp when the task was started */
+    @JsonProperty("startedAt")
+    private OffsetDateTime startedAt;
+
+    /** ISO 8601 timestamp when the task finished */
+    @JsonProperty("completedAt")
+    private OffsetDateTime completedAt;
+
+    /** Command being executed */
+    @JsonProperty("command")
+    private String command;
+
+    /** Whether the shell runs inside a managed PTY session or as an independent background process */
+    @JsonProperty("attachmentMode")
+    private TaskShellInfoAttachmentMode attachmentMode;
+
+    /** Whether task execution is synchronously awaited or managed in the background */
+    @JsonProperty("executionMode")
+    private TaskExecutionMode executionMode;
+
+    /** Whether this shell task can be promoted to background mode */
+    @JsonProperty("canPromoteToBackground")
+    private Boolean canPromoteToBackground;
+
+    /** Path to the detached shell log, when available */
+    @JsonProperty("logPath")
+    private String logPath;
+
+    /** Process ID when available */
+    @JsonProperty("pid")
+    private Long pid;
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public TaskStatus getStatus() { return status; }
+    public void setStatus(TaskStatus status) { this.status = status; }
+
+    public OffsetDateTime getStartedAt() { return startedAt; }
+    public void setStartedAt(OffsetDateTime startedAt) { this.startedAt = startedAt; }
+
+    public OffsetDateTime getCompletedAt() { return completedAt; }
+    public void setCompletedAt(OffsetDateTime completedAt) { this.completedAt = completedAt; }
+
+    public String getCommand() { return command; }
+    public void setCommand(String command) { this.command = command; }
+
+    public TaskShellInfoAttachmentMode getAttachmentMode() { return attachmentMode; }
+    public void setAttachmentMode(TaskShellInfoAttachmentMode attachmentMode) { this.attachmentMode = attachmentMode; }
+
+    public TaskExecutionMode getExecutionMode() { return executionMode; }
+    public void setExecutionMode(TaskExecutionMode executionMode) { this.executionMode = executionMode; }
+
+    public Boolean getCanPromoteToBackground() { return canPromoteToBackground; }
+    public void setCanPromoteToBackground(Boolean canPromoteToBackground) { this.canPromoteToBackground = canPromoteToBackground; }
+
+    public String getLogPath() { return logPath; }
+    public void setLogPath(String logPath) { this.logPath = logPath; }
+
+    public Long getPid() { return pid; }
+    public void setPid(Long pid) { this.pid = pid; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/TaskShellInfoAttachmentMode.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/TaskShellInfoAttachmentMode.java
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import javax.annotation.processing.Generated;
+
+/**
+ * Whether the shell runs inside a managed PTY session or as an independent background process
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public enum TaskShellInfoAttachmentMode {
+    /** The {@code attached} variant. */
+    ATTACHED("attached"),
+    /** The {@code detached} variant. */
+    DETACHED("detached");
+
+    private final String value;
+    TaskShellInfoAttachmentMode(String value) { this.value = value; }
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() { return value; }
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static TaskShellInfoAttachmentMode fromValue(String value) {
+        for (TaskShellInfoAttachmentMode v : values()) {
+            if (v.value.equals(value)) return v;
+        }
+        throw new IllegalArgumentException("Unknown TaskShellInfoAttachmentMode value: " + value);
+    }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/TaskStatus.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/TaskStatus.java
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import javax.annotation.processing.Generated;
+
+/**
+ * Current lifecycle status of the task
+ *
+ * @since 1.0.0
+ */
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public enum TaskStatus {
+    /** The {@code running} variant. */
+    RUNNING("running"),
+    /** The {@code idle} variant. */
+    IDLE("idle"),
+    /** The {@code completed} variant. */
+    COMPLETED("completed"),
+    /** The {@code failed} variant. */
+    FAILED("failed"),
+    /** The {@code cancelled} variant. */
+    CANCELLED("cancelled");
+
+    private final String value;
+    TaskStatus(String value) { this.value = value; }
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() { return value; }
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static TaskStatus fromValue(String value) {
+        for (TaskStatus v : values()) {
+            if (v.value.equals(value)) return v;
+        }
+        throw new IllegalArgumentException("Unknown TaskStatus value: " + value);
+    }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/TokenAuthInfo.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/TokenAuthInfo.java
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `TokenAuthInfo` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class TokenAuthInfo extends AuthInfo {
+
+    @JsonProperty("type")
+    private final String type = "token";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Authentication host. */
+    @JsonProperty("host")
+    private String host;
+
+    /** The token value itself. Treat as a secret. */
+    @JsonProperty("token")
+    private String token;
+
+    /** Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this verbatim and does not re-fetch when set. */
+    @JsonProperty("copilotUser")
+    private CopilotUserResponse copilotUser;
+
+    public String getHost() { return host; }
+    public void setHost(String host) { this.host = host; }
+
+    public String getToken() { return token; }
+    public void setToken(String token) { this.token = token; }
+
+    public CopilotUserResponse getCopilotUser() { return copilotUser; }
+    public void setCopilotUser(CopilotUserResponse copilotUser) { this.copilotUser = copilotUser; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/UserAuthInfo.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/UserAuthInfo.java
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `UserAuthInfo` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserAuthInfo extends AuthInfo {
+
+    @JsonProperty("type")
+    private final String type = "user";
+
+    @Override
+    public String getType() { return type; }
+
+    /** Authentication host. */
+    @JsonProperty("host")
+    private String host;
+
+    /** OAuth user login. */
+    @JsonProperty("login")
+    private String login;
+
+    /** Snapshot of the authenticated user's Copilot subscription info, if known. Mirrors the GitHub API `/copilot_internal/v2/token` user response shape — the runtime trusts this verbatim and does not re-fetch when set. */
+    @JsonProperty("copilotUser")
+    private CopilotUserResponse copilotUser;
+
+    public String getHost() { return host; }
+    public void setHost(String host) { this.host = host; }
+
+    public String getLogin() { return login; }
+    public void setLogin(String login) { this.login = login; }
+
+    public CopilotUserResponse getCopilotUser() { return copilotUser; }
+    public void setCopilotUser(CopilotUserResponse copilotUser) { this.copilotUser = copilotUser; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/UserToolSessionApproval.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/UserToolSessionApproval.java
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import javax.annotation.processing.Generated;
+
+/**
+ * The approval to add as a session-scoped rule
+ *
+ * @since 1.0.0
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = UserToolSessionApprovalCommands.class, name = "commands"),
+    @JsonSubTypes.Type(value = UserToolSessionApprovalRead.class, name = "read"),
+    @JsonSubTypes.Type(value = UserToolSessionApprovalWrite.class, name = "write"),
+    @JsonSubTypes.Type(value = UserToolSessionApprovalMcp.class, name = "mcp"),
+    @JsonSubTypes.Type(value = UserToolSessionApprovalMemory.class, name = "memory"),
+    @JsonSubTypes.Type(value = UserToolSessionApprovalCustomTool.class, name = "custom-tool"),
+    @JsonSubTypes.Type(value = UserToolSessionApprovalExtensionManagement.class, name = "extension-management"),
+    @JsonSubTypes.Type(value = UserToolSessionApprovalExtensionPermissionAccess.class, name = "extension-permission-access")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public abstract class UserToolSessionApproval {
+
+    /**
+     * Returns the discriminator value for this variant.
+     *
+     * @return the kind discriminator
+     */
+    public abstract String getKind();
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/UserToolSessionApprovalCommands.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/UserToolSessionApprovalCommands.java
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `UserToolSessionApprovalCommands` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserToolSessionApprovalCommands extends UserToolSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "commands";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Command identifiers approved by the user */
+    @JsonProperty("commandIdentifiers")
+    private List<String> commandIdentifiers;
+
+    public List<String> getCommandIdentifiers() { return commandIdentifiers; }
+    public void setCommandIdentifiers(List<String> commandIdentifiers) { this.commandIdentifiers = commandIdentifiers; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/UserToolSessionApprovalCustomTool.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/UserToolSessionApprovalCustomTool.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `UserToolSessionApprovalCustomTool` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserToolSessionApprovalCustomTool extends UserToolSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "custom-tool";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Custom tool name */
+    @JsonProperty("toolName")
+    private String toolName;
+
+    public String getToolName() { return toolName; }
+    public void setToolName(String toolName) { this.toolName = toolName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/UserToolSessionApprovalExtensionManagement.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/UserToolSessionApprovalExtensionManagement.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `UserToolSessionApprovalExtensionManagement` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserToolSessionApprovalExtensionManagement extends UserToolSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "extension-management";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Optional operation identifier */
+    @JsonProperty("operation")
+    private String operation;
+
+    public String getOperation() { return operation; }
+    public void setOperation(String operation) { this.operation = operation; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/UserToolSessionApprovalExtensionPermissionAccess.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/UserToolSessionApprovalExtensionPermissionAccess.java
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `UserToolSessionApprovalExtensionPermissionAccess` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserToolSessionApprovalExtensionPermissionAccess extends UserToolSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "extension-permission-access";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** Extension name */
+    @JsonProperty("extensionName")
+    private String extensionName;
+
+    public String getExtensionName() { return extensionName; }
+    public void setExtensionName(String extensionName) { this.extensionName = extensionName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/UserToolSessionApprovalMcp.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/UserToolSessionApprovalMcp.java
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `UserToolSessionApprovalMcp` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserToolSessionApprovalMcp extends UserToolSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "mcp";
+
+    @Override
+    public String getKind() { return kind; }
+
+    /** MCP server name */
+    @JsonProperty("serverName")
+    private String serverName;
+
+    /** Optional MCP tool name, or null for all tools on the server */
+    @JsonProperty("toolName")
+    private String toolName;
+
+    public String getServerName() { return serverName; }
+    public void setServerName(String serverName) { this.serverName = serverName; }
+
+    public String getToolName() { return toolName; }
+    public void setToolName(String toolName) { this.toolName = toolName; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/UserToolSessionApprovalMemory.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/UserToolSessionApprovalMemory.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `UserToolSessionApprovalMemory` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserToolSessionApprovalMemory extends UserToolSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "memory";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/UserToolSessionApprovalRead.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/UserToolSessionApprovalRead.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `UserToolSessionApprovalRead` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserToolSessionApprovalRead extends UserToolSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "read";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/generated/java/com/github/copilot/generated/rpc/UserToolSessionApprovalWrite.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/UserToolSessionApprovalWrite.java
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+package com.github.copilot.generated.rpc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.processing.Generated;
+
+/**
+ * Schema for the `UserToolSessionApprovalWrite` type.
+ *
+ * @since 1.0.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@javax.annotation.processing.Generated("copilot-sdk-codegen")
+public final class UserToolSessionApprovalWrite extends UserToolSessionApproval {
+
+    @JsonProperty("kind")
+    private final String kind = "write";
+
+    @Override
+    public String getKind() { return kind; }
+}

--- a/java/src/main/java/module-info.java
+++ b/java/src/main/java/module-info.java
@@ -22,5 +22,6 @@ module com.github.copilot.java {
 
     opens com.github.copilot to com.fasterxml.jackson.databind;
     opens com.github.copilot.generated to com.fasterxml.jackson.databind;
+    opens com.github.copilot.generated.rpc to com.fasterxml.jackson.databind;
     opens com.github.copilot.rpc to com.fasterxml.jackson.databind;
 }

--- a/java/src/test/java/com/github/copilot/SlashCommandsIT.java
+++ b/java/src/test/java/com/github/copilot/SlashCommandsIT.java
@@ -5,8 +5,14 @@
 package com.github.copilot;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
@@ -15,7 +21,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.github.copilot.generated.rpc.SessionCommandsListResult;
+import com.github.copilot.generated.rpc.SessionCommandsInvokeParams;
+import com.github.copilot.generated.rpc.SlashCommandAgentPromptResult;
+import com.github.copilot.generated.rpc.SlashCommandCompletedResult;
 import com.github.copilot.generated.rpc.SlashCommandInfo;
+import com.github.copilot.generated.rpc.SlashCommandInvocationResult;
+import com.github.copilot.generated.rpc.SlashCommandSelectSubcommandResult;
+import com.github.copilot.generated.rpc.SlashCommandTextResult;
 import com.github.copilot.rpc.CopilotClientOptions;
 import com.github.copilot.rpc.PermissionHandler;
 import com.github.copilot.rpc.SessionConfig;
@@ -71,5 +83,101 @@ class SlashCommandsIT {
                     "Command name should match /^[a-z].*$/ but was: " + cmd.name());
         }
         System.out.println("=== Total: " + result.commands().size() + " commands ===");
+    }
+
+    @Test
+    void autoPilotToggle() throws Exception {
+        SlashCommandInvocationResult first = session.getRpc().commands
+                .invoke(new SessionCommandsInvokeParams(null, "autopilot", null)).get(15, TimeUnit.SECONDS);
+        SlashCommandInvocationResult second = session.getRpc().commands
+                .invoke(new SessionCommandsInvokeParams(null, "autopilot", null)).get(15, TimeUnit.SECONDS);
+
+        String firstOutput = extractDisplayText(first);
+        String secondOutput = extractDisplayText(second);
+
+        assertTrue(!firstOutput.isBlank(), "First /autopilot invocation should return non-empty output");
+        assertTrue(!secondOutput.isBlank(), "Second /autopilot invocation should return non-empty output");
+        assertNotEquals(firstOutput, secondOutput,
+                "Two consecutive /autopilot invocations should produce different output because mode toggles");
+
+        List<String> firstTokens = tokenizeForComparison(firstOutput);
+        List<String> secondTokens = tokenizeForComparison(secondOutput);
+        assertTrue(!firstTokens.isEmpty(), "First /autopilot output should include at least one token");
+        assertTrue(!secondTokens.isEmpty(), "Second /autopilot output should include at least one token");
+
+        List<String> commonInOrder = commonTokensInOrder(firstTokens, secondTokens);
+        assertTrue(!commonInOrder.isEmpty(),
+                "Outputs should share at least one token in the same order to indicate similar structure");
+
+        Set<String> firstOnly = new HashSet<>(firstTokens);
+        firstOnly.removeAll(new HashSet<>(secondTokens));
+        Set<String> secondOnly = new HashSet<>(secondTokens);
+        secondOnly.removeAll(new HashSet<>(firstTokens));
+        assertTrue(!firstOnly.isEmpty() || !secondOnly.isEmpty(),
+                "Outputs should differ by at least one token to reflect the toggle change");
+
+        System.out.println("First /autopilot result: " + firstOutput);
+        System.out.println("Second /autopilot result: " + secondOutput);
+    }
+
+    private static String extractDisplayText(SlashCommandInvocationResult result) {
+        assertNotNull(result, "slash command result must not be null");
+
+        if (result instanceof SlashCommandTextResult textResult) {
+            return valueOrEmpty(textResult.getText());
+        }
+        if (result instanceof SlashCommandCompletedResult completedResult) {
+            return valueOrEmpty(completedResult.getMessage());
+        }
+        if (result instanceof SlashCommandAgentPromptResult promptResult) {
+            String display = valueOrEmpty(promptResult.getDisplayPrompt());
+            if (!display.isBlank()) {
+                return display;
+            }
+            return valueOrEmpty(promptResult.getPrompt());
+        }
+        if (result instanceof SlashCommandSelectSubcommandResult selectResult) {
+            String title = valueOrEmpty(selectResult.getTitle());
+            if (!title.isBlank()) {
+                return title;
+            }
+            return valueOrEmpty(selectResult.getCommand());
+        }
+
+        return valueOrEmpty(result.getKind());
+    }
+
+    private static String valueOrEmpty(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private static List<String> tokenizeForComparison(String text) {
+        List<String> tokens = new ArrayList<>();
+        Pattern wordPattern = Pattern.compile("[\\p{L}\\p{N}]+", Pattern.UNICODE_CHARACTER_CLASS);
+        var matcher = wordPattern.matcher(text.toLowerCase(Locale.ROOT));
+        while (matcher.find()) {
+            tokens.add(matcher.group());
+        }
+        return tokens;
+    }
+
+    private static List<String> commonTokensInOrder(List<String> first, List<String> second) {
+        List<String> common = new ArrayList<>();
+        int secondIndex = 0;
+
+        for (String token : first) {
+            while (secondIndex < second.size()) {
+                String candidate = second.get(secondIndex++);
+                if (token.equals(candidate)) {
+                    common.add(token);
+                    break;
+                }
+            }
+            if (secondIndex >= second.size()) {
+                break;
+            }
+        }
+
+        return common;
     }
 }

--- a/java/src/test/java/com/github/copilot/SlashCommandsIT.java
+++ b/java/src/test/java/com/github/copilot/SlashCommandsIT.java
@@ -24,7 +24,8 @@ import com.github.copilot.rpc.SessionConfig;
  * Failsafe integration test that exercises slash commands against the live
  * Copilot CLI (not the replay proxy).
  * <p>
- * Requires the CLI to be installed and the user to be signed in.
+ * Requires the CLI to be installed and the user to be signed in. Uses
+ * {@link TestUtil#findCliPath()} so the test harness binary is found in CI.
  */
 class SlashCommandsIT {
 
@@ -33,7 +34,8 @@ class SlashCommandsIT {
 
     @BeforeAll
     static void setup() throws Exception {
-        CopilotClientOptions options = new CopilotClientOptions().setUseLoggedInUser(true);
+        String cliPath = TestUtil.findCliPath();
+        CopilotClientOptions options = new CopilotClientOptions().setCliPath(cliPath).setUseLoggedInUser(true);
         client = new CopilotClient(options);
         client.start().get(30, TimeUnit.SECONDS);
         session = client.createSession(new SessionConfig().setOnPermissionRequest(PermissionHandler.APPROVE_ALL))

--- a/java/src/test/java/com/github/copilot/SlashCommandsIT.java
+++ b/java/src/test/java/com/github/copilot/SlashCommandsIT.java
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+package com.github.copilot;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.github.copilot.generated.rpc.SessionCommandsListResult;
+import com.github.copilot.generated.rpc.SlashCommandInfo;
+import com.github.copilot.rpc.CopilotClientOptions;
+import com.github.copilot.rpc.PermissionHandler;
+import com.github.copilot.rpc.SessionConfig;
+
+/**
+ * Failsafe integration test that exercises slash commands against the live
+ * Copilot CLI (not the replay proxy).
+ * <p>
+ * Requires the CLI to be installed and the user to be signed in.
+ */
+class SlashCommandsIT {
+
+    private static CopilotClient client;
+    private static CopilotSession session;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        CopilotClientOptions options = new CopilotClientOptions()
+                .setUseLoggedInUser(true);
+        client = new CopilotClient(options);
+        client.start().get(30, TimeUnit.SECONDS);
+        session = client.createSession(new SessionConfig()
+                .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)).get(30, TimeUnit.SECONDS);
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        if (session != null) {
+            session.close();
+        }
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Test
+    void listCommandsReturnsAtLeast20() throws Exception {
+        SessionCommandsListResult result =
+                session.getRpc().commands.list().get(15, TimeUnit.SECONDS);
+
+        assertNotNull(result, "commands.list result must not be null");
+        assertNotNull(result.commands(), "commands list must not be null");
+        assertTrue(result.commands().size() >= 20,
+                "Expected at least 20 commands but got " + result.commands().size());
+
+        Pattern namePattern = Pattern.compile("^[a-z].*$");
+
+        // Print every command so we can pick one for the next iteration
+        System.out.println("=== Available slash commands ===");
+        for (SlashCommandInfo cmd : result.commands()) {
+            System.out.printf("  /%s  kind=%s  desc=%s  aliases=%s%n",
+                    cmd.name(), cmd.kind(), cmd.description(), cmd.aliases());
+            assertTrue(namePattern.matcher(cmd.name()).matches(),
+                    "Command name should match /^[a-z].*$/ but was: " + cmd.name());
+        }
+        System.out.println("=== Total: " + result.commands().size() + " commands ===");
+    }
+}

--- a/java/src/test/java/com/github/copilot/SlashCommandsIT.java
+++ b/java/src/test/java/com/github/copilot/SlashCommandsIT.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.AfterAll;
@@ -118,6 +120,63 @@ class SlashCommandsIT {
 
         System.out.println("First /autopilot result: " + firstOutput);
         System.out.println("Second /autopilot result: " + secondOutput);
+    }
+
+    @Test
+    void listDirs() throws Exception {
+        SlashCommandInvocationResult result = session.getRpc().commands
+                .invoke(new SessionCommandsInvokeParams(null, "list-dirs", null)).get(15, TimeUnit.SECONDS);
+
+        String output = extractDisplayText(result);
+        assertTrue(Pattern.compile("(?s)^.*Total: [0-9]+ directories.*$").matcher(output).matches(),
+                "Expected /list-dirs output to include total directories count");
+        System.out.println("/list-dirs result:");
+        System.out.println(output);
+    }
+
+    @Test
+    void addDir() throws Exception {
+        String buildDirectory = System.getProperty("project.build.directory");
+        assertNotNull(buildDirectory, "System property 'project.build.directory' must be set by failsafe");
+
+        Path addDirPath = Path.of(buildDirectory, "addDirTest").toAbsolutePath().normalize();
+        Files.createDirectories(addDirPath);
+        String addDirPathString = addDirPath.toString();
+
+        SlashCommandInvocationResult beforeListResult = session.getRpc().commands
+                .invoke(new SessionCommandsInvokeParams(null, "list-dirs", null)).get(15, TimeUnit.SECONDS);
+        String beforeListOutput = extractDisplayText(beforeListResult);
+        System.out.println("/list-dirs (before /add-dir) result:");
+        System.out.println(beforeListOutput);
+
+        SlashCommandInvocationResult addDirResult = session.getRpc().commands
+                .invoke(new SessionCommandsInvokeParams(null, "add-dir", addDirPathString)).get(15, TimeUnit.SECONDS);
+        String addDirOutput = extractDisplayText(addDirResult);
+        System.out.println("/add-dir result:");
+        System.out.println(addDirOutput);
+
+        SlashCommandInvocationResult afterListResult = session.getRpc().commands
+                .invoke(new SessionCommandsInvokeParams(null, "list-dirs", null)).get(15, TimeUnit.SECONDS);
+        String afterListOutput = extractDisplayText(afterListResult);
+        System.out.println("/list-dirs (after /add-dir) result:");
+        System.out.println(afterListOutput);
+
+        assertTrue(afterListOutput.contains(addDirPathString),
+                "Expected /list-dirs output to contain added directory path: " + addDirPathString);
+    }
+
+    @Test
+    void usage() throws Exception {
+        SlashCommandInvocationResult result = session.getRpc().commands
+                .invoke(new SessionCommandsInvokeParams(null, "usage", null)).get(15, TimeUnit.SECONDS);
+
+        String output = extractDisplayText(result);
+        assertTrue(Pattern.compile("(?s)^.*Changes:.*$").matcher(output).matches(),
+                "Expected /usage output to include a Changes summary line");
+        assertTrue(Pattern.compile("(?s)^.*Requests:.*$").matcher(output).matches(),
+                "Expected /usage output to include a Requests/AI Units summary line");
+        System.out.println("/usage result:");
+        System.out.println(output);
     }
 
     private static String extractDisplayText(SlashCommandInvocationResult result) {

--- a/java/src/test/java/com/github/copilot/SlashCommandsIT.java
+++ b/java/src/test/java/com/github/copilot/SlashCommandsIT.java
@@ -33,12 +33,11 @@ class SlashCommandsIT {
 
     @BeforeAll
     static void setup() throws Exception {
-        CopilotClientOptions options = new CopilotClientOptions()
-                .setUseLoggedInUser(true);
+        CopilotClientOptions options = new CopilotClientOptions().setUseLoggedInUser(true);
         client = new CopilotClient(options);
         client.start().get(30, TimeUnit.SECONDS);
-        session = client.createSession(new SessionConfig()
-                .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)).get(30, TimeUnit.SECONDS);
+        session = client.createSession(new SessionConfig().setOnPermissionRequest(PermissionHandler.APPROVE_ALL))
+                .get(30, TimeUnit.SECONDS);
     }
 
     @AfterAll
@@ -53,21 +52,19 @@ class SlashCommandsIT {
 
     @Test
     void listCommandsReturnsAtLeast20() throws Exception {
-        SessionCommandsListResult result =
-                session.getRpc().commands.list().get(15, TimeUnit.SECONDS);
+        SessionCommandsListResult result = session.getRpc().commands.list().get(15, TimeUnit.SECONDS);
 
         assertNotNull(result, "commands.list result must not be null");
         assertNotNull(result.commands(), "commands list must not be null");
-        assertTrue(result.commands().size() >= 20,
-                "Expected at least 20 commands but got " + result.commands().size());
+        assertTrue(result.commands().size() >= 20, "Expected at least 20 commands but got " + result.commands().size());
 
         Pattern namePattern = Pattern.compile("^[a-z].*$");
 
         // Print every command so we can pick one for the next iteration
         System.out.println("=== Available slash commands ===");
         for (SlashCommandInfo cmd : result.commands()) {
-            System.out.printf("  /%s  kind=%s  desc=%s  aliases=%s%n",
-                    cmd.name(), cmd.kind(), cmd.description(), cmd.aliases());
+            System.out.printf("  /%s  kind=%s  desc=%s  aliases=%s%n", cmd.name(), cmd.kind(), cmd.description(),
+                    cmd.aliases());
             assertTrue(namePattern.matcher(cmd.name()).matches(),
                     "Command name should match /^[a-z].*$/ but was: " + cmd.name());
         }

--- a/java/src/test/java/com/github/copilot/TestUtil.java
+++ b/java/src/test/java/com/github/copilot/TestUtil.java
@@ -76,8 +76,8 @@ public final class TestUtil {
         Path current = Paths.get(System.getProperty("user.dir"));
         while (current != null) {
             // Test harness platform-specific binary
-            Path platformBinary = current
-                    .resolve("test/harness/node_modules/@github/copilot-" + platform + "-" + cpuArch + "/" + binaryName);
+            Path platformBinary = current.resolve(
+                    "test/harness/node_modules/@github/copilot-" + platform + "-" + cpuArch + "/" + binaryName);
             if (platformBinary.toFile().exists()) {
                 return platformBinary.toString();
             }

--- a/java/src/test/java/com/github/copilot/TestUtil.java
+++ b/java/src/test/java/com/github/copilot/TestUtil.java
@@ -65,8 +65,30 @@ public final class TestUtil {
             return copilotInPath;
         }
 
+        // Walk parent directories looking for the CLI in the test harness or nodejs
+        // installation. Mirrors the resolution order in E2ETestContext.getCliPath().
+        String os = System.getProperty("os.name").toLowerCase();
+        String arch = System.getProperty("os.arch").toLowerCase();
+        String platform = os.contains("mac") ? "darwin" : os.contains("win") ? "win32" : "linux";
+        String cpuArch = arch.contains("aarch64") || arch.contains("arm64") ? "arm64" : "x64";
+        String binaryName = os.contains("win") ? "copilot.exe" : "copilot";
+
         Path current = Paths.get(System.getProperty("user.dir"));
         while (current != null) {
+            // Test harness platform-specific binary
+            Path platformBinary = current
+                    .resolve("test/harness/node_modules/@github/copilot-" + platform + "-" + cpuArch + "/" + binaryName);
+            if (platformBinary.toFile().exists()) {
+                return platformBinary.toString();
+            }
+
+            // Test harness npm-loader.js
+            Path npmLoader = current.resolve("test/harness/node_modules/@github/copilot/npm-loader.js");
+            if (npmLoader.toFile().exists()) {
+                return npmLoader.toString();
+            }
+
+            // nodejs installation
             Path cliPath = current.resolve("nodejs/node_modules/@github/copilot/index.js");
             if (cliPath.toFile().exists()) {
                 return cliPath.toString();

--- a/java/src/test/java/com/github/copilot/generated/GeneratedTypesJacksonRoundTripTest.java
+++ b/java/src/test/java/com/github/copilot/generated/GeneratedTypesJacksonRoundTripTest.java
@@ -59,9 +59,6 @@ class GeneratedTypesJacksonRoundTripTest {
         for (Class<?> cls : discoverGeneratedClasses()) {
             if (!cls.isRecord())
                 continue;
-            // Skip abstract/sealed event base class — it requires a "type" discriminator
-            if (cls == SessionEvent.class)
-                continue;
             tests.add(DynamicTest.dynamicTest("record round-trip: " + cls.getSimpleName(), () -> {
                 // Deserialize from empty JSON — all fields will be null/default
                 Object instance = MAPPER.readValue("{}", cls);


### PR DESCRIPTION
### Java

Last minute gap analysis promted by this question by Zidong Li:

> Just curious whether you know how to trigger slash commands in SDK. There's one kind of skill that disables agents calling. Those skills can be invoked in copilot cli by /<skill> manually. But using SDKs, if I send the text directly to agents, it's just treated as plain text to LLM, but LLM actually doesn't have the skill in context so it will not invoke the skill. Did you know any conversation about this?

prompted me to investigate this. Turns out the ability to invoke slash commands was there, but the ability to obtain the responses was not.