### PR TITLE
fix(python): derive __version__ from package metadata; align Node version sentinel

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@github/copilot-sdk",
-    "version": "0.1.8",
+    "version": "0.0.0-dev",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@github/copilot-sdk",
-            "version": "0.1.8",
+            "version": "0.0.0-dev",
             "license": "MIT",
             "dependencies": {
                 "@github/copilot": "^1.0.57-3",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/github/copilot-sdk.git"
     },
-    "version": "0.1.8",
+    "version": "0.0.0-dev",
     "description": "TypeScript SDK for programmatic control of GitHub Copilot CLI via JSON-RPC",
     "main": "./dist/cjs/index.js",
     "types": "./dist/index.d.ts",
@@ -44,7 +44,7 @@
         "generate": "cd ../scripts/codegen && npm run generate",
         "update:protocol-version": "tsx scripts/update-protocol-version.ts",
         "prepublishOnly": "npm run build",
-        "package": "npm run clean && npm run build && node scripts/set-version.js && npm pack && npm version 0.1.0 --no-git-tag-version --allow-same-version"
+        "package": "npm run clean && npm run build && node scripts/set-version.js && npm pack && npm version 0.0.0-dev --no-git-tag-version --allow-same-version"
     },
     "keywords": [
         "github",

--- a/nodejs/samples/package-lock.json
+++ b/nodejs/samples/package-lock.json
@@ -15,7 +15,7 @@
         },
         "..": {
             "name": "@github/copilot-sdk",
-            "version": "0.1.8",
+            "version": "0.0.0-dev",
             "license": "MIT",
             "dependencies": {
                 "@github/copilot": "^1.0.57-3",

--- a/nodejs/scripts/set-version.js
+++ b/nodejs/scripts/set-version.js
@@ -3,7 +3,7 @@ import { readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
-const version = process.env.VERSION || "0.1.0-dev";
+const version = process.env.VERSION || "0.0.0-dev";
 const packageJsonPath = join(dirname(fileURLToPath(import.meta.url)), "..", "package.json");
 
 const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));

--- a/python/copilot/__init__.py
+++ b/python/copilot/__init__.py
@@ -4,6 +4,9 @@ Copilot SDK - Python Client for GitHub Copilot CLI
 JSON-RPC based SDK for programmatic control of GitHub Copilot CLI
 """
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
 from ._mode import (
     BUILTIN_TOOLS_ISOLATED,
     CopilotClientMode,
@@ -145,7 +148,13 @@ from .tools import (
     define_tool,
 )
 
-__version__ = "0.1.0"
+try:
+    __version__ = _pkg_version("github-copilot-sdk")
+except PackageNotFoundError:
+    # No installed package metadata (e.g. running from a source checkout that
+    # was never installed). Use a sentinel that can never masquerade as a real
+    # release rather than a hardcoded version that would silently go stale.
+    __version__ = "0.0.0.dev0"
 
 __all__ = [
     "AutoModeSwitchHandler",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "github-copilot-sdk"
-version = "0.1.0"
+# Placeholder; the real version is injected at publish time (see
+# .github/workflows/publish.yml). Kept as a dev sentinel so source/editable
+# installs never report a stale real version, matching the .NET and Rust SDKs.
+version = "0.0.0.dev0"
 description = "Python SDK for GitHub Copilot CLI"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

The Python SDK was baking in a stale, hardcoded version number. `python/copilot/__init__.py` had `__version__ = "0.1.0"` and `python/pyproject.toml` had `version = "0.1.0"`. The publish workflow only rewrites `pyproject.toml` at release time (`sed 's/^version = .*/...'`), so the public runtime `__version__` never got updated and permanently reported a stale value regardless of what was actually published.

This PR implements the correct fix and brings the Node SDK in line with the dev-sentinel convention already used by the .NET and Rust SDKs.

## Changes

### Python (the actual fix)
- `__version__` is now derived from the installed package metadata via `importlib.metadata.version("github-copilot-sdk")`, so it always matches what was installed.
- The fallback (when no package metadata is present, e.g. a raw source checkout) is a `0.0.0.dev0` dev sentinel rather than a real-looking number that would silently go stale again.
- `pyproject.toml` version is now the `0.0.0.dev0` dev sentinel; CI injects the real version at publish time.

### Node (consistency alignment)
- `package.json` version `0.1.8` → `0.0.0-dev`, and the `package` script's trailing `npm version 0.1.0` → `0.0.0-dev`.
- `scripts/set-version.js` default fallback `0.1.0-dev` → `0.0.0-dev`.
- `package-lock.json` (root + `packages[""]`) and `samples/package-lock.json` (`packages[".."]`) synced to `0.0.0-dev` to keep `npm ci` happy.

The publish flow is unchanged — CI still injects the real `VERSION` at publish time; only the committed defaults become unmistakable dev placeholders.

## Audit of the other SDKs

No changes needed; they were already correct:

| SDK | Version source | Status |
|-----|----------------|--------|
| .NET | `<Version>0.0.0-dev</Version>` (set via `dotnet pack -p:Version=`) | ✅ already a dev sentinel |
| Rust | `version = "0.0.0-dev"` (set via `sed`) | ✅ already a dev sentinel |
| Go | tag-based (`go/v…`), no embedded version | ✅ n/a |
| Java | `…-SNAPSHOT`, managed by maven-release-plugin | ✅ Maven dev convention |

Only Python exposed a runtime `__version__`, and only Node committed a real-looking number — both addressed here.

## Validation
- `__version__` resolves from installed metadata; fallback returns the sentinel.
- `0.0.0.dev0` is valid PEP 440; `0.0.0-dev` is valid semver.
- The publish workflow's `sed '^version = .*'` still matches exactly one line.
- `package.json` and all lockfiles agree on `0.0.0-dev`; JSON validated.
- `ruff check` passes on the modified Python file (stdlib import correctly placed for isort).
- No code reads `copilot.__version__` and no tests assert on it.

Reviewed by two independent code-review passes (GPT-5.5 and Opus 4.7); the one issue surfaced (stale `samples/package-lock.json`) is fixed here.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
