### PR TITLE
Map `session.mcp.apps.callTool` result to `JsonNode` and harden `mvn clean`

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -167,37 +167,33 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
                 <version>3.4.1</version>
-                <configuration>
-                    <!--
-                        The E2E test harness spawns Node.js child processes
-                        (npx tsx server.ts) whose CWD is inside
-                        target/copilot-sdk/test/harness/. On macOS, orphaned
-                        node processes can briefly hold file descriptors on
-                        the directory tree after the test JVM exits, causing
-                        the first 'mvn clean' to fail with
-                        "Failed to delete target/copilot-sdk".
-
-                        retryOnError + retryCount give the OS time to reap
-                        those processes before the clean phase gives up.
-                    -->
-                    <retryOnError>true</retryOnError>
-                </configuration>
                 <executions>
                     <execution>
                         <!--
-                            The VS Code Roslyn language server monitors .csproj
-                            files in the cloned repo at target/copilot-sdk/dotnet/
-                            and immediately re-creates obj/ metadata after the
-                            default-clean execution deletes target/. By running a
-                            second clean in post-clean, the resurrected directories
-                            are swept away and Roslyn does not recreate them again
-                            (the .csproj is already gone).
+                            The default-clean execution uses failOnError=false
+                            because external processes (VS Code language servers,
+                            orphaned Node.js test-harness processes) can hold
+                            file descriptors on target/copilot-sdk/ just long
+                            enough to prevent deletion. The post-clean-sweep
+                            retries immediately afterward (by which time the
+                            transient locks have cleared) to ensure target/ is
+                            fully removed.
                         -->
+                        <id>default-clean</id>
+                        <configuration>
+                            <retryOnError>true</retryOnError>
+                            <failOnError>false</failOnError>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>post-clean-sweep</id>
                         <phase>post-clean</phase>
                         <goals>
                             <goal>clean</goal>
                         </goals>
+                        <configuration>
+                            <retryOnError>true</retryOnError>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -182,6 +182,24 @@
                     -->
                     <retryOnError>true</retryOnError>
                 </configuration>
+                <executions>
+                    <execution>
+                        <!--
+                            The VS Code Roslyn language server monitors .csproj
+                            files in the cloned repo at target/copilot-sdk/dotnet/
+                            and immediately re-creates obj/ metadata after the
+                            default-clean execution deletes target/. By running a
+                            second clean in post-clean, the resurrected directories
+                            are swept away and Roslyn does not recreate them again
+                            (the .csproj is already gone).
+                        -->
+                        <id>post-clean-sweep</id>
+                        <phase>post-clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/java/scripts/codegen/java.ts
+++ b/java/scripts/codegen/java.ts
@@ -1433,6 +1433,18 @@ function wrapperResultClassName(method: RpcMethodNode): string {
     ) {
         return rpcMethodToClassName(method.rpcMethod) + "Result";
     }
+
+    // Free-form object with additionalProperties (e.g., x-opaque-json) → JsonNode
+    if (
+        result &&
+        typeof result === "object" &&
+        result.type === "object" &&
+        result.additionalProperties &&
+        !result.properties
+    ) {
+        return "JsonNode";
+    }
+
     return "Void";
 }
 
@@ -1571,7 +1583,13 @@ async function generateNamespaceApiFile(
     for (const [key, method] of tree.methods) {
         const resultClass = wrapperResultClassName(method);
         const paramsClass = wrapperParamsClassName(method);
-        if (resultClass !== "Void") allImports.add(`${packageName}.${resultClass}`);
+        if (resultClass !== "Void") {
+            if (resultClass === "JsonNode") {
+                allImports.add("com.fasterxml.jackson.databind.JsonNode");
+            } else {
+                allImports.add(`${packageName}.${resultClass}`);
+            }
+        }
         if (paramsClass) allImports.add(`${packageName}.${paramsClass}`);
 
         const { lines, needsMapper: nm } = generateApiMethod(key, method, isSession, sessionIdExpr);
@@ -1690,7 +1708,13 @@ async function generateRpcRootFile(
     for (const [key, method] of tree.methods) {
         const resultClass = wrapperResultClassName(method);
         const paramsClass = wrapperParamsClassName(method);
-        if (resultClass !== "Void") allImports.add(`${packageName}.${resultClass}`);
+        if (resultClass !== "Void") {
+            if (resultClass === "JsonNode") {
+                allImports.add("com.fasterxml.jackson.databind.JsonNode");
+            } else {
+                allImports.add(`${packageName}.${resultClass}`);
+            }
+        }
         if (paramsClass) allImports.add(`${packageName}.${paramsClass}`);
 
         const { lines, needsMapper: nm } = generateApiMethod(key, method, isSession, sessionIdExpr);

--- a/java/src/generated/java/com/github/copilot/generated/rpc/SessionMcpAppsApi.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/SessionMcpAppsApi.java
@@ -7,6 +7,7 @@
 
 package com.github.copilot.generated.rpc;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.processing.Generated;
 
@@ -68,10 +69,10 @@ public final class SessionMcpAppsApi {
      * @apiNote This method is experimental and may change in a future version.
      * @since 1.0.0
      */
-    public CompletableFuture<Void> callTool(SessionMcpAppsCallToolParams params) {
+    public CompletableFuture<JsonNode> callTool(SessionMcpAppsCallToolParams params) {
         com.fasterxml.jackson.databind.node.ObjectNode _p = MAPPER.valueToTree(params);
         _p.put("sessionId", this.sessionId);
-        return caller.invoke("session.mcp.apps.callTool", _p, Void.class);
+        return caller.invoke("session.mcp.apps.callTool", _p, JsonNode.class);
     }
 
     /**

--- a/java/src/test/java/com/github/copilot/RpcWrappersTest.java
+++ b/java/src/test/java/com/github/copilot/RpcWrappersTest.java
@@ -389,6 +389,56 @@ class RpcWrappersTest {
                 "getRpc() must throw IllegalStateException if called before start()");
     }
 
+    // ── session.mcp.apps.callTool tests ───────────────────────────────────────
+
+    @Test
+    void sessionRpc_mcp_apps_callTool_invokes_correct_rpc_method() {
+        var stub = new StubCaller();
+        var session = new SessionRpc(stub, "sess-mcp");
+
+        var params = new com.github.copilot.generated.rpc.SessionMcpAppsCallToolParams(null, "my-server", "my-tool",
+                null, null);
+        session.mcp.apps.callTool(params);
+
+        assertEquals(1, stub.calls.size());
+        assertEquals("session.mcp.apps.callTool", stub.calls.get(0).method());
+    }
+
+    @Test
+    void sessionRpc_mcp_apps_callTool_injects_sessionId() {
+        var stub = new StubCaller();
+        var session = new SessionRpc(stub, "sess-ct-inject");
+
+        var params = new com.github.copilot.generated.rpc.SessionMcpAppsCallToolParams(null, "server1", "tool1", null,
+                null);
+        session.mcp.apps.callTool(params);
+
+        var sentParams = stub.calls.get(0).params();
+        assertInstanceOf(com.fasterxml.jackson.databind.node.ObjectNode.class, sentParams);
+        var node = (com.fasterxml.jackson.databind.node.ObjectNode) sentParams;
+        assertEquals("sess-ct-inject", node.get("sessionId").asText());
+    }
+
+    @Test
+    void sessionRpc_mcp_apps_callTool_returns_jsonNode_payload() throws Exception {
+        var stub = new StubCaller();
+        var mapper = new ObjectMapper();
+        var expectedResult = mapper.createObjectNode();
+        expectedResult.put("content", "hello world");
+        expectedResult.put("isError", false);
+        stub.nextResult = expectedResult;
+
+        var session = new SessionRpc(stub, "sess-payload");
+        var params = new com.github.copilot.generated.rpc.SessionMcpAppsCallToolParams(null, "echo-server", "echo",
+                null, null);
+        var future = session.mcp.apps.callTool(params);
+
+        var result = future.get();
+        assertInstanceOf(com.fasterxml.jackson.databind.JsonNode.class, result);
+        assertEquals("hello world", result.get("content").asText());
+        assertEquals(false, result.get("isError").asBoolean());
+    }
+
     /**
      * Helper that creates a loopback socket pair. The client side is used by
      * {@link JsonRpcClient}; the server side can be read to inspect outbound


### PR DESCRIPTION
Two independent improvements to the Java SDK:

1. **Fix `session.mcp.apps.callTool` return type** — The RPC method returns a free-form JSON object but Java codegen was mapping it to `Void`. This change teaches the codegen to recognize free-form object schemas and map them to `JsonNode`.

2. **Make `mvn clean` resilient to external file locks** — External processes (VS Code language servers, orphaned Node.js test-harness processes) can hold file descriptors on `target/copilot-sdk/` just long enough to cause `mvn clean` to fail. A two-phase clean strategy ensures `target/` is fully removed.

## Changes

### Codegen: free-form object → `JsonNode` mapping

**`java/scripts/codegen/java.ts`**
- `wrapperResultClassName()` now recognizes free-form object schemas (`type=object` + `additionalProperties`, no `properties`) and returns `"JsonNode"` instead of falling through to `Void`.
- `generateNamespaceApiFile()` and `generateRpcRootFile()` import `com.fasterxml.jackson.databind.JsonNode` when any method in the namespace uses the `JsonNode` result type.

**`java/src/generated/java/com/github/copilot/generated/rpc/SessionMcpAppsApi.java`** (regenerated)
- `callTool()` now returns `CompletableFuture<JsonNode>` instead of `CompletableFuture<Void>`.

**`java/src/test/java/com/github/copilot/RpcWrappersTest.java`**
- 3 new unit tests using the existing `StubCaller` pattern:
  - `sessionRpc_mcp_apps_callTool_invokes_correct_rpc_method()` — verifies method name dispatch
  - `sessionRpc_mcp_apps_callTool_injects_sessionId()` — verifies sessionId is injected into params
  - `sessionRpc_mcp_apps_callTool_returns_jsonNode_payload()` — verifies the future resolves to a `JsonNode` with expected content

### Build: harden `mvn clean`

**`java/pom.xml`**
- `default-clean` execution: set `failOnError=false` so transient file locks don't fail the build.
- New `post-clean-sweep` execution in `post-clean` phase: retries deletion after the transient locks have cleared, ensuring `target/` is fully removed.
- Removed stale comment referencing nonexistent `retryCount` parameter.

## Test results

All 1684 unit tests pass on both JDK 25 and JDK 17. All 6 integration tests (5 SlashCommandsIT + 1 InternalExecutorProviderIT) pass. Zero failures, zero errors.

## Commits

- `bfdce49c` — java: map session.mcp.apps.callTool result to JsonNode
- `7206e842` — Ensure lingering content from test harness approach does not remain after mvn clean
- `e391d6af` — Ensure lingering content from test harness approach does not remain after mvn clean
