### PR TITLE
fix(nodejs): Map suppressResumeEvent to disableResume on the wire

### DIFF
--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -2385,7 +2385,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         bool? EnableHostGitOperations,
         bool? EnableSessionStore,
         bool? EnableSkills,
-        bool? SuppressResumeEvent,
+        [property: JsonPropertyName("disableResume")] bool? SuppressResumeEvent,
         bool? Streaming,
         bool? IncludeSubAgentStreamingEvents,
         IDictionary<string, McpServerConfig>? McpServers,

--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -1338,7 +1338,7 @@ export class CopilotClient {
                 instructionDirectories: config.instructionDirectories,
                 disabledSkills: config.disabledSkills,
                 infiniteSessions: config.infiniteSessions,
-                suppressResumeEvent: config.suppressResumeEvent,
+                disableResume: config.suppressResumeEvent,
                 continuePendingWork: config.continuePendingWork,
                 gitHubToken: config.gitHubToken,
                 remoteSession: config.remoteSession,

--- a/nodejs/test/e2e/suspend.e2e.test.ts
+++ b/nodejs/test/e2e/suspend.e2e.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it, onTestFinished } from "vitest";
 import { z } from "zod";
 import { approveAll, CopilotClient, defineTool, RuntimeConnection } from "../../src/index.js";
 import type { PermissionRequest, PermissionRequestResult, SessionEvent } from "../../src/index.js";
-import { createSdkTestContext } from "./harness/sdkTestContext.js";
+import { createSdkTestContext, DEFAULT_GITHUB_TOKEN } from "./harness/sdkTestContext.js";
 
 const SUSPEND_TIMEOUT_MS = 60_000;
 const TEST_TIMEOUT_MS = 180_000;
@@ -65,6 +65,7 @@ describe("Suspend RPC", async () => {
         const server = new CopilotClient({
             workingDirectory: workDir,
             env,
+            gitHubToken: DEFAULT_GITHUB_TOKEN,
             connection: RuntimeConnection.forTcp({
                 path: process.env.COPILOT_CLI_PATH,
                 connectionToken: SHARED_TOKEN,


### PR DESCRIPTION
## Summary

The Node.js and .NET SDKs send the wrong wire field name when mapping `suppressResumeEvent` to the JSON-RPC `session.resume` payload. The server expects `disableResume`, but:

- **Node.js** sends `suppressResumeEvent` as-is (silently dropped by the server)
- **.NET** relies on `JsonSerializerDefaults.Web` camelCasing, which produces `suppressResumeEvent` instead of `disableResume`

The Rust, Go, and Java SDKs already handle this correctly with explicit rename annotations.

## Changes

- `nodejs/src/client.ts` — map `config.suppressResumeEvent` to `disableResume` in the `session.resume` RPC payload
- `dotnet/src/Client.cs` — add `[property: JsonPropertyName("disableResume")]` to `SuppressResumeEvent` (same pattern as `ConfigDirectory` → `configDir`)
- `nodejs/test/e2e/suspend.e2e.test.ts` — add `gitHubToken` to the suspend test server so the test works without `COPILOT_HMAC_KEY` (matching pattern in other multi-client E2E tests)

No public API changes — the user-facing field names remain the same in both SDKs.