### PR TITLE
De-flake builtin_tools E2E tests with a longer send timeout

### DIFF
--- a/dotnet/test/E2E/BuiltinToolsE2ETests.cs
+++ b/dotnet/test/E2E/BuiltinToolsE2ETests.cs
@@ -16,6 +16,12 @@ namespace GitHub.Copilot.Test.E2E;
 public class BuiltinToolsE2ETests(E2ETestFixture fixture, ITestOutputHelper output)
     : E2ETestBase(fixture, "builtin_tools", output)
 {
+    // Built-in tool tests spawn a real CLI subprocess and execute actual shell /
+    // file tools. Under slow/concurrent CI (notably Windows) this agent loop can
+    // briefly exceed the 60s SendAndWaitAsync default, so give it extra headroom
+    // while still failing fast on a genuine hang.
+    private static readonly TimeSpan SendTimeout = TimeSpan.FromSeconds(120);
+
     [Fact]
     public async Task Should_Capture_Exit_Code_In_Output()
     {
@@ -23,7 +29,7 @@ public class BuiltinToolsE2ETests(E2ETestFixture fixture, ITestOutputHelper outp
         var msg = await session.SendAndWaitAsync(new MessageOptions
         {
             Prompt = "Run 'echo hello && echo world'. Tell me the exact output.",
-        });
+        }, SendTimeout);
         var content = msg?.Data.Content ?? string.Empty;
         Assert.Contains("hello", content);
         Assert.Contains("world", content);
@@ -44,7 +50,7 @@ public class BuiltinToolsE2ETests(E2ETestFixture fixture, ITestOutputHelper outp
         var msg = await session.SendAndWaitAsync(new MessageOptions
         {
             Prompt = "Run 'echo error_msg >&2; echo ok' and tell me what stderr said. Reply with just the stderr content.",
-        });
+        }, SendTimeout);
         Assert.Contains("error_msg", msg?.Data.Content ?? string.Empty);
     }
 
@@ -56,7 +62,7 @@ public class BuiltinToolsE2ETests(E2ETestFixture fixture, ITestOutputHelper outp
         var msg = await session.SendAndWaitAsync(new MessageOptions
         {
             Prompt = "Read lines 2 through 4 of the file 'lines.txt' in this directory. Tell me what those lines contain.",
-        });
+        }, SendTimeout);
         var content = msg?.Data.Content ?? string.Empty;
         Assert.Contains("line2", content);
         Assert.Contains("line4", content);
@@ -69,7 +75,7 @@ public class BuiltinToolsE2ETests(E2ETestFixture fixture, ITestOutputHelper outp
         var msg = await session.SendAndWaitAsync(new MessageOptions
         {
             Prompt = "Try to read the file 'does_not_exist.txt'. If it doesn't exist, say 'FILE_NOT_FOUND'.",
-        });
+        }, SendTimeout);
         var content = (msg?.Data.Content ?? string.Empty).ToUpperInvariant();
         // Match any of the common phrasings for a missing-file response.
         Assert.True(
@@ -90,7 +96,7 @@ public class BuiltinToolsE2ETests(E2ETestFixture fixture, ITestOutputHelper outp
         var msg = await session.SendAndWaitAsync(new MessageOptions
         {
             Prompt = "Edit the file 'edit_me.txt': replace 'Hello World' with 'Hi Universe'. Then read it back and tell me its contents.",
-        });
+        }, SendTimeout);
         Assert.Contains("Hi Universe", msg?.Data.Content ?? string.Empty);
     }
 
@@ -101,7 +107,7 @@ public class BuiltinToolsE2ETests(E2ETestFixture fixture, ITestOutputHelper outp
         var msg = await session.SendAndWaitAsync(new MessageOptions
         {
             Prompt = "Create a file called 'new_file.txt' with the content 'Created by test'. Then read it back to confirm.",
-        });
+        }, SendTimeout);
         Assert.Contains("Created by test", msg?.Data.Content ?? string.Empty);
     }
 
@@ -113,7 +119,7 @@ public class BuiltinToolsE2ETests(E2ETestFixture fixture, ITestOutputHelper outp
         var msg = await session.SendAndWaitAsync(new MessageOptions
         {
             Prompt = "Search for lines starting with 'ap' in the file 'data.txt'. Tell me which lines matched.",
-        });
+        }, SendTimeout);
         var content = msg?.Data.Content ?? string.Empty;
         Assert.Contains("apple", content);
         Assert.Contains("apricot", content);
@@ -130,7 +136,7 @@ public class BuiltinToolsE2ETests(E2ETestFixture fixture, ITestOutputHelper outp
         var msg = await session.SendAndWaitAsync(new MessageOptions
         {
             Prompt = "Find all .ts files in this directory (recursively). List the filenames you found.",
-        });
+        }, SendTimeout);
         Assert.Contains("index.ts", msg?.Data.Content ?? string.Empty);
     }
 }

--- a/go/internal/e2e/builtin_tools_e2e_test.go
+++ b/go/internal/e2e/builtin_tools_e2e_test.go
@@ -1,15 +1,23 @@
 package e2e
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	copilot "github.com/github/copilot-sdk/go"
 	"github.com/github/copilot-sdk/go/internal/e2e/testharness"
 )
+
+// Built-in tool tests spawn a real CLI subprocess and execute actual shell /
+// file tools. Under slow/concurrent CI (notably Windows) this agent loop can
+// briefly exceed the 60s SendAndWait default, so give it extra headroom while
+// still failing fast on a genuine hang.
+const sendTimeout = 120 * time.Second
 
 func TestBuiltinToolsE2E(t *testing.T) {
 	ctx := testharness.NewTestContext(t)
@@ -27,7 +35,9 @@ func TestBuiltinToolsE2E(t *testing.T) {
 		}
 		t.Cleanup(func() { _ = session.Disconnect() })
 
-		msg, err := session.SendAndWait(t.Context(), copilot.MessageOptions{
+		sendCtx, cancel := context.WithTimeout(t.Context(), sendTimeout)
+		defer cancel()
+		msg, err := session.SendAndWait(sendCtx, copilot.MessageOptions{
 			Prompt: "Run 'echo hello && echo world'. Tell me the exact output.",
 		})
 		if err != nil {
@@ -55,7 +65,9 @@ func TestBuiltinToolsE2E(t *testing.T) {
 		}
 		t.Cleanup(func() { _ = session.Disconnect() })
 
-		msg, err := session.SendAndWait(t.Context(), copilot.MessageOptions{
+		sendCtx, cancel := context.WithTimeout(t.Context(), sendTimeout)
+		defer cancel()
+		msg, err := session.SendAndWait(sendCtx, copilot.MessageOptions{
 			Prompt: "Run 'echo error_msg >&2; echo ok' and tell me what stderr said. Reply with just the stderr content.",
 		})
 		if err != nil {
@@ -82,7 +94,9 @@ func TestBuiltinToolsE2E(t *testing.T) {
 		}
 		t.Cleanup(func() { _ = session.Disconnect() })
 
-		msg, err := session.SendAndWait(t.Context(), copilot.MessageOptions{
+		sendCtx, cancel := context.WithTimeout(t.Context(), sendTimeout)
+		defer cancel()
+		msg, err := session.SendAndWait(sendCtx, copilot.MessageOptions{
 			Prompt: "Read lines 2 through 4 of the file 'lines.txt' in this directory. Tell me what those lines contain.",
 		})
 		if err != nil {
@@ -106,7 +120,9 @@ func TestBuiltinToolsE2E(t *testing.T) {
 		}
 		t.Cleanup(func() { _ = session.Disconnect() })
 
-		msg, err := session.SendAndWait(t.Context(), copilot.MessageOptions{
+		sendCtx, cancel := context.WithTimeout(t.Context(), sendTimeout)
+		defer cancel()
+		msg, err := session.SendAndWait(sendCtx, copilot.MessageOptions{
 			Prompt: "Try to read the file 'does_not_exist.txt'. If it doesn't exist, say 'FILE_NOT_FOUND'.",
 		})
 		if err != nil {
@@ -139,7 +155,9 @@ func TestBuiltinToolsE2E(t *testing.T) {
 		}
 		t.Cleanup(func() { _ = session.Disconnect() })
 
-		msg, err := session.SendAndWait(t.Context(), copilot.MessageOptions{
+		sendCtx, cancel := context.WithTimeout(t.Context(), sendTimeout)
+		defer cancel()
+		msg, err := session.SendAndWait(sendCtx, copilot.MessageOptions{
 			Prompt: "Edit the file 'edit_me.txt': replace 'Hello World' with 'Hi Universe'. Then read it back and tell me its contents.",
 		})
 		if err != nil {
@@ -162,7 +180,9 @@ func TestBuiltinToolsE2E(t *testing.T) {
 		}
 		t.Cleanup(func() { _ = session.Disconnect() })
 
-		msg, err := session.SendAndWait(t.Context(), copilot.MessageOptions{
+		sendCtx, cancel := context.WithTimeout(t.Context(), sendTimeout)
+		defer cancel()
+		msg, err := session.SendAndWait(sendCtx, copilot.MessageOptions{
 			Prompt: "Create a file called 'new_file.txt' with the content 'Created by test'. Then read it back to confirm.",
 		})
 		if err != nil {
@@ -189,7 +209,9 @@ func TestBuiltinToolsE2E(t *testing.T) {
 		}
 		t.Cleanup(func() { _ = session.Disconnect() })
 
-		msg, err := session.SendAndWait(t.Context(), copilot.MessageOptions{
+		sendCtx, cancel := context.WithTimeout(t.Context(), sendTimeout)
+		defer cancel()
+		msg, err := session.SendAndWait(sendCtx, copilot.MessageOptions{
 			Prompt: "Search for lines starting with 'ap' in the file 'data.txt'. Tell me which lines matched.",
 		})
 		if err != nil {
@@ -223,7 +245,9 @@ func TestBuiltinToolsE2E(t *testing.T) {
 		}
 		t.Cleanup(func() { _ = session.Disconnect() })
 
-		msg, err := session.SendAndWait(t.Context(), copilot.MessageOptions{
+		sendCtx, cancel := context.WithTimeout(t.Context(), sendTimeout)
+		defer cancel()
+		msg, err := session.SendAndWait(sendCtx, copilot.MessageOptions{
 			Prompt: "Find all .ts files in this directory (recursively). List the filenames you found.",
 		})
 		if err != nil {

--- a/nodejs/test/e2e/builtin_tools.e2e.test.ts
+++ b/nodejs/test/e2e/builtin_tools.e2e.test.ts
@@ -8,93 +8,158 @@ import { describe, expect, it } from "vitest";
 import { approveAll } from "../../src/index.js";
 import { createSdkTestContext } from "./harness/sdkTestContext";
 
+// Built-in tool tests spawn a real CLI subprocess and execute actual shell /
+// file tools. Under slow/concurrent CI (notably Windows) this agent loop can
+// briefly exceed the default send/test timeouts, so give it extra headroom
+// while still failing fast on a genuine hang. The per-test timeout must clear
+// the send timeout (and the global 30s vitest testTimeout, which would
+// otherwise bind first).
+const SEND_TIMEOUT_MS = 120_000;
+const TEST_TIMEOUT_MS = 180_000;
+
 describe("Built-in Tools", async () => {
     const { copilotClient: client, workDir } = await createSdkTestContext();
 
     describe("bash", () => {
-        it("should capture exit code in output", async () => {
-            const session = await client.createSession({ onPermissionRequest: approveAll });
-            const msg = await session.sendAndWait({
-                prompt: "Run 'echo hello && echo world'. Tell me the exact output.",
-            });
-            expect(msg?.data.content).toContain("hello");
-            expect(msg?.data.content).toContain("world");
-        });
+        it(
+            "should capture exit code in output",
+            async () => {
+                const session = await client.createSession({ onPermissionRequest: approveAll });
+                const msg = await session.sendAndWait(
+                    {
+                        prompt: "Run 'echo hello && echo world'. Tell me the exact output.",
+                    },
+                    SEND_TIMEOUT_MS
+                );
+                expect(msg?.data.content).toContain("hello");
+                expect(msg?.data.content).toContain("world");
+            },
+            TEST_TIMEOUT_MS
+        );
 
-        it.skipIf(process.platform === "win32")("should capture stderr output", async () => {
-            const session = await client.createSession({ onPermissionRequest: approveAll });
-            const msg = await session.sendAndWait({
-                prompt: "Run 'echo error_msg >&2; echo ok' and tell me what stderr said. Reply with just the stderr content.",
-            });
-            expect(msg?.data.content).toContain("error_msg");
-        });
+        it.skipIf(process.platform === "win32")(
+            "should capture stderr output",
+            async () => {
+                const session = await client.createSession({ onPermissionRequest: approveAll });
+                const msg = await session.sendAndWait(
+                    {
+                        prompt: "Run 'echo error_msg >&2; echo ok' and tell me what stderr said. Reply with just the stderr content.",
+                    },
+                    SEND_TIMEOUT_MS
+                );
+                expect(msg?.data.content).toContain("error_msg");
+            },
+            TEST_TIMEOUT_MS
+        );
     });
 
     describe("view", () => {
-        it("should read file with line range", async () => {
-            await writeFile(join(workDir, "lines.txt"), "line1\nline2\nline3\nline4\nline5\n");
-            const session = await client.createSession({ onPermissionRequest: approveAll });
-            const msg = await session.sendAndWait({
-                prompt: "Read lines 2 through 4 of the file 'lines.txt' in this directory. Tell me what those lines contain.",
-            });
-            expect(msg?.data.content).toContain("line2");
-            expect(msg?.data.content).toContain("line4");
-        });
+        it(
+            "should read file with line range",
+            async () => {
+                await writeFile(join(workDir, "lines.txt"), "line1\nline2\nline3\nline4\nline5\n");
+                const session = await client.createSession({ onPermissionRequest: approveAll });
+                const msg = await session.sendAndWait(
+                    {
+                        prompt: "Read lines 2 through 4 of the file 'lines.txt' in this directory. Tell me what those lines contain.",
+                    },
+                    SEND_TIMEOUT_MS
+                );
+                expect(msg?.data.content).toContain("line2");
+                expect(msg?.data.content).toContain("line4");
+            },
+            TEST_TIMEOUT_MS
+        );
 
-        it("should handle nonexistent file gracefully", async () => {
-            const session = await client.createSession({ onPermissionRequest: approveAll });
-            const msg = await session.sendAndWait({
-                prompt: "Try to read the file 'does_not_exist.txt'. If it doesn't exist, say 'FILE_NOT_FOUND'.",
-            });
-            expect(msg?.data.content?.toUpperCase()).toMatch(
-                /NOT.FOUND|NOT.EXIST|NO.SUCH|FILE_NOT_FOUND|DOES.NOT.EXIST|ERROR/i
-            );
-        });
+        it(
+            "should handle nonexistent file gracefully",
+            async () => {
+                const session = await client.createSession({ onPermissionRequest: approveAll });
+                const msg = await session.sendAndWait(
+                    {
+                        prompt: "Try to read the file 'does_not_exist.txt'. If it doesn't exist, say 'FILE_NOT_FOUND'.",
+                    },
+                    SEND_TIMEOUT_MS
+                );
+                expect(msg?.data.content?.toUpperCase()).toMatch(
+                    /NOT.FOUND|NOT.EXIST|NO.SUCH|FILE_NOT_FOUND|DOES.NOT.EXIST|ERROR/i
+                );
+            },
+            TEST_TIMEOUT_MS
+        );
     });
 
     describe("edit", () => {
-        it("should edit a file successfully", async () => {
-            await writeFile(join(workDir, "edit_me.txt"), "Hello World\nGoodbye World\n");
-            const session = await client.createSession({ onPermissionRequest: approveAll });
-            const msg = await session.sendAndWait({
-                prompt: "Edit the file 'edit_me.txt': replace 'Hello World' with 'Hi Universe'. Then read it back and tell me its contents.",
-            });
-            expect(msg?.data.content).toContain("Hi Universe");
-        });
+        it(
+            "should edit a file successfully",
+            async () => {
+                await writeFile(join(workDir, "edit_me.txt"), "Hello World\nGoodbye World\n");
+                const session = await client.createSession({ onPermissionRequest: approveAll });
+                const msg = await session.sendAndWait(
+                    {
+                        prompt: "Edit the file 'edit_me.txt': replace 'Hello World' with 'Hi Universe'. Then read it back and tell me its contents.",
+                    },
+                    SEND_TIMEOUT_MS
+                );
+                expect(msg?.data.content).toContain("Hi Universe");
+            },
+            TEST_TIMEOUT_MS
+        );
     });
 
     describe("create_file", () => {
-        it("should create a new file", async () => {
-            const session = await client.createSession({ onPermissionRequest: approveAll });
-            const msg = await session.sendAndWait({
-                prompt: "Create a file called 'new_file.txt' with the content 'Created by test'. Then read it back to confirm.",
-            });
-            expect(msg?.data.content).toContain("Created by test");
-        });
+        it(
+            "should create a new file",
+            async () => {
+                const session = await client.createSession({ onPermissionRequest: approveAll });
+                const msg = await session.sendAndWait(
+                    {
+                        prompt: "Create a file called 'new_file.txt' with the content 'Created by test'. Then read it back to confirm.",
+                    },
+                    SEND_TIMEOUT_MS
+                );
+                expect(msg?.data.content).toContain("Created by test");
+            },
+            TEST_TIMEOUT_MS
+        );
     });
 
     describe("grep", () => {
-        it("should search for patterns in files", async () => {
-            await writeFile(join(workDir, "data.txt"), "apple\nbanana\napricot\ncherry\n");
-            const session = await client.createSession({ onPermissionRequest: approveAll });
-            const msg = await session.sendAndWait({
-                prompt: "Search for lines starting with 'ap' in the file 'data.txt'. Tell me which lines matched.",
-            });
-            expect(msg?.data.content).toContain("apple");
-            expect(msg?.data.content).toContain("apricot");
-        });
+        it(
+            "should search for patterns in files",
+            async () => {
+                await writeFile(join(workDir, "data.txt"), "apple\nbanana\napricot\ncherry\n");
+                const session = await client.createSession({ onPermissionRequest: approveAll });
+                const msg = await session.sendAndWait(
+                    {
+                        prompt: "Search for lines starting with 'ap' in the file 'data.txt'. Tell me which lines matched.",
+                    },
+                    SEND_TIMEOUT_MS
+                );
+                expect(msg?.data.content).toContain("apple");
+                expect(msg?.data.content).toContain("apricot");
+            },
+            TEST_TIMEOUT_MS
+        );
     });
 
     describe("glob", () => {
-        it("should find files by pattern", async () => {
-            await mkdir(join(workDir, "src"), { recursive: true });
-            await writeFile(join(workDir, "src", "index.ts"), "export const index = 1;");
-            await writeFile(join(workDir, "README.md"), "# Readme");
-            const session = await client.createSession({ onPermissionRequest: approveAll });
-            const msg = await session.sendAndWait({
-                prompt: "Find all .ts files in this directory (recursively). List the filenames you found.",
-            });
-            expect(msg?.data.content).toContain("index.ts");
-        });
+        it(
+            "should find files by pattern",
+            async () => {
+                await mkdir(join(workDir, "src"), { recursive: true });
+                await writeFile(join(workDir, "src", "index.ts"), "export const index = 1;");
+                await writeFile(join(workDir, "README.md"), "# Readme");
+                const session = await client.createSession({ onPermissionRequest: approveAll });
+                const msg = await session.sendAndWait(
+                    {
+                        prompt: "Find all .ts files in this directory (recursively). List the filenames you found.",
+                    },
+                    SEND_TIMEOUT_MS
+                );
+                expect(msg?.data.content).toContain("index.ts");
+            },
+            TEST_TIMEOUT_MS
+        );
     });
 });

--- a/python/e2e/test_builtin_tools_e2e.py
+++ b/python/e2e/test_builtin_tools_e2e.py
@@ -14,6 +14,12 @@ from .testharness import E2ETestContext
 
 pytestmark = pytest.mark.asyncio(loop_scope="module")
 
+# Built-in tool tests spawn a real CLI subprocess and execute actual shell /
+# file tools. Under slow/concurrent CI (notably Windows) this agent loop can
+# briefly exceed the 60s send_and_wait default, so give it extra headroom while
+# still failing fast on a genuine hang.
+SEND_TIMEOUT = 120.0
+
 
 class TestBuiltinTools:
     async def test_should_capture_exit_code_in_output(self, ctx: E2ETestContext):
@@ -22,7 +28,8 @@ class TestBuiltinTools:
         )
         try:
             message = await session.send_and_wait(
-                "Run 'echo hello && echo world'. Tell me the exact output."
+                "Run 'echo hello && echo world'. Tell me the exact output.",
+                timeout=SEND_TIMEOUT,
             )
             content = message.data.content if message else ""
             assert "hello" in content
@@ -41,7 +48,8 @@ class TestBuiltinTools:
         try:
             message = await session.send_and_wait(
                 "Run 'echo error_msg >&2; echo ok' and tell me what stderr said. "
-                "Reply with just the stderr content."
+                "Reply with just the stderr content.",
+                timeout=SEND_TIMEOUT,
             )
             assert message is not None
             assert "error_msg" in message.data.content
@@ -58,7 +66,8 @@ class TestBuiltinTools:
         try:
             message = await session.send_and_wait(
                 "Read lines 2 through 4 of the file 'lines.txt' in this directory. "
-                "Tell me what those lines contain."
+                "Tell me what those lines contain.",
+                timeout=SEND_TIMEOUT,
             )
             content = message.data.content if message else ""
             assert "line2" in content
@@ -73,7 +82,8 @@ class TestBuiltinTools:
         try:
             message = await session.send_and_wait(
                 "Try to read the file 'does_not_exist.txt'. "
-                "If it doesn't exist, say 'FILE_NOT_FOUND'."
+                "If it doesn't exist, say 'FILE_NOT_FOUND'.",
+                timeout=SEND_TIMEOUT,
             )
             content = message.data.content if message else ""
             assert re.search(
@@ -94,7 +104,8 @@ class TestBuiltinTools:
         try:
             message = await session.send_and_wait(
                 "Edit the file 'edit_me.txt': replace 'Hello World' with "
-                "'Hi Universe'. Then read it back and tell me its contents."
+                "'Hi Universe'. Then read it back and tell me its contents.",
+                timeout=SEND_TIMEOUT,
             )
             assert message is not None
             assert "Hi Universe" in message.data.content
@@ -108,7 +119,8 @@ class TestBuiltinTools:
         try:
             message = await session.send_and_wait(
                 "Create a file called 'new_file.txt' with the content "
-                "'Created by test'. Then read it back to confirm."
+                "'Created by test'. Then read it back to confirm.",
+                timeout=SEND_TIMEOUT,
             )
             assert message is not None
             assert "Created by test" in message.data.content
@@ -125,7 +137,8 @@ class TestBuiltinTools:
         try:
             message = await session.send_and_wait(
                 "Search for lines starting with 'ap' in the file 'data.txt'. "
-                "Tell me which lines matched."
+                "Tell me which lines matched.",
+                timeout=SEND_TIMEOUT,
             )
             content = message.data.content if message else ""
             assert "apple" in content
@@ -144,7 +157,8 @@ class TestBuiltinTools:
         )
         try:
             message = await session.send_and_wait(
-                "Find all .ts files in this directory (recursively). List the filenames you found."
+                "Find all .ts files in this directory (recursively). List the filenames you found.",
+                timeout=SEND_TIMEOUT,
             )
             assert message is not None
             assert "index.ts" in message.data.content

--- a/rust/tests/e2e/builtin_tools.rs
+++ b/rust/tests/e2e/builtin_tools.rs
@@ -1,4 +1,18 @@
+use std::time::Duration;
+
+use github_copilot_sdk::MessageOptions;
+
 use super::support::{assistant_message_content, with_e2e_context};
+
+/// Built-in tool tests spawn a real CLI subprocess and execute actual shell /
+/// file tools. Under concurrent Windows CI load (e2e runs 4-wide on a 4-vCPU
+/// runner) this agent loop can briefly exceed the 60s `send_and_wait` default,
+/// so give it extra headroom while still failing fast on a genuine hang.
+const SEND_TIMEOUT: Duration = Duration::from_secs(120);
+
+fn message(prompt: &str) -> MessageOptions {
+    MessageOptions::from(prompt).with_wait_timeout(SEND_TIMEOUT)
+}
 
 #[tokio::test]
 async fn should_capture_exit_code_in_output() {
@@ -15,7 +29,9 @@ async fn should_capture_exit_code_in_output() {
                     .expect("create session");
 
                 let msg = session
-                    .send_and_wait("Run 'echo hello && echo world'. Tell me the exact output.")
+                    .send_and_wait(message(
+                        "Run 'echo hello && echo world'. Tell me the exact output.",
+                    ))
                     .await
                     .expect("send")
                     .expect("assistant message");
@@ -46,7 +62,7 @@ async fn should_capture_stderr_output() {
                 .expect("create session");
 
             let msg = session
-                .send_and_wait("Run 'echo error_msg >&2; echo ok' and tell me what stderr said. Reply with just the stderr content.")
+                .send_and_wait(message("Run 'echo error_msg >&2; echo ok' and tell me what stderr said. Reply with just the stderr content."))
                 .await
                 .expect("send")
                 .expect("assistant message");
@@ -73,7 +89,7 @@ async fn should_read_file_with_line_range() {
                 .expect("create session");
 
             let msg = session
-                .send_and_wait("Read lines 2 through 4 of the file 'lines.txt' in this directory. Tell me what those lines contain.")
+                .send_and_wait(message("Read lines 2 through 4 of the file 'lines.txt' in this directory. Tell me what those lines contain."))
                 .await
                 .expect("send")
                 .expect("assistant message");
@@ -103,7 +119,7 @@ async fn should_handle_nonexistent_file_gracefully() {
                     .expect("create session");
 
                 let msg = session
-                    .send_and_wait("Try to read the file 'does_not_exist.txt'. If it doesn't exist, say 'FILE_NOT_FOUND'.")
+                    .send_and_wait(message("Try to read the file 'does_not_exist.txt'. If it doesn't exist, say 'FILE_NOT_FOUND'."))
                     .await
                     .expect("send")
                     .expect("assistant message");
@@ -140,7 +156,7 @@ async fn should_edit_a_file_successfully() {
                 .expect("create session");
 
             let msg = session
-                .send_and_wait("Edit the file 'edit_me.txt': replace 'Hello World' with 'Hi Universe'. Then read it back and tell me its contents.")
+                .send_and_wait(message("Edit the file 'edit_me.txt': replace 'Hello World' with 'Hi Universe'. Then read it back and tell me its contents."))
                 .await
                 .expect("send")
                 .expect("assistant message");
@@ -165,7 +181,7 @@ async fn should_create_a_new_file() {
                 .expect("create session");
 
             let msg = session
-                .send_and_wait("Create a file called 'new_file.txt' with the content 'Created by test'. Then read it back to confirm.")
+                .send_and_wait(message("Create a file called 'new_file.txt' with the content 'Created by test'. Then read it back to confirm."))
                 .await
                 .expect("send")
                 .expect("assistant message");
@@ -195,7 +211,7 @@ async fn should_search_for_patterns_in_files() {
                     .expect("create session");
 
                 let msg = session
-                    .send_and_wait("Search for lines starting with 'ap' in the file 'data.txt'. Tell me which lines matched.")
+                    .send_and_wait(message("Search for lines starting with 'ap' in the file 'data.txt'. Tell me which lines matched."))
                     .await
                     .expect("send")
                     .expect("assistant message");
@@ -228,7 +244,7 @@ async fn should_find_files_by_pattern() {
                 .expect("create session");
 
             let msg = session
-                .send_and_wait("Find all .ts files in this directory (recursively). List the filenames you found.")
+                .send_and_wait(message("Find all .ts files in this directory (recursively). List the filenames you found."))
                 .await
                 .expect("send")
                 .expect("assistant message");


### PR DESCRIPTION
## Why

The builtin_tools E2E test `should_capture_exit_code_in_output` (prompt: "Run 'echo hello && echo world'. Tell me the exact output.") flaked once on the Windows Rust CI job and passed on re-run, so the failure looked like flakiness rather than a real regression.

## Root cause

I pulled the failed job log. `send_and_wait` hit its **60s** default and the Rust test's `.expect("send")` panicked with `Session(Timeout(60s))`. The deeper question was whether 60s indicated a hang/deadlock. It does not:

- The Rust `IdleWaiter` is race-free (registered before send, RAII-cleared, timeout wraps the whole send+wait), and replay matching is deterministic (verified over repeated local runs).
- The failure sat inside a ~90s window where multiple *unrelated* tests were simultaneously slow (`ask_user::should_receive_choices` ~50s, `should_edit_a_file_successfully` ~62s but passed, our test 60s). A real deadlock would not cluster temporally; shared-resource contention does.

The actual cause is **transient Windows CI contention**: the Rust suite runs e2e with `RUST_E2E_CONCURRENCY: 4` and `--test-threads=4` on a 4-vCPU runner, and each test spawns its own `copilot.exe` CLI plus a Node replay proxy (and the builtin_tools tests additionally spawn a real shell/PowerShell). Under that load a normally-few-second agent loop got starved past the 60s default. Only Rust flaked because only Rust runs its e2e tests concurrently; Node/Python/Go/.NET run them serially.

## Approach

Raise the per-send wait timeout for the builtin_tools E2E suites from 60s to **120s** (double the default; still well under Rust's 300s Windows test budget, so a genuine hang still fails fast). Applied suite-wide because every builtin_tools test shares the same "spawn CLI + run a real builtin tool" exposure, so a sibling would otherwise flake next. Assertions, snapshots, Windows skips, and CI concurrency are left untouched, so coverage is unchanged.

Done consistently across all five SDKs that carry this test:

- **Rust** (`rust/tests/e2e/builtin_tools.rs`): `SEND_TIMEOUT` const + a `message()` helper using `MessageOptions::with_wait_timeout`.
- **Python** (`python/e2e/test_builtin_tools_e2e.py`): `SEND_TIMEOUT = 120.0` passed as `timeout=`.
- **Go** (`go/internal/e2e/builtin_tools_e2e_test.go`): `const sendTimeout = 120 * time.Second`; each subtest wraps the call ctx with `context.WithTimeout` (Go honors a ctx deadline, else 60s).
- **Node** (`nodejs/test/e2e/builtin_tools.e2e.test.ts`): pass `120_000` as the send timeout and raise each test's vitest timeout to `180_000`, because the global 30s `testTimeout` would otherwise bind first.
- **.NET** (`dotnet/test/E2E/BuiltinToolsE2ETests.cs`): `SendTimeout = TimeSpan.FromSeconds(120)` passed to each `SendAndWaitAsync`.

Each language carries a short comment explaining the slow/concurrent-Windows-CI rationale so the larger value is not mysterious. Java has no builtin_tools e2e test, so it needs no change.

## Validation

- Static checks clean in every language: Rust `cargo build` + `cargo fmt`; Go `gofmt` + `go vet`; Python `ruff`; Node `tsc` + `eslint` + `prettier`; .NET `dotnet build` (0 warnings) + `dotnet format --verify-no-changes`.
- Ran the Node builtin_tools E2E suite end-to-end (same replay harness): 7 passed, 1 skipped on Windows, including the target test.

Generated by Copilot