### PR TITLE
java: disable ModeHandlersTest pending snapshot re-recording (#1547)

### DIFF
--- a/java/src/test/java/com/github/copilot/ModeHandlersTest.java
+++ b/java/src/test/java/com/github/copilot/ModeHandlersTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.github.copilot.generated.ExitPlanModeAction;
@@ -67,6 +68,7 @@ public class ModeHandlersTest {
     }
 
     @Test
+    @Disabled("Snapshot needs re-recording for CLI 1.0.57: https://github.com/github/copilot-sdk/issues/1547")
     void shouldInvokeExitPlanModeHandlerWhenModelUsesTool() throws Exception {
         final String summary = "Greeting file implementation plan";
         configureAuthenticatedUser("should_invoke_exit_plan_mode_handler_when_model_uses_tool");


### PR DESCRIPTION
The exit_plan_mode snapshot was recorded against CLI 1.0.55-5 and no longer matches the request patterns CLI 1.0.57 sends to the replay proxy, causing a 500 Proxy error.

See #1547 