### PR TITLE
Revert temporary beta-as-latest publishing behavior

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,10 +59,13 @@ jobs:
           if [ -n "${{ github.event.inputs.version }}" ]; then
             VERSION="${{ github.event.inputs.version }}"
             # Validate version format matches dist-tag
-            # TEMPORARY: skips validation for "latest" so prerelease versions
-            # can be published under that tag. To ship stable 1.0.0, revert the
-            # commit that introduced this temporary change.
-            if [ "${{ github.event.inputs.dist-tag }}" != "latest" ]; then
+            if [ "${{ github.event.inputs.dist-tag }}" = "latest" ]; then
+              if [[ "$VERSION" == *-* ]]; then
+                echo "❌ Error: Version '$VERSION' has a prerelease suffix but dist-tag is 'latest'" >> $GITHUB_STEP_SUMMARY
+                echo "Use a version without suffix (e.g., '1.0.0') for latest releases"
+                exit 1
+              fi
+            else
               if [[ "$VERSION" != *-* ]]; then
                 echo "❌ Error: Version '$VERSION' has no prerelease suffix but dist-tag is '${{ github.event.inputs.dist-tag }}'" >> $GITHUB_STEP_SUMMARY
                 echo "Use a version with suffix (e.g., '1.0.0-preview.0') for prerelease/unstable"
@@ -231,11 +234,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      # TEMPORARY: both "latest" and "prerelease" create GitHub pre-releases
-      # since "latest" publishes beta versions. To ship stable 1.0.0, revert
-      # the commit that introduced this temporary change.
       - name: Create GitHub Release
-        if: github.event.inputs.dist-tag == 'latest' || github.event.inputs.dist-tag == 'prerelease'
+        if: github.event.inputs.dist-tag == 'latest'
+        run: |
+          NOTES_FLAG=""
+          if git rev-parse "v${{ needs.version.outputs.current }}" >/dev/null 2>&1; then
+            NOTES_FLAG="--notes-start-tag v${{ needs.version.outputs.current }}"
+          fi
+          gh release create "v${{ needs.version.outputs.version }}" \
+            --title "v${{ needs.version.outputs.version }}" \
+            --generate-notes $NOTES_FLAG \
+            --target ${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create GitHub Pre-Release
+        if: github.event.inputs.dist-tag == 'prerelease'
         run: |
           NOTES_FLAG=""
           if git rev-parse "v${{ needs.version.outputs.current-prerelease }}" >/dev/null 2>&1; then

--- a/nodejs/scripts/calculate-version.js
+++ b/nodejs/scripts/calculate-version.js
@@ -43,13 +43,10 @@ export function calculateVersion(command, { latest, prerelease, unstable }) {
         }
     }
 
-    // TEMPORARY: "latest" uses prerelease increments so we publish beta versions
-    // under the "latest" dist-tag. To ship stable 1.0.0, revert the commit that
-    // introduced this temporary change.
-    const increment = "prerelease";
+    const increment = command === "latest" ? "patch" : "prerelease";
     const isIncrementingExistingPrerelease = semver.prerelease(higherVersion) !== null;
     const prereleaseIdentifier =
-        command === "prerelease" || command === "latest"
+        command === "prerelease"
             ? isIncrementingExistingPrerelease
                 ? undefined
                 : "preview"

--- a/nodejs/test/get-version.test.ts
+++ b/nodejs/test/get-version.test.ts
@@ -2,15 +2,13 @@ import { describe, expect, it } from "vitest";
 import { calculateVersion } from "../scripts/calculate-version.js";
 
 describe("get-version", () => {
-    // TEMPORARY: these two tests reflect beta-as-latest behavior. To ship
-    // stable 1.0.0, revert the commit that introduced this temporary change.
-    it("increments latest versions as prerelease (temporary beta behavior)", () => {
-        expect(calculateVersion("latest", { latest: "1.0.1" })).toBe("1.0.2-preview.0");
+    it("increments stable latest versions by patch", () => {
+        expect(calculateVersion("latest", { latest: "1.0.1" })).toBe("1.0.2");
     });
 
-    it("continues beta prerelease for latest releases (temporary beta behavior)", () => {
+    it("promotes a higher prerelease to stable for latest releases", () => {
         expect(calculateVersion("latest", { latest: "0.3.0", prerelease: "1.0.0-beta.1" })).toBe(
-            "1.0.0-beta.2"
+            "1.0.0"
         );
     });
 


### PR DESCRIPTION
Reverts #1283 (commit 4e3dc73c) which temporarily routed the `latest` dist-tag through the prerelease pipeline so we could publish `1.0.0-beta.*` under `latest`.

With `1.0.0` ready to ship, restore the original publish behavior:

- `publish.yml`: re-enforce that `latest` requires a non-prerelease version, and route `latest` to `Create GitHub Release` (real release) while `prerelease` continues to produce a Pre-Release.
- `calculate-version.js`: `latest` increments by `patch` again, and a higher prerelease (e.g. `1.0.0-beta.N`) gets promoted to stable (`1.0.0`).
- `get-version.test.ts`: the two `(temporary beta behavior)` tests revert to their original stable-promotion assertions.

Revert applied cleanly with no conflicts; no other commits since #1283 touched these regions.