### PR TITLE
Fix MCP E2E send wait race

### DIFF
--- a/dotnet/test/E2E/SessionMcpAndAgentConfigE2ETests.cs
+++ b/dotnet/test/E2E/SessionMcpAndAgentConfigE2ETests.cs
@@ -23,9 +23,7 @@ public class SessionMcpAndAgentConfigE2ETests(E2ETestFixture fixture, ITestOutpu
         await WaitForMcpServerStatusAsync(session, "test-server", McpServerStatus.Connected);
 
         // Simple interaction to verify session works
-        await session.SendAsync(new MessageOptions { Prompt = "What is 2+2?" });
-
-        var message = await TestHelper.GetFinalAssistantMessageAsync(session);
+        var message = await session.SendAndWaitAsync(new MessageOptions { Prompt = "What is 2+2?" });
         Assert.NotNull(message);
         Assert.Contains("4", message!.Data.Content);
 
@@ -112,9 +110,7 @@ public class SessionMcpAndAgentConfigE2ETests(E2ETestFixture fixture, ITestOutpu
         Assert.Matches(@"^[a-f0-9-]+$", session.SessionId);
 
         // Simple interaction to verify session works
-        await session.SendAsync(new MessageOptions { Prompt = "What is 5+5?" });
-
-        var message = await TestHelper.GetFinalAssistantMessageAsync(session);
+        var message = await session.SendAndWaitAsync(new MessageOptions { Prompt = "What is 5+5?" });
         Assert.NotNull(message);
         Assert.Contains("10", message!.Data.Content);
 


### PR DESCRIPTION
Fixes a race in the MCP and custom-agent configuration E2E coverage where the test sent a prompt and only then waited for the final assistant message. If the replayed turn completed quickly, the ephemeral `session.idle` event could be missed and the test would time out.

This switches those simple verification prompts to `SendAndWaitAsync`, which registers its event handler before sending.

Tests:
- `dotnet build dotnet\test\GitHub.Copilot.SDK.Test.csproj -f net8.0 --no-restore --nologo`

Generated by Copilot