### PR TITLE
TypeScript SDK: Use generated types for model info and remove duplicates

### DIFF
--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -8,24 +8,40 @@
 
 // Import and re-export generated session event types
 import type { Canvas } from "./canvas.js";
-import type { SessionFsProvider } from "./sessionFsProvider.js";
 import type {
-    ReasoningSummary,
+    ModelCapabilities,
+    Model as ModelInfo,
+    OpenCanvasInstance,
+    RemoteSessionMode,
+} from "./generated/rpc.js";
+import type {
     SessionEvent as GeneratedSessionEvent,
+    PermissionRequest,
+    ReasoningSummary,
 } from "./generated/session-events.js";
 import type { CopilotSession } from "./session.js";
-import type { RemoteSessionMode } from "./generated/rpc.js";
-import type { OpenCanvasInstance } from "./generated/rpc.js";
+import type { SessionFsProvider } from "./sessionFsProvider.js";
 import type { ToolSet } from "./toolSet.js";
-export type { RemoteSessionMode } from "./generated/rpc.js";
-export type SessionEvent = GeneratedSessionEvent;
+export type {
+    ModelBilling,
+    ModelCapabilities,
+    Model as ModelInfo,
+    ModelPickerCategory,
+    ModelPickerPriceCategory,
+    ModelPolicy,
+    ModelPolicyState,
+    RemoteSessionMode,
+} from "./generated/rpc.js";
 export type { ReasoningSummary } from "./generated/session-events.js";
-export type { SessionFsProvider } from "./sessionFsProvider.js";
 export { createSessionFsAdapter } from "./sessionFsProvider.js";
-export type { SessionFsFileInfo } from "./sessionFsProvider.js";
-export type { SessionFsSqliteQueryResult } from "./sessionFsProvider.js";
-export type { SessionFsSqliteQueryType } from "./sessionFsProvider.js";
-export type { SessionFsSqliteProvider } from "./sessionFsProvider.js";
+export type {
+    SessionFsFileInfo,
+    SessionFsProvider,
+    SessionFsSqliteProvider,
+    SessionFsSqliteQueryResult,
+    SessionFsSqliteQueryType,
+} from "./sessionFsProvider.js";
+export type SessionEvent = GeneratedSessionEvent;
 
 /**
  * Options for creating a CopilotClient
@@ -923,7 +939,6 @@ export type SystemMessageConfig =
  * `fileName`/`diff`, mcp `toolName`/`args`).
  */
 export type { PermissionRequest } from "./generated/session-events.js";
-import type { PermissionRequest } from "./generated/session-events.js";
 
 import type { PermissionDecisionRequest } from "./generated/rpc.js";
 
@@ -2334,26 +2349,6 @@ export interface GetAuthStatusResponse {
     statusMessage?: string;
 }
 
-/**
- * Model capabilities and limits
- */
-export interface ModelCapabilities {
-    supports: {
-        vision: boolean;
-        /** Whether this model supports reasoning effort configuration */
-        reasoningEffort: boolean;
-    };
-    limits: {
-        max_prompt_tokens?: number;
-        max_context_window_tokens: number;
-        vision?: {
-            supported_media_types: string[];
-            max_prompt_images: number;
-            max_prompt_image_size: number;
-        };
-    };
-}
-
 /** Recursively makes all properties optional, preserving arrays as-is. */
 type DeepPartial<T> = T extends readonly (infer U)[]
     ? DeepPartial<U>[]
@@ -2363,41 +2358,6 @@ type DeepPartial<T> = T extends readonly (infer U)[]
 
 /** Deep-partial override for model capabilities — every property at any depth is optional. */
 export type ModelCapabilitiesOverride = DeepPartial<ModelCapabilities>;
-
-/**
- * Model policy state
- */
-export interface ModelPolicy {
-    state: "enabled" | "disabled" | "unconfigured";
-    terms: string;
-}
-
-/**
- * Model billing information
- */
-export interface ModelBilling {
-    multiplier?: number;
-}
-
-/**
- * Information about an available model
- */
-export interface ModelInfo {
-    /** Model identifier (e.g., "claude-sonnet-4.5") */
-    id: string;
-    /** Display name */
-    name: string;
-    /** Model capabilities and limits */
-    capabilities: ModelCapabilities;
-    /** Policy state */
-    policy?: ModelPolicy;
-    /** Billing information */
-    billing?: ModelBilling;
-    /** Supported reasoning effort levels (only present if model supports reasoning effort) */
-    supportedReasoningEfforts?: ReasoningEffort[];
-    /** Default reasoning effort level (only present if model supports reasoning effort) */
-    defaultReasoningEffort?: ReasoningEffort;
-}
 
 // ============================================================================
 // Session Lifecycle Types (for TUI+server mode)


### PR DESCRIPTION
Replace local duplicate model info types (which need to be manually updated) with types from generated files.

I tried this approach since I see the same pattern used for `SessionEvent` and `RemoteSessionMode`: https://github.com/github/copilot-sdk/blob/afbebc78f119bdc8116b50e53af342657d6b2c5a/nodejs/src/types.ts#L12-L21


According to Copilot, these are the effective changes in the API if we decided to go ahead with this approach:

> Main breaking changes: generated `ModelCapabilities` makes `supports`, `limits`, and several nested fields optional; generated `ModelPolicy` makes `terms` optional; generated `Model` widens reasoning effort fields from `ReasoningEffort` to `string`.


## ModelInfo

Now exported as generated `Model` aliased to `ModelInfo`.

| Attribute name | Before | After | Comment |
|---|---|---|---|
| Type declaration | `interface ModelInfo` | `Model` re-exported as `ModelInfo` | Structural API preserved, but symbol kind/name changed. Potentially breaking for declaration merging or tools expecting an interface literally named `ModelInfo`. |
| `id` | `string` | `string` | No change. |
| `name` | `string` | `string` | No change. |
| `capabilities` | `ModelCapabilities` | `ModelCapabilities` | Same top-level name, but nested shape changed. See `ModelCapabilities`. |
| `policy` | `ModelPolicy \| undefined` | `ModelPolicy \| undefined` | Same optional field, but `ModelPolicy.terms` changed. |
| `billing` | `ModelBilling \| undefined` | `ModelBilling \| undefined` | Same optional field, but `ModelBilling` now has optional `tokenPrices`. |
| `supportedReasoningEfforts` | `ReasoningEffort[] \| undefined` | `string[] \| undefined` | **Breaking/type precision loss** for consumers reading this as `ReasoningEffort[]`; now must validate or narrow strings manually. |
| `defaultReasoningEffort` | `ReasoningEffort \| undefined` | `string \| undefined` | **Breaking/type precision loss** for consumers assigning directly to `ReasoningEffort`. |
| `modelPickerCategory` | Not present | `ModelPickerCategory \| undefined` | Additive optional generated field. |
| `modelPickerPriceCategory` | Not present | `ModelPickerPriceCategory \| undefined` | Additive optional generated field. |

## ModelCapabilities

| Attribute name | Before | After | Comment |
|---|---|---|---|
| `supports` | `{ vision: boolean; reasoningEffort: boolean }` | `ModelCapabilitiesSupports \| undefined` | **Breaking for readers**: `capabilities.supports` can now be absent. More permissive for providers. |
| `supports.vision` | `boolean` | `boolean \| undefined` | **Breaking for readers**: guard/default needed. |
| `supports.reasoningEffort` | `boolean` | `boolean \| undefined` | **Breaking for readers**: guard/default needed. |
| `limits` | `{ max_prompt_tokens?: number; max_context_window_tokens: number; vision?: ... }` | `ModelCapabilitiesLimits \| undefined` | **Breaking for readers**: `capabilities.limits` can now be absent. |
| `limits.max_prompt_tokens` | `number \| undefined` | `number \| undefined` | Same field optionality, ignoring optional parent. |
| `limits.max_context_window_tokens` | `number` | `number \| undefined` | **Breaking for readers**: previously guaranteed. |
| `limits.max_output_tokens` | Not present | `number \| undefined` | Additive optional generated field. |
| `limits.vision` | Vision limits object or `undefined` | `ModelCapabilitiesLimitsVision \| undefined` | Same optional field, now named generated type. |
| `limits.vision.supported_media_types` | `string[]` | `string[]` | No change once `vision` exists. |
| `limits.vision.max_prompt_images` | `number` | `number` | No change once `vision` exists. |
| `limits.vision.max_prompt_image_size` | `number` | `number` | No change once `vision` exists. |

## ModelPolicy

| Attribute name | Before | After | Comment |
|---|---|---|---|
| `state` | `"enabled" \| "disabled" \| "unconfigured"` | `ModelPolicyState` | Same union values, now named generated alias. |
| `terms` | `string` | `string \| undefined` | **Breaking for readers**: callers can no longer assume terms exists. More permissive for model providers. |

## ModelBilling

| Attribute name | Before | After | Comment |
|---|---|---|---|
| `multiplier` | `number \| undefined` | `number \| undefined` | No change. |
| `tokenPrices` | Not present | `ModelBillingTokenPrices \| undefined` | Additive optional generated field. Previously excess property for object literals typed as `ModelBilling`; now accepted. |

## ModelBillingTokenPrices

New generated nested type reachable through `ModelBilling.tokenPrices`.

| Attribute name | Before | After | Comment |
|---|---|---|---|
| `inputPrice` | Not present | `number \| undefined` | Additive optional field. |
| `outputPrice` | Not present | `number \| undefined` | Additive optional field. |
| `cachePrice` | Not present | `number \| undefined` | Additive optional field. |
| `batchSize` | Not present | `number \| undefined` | Additive optional field. |
| `contextMax` | Not present | `number \| undefined` | Additive optional field. |
| `longContext` | Not present | `ModelBillingTokenPricesLongContext \| undefined` | Additive optional nested field. |

## ModelBillingTokenPricesLongContext

New generated nested type reachable through `ModelBilling.tokenPrices.longContext`.

| Attribute name | Before | After | Comment |
|---|---|---|---|
| `inputPrice` | Not present | `number \| undefined` | Additive optional field. |
| `outputPrice` | Not present | `number \| undefined` | Additive optional field. |
| `cachePrice` | Not present | `number \| undefined` | Additive optional field. |
| `contextMax` | Not present | `number \| undefined` | Additive optional field. |

## ModelCapabilitiesOverride

Not removed, but its expansion changes because it is still `DeepPartial<ModelCapabilities>` and `ModelCapabilities` now comes from generated RPC types.

| Attribute name | Before | After | Comment |
|---|---|---|---|
| `supports.vision` | `boolean \| undefined` | `boolean \| undefined` | No effective change. |
| `supports.reasoningEffort` | `boolean \| undefined` | `boolean \| undefined` | No effective change. |
| `limits.max_prompt_tokens` | `number \| undefined` | `number \| undefined` | No effective change. |
| `limits.max_context_window_tokens` | `number \| undefined` | `number \| undefined` | No effective change because old type was already deep-partial. |
| `limits.max_output_tokens` | Not present | `number \| undefined` | Additive optional override. |
| `limits.vision.supported_media_types` | `string[] \| undefined` | `string[] \| undefined` | No effective change. |
| `limits.vision.max_prompt_images` | `number \| undefined` | `number \| undefined` | No effective change. |
| `limits.vision.max_prompt_image_size` | `number \| undefined` | `number \| undefined` | No effective change. |

