### PR TITLE
Normalize shell completion markers in replay proxy

### DIFF
--- a/test/harness/replayingCapiProxy.test.ts
+++ b/test/harness/replayingCapiProxy.test.ts
@@ -745,6 +745,88 @@ Always include PINEAPPLE_COCONUT_42.
       }
     });
 
+    test("matches shell tool results with shell ID completion markers", async () => {
+      const originalShellConfig =
+        process.platform === "win32" ? ShellConfig.powerShell : ShellConfig.bash;
+      const cachePath = path.join(tempDir, "cache.yaml");
+      const cacheContent = yaml.stringify({
+        models: ["test-model"],
+        conversations: [
+          {
+            messages: [
+              { role: "system", content: "${system}" },
+              { role: "user", content: "Run command" },
+              {
+                role: "assistant",
+                tool_calls: [
+                  {
+                    id: "toolcall_0",
+                    type: "function",
+                    function: {
+                      name: "${shell}",
+                      arguments: '{"command":"echo ok"}',
+                    },
+                  },
+                ],
+              },
+              {
+                role: "tool",
+                tool_call_id: "toolcall_0",
+                content: "ok\n<exited with exit code 0>",
+              },
+              { role: "assistant", content: "Done" },
+            ],
+          },
+        ],
+      } satisfies NormalizedData);
+      await writeFile(cachePath, cacheContent);
+
+      const proxy = new ReplayingCapiProxy(
+        "http://localhost:9999",
+        cachePath,
+        workDir,
+      );
+      const proxyUrl = await proxy.start();
+
+      try {
+        const response = await makeRequest(proxyUrl, "/chat/completions", {
+          body: {
+            model: "test-model",
+            messages: [
+              { role: "system", content: "System prompt" },
+              { role: "user", content: "Run command" },
+              {
+                role: "assistant",
+                tool_calls: [
+                  {
+                    id: "runtime-call-id",
+                    type: "function",
+                    function: {
+                      name: originalShellConfig.shellToolName,
+                      arguments: '{"command":"echo ok"}',
+                    },
+                  },
+                ],
+              },
+              {
+                role: "tool",
+                tool_call_id: "runtime-call-id",
+                content: "ok\n<shellId: 42 completed with exit code 0>",
+              },
+            ],
+          },
+        });
+
+        expect(response.status).toBe(200);
+        expect(
+          (JSON.parse(response.body) as ChatCompletion).choices[0].message
+            .content,
+        ).toBe("Done");
+      } finally {
+        await proxy.stop();
+      }
+    });
+
     test("expands workdir placeholder in cached response", async () => {
       const cachePath = path.join(tempDir, "cache.yaml");
       const cacheContent = yaml.stringify({

--- a/test/harness/replayingCapiProxy.ts
+++ b/test/harness/replayingCapiProxy.ts
@@ -54,6 +54,7 @@ export class ReplayingCapiProxy extends CapturingHttpProxy {
   private startPromise: Promise<string> | null = null;
   private defaultToolResultNormalizers: ToolResultNormalizer[] = [
     { toolName: "*", normalizer: normalizeLargeOutputFilepaths },
+    { toolName: "${shell}", normalizer: normalizeShellExitMarkers },
     { toolName: "*", normalizer: normalizeGhAuthMessages },
     { toolName: "read_agent", normalizer: normalizeReadAgentTimings },
   ];
@@ -1085,6 +1086,13 @@ function normalizeLargeOutputFilepaths(result: string): string {
       /(?:[A-Za-z]:)?[^\s"'`]*[\\/]session-state[\\/]temp[\\/]PLACEHOLDER-copilot-tool-output-PLACEHOLDER/g,
       "/session-state/temp/PLACEHOLDER-copilot-tool-output-PLACEHOLDER",
     );
+}
+
+function normalizeShellExitMarkers(result: string): string {
+  return result.replace(
+    /<shellId:\s*[^>\r\n]+?\s+completed with exit code (-?\d+)>/g,
+    "<exited with exit code $1>",
+  );
 }
 
 // The `gh` CLI emits different "not authenticated" help text depending on the


### PR DESCRIPTION
The runtime now includes dynamic shell IDs in completed shell tool output, which made existing CAPI replay snapshots miss cached responses even though the semantic shell result was unchanged.

This updates the replay proxy to normalize completed shell output like `<shellId: 42 completed with exit code 0>` back to the stable `<exited with exit code 0>` form before matching snapshots. That keeps the snapshots portable across runtime output-format changes without rewriting every affected fixture. A regression test covers replaying a cached shell result with the older marker against a request containing the newer shell-ID marker.

Validation:
- `cd test/harness && npm test -- replayingCapiProxy.test.ts`
- `GITHUB_ACTIONS=true dotnet test .\dotnet\test\GitHub.Copilot.SDK.Test.csproj --framework net8.0 --no-build --filter "FullyQualifiedName~BuiltinToolsE2ETests.Should_Capture_Exit_Code_In_Output|FullyQualifiedName~BuiltinToolsE2ETests.Should_Capture_Stderr_Output|FullyQualifiedName~SessionE2ETests.Send_Returns_Immediately_While_Events_Stream_In_Background|FullyQualifiedName~PermissionE2ETests.Should_Wait_For_Slow_Permission_Handler|FullyQualifiedName~PermissionE2ETests.Should_Short_Circuit_Permission_Handler_When_Set_Approve_All_Enabled|FullyQualifiedName~PermissionE2ETests.Should_Receive_ToolCallId_In_Permission_Requests|FullyQualifiedName~PermissionE2ETests.Should_Handle_Async_Permission_Handler|FullyQualifiedName~PermissionE2ETests.Should_Resume_Session_With_Permission_Handler"`

Generated by Copilot