### PR TITLE
TypeScript SDK: update client API to add model token pricing

### DIFF
--- a/nodejs/src/index.ts
+++ b/nodejs/src/index.ts
@@ -81,6 +81,8 @@ export type {
     DefaultAgentConfig,
     MessageOptions,
     ModelBilling,
+    ModelBillingTokenPrices,
+    ModelBillingTokenPricesLongContext,
     ModelCapabilities,
     ModelCapabilitiesOverride,
     ModelInfo,

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -2377,6 +2377,56 @@ export interface ModelPolicy {
  */
 export interface ModelBilling {
     multiplier?: number;
+    tokenPrices?: ModelBillingTokenPrices;
+}
+
+/**
+ * Token-level pricing information for this model
+ */
+export interface ModelBillingTokenPrices {
+    /**
+     * AI Credits cost per billing batch of input tokens
+     */
+    inputPrice?: number;
+    /**
+     * AI Credits cost per billing batch of output tokens
+     */
+    outputPrice?: number;
+    /**
+     * AI Credits cost per billing batch of cached tokens
+     */
+    cachePrice?: number;
+    /**
+     * Number of tokens per standard billing batch
+     */
+    batchSize?: number;
+    /**
+     * Prompt token budget (max_prompt_tokens) for the default tier. The total context window is this value plus the model's max_output_tokens.
+     */
+    contextMax?: number;
+    longContext?: ModelBillingTokenPricesLongContext;
+}
+
+/**
+ * Long context tier pricing (available for models with extended context windows)
+ */
+export interface ModelBillingTokenPricesLongContext {
+    /**
+     * AI Credits cost per billing batch of input tokens
+     */
+    inputPrice?: number;
+    /**
+     * AI Credits cost per billing batch of output tokens
+     */
+    outputPrice?: number;
+    /**
+     * AI Credits cost per billing batch of cached tokens
+     */
+    cachePrice?: number;
+    /**
+     * Prompt token budget (max_prompt_tokens) for the long context tier. The total context window is this value plus the model's max_output_tokens.
+     */
+    contextMax?: number;
 }
 
 /**


### PR DESCRIPTION
Alternative to #1564 

Add token-level billing types to Node SDK types: add tokenPrices to ModelBilling and new interfaces ModelBillingTokenPrices and ModelBillingTokenPricesLongContext. Include fields for input/output/cache prices, batchSize, contextMax, and longContext tier. Provides structured metadata for model pricing and long-context tiers used by billing and UI logic.

This continues the existing approach of having this "higher-level API", sitting on top of the RPC API, manually updated. Either this or #1564 are needed to unblock https://github.com/github/desktop/issues/1165