### PR TITLE
Stop compiling Java in dependency update workflow

### DIFF
--- a/.github/workflows/update-copilot-dependency.yml
+++ b/.github/workflows/update-copilot-dependency.yml
@@ -114,10 +114,6 @@ jobs:
         working-directory: ./java
         run: mvn generate-sources -Pcodegen
 
-      - name: Compile Java SDK (validate generated code)
-        working-directory: ./java
-        run: mvn compile -Pskip-test-harness
-
       - name: Create pull request
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The dependency update workflow should only refresh dependencies and generated sources, then open the update PR. The removed Java compile validation step was causing update automation to fail on handwritten Java compilation errors that belong in normal Java CI or follow-up adaptation work.

This keeps Java codegen in place (`mvn generate-sources -Pcodegen`) but removes the subsequent `mvn compile -Pskip-test-harness` step, so the workflow no longer performs compilation for any language.

Generated by Copilot