### PR TITLE
Update grep replay snapshot for absolute paths

### DIFF
--- a/test/snapshots/builtin_tools/should_search_for_patterns_in_files.yaml
+++ b/test/snapshots/builtin_tools/should_search_for_patterns_in_files.yaml
@@ -50,3 +50,33 @@ conversations:
           The search found **2 lines** starting with 'ap':
           - Line 1: `apple`
           - Line 3: `apricot`
+  - messages:
+      - role: system
+        content: ${system}
+      - role: user
+        content: Search for lines starting with 'ap' in the file 'data.txt'. Tell me which lines matched.
+      - role: assistant
+        tool_calls:
+          - id: toolcall_0
+            type: function
+            function:
+              name: report_intent
+              arguments: '{"intent":"Searching file for pattern"}'
+          - id: toolcall_1
+            type: function
+            function:
+              name: grep
+              arguments: '{"pattern":"^ap","path":"${workdir}/data.txt","output_mode":"content","-n":true}'
+      - role: tool
+        tool_call_id: toolcall_0
+        content: Intent logged
+      - role: tool
+        tool_call_id: toolcall_1
+        content: |-
+          ${workdir}/data.txt:1:apple
+          ${workdir}/data.txt:3:apricot
+      - role: assistant
+        content: |-
+          The search found **2 lines** starting with 'ap':
+          - Line 1: `apple`
+          - Line 3: `apricot`


### PR DESCRIPTION
Runtime github/copilot-agent-runtime#9819 now honors the legacy grep `path` argument, so the builtin tools replay can receive grep output rooted at `${workdir}` instead of `./`. The C# SDK non-blocking CI leg was missing the cached response for that variant and surfaced repeated proxy 500s.

This adds an alternate conversation to `should_search_for_patterns_in_files.yaml` for the normalized absolute-path grep result while keeping the existing relative-path variant. That lets replay match both runtime output formats.

Generated by Copilot