### PR TITLE
Fix flaky SessionFs workspace metadata E2E test

### DIFF
--- a/dotnet/test/E2E/SessionFsE2ETests.cs
+++ b/dotnet/test/E2E/SessionFsE2ETests.cs
@@ -410,8 +410,10 @@ public class SessionFsE2ETests(E2ETestFixture fixture, ITestOutputHelper output)
             Assert.Contains("56", msg?.Data.Content ?? string.Empty);
 
             var workspaceYamlPath = GetStoredPath(providerRoot, session.SessionId, $"{SessionFsConfig.SessionStatePath}/workspace.yaml");
-            await WaitForConditionAsync(() => File.Exists(workspaceYamlPath), TimeSpan.FromSeconds(30));
-            Assert.Contains(session.SessionId, await ReadAllTextSharedAsync(workspaceYamlPath));
+            await WaitForConditionAsync(
+                async () => File.Exists(workspaceYamlPath)
+                    && (await ReadAllTextSharedAsync(workspaceYamlPath)).Contains(session.SessionId),
+                TimeSpan.FromSeconds(30));
 
             var indexPath = GetStoredPath(providerRoot, session.SessionId, $"{SessionFsConfig.SessionStatePath}/checkpoints/index.md");
             await WaitForConditionAsync(() => File.Exists(indexPath), TimeSpan.FromSeconds(30));
@@ -442,8 +444,10 @@ public class SessionFsE2ETests(E2ETestFixture fixture, ITestOutputHelper output)
             await session.Rpc.Plan.UpdateAsync("# Test Plan\n\nThis is a test.");
 
             var planPath = GetStoredPath(providerRoot, session.SessionId, $"{SessionFsConfig.SessionStatePath}/plan.md");
-            await WaitForConditionAsync(() => File.Exists(planPath), TimeSpan.FromSeconds(30));
-            Assert.Contains("This is a test.", await ReadAllTextSharedAsync(planPath));
+            await WaitForConditionAsync(
+                async () => File.Exists(planPath)
+                    && (await ReadAllTextSharedAsync(planPath)).Contains("This is a test."),
+                TimeSpan.FromSeconds(30));
 
             await session.DisposeAsync();
         }

--- a/python/e2e/test_session_fs_e2e.py
+++ b/python/e2e/test_session_fs_e2e.py
@@ -235,9 +235,7 @@ class TestSessionFs:
         workspace_yaml_path = provider_path(
             provider_root, session.session_id, f"{SESSION_STATE_PATH}/workspace.yaml"
         )
-        await wait_for_path(workspace_yaml_path)
-        yaml_content = workspace_yaml_path.read_text(encoding="utf-8")
-        assert "id:" in yaml_content
+        await wait_for_content(workspace_yaml_path, "id:")
 
         # Checkpoint index should also exist
         index_path = provider_path(
@@ -265,9 +263,7 @@ class TestSessionFs:
         plan_path = provider_path(
             provider_root, session.session_id, f"{SESSION_STATE_PATH}/plan.md"
         )
-        await wait_for_path(plan_path)
-        content = plan_path.read_text(encoding="utf-8")
-        assert "# Test Plan" in content
+        await wait_for_content(plan_path, "# Test Plan")
 
         await session.disconnect()
 


### PR DESCRIPTION
## Why

The `Should_Write_Workspace_Metadata_Via_SessionFs` C# E2E test fails intermittently in CI (e.g. [this run](https://github.com/github/copilot-agent-runtime/actions/runs/27144359229/job/80121602849)) with:

```
Assert.Contains() Failure: Sub-string not found
String:    ""
Not found: "<session-id>"
```

## Root cause

The test waited only for `workspace.yaml` to **exist** before reading it. The runtime writes that file via the SessionFs provider using a truncate-then-write (`File.WriteAllTextAsync`), so `File.Exists` returns true the moment the file is created/truncated to 0 bytes, before the content is flushed. The test could read the empty file in that window and fail the assertion. The same race existed in the sibling `plan.md` test.

## Fix

Wait for the expected **content** (not just existence) before asserting. Since the content-aware wait already throws on timeout, the trailing `Assert.Contains` calls became redundant and were removed, leaving the wait as the assertion (matching the existing `index.md` wait-only style in this file).

I checked the equivalent test in every other language suite:

- **Python**: had the same disk-read race; switched both the `workspace.yaml` and `plan.md` tests to the already-present (but unused) `wait_for_content` helper.
- **Go**: already robust (`waitForFileContent`), no change.
- **Node**: not susceptible; it uses an in-memory provider with atomic writes and reads back through the provider rather than raw disk. No change.
- **Rust / Java**: no equivalent SessionFs workspace-metadata test exists. No change.

## Validation

Both .NET target frameworks (net8.0 + net472) build clean, and `ruff check` passes on the Python file.