### PR TITLE
Handle session.canvas.closed by removing from open_canvases snapshot

### DIFF
--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -132,7 +132,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
     /// </summary>
     /// <remarks>
     /// Populated from the most recent <c>session.resume</c> response and live
-    /// <c>session.canvas.opened</c> events.
+    /// <c>session.canvas.opened</c> and <c>session.canvas.closed</c> events.
     /// </remarks>
     [Experimental(Diagnostics.Experimental)]
     public IReadOnlyList<OpenCanvasInstance> OpenCanvases => _openCanvases;
@@ -892,6 +892,19 @@ public sealed partial class CopilotSession : IAsyncDisposable
 
     private void UpdateOpenCanvasesFromEvent(SessionEvent sessionEvent)
     {
+        if (sessionEvent is SessionCanvasClosedEvent closedEvent)
+        {
+            var closedInstanceId = closedEvent.Data.InstanceId;
+            if (string.IsNullOrEmpty(closedInstanceId))
+            {
+                _logger.LogWarning("failed to deserialize session.canvas.closed payload");
+                return;
+            }
+
+            RemoveOpenCanvas(closedInstanceId);
+            return;
+        }
+
         if (sessionEvent is not SessionCanvasOpenedEvent canvasEvent)
             return;
 
@@ -928,6 +941,12 @@ public sealed partial class CopilotSession : IAsyncDisposable
             canvases[index] = canvas;
         else
             canvases.Add(canvas);
+        _openCanvases = canvases.AsReadOnly();
+    }
+
+    private void RemoveOpenCanvas(string instanceId)
+    {
+        var canvases = _openCanvases.Where(open => open.InstanceId != instanceId).ToList();
         _openCanvases = canvases.AsReadOnly();
     }
 

--- a/dotnet/test/Unit/CanvasTests.cs
+++ b/dotnet/test/Unit/CanvasTests.cs
@@ -230,6 +230,93 @@ public class CanvasTests
     }
 
     [Fact]
+    public void SessionCanvasClosedEvent_RemovesOpenCanvasSnapshots()
+    {
+        var session = CreateSession();
+
+        DispatchEvent(session, new SessionCanvasOpenedEvent
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = new SessionCanvasOpenedData
+            {
+                Availability = CanvasOpenedAvailability.Ready,
+                CanvasId = "counter",
+                ExtensionId = "project:counter",
+                InstanceId = "counter-1",
+                Title = "Counter",
+                Reopen = false,
+            }
+        });
+        DispatchEvent(session, new SessionCanvasOpenedEvent
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = new SessionCanvasOpenedData
+            {
+                Availability = CanvasOpenedAvailability.Ready,
+                CanvasId = "logs",
+                ExtensionId = "project:logs",
+                InstanceId = "logs-1",
+                Title = "Logs",
+                Reopen = false,
+            }
+        });
+
+        Assert.Collection(
+            session.OpenCanvases,
+            canvas => Assert.Equal("counter-1", canvas.InstanceId),
+            canvas => Assert.Equal("logs-1", canvas.InstanceId));
+
+        // Closing one instance removes it; the other remains.
+        DispatchEvent(session, new SessionCanvasClosedEvent
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = new SessionCanvasClosedData
+            {
+                CanvasId = "counter",
+                ExtensionId = "project:counter",
+                InstanceId = "counter-1",
+            }
+        });
+
+        Assert.Collection(
+            session.OpenCanvases,
+            canvas => Assert.Equal("logs-1", canvas.InstanceId));
+
+        // Closing an absent instance is a no-op (idempotent).
+        DispatchEvent(session, new SessionCanvasClosedEvent
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = new SessionCanvasClosedData
+            {
+                CanvasId = "counter",
+                ExtensionId = "project:counter",
+                InstanceId = "counter-1",
+            }
+        });
+
+        // A closed event with an empty instance id leaves the snapshot intact.
+        DispatchEvent(session, new SessionCanvasClosedEvent
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = new SessionCanvasClosedData
+            {
+                CanvasId = "logs",
+                ExtensionId = "project:logs",
+                InstanceId = "",
+            }
+        });
+
+        Assert.Collection(
+            session.OpenCanvases,
+            canvas => Assert.Equal("logs-1", canvas.InstanceId));
+    }
+
+    [Fact]
     public void ExtensionInfo_Serializes_SourceAndName()
     {
         var options = GetSerializerOptions();

--- a/go/session.go
+++ b/go/session.go
@@ -100,7 +100,8 @@ func (s *Session) WorkspacePath() string {
 
 // OpenCanvases returns the open-canvas snapshot last reported by the runtime.
 // The snapshot is populated from session.resume and live session.canvas.opened
-// events. The returned slice is a copy and is safe to mutate by the caller.
+// and session.canvas.closed events. The returned slice is a copy and is safe to
+// mutate by the caller.
 func (s *Session) OpenCanvases() []rpc.OpenCanvasInstance {
 	s.openCanvasesMu.RLock()
 	defer s.openCanvasesMu.RUnlock()
@@ -130,27 +131,44 @@ func (s *Session) upsertOpenCanvas(canvas rpc.OpenCanvasInstance) {
 	s.openCanvases = append(s.openCanvases, canvas)
 }
 
+func (s *Session) removeOpenCanvas(instanceID string) {
+	s.openCanvasesMu.Lock()
+	defer s.openCanvasesMu.Unlock()
+	filtered := make([]rpc.OpenCanvasInstance, 0, len(s.openCanvases))
+	for _, canvas := range s.openCanvases {
+		if canvas.InstanceID != instanceID {
+			filtered = append(filtered, canvas)
+		}
+	}
+	s.openCanvases = filtered
+}
+
 func (s *Session) updateOpenCanvasesFromEvent(event SessionEvent) {
-	data, ok := event.Data.(*SessionCanvasOpenedData)
-	if !ok {
-		return
+	switch data := event.Data.(type) {
+	case *SessionCanvasOpenedData:
+		if data.InstanceID == "" || data.CanvasID == "" || data.ExtensionID == "" || data.Availability == "" {
+			fmt.Printf("failed to deserialize session.canvas.opened payload\n")
+			return
+		}
+		s.upsertOpenCanvas(rpc.OpenCanvasInstance{
+			Availability:  rpc.CanvasInstanceAvailability(data.Availability),
+			CanvasID:      data.CanvasID,
+			ExtensionID:   data.ExtensionID,
+			ExtensionName: data.ExtensionName,
+			Input:         data.Input,
+			InstanceID:    data.InstanceID,
+			Reopen:        data.Reopen,
+			Status:        data.Status,
+			Title:         data.Title,
+			URL:           data.URL,
+		})
+	case *SessionCanvasClosedData:
+		if data.InstanceID == "" {
+			fmt.Printf("failed to deserialize session.canvas.closed payload\n")
+			return
+		}
+		s.removeOpenCanvas(data.InstanceID)
 	}
-	if data.InstanceID == "" || data.CanvasID == "" || data.ExtensionID == "" || data.Availability == "" {
-		fmt.Printf("failed to deserialize session.canvas.opened payload\n")
-		return
-	}
-	s.upsertOpenCanvas(rpc.OpenCanvasInstance{
-		Availability:  rpc.CanvasInstanceAvailability(data.Availability),
-		CanvasID:      data.CanvasID,
-		ExtensionID:   data.ExtensionID,
-		ExtensionName: data.ExtensionName,
-		Input:         data.Input,
-		InstanceID:    data.InstanceID,
-		Reopen:        data.Reopen,
-		Status:        data.Status,
-		Title:         data.Title,
-		URL:           data.URL,
-	})
 }
 
 func (s *Session) registerCanvasHandler(handler CanvasHandler) {

--- a/go/session_test.go
+++ b/go/session_test.go
@@ -659,6 +659,72 @@ func TestSession_Capabilities(t *testing.T) {
 			t.Fatalf("expected stale availability, got %q", open[0].Availability)
 		}
 	})
+
+	t.Run("session.canvas.closed event removes open canvas snapshots", func(t *testing.T) {
+		session, cleanup := newTestSession()
+		defer cleanup()
+
+		session.dispatchEvent(SessionEvent{
+			Data: &SessionCanvasOpenedData{
+				ExtensionID:  "project:counter",
+				CanvasID:     "counter",
+				InstanceID:   "counter-1",
+				Title:        ptr("Counter"),
+				Availability: CanvasOpenedAvailabilityReady,
+			},
+		})
+		session.dispatchEvent(SessionEvent{
+			Data: &SessionCanvasOpenedData{
+				ExtensionID:  "project:logs",
+				CanvasID:     "logs",
+				InstanceID:   "logs-1",
+				Title:        ptr("Logs"),
+				Availability: CanvasOpenedAvailabilityReady,
+			},
+		})
+
+		if open := session.OpenCanvases(); len(open) != 2 {
+			t.Fatalf("expected 2 open canvases, got %d", len(open))
+		}
+
+		// Closing one instance removes it; the other remains.
+		session.dispatchEvent(SessionEvent{
+			Data: &SessionCanvasClosedData{
+				ExtensionID: "project:counter",
+				CanvasID:    "counter",
+				InstanceID:  "counter-1",
+			},
+		})
+		open := session.OpenCanvases()
+		if len(open) != 1 || open[0].InstanceID != "logs-1" {
+			t.Fatalf("expected only logs-1 to remain, got %+v", open)
+		}
+
+		// Closing an absent instance is a no-op (idempotent).
+		session.dispatchEvent(SessionEvent{
+			Data: &SessionCanvasClosedData{
+				ExtensionID: "project:counter",
+				CanvasID:    "counter",
+				InstanceID:  "counter-1",
+			},
+		})
+		open = session.OpenCanvases()
+		if len(open) != 1 || open[0].InstanceID != "logs-1" {
+			t.Fatalf("idempotent close should leave logs-1, got %+v", open)
+		}
+
+		// A closed event missing instanceID leaves the snapshot intact.
+		session.dispatchEvent(SessionEvent{
+			Data: &SessionCanvasClosedData{
+				ExtensionID: "project:logs",
+				CanvasID:    "logs",
+			},
+		})
+		open = session.OpenCanvases()
+		if len(open) != 1 || open[0].InstanceID != "logs-1" {
+			t.Fatalf("invalid close should leave logs-1, got %+v", open)
+		}
+	})
 }
 
 // waitForCapability polls Session.Capabilities() until predicate matches or timeout.

--- a/nodejs/src/session.ts
+++ b/nodejs/src/session.ts
@@ -507,6 +507,8 @@ export class CopilotSession {
             this._capabilities = { ...this._capabilities, ...event.data };
         } else if (event.type === "session.canvas.opened") {
             this.upsertOpenCanvasFromEvent(event.data);
+        } else if (event.type === "session.canvas.closed") {
+            this.removeOpenCanvasFromEvent(event.data);
         }
     }
 
@@ -516,6 +518,25 @@ export class CopilotSession {
             return;
         }
         this.upsertOpenCanvas(data);
+    }
+
+    private removeOpenCanvasFromEvent(data: unknown): void {
+        if (
+            !data ||
+            typeof data !== "object" ||
+            typeof (data as { instanceId?: unknown }).instanceId !== "string" ||
+            (data as { instanceId: string }).instanceId.length === 0
+        ) {
+            console.warn("failed to deserialize session.canvas.closed payload");
+            return;
+        }
+        this.removeOpenCanvas((data as { instanceId: string }).instanceId);
+    }
+
+    private removeOpenCanvas(instanceId: string): void {
+        this.openCanvasInstances = this.openCanvasInstances.filter(
+            (open) => open.instanceId !== instanceId
+        );
     }
 
     private upsertOpenCanvas(instance: OpenCanvasInstance): void {
@@ -851,8 +872,8 @@ export class CopilotSession {
     /**
      * Snapshot of canvas instances currently known to be open for this session.
      * Populated from the `session.resume` response and live `session.canvas.opened`
-     * events. Returns a defensive copy — mutating the returned array has no effect
-     * on the session.
+     * and `session.canvas.closed` events. Returns a defensive copy — mutating the
+     * returned array has no effect on the session.
      */
     get openCanvases(): OpenCanvasInstance[] {
         return [...this.openCanvasInstances];

--- a/nodejs/test/client.test.ts
+++ b/nodejs/test/client.test.ts
@@ -317,6 +317,69 @@ describe("CopilotClient", () => {
         warn.mockRestore();
     });
 
+    it("removes open canvases on live session.canvas.closed events", () => {
+        const session = new CopilotSession("session-1", {} as any);
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        (session as any)._dispatchEvent({
+            type: "session.canvas.opened",
+            data: {
+                extensionId: "project:counter",
+                canvasId: "counter",
+                instanceId: "counter-1",
+                title: "Counter",
+                reopen: false,
+                availability: "ready",
+            },
+        });
+        (session as any)._dispatchEvent({
+            type: "session.canvas.opened",
+            data: {
+                extensionId: "project:logs",
+                canvasId: "logs",
+                instanceId: "logs-1",
+                title: "Logs",
+                reopen: false,
+                availability: "ready",
+            },
+        });
+        expect(session.openCanvases.map((canvas) => canvas.instanceId)).toEqual([
+            "counter-1",
+            "logs-1",
+        ]);
+
+        // Closing one instance removes it; the other remains.
+        (session as any)._dispatchEvent({
+            type: "session.canvas.closed",
+            data: {
+                extensionId: "project:counter",
+                canvasId: "counter",
+                instanceId: "counter-1",
+            },
+        });
+        expect(session.openCanvases.map((canvas) => canvas.instanceId)).toEqual(["logs-1"]);
+
+        // Closing an absent instance is a no-op (idempotent).
+        (session as any)._dispatchEvent({
+            type: "session.canvas.closed",
+            data: {
+                extensionId: "project:counter",
+                canvasId: "counter",
+                instanceId: "counter-1",
+            },
+        });
+        expect(session.openCanvases.map((canvas) => canvas.instanceId)).toEqual(["logs-1"]);
+
+        // A closed event missing instanceId warns and leaves the snapshot intact.
+        (session as any)._dispatchEvent({
+            type: "session.canvas.closed",
+            data: { extensionId: "project:logs", canvasId: "logs" },
+        });
+        expect(warn).toHaveBeenCalledWith("failed to deserialize session.canvas.closed payload");
+        expect(session.openCanvases.map((canvas) => canvas.instanceId)).toEqual(["logs-1"]);
+        warn.mockRestore();
+    });
+
     it("returns canvas_action_no_handler when no per-action handler is registered", async () => {
         const canvas = createCanvas({
             id: "counter",

--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -67,6 +67,7 @@ from .generated.session_events import (
     ExternalToolRequestedData,
     PermissionRequest,
     PermissionRequestedData,
+    SessionCanvasClosedData,
     SessionCanvasOpenedData,
     SessionErrorData,
     SessionEvent,
@@ -1564,6 +1565,14 @@ class CopilotSession:
                 except Exception as exc:
                     logger.warning("failed to deserialize session.canvas.opened payload: %s", exc)
 
+            case SessionCanvasClosedData() as data:
+                try:
+                    if not data.instance_id:
+                        raise ValueError("missing required closed canvas fields")
+                    self._remove_open_canvas(data.instance_id)
+                except Exception as exc:
+                    logger.warning("failed to deserialize session.canvas.closed payload: %s", exc)
+
     async def _execute_tool_and_respond(
         self,
         request_id: str,
@@ -1915,11 +1924,18 @@ class CopilotSession:
                     return
             self._open_canvases.append(instance)
 
+    def _remove_open_canvas(self, instance_id: str) -> None:
+        with self._open_canvases_lock:
+            self._open_canvases = [
+                canvas for canvas in self._open_canvases if canvas.instance_id != instance_id
+            ]
+
     @property
     def open_canvases(self) -> list[OpenCanvasInstance]:
         """Open canvas instances currently known to be open for this session.
 
-        Populated from ``session.resume`` and live ``session.canvas.opened`` events.
+        Populated from ``session.resume`` and live ``session.canvas.opened`` and
+        ``session.canvas.closed`` events.
         """
         with self._open_canvases_lock:
             return list(self._open_canvases)

--- a/python/test_canvas.py
+++ b/python/test_canvas.py
@@ -27,6 +27,7 @@ from copilot.rpc import (
 from copilot.session import CopilotSession
 from copilot.session_events import (
     CanvasOpenedAvailability,
+    SessionCanvasClosedData,
     SessionCanvasOpenedData,
     SessionEvent,
     SessionEventType,
@@ -303,3 +304,73 @@ def test_session_canvas_opened_updates_open_canvases(caplog: pytest.LogCaptureFi
     assert open_canvases[0].reopen is True
     assert open_canvases[0].availability == CanvasInstanceAvailability.STALE
     assert open_canvases[1].instance_id == "logs-1"
+
+
+def test_session_canvas_closed_removes_open_canvases(caplog: pytest.LogCaptureFixture):
+    session = CopilotSession("sess-1", client=None)
+
+    for canvas_id, instance_id in (("counter", "counter-1"), ("logs", "logs-1")):
+        session._dispatch_event(
+            SessionEvent(
+                data=SessionCanvasOpenedData(
+                    availability=CanvasOpenedAvailability.READY,
+                    canvas_id=canvas_id,
+                    extension_id=f"project:{canvas_id}",
+                    instance_id=instance_id,
+                    reopen=False,
+                ),
+                id=uuid4(),
+                timestamp=datetime.now(UTC),
+                type=SessionEventType.SESSION_CANVAS_OPENED,
+            )
+        )
+    assert [canvas.instance_id for canvas in session.open_canvases] == [
+        "counter-1",
+        "logs-1",
+    ]
+
+    # Closing one instance removes it; the other remains.
+    session._dispatch_event(
+        SessionEvent(
+            data=SessionCanvasClosedData(
+                canvas_id="counter",
+                extension_id="project:counter",
+                instance_id="counter-1",
+            ),
+            id=uuid4(),
+            timestamp=datetime.now(UTC),
+            type=SessionEventType.SESSION_CANVAS_CLOSED,
+        )
+    )
+    assert [canvas.instance_id for canvas in session.open_canvases] == ["logs-1"]
+
+    # Closing an absent instance is a no-op (idempotent).
+    session._dispatch_event(
+        SessionEvent(
+            data=SessionCanvasClosedData(
+                canvas_id="counter",
+                extension_id="project:counter",
+                instance_id="counter-1",
+            ),
+            id=uuid4(),
+            timestamp=datetime.now(UTC),
+            type=SessionEventType.SESSION_CANVAS_CLOSED,
+        )
+    )
+    assert [canvas.instance_id for canvas in session.open_canvases] == ["logs-1"]
+
+    # A closed event with an empty instance_id warns and leaves the snapshot intact.
+    session._dispatch_event(
+        SessionEvent(
+            data=SessionCanvasClosedData(
+                canvas_id="logs",
+                extension_id="project:logs",
+                instance_id="",
+            ),
+            id=uuid4(),
+            timestamp=datetime.now(UTC),
+            type=SessionEventType.SESSION_CANVAS_CLOSED,
+        )
+    )
+    assert "failed to deserialize session.canvas.closed payload" in caplog.text
+    assert [canvas.instance_id for canvas in session.open_canvases] == ["logs-1"]

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -13,8 +13,8 @@ use tracing::{Instrument, warn};
 use crate::canvas::CanvasHandler;
 use crate::generated::api_types::{LogRequest, ModelSwitchToRequest, OpenCanvasInstance};
 use crate::generated::session_events::{
-    CommandExecuteData, ElicitationRequestedData, ExternalToolRequestedData, SessionErrorData,
-    SessionEventType,
+    CommandExecuteData, ElicitationRequestedData, ExternalToolRequestedData,
+    SessionCanvasClosedData, SessionErrorData, SessionEventType,
 };
 use crate::handler::{
     AutoModeSwitchHandler, AutoModeSwitchResponse, ElicitationHandler, ExitPlanModeHandler,
@@ -1375,6 +1375,10 @@ fn upsert_open_canvas_snapshot(
     }
 }
 
+fn remove_open_canvas_snapshot(snapshots: &mut Vec<OpenCanvasInstance>, instance_id: &str) {
+    snapshots.retain(|open| open.instance_id != instance_id);
+}
+
 #[allow(clippy::too_many_arguments)]
 fn spawn_event_loop(
     session_id: SessionId,
@@ -1570,6 +1574,18 @@ async fn handle_notification(
                 upsert_open_canvas_snapshot(&mut open_canvases.write(), open_canvas);
             }
             Err(e) => warn!(error = %e, "failed to deserialize session.canvas.opened payload"),
+        }
+    }
+    if event_type == SessionEventType::SessionCanvasClosed {
+        match serde_json::from_value::<SessionCanvasClosedData>(notification.event.data.clone()) {
+            Ok(closed) => {
+                if closed.instance_id.is_empty() {
+                    warn!("failed to deserialize session.canvas.closed payload");
+                } else {
+                    remove_open_canvas_snapshot(&mut open_canvases.write(), &closed.instance_id);
+                }
+            }
+            Err(e) => warn!(error = %e, "failed to deserialize session.canvas.closed payload"),
         }
     }
 

--- a/rust/tests/session_test.rs
+++ b/rust/tests/session_test.rs
@@ -2743,6 +2743,109 @@ async fn session_canvas_opened_updates_open_canvas_snapshots() {
 }
 
 #[tokio::test]
+async fn session_canvas_closed_removes_open_canvas_snapshot() {
+    let (session, mut server) = create_session_pair().await;
+    assert!(session.open_canvases().is_empty());
+
+    server
+        .send_event(
+            "session.canvas.opened",
+            serde_json::json!({
+                "extensionId": "project:counter",
+                "canvasId": "counter",
+                "instanceId": "counter-1",
+                "title": "Counter",
+                "reopen": false,
+                "availability": "ready"
+            }),
+        )
+        .await;
+    server
+        .send_event(
+            "session.canvas.opened",
+            serde_json::json!({
+                "extensionId": "project:logs",
+                "canvasId": "logs",
+                "instanceId": "logs-1",
+                "title": "Logs",
+                "reopen": false,
+                "availability": "ready"
+            }),
+        )
+        .await;
+
+    let mut open = Vec::new();
+    for _ in 0..50 {
+        open = session.open_canvases();
+        if open.len() == 2 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert_eq!(open.len(), 2);
+
+    // Closing one instance removes it while the other remains.
+    server
+        .send_event(
+            "session.canvas.closed",
+            serde_json::json!({
+                "extensionId": "project:counter",
+                "canvasId": "counter",
+                "instanceId": "counter-1"
+            }),
+        )
+        .await;
+
+    for _ in 0..50 {
+        open = session.open_canvases();
+        if open.len() == 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert_eq!(open.len(), 1);
+    assert_eq!(open[0].instance_id, "logs-1");
+
+    // Closing an absent instance is a no-op (idempotent).
+    server
+        .send_event(
+            "session.canvas.closed",
+            serde_json::json!({
+                "extensionId": "project:counter",
+                "canvasId": "counter",
+                "instanceId": "counter-1"
+            }),
+        )
+        .await;
+
+    // Give the event loop time to process; the snapshot must stay unchanged.
+    for _ in 0..10 {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        open = session.open_canvases();
+        assert_eq!(open.len(), 1);
+    }
+    assert_eq!(open[0].instance_id, "logs-1");
+
+    // A closed event with an empty instance_id is ignored and leaves the snapshot intact.
+    server
+        .send_event(
+            "session.canvas.closed",
+            serde_json::json!({
+                "extensionId": "project:logs",
+                "canvasId": "logs",
+                "instanceId": ""
+            }),
+        )
+        .await;
+    for _ in 0..10 {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        open = session.open_canvases();
+        assert_eq!(open.len(), 1);
+    }
+    assert_eq!(open[0].instance_id, "logs-1");
+}
+
+#[tokio::test]
 async fn elicitation_methods_fail_without_capability() {
     let (session, _server) = create_session_pair().await;
 


### PR DESCRIPTION
## What

Completes the symmetric pair with `session.canvas.opened`: the SDKs now **remove** a canvas from their in-memory `open_canvases` snapshot when the runtime emits `session.canvas.closed`.

## Why

The runtime now emits a symmetric `session.canvas.closed` ephemeral event (payload `{ instanceId, extensionId, canvasId }`, `instanceId` required + non-empty) when a canvas is genuinely removed — mirroring the existing `session.canvas.opened` (copilot-agent-runtime #9489, shipped in **CLI 1.0.60**).

The generated event types already landed via codegen, but the hand-written handlers only ever **upserted** on open, so the snapshot was append-only and never shrank on close. This left consumers' open-canvas state stale.

The consumer driving this is **github-app's "sticky terminal canvas" fix**: a right-panel canvas the user closes resurrects on warm session-reselect. That fix needs the SDK snapshot to shrink on close so reselect stops resurrecting closed canvases.

## How

Adds a symmetric removal handler in every SDK that maintains the open-canvases snapshot — **Rust, Node, Python, Go, .NET**. Each:

- removes the matching `instanceId` on `session.canvas.closed`, acquiring the **same lock** the upsert path uses;
- **warns and no-ops** on an empty/missing `instanceId`;
- is **idempotent** (closing an absent `instanceId` is a no-op);
- leaves the **resume path untouched** and does **not** treat opened/stale events as removals (only the explicit closed event removes — provider unregister still marks instances *stale* via a re-emitted `opened`, which continues to upsert).

Generated files were not hand-edited; the change is purely in the hand-written session handlers + unit tests.

### Java — intentionally excluded

Java has **no open-canvases snapshot feature** in `java/src/main` at all (no accessor, no opened-upsert handler, no resume capture) — only the generated event types exist. There is nothing symmetric to add; covering it would mean building the entire feature net-new, which is out of scope for this focused bug fix.

## Tests

New unit tests in each language open two canvases, close one (assert the closed instance is gone and the other remains), and cover idempotency (closing an absent id) and the empty-`instanceId` no-op.

- Rust: `cargo test --features test-support --test session_test` — pass
- Node: `vitest run test/client.test.ts` — 95 pass
- Python: `pytest test_canvas.py` — 12 pass
- Go: `go test .` — pass
- .NET: `dotnet test --filter CanvasTests` — 10 pass