### PR TITLE
Make exit_plan_mode E2E snapshot tolerant of reworded CLI tool result

### DIFF
--- a/test/snapshots/mode_handlers/should_invoke_exit_plan_mode_handler_when_model_uses_tool.yaml
+++ b/test/snapshots/mode_handlers/should_invoke_exit_plan_mode_handler_when_model_uses_tool.yaml
@@ -1,5 +1,15 @@
 models:
   - claude-sonnet-4.5
+# Two stored conversations cover the two CLI versions of the exit_plan_mode
+# post-approval tool result. The CLI injects this text and feeds it back to the
+# model; the SDK never asserts on its exact wording. The interactive-mode message
+# was reworded in copilot-agent-runtime:
+#   conv0: CLI 1.0.61 and earlier -> "...interactive mode (edits require manual
+#          approval). Proceed with implementing the plan."
+#   conv1: newer runtime builds   -> "...interactive mode. Start implementing the
+#          plan now, in this same response. ..."
+# The replay proxy matches a request as a strict prefix of a stored conversation
+# and returns the next assistant message, so both versions resolve correctly.
 conversations:
   - messages:
       - role: system
@@ -19,5 +29,25 @@ conversations:
           Plan approved! Exited plan mode.
 
           You are now in interactive mode (edits require manual approval). Proceed with implementing the plan.
+      - role: assistant
+        content: Plan approved; I will wait for the next instruction before making changes.
+  - messages:
+      - role: system
+        content: ${system}
+      - role: user
+        content: Create a brief implementation plan for adding a greeting.txt file, then request approval with exit_plan_mode.
+      - role: assistant
+        tool_calls:
+          - id: toolcall_0
+            type: function
+            function:
+              name: exit_plan_mode
+              arguments: '{"summary":"Greeting file implementation plan","actions":["interactive","autopilot","exit_only"],"recommendedAction":"interactive"}'
+      - role: tool
+        tool_call_id: toolcall_0
+        content: |-
+          Plan approved! Exited plan mode.
+
+          You are now in interactive mode. Start implementing the plan now, in this same response. Approving the plan is your go-signal, so do not stop to ask whether to proceed or wait for another message.
       - role: assistant
         content: Plan approved; I will wait for the next instruction before making changes.


### PR DESCRIPTION
## Why

The `Copilot SDK C# tests (non-blocking)` leg in copilot-agent-runtime started failing on `ModeHandlersE2ETests.Should_Invoke_Exit_Plan_Mode_Handler_When_Model_Uses_Tool` (example: [run 27386789669](https://github.com/github/copilot-agent-runtime/actions/runs/27386789669/job/80938744651?pr=10182)). The replay proxy returned `500` (`CAPIError: 500 Proxy error`) because the recorded snapshot no longer matched the request the CLI sends.

Root cause: the runtime reworded the `exit_plan_mode` post-approval tool result for **interactive** mode (copilot-agent-runtime `src/runtime/src/tools/exit_plan_mode.rs`, commit `a0ed9a510e`):

- old: `...interactive mode (edits require manual approval). Proceed with implementing the plan.`
- new: `...interactive mode. Start implementing the plan now, in this same response. ...`

That leg builds the CLI from source, so it feeds the new wording back into the conversation. The proxy matches the request against the stored conversation and could not find the new tool-result text.

## The constraint

Simply swapping to the new text would break this repo's own CI: the published `@github/copilot@1.0.61` pinned by the E2E harness (and used by every language leg) still emits the *old* wording. I verified this by inspecting the published package binary. So the snapshot has to satisfy both CLI versions during the transition.

## Approach

Added a second conversation variant to the shared snapshot so the replay proxy matches **either** wording. The proxy matches a request as a strict prefix of any stored conversation and returns the next assistant message, so the old CLI resolves against `conv0` and the new runtime against `conv1`. This follows the existing convention in the repo (64 snapshots already use multiple conversations, including version-keyed variants with explanatory comments). A comment documents why both variants exist.

This is a single shared fixture, so it covers the C# leg plus the Node, Python, Go, Java, and Rust legs that exercise the same scenario. The SDK never asserts on this CLI-internal text; it only checks handler invocation, events, and a non-null response.

## Validation

Drove the real replay proxy at the HTTP level (where matching happens): loaded the updated snapshot and posted all three request shapes. Turn 1 returns the `exit_plan_mode` tool call; turn 2 with the old text and turn 2 with the new text both return `200` with the final assistant message.

Once a CLI version carrying the new wording is published and the harness pin is bumped, the old `conv0` variant can be pruned.