### PR TITLE
fix(python): round sub-millisecond durations in to_timedelta_int

### DIFF
--- a/python/copilot/generated/session_events.py
+++ b/python/copilot/generated/session_events.py
@@ -51,7 +51,8 @@ def from_timedelta(x: Any) -> timedelta:
 def to_timedelta_int(x: timedelta) -> int:
     assert isinstance(x, timedelta)
     milliseconds = x.total_seconds() * 1000.0
-    # Durations can carry sub-millisecond precision; round to the nearest whole ms.
+    # Durations can carry sub-millisecond precision; round to the nearest whole ms
+    # using Python's default banker's rounding (round-half-to-even).
     return round(milliseconds)
 
 

--- a/python/copilot/generated/session_events.py
+++ b/python/copilot/generated/session_events.py
@@ -51,8 +51,8 @@ def from_timedelta(x: Any) -> timedelta:
 def to_timedelta_int(x: timedelta) -> int:
     assert isinstance(x, timedelta)
     milliseconds = x.total_seconds() * 1000.0
-    assert milliseconds.is_integer()
-    return int(milliseconds)
+    # Durations can carry sub-millisecond precision; round to the nearest whole ms.
+    return round(milliseconds)
 
 
 def to_timedelta(x: timedelta) -> float:

--- a/scripts/codegen/python.ts
+++ b/scripts/codegen/python.ts
@@ -2538,8 +2538,8 @@ export function generatePythonSessionEventsCode(schema: JSONSchema7): string {
             out.push(`def to_timedelta_int(x: timedelta) -> int:`);
             out.push(`    assert isinstance(x, timedelta)`);
             out.push(`    milliseconds = x.total_seconds() * 1000.0`);
-            out.push(`    assert milliseconds.is_integer()`);
-            out.push(`    return int(milliseconds)`);
+            out.push(`    # Durations can carry sub-millisecond precision; round to the nearest whole ms.`);
+            out.push(`    return round(milliseconds)`);
             out.push(``);
             out.push(``);
         }

--- a/scripts/codegen/python.ts
+++ b/scripts/codegen/python.ts
@@ -2538,7 +2538,8 @@ export function generatePythonSessionEventsCode(schema: JSONSchema7): string {
             out.push(`def to_timedelta_int(x: timedelta) -> int:`);
             out.push(`    assert isinstance(x, timedelta)`);
             out.push(`    milliseconds = x.total_seconds() * 1000.0`);
-            out.push(`    # Durations can carry sub-millisecond precision; round to the nearest whole ms.`);
+            out.push(`    # Durations can carry sub-millisecond precision; round to the nearest whole ms`);
+            out.push(`    # using Python's default banker's rounding (round-half-to-even).`);
             out.push(`    return round(milliseconds)`);
             out.push(``);
             out.push(``);


### PR DESCRIPTION
A timedelta carries microsecond precision, so `x.total_seconds() * 1000.0` in `to_timedelta_int` can be a non-integer float (e.g. 1.234). The old `is_integer()` assert then failed on such durations and aborted SessionEvent serialization. Round to the nearest whole millisecond instead.