### PR TITLE
Add embeddedcli.Path() accessor for the resolved CLI path

### DIFF
--- a/go/embeddedcli/installer.go
+++ b/go/embeddedcli/installer.go
@@ -15,3 +15,11 @@ type Config = embeddedcli.Config
 func Setup(cfg Config) {
 	embeddedcli.Setup(cfg)
 }
+
+// Path returns the absolute path to the embedded Copilot CLI, installing it on
+// first call if necessary. It returns an empty string when no embedded CLI was
+// configured via Setup (e.g. a build compiled without the embedded runtime).
+// The result is computed once and cached for the life of the process.
+func Path() string {
+	return embeddedcli.Path()
+}


### PR DESCRIPTION
## What

Adds a small, additive public accessor `embeddedcli.Path()` that returns the absolute path to the embedded Copilot CLI (installing it on first call), wrapping the existing `internal/embeddedcli.Path` value.

```go
// Path returns the absolute path to the embedded Copilot CLI, installing it on
// first call if necessary. It returns an empty string when no embedded CLI was
// configured via Setup (e.g. a build compiled without the embedded runtime).
// The result is computed once and cached for the life of the process.
func Path() string {
	return embeddedcli.Path()
}
```

## Why

The public `embeddedcli` package exposes `Config` and `Setup`, but currently offers no way to read back the resolved CLI path after `Setup`. A consumer that embeds the CLI (e.g. a packaged desktop app shipping the runtime) needs the resolved path to spawn `copilot …` subcommands directly — for instance when there is no `copilot` on `PATH` in a shipped build.

The value already exists in `internal/embeddedcli.Path`, but `internal/` isn't importable by downstream modules. This exposes it through the public surface, mirroring the existing `Setup` wrapper one-to-one.

## Notes

- Purely additive; no behavior change to existing APIs.
- `internal/embeddedcli.Path` already returns `""` when `Setup` was never called and is memoized via `sync.OnceValue`, so the documented semantics are inherited as-is.
