### PR TITLE
Update .NET SDK contribution prerequisite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ This is a multi-language SDK repository. Install the tools for the SDK(s) you pl
 
 ### .NET SDK
 
-1. Install [.NET 8.0+](https://dotnet.microsoft.com/download)
+1. Install [.NET SDK 10+](https://dotnet.microsoft.com/download)
 1. Install .NET dependencies: `cd dotnet && dotnet restore`
 
 ## Submitting a Pull Request


### PR DESCRIPTION
## Summary
- Update the .NET SDK prerequisite in CONTRIBUTING.md from .NET 8.0+ to .NET SDK 10+
- Align the contributing guidance with dotnet/global.json, which specifies SDK 10.0.100

## Testing
- Not run (documentation-only change)