### PR TITLE
Generate package-info.java for generated packages

### DIFF
--- a/java/scripts/codegen/java.ts
+++ b/java/scripts/codegen/java.ts
@@ -2053,6 +2053,101 @@ async function generateRpcWrappers(schemaPath: string): Promise<void> {
     console.log(`✅ RPC wrapper classes generated`);
 }
 
+// ── Package-info generation ──────────────────────────────────────────────────
+
+async function generateGeneratedPackageInfo(packageDir: string): Promise<void> {
+    const lines: string[] = [];
+    lines.push(COPYRIGHT);
+    lines.push("");
+    lines.push(AUTO_GENERATED_HEADER);
+    lines.push(GENERATED_FROM_SESSION_EVENTS);
+    lines.push("");
+    lines.push(`/**`);
+    lines.push(` * Auto-generated session event types for the GitHub Copilot SDK.`);
+    lines.push(` *`);
+    lines.push(` * <p>`);
+    lines.push(` * This package contains Java classes generated from the Copilot CLI's`);
+    lines.push(` * {@code session-events.schema.json}. Each event type corresponds to a`);
+    lines.push(` * notification emitted during a {@link com.github.copilot.CopilotSession}`);
+    lines.push(` * interaction.`);
+    lines.push(` *`);
+    lines.push(` * <h2>Key Classes</h2>`);
+    lines.push(` * <ul>`);
+    lines.push(` * <li>{@link com.github.copilot.generated.SessionEvent} - Abstract sealed base`);
+    lines.push(` * class for all session events. Deserialized polymorphically via the`);
+    lines.push(` * {@code type} discriminator.</li>`);
+    lines.push(` * <li>{@link com.github.copilot.generated.UnknownSessionEvent} - Fallback for`);
+    lines.push(` * event types not yet known to this SDK version, preserving forward`);
+    lines.push(` * compatibility.</li>`);
+    lines.push(` * </ul>`);
+    lines.push(` *`);
+    lines.push(` * <h2>Example Usage</h2>`);
+    lines.push(` *`);
+    lines.push(` * <pre>{@code`);
+    lines.push(` * session.on(AssistantMessageEvent.class, msg -> {`);
+    lines.push(` *     System.out.println(msg.getData().content());`);
+    lines.push(` * });`);
+    lines.push(` * }</pre>`);
+    lines.push(` *`);
+    lines.push(` * <h2>Related Packages</h2>`);
+    lines.push(` * <ul>`);
+    lines.push(` * <li>{@link com.github.copilot} - Core SDK classes</li>`);
+    lines.push(` * <li>{@link com.github.copilot.generated.rpc} - Auto-generated RPC`);
+    lines.push(` * parameter and result types</li>`);
+    lines.push(` * </ul>`);
+    lines.push(` *`);
+    lines.push(` * @see com.github.copilot.CopilotSession`);
+    lines.push(` * @see com.github.copilot.generated.SessionEvent`);
+    lines.push(` */`);
+    lines.push(`package com.github.copilot.generated;`);
+    lines.push("");
+
+    await writeGeneratedFile(`${packageDir}/package-info.java`, lines.join("\n"));
+}
+
+async function generateRpcPackageInfo(packageDir: string): Promise<void> {
+    const lines: string[] = [];
+    lines.push(COPYRIGHT);
+    lines.push("");
+    lines.push(AUTO_GENERATED_HEADER);
+    lines.push(GENERATED_FROM_API);
+    lines.push("");
+    lines.push(`/**`);
+    lines.push(` * Auto-generated RPC parameter and result types for the GitHub Copilot SDK.`);
+    lines.push(` *`);
+    lines.push(` * <p>`);
+    lines.push(` * This package contains Java records and classes generated from the Copilot`);
+    lines.push(` * CLI's {@code api.schema.json}. These types represent the request parameters`);
+    lines.push(` * and response payloads for all JSON-RPC methods exposed by the CLI.`);
+    lines.push(` *`);
+    lines.push(` * <h2>Key Classes</h2>`);
+    lines.push(` * <ul>`);
+    lines.push(` * <li>{@link com.github.copilot.generated.rpc.RpcCaller} - Functional interface`);
+    lines.push(` * for invoking JSON-RPC methods with typed responses.</li>`);
+    lines.push(` * <li>{@link com.github.copilot.generated.rpc.ServerRpc} - Typed client for`);
+    lines.push(` * server-level RPC methods (session management, model listing, etc.).</li>`);
+    lines.push(` * <li>{@link com.github.copilot.generated.rpc.SessionRpc} - Typed client for`);
+    lines.push(` * session-scoped RPC methods (send messages, manage tools, etc.). Automatically`);
+    lines.push(` * injects the {@code sessionId} into every call.</li>`);
+    lines.push(` * </ul>`);
+    lines.push(` *`);
+    lines.push(` * <h2>Related Packages</h2>`);
+    lines.push(` * <ul>`);
+    lines.push(` * <li>{@link com.github.copilot} - Core SDK classes</li>`);
+    lines.push(` * <li>{@link com.github.copilot.generated} - Auto-generated session event`);
+    lines.push(` * types</li>`);
+    lines.push(` * </ul>`);
+    lines.push(` *`);
+    lines.push(` * @see com.github.copilot.CopilotClient`);
+    lines.push(` * @see com.github.copilot.generated.rpc.ServerRpc`);
+    lines.push(` * @see com.github.copilot.generated.rpc.SessionRpc`);
+    lines.push(` */`);
+    lines.push(`package com.github.copilot.generated.rpc;`);
+    lines.push("");
+
+    await writeGeneratedFile(`${packageDir}/package-info.java`, lines.join("\n"));
+}
+
 // ── Main entry point ──────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
@@ -2073,6 +2168,12 @@ async function main(): Promise<void> {
     await generateSessionEvents(sessionEventsSchemaPath);
     await generateRpcTypes(apiSchemaPath);
     await generateRpcWrappers(apiSchemaPath);
+
+    // Generate package-info.java for each generated package
+    const generatedPkgDir = `src/generated/java/com/github/copilot/generated`;
+    const rpcPkgDir = `src/generated/java/com/github/copilot/generated/rpc`;
+    await generateGeneratedPackageInfo(generatedPkgDir);
+    await generateRpcPackageInfo(rpcPkgDir);
 
     console.log("\n✅ Java code generation complete!");
 }

--- a/java/src/generated/java/com/github/copilot/generated/package-info.java
+++ b/java/src/generated/java/com/github/copilot/generated/package-info.java
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: session-events.schema.json
+
+/**
+ * Auto-generated session event types for the GitHub Copilot SDK.
+ *
+ * <p>
+ * This package contains Java classes generated from the Copilot CLI's
+ * {@code session-events.schema.json}. Each event type corresponds to a
+ * notification emitted during a {@link com.github.copilot.CopilotSession}
+ * interaction.
+ *
+ * <h2>Key Classes</h2>
+ * <ul>
+ * <li>{@link com.github.copilot.generated.SessionEvent} - Abstract sealed base
+ * class for all session events. Deserialized polymorphically via the
+ * {@code type} discriminator.</li>
+ * <li>{@link com.github.copilot.generated.UnknownSessionEvent} - Fallback for
+ * event types not yet known to this SDK version, preserving forward
+ * compatibility.</li>
+ * </ul>
+ *
+ * <h2>Example Usage</h2>
+ *
+ * <pre>{@code
+ * session.on(AssistantMessageEvent.class, msg -> {
+ *     System.out.println(msg.getData().content());
+ * });
+ * }</pre>
+ *
+ * <h2>Related Packages</h2>
+ * <ul>
+ * <li>{@link com.github.copilot} - Core SDK classes</li>
+ * <li>{@link com.github.copilot.generated.rpc} - Auto-generated RPC
+ * parameter and result types</li>
+ * </ul>
+ *
+ * @see com.github.copilot.CopilotSession
+ * @see com.github.copilot.generated.SessionEvent
+ */
+package com.github.copilot.generated;

--- a/java/src/generated/java/com/github/copilot/generated/rpc/package-info.java
+++ b/java/src/generated/java/com/github/copilot/generated/rpc/package-info.java
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Generated from: api.schema.json
+
+/**
+ * Auto-generated RPC parameter and result types for the GitHub Copilot SDK.
+ *
+ * <p>
+ * This package contains Java records and classes generated from the Copilot
+ * CLI's {@code api.schema.json}. These types represent the request parameters
+ * and response payloads for all JSON-RPC methods exposed by the CLI.
+ *
+ * <h2>Key Classes</h2>
+ * <ul>
+ * <li>{@link com.github.copilot.generated.rpc.RpcCaller} - Functional interface
+ * for invoking JSON-RPC methods with typed responses.</li>
+ * <li>{@link com.github.copilot.generated.rpc.ServerRpc} - Typed client for
+ * server-level RPC methods (session management, model listing, etc.).</li>
+ * <li>{@link com.github.copilot.generated.rpc.SessionRpc} - Typed client for
+ * session-scoped RPC methods (send messages, manage tools, etc.). Automatically
+ * injects the {@code sessionId} into every call.</li>
+ * </ul>
+ *
+ * <h2>Related Packages</h2>
+ * <ul>
+ * <li>{@link com.github.copilot} - Core SDK classes</li>
+ * <li>{@link com.github.copilot.generated} - Auto-generated session event
+ * types</li>
+ * </ul>
+ *
+ * @see com.github.copilot.CopilotClient
+ * @see com.github.copilot.generated.rpc.ServerRpc
+ * @see com.github.copilot.generated.rpc.SessionRpc
+ */
+package com.github.copilot.generated.rpc;


### PR DESCRIPTION
Fixes #1694

## java/scripts/codegen/java.ts

- Added `generateGeneratedPackageInfo()` to emit `package-info.java` for the `com.github.copilot.generated` package. Includes Javadoc describing session event types, key classes (`SessionEvent`, `UnknownSessionEvent`), a usage example, and cross-references to related packages.
- Added `generateRpcPackageInfo()` to emit `package-info.java` for the `com.github.copilot.generated.rpc` package. Includes Javadoc describing RPC parameter/result types, key classes (`RpcCaller`, `ServerRpc`, `SessionRpc`), and cross-references.
- Updated `main()` to call both new functions after existing generation steps. The files are regenerated on each run since the output directory is cleaned first.

## java/src/generated/java/com/github/copilot/generated/package-info.java

- New auto-generated file. Provides package-level Javadoc for the session event types package, following the same style as the hand-written `com.github.copilot` package-info.

## java/src/generated/java/com/github/copilot/generated/rpc/package-info.java

- New auto-generated file. Provides package-level Javadoc for the RPC types package, following the same style as the hand-written `com.github.copilot` package-info.