### PR TITLE
fix(nodejs): validate sendAndWait timeout to fix malformed error message

### DIFF
--- a/nodejs/src/session.ts
+++ b/nodejs/src/session.ts
@@ -286,7 +286,12 @@ export class CopilotSession {
             timeout !== undefined &&
             (typeof timeout !== "number" || !Number.isFinite(timeout) || timeout < 0)
         ) {
-            const received = typeof timeout === "number" ? `${timeout}` : typeof timeout;
+            const received =
+                timeout === null
+                    ? "null"
+                    : typeof timeout === "number"
+                      ? `${timeout}`
+                      : typeof timeout;
             throw new TypeError(
                 `sendAndWait timeout must be a non-negative number of milliseconds (got ${received})`
             );

--- a/nodejs/src/session.ts
+++ b/nodejs/src/session.ts
@@ -282,10 +282,10 @@ export class CopilotSession {
         // an object or NaN is coerced to a 0ms delay, producing a spurious
         // immediate timeout with a malformed "Timeout after [object Object]ms"
         // message instead of a clear, actionable error.
-        if (
-            timeout !== undefined &&
-            (typeof timeout !== "number" || !Number.isFinite(timeout) || timeout < 0)
-        ) {
+        const isValidTimeout =
+            timeout === undefined ||
+            (typeof timeout === "number" && Number.isFinite(timeout) && timeout >= 0);
+        if (!isValidTimeout) {
             const received =
                 timeout === null
                     ? "null"

--- a/nodejs/src/session.ts
+++ b/nodejs/src/session.ts
@@ -255,6 +255,7 @@ export class CopilotSession {
      * @param timeout - Timeout in milliseconds (default: 60000). Controls how long to wait; does not abort in-flight agent work.
      * @returns A promise that resolves with the final assistant message when the session becomes idle,
      *          or undefined if no assistant message was received
+     * @throws TypeError if `timeout` is provided but is not a non-negative finite number of milliseconds
      * @throws Error if the timeout is reached before the session becomes idle
      * @throws Error if the session has been disconnected or the connection fails
      *
@@ -276,6 +277,21 @@ export class CopilotSession {
     ): Promise<AssistantMessageEvent | undefined> {
         const options: MessageOptions =
             typeof optionsOrPrompt === "string" ? { prompt: optionsOrPrompt } : optionsOrPrompt;
+
+        // Guard against a non-numeric timeout reaching setTimeout(). Without this,
+        // an object or NaN is coerced to a 0ms delay, producing a spurious
+        // immediate timeout with a malformed "Timeout after [object Object]ms"
+        // message instead of a clear, actionable error.
+        if (
+            timeout !== undefined &&
+            (typeof timeout !== "number" || !Number.isFinite(timeout) || timeout < 0)
+        ) {
+            const received = typeof timeout === "number" ? `${timeout}` : typeof timeout;
+            throw new TypeError(
+                `sendAndWait timeout must be a non-negative number of milliseconds (got ${received})`
+            );
+        }
+
         const effectiveTimeout = timeout ?? 60_000;
 
         let resolveIdle: () => void;

--- a/nodejs/test/client.test.ts
+++ b/nodejs/test/client.test.ts
@@ -24,6 +24,38 @@ describe("CopilotClient", () => {
         expect(spy).not.toHaveBeenCalled();
     });
 
+    describe("sendAndWait timeout validation", () => {
+        // Regression for #915: a non-numeric timeout used to reach setTimeout(),
+        // which coerced it to a 0ms delay and rejected with a malformed
+        // "Timeout after [object Object]ms" message instead of a clear error.
+        it("rejects with a TypeError mentioning the received timeout type", async () => {
+            const session = new CopilotSession("session-1", {} as any);
+            await expect(session.sendAndWait("hello", { ms: 30000 } as any)).rejects.toThrow(
+                TypeError
+            );
+            await expect(session.sendAndWait("hello", { ms: 30000 } as any)).rejects.toThrowError(
+                /sendAndWait timeout must be a non-negative number of milliseconds/
+            );
+        });
+
+        it("does not produce an [object Object] message for an object timeout", async () => {
+            const session = new CopilotSession("session-1", {} as any);
+            await expect(session.sendAndWait("hello", { ms: 30000 } as any)).rejects.toThrowError(
+                /timeout must be a non-negative number of milliseconds \(got object\)/
+            );
+        });
+
+        it("rejects when timeout is NaN", async () => {
+            const session = new CopilotSession("session-1", {} as any);
+            await expect(session.sendAndWait("hello", NaN)).rejects.toThrowError(/got NaN/);
+        });
+
+        it("rejects when timeout is negative", async () => {
+            const session = new CopilotSession("session-1", {} as any);
+            await expect(session.sendAndWait("hello", -1)).rejects.toThrowError(/got -1/);
+        });
+    });
+
     it("forwards canvas declarations and request flags in session.create", async () => {
         const client = new CopilotClient();
         await client.start();

--- a/nodejs/test/client.test.ts
+++ b/nodejs/test/client.test.ts
@@ -28,31 +28,47 @@ describe("CopilotClient", () => {
         // Regression for #915: a non-numeric timeout used to reach setTimeout(),
         // which coerced it to a 0ms delay and rejected with a malformed
         // "Timeout after [object Object]ms" message instead of a clear error.
-        it("rejects with a TypeError mentioning the received timeout type", async () => {
+        async function captureRejection(promise: Promise<unknown>): Promise<Error> {
+            return promise.then(
+                () => {
+                    throw new Error("expected sendAndWait to reject");
+                },
+                (error) => error
+            );
+        }
+
+        it("rejects an object timeout with a clear TypeError", async () => {
             const session = new CopilotSession("session-1", {} as any);
-            await expect(session.sendAndWait("hello", { ms: 30000 } as any)).rejects.toThrow(
-                TypeError
+            const error = await captureRejection(
+                session.sendAndWait("hello", { ms: 30000 } as any)
             );
-            await expect(session.sendAndWait("hello", { ms: 30000 } as any)).rejects.toThrowError(
-                /sendAndWait timeout must be a non-negative number of milliseconds/
+            expect(error).toBeInstanceOf(TypeError);
+            expect(error.message).toBe(
+                "sendAndWait timeout must be a non-negative number of milliseconds (got object)"
             );
+            expect(error.message).not.toContain("[object Object]");
         });
 
-        it("does not produce an [object Object] message for an object timeout", async () => {
+        it("reports a null timeout as null rather than object", async () => {
             const session = new CopilotSession("session-1", {} as any);
-            await expect(session.sendAndWait("hello", { ms: 30000 } as any)).rejects.toThrowError(
-                /timeout must be a non-negative number of milliseconds \(got object\)/
+            const error = await captureRejection(session.sendAndWait("hello", null as any));
+            expect(error.message).toBe(
+                "sendAndWait timeout must be a non-negative number of milliseconds (got null)"
             );
         });
 
         it("rejects when timeout is NaN", async () => {
             const session = new CopilotSession("session-1", {} as any);
-            await expect(session.sendAndWait("hello", NaN)).rejects.toThrowError(/got NaN/);
+            await expect(session.sendAndWait("hello", NaN)).rejects.toThrowError(
+                "sendAndWait timeout must be a non-negative number of milliseconds (got NaN)"
+            );
         });
 
         it("rejects when timeout is negative", async () => {
             const session = new CopilotSession("session-1", {} as any);
-            await expect(session.sendAndWait("hello", -1)).rejects.toThrowError(/got -1/);
+            await expect(session.sendAndWait("hello", -1)).rejects.toThrowError(
+                "sendAndWait timeout must be a non-negative number of milliseconds (got -1)"
+            );
         });
     });
 


### PR DESCRIPTION
## Summary

Fixes the malformed timeout error reported in #915.

When `session.sendAndWait()` received a non-numeric `timeout` (e.g. an object or `NaN`), the value was passed straight to `setTimeout()`, which coerces an invalid delay to **0ms**. The session then rejected almost immediately with a misleading message:

> `Timeout after [object Object]ms waiting for session.idle`

instead of surfacing the real problem (an invalid argument).

This PR validates the `timeout` argument up front and throws a clear `TypeError` when it is not a non-negative finite number of milliseconds:

> `sendAndWait timeout must be a non-negative number of milliseconds (got object)`

This also fixes the secondary symptom of a **spurious immediate timeout** caused by the `NaN`/object → `0ms` coercion.

## Changes

- `nodejs/src/session.ts`: validate `timeout` in `sendAndWait()` before use; document the new `@throws` in the JSDoc.
- `nodejs/test/client.test.ts`: add regression tests covering object, `NaN`, and negative timeouts, asserting the error message no longer contains `[object Object]`.

## Scope note

#915 also reports that `resumeSession()` with `customAgents` never reaches `idle`. The SDK already forwards `customAgents` in the `session.resume` payload, so that behavior is on the CLI runtime side and is not addressable in this SDK. This PR therefore targets only the malformed-message bug.

## Testing

From `nodejs/`:
- `npx vitest run test/client.test.ts -t "sendAndWait timeout validation"` (fails before the fix, passes after)
- `npx vitest run test/client.test.ts` — all 111 pass
- `npm run lint` — 0 errors
- `npm run format:check` — clean
- `npm run typecheck` — clean
