### PR TITLE
Add preamble section and preserve action to SDKs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1911,9 +1911,11 @@ const session = await client.createSession({
 });
 ```
 
-Available section IDs: `identity`, `tone`, `tool_efficiency`, `environment_context`, `code_change_rules`, `guidelines`, `safety`, `tool_instructions`, `custom_instructions`, `runtime_instructions`, `last_instructions`.
+Available section IDs: `preamble`, `identity`, `tone`, `tool_efficiency`, `environment_context`, `code_change_rules`, `guidelines`, `safety`, `tool_instructions`, `custom_instructions`, `runtime_instructions`, `last_instructions`.
 
-Each override supports four actions: `replace`, `remove`, `append`, and `prepend`. Unknown section IDs are handled gracefully—content is appended to additional instructions and a warning is emitted; `remove` on unknown sections is silently ignored.
+`identity` and `tool_instructions` are section *groups*: they target a collection of related sub-sections as a unit. Use `preamble` to target just the identity preamble without affecting its sibling sub-sections.
+
+Each override supports five actions: `replace`, `remove`, `append`, `prepend`, and `preserve`. The `preserve` action is a no-op that opts an individually-addressable section out of a group-level `remove` (for example, keep `tone` when removing the `identity` group). Unknown section IDs are handled gracefully—content is appended to additional instructions and a warning is emitted; `remove` on unknown sections is silently ignored.
 
 See the language-specific SDK READMEs for examples in [TypeScript](../nodejs/README.md), [Python](../python/README.md), [Go](../go/README.md), [Rust](../rust/README.md), [Java](../java/README.md), and [C#](../dotnet/README.md).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1915,7 +1915,7 @@ Available section IDs: `preamble`, `identity`, `tone`, `tool_efficiency`, `envir
 
 `identity` and `tool_instructions` are section *groups*: they target a collection of related sub-sections as a unit. Use `preamble` to target just the identity preamble without affecting its sibling sub-sections.
 
-Each override supports five actions: `replace`, `remove`, `append`, `prepend`, and `preserve`. The `preserve` action is a no-op that opts an individually-addressable section out of a group-level `remove` (for example, keep `tone` when removing the `identity` group). Unknown section IDs are handled gracefully—content is appended to additional instructions and a warning is emitted; `remove` on unknown sections is silently ignored.
+Each override supports five actions: `replace`, `remove`, `append`, `prepend`, and `preserve`. The `preserve` action is a no-op that opts an individually-addressable section out of a group-level `remove` (for example, keep `tone` when removing the `identity` group). Unknown section IDs are handled gracefully: content from `replace`/`append`/`prepend` overrides is appended to additional instructions, and `remove` overrides are silently ignored.
 
 See the language-specific SDK READMEs for examples in [TypeScript](../nodejs/README.md), [Python](../python/README.md), [Go](../go/README.md), [Rust](../rust/README.md), [Java](../java/README.md), and [C#](../dotnet/README.md).
 

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -676,9 +676,9 @@ var session = await client.CreateSessionAsync(new SessionConfig
 });
 ```
 
-Available section IDs are defined as static properties on the `SystemMessageSection` struct: `Identity`, `Tone`, `ToolEfficiency`, `EnvironmentContext`, `CodeChangeRules`, `Guidelines`, `Safety`, `ToolInstructions`, `CustomInstructions`, `RuntimeInstructions`, `LastInstructions`.
+Available section IDs are defined as static properties on the `SystemMessageSection` struct: `Preamble`, `Identity`, `Tone`, `ToolEfficiency`, `EnvironmentContext`, `CodeChangeRules`, `Guidelines`, `Safety`, `ToolInstructions`, `CustomInstructions`, `RuntimeInstructions`, `LastInstructions`. `Identity` and `ToolInstructions` are section groups that target a collection of related sub-sections as a unit; use `Preamble` to target just the identity preamble.
 
-Each section override supports four actions: `Replace`, `Remove`, `Append`, and `Prepend`. Unknown section IDs are handled gracefully: content is appended to additional instructions, and `Remove` overrides are silently ignored.
+Each section override supports five actions: `Replace`, `Remove`, `Append`, `Prepend`, and `Preserve` (a no-op that opts an individually-addressable section out of a group-level `Remove`). Unknown section IDs are handled gracefully: content is appended to additional instructions, and `Remove` overrides are silently ignored.
 
 #### Replace Mode
 

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -1840,6 +1840,13 @@ public enum SectionOverrideAction
     /// <summary>Prepend content before the existing section.</summary>
     [JsonStringEnumMemberName("prepend")]
     Prepend,
+    /// <summary>
+    /// No-op marker that opts an individually-addressable section out of a group-level
+    /// remove (e.g. keep <see cref="SystemMessageSection.Tone"/> when removing the
+    /// <see cref="SystemMessageSection.Identity"/> group).
+    /// </summary>
+    [JsonStringEnumMemberName("preserve")]
+    Preserve,
     /// <summary>Transform the section content via a callback.</summary>
     [JsonStringEnumMemberName("transform")]
     Transform
@@ -1878,6 +1885,8 @@ public sealed class SectionOverride
 public readonly struct SystemMessageSection : IEquatable<SystemMessageSection>
 {
     /// <summary>Agent identity preamble and mode statement.</summary>
+    public static SystemMessageSection Preamble { get; } = new("preamble");
+    /// <summary>Section group covering the identity preamble and its sibling sub-sections (tone, tool efficiency, etc.).</summary>
     public static SystemMessageSection Identity { get; } = new("identity");
     /// <summary>Response style, conciseness rules, output formatting preferences.</summary>
     public static SystemMessageSection Tone { get; } = new("tone");

--- a/dotnet/test/E2E/SystemMessageSectionsE2ETests.cs
+++ b/dotnet/test/E2E/SystemMessageSectionsE2ETests.cs
@@ -40,4 +40,34 @@ public class SystemMessageSectionsE2ETests(E2ETestFixture fixture, ITestOutputHe
             content.Contains("botanica") || content.Contains("garden") || content.Contains("plant"),
             $"Expected response to reflect the replaced identity section, but got: {response.Data.Content}");
     }
+
+    [Fact]
+    public async Task Should_Use_Replaced_Preamble_Section_In_Response()
+    {
+        var session = await CreateSessionAsync(new SessionConfig
+        {
+            OnPermissionRequest = PermissionHandler.ApproveAll,
+            SystemMessage = new SystemMessageConfig
+            {
+                Mode = SystemMessageMode.Customize,
+                Sections = new Dictionary<SystemMessageSection, SectionOverride>
+                {
+                    [SystemMessageSection.Preamble] = new SectionOverride
+                    {
+                        Action = SectionOverrideAction.Replace,
+                        Content = "You are a helpful gardening assistant called Botanica. You only answer questions about plants and gardening."
+                    }
+                }
+            }
+        });
+
+        await session.SendAsync(new MessageOptions { Prompt = "Who are you?" });
+        var response = await TestHelper.GetFinalAssistantMessageAsync(session);
+
+        Assert.NotNull(response);
+        var content = response.Data.Content.ToLowerInvariant();
+        Assert.True(
+            content.Contains("botanica") || content.Contains("garden") || content.Contains("plant"),
+            $"Expected response to reflect the replaced preamble section, but got: {response.Data.Content}");
+    }
 }

--- a/go/README.md
+++ b/go/README.md
@@ -165,7 +165,7 @@ Event types: `SessionLifecycleCreated`, `SessionLifecycleDeleted`, `SessionLifec
 - `SystemMessage` (\*SystemMessageConfig): System message configuration. Supports three modes:
   - **append** (default): Appends `Content` after the SDK-managed prompt
   - **replace**: Replaces the entire prompt with `Content`
-  - **customize**: Selectively override individual sections via `Sections` map (keys: `SectionIdentity`, `SectionTone`, `SectionToolEfficiency`, `SectionEnvironmentContext`, `SectionCodeChangeRules`, `SectionGuidelines`, `SectionSafety`, `SectionToolInstructions`, `SectionCustomInstructions`, `SectionRuntimeInstructions`, `SectionLastInstructions`; values: `SectionOverride` with `Action` and optional `Content`)
+  - **customize**: Selectively override individual sections via `Sections` map (keys: `SectionPreamble`, `SectionIdentity`, `SectionTone`, `SectionToolEfficiency`, `SectionEnvironmentContext`, `SectionCodeChangeRules`, `SectionGuidelines`, `SectionSafety`, `SectionToolInstructions`, `SectionCustomInstructions`, `SectionRuntimeInstructions`, `SectionLastInstructions`; values: `SectionOverride` with `Action` and optional `Content`)
 - `Provider` (\*ProviderConfig): Custom API provider configuration (BYOK). See [Custom Providers](#custom-providers) section.
 - `Streaming` (*bool): Enable streaming delta events (nil = runtime default)
 - `InfiniteSessions` (\*InfiniteSessionConfig): Automatic context compaction configuration

--- a/go/README.md
+++ b/go/README.md
@@ -238,14 +238,17 @@ session, err := client.CreateSession(ctx, &copilot.SessionConfig{
 })
 ```
 
-Available section constants: `SectionIdentity`, `SectionTone`, `SectionToolEfficiency`, `SectionEnvironmentContext`, `SectionCodeChangeRules`, `SectionGuidelines`, `SectionSafety`, `SectionToolInstructions`, `SectionCustomInstructions`, `SectionRuntimeInstructions`, `SectionLastInstructions`.
+Available section constants: `SectionPreamble`, `SectionIdentity`, `SectionTone`, `SectionToolEfficiency`, `SectionEnvironmentContext`, `SectionCodeChangeRules`, `SectionGuidelines`, `SectionSafety`, `SectionToolInstructions`, `SectionCustomInstructions`, `SectionRuntimeInstructions`, `SectionLastInstructions`.
 
-Each section override supports four actions:
+`SectionIdentity` and `SectionToolInstructions` are section _groups_ that target a collection of related sub-sections as a unit. Use `SectionPreamble` to target just the identity preamble without affecting its sibling sub-sections.
+
+Each section override supports five actions:
 
 - **`replace`** — Replace the section content entirely
 - **`remove`** — Remove the section from the prompt
 - **`append`** — Add content after the existing section
 - **`prepend`** — Add content before the existing section
+- **`preserve`** — No-op that opts an individually-addressable section out of a group-level `remove`
 
 Unknown section IDs are handled gracefully: content from `replace`/`append`/`prepend` overrides is appended to additional instructions, and `remove` overrides are silently ignored.
 

--- a/go/internal/e2e/system_message_sections_e2e_test.go
+++ b/go/internal/e2e/system_message_sections_e2e_test.go
@@ -54,4 +54,43 @@ func TestSystemMessageSectionsE2E(t *testing.T) {
 			t.Errorf("Expected response to reflect the replaced identity section, but got: %s", ad.Content)
 		}
 	})
+
+	t.Run("should_use_replaced_preamble_section_in_response", func(t *testing.T) {
+		ctx.ConfigureForTest(t)
+
+		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
+			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+			SystemMessage: &copilot.SystemMessageConfig{
+				Mode: "customize",
+				Sections: map[string]copilot.SectionOverride{
+					copilot.SectionPreamble: {
+						Action:  copilot.SectionActionReplace,
+						Content: "You are a helpful gardening assistant called Botanica. You only answer questions about plants and gardening.",
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("Failed to create session: %v", err)
+		}
+
+		response, err := session.SendAndWait(t.Context(), copilot.MessageOptions{
+			Prompt: "Who are you?",
+		})
+		if err != nil {
+			t.Fatalf("Failed to send message: %v", err)
+		}
+		if response == nil {
+			t.Fatal("Expected a response from the assistant")
+		}
+
+		ad, ok := response.Data.(*copilot.AssistantMessageData)
+		if !ok {
+			t.Fatalf("Expected AssistantMessageData, got %T", response.Data)
+		}
+		content := strings.ToLower(ad.Content)
+		if !strings.Contains(content, "botanica") && !strings.Contains(content, "garden") && !strings.Contains(content, "plant") {
+			t.Errorf("Expected response to reflect the replaced preamble section, but got: %s", ad.Content)
+		}
+	})
 }

--- a/go/types.go
+++ b/go/types.go
@@ -215,7 +215,10 @@ func Int(v int) *int {
 
 // Known system message section identifiers for the "customize" mode.
 const (
-	// SectionIdentity is the agent identity preamble and mode statement.
+	// SectionPreamble is the agent identity preamble and mode statement.
+	SectionPreamble = "preamble"
+	// SectionIdentity is the section group covering the identity preamble and its
+	// sibling sub-sections (tone, tool efficiency, etc.).
 	SectionIdentity = "identity"
 	// SectionTone covers response style, conciseness rules, and output formatting preferences.
 	SectionTone = "tone"
@@ -254,6 +257,10 @@ const (
 	SectionActionAppend SectionOverrideAction = "append"
 	// SectionActionPrepend prepends to existing section content.
 	SectionActionPrepend SectionOverrideAction = "prepend"
+	// SectionActionPreserve is a no-op marker that opts an individually-addressable
+	// section out of a group-level "remove" (e.g. keep "tone" when removing the
+	// "identity" group).
+	SectionActionPreserve SectionOverrideAction = "preserve"
 )
 
 // SectionTransformFn is a callback that receives the current content of a system message section

--- a/java/src/main/java/com/github/copilot/rpc/SectionOverrideAction.java
+++ b/java/src/main/java/com/github/copilot/rpc/SectionOverrideAction.java
@@ -29,6 +29,13 @@ public enum SectionOverrideAction {
     PREPEND("prepend"),
 
     /**
+     * No-op marker that opts an individually-addressable section out of a
+     * group-level {@link #REMOVE} (e.g. keep {@link SystemMessageSections#TONE}
+     * when removing the {@link SystemMessageSections#IDENTITY} group).
+     */
+    PRESERVE("preserve"),
+
+    /**
      * Transform the section content via a callback.
      * <p>
      * When this action is used, the {@link SectionOverride#getTransform()} callback

--- a/java/src/main/java/com/github/copilot/rpc/SystemMessageSections.java
+++ b/java/src/main/java/com/github/copilot/rpc/SystemMessageSections.java
@@ -28,6 +28,12 @@ package com.github.copilot.rpc;
 public abstract sealed class SystemMessageSections permits SystemPromptSections {
 
     /** Agent identity preamble and mode statement. */
+    public static final String PREAMBLE = "preamble";
+
+    /**
+     * Section group covering the identity preamble and its sibling sub-sections
+     * (tone, tool efficiency, etc.).
+     */
     public static final String IDENTITY = "identity";
 
     /** Response style, conciseness rules, output formatting preferences. */

--- a/java/src/test/java/com/github/copilot/SystemMessageSectionsIT.java
+++ b/java/src/test/java/com/github/copilot/SystemMessageSectionsIT.java
@@ -118,6 +118,7 @@ class SystemMessageSectionsIT {
      */
     @Test
     void deprecatedSystemPromptSectionsMatchesSystemMessageSections() {
+        assertEquals(SystemMessageSections.PREAMBLE, SystemPromptSections.PREAMBLE);
         assertEquals(SystemMessageSections.IDENTITY, SystemPromptSections.IDENTITY);
         assertEquals(SystemMessageSections.TONE, SystemPromptSections.TONE);
         assertEquals(SystemMessageSections.TOOL_EFFICIENCY, SystemPromptSections.TOOL_EFFICIENCY);
@@ -143,7 +144,7 @@ class SystemMessageSectionsIT {
                         && Modifier.isFinal(f.getModifiers()) && f.getType() == String.class)
                 .map(Field::getName).collect(Collectors.toSet());
 
-        assertEquals(11, parentConstants.size(), "Expected 11 section constants in SystemMessageSections");
+        assertEquals(12, parentConstants.size(), "Expected 12 section constants in SystemMessageSections");
 
         for (String constantName : parentConstants) {
             Field parentField = SystemMessageSections.class.getDeclaredField(constantName);
@@ -183,6 +184,43 @@ class SystemMessageSectionsIT {
                 String content = response.getData().content().toLowerCase();
                 assertTrue(content.contains("botanica") || content.contains("garden") || content.contains("plant"),
                         "Expected response to reflect the replaced identity section, but got: "
+                                + response.getData().content());
+            } finally {
+                session.close();
+            }
+        }
+    }
+
+    /**
+     * Verifies that replacing the {@link SystemMessageSections#PREAMBLE} section
+     * via {@link SectionOverrideAction#REPLACE} causes the assistant to adopt the
+     * custom identity in its response without affecting sibling sections.
+     *
+     * @see Snapshot:
+     *      system_message_sections/should_use_replaced_preamble_section_in_response
+     */
+    @Test
+    void shouldUseReplacedPreambleSectionInResponse() throws Exception {
+        ctx.configureForTest("system_message_sections", "should_use_replaced_preamble_section_in_response");
+
+        var systemMessage = new SystemMessageConfig().setMode(SystemMessageMode.CUSTOMIZE)
+                .setSections(Map.of(SystemMessageSections.PREAMBLE,
+                        new SectionOverride().setAction(SectionOverrideAction.REPLACE)
+                                .setContent("You are a helpful gardening assistant called Botanica. "
+                                        + "You only answer questions about plants and gardening.")));
+
+        try (CopilotClient client = ctx.createClient()) {
+            CopilotSession session = client.createSession(new SessionConfig().setSystemMessage(systemMessage)
+                    .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)).get(30, TimeUnit.SECONDS);
+
+            try {
+                AssistantMessageEvent response = session
+                        .sendAndWait(new MessageOptions().setPrompt("Who are you?"), 60_000).get(90, TimeUnit.SECONDS);
+
+                assertNotNull(response, "Expected a response from the assistant");
+                String content = response.getData().content().toLowerCase();
+                assertTrue(content.contains("botanica") || content.contains("garden") || content.contains("plant"),
+                        "Expected response to reflect the replaced preamble section, but got: "
                                 + response.getData().content());
             } finally {
                 session.close();

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -618,14 +618,17 @@ const session = await client.createSession({
 });
 ```
 
-Available section IDs: `identity`, `tone`, `tool_efficiency`, `environment_context`, `code_change_rules`, `guidelines`, `safety`, `tool_instructions`, `custom_instructions`, `runtime_instructions`, `last_instructions`. Use the `SYSTEM_MESSAGE_SECTIONS` constant for descriptions of each section.
+Available section IDs: `preamble`, `identity`, `tone`, `tool_efficiency`, `environment_context`, `code_change_rules`, `guidelines`, `safety`, `tool_instructions`, `custom_instructions`, `runtime_instructions`, `last_instructions`. Use the `SYSTEM_MESSAGE_SECTIONS` constant for descriptions of each section.
 
-Each section override supports four actions:
+`identity` and `tool_instructions` are section _groups_ that target a collection of related sub-sections as a unit. Use `preamble` to target just the identity preamble without affecting its sibling sub-sections.
+
+Each section override supports five actions:
 
 - **`replace`** — Replace the section content entirely
 - **`remove`** — Remove the section from the prompt
 - **`append`** — Add content after the existing section
 - **`prepend`** — Add content before the existing section
+- **`preserve`** — No-op that opts an individually-addressable section out of a group-level `remove`
 
 Unknown section IDs are handled gracefully: content from `replace`/`append`/`prepend` overrides is appended to additional instructions, and `remove` overrides are silently ignored.
 

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -835,6 +835,7 @@ export interface ToolCallResponsePayload {
  * Each section corresponds to a distinct part of the system prompt.
  */
 export type SystemMessageSection =
+    | "preamble"
     | "identity"
     | "tone"
     | "tool_efficiency"
@@ -849,7 +850,11 @@ export type SystemMessageSection =
 
 /** Section metadata for documentation and tooling. */
 export const SYSTEM_MESSAGE_SECTIONS: Record<SystemMessageSection, { description: string }> = {
-    identity: { description: "Agent identity preamble and mode statement" },
+    preamble: { description: "Agent identity preamble and mode statement" },
+    identity: {
+        description:
+            "Section group covering the identity preamble and its sibling sub-sections (tone, tool efficiency, etc.)",
+    },
     tone: { description: "Response style, conciseness rules, output formatting preferences" },
     tool_efficiency: { description: "Tool usage patterns, parallel calling, batching guidelines" },
     environment_context: { description: "CWD, OS, git root, directory listing, available tools" },
@@ -880,6 +885,8 @@ export type SectionTransformFn = (currentContent: string) => string | Promise<st
  * - `"remove"`: Remove the section
  * - `"append"`: Append to existing section content
  * - `"prepend"`: Prepend to existing section content
+ * - `"preserve"`: No-op marker that opts an individually-addressable section out of a
+ *   group-level `"remove"` (e.g. keep `tone` when removing the `identity` group)
  * - `function`: Transform callback — receives current section content, returns new content
  */
 export type SectionOverrideAction =
@@ -887,6 +894,7 @@ export type SectionOverrideAction =
     | "remove"
     | "append"
     | "prepend"
+    | "preserve"
     | SectionTransformFn;
 
 /**

--- a/nodejs/test/e2e/system_message_sections.e2e.test.ts
+++ b/nodejs/test/e2e/system_message_sections.e2e.test.ts
@@ -35,4 +35,31 @@ describe("System message sections", async () => {
 
         await session.disconnect();
     });
+
+    it("should_use_replaced_preamble_section_in_response", async () => {
+        const session = await client.createSession({
+            onPermissionRequest: approveAll,
+            systemMessage: {
+                mode: "customize",
+                sections: {
+                    preamble: {
+                        action: "replace",
+                        content:
+                            "You are a helpful gardening assistant called Botanica. You only answer questions about plants and gardening.",
+                    },
+                },
+            },
+        });
+
+        const response = await session.sendAndWait({ prompt: "Who are you?" });
+
+        expect(response).not.toBeNull();
+        const content = response!.data.content.toLowerCase();
+        expect(
+            content.includes("botanica") || content.includes("garden") || content.includes("plant"),
+            `Expected response to reflect the replaced preamble section, but got: ${response!.data.content}`
+        ).toBe(true);
+
+        await session.disconnect();
+    });
 });

--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -253,10 +253,17 @@ class SystemMessageReplaceConfig(TypedDict):
 SectionTransformFn = Callable[[str], str | Awaitable[str]]
 """Transform callback: receives current section content, returns new content."""
 
-SectionOverrideAction = Literal["replace", "remove", "append", "prepend"] | SectionTransformFn
-"""Override action: a string literal for static overrides, or a callback for transforms."""
+SectionOverrideAction = (
+    Literal["replace", "remove", "append", "prepend", "preserve"] | SectionTransformFn
+)
+"""Override action: a string literal for static overrides, or a callback for transforms.
+
+``"preserve"`` is a no-op marker that opts an individually-addressable section out of a
+group-level ``"remove"`` (e.g. keep ``tone`` when removing the ``identity`` group).
+"""
 
 SystemMessageSection = Literal[
+    "preamble",
     "identity",
     "tone",
     "tool_efficiency",
@@ -271,7 +278,11 @@ SystemMessageSection = Literal[
 ]
 
 SYSTEM_MESSAGE_SECTIONS: dict[SystemMessageSection, str] = {
-    "identity": "Agent identity preamble and mode statement",
+    "preamble": "Agent identity preamble and mode statement",
+    "identity": (
+        "Section group covering the identity preamble and its sibling sub-sections"
+        " (tone, tool efficiency, etc.)"
+    ),
     "tone": "Response style, conciseness rules, output formatting preferences",
     "tool_efficiency": "Tool usage patterns, parallel calling, batching guidelines",
     "environment_context": "CWD, OS, git root, directory listing, available tools",

--- a/python/e2e/test_system_message_sections_e2e.py
+++ b/python/e2e/test_system_message_sections_e2e.py
@@ -44,7 +44,7 @@ class TestSystemMessageSections:
         await session.disconnect()
 
     async def test_should_use_replaced_preamble_section_in_response(self, ctx: E2ETestContext):
-        """Test that replacing only the preamble section causes the assistant to adopt a new persona"""
+        """Test that replacing only the preamble section changes the assistant persona"""
         session = await ctx.client.create_session(
             system_message={
                 "mode": "customize",

--- a/python/e2e/test_system_message_sections_e2e.py
+++ b/python/e2e/test_system_message_sections_e2e.py
@@ -42,3 +42,32 @@ class TestSystemMessageSections:
         )
 
         await session.disconnect()
+
+    async def test_should_use_replaced_preamble_section_in_response(self, ctx: E2ETestContext):
+        """Test that replacing only the preamble section causes the assistant to adopt a new persona"""
+        session = await ctx.client.create_session(
+            system_message={
+                "mode": "customize",
+                "sections": {
+                    "preamble": {
+                        "action": "replace",
+                        "content": (
+                            "You are a helpful gardening assistant called Botanica."
+                            " You only answer questions about plants and gardening."
+                        ),
+                    },
+                },
+            },
+            on_permission_request=PermissionHandler.approve_all,
+        )
+
+        response = await session.send_and_wait("Who are you?")
+
+        assert response is not None, "Expected a response from the assistant"
+        content = response.data.content.lower()
+        assert "botanica" in content or "garden" in content or "plant" in content, (
+            f"Expected response to reflect the replaced preamble section,"
+            f" but got: {response.data.content}"
+        )
+
+        await session.disconnect()

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -3596,11 +3596,12 @@ impl SystemMessageConfig {
 ///
 /// Used within [`SystemMessageConfig::sections`] when `mode` is `"customize"`.
 /// The `action` field determines the operation: `"replace"`, `"remove"`,
-/// `"append"`, `"prepend"`, or `"transform"`.
+/// `"append"`, `"prepend"`, `"preserve"`, or `"transform"`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SectionOverride {
-    /// Override action: `"replace"`, `"remove"`, `"append"`, `"prepend"`, or `"transform"`.
+    /// Override action: `"replace"`, `"remove"`, `"append"`, `"prepend"`,
+    /// `"preserve"`, or `"transform"`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub action: Option<String>,
     /// Content for the override operation.

--- a/rust/tests/e2e/system_message_sections.rs
+++ b/rust/tests/e2e/system_message_sections.rs
@@ -57,3 +57,57 @@ async fn should_use_replaced_identity_section_in_response() {
     )
     .await;
 }
+
+#[tokio::test]
+async fn should_use_replaced_preamble_section_in_response() {
+    with_e2e_context(
+        "system_message_sections",
+        "should_use_replaced_preamble_section_in_response",
+        |ctx| {
+            Box::pin(async move {
+                ctx.set_default_copilot_user();
+                let mut sections = HashMap::new();
+                sections.insert(
+                    "preamble".to_string(),
+                    SectionOverride {
+                        action: Some("replace".to_string()),
+                        content: Some(
+                            "You are a helpful gardening assistant called Botanica. \
+                             You only answer questions about plants and gardening."
+                                .to_string(),
+                        ),
+                    },
+                );
+                let client = ctx.start_client().await;
+                let session = client
+                    .create_session(
+                        ctx.approve_all_session_config().with_system_message(
+                            SystemMessageConfig::new()
+                                .with_mode("customize")
+                                .with_sections(sections),
+                        ),
+                    )
+                    .await
+                    .expect("create session");
+
+                let answer = session
+                    .send_and_wait("Who are you?")
+                    .await
+                    .expect("send")
+                    .expect("assistant message");
+                let content = assistant_message_content(&answer).to_lowercase();
+                assert!(
+                    content.contains("botanica")
+                        || content.contains("garden")
+                        || content.contains("plant"),
+                    "Expected response to reflect the replaced preamble section, but got: {}",
+                    assistant_message_content(&answer)
+                );
+
+                session.disconnect().await.expect("disconnect session");
+                client.stop().await.expect("stop client");
+            })
+        },
+    )
+    .await;
+}

--- a/test/snapshots/system_message_sections/should_use_replaced_preamble_section_in_response.yaml
+++ b/test/snapshots/system_message_sections/should_use_replaced_preamble_section_in_response.yaml
@@ -1,0 +1,17 @@
+models:
+  - claude-sonnet-4.5
+conversations:
+  - messages:
+      - role: system
+        content: ${system}
+      - role: user
+        content: Who are you?
+      - role: assistant
+        content: >-
+          I'm **Botanica**, your helpful gardening assistant! 🌱 I'm here to answer questions about plants, gardening,
+          horticulture, and everything related to growing and caring for greenery. Whether you need advice on soil,
+          watering, pests, plant identification, or growing tips, I'm here to help!
+
+
+          I'm powered by claude-sonnet-4.5, but I focus specifically on gardening topics. What plant or gardening
+          question can I help you with today?


### PR DESCRIPTION
## Why

The runtime recently reworked system prompt customization ([copilot-agent-runtime#10025](https://github.com/github/copilot-agent-runtime/pull/10025)) to fix a bug where `identity: { action: "replace" }` silently deleted sibling sections (tone, tool efficiency, etc.). That fix introduced a new `preamble` section ID and a new `preserve` action, but the SDKs didn't expose either, so clients couldn't target just the identity preamble or opt a section out of a group-level remove.

## What

This brings all six SDKs in line with the new runtime model:

* **New `preamble` section** — targets just the identity preamble without touching its sibling sub-sections. The `identity` and `tool_instructions` IDs are now documented as section *groups*.
* **New `preserve` action** — a no-op that protects an individually-addressable section (e.g. `tone`) from a group-level `remove` on its parent group.

Changes are applied consistently across the type/constant definitions for Node, Go, Python, .NET, and Java. Rust uses free-form section/action strings, so only its doc comments needed updating. Docs in `getting-started.md` and the Node/Go/.NET READMEs are updated to describe the groups and the fifth action.

## Tests

Added an end-to-end `should_use_replaced_preamble_section_in_response` test to all six SDKs, backed by a shared replay snapshot under `test/snapshots/`. The test replaces the `preamble` section with a custom persona and asserts the persona surfaces in the assistant's reply, validating the customization flows through the full SDK -> RPC -> CLI stack.

A couple of notes for reviewers:

* The snapshot was recorded against the real Copilot API (not hand-authored), then verified to replay cleanly. The replay proxy normalizes the system prompt to a `${system}` placeholder, so the test asserts on observable assistant output rather than raw prompt bytes.
* The Java test that asserts the exact count of section constants was bumped from 11 to 12 to account for `PREAMBLE`.
* A `preserve`-specific E2E test was intentionally omitted: its effect lives entirely in the system-prompt bytes that the harness normalizes away, so it would carry no real signal. The constant additions are the meaningful SDK surface here.

Verified: Node/Go/Python E2E pass on replay; .NET/Java/Rust compile and format clean.