### PR TITLE
Add Go low-level tool-definition E2E test [2/6]

### DIFF
--- a/go/internal/e2e/tools_e2e_test.go
+++ b/go/internal/e2e/tools_e2e_test.go
@@ -94,19 +94,23 @@ func TestToolsE2E(t *testing.T) {
 			Keyword string `json:"keyword" jsonschema:"Search keyword"`
 		}
 
+		var mu sync.Mutex
 		currentPhase := ""
+		searchKeyword := ""
 
 		setCurrentPhaseTool := copilot.DefineTool("set_current_phase", "Sets the current phase of the agent",
 			func(params PhaseArgs, inv copilot.ToolInvocation) (string, error) {
+				mu.Lock()
 				currentPhase = params.Phase
+				mu.Unlock()
 				return "Phase set to " + params.Phase, nil
 			})
 
 		searchItemsTool := copilot.DefineTool("search_items", "Search for items by keyword",
 			func(params SearchArgs, inv copilot.ToolInvocation) (string, error) {
-				if params.Keyword != "copilot" {
-					t.Fatalf("Expected keyword to be 'copilot', got %q", params.Keyword)
-				}
+				mu.Lock()
+				searchKeyword = params.Keyword
+				mu.Unlock()
 				return "Found: item_alpha, item_beta", nil
 			})
 
@@ -153,8 +157,15 @@ func TestToolsE2E(t *testing.T) {
 		if !strings.Contains(lower, "item_alpha") && !strings.Contains(lower, "item_beta") {
 			t.Errorf("Expected response to contain 'item_alpha' or 'item_beta', got %q", content)
 		}
-		if currentPhase != "analyzing" {
-			t.Errorf("Expected currentPhase to be 'analyzing', got %q", currentPhase)
+		mu.Lock()
+		gotPhase := currentPhase
+		gotKeyword := searchKeyword
+		mu.Unlock()
+		if gotKeyword != "copilot" {
+			t.Errorf("Expected search keyword to be 'copilot', got %q", gotKeyword)
+		}
+		if gotPhase != "analyzing" {
+			t.Errorf("Expected currentPhase to be 'analyzing', got %q", gotPhase)
 		}
 	})
 

--- a/go/internal/e2e/tools_e2e_test.go
+++ b/go/internal/e2e/tools_e2e_test.go
@@ -84,6 +84,80 @@ func TestToolsE2E(t *testing.T) {
 		}
 	})
 
+	t.Run("low_level_tool_definition", func(t *testing.T) {
+		ctx.ConfigureForTest(t)
+
+		type PhaseArgs struct {
+			Phase string `json:"phase" jsonschema:"Current phase,enum=searching,enum=analyzing,enum=done"`
+		}
+		type SearchArgs struct {
+			Keyword string `json:"keyword" jsonschema:"Search keyword"`
+		}
+
+		currentPhase := ""
+
+		setCurrentPhaseTool := copilot.DefineTool("set_current_phase", "Sets the current phase of the agent",
+			func(params PhaseArgs, inv copilot.ToolInvocation) (string, error) {
+				currentPhase = params.Phase
+				return "Phase set to " + params.Phase, nil
+			})
+
+		searchItemsTool := copilot.DefineTool("search_items", "Search for items by keyword",
+			func(params SearchArgs, inv copilot.ToolInvocation) (string, error) {
+				if params.Keyword != "copilot" {
+					t.Fatalf("Expected keyword to be 'copilot', got %q", params.Keyword)
+				}
+				return "Found: item_alpha, item_beta", nil
+			})
+
+		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
+			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+			AvailableTools:      copilot.NewToolSet().AddCustom("*").AddBuiltIn("web_fetch").ToSlice(),
+			Tools: []copilot.Tool{
+				setCurrentPhaseTool,
+				searchItemsTool,
+			},
+		})
+		if err != nil {
+			t.Fatalf("Failed to create session: %v", err)
+		}
+
+		_, err = session.Send(t.Context(), copilot.MessageOptions{
+			Prompt: "First, set the current phase to 'analyzing'. Then search for items with keyword 'copilot'. Report the phase and search results.",
+		})
+		if err != nil {
+			t.Fatalf("Failed to send message: %v", err)
+		}
+
+		answer, err := testharness.GetFinalAssistantMessage(t.Context(), session)
+		if err != nil {
+			t.Fatalf("Failed to get assistant message: %v", err)
+		}
+
+		if answer == nil {
+			t.Fatalf("Expected non-nil assistant message")
+		}
+		ad, ok := answer.Data.(*copilot.AssistantMessageData)
+		if !ok {
+			t.Fatalf("Expected AssistantMessageData")
+		}
+
+		content := ad.Content
+		if content == "" {
+			t.Fatalf("Expected non-empty response")
+		}
+		lower := strings.ToLower(content)
+		if !strings.Contains(lower, "analyzing") {
+			t.Errorf("Expected response to contain 'analyzing', got %q", content)
+		}
+		if !strings.Contains(lower, "item_alpha") && !strings.Contains(lower, "item_beta") {
+			t.Errorf("Expected response to contain 'item_alpha' or 'item_beta', got %q", content)
+		}
+		if currentPhase != "analyzing" {
+			t.Errorf("Expected currentPhase to be 'analyzing', got %q", currentPhase)
+		}
+	})
+
 	t.Run("handles tool calling errors", func(t *testing.T) {
 		ctx.ConfigureForTest(t)
 


### PR DESCRIPTION
## Summary

Adds the Go low-level tool-definition E2E scenario to `go/internal/e2e/tools_e2e_test.go` as part of the PR-1692 breakout sequence.

This PR is related to issue #1682 but does **not** fix #1682.

## What changed

- Adds `low_level_tool_definition` coverage in Go E2E tests.
- Reuses the shared snapshot introduced by PR #1721:
  - `test/snapshots/tools/low_level_tool_definition.yaml`
- Keeps the test aligned with snapshot behavior by defining only the tools that the snapshot actually exercises (`set_current_phase`, `search_items`).
- Validates decoded keyword arguments in the search tool path.

## Dependency / sequencing

- Depends on PR #1721 being merged first (already merged), because it introduces the shared snapshot used by this test.
- Part of the #1692 breakout plan (PR 2 of 6).

## Related

- Issue: #1682 (not fixed by this PR)
- PR #1721
- Original combined PR: #1692