### PR TITLE
Add .NET low-level tool-definition E2E test [6/6]

### DIFF
--- a/dotnet/test/E2E/SessionLifecycleE2ETests.cs
+++ b/dotnet/test/E2E/SessionLifecycleE2ETests.cs
@@ -25,7 +25,7 @@ public class SessionLifecycleE2ETests(E2ETestFixture fixture, ITestOutputHelper 
 
         // Sessions must have activity to be persisted to disk
         await session1.SendAndWaitAsync(new MessageOptions { Prompt = "Say hello" });
-        await session2.SendAndWaitAsync(new MessageOptions { Prompt = "Say hi" });
+        await session2.SendAndWaitAsync(new MessageOptions { Prompt = "Say world" });
 
         IList<SessionMetadata>? sessions = null;
         await TestHelper.WaitForConditionAsync(

--- a/dotnet/test/E2E/SessionLifecycleE2ETests.cs
+++ b/dotnet/test/E2E/SessionLifecycleE2ETests.cs
@@ -25,7 +25,7 @@ public class SessionLifecycleE2ETests(E2ETestFixture fixture, ITestOutputHelper 
 
         // Sessions must have activity to be persisted to disk
         await session1.SendAndWaitAsync(new MessageOptions { Prompt = "Say hello" });
-        await session2.SendAndWaitAsync(new MessageOptions { Prompt = "Say world" });
+        await session2.SendAndWaitAsync(new MessageOptions { Prompt = "Say hi" });
 
         IList<SessionMetadata>? sessions = null;
         await TestHelper.WaitForConditionAsync(

--- a/dotnet/test/E2E/ToolsE2ETests.cs
+++ b/dotnet/test/E2E/ToolsE2ETests.cs
@@ -62,6 +62,59 @@ public partial class ToolsE2ETests(E2ETestFixture fixture, ITestOutputHelper out
     }
 
     [Fact]
+    public async Task Low_Level_Tool_Definition()
+    {
+        string currentPhase = string.Empty;
+
+        var session = await CreateSessionAsync(new SessionConfig
+        {
+            Tools =
+            [
+                AIFunctionFactory.Create(SetCurrentPhase, new AIFunctionFactoryOptions
+                {
+                    Name = "set_current_phase",
+                    Description = "Sets the current phase of the agent",
+                }),
+                AIFunctionFactory.Create(SearchItems, new AIFunctionFactoryOptions
+                {
+                    Name = "search_items",
+                    Description = "Search for items by keyword",
+                }),
+            ],
+            AvailableTools = new ToolSet().AddCustom("*").AddBuiltIn("web_fetch"),
+            OnPermissionRequest = PermissionHandler.ApproveAll,
+        });
+
+        await session.SendAsync(new MessageOptions
+        {
+            Prompt = "First, set the current phase to 'analyzing'. Then search for items with keyword 'copilot'. Report the phase and search results."
+        });
+
+        var assistantMessage = await TestHelper.GetFinalAssistantMessageAsync(session);
+
+        Assert.NotNull(assistantMessage);
+        var content = assistantMessage!.Data.Content ?? string.Empty;
+        Assert.NotEmpty(content);
+        Assert.Contains("analyzing", content, StringComparison.OrdinalIgnoreCase);
+        Assert.True(content.Contains("item_alpha", StringComparison.OrdinalIgnoreCase)
+            || content.Contains("item_beta", StringComparison.OrdinalIgnoreCase),
+            $"Expected content to mention item_alpha or item_beta, got: {content}");
+        Assert.Equal("analyzing", currentPhase);
+
+        Task<string> SetCurrentPhase(string phase)
+        {
+            currentPhase = phase;
+            return Task.FromResult($"Phase set to {phase}");
+        }
+
+        Task<string> SearchItems(AIFunctionArguments args)
+        {
+            Assert.Equal("copilot", args["keyword"]?.ToString());
+            return Task.FromResult("Found: item_alpha, item_beta");
+        }
+    }
+
+    [Fact]
     public async Task Handles_Tool_Calling_Errors()
     {
         var getUserLocation = AIFunctionFactory.Create(


### PR DESCRIPTION
## Summary

Adds .NET low-level tool-definition E2E coverage and includes the session-lifecycle replay prompt alignment fix.

This PR is related to issue #1682 but does **not** fix #1682.

## What changed

- Adds `Low_Level_Tool_Definition` coverage in:
  - `dotnet/test/E2E/ToolsE2ETests.cs`
- Includes session-lifecycle prompt alignment fix:
  - `dotnet/test/E2E/SessionLifecycleE2ETests.cs`
- Reuses the shared low-level snapshot introduced by PR #1721:
  - `test/snapshots/tools/low_level_tool_definition.yaml`
- Aligns low-level tool definitions with snapshot-exercised paths only and validates keyword argument handling in the search tool.

## Dependency / sequencing

- Depends on PR #1721 being merged first (already merged).
- Part of the #1692 breakout plan (PR 6 of 6).

## Related

- Issue: #1682 (not fixed by this PR)
- PR #1721
- Original combined PR: #1692