### PR TITLE
normalize-sharing-prompts-during-iteration

### DIFF
--- a/.github/workflows/block-remove-before-merge.yml
+++ b/.github/workflows/block-remove-before-merge.yml
@@ -1,0 +1,27 @@
+name: "Block remove-before-merge paths"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  check-paths:
+    name: "No remove-before-merge directories"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for remove-before-merge paths in PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          FILES=$(gh api repos/$REPO/pulls/$PR_NUMBER/files --paginate --jq '.[].filename')
+          BLOCKED=$(echo "$FILES" | grep -E '(^|/)[-a-zA-Z0-9_]+-remove-before-merge(/|$)' || true)
+          if [ -n "$BLOCKED" ]; then
+            echo "::error::This PR contains files under a 'remove-before-merge' directory. Remove them before merging."
+            echo ""
+            echo "Offending paths:"
+            echo "$BLOCKED"
+            exit 1
+          fi
+          echo "No remove-before-merge paths found. ✅"

--- a/.github/workflows/block-remove-before-merge.yml
+++ b/.github/workflows/block-remove-before-merge.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
+
+permissions:
+  pull-requests: read
+
 jobs:
   check-paths:
     name: "No remove-before-merge directories"

--- a/.github/workflows/block-remove-before-merge.yml
+++ b/.github/workflows/block-remove-before-merge.yml
@@ -3,7 +3,7 @@ name: "Block remove-before-merge paths"
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-
+  merge_group:
 jobs:
   check-paths:
     name: "No remove-before-merge directories"


### PR DESCRIPTION
`.github/workflows/block-remove-before-merge.yml`

I find it useful to store prompt and design files in a directory such as `1682-java-tool-ergonomics-prompts-remove-before-merge` and have them live on the topic branch during iteration. But I never want to accidentally have those files merged.

This workflow prevents such accidental merges from happening.