### PR TITLE
Fix codegen schema resolution for new @github/copilot package layout

### DIFF
--- a/java/scripts/codegen/java.ts
+++ b/java/scripts/codegen/java.ts
@@ -176,7 +176,11 @@ async function resolveCopilotSchemaPath(fileName: string): Promise<string> {
                     candidates.push(path.join(githubScopeDir, entry, "schemas", fileName));
                 }
             }
-        } catch {
+        } catch (err) {
+            const code = (err as NodeJS.ErrnoException).code;
+            if (code !== "ENOENT" && code !== "ENOTDIR") {
+                throw err;
+            }
             // @github scope directory may not exist; try the next location.
         }
     }
@@ -190,7 +194,7 @@ async function resolveCopilotSchemaPath(fileName: string): Promise<string> {
         }
     }
 
-    throw new Error(`${fileName} not found. Run 'npm ci' in scripts/codegen first.`);
+    throw new Error(`${fileName} not found. Run 'npm ci' in java/scripts/codegen or java/nodejs first.`);
 }
 
 async function getSessionEventsSchemaPath(): Promise<string> {

--- a/java/scripts/codegen/java.ts
+++ b/java/scripts/codegen/java.ts
@@ -148,36 +148,57 @@ function toEnumConstant(value: string): string {
 
 // ── Schema path resolution ───────────────────────────────────────────────────
 
-async function getSessionEventsSchemaPath(): Promise<string> {
-    const candidates = [
-        path.join(REPO_ROOT, "scripts/codegen/node_modules/@github/copilot/schemas/session-events.schema.json"),
-        path.join(REPO_ROOT, "nodejs/node_modules/@github/copilot/schemas/session-events.schema.json"),
+/**
+ * Resolve a JSON schema shipped by the `@github/copilot` CLI package.
+ *
+ * The CLI package layout changed in 1.0.64-1: the umbrella `@github/copilot`
+ * package became a thin loader and its bundled assets (including the JSON
+ * schemas) moved into the platform-specific packages installed as optional
+ * dependencies, e.g. `@github/copilot-linux-x64` or `@github/copilot-win32-x64`.
+ *
+ * We search both the Java codegen install (`scripts/codegen/node_modules`) and
+ * the Node SDK install (`nodejs/node_modules`), checking the umbrella package
+ * first (older versions) and then whichever platform package is present.
+ */
+async function resolveCopilotSchemaPath(fileName: string): Promise<string> {
+    const nodeModulesDirs = [
+        path.join(REPO_ROOT, "scripts/codegen/node_modules"),
+        path.join(REPO_ROOT, "nodejs/node_modules"),
     ];
-    for (const p of candidates) {
+
+    const candidates: string[] = [];
+    for (const nodeModulesDir of nodeModulesDirs) {
+        candidates.push(path.join(nodeModulesDir, "@github/copilot/schemas", fileName));
+        const githubScopeDir = path.join(nodeModulesDir, "@github");
         try {
-            await fs.access(p);
-            return p;
+            for (const entry of await fs.readdir(githubScopeDir)) {
+                if (entry.startsWith("copilot-")) {
+                    candidates.push(path.join(githubScopeDir, entry, "schemas", fileName));
+                }
+            }
         } catch {
-            // try next
+            // @github scope directory may not exist; try the next location.
         }
     }
-    throw new Error("session-events.schema.json not found. Run 'npm ci' in scripts/codegen first.");
+
+    for (const candidate of candidates) {
+        try {
+            await fs.access(candidate);
+            return candidate;
+        } catch {
+            // Try the next candidate.
+        }
+    }
+
+    throw new Error(`${fileName} not found. Run 'npm ci' in scripts/codegen first.`);
+}
+
+async function getSessionEventsSchemaPath(): Promise<string> {
+    return resolveCopilotSchemaPath("session-events.schema.json");
 }
 
 async function getApiSchemaPath(): Promise<string> {
-    const candidates = [
-        path.join(REPO_ROOT, "scripts/codegen/node_modules/@github/copilot/schemas/api.schema.json"),
-        path.join(REPO_ROOT, "nodejs/node_modules/@github/copilot/schemas/api.schema.json"),
-    ];
-    for (const p of candidates) {
-        try {
-            await fs.access(p);
-            return p;
-        } catch {
-            // try next
-        }
-    }
-    throw new Error("api.schema.json not found. Run 'npm ci' in scripts/codegen first.");
+    return resolveCopilotSchemaPath("api.schema.json");
 }
 
 // ── File writing ─────────────────────────────────────────────────────────────

--- a/scripts/codegen/utils.ts
+++ b/scripts/codegen/utils.ts
@@ -45,23 +45,55 @@ export type SchemaWithSharedDefinitions<T extends JSONSchema7 = JSONSchema7> = T
 };
 // ── Schema paths ────────────────────────────────────────────────────────────
 
-export async function getSessionEventsSchemaPath(): Promise<string> {
-    const schemaPath = path.join(
-        REPO_ROOT,
-        "nodejs/node_modules/@github/copilot/schemas/session-events.schema.json"
+const SDK_NODE_MODULES = path.join(REPO_ROOT, "nodejs/node_modules");
+
+/**
+ * Resolve a JSON schema shipped by the `@github/copilot` CLI package.
+ *
+ * The CLI package layout changed in 1.0.64-1: the umbrella `@github/copilot`
+ * package became a thin loader and its bundled assets (including the JSON
+ * schemas) moved into the platform-specific packages installed as optional
+ * dependencies, e.g. `@github/copilot-linux-x64` or `@github/copilot-win32-x64`.
+ *
+ * To support both layouts we look in the umbrella package first (older
+ * versions) and then in whichever platform package was installed for the
+ * current host.
+ */
+async function resolveCopilotSchemaPath(nodeModulesDir: string, fileName: string): Promise<string> {
+    const candidates = [path.join(nodeModulesDir, "@github/copilot/schemas", fileName)];
+
+    const githubScopeDir = path.join(nodeModulesDir, "@github");
+    try {
+        for (const entry of await fs.readdir(githubScopeDir)) {
+            if (entry.startsWith("copilot-")) {
+                candidates.push(path.join(githubScopeDir, entry, "schemas", fileName));
+            }
+        }
+    } catch {
+        // @github scope directory may not exist yet; fall through to the error below.
+    }
+
+    for (const candidate of candidates) {
+        try {
+            await fs.access(candidate);
+            return candidate;
+        } catch {
+            // Try the next candidate.
+        }
+    }
+
+    throw new Error(
+        `${fileName} not found under ${githubScopeDir}. Run 'npm ci' in nodejs/ first.`
     );
-    await fs.access(schemaPath);
-    return schemaPath;
+}
+
+export async function getSessionEventsSchemaPath(): Promise<string> {
+    return resolveCopilotSchemaPath(SDK_NODE_MODULES, "session-events.schema.json");
 }
 
 export async function getApiSchemaPath(cliArg?: string): Promise<string> {
     if (cliArg) return cliArg;
-    const schemaPath = path.join(
-        REPO_ROOT,
-        "nodejs/node_modules/@github/copilot/schemas/api.schema.json"
-    );
-    await fs.access(schemaPath);
-    return schemaPath;
+    return resolveCopilotSchemaPath(SDK_NODE_MODULES, "api.schema.json");
 }
 
 // ── Brand casing normalization ──────────────────────────────────────────────

--- a/scripts/codegen/utils.ts
+++ b/scripts/codegen/utils.ts
@@ -69,7 +69,11 @@ async function resolveCopilotSchemaPath(nodeModulesDir: string, fileName: string
                 candidates.push(path.join(githubScopeDir, entry, "schemas", fileName));
             }
         }
-    } catch {
+    } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code !== "ENOENT" && code !== "ENOTDIR") {
+            throw err;
+        }
         // @github scope directory may not exist yet; fall through to the error below.
     }
 


### PR DESCRIPTION
## Why

The "Update @github/copilot Dependency" workflow [started failing](https://github.com/github/copilot-sdk/actions/runs/27850154158/job/82427499474) at the codegen step when bumping to `1.0.64-1`:

```
ENOENT: ... nodejs/node_modules/@github/copilot/schemas/session-events.schema.json
```

In `1.0.64-1` the `@github/copilot` CLI package was restructured: the umbrella package became a thin loader (`npm-loader.js`), and its bundled assets, including `api.schema.json` and `session-events.schema.json`, moved into the platform-specific optional-dependency packages (`@github/copilot-linux-x64`, `@github/copilot-win32-x64`, etc.). Our codegen scripts hardcoded the old `@github/copilot/schemas/...` path, which no longer exists.

## Approach

Both schema resolvers now check the umbrella package first (older versions), then fall back to scanning the `@github` scope for any installed `@github/copilot-*` platform package and reading `schemas/<file>` from it. This is host-agnostic, so it works on Linux CI and on Windows.

- `scripts/codegen/utils.ts` - resolver for the TS/C#/Python/Go/Rust generators
- `java/scripts/codegen/java.ts` - resolver for the Java generator (preserves its existing two-location search order)

The Java codegen would have hit the same failure at its later (skipped) step, so it gets the same fix.

## Notes

- The umbrella path is always tried first, so older single-package layouts keep working unchanged.
- Matching is safe: the exact name `@github/copilot` does not match the `copilot-` prefix, and any non-platform match simply fails the `fs.access` check and falls through. Since all platform packages of a given version ship identical schemas, `readdir` ordering does not affect correctness.

## Validation

Reproduced the real `1.0.64-1` install layout locally and ran both generators end to end. The previously-failing `tsx typescript.ts` step and the Java generator both resolved schemas from the platform package and succeeded.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>