### PR TITLE
Add Azure Managed Identity support for BYOK providers

### DIFF
--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -6172,6 +6172,27 @@ public sealed class ProviderConfigAzure
     public string? ApiVersion { get; set; }
 }
 
+/// <summary>Azure managed identity authentication for a BYOK provider. An empty object selects the system-assigned identity with the default scope; set at most one of clientId, objectId, or resourceId to select a user-assigned identity, and/or scope for a custom token audience. Mutually exclusive with apiKey/bearerToken.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class ManagedIdentityConfig
+{
+    /// <summary>Client (application) ID of the user-assigned managed identity.</summary>
+    [JsonPropertyName("clientId")]
+    public string? ClientId { get; set; }
+
+    /// <summary>Object (principal) ID of the user-assigned managed identity.</summary>
+    [JsonPropertyName("objectId")]
+    public string? ObjectId { get; set; }
+
+    /// <summary>ARM resource ID of the user-assigned managed identity.</summary>
+    [JsonPropertyName("resourceId")]
+    public string? ResourceId { get; set; }
+
+    /// <summary>AAD token scope/audience. Defaults to https://cognitiveservices.azure.com/.default.</summary>
+    [JsonPropertyName("scope")]
+    public string? Scope { get; set; }
+}
+
 /// <summary>Custom model-provider configuration (BYOK).</summary>
 [Experimental(Diagnostics.Experimental)]
 public sealed class ProviderConfig
@@ -6195,6 +6216,10 @@ public sealed class ProviderConfig
     /// <summary>Custom HTTP headers to include in all outbound requests to the provider.</summary>
     [JsonPropertyName("headers")]
     public IDictionary<string, string>? Headers { get; set; }
+
+    /// <summary>Authenticate with an Azure managed identity instead of apiKey/bearerToken. An empty object selects the system-assigned identity; set clientId/objectId/resourceId for a user-assigned identity and/or scope for a custom token audience. The runtime acquires and auto-refreshes the AAD token.</summary>
+    [JsonPropertyName("managedIdentity")]
+    public ManagedIdentityConfig? ManagedIdentity { get; set; }
 
     /// <summary>Maximum context window tokens for the model.</summary>
     [JsonPropertyName("maxContextWindowTokens")]
@@ -20696,6 +20721,7 @@ internal static class ClientSessionApiRegistration
 [JsonSerializable(typeof(LogRequest))]
 [JsonSerializable(typeof(LogResult))]
 [JsonSerializable(typeof(LspInitializeRequest))]
+[JsonSerializable(typeof(ManagedIdentityConfig))]
 [JsonSerializable(typeof(MarketplaceAddResult))]
 [JsonSerializable(typeof(MarketplaceBrowseResult))]
 [JsonSerializable(typeof(MarketplaceInfo))]

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -2024,6 +2024,15 @@ public sealed class ProviderConfig
     public IDictionary<string, string>? Headers { get; set; }
 
     /// <summary>
+    /// Authenticate with an Azure managed identity instead of <see cref="ApiKey"/>/<see cref="BearerToken"/>.
+    /// An empty object selects the system-assigned identity; set ClientId/ObjectId/ResourceId for a
+    /// user-assigned identity and/or Scope for a custom token audience. The runtime acquires and
+    /// auto-refreshes the AAD token.
+    /// </summary>
+    [JsonPropertyName("managedIdentity")]
+    public ManagedIdentityConfig? ManagedIdentity { get; set; }
+
+    /// <summary>
     /// Well-known model name used by the runtime to look up agent configuration
     /// (tools, prompts, reasoning behavior) and default token limits. Also used
     /// as the wire model when <see cref="WireModel"/> is not set.
@@ -2133,6 +2142,15 @@ public sealed class NamedProviderConfig
     /// </summary>
     [JsonPropertyName("headers")]
     public IDictionary<string, string>? Headers { get; set; }
+
+    /// <summary>
+    /// Authenticate with an Azure managed identity instead of <see cref="ApiKey"/>/<see cref="BearerToken"/>.
+    /// An empty object selects the system-assigned identity; set ClientId/ObjectId/ResourceId for a
+    /// user-assigned identity and/or Scope for a custom token audience. The runtime acquires and
+    /// auto-refreshes the AAD token.
+    /// </summary>
+    [JsonPropertyName("managedIdentity")]
+    public ManagedIdentityConfig? ManagedIdentity { get; set; }
 }
 
 /// <summary>
@@ -3687,6 +3705,7 @@ public sealed class SystemMessageTransformRpcResponse
 [JsonSerializable(typeof(GetStatusResponse))]
 [JsonSerializable(typeof(McpServerConfig))]
 [JsonSerializable(typeof(MessageOptions))]
+[JsonSerializable(typeof(GitHub.Copilot.Rpc.ManagedIdentityConfig))]
 [JsonSerializable(typeof(ModelBilling))]
 [JsonSerializable(typeof(GitHub.Copilot.Rpc.ModelBillingTokenPrices))]
 [JsonSerializable(typeof(GitHub.Copilot.Rpc.ModelBillingTokenPricesLongContext))]

--- a/dotnet/test/E2E/ManagedIdentityE2ETests.cs
+++ b/dotnet/test/E2E/ManagedIdentityE2ETests.cs
@@ -1,0 +1,237 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+using GitHub.Copilot.Rpc;
+using GitHub.Copilot.Test.Harness;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace GitHub.Copilot.Test.E2E;
+
+/// <summary>
+/// End-to-end coverage for Azure managed identity (MI) authentication on a BYOK
+/// provider. Proves the full SDK → runtime → Rust credential chain wiring without
+/// any real network:
+///
+///  - The shared <b>mock identity endpoint</b> (<c>test/harness/mockIdentityServer.ts</c>,
+///    spawned via <see cref="MockIdentityServer"/>) plays the App Service / Functions
+///    managed identity contract (<c>IDENTITY_ENDPOINT</c> + <c>IDENTITY_HEADER</c>). It
+///    returns a fixed fake AAD token and records the <c>resource</c> + identity query
+///    parameters the runtime asked for.
+///  - The shared <b>mock model endpoint</b> (<c>test/harness/mockModelServer.ts</c>,
+///    spawned via <see cref="MockModelServer"/>) is the BYOK provider's <c>baseUrl</c>. It
+///    records the <c>Authorization</c> header the runtime sent and replies with a minimal
+///    chat completion so the turn finishes cleanly.
+///
+/// Both mock servers are the same shared harness servers the Node SDK uses. The session is
+/// configured with <see cref="ProviderConfig.ManagedIdentity"/> (no apiKey/bearerToken), runs
+/// one real turn, and we assert the model request carried
+/// <c>Authorization: Bearer &lt;fake-token&gt;</c> and that the identity endpoint was asked for
+/// the right resource + identity. Because the BYOK base URL is the mock model server (not the
+/// replay proxy), the test needs no recorded snapshot and never touches the network.
+/// </summary>
+public class ManagedIdentityE2ETests(E2ETestFixture fixture, ITestOutputHelper output)
+    : E2ETestBase(fixture, "managed_identity", output)
+{
+    /// <summary>
+    /// Spawns both shared mock servers, injects the standard Azure managed
+    /// identity env vars (pointing the runtime's credential chain at the mock
+    /// identity endpoint), and hands the caller a client whose runtime subprocess
+    /// resolves managed identities against those mocks.
+    /// </summary>
+    private async Task<(CopilotClient Client, MockIdentityServer Identity, MockModelServer Model)> CreateManagedIdentityClientAsync()
+    {
+        var identity = new MockIdentityServer();
+        var model = new MockModelServer();
+        try
+        {
+            await identity.StartAsync();
+            await model.StartAsync();
+
+            var env = new Dictionary<string, string>(Ctx.GetEnvironment())
+            {
+                ["IDENTITY_ENDPOINT"] = identity.Endpoint,
+                ["IDENTITY_HEADER"] = identity.Header,
+                ["AZURE_TOKEN_CREDENTIALS"] = "ManagedIdentityCredential",
+                // Ensure no ambient user-assigned id leaks in from the host environment.
+                ["AZURE_CLIENT_ID"] = "",
+            };
+
+            var client = Ctx.CreateClient(options: new CopilotClientOptions { Environment = env });
+            return (client, identity, model);
+        }
+        catch
+        {
+            await identity.DisposeAsync();
+            await model.DisposeAsync();
+            throw;
+        }
+    }
+
+    /// <summary>Runs one turn against a BYOK provider that authenticates via managed identity.</summary>
+    private static async Task RunTurnAsync(CopilotClient client, ProviderConfig provider)
+    {
+        var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            OnPermissionRequest = PermissionHandler.ApproveAll,
+            Provider = provider,
+        });
+        try
+        {
+            await session.SendAndWaitAsync(new MessageOptions { Prompt = "What is 5+5?" }, TimeSpan.FromMinutes(3));
+        }
+        finally
+        {
+            // disconnect may fail since the BYOK provider is a local mock
+            try { await session.DisposeAsync(); } catch { /* ignore */ }
+        }
+    }
+
+    [Fact]
+    public async Task Should_Acquire_System_Assigned_Token_And_Inject_It_As_A_Bearer()
+    {
+        var (client, identity, model) = await CreateManagedIdentityClientAsync();
+        await using var _identity = identity;
+        await using var _model = model;
+
+        await RunTurnAsync(client, new ProviderConfig
+        {
+            Type = "openai",
+            WireApi = "completions",
+            BaseUrl = model.BaseUrl,
+            ModelId = "claude-sonnet-4.5",
+            ManagedIdentity = new ManagedIdentityConfig(),
+        });
+
+        List<RecordedModelRequest> modelRequests = [];
+        await TestHelper.WaitForConditionAsync(
+            async () => { modelRequests = await model.GetRecordedRequestsAsync(); return modelRequests.Count >= 1; },
+            timeout: TimeSpan.FromSeconds(10),
+            timeoutMessage: "Timed out waiting for a model request");
+
+        // The runtime acquired the fake token from the identity endpoint and
+        // injected it as the model request's bearer credential.
+        Assert.Equal($"Bearer {identity.Token}", modelRequests[0].Authorization);
+
+        // The identity endpoint was hit with the App Service secret header, the
+        // default cognitiveservices resource, and NO identity selector (system assigned).
+        var identityRequests = await identity.GetRecordedRequestsAsync();
+        Assert.NotEmpty(identityRequests);
+        Assert.Equal(identity.Header, identityRequests[0].IdentityHeader);
+        Assert.Equal("https://cognitiveservices.azure.com", identityRequests[0].Resource);
+        Assert.Empty(identityRequests[0].IdentityParams);
+    }
+
+    [Fact]
+    public async Task Should_Acquire_User_Assigned_ClientId_Token_With_Custom_Scope()
+    {
+        var (client, identity, model) = await CreateManagedIdentityClientAsync();
+        await using var _identity = identity;
+        await using var _model = model;
+
+        await RunTurnAsync(client, new ProviderConfig
+        {
+            Type = "openai",
+            WireApi = "completions",
+            BaseUrl = model.BaseUrl,
+            ModelId = "claude-sonnet-4.5",
+            ManagedIdentity = new ManagedIdentityConfig
+            {
+                ClientId = "11111111-2222-3333-4444-555555555555",
+                Scope = "https://gateway.example.test/.default",
+            },
+        });
+
+        List<RecordedModelRequest> modelRequests = [];
+        await TestHelper.WaitForConditionAsync(
+            async () => { modelRequests = await model.GetRecordedRequestsAsync(); return modelRequests.Count >= 1; },
+            timeout: TimeSpan.FromSeconds(10),
+            timeoutMessage: "Timed out waiting for a model request");
+
+        Assert.Equal($"Bearer {identity.Token}", modelRequests[0].Authorization);
+
+        var identityRequests = await identity.GetRecordedRequestsAsync();
+        Assert.NotEmpty(identityRequests);
+        Assert.Equal(identity.Header, identityRequests[0].IdentityHeader);
+        // The custom scope's resource (scope minus the /.default suffix).
+        Assert.Equal("https://gateway.example.test", identityRequests[0].Resource);
+        // The user-assigned client id was sent as the App Service client_id param.
+        Assert.Equal(
+            new Dictionary<string, string> { ["client_id"] = "11111111-2222-3333-4444-555555555555" },
+            identityRequests[0].IdentityParams);
+    }
+
+    [Fact]
+    public async Task Should_Reuse_Cached_Token_Across_Turns_While_Valid()
+    {
+        var (client, identity, model) = await CreateManagedIdentityClientAsync();
+        await using var _identity = identity;
+        await using var _model = model;
+
+        // A unique scope keeps this turn's cache key isolated (the runtime caches
+        // process-wide by scope + identity). Default lifetime (1h) is well outside
+        // the runtime's 5-minute refresh buffer, so the first token stays cached.
+        var provider = new ProviderConfig
+        {
+            Type = "openai",
+            WireApi = "completions",
+            BaseUrl = model.BaseUrl,
+            ModelId = "claude-sonnet-4.5",
+            ManagedIdentity = new ManagedIdentityConfig { Scope = "https://cache-test.example.test/.default" },
+        };
+
+        await RunTurnAsync(client, provider);
+        await RunTurnAsync(client, provider);
+
+        // Two turns, but the identity endpoint was only hit once: the second turn
+        // reused the cached token instead of re-acquiring one.
+        var identityRequests = await identity.GetRecordedRequestsAsync();
+        Assert.Single(identityRequests);
+
+        // Every model request across both turns carried that one cached token.
+        var modelRequests = await model.GetRecordedRequestsAsync();
+        Assert.True(modelRequests.Count >= 2, $"expected >= 2 model requests, saw {modelRequests.Count}");
+        Assert.All(modelRequests, request => Assert.Equal($"Bearer {identity.Token}", request.Authorization));
+    }
+
+    [Fact]
+    public async Task Should_Refresh_Token_On_Next_Turn_Once_Within_Expiry_Buffer()
+    {
+        var (client, identity, model) = await CreateManagedIdentityClientAsync();
+        await using var _identity = identity;
+        await using var _model = model;
+
+        // Mint short-lived, rotating tokens: a 1-second lifetime is inside the
+        // runtime's 5-minute refresh buffer, so the cached token is treated as
+        // stale immediately and re-acquired on the next turn. Rotation makes the
+        // refreshed token observably different from the first one.
+        await identity.ConfigureAsync(expiresInSeconds: 1, rotateTokens: true);
+
+        var provider = new ProviderConfig
+        {
+            Type = "openai",
+            WireApi = "completions",
+            BaseUrl = model.BaseUrl,
+            ModelId = "claude-sonnet-4.5",
+            ManagedIdentity = new ManagedIdentityConfig { Scope = "https://refresh-test.example.test/.default" },
+        };
+
+        await RunTurnAsync(client, provider);
+        var firstTurnRequests = await model.GetRecordedRequestsAsync();
+        var firstTurnBearer = firstTurnRequests.Count > 0 ? firstTurnRequests[^1].Authorization : null;
+
+        await RunTurnAsync(client, provider);
+        var secondTurnRequests = await model.GetRecordedRequestsAsync();
+        var secondTurnBearer = secondTurnRequests.Count > 0 ? secondTurnRequests[^1].Authorization : null;
+
+        // The endpoint was hit again for the second turn rather than serving a cached token.
+        var identityRequests = await identity.GetRecordedRequestsAsync();
+        Assert.True(identityRequests.Count >= 2, $"expected >= 2 identity requests, saw {identityRequests.Count}");
+
+        // The second turn's model request carried a freshly minted token, not the
+        // one from the first turn — proving automatic refresh.
+        Assert.NotEqual(firstTurnBearer, secondTurnBearer);
+        Assert.Equal($"Bearer {identityRequests[^1].IssuedToken}", secondTurnBearer);
+    }
+}

--- a/dotnet/test/Harness/MockHarnessServer.cs
+++ b/dotnet/test/Harness/MockHarnessServer.cs
@@ -1,0 +1,316 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+using System.Diagnostics;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace GitHub.Copilot.Test.Harness;
+
+/// <summary>
+/// Base class that spawns one of the shared mock servers in <c>test/harness</c>
+/// (via its <c>npm run start:*</c> script, mirroring <see cref="CapiProxy"/>) and
+/// parses its single-line <c>Listening: {json}</c> startup banner. The parsed
+/// connection info is exposed as a <see cref="JsonElement"/> so subclasses can
+/// pull whatever fields their endpoint advertises.
+///
+/// These servers live in the shared harness so every SDK language drives the
+/// exact same mock endpoints rather than re-implementing them per language.
+/// </summary>
+public abstract class MockHarnessServer : IAsyncDisposable
+{
+    private Process? _process;
+    private Task<JsonElement>? _startupTask;
+
+    /// <summary>The npm script (in <c>test/harness/package.json</c>) that launches this server.</summary>
+    protected abstract string NpmScript { get; }
+
+    /// <summary>Human-readable name used in error messages.</summary>
+    protected abstract string DisplayName { get; }
+
+    /// <summary>Parsed <c>Listening:</c> banner; available after <see cref="StartAsync"/> completes.</summary>
+    protected JsonElement Info { get; private set; }
+
+    private static readonly HttpClient HttpClient = new();
+
+    public Task StartAsync()
+    {
+        return EnsureStartedAsync();
+    }
+
+    protected async Task<JsonElement> EnsureStartedAsync()
+    {
+        Info = await (_startupTask ??= StartCoreAsync());
+        return Info;
+    }
+
+    private async Task<JsonElement> StartCoreAsync()
+    {
+        string filename;
+        string args;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            filename = "cmd.exe";
+            args = $"/c npm.cmd run {NpmScript}";
+        }
+        else
+        {
+            filename = "npm";
+            args = $"run {NpmScript}";
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = filename,
+            WorkingDirectory = Path.Join(FindRepoRoot(), "test", "harness"),
+            Arguments = args,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+
+        _process = new Process { StartInfo = startInfo };
+
+        var tcs = new TaskCompletionSource<JsonElement>();
+        var errorOutput = new StringBuilder();
+
+        _process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data == null) return;
+            var match = Regex.Match(e.Data, @"^Listening: (?<json>\{.*\})$");
+            if (!match.Success)
+            {
+                return;
+            }
+            try
+            {
+                using var doc = JsonDocument.Parse(match.Groups["json"].Value);
+                tcs.TrySetResult(doc.RootElement.Clone());
+            }
+            catch (Exception ex) when (ex is JsonException or NotSupportedException)
+            {
+                tcs.TrySetException(
+                    new InvalidOperationException(
+                        $"Failed to parse {DisplayName} startup metadata: {match.Groups["json"].Value}",
+                        ex));
+            }
+        };
+
+        _process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data == null) return;
+            errorOutput.AppendLine(e.Data);
+            Console.Error.WriteLine(e.Data);
+        };
+
+        _process.Start();
+        _process.BeginOutputReadLine();
+        _process.BeginErrorReadLine();
+        _ = _process.WaitForExitAsync().ContinueWith(_ =>
+        {
+            if (_process?.ExitCode is int exitCode && exitCode != 0)
+            {
+                tcs.TrySetException(
+                    new Exception($"{DisplayName} exited with code {exitCode}: {errorOutput}"));
+            }
+        });
+
+        // Longer timeout on Windows due to slower process startup (matches CapiProxy).
+        var timeoutSeconds = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 30 : 10;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
+        cts.Token.Register(() => tcs.TrySetException(new TimeoutException($"Timeout waiting for {DisplayName}")));
+
+        return await tcs.Task;
+    }
+
+    /// <summary>Returns a required string field from the startup banner.</summary>
+    protected string InfoString(string property)
+    {
+        return Info.GetProperty(property).GetString()
+            ?? throw new InvalidOperationException($"{DisplayName} banner missing string '{property}'");
+    }
+
+    /// <summary>GETs the given control URL and returns the parsed JSON document.</summary>
+    protected static async Task<JsonDocument> GetJsonAsync(string url)
+    {
+        var json = await HttpClient.GetStringAsync(url);
+        return JsonDocument.Parse(json);
+    }
+
+    /// <summary>POSTs to the given control URL with an optional JSON body.</summary>
+    protected static async Task PostAsync(string url, string? jsonBody = null)
+    {
+        using var content = jsonBody == null
+            ? null
+            : new StringContent(jsonBody, Encoding.UTF8, "application/json");
+        using var response = await HttpClient.PostAsync(url, content);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task StopAsync()
+    {
+        if (_startupTask != null)
+        {
+            try
+            {
+                var info = await _startupTask;
+                if (info.TryGetProperty("stopUrl", out var stopUrl) && stopUrl.GetString() is string url)
+                {
+                    await PostAsync(url);
+                }
+            }
+            catch { /* best effort; fall through to killing the process */ }
+        }
+
+        if (_process is { HasExited: false })
+        {
+            try { _process.Kill(entireProcessTree: true); await _process.WaitForExitAsync(); }
+            catch { /* ignore */ }
+        }
+
+        _process?.Dispose();
+        _process = null;
+        _startupTask = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync();
+        GC.SuppressFinalize(this);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "nodejs")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+        throw new InvalidOperationException("Could not find repository root");
+    }
+}
+
+/// <summary>
+/// Spawns the shared mock Azure managed identity token endpoint
+/// (<c>test/harness/mockIdentityServer.ts</c>) and exposes its endpoint + control
+/// URLs. The C# reference consumer of the shared endpoint; mirrors the Node
+/// <c>MockIdentityServer</c> wrapper.
+/// </summary>
+public sealed class MockIdentityServer : MockHarnessServer
+{
+    protected override string NpmScript => "start:mock-identity";
+    protected override string DisplayName => "mock identity server";
+
+    /// <summary>Value to assign to the <c>IDENTITY_ENDPOINT</c> env var.</summary>
+    public string Endpoint => InfoString("endpoint");
+
+    /// <summary>Secret to assign to the <c>IDENTITY_HEADER</c> env var.</summary>
+    public string Header => InfoString("header");
+
+    /// <summary>Fake bearer token the runtime injects (<c>Authorization: Bearer &lt;token&gt;</c>).</summary>
+    public string Token => InfoString("token");
+
+    /// <summary>Token requests recorded by the endpoint so far, in arrival order.</summary>
+    public async Task<List<RecordedIdentityRequest>> GetRecordedRequestsAsync()
+    {
+        using var doc = await GetJsonAsync(InfoString("recordedUrl"));
+        var result = new List<RecordedIdentityRequest>();
+        foreach (var element in doc.RootElement.EnumerateArray())
+        {
+            var identityParams = new Dictionary<string, string>(StringComparer.Ordinal);
+            if (element.TryGetProperty("identityParams", out var p) && p.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var prop in p.EnumerateObject())
+                {
+                    identityParams[prop.Name] = prop.Value.GetString() ?? string.Empty;
+                }
+            }
+            result.Add(new RecordedIdentityRequest(
+                Resource: GetNullableString(element, "resource"),
+                IdentityHeader: GetNullableString(element, "identityHeader"),
+                IdentityParams: identityParams,
+                IssuedToken: GetNullableString(element, "issuedToken") ?? string.Empty));
+        }
+        return result;
+    }
+
+    /// <summary>Clears recorded requests and restores the default token behaviour.</summary>
+    public Task ResetAsync() => PostAsync(InfoString("resetUrl"));
+
+    /// <summary>Sets the endpoint's token lifetime / rotation behaviour.</summary>
+    public Task ConfigureAsync(int? expiresInSeconds = null, bool? rotateTokens = null)
+    {
+        var fields = new List<string>();
+        if (expiresInSeconds.HasValue)
+        {
+            fields.Add($"\"expiresInSeconds\":{expiresInSeconds.Value}");
+        }
+        if (rotateTokens.HasValue)
+        {
+            fields.Add($"\"rotateTokens\":{(rotateTokens.Value ? "true" : "false")}");
+        }
+        return PostAsync(InfoString("configureUrl"), "{" + string.Join(",", fields) + "}");
+    }
+
+    private static string? GetNullableString(JsonElement element, string property)
+    {
+        return element.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+    }
+}
+
+/// <summary>
+/// Spawns the shared mock BYOK model (OpenAI-compatible) endpoint
+/// (<c>test/harness/mockModelServer.ts</c>) and exposes its base + control URLs.
+/// The C# reference consumer of the shared endpoint; mirrors the Node
+/// <c>MockModelServer</c> wrapper.
+/// </summary>
+public sealed class MockModelServer : MockHarnessServer
+{
+    protected override string NpmScript => "start:mock-model";
+    protected override string DisplayName => "mock model server";
+
+    /// <summary>Base URL to assign as the BYOK provider's <c>baseUrl</c>.</summary>
+    public string BaseUrl => InfoString("baseUrl");
+
+    /// <summary>Inference requests recorded by the endpoint so far, in arrival order.</summary>
+    public async Task<List<RecordedModelRequest>> GetRecordedRequestsAsync()
+    {
+        using var doc = await GetJsonAsync(InfoString("recordedUrl"));
+        var result = new List<RecordedModelRequest>();
+        foreach (var element in doc.RootElement.EnumerateArray())
+        {
+            result.Add(new RecordedModelRequest(
+                Authorization: element.TryGetProperty("authorization", out var a) && a.ValueKind == JsonValueKind.String
+                    ? a.GetString()
+                    : null,
+                Path: element.TryGetProperty("path", out var p) ? p.GetString() ?? string.Empty : string.Empty,
+                Method: element.TryGetProperty("method", out var m) ? m.GetString() ?? string.Empty : string.Empty));
+        }
+        return result;
+    }
+
+    /// <summary>Clears the endpoint's recorded inference requests.</summary>
+    public Task ResetAsync() => PostAsync(InfoString("resetUrl"));
+}
+
+/// <summary>A token request the runtime made to the mock identity endpoint.</summary>
+public sealed record RecordedIdentityRequest(
+    string? Resource,
+    string? IdentityHeader,
+    Dictionary<string, string> IdentityParams,
+    string IssuedToken);
+
+/// <summary>An inference request the runtime made to the mock model endpoint.</summary>
+public sealed record RecordedModelRequest(
+    string? Authorization,
+    string Path,
+    string Method);

--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -539,6 +539,14 @@ export type SessionLogLevel =
   /** Error message describing a failure. */
   | "error";
 /**
+ * Azure managed identity authentication for a BYOK provider. `true` selects the system-assigned identity with the default scope; an object selects a user-assigned identity and/or a custom scope. Mutually exclusive with apiKey/bearerToken.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ManagedIdentityConfig".
+ */
+/** @experimental */
+export type ManagedIdentityConfig = boolean | ManagedIdentityOptions;
+/**
  * UI theme preference per SEP-1865
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -4666,6 +4674,31 @@ export interface LspInitializeRequest {
   force?: boolean;
 }
 /**
+ * User-assigned managed identity selector and/or custom token scope. Set at most one of clientId, objectId, or resourceId.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ManagedIdentityOptions".
+ */
+/** @experimental */
+export interface ManagedIdentityOptions {
+  /**
+   * Client (application) ID of the user-assigned managed identity.
+   */
+  clientId?: string;
+  /**
+   * Object (principal) ID of the user-assigned managed identity.
+   */
+  objectId?: string;
+  /**
+   * ARM resource ID of the user-assigned managed identity.
+   */
+  resourceId?: string;
+  /**
+   * AAD token scope/audience. Defaults to https://cognitiveservices.azure.com/.default.
+   */
+  scope?: string;
+}
+/**
  * Result of registering a new marketplace.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -6510,6 +6543,7 @@ export interface NamedProviderConfig {
    */
   bearerToken?: string;
   azure?: ProviderConfigAzure;
+  managedIdentity?: ManagedIdentityConfig;
   /**
    * Custom HTTP headers to include in all outbound requests to the provider.
    */
@@ -8396,6 +8430,7 @@ export interface ProviderConfig {
    */
   bearerToken?: string;
   azure?: ProviderConfigAzure;
+  managedIdentity?: ManagedIdentityConfig;
   /**
    * Well-known model ID used for capability lookup. When set, agent behavior config and token limits are inferred from this model.
    */

--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -539,14 +539,6 @@ export type SessionLogLevel =
   /** Error message describing a failure. */
   | "error";
 /**
- * Azure managed identity authentication for a BYOK provider. `true` selects the system-assigned identity with the default scope; an object selects a user-assigned identity and/or a custom scope. Mutually exclusive with apiKey/bearerToken.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "ManagedIdentityConfig".
- */
-/** @experimental */
-export type ManagedIdentityConfig = boolean | ManagedIdentityOptions;
-/**
  * UI theme preference per SEP-1865
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -4674,13 +4666,13 @@ export interface LspInitializeRequest {
   force?: boolean;
 }
 /**
- * User-assigned managed identity selector and/or custom token scope. Set at most one of clientId, objectId, or resourceId.
+ * Azure managed identity authentication for a BYOK provider. An empty object selects the system-assigned identity with the default scope; set at most one of clientId, objectId, or resourceId to select a user-assigned identity, and/or scope for a custom token audience. Mutually exclusive with apiKey/bearerToken.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "ManagedIdentityOptions".
+ * via the `definition` "ManagedIdentityConfig".
  */
 /** @experimental */
-export interface ManagedIdentityOptions {
+export interface ManagedIdentityConfig {
   /**
    * Client (application) ID of the user-assigned managed identity.
    */

--- a/nodejs/src/index.ts
+++ b/nodejs/src/index.ts
@@ -82,7 +82,6 @@ export type {
     DefaultAgentConfig,
     MessageOptions,
     ManagedIdentityConfig,
-    ManagedIdentityOptions,
     ModelBilling,
     ModelBillingTokenPrices,
     ModelBillingTokenPricesLongContext,

--- a/nodejs/src/index.ts
+++ b/nodejs/src/index.ts
@@ -81,6 +81,8 @@ export type {
     MCPServerConfig,
     DefaultAgentConfig,
     MessageOptions,
+    ManagedIdentityConfig,
+    ManagedIdentityOptions,
     ModelBilling,
     ModelBillingTokenPrices,
     ModelBillingTokenPricesLongContext,

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -15,12 +15,14 @@ import type {
 } from "./generated/session-events.js";
 import type { CopilotSession } from "./session.js";
 import type {
+    ManagedIdentityConfig,
     ModelBillingTokenPrices,
     OpenCanvasInstance,
     RemoteSessionMode,
 } from "./generated/rpc.js";
 import type { ToolSet } from "./toolSet.js";
 export type { RemoteSessionMode } from "./generated/rpc.js";
+export type { ManagedIdentityConfig, ManagedIdentityOptions } from "./generated/rpc.js";
 export type {
     ModelBillingTokenPrices,
     ModelBillingTokenPricesLongContext,
@@ -2126,47 +2128,6 @@ export interface ResumeSessionConfig extends SessionConfigBase {
      */
     openCanvases?: OpenCanvasInstance[];
 }
-
-/**
- * User-assigned managed identity selector and/or custom token scope. Set at
- * most one of {@link clientId}, {@link objectId}, or {@link resourceId}.
- *
- * @experimental Part of the experimental Azure managed identity BYOK surface and
- * may change or be removed in future SDK or CLI releases.
- */
-export interface ManagedIdentityOptions {
-    /**
-     * Client (application) ID of the user-assigned managed identity.
-     */
-    clientId?: string;
-
-    /**
-     * Object (principal) ID of the user-assigned managed identity.
-     */
-    objectId?: string;
-
-    /**
-     * ARM resource ID of the user-assigned managed identity.
-     */
-    resourceId?: string;
-
-    /**
-     * AAD token scope/audience. Defaults to
-     * `https://cognitiveservices.azure.com/.default`.
-     */
-    scope?: string;
-}
-
-/**
- * Azure managed identity authentication for a BYOK provider. `true` selects the
- * system-assigned identity with the default scope; an object selects a
- * user-assigned identity and/or a custom scope. Mutually exclusive with
- * {@link ProviderConfig.apiKey}/{@link ProviderConfig.bearerToken}.
- *
- * @experimental Part of the experimental Azure managed identity BYOK surface and
- * may change or be removed in future SDK or CLI releases.
- */
-export type ManagedIdentityConfig = boolean | ManagedIdentityOptions;
 
 /**
  * Configuration for a custom API provider.

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -2128,6 +2128,47 @@ export interface ResumeSessionConfig extends SessionConfigBase {
 }
 
 /**
+ * User-assigned managed identity selector and/or custom token scope. Set at
+ * most one of {@link clientId}, {@link objectId}, or {@link resourceId}.
+ *
+ * @experimental Part of the experimental Azure managed identity BYOK surface and
+ * may change or be removed in future SDK or CLI releases.
+ */
+export interface ManagedIdentityOptions {
+    /**
+     * Client (application) ID of the user-assigned managed identity.
+     */
+    clientId?: string;
+
+    /**
+     * Object (principal) ID of the user-assigned managed identity.
+     */
+    objectId?: string;
+
+    /**
+     * ARM resource ID of the user-assigned managed identity.
+     */
+    resourceId?: string;
+
+    /**
+     * AAD token scope/audience. Defaults to
+     * `https://cognitiveservices.azure.com/.default`.
+     */
+    scope?: string;
+}
+
+/**
+ * Azure managed identity authentication for a BYOK provider. `true` selects the
+ * system-assigned identity with the default scope; an object selects a
+ * user-assigned identity and/or a custom scope. Mutually exclusive with
+ * {@link ProviderConfig.apiKey}/{@link ProviderConfig.bearerToken}.
+ *
+ * @experimental Part of the experimental Azure managed identity BYOK surface and
+ * may change or be removed in future SDK or CLI releases.
+ */
+export type ManagedIdentityConfig = boolean | ManagedIdentityOptions;
+
+/**
  * Configuration for a custom API provider.
  */
 export interface ProviderConfig {
@@ -2167,6 +2208,17 @@ export interface ProviderConfig {
          */
         apiVersion?: string;
     };
+
+    /**
+     * Authenticate with an Azure managed identity instead of
+     * {@link apiKey}/{@link bearerToken}. `true` selects the system-assigned
+     * identity; an object selects a user-assigned identity and/or a custom token
+     * scope. The runtime acquires and auto-refreshes the AAD token.
+     *
+     * @experimental Part of the experimental Azure managed identity BYOK surface
+     * and may change or be removed in future SDK or CLI releases.
+     */
+    managedIdentity?: ManagedIdentityConfig;
 
     /**
      * Custom HTTP headers to include in outbound provider requests.
@@ -2259,6 +2311,17 @@ export interface NamedProviderConfig {
          */
         apiVersion?: string;
     };
+
+    /**
+     * Authenticate with an Azure managed identity instead of
+     * {@link apiKey}/{@link bearerToken}. `true` selects the system-assigned
+     * identity; an object selects a user-assigned identity and/or a custom token
+     * scope. The runtime acquires and auto-refreshes the AAD token.
+     *
+     * @experimental Part of the experimental Azure managed identity BYOK surface
+     * and may change or be removed in future SDK or CLI releases.
+     */
+    managedIdentity?: ManagedIdentityConfig;
 
     /**
      * Custom HTTP headers to include in all outbound requests to the provider.

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -22,7 +22,7 @@ import type {
 } from "./generated/rpc.js";
 import type { ToolSet } from "./toolSet.js";
 export type { RemoteSessionMode } from "./generated/rpc.js";
-export type { ManagedIdentityConfig, ManagedIdentityOptions } from "./generated/rpc.js";
+export type { ManagedIdentityConfig } from "./generated/rpc.js";
 export type {
     ModelBillingTokenPrices,
     ModelBillingTokenPricesLongContext,

--- a/nodejs/test/e2e/harness/MockIdentityServer.ts
+++ b/nodejs/test/e2e/harness/MockIdentityServer.ts
@@ -6,6 +6,7 @@ import { ChildProcess, spawn } from "child_process";
 import { resolve } from "path";
 import { createInterface } from "readline";
 import type {
+    MockIdentityConfig,
     MockIdentityEndpointInfo,
     RecordedIdentityRequest,
 } from "../../../../test/harness/mockIdentityEndpoint";
@@ -88,9 +89,18 @@ export class MockIdentityServer {
         return (await response.json()) as RecordedIdentityRequest[];
     }
 
-    /** Clears the endpoint's recorded token requests. */
+    /** Clears the endpoint's recorded token requests and restores defaults. */
     async reset(): Promise<void> {
         await fetch(this.requireInfo().resetUrl, { method: "POST" });
+    }
+
+    /** Sets the endpoint's token lifetime / rotation behaviour. */
+    async configure(config: MockIdentityConfig): Promise<void> {
+        await fetch(this.requireInfo().configureUrl, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(config),
+        });
     }
 
     async stop(): Promise<void> {

--- a/nodejs/test/e2e/harness/MockIdentityServer.ts
+++ b/nodejs/test/e2e/harness/MockIdentityServer.ts
@@ -1,0 +1,119 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ChildProcess, spawn } from "child_process";
+import { resolve } from "path";
+import { createInterface } from "readline";
+import type {
+    MockIdentityEndpointInfo,
+    RecordedIdentityRequest,
+} from "../../../../test/harness/mockIdentityEndpoint";
+
+const ENTRYPOINT_PATH = resolve(__dirname, "../../../../test/harness/mockIdentityServer.ts");
+
+/**
+ * Spawns the shared mock managed identity endpoint (`test/harness/mockIdentityServer.ts`)
+ * as a child process and exposes its endpoint + control URLs. This is the
+ * Node reference consumer of the shared endpoint; other SDK languages spawn the
+ * same entrypoint and parse its `Listening:` banner the same way.
+ */
+export class MockIdentityServer {
+    private process: ChildProcess | undefined;
+    private info: MockIdentityEndpointInfo | undefined;
+
+    async start(): Promise<MockIdentityEndpointInfo> {
+        const child = spawn("npx", ["tsx", ENTRYPOINT_PATH], {
+            stdio: ["ignore", "pipe", "inherit"],
+            shell: true,
+        });
+        this.process = child;
+
+        this.info = await new Promise<MockIdentityEndpointInfo>((resolveInfo, reject) => {
+            const reader = createInterface({ input: child.stdout! });
+            const lines: string[] = [];
+            const cleanup = () => {
+                reader.off("line", onLine);
+                child.off("exit", onExit);
+                reader.close();
+            };
+            const onLine = (line: string) => {
+                lines.push(line);
+                const match = line.match(/^Listening: (\{.*\})$/);
+                if (!match) {
+                    return;
+                }
+                try {
+                    const info = JSON.parse(match[1]) as MockIdentityEndpointInfo;
+                    cleanup();
+                    resolveInfo(info);
+                } catch (error) {
+                    cleanup();
+                    reject(error);
+                }
+            };
+            const onExit = (code: number | null) => {
+                cleanup();
+                reject(
+                    new Error(
+                        `Mock identity server exited before startup with code ${code}: ${lines.join("\n")}`
+                    )
+                );
+            };
+            reader.on("line", onLine);
+            child.once("exit", onExit);
+        });
+
+        return this.info;
+    }
+
+    /** URL to assign to the `IDENTITY_ENDPOINT` env var. */
+    get endpoint(): string {
+        return this.requireInfo().endpoint;
+    }
+
+    /** Secret to assign to the `IDENTITY_HEADER` env var. */
+    get header(): string {
+        return this.requireInfo().header;
+    }
+
+    /** Fake bearer token the runtime injects (`Authorization: Bearer <token>`). */
+    get token(): string {
+        return this.requireInfo().token;
+    }
+
+    /** Token requests recorded by the endpoint so far, in arrival order. */
+    async getRecordedRequests(): Promise<RecordedIdentityRequest[]> {
+        const response = await fetch(this.requireInfo().recordedUrl);
+        return (await response.json()) as RecordedIdentityRequest[];
+    }
+
+    /** Clears the endpoint's recorded token requests. */
+    async reset(): Promise<void> {
+        await fetch(this.requireInfo().resetUrl, { method: "POST" });
+    }
+
+    async stop(): Promise<void> {
+        const child = this.process;
+        if (!child) {
+            return;
+        }
+        this.process = undefined;
+        const exited = new Promise<void>((resolveExit) => child.once("exit", () => resolveExit()));
+        try {
+            await fetch(this.requireInfo().stopUrl, { method: "POST" });
+        } catch {
+            // Endpoint may already be gone; fall back to killing the process.
+        }
+        const killTimer = setTimeout(() => child.kill(), 2_000);
+        await exited;
+        clearTimeout(killTimer);
+    }
+
+    private requireInfo(): MockIdentityEndpointInfo {
+        if (!this.info) {
+            throw new Error("MockIdentityServer has not been started; call start() first.");
+        }
+        return this.info;
+    }
+}

--- a/nodejs/test/e2e/harness/MockModelServer.ts
+++ b/nodejs/test/e2e/harness/MockModelServer.ts
@@ -1,0 +1,109 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ChildProcess, spawn } from "child_process";
+import { resolve } from "path";
+import { createInterface } from "readline";
+import type {
+    MockModelEndpointInfo,
+    RecordedModelRequest,
+} from "../../../../test/harness/mockModelEndpoint";
+
+const ENTRYPOINT_PATH = resolve(__dirname, "../../../../test/harness/mockModelServer.ts");
+
+/**
+ * Spawns the shared mock BYOK model endpoint (`test/harness/mockModelServer.ts`)
+ * as a child process and exposes its base + control URLs. This is the Node
+ * reference consumer of the shared endpoint; other SDK languages spawn the same
+ * entrypoint and parse its `Listening:` banner the same way.
+ */
+export class MockModelServer {
+    private process: ChildProcess | undefined;
+    private info: MockModelEndpointInfo | undefined;
+
+    async start(): Promise<MockModelEndpointInfo> {
+        const child = spawn("npx", ["tsx", ENTRYPOINT_PATH], {
+            stdio: ["ignore", "pipe", "inherit"],
+            shell: true,
+        });
+        this.process = child;
+
+        this.info = await new Promise<MockModelEndpointInfo>((resolveInfo, reject) => {
+            const reader = createInterface({ input: child.stdout! });
+            const lines: string[] = [];
+            const cleanup = () => {
+                reader.off("line", onLine);
+                child.off("exit", onExit);
+                reader.close();
+            };
+            const onLine = (line: string) => {
+                lines.push(line);
+                const match = line.match(/^Listening: (\{.*\})$/);
+                if (!match) {
+                    return;
+                }
+                try {
+                    const info = JSON.parse(match[1]) as MockModelEndpointInfo;
+                    cleanup();
+                    resolveInfo(info);
+                } catch (error) {
+                    cleanup();
+                    reject(error);
+                }
+            };
+            const onExit = (code: number | null) => {
+                cleanup();
+                reject(
+                    new Error(
+                        `Mock model server exited before startup with code ${code}: ${lines.join("\n")}`
+                    )
+                );
+            };
+            reader.on("line", onLine);
+            child.once("exit", onExit);
+        });
+
+        return this.info;
+    }
+
+    /** Base URL to assign as the BYOK provider's `baseUrl`. */
+    get baseUrl(): string {
+        return this.requireInfo().baseUrl;
+    }
+
+    /** Inference requests recorded by the endpoint so far, in arrival order. */
+    async getRecordedRequests(): Promise<RecordedModelRequest[]> {
+        const response = await fetch(this.requireInfo().recordedUrl);
+        return (await response.json()) as RecordedModelRequest[];
+    }
+
+    /** Clears the endpoint's recorded inference requests. */
+    async reset(): Promise<void> {
+        await fetch(this.requireInfo().resetUrl, { method: "POST" });
+    }
+
+    async stop(): Promise<void> {
+        const child = this.process;
+        if (!child) {
+            return;
+        }
+        this.process = undefined;
+        const exited = new Promise<void>((resolveExit) => child.once("exit", () => resolveExit()));
+        try {
+            await fetch(this.requireInfo().stopUrl, { method: "POST" });
+        } catch {
+            // Endpoint may already be gone; fall back to killing the process.
+        }
+        const killTimer = setTimeout(() => child.kill(), 2_000);
+        await exited;
+        clearTimeout(killTimer);
+    }
+
+    private requireInfo(): MockModelEndpointInfo {
+        if (!this.info) {
+            throw new Error("MockModelServer has not been started; call start() first.");
+        }
+        return this.info;
+    }
+}

--- a/nodejs/test/e2e/managed_identity.e2e.test.ts
+++ b/nodejs/test/e2e/managed_identity.e2e.test.ts
@@ -236,4 +236,64 @@ describe("BYOK managed identity authentication", async () => {
             client_id: "11111111-2222-3333-4444-555555555555",
         });
     });
+
+    it("reuses a cached token across turns while it is still valid", async () => {
+        // A unique scope keeps this turn's cache key isolated from the other
+        // tests (the runtime caches process-wide by scope + identity).
+        const provider: ProviderConfig = {
+            type: "openai",
+            wireApi: "completions",
+            baseUrl: modelBaseUrl,
+            modelId: "claude-sonnet-4.5",
+            managedIdentity: { scope: "https://cache-test.example.test/.default" },
+        };
+
+        // Default lifetime (1h) is well outside the runtime's 5-minute refresh
+        // buffer, so the token acquired on the first turn stays cached.
+        await runTurn(provider);
+        await runTurn(provider);
+
+        // Two turns, but the identity endpoint was only hit once: the second
+        // turn reused the cached token instead of re-acquiring one.
+        const identityRequests = await identity.getRecordedRequests();
+        expect(identityRequests.length).toBe(1);
+
+        // Every model request across both turns carried that one cached token.
+        expect(modelRequests.length).toBeGreaterThanOrEqual(2);
+        for (const request of modelRequests) {
+            expect(request.authorization).toBe(`Bearer ${identity.token}`);
+        }
+    });
+
+    it("refreshes the token on the next turn once it is within the expiry buffer", async () => {
+        // Mint short-lived, rotating tokens: a 1-second lifetime is inside the
+        // runtime's 5-minute refresh buffer, so the cached token is treated as
+        // stale immediately and re-acquired on the next turn. Rotation makes the
+        // refreshed token observably different from the first one.
+        await identity.configure({ expiresInSeconds: 1, rotateTokens: true });
+
+        const provider: ProviderConfig = {
+            type: "openai",
+            wireApi: "completions",
+            baseUrl: modelBaseUrl,
+            modelId: "claude-sonnet-4.5",
+            managedIdentity: { scope: "https://refresh-test.example.test/.default" },
+        };
+
+        await runTurn(provider);
+        const firstTurnBearer = modelRequests.at(-1)?.authorization;
+
+        await runTurn(provider);
+        const secondTurnBearer = modelRequests.at(-1)?.authorization;
+
+        // The endpoint was hit again for the second turn rather than serving a
+        // cached token.
+        const identityRequests = await identity.getRecordedRequests();
+        expect(identityRequests.length).toBeGreaterThanOrEqual(2);
+
+        // The second turn's model request carried a freshly minted token, not
+        // the one from the first turn — proving automatic refresh.
+        expect(secondTurnBearer).not.toBe(firstTurnBearer);
+        expect(secondTurnBearer).toBe(`Bearer ${identityRequests.at(-1)?.issuedToken}`);
+    });
 });

--- a/nodejs/test/e2e/managed_identity.e2e.test.ts
+++ b/nodejs/test/e2e/managed_identity.e2e.test.ts
@@ -2,12 +2,12 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
-import { createServer, IncomingMessage, Server, ServerResponse } from "http";
-import { AddressInfo } from "net";
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import { approveAll } from "../../src/index.js";
 import type { ProviderConfig } from "../../src/index.js";
+import type { RecordedModelRequest } from "../../../../test/harness/mockModelEndpoint";
 import { MockIdentityServer } from "./harness/MockIdentityServer.js";
+import { MockModelServer } from "./harness/MockModelServer.js";
 import { createSdkTestContext } from "./harness/sdkTestContext.js";
 import { retry } from "./harness/sdkTestHelper.js";
 
@@ -22,43 +22,19 @@ import { retry } from "./harness/sdkTestHelper.js";
  *    returns a fixed fake AAD token and records the `resource` + identity query
  *    parameters the runtime asked for. Living in the shared harness lets every
  *    SDK language reuse it.
- *  - A local **mock model endpoint** is the BYOK provider's `baseUrl`. It records
- *    the `Authorization` header the runtime sent and replies with a minimal
- *    streamed chat completion so the turn finishes cleanly.
+ *  - The shared **mock model endpoint** (`test/harness/mockModelServer.ts`,
+ *    spawned via {@link MockModelServer}) is the BYOK provider's `baseUrl`. It
+ *    records the `Authorization` header the runtime sent and replies with a
+ *    minimal streamed chat completion so the turn finishes cleanly.
  *
- * The session is configured with `managedIdentity` (no apiKey/bearerToken), runs
- * one real turn, and we assert the model request carried
+ * Both mock servers live in the shared harness so every SDK language reuses
+ * them. The session is configured with `managedIdentity` (no apiKey/bearerToken),
+ * runs one real turn, and we assert the model request carried
  * `Authorization: Bearer <fake-token>` and that the identity endpoint was asked
  * for the right resource + identity. Because the BYOK base URL is the mock model
  * server (not the replay proxy), the test needs no recorded snapshot and never
  * touches the network.
  */
-
-interface ModelRequest {
-    authorization: string | undefined;
-    path: string;
-}
-
-/** Reads the full request body as a string. */
-function readBody(req: IncomingMessage): Promise<string> {
-    return new Promise((resolve, reject) => {
-        const chunks: Buffer[] = [];
-        req.on("data", (c: Buffer) => chunks.push(c));
-        req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
-        req.on("error", reject);
-    });
-}
-
-function listen(server: Server): Promise<number> {
-    return new Promise((resolve, reject) => {
-        server.once("error", reject);
-        server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port));
-    });
-}
-
-function close(server: Server): Promise<void> {
-    return new Promise((resolve) => server.close(() => resolve()));
-}
 
 describe("BYOK managed identity authentication", async () => {
     const { copilotClient: client, env } = await createSdkTestContext();
@@ -67,76 +43,11 @@ describe("BYOK managed identity authentication", async () => {
     const identity = new MockIdentityServer();
     await identity.start();
 
-    const modelRequests: ModelRequest[] = [];
-
-    // BYOK model endpoint. Records the Authorization header the runtime injected
-    // and returns a minimal streamed OpenAI chat completion so the turn ends.
-    const modelServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-        const body = await readBody(req);
-        modelRequests.push({
-            authorization: (req.headers["authorization"] as string | undefined) ?? undefined,
-            path: req.url ?? "",
-        });
-        let wantsStream = false;
-        try {
-            wantsStream = (JSON.parse(body) as { stream?: boolean }).stream === true;
-        } catch {
-            // Non-JSON body: fall back to a non-streaming reply.
-        }
-
-        if (wantsStream) {
-            res.writeHead(200, { "content-type": "text/event-stream" });
-            const base = {
-                id: "mock-completion",
-                object: "chat.completion.chunk",
-                created: Math.floor(Date.now() / 1000),
-                model: "mock-model",
-            };
-            res.write(
-                `data: ${JSON.stringify({
-                    ...base,
-                    choices: [
-                        {
-                            index: 0,
-                            delta: { role: "assistant", content: "OK" },
-                            finish_reason: null,
-                            logprobs: null,
-                        },
-                    ],
-                })}\n\n`
-            );
-            res.write(
-                `data: ${JSON.stringify({
-                    ...base,
-                    choices: [{ index: 0, delta: {}, finish_reason: "stop", logprobs: null }],
-                })}\n\n`
-            );
-            res.write("data: [DONE]\n\n");
-            res.end();
-        } else {
-            res.writeHead(200, { "content-type": "application/json" });
-            res.end(
-                JSON.stringify({
-                    id: "mock-completion",
-                    object: "chat.completion",
-                    created: Math.floor(Date.now() / 1000),
-                    model: "mock-model",
-                    choices: [
-                        {
-                            index: 0,
-                            message: { role: "assistant", content: "OK" },
-                            finish_reason: "stop",
-                            logprobs: null,
-                        },
-                    ],
-                    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
-                })
-            );
-        }
-    });
-
-    const modelPort = await listen(modelServer);
-    const modelBaseUrl = `http://127.0.0.1:${modelPort}`;
+    // BYOK model endpoint, shared across SDKs. Records the Authorization header
+    // the runtime injected and returns a minimal OpenAI chat completion.
+    const model = new MockModelServer();
+    await model.start();
+    const modelBaseUrl = model.baseUrl;
 
     // The harness env object is the same one passed to the CLI subprocess, so
     // mutating it before the first createSession() configures managed identity
@@ -149,12 +60,12 @@ describe("BYOK managed identity authentication", async () => {
 
     beforeEach(async () => {
         await identity.reset();
-        modelRequests.length = 0;
+        await model.reset();
     });
 
     afterAll(async () => {
         await identity.stop();
-        await close(modelServer);
+        await model.stop();
     });
 
     async function runTurn(provider: ProviderConfig): Promise<void> {
@@ -182,9 +93,13 @@ describe("BYOK managed identity authentication", async () => {
             managedIdentity: {},
         });
 
+        let modelRequests: RecordedModelRequest[] = [];
         await retry(
             "capture a model request",
-            async () => expect(modelRequests.length).toBeGreaterThanOrEqual(1),
+            async () => {
+                modelRequests = await model.getRecordedRequests();
+                expect(modelRequests.length).toBeGreaterThanOrEqual(1);
+            },
             1_200
         );
 
@@ -217,9 +132,13 @@ describe("BYOK managed identity authentication", async () => {
             },
         });
 
+        let modelRequests: RecordedModelRequest[] = [];
         await retry(
             "capture a model request",
-            async () => expect(modelRequests.length).toBeGreaterThanOrEqual(1),
+            async () => {
+                modelRequests = await model.getRecordedRequests();
+                expect(modelRequests.length).toBeGreaterThanOrEqual(1);
+            },
             1_200
         );
 
@@ -259,6 +178,7 @@ describe("BYOK managed identity authentication", async () => {
         expect(identityRequests.length).toBe(1);
 
         // Every model request across both turns carried that one cached token.
+        const modelRequests = await model.getRecordedRequests();
         expect(modelRequests.length).toBeGreaterThanOrEqual(2);
         for (const request of modelRequests) {
             expect(request.authorization).toBe(`Bearer ${identity.token}`);
@@ -281,10 +201,12 @@ describe("BYOK managed identity authentication", async () => {
         };
 
         await runTurn(provider);
-        const firstTurnBearer = modelRequests.at(-1)?.authorization;
+        const firstTurnRequests = await model.getRecordedRequests();
+        const firstTurnBearer = firstTurnRequests.at(-1)?.authorization;
 
         await runTurn(provider);
-        const secondTurnBearer = modelRequests.at(-1)?.authorization;
+        const secondTurnRequests = await model.getRecordedRequests();
+        const secondTurnBearer = secondTurnRequests.at(-1)?.authorization;
 
         // The endpoint was hit again for the second turn rather than serving a
         // cached token.

--- a/nodejs/test/e2e/managed_identity.e2e.test.ts
+++ b/nodejs/test/e2e/managed_identity.e2e.test.ts
@@ -1,0 +1,271 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createServer, IncomingMessage, Server, ServerResponse } from "http";
+import { AddressInfo } from "net";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { approveAll } from "../../src/index.js";
+import type { ProviderConfig } from "../../src/index.js";
+import { createSdkTestContext } from "./harness/sdkTestContext.js";
+import { retry } from "./harness/sdkTestHelper.js";
+
+/**
+ * End-to-end coverage for Azure managed identity (MI) authentication on a BYOK
+ * provider. Proves the full SDK → runtime → Rust credential chain wiring without
+ * any real network:
+ *
+ *  - A local **mock identity endpoint** plays the App Service / Functions managed
+ *    identity contract (`IDENTITY_ENDPOINT` + `IDENTITY_HEADER`). It returns a
+ *    fixed fake AAD token and records the `resource` + identity query parameters
+ *    the runtime asked for.
+ *  - A local **mock model endpoint** is the BYOK provider's `baseUrl`. It records
+ *    the `Authorization` header the runtime sent and replies with a minimal
+ *    streamed chat completion so the turn finishes cleanly.
+ *
+ * The session is configured with `managedIdentity` (no apiKey/bearerToken), runs
+ * one real turn, and we assert the model request carried
+ * `Authorization: Bearer <fake-token>` and that the identity endpoint was asked
+ * for the right resource + identity. Because the BYOK base URL is the mock model
+ * server (not the replay proxy), the test needs no recorded snapshot and never
+ * touches the network.
+ */
+
+const FAKE_MI_TOKEN = "fake-managed-identity-token";
+const IDENTITY_HEADER_SECRET = "fake-identity-header-secret";
+
+interface IdentityRequest {
+    resource: string | null;
+    apiVersion: string | null;
+    identityHeader: string | undefined;
+    /** Identity-selector query params present (client_id / principal_id / mi_res_id). */
+    identityParams: Record<string, string>;
+}
+
+interface ModelRequest {
+    authorization: string | undefined;
+    path: string;
+}
+
+/** Reads the full request body as a string. */
+function readBody(req: IncomingMessage): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+        req.on("error", reject);
+    });
+}
+
+function listen(server: Server): Promise<number> {
+    return new Promise((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port));
+    });
+}
+
+function close(server: Server): Promise<void> {
+    return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe("BYOK managed identity authentication", async () => {
+    const { copilotClient: client, env } = await createSdkTestContext();
+
+    const identityRequests: IdentityRequest[] = [];
+    const modelRequests: ModelRequest[] = [];
+
+    // App Service / Functions managed identity endpoint. Validates the secret
+    // header, records what was asked for, and returns a fixed fake token.
+    const identityServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+        const url = new URL(req.url ?? "/", "http://127.0.0.1");
+        const identityParams: Record<string, string> = {};
+        for (const key of ["client_id", "principal_id", "mi_res_id"]) {
+            const value = url.searchParams.get(key);
+            if (value !== null) {
+                identityParams[key] = value;
+            }
+        }
+        identityRequests.push({
+            resource: url.searchParams.get("resource"),
+            apiVersion: url.searchParams.get("api-version"),
+            identityHeader: (req.headers["x-identity-header"] as string | undefined) ?? undefined,
+            identityParams,
+        });
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(
+            JSON.stringify({
+                access_token: FAKE_MI_TOKEN,
+                expires_in: 3600,
+                token_type: "Bearer",
+                resource: url.searchParams.get("resource"),
+            })
+        );
+    });
+
+    // BYOK model endpoint. Records the Authorization header the runtime injected
+    // and returns a minimal streamed OpenAI chat completion so the turn ends.
+    const modelServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+        const body = await readBody(req);
+        modelRequests.push({
+            authorization: (req.headers["authorization"] as string | undefined) ?? undefined,
+            path: req.url ?? "",
+        });
+        let wantsStream = false;
+        try {
+            wantsStream = (JSON.parse(body) as { stream?: boolean }).stream === true;
+        } catch {
+            // Non-JSON body: fall back to a non-streaming reply.
+        }
+
+        if (wantsStream) {
+            res.writeHead(200, { "content-type": "text/event-stream" });
+            const base = {
+                id: "mock-completion",
+                object: "chat.completion.chunk",
+                created: Math.floor(Date.now() / 1000),
+                model: "mock-model",
+            };
+            res.write(
+                `data: ${JSON.stringify({
+                    ...base,
+                    choices: [
+                        {
+                            index: 0,
+                            delta: { role: "assistant", content: "OK" },
+                            finish_reason: null,
+                            logprobs: null,
+                        },
+                    ],
+                })}\n\n`
+            );
+            res.write(
+                `data: ${JSON.stringify({
+                    ...base,
+                    choices: [{ index: 0, delta: {}, finish_reason: "stop", logprobs: null }],
+                })}\n\n`
+            );
+            res.write("data: [DONE]\n\n");
+            res.end();
+        } else {
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(
+                JSON.stringify({
+                    id: "mock-completion",
+                    object: "chat.completion",
+                    created: Math.floor(Date.now() / 1000),
+                    model: "mock-model",
+                    choices: [
+                        {
+                            index: 0,
+                            message: { role: "assistant", content: "OK" },
+                            finish_reason: "stop",
+                            logprobs: null,
+                        },
+                    ],
+                    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+                })
+            );
+        }
+    });
+
+    const identityPort = await listen(identityServer);
+    const modelPort = await listen(modelServer);
+    const modelBaseUrl = `http://127.0.0.1:${modelPort}`;
+
+    // The harness env object is the same one passed to the CLI subprocess, so
+    // mutating it before the first createSession() configures managed identity
+    // resolution inside the runtime. These are all standard Azure env vars.
+    env.IDENTITY_ENDPOINT = `http://127.0.0.1:${identityPort}/msi/token`;
+    env.IDENTITY_HEADER = IDENTITY_HEADER_SECRET;
+    env.AZURE_TOKEN_CREDENTIALS = "ManagedIdentityCredential";
+    // Ensure no ambient user-assigned id leaks in from the host environment.
+    env.AZURE_CLIENT_ID = "";
+
+    beforeEach(() => {
+        identityRequests.length = 0;
+        modelRequests.length = 0;
+    });
+
+    afterAll(async () => {
+        await close(identityServer);
+        await close(modelServer);
+    });
+
+    async function runTurn(provider: ProviderConfig): Promise<void> {
+        const session = await client.createSession({
+            onPermissionRequest: approveAll,
+            provider,
+        });
+        try {
+            await session.sendAndWait({ prompt: "What is 5+5?" });
+        } finally {
+            try {
+                await session.disconnect();
+            } catch {
+                // disconnect may fail since the BYOK provider is a local mock
+            }
+        }
+    }
+
+    it("acquires a system-assigned managed identity token and injects it as a bearer", async () => {
+        await runTurn({
+            type: "openai",
+            wireApi: "completions",
+            baseUrl: modelBaseUrl,
+            modelId: "claude-sonnet-4.5",
+            managedIdentity: true,
+        });
+
+        await retry(
+            "capture a model request",
+            async () => expect(modelRequests.length).toBeGreaterThanOrEqual(1),
+            1_200
+        );
+
+        // The runtime acquired the fake token from the identity endpoint and
+        // injected it as the model request's bearer credential.
+        expect(modelRequests[0].authorization).toBe(`Bearer ${FAKE_MI_TOKEN}`);
+
+        // The identity endpoint was hit with the App Service secret header, the
+        // default cognitiveservices resource, and NO identity selector (system
+        // assigned).
+        expect(identityRequests.length).toBeGreaterThanOrEqual(1);
+        const idReq = identityRequests[0];
+        expect(idReq.identityHeader).toBe(IDENTITY_HEADER_SECRET);
+        expect(idReq.resource).toBe("https://cognitiveservices.azure.com");
+        expect(idReq.identityParams).toEqual({});
+    });
+
+    it("acquires a user-assigned managed identity (clientId) with a custom scope", async () => {
+        // A custom scope keeps this turn's token cache key distinct from the
+        // system-assigned test above (the runtime caches by scope + identity).
+        await runTurn({
+            type: "openai",
+            wireApi: "completions",
+            baseUrl: modelBaseUrl,
+            modelId: "claude-sonnet-4.5",
+            managedIdentity: {
+                clientId: "11111111-2222-3333-4444-555555555555",
+                scope: "https://gateway.example.test/.default",
+            },
+        });
+
+        await retry(
+            "capture a model request",
+            async () => expect(modelRequests.length).toBeGreaterThanOrEqual(1),
+            1_200
+        );
+
+        expect(modelRequests[0].authorization).toBe(`Bearer ${FAKE_MI_TOKEN}`);
+
+        expect(identityRequests.length).toBeGreaterThanOrEqual(1);
+        const idReq = identityRequests[0];
+        expect(idReq.identityHeader).toBe(IDENTITY_HEADER_SECRET);
+        // The custom scope's resource (scope minus the /.default suffix).
+        expect(idReq.resource).toBe("https://gateway.example.test");
+        // The user-assigned client id was sent as the App Service client_id param.
+        expect(idReq.identityParams).toEqual({
+            client_id: "11111111-2222-3333-4444-555555555555",
+        });
+    });
+});

--- a/nodejs/test/e2e/managed_identity.e2e.test.ts
+++ b/nodejs/test/e2e/managed_identity.e2e.test.ts
@@ -7,6 +7,7 @@ import { AddressInfo } from "net";
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import { approveAll } from "../../src/index.js";
 import type { ProviderConfig } from "../../src/index.js";
+import { MockIdentityServer } from "./harness/MockIdentityServer.js";
 import { createSdkTestContext } from "./harness/sdkTestContext.js";
 import { retry } from "./harness/sdkTestHelper.js";
 
@@ -15,10 +16,12 @@ import { retry } from "./harness/sdkTestHelper.js";
  * provider. Proves the full SDK → runtime → Rust credential chain wiring without
  * any real network:
  *
- *  - A local **mock identity endpoint** plays the App Service / Functions managed
- *    identity contract (`IDENTITY_ENDPOINT` + `IDENTITY_HEADER`). It returns a
- *    fixed fake AAD token and records the `resource` + identity query parameters
- *    the runtime asked for.
+ *  - The shared **mock identity endpoint** (`test/harness/mockIdentityServer.ts`,
+ *    spawned via {@link MockIdentityServer}) plays the App Service / Functions
+ *    managed identity contract (`IDENTITY_ENDPOINT` + `IDENTITY_HEADER`). It
+ *    returns a fixed fake AAD token and records the `resource` + identity query
+ *    parameters the runtime asked for. Living in the shared harness lets every
+ *    SDK language reuse it.
  *  - A local **mock model endpoint** is the BYOK provider's `baseUrl`. It records
  *    the `Authorization` header the runtime sent and replies with a minimal
  *    streamed chat completion so the turn finishes cleanly.
@@ -30,17 +33,6 @@ import { retry } from "./harness/sdkTestHelper.js";
  * server (not the replay proxy), the test needs no recorded snapshot and never
  * touches the network.
  */
-
-const FAKE_MI_TOKEN = "fake-managed-identity-token";
-const IDENTITY_HEADER_SECRET = "fake-identity-header-secret";
-
-interface IdentityRequest {
-    resource: string | null;
-    apiVersion: string | null;
-    identityHeader: string | undefined;
-    /** Identity-selector query params present (client_id / principal_id / mi_res_id). */
-    identityParams: Record<string, string>;
-}
 
 interface ModelRequest {
     authorization: string | undefined;
@@ -71,36 +63,11 @@ function close(server: Server): Promise<void> {
 describe("BYOK managed identity authentication", async () => {
     const { copilotClient: client, env } = await createSdkTestContext();
 
-    const identityRequests: IdentityRequest[] = [];
-    const modelRequests: ModelRequest[] = [];
+    // App Service / Functions managed identity endpoint, shared across SDKs.
+    const identity = new MockIdentityServer();
+    await identity.start();
 
-    // App Service / Functions managed identity endpoint. Validates the secret
-    // header, records what was asked for, and returns a fixed fake token.
-    const identityServer = createServer((req: IncomingMessage, res: ServerResponse) => {
-        const url = new URL(req.url ?? "/", "http://127.0.0.1");
-        const identityParams: Record<string, string> = {};
-        for (const key of ["client_id", "principal_id", "mi_res_id"]) {
-            const value = url.searchParams.get(key);
-            if (value !== null) {
-                identityParams[key] = value;
-            }
-        }
-        identityRequests.push({
-            resource: url.searchParams.get("resource"),
-            apiVersion: url.searchParams.get("api-version"),
-            identityHeader: (req.headers["x-identity-header"] as string | undefined) ?? undefined,
-            identityParams,
-        });
-        res.writeHead(200, { "content-type": "application/json" });
-        res.end(
-            JSON.stringify({
-                access_token: FAKE_MI_TOKEN,
-                expires_in: 3600,
-                token_type: "Bearer",
-                resource: url.searchParams.get("resource"),
-            })
-        );
-    });
+    const modelRequests: ModelRequest[] = [];
 
     // BYOK model endpoint. Records the Authorization header the runtime injected
     // and returns a minimal streamed OpenAI chat completion so the turn ends.
@@ -168,26 +135,25 @@ describe("BYOK managed identity authentication", async () => {
         }
     });
 
-    const identityPort = await listen(identityServer);
     const modelPort = await listen(modelServer);
     const modelBaseUrl = `http://127.0.0.1:${modelPort}`;
 
     // The harness env object is the same one passed to the CLI subprocess, so
     // mutating it before the first createSession() configures managed identity
     // resolution inside the runtime. These are all standard Azure env vars.
-    env.IDENTITY_ENDPOINT = `http://127.0.0.1:${identityPort}/msi/token`;
-    env.IDENTITY_HEADER = IDENTITY_HEADER_SECRET;
+    env.IDENTITY_ENDPOINT = identity.endpoint;
+    env.IDENTITY_HEADER = identity.header;
     env.AZURE_TOKEN_CREDENTIALS = "ManagedIdentityCredential";
     // Ensure no ambient user-assigned id leaks in from the host environment.
     env.AZURE_CLIENT_ID = "";
 
-    beforeEach(() => {
-        identityRequests.length = 0;
+    beforeEach(async () => {
+        await identity.reset();
         modelRequests.length = 0;
     });
 
     afterAll(async () => {
-        await close(identityServer);
+        await identity.stop();
         await close(modelServer);
     });
 
@@ -224,14 +190,15 @@ describe("BYOK managed identity authentication", async () => {
 
         // The runtime acquired the fake token from the identity endpoint and
         // injected it as the model request's bearer credential.
-        expect(modelRequests[0].authorization).toBe(`Bearer ${FAKE_MI_TOKEN}`);
+        expect(modelRequests[0].authorization).toBe(`Bearer ${identity.token}`);
 
         // The identity endpoint was hit with the App Service secret header, the
         // default cognitiveservices resource, and NO identity selector (system
         // assigned).
+        const identityRequests = await identity.getRecordedRequests();
         expect(identityRequests.length).toBeGreaterThanOrEqual(1);
         const idReq = identityRequests[0];
-        expect(idReq.identityHeader).toBe(IDENTITY_HEADER_SECRET);
+        expect(idReq.identityHeader).toBe(identity.header);
         expect(idReq.resource).toBe("https://cognitiveservices.azure.com");
         expect(idReq.identityParams).toEqual({});
     });
@@ -256,11 +223,12 @@ describe("BYOK managed identity authentication", async () => {
             1_200
         );
 
-        expect(modelRequests[0].authorization).toBe(`Bearer ${FAKE_MI_TOKEN}`);
+        expect(modelRequests[0].authorization).toBe(`Bearer ${identity.token}`);
 
+        const identityRequests = await identity.getRecordedRequests();
         expect(identityRequests.length).toBeGreaterThanOrEqual(1);
         const idReq = identityRequests[0];
-        expect(idReq.identityHeader).toBe(IDENTITY_HEADER_SECRET);
+        expect(idReq.identityHeader).toBe(identity.header);
         // The custom scope's resource (scope minus the /.default suffix).
         expect(idReq.resource).toBe("https://gateway.example.test");
         // The user-assigned client id was sent as the App Service client_id param.

--- a/nodejs/test/e2e/managed_identity.e2e.test.ts
+++ b/nodejs/test/e2e/managed_identity.e2e.test.ts
@@ -179,7 +179,7 @@ describe("BYOK managed identity authentication", async () => {
             wireApi: "completions",
             baseUrl: modelBaseUrl,
             modelId: "claude-sonnet-4.5",
-            managedIdentity: true,
+            managedIdentity: {},
         });
 
         await retry(

--- a/test/harness/mockIdentityEndpoint.ts
+++ b/test/harness/mockIdentityEndpoint.ts
@@ -19,6 +19,11 @@ const RECORDED_PATH = "/__identity/recorded";
 const RESET_PATH = "/__identity/reset";
 /** Control path: POST closes the endpoint so its process can exit cleanly. */
 const STOP_PATH = "/__identity/stop";
+/** Control path: POST sets the token lifetime / rotation behaviour. */
+const CONFIGURE_PATH = "/__identity/configure";
+
+/** Default token lifetime, comfortably outside the runtime's refresh buffer. */
+const DEFAULT_EXPIRES_IN_SECONDS = 3600;
 
 /** App Service / Functions managed identity selector query params. */
 const IDENTITY_SELECTOR_PARAMS = ["client_id", "principal_id", "mi_res_id"] as const;
@@ -37,6 +42,28 @@ export interface RecordedIdentityRequest {
    * `principal_id`, or `mi_res_id`.
    */
   identityParams: Record<string, string>;
+  /**
+   * The exact `access_token` value returned for this request. With token
+   * rotation enabled this changes per request, letting tests prove a refreshed
+   * token (rather than a cached one) reached the model.
+   */
+  issuedToken: string;
+}
+
+/** Token lifetime / rotation behaviour of the mock identity endpoint. */
+export interface MockIdentityConfig {
+  /**
+   * Lifetime to report via `expires_in` (seconds). Set this below the runtime's
+   * 5-minute refresh buffer (e.g. `1`) to make every cached token immediately
+   * eligible for refresh.
+   */
+  expiresInSeconds?: number;
+  /**
+   * When true, each token request returns a distinct token value
+   * (`<token>-<n>`) so tests can observe refreshes. When false (default) the
+   * fixed {@link MOCK_IDENTITY_TOKEN} is always returned.
+   */
+  rotateTokens?: boolean;
 }
 
 /** Connection details a test needs to exercise the mock identity endpoint. */
@@ -53,6 +80,8 @@ export interface MockIdentityEndpointInfo {
   resetUrl: string;
   /** POST URL that closes the endpoint so its host process can exit. */
   stopUrl: string;
+  /** POST URL that sets the token lifetime / rotation behaviour. */
+  configureUrl: string;
 }
 
 /**
@@ -70,6 +99,9 @@ export class MockIdentityEndpoint {
   private server: http.Server | undefined;
   private readonly requests: RecordedIdentityRequest[] = [];
   private baseUrl = "";
+  private expiresInSeconds = DEFAULT_EXPIRES_IN_SECONDS;
+  private rotateTokens = false;
+  private issueCount = 0;
 
   /** Starts the endpoint on a random loopback port. */
   async start(): Promise<MockIdentityEndpointInfo> {
@@ -93,7 +125,18 @@ export class MockIdentityEndpoint {
       recordedUrl: `${this.baseUrl}${RECORDED_PATH}`,
       resetUrl: `${this.baseUrl}${RESET_PATH}`,
       stopUrl: `${this.baseUrl}${STOP_PATH}`,
+      configureUrl: `${this.baseUrl}${CONFIGURE_PATH}`,
     };
+  }
+
+  /** Sets the token lifetime / rotation behaviour. */
+  configure(config: MockIdentityConfig): void {
+    if (config.expiresInSeconds !== undefined) {
+      this.expiresInSeconds = config.expiresInSeconds;
+    }
+    if (config.rotateTokens !== undefined) {
+      this.rotateTokens = config.rotateTokens;
+    }
   }
 
   /** Token requests recorded so far, in arrival order. */
@@ -101,9 +144,12 @@ export class MockIdentityEndpoint {
     return this.requests;
   }
 
-  /** Clears the recorded token requests. */
+  /** Clears recorded requests and restores the default token behaviour. */
   reset(): void {
     this.requests.length = 0;
+    this.expiresInSeconds = DEFAULT_EXPIRES_IN_SECONDS;
+    this.rotateTokens = false;
+    this.issueCount = 0;
   }
 
   async stop(): Promise<void> {
@@ -130,6 +176,18 @@ export class MockIdentityEndpoint {
       return;
     }
 
+    if (req.method === "POST" && url.pathname === CONFIGURE_PATH) {
+      void readBody(req).then((body) => {
+        try {
+          this.configure(body ? (JSON.parse(body) as MockIdentityConfig) : {});
+          respondJson(res, 200, { ok: true });
+        } catch {
+          respondJson(res, 400, { error: "Invalid configure body" });
+        }
+      });
+      return;
+    }
+
     if (req.method === "GET" && url.pathname === RECORDED_PATH) {
       respondJson(res, 200, this.requests);
       return;
@@ -148,20 +206,34 @@ export class MockIdentityEndpoint {
       }
     }
     const resource = url.searchParams.get("resource");
+    const issuedToken = this.rotateTokens
+      ? `${MOCK_IDENTITY_TOKEN}-${++this.issueCount}`
+      : MOCK_IDENTITY_TOKEN;
     this.requests.push({
       resource,
       apiVersion: url.searchParams.get("api-version"),
       identityHeader: (req.headers["x-identity-header"] as string | undefined) ?? undefined,
       identityParams,
+      issuedToken,
     });
 
     respondJson(res, 200, {
-      access_token: MOCK_IDENTITY_TOKEN,
-      expires_in: 3600,
+      access_token: issuedToken,
+      expires_in: this.expiresInSeconds,
       token_type: "Bearer",
       resource,
     });
   }
+}
+
+/** Reads the full request body as a string. */
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
 }
 
 function respondJson(res: http.ServerResponse, statusCode: number, body: unknown): void {

--- a/test/harness/mockIdentityEndpoint.ts
+++ b/test/harness/mockIdentityEndpoint.ts
@@ -1,0 +1,174 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import http from "http";
+import type { AddressInfo } from "net";
+
+/** Fixed fake AAD token the mock identity endpoint mints for every request. */
+export const MOCK_IDENTITY_TOKEN = "fake-managed-identity-token";
+
+/** Secret the runtime must echo back in the `x-identity-header` header. */
+export const MOCK_IDENTITY_HEADER_SECRET = "fake-identity-header-secret";
+
+/** Path the token is served from (the value baked into `IDENTITY_ENDPOINT`). */
+const TOKEN_PATH = "/msi/token";
+/** Control path: GET returns the recorded token requests as JSON. */
+const RECORDED_PATH = "/__identity/recorded";
+/** Control path: POST clears the recorded token requests. */
+const RESET_PATH = "/__identity/reset";
+/** Control path: POST closes the endpoint so its process can exit cleanly. */
+const STOP_PATH = "/__identity/stop";
+
+/** App Service / Functions managed identity selector query params. */
+const IDENTITY_SELECTOR_PARAMS = ["client_id", "principal_id", "mi_res_id"] as const;
+
+/** A single token request the runtime made to the mock identity endpoint. */
+export interface RecordedIdentityRequest {
+  /** `resource` query parameter the runtime asked a token for. */
+  resource: string | null;
+  /** `api-version` query parameter. */
+  apiVersion: string | null;
+  /** Value of the `x-identity-header` secret header (undefined if absent). */
+  identityHeader: string | undefined;
+  /**
+   * Identity selector params present on the request. System-assigned identities
+   * send none; user-assigned identities send exactly one of `client_id`,
+   * `principal_id`, or `mi_res_id`.
+   */
+  identityParams: Record<string, string>;
+}
+
+/** Connection details a test needs to exercise the mock identity endpoint. */
+export interface MockIdentityEndpointInfo {
+  /** URL to assign to the `IDENTITY_ENDPOINT` env var. */
+  endpoint: string;
+  /** Secret to assign to the `IDENTITY_HEADER` env var. */
+  header: string;
+  /** Fake bearer token the runtime injects (`Authorization: Bearer <token>`). */
+  token: string;
+  /** GET URL returning the recorded token requests as JSON. */
+  recordedUrl: string;
+  /** POST URL clearing the recorded token requests. */
+  resetUrl: string;
+  /** POST URL that closes the endpoint so its host process can exit. */
+  stopUrl: string;
+}
+
+/**
+ * A mock of the Azure App Service / Functions managed identity token endpoint
+ * (the `IDENTITY_ENDPOINT` + `IDENTITY_HEADER` contract). It mints a fixed fake
+ * AAD token and records the resource + identity selector each token request
+ * asked for, so e2e tests can assert the runtime resolved the managed identity
+ * correctly.
+ *
+ * It lives in the shared harness and is exposed over HTTP (token + control
+ * endpoints) so SDK e2e tests in any language can drive BYOK managed identity
+ * without re-implementing the endpoint.
+ */
+export class MockIdentityEndpoint {
+  private server: http.Server | undefined;
+  private readonly requests: RecordedIdentityRequest[] = [];
+  private baseUrl = "";
+
+  /** Starts the endpoint on a random loopback port. */
+  async start(): Promise<MockIdentityEndpointInfo> {
+    const server = http.createServer((req, res) => this.handle(req, res));
+    this.server = server;
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+    this.baseUrl = `http://127.0.0.1:${port}`;
+    return this.info();
+  }
+
+  /** Connection details for the running endpoint. */
+  info(): MockIdentityEndpointInfo {
+    return {
+      endpoint: `${this.baseUrl}${TOKEN_PATH}`,
+      header: MOCK_IDENTITY_HEADER_SECRET,
+      token: MOCK_IDENTITY_TOKEN,
+      recordedUrl: `${this.baseUrl}${RECORDED_PATH}`,
+      resetUrl: `${this.baseUrl}${RESET_PATH}`,
+      stopUrl: `${this.baseUrl}${STOP_PATH}`,
+    };
+  }
+
+  /** Token requests recorded so far, in arrival order. */
+  recordedRequests(): readonly RecordedIdentityRequest[] {
+    return this.requests;
+  }
+
+  /** Clears the recorded token requests. */
+  reset(): void {
+    this.requests.length = 0;
+  }
+
+  async stop(): Promise<void> {
+    const server = this.server;
+    if (!server) {
+      return;
+    }
+    this.server = undefined;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+
+  private handle(req: http.IncomingMessage, res: http.ServerResponse): void {
+    const url = new URL(req.url ?? "/", this.baseUrl);
+
+    if (req.method === "POST" && url.pathname === RESET_PATH) {
+      this.reset();
+      respondJson(res, 200, { ok: true });
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === STOP_PATH) {
+      respondJson(res, 200, { ok: true });
+      res.on("finish", () => void this.stop());
+      return;
+    }
+
+    if (req.method === "GET" && url.pathname === RECORDED_PATH) {
+      respondJson(res, 200, this.requests);
+      return;
+    }
+
+    if (url.pathname !== TOKEN_PATH) {
+      respondJson(res, 404, { error: "Not Found (mock identity endpoint)" });
+      return;
+    }
+
+    const identityParams: Record<string, string> = {};
+    for (const key of IDENTITY_SELECTOR_PARAMS) {
+      const value = url.searchParams.get(key);
+      if (value !== null) {
+        identityParams[key] = value;
+      }
+    }
+    const resource = url.searchParams.get("resource");
+    this.requests.push({
+      resource,
+      apiVersion: url.searchParams.get("api-version"),
+      identityHeader: (req.headers["x-identity-header"] as string | undefined) ?? undefined,
+      identityParams,
+    });
+
+    respondJson(res, 200, {
+      access_token: MOCK_IDENTITY_TOKEN,
+      expires_in: 3600,
+      token_type: "Bearer",
+      resource,
+    });
+  }
+}
+
+function respondJson(res: http.ServerResponse, statusCode: number, body: unknown): void {
+  const data = JSON.stringify(body);
+  res.writeHead(statusCode, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(data),
+  });
+  res.end(data);
+}

--- a/test/harness/mockIdentityServer.ts
+++ b/test/harness/mockIdentityServer.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { MockIdentityEndpoint } from "./mockIdentityEndpoint";
+
+// Standalone entrypoint for the mock Azure managed identity token endpoint.
+// Intended to be spawned as a child process by E2E tests in any SDK language:
+// read the `Listening:` line below for the endpoint + control URLs, set
+// IDENTITY_ENDPOINT / IDENTITY_HEADER from it, then POST the stopUrl (or kill
+// the process) when done. Kept separate from the CAPI record/replay proxy so it
+// can be used on its own.
+
+const endpoint = new MockIdentityEndpoint();
+const info = await endpoint.start();
+
+// Single-line, machine-parseable startup banner mirroring server.ts.
+console.log(`Listening: ${JSON.stringify(info)}`);
+
+const shutdown = async () => {
+  await endpoint.stop();
+  process.exit(0);
+};
+process.on("SIGTERM", () => void shutdown());
+process.on("SIGINT", () => void shutdown());

--- a/test/harness/mockModelEndpoint.ts
+++ b/test/harness/mockModelEndpoint.ts
@@ -1,0 +1,216 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import http from "http";
+import type { AddressInfo } from "net";
+
+/** Control path: GET returns the recorded model requests as JSON. */
+const RECORDED_PATH = "/__model/recorded";
+/** Control path: POST clears the recorded model requests. */
+const RESET_PATH = "/__model/reset";
+/** Control path: POST closes the endpoint so its process can exit cleanly. */
+const STOP_PATH = "/__model/stop";
+
+/** A single inference request the runtime made to the mock model endpoint. */
+export interface RecordedModelRequest {
+  /** Value of the `Authorization` header (undefined if absent). */
+  authorization: string | undefined;
+  /** Request path the runtime called (e.g. `/chat/completions`). */
+  path: string;
+  /** Request method. */
+  method: string;
+}
+
+/** Connection details a test needs to exercise the mock model endpoint. */
+export interface MockModelEndpointInfo {
+  /** Base URL to assign as the BYOK provider's `baseUrl`. */
+  baseUrl: string;
+  /** GET URL returning the recorded model requests as JSON. */
+  recordedUrl: string;
+  /** POST URL clearing the recorded model requests. */
+  resetUrl: string;
+  /** POST URL that closes the endpoint so its host process can exit. */
+  stopUrl: string;
+}
+
+/**
+ * A mock of a BYOK provider's OpenAI-compatible inference endpoint. It records
+ * the `Authorization` header (and path/method) of every inference request the
+ * runtime sent — so e2e tests can assert the credential the runtime injected —
+ * and replies with a minimal OpenAI chat completion (streamed or not) so the
+ * turn finishes cleanly.
+ *
+ * It lives in the shared harness and is exposed over HTTP (inference + control
+ * endpoints) so SDK e2e tests in any language can point a BYOK provider at it
+ * without re-implementing the endpoint.
+ */
+export class MockModelEndpoint {
+  private server: http.Server | undefined;
+  private readonly requests: RecordedModelRequest[] = [];
+  private baseUrl = "";
+
+  /** Starts the endpoint on a random loopback port. */
+  async start(): Promise<MockModelEndpointInfo> {
+    const server = http.createServer((req, res) => {
+      void this.handle(req, res);
+    });
+    this.server = server;
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+    this.baseUrl = `http://127.0.0.1:${port}`;
+    return this.info();
+  }
+
+  /** Connection details for the running endpoint. */
+  info(): MockModelEndpointInfo {
+    return {
+      baseUrl: this.baseUrl,
+      recordedUrl: `${this.baseUrl}${RECORDED_PATH}`,
+      resetUrl: `${this.baseUrl}${RESET_PATH}`,
+      stopUrl: `${this.baseUrl}${STOP_PATH}`,
+    };
+  }
+
+  /** Inference requests recorded so far, in arrival order. */
+  recordedRequests(): readonly RecordedModelRequest[] {
+    return this.requests;
+  }
+
+  /** Clears recorded requests. */
+  reset(): void {
+    this.requests.length = 0;
+  }
+
+  async stop(): Promise<void> {
+    const server = this.server;
+    if (!server) {
+      return;
+    }
+    this.server = undefined;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+
+  private async handle(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ): Promise<void> {
+    const url = new URL(req.url ?? "/", this.baseUrl);
+
+    if (req.method === "POST" && url.pathname === RESET_PATH) {
+      this.reset();
+      respondJson(res, 200, { ok: true });
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === STOP_PATH) {
+      respondJson(res, 200, { ok: true });
+      res.on("finish", () => void this.stop());
+      return;
+    }
+
+    if (req.method === "GET" && url.pathname === RECORDED_PATH) {
+      respondJson(res, 200, this.requests);
+      return;
+    }
+
+    // Any other path is treated as an inference request.
+    const body = await readBody(req);
+    this.requests.push({
+      authorization:
+        (req.headers["authorization"] as string | undefined) ?? undefined,
+      path: req.url ?? "",
+      method: req.method ?? "GET",
+    });
+
+    let wantsStream = false;
+    try {
+      wantsStream = (JSON.parse(body) as { stream?: boolean }).stream === true;
+    } catch {
+      // Non-JSON body: fall back to a non-streaming reply.
+    }
+
+    if (wantsStream) {
+      respondStream(res);
+    } else {
+      respondCompletion(res);
+    }
+  }
+}
+
+/** Reads the full request body as a string. */
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+/** Writes a minimal streamed OpenAI chat completion ending in `[DONE]`. */
+function respondStream(res: http.ServerResponse): void {
+  res.writeHead(200, { "content-type": "text/event-stream" });
+  const base = {
+    id: "mock-completion",
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model: "mock-model",
+  };
+  res.write(
+    `data: ${JSON.stringify({
+      ...base,
+      choices: [
+        {
+          index: 0,
+          delta: { role: "assistant", content: "OK" },
+          finish_reason: null,
+          logprobs: null,
+        },
+      ],
+    })}\n\n`,
+  );
+  res.write(
+    `data: ${JSON.stringify({
+      ...base,
+      choices: [{ index: 0, delta: {}, finish_reason: "stop", logprobs: null }],
+    })}\n\n`,
+  );
+  res.write("data: [DONE]\n\n");
+  res.end();
+}
+
+/** Writes a minimal non-streaming OpenAI chat completion. */
+function respondCompletion(res: http.ServerResponse): void {
+  respondJson(res, 200, {
+    id: "mock-completion",
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: "mock-model",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: "OK" },
+        finish_reason: "stop",
+        logprobs: null,
+      },
+    ],
+    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+  });
+}
+
+function respondJson(
+  res: http.ServerResponse,
+  statusCode: number,
+  body: unknown,
+): void {
+  const data = JSON.stringify(body);
+  res.writeHead(statusCode, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(data),
+  });
+  res.end(data);
+}

--- a/test/harness/mockModelServer.ts
+++ b/test/harness/mockModelServer.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { MockModelEndpoint } from "./mockModelEndpoint";
+
+// Standalone entrypoint for the mock BYOK model (OpenAI-compatible) endpoint.
+// Intended to be spawned as a child process by E2E tests in any SDK language:
+// read the `Listening:` line below for the base + control URLs, point a BYOK
+// provider's baseUrl at it, then GET the recordedUrl to inspect the credential
+// the runtime injected and POST the stopUrl (or kill the process) when done.
+// Kept separate from the CAPI record/replay proxy so it can be used on its own.
+
+const endpoint = new MockModelEndpoint();
+const info = await endpoint.start();
+
+// Single-line, machine-parseable startup banner mirroring server.ts.
+console.log(`Listening: ${JSON.stringify(info)}`);
+
+const shutdown = async () => {
+  await endpoint.stop();
+  process.exit(0);
+};
+process.on("SIGTERM", () => void shutdown());
+process.on("SIGINT", () => void shutdown());

--- a/test/harness/package.json
+++ b/test/harness/package.json
@@ -8,6 +8,8 @@
   "main": "server.ts",
   "scripts": {
     "start": "tsx server.ts",
+    "start:mock-identity": "tsx mockIdentityServer.ts",
+    "start:mock-model": "tsx mockModelServer.ts",
     "test": "vitest run"
   },
   "engines": {


### PR DESCRIPTION
## Summary

Adds Azure Managed Identity (MI) support to the Node SDK for BYOK providers, matching the runtime contract. App developers can authenticate a BYOK provider with a system- or user-assigned managed identity instead of a static `apiKey`/`bearerToken`, and the runtime handles token acquisition, caching, and refresh automatically.

## Usage

```ts
// System-assigned identity (default cognitiveservices scope)
provider: { type: "openai", baseUrl, modelId, managedIdentity: {} }

// User-assigned identity (clientId | objectId | resourceId) and/or custom scope
provider: { type: "openai", baseUrl, modelId, managedIdentity: { clientId: "..." } }
```

`managedIdentity` is the generated `ManagedIdentityConfig` type. It is a single all-optional object: an empty object selects the system-assigned identity; setting at most one of `clientId`/`objectId`/`resourceId` selects a user-assigned identity; `scope` overrides the token audience. It is mutually exclusive with `apiKey`/`bearerToken`.

## What's included

- Re-export the generated `ManagedIdentityConfig` type from the public SDK surface (`types.ts`, `index.ts`).
- A shared, language-agnostic mock identity endpoint (`test/harness/`) plus a Node entrypoint, so other-language SDK e2e suites can reuse the same fake IMDS/App-Service identity server.
- Hermetic e2e coverage (`managed_identity.e2e.test.ts`): system-assigned bearer injection, user-assigned `clientId` with custom scope, token caching across turns, and token refresh within the expiry buffer — no network access.

## Wire shape

`managedIdentity` is a single object (not a `boolean | object` union). The union shape was rejected by the runtime's own SDK-mappability lint and could not be code-generated for statically-typed SDKs, so the runtime contract uses one all-optional object; `{}` replaces the former `true`.

## Testing

- `npm run typecheck` (both tsconfigs), prettier, eslint: green
- 4/4 managed-identity e2e tests pass against the runtime `dist-cli`
