### PR TITLE
Address stephentoub review feedback on HTTP request callback support (+ cross-SDK parity)

### DIFF
--- a/dotnet/src/CopilotRequestHandler.cs
+++ b/dotnet/src/CopilotRequestHandler.cs
@@ -3,6 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using GitHub.Copilot.Rpc;
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.WebSockets;
@@ -76,13 +77,10 @@ public readonly struct CopilotWebSocketMessage(ReadOnlyMemory<byte> data, bool i
     public bool IsBinary { get; } = isBinary;
 
     /// <summary>Decodes the payload as UTF-8 text.</summary>
-    public string GetText() => Encoding.UTF8.GetString(Data.ToArray());
+    public string GetText() => Encoding.UTF8.GetString(Data.Span);
 
     /// <summary>Creates a text message from a UTF-8 string.</summary>
-    public static CopilotWebSocketMessage Text(string text) => new(Encoding.UTF8.GetBytes(text), isBinary: false);
-
-    /// <summary>Creates a binary message from raw bytes.</summary>
-    public static CopilotWebSocketMessage Binary(ReadOnlyMemory<byte> data) => new(data, isBinary: true);
+    public static CopilotWebSocketMessage FromText(string text) => new(Encoding.UTF8.GetBytes(text), isBinary: false);
 }
 
 /// <summary>
@@ -253,7 +251,12 @@ public class CopilotWebSocketForwarder : CopilotWebSocketHandler
         await socket.ConnectAsync(ToWebSocketUri(_url), Context.CancellationToken).ConfigureAwait(false);
         _upstream = socket;
         _pumpCts = CancellationTokenSource.CreateLinkedTokenSource(Context.CancellationToken);
-        _responsePump = Task.Run(() => PumpResponsesAsync(_pumpCts.Token), _pumpCts.Token);
+
+        // Start the pump without a cancellation token on Task.Run itself: if the
+        // linked token is already cancelled, we still want PumpResponsesAsync to
+        // run so its cleanup (closing the upstream and finalising the response)
+        // executes rather than the task being cancelled before it ever starts.
+        _responsePump = Task.Run(() => PumpResponsesAsync(_pumpCts.Token));
     }
 
     /// <summary>
@@ -270,10 +273,10 @@ public class CopilotWebSocketForwarder : CopilotWebSocketHandler
 
         var type = message.IsBinary ? WebSocketMessageType.Binary : WebSocketMessageType.Text;
         return _upstream.SendAsync(
-            new ArraySegment<byte>(message.Data.ToArray()),
+            message.Data,
             type,
             endOfMessage: true,
-            Context.CancellationToken);
+            Context.CancellationToken).AsTask();
     }
 
     /// <inheritdoc />
@@ -346,34 +349,41 @@ public class CopilotWebSocketForwarder : CopilotWebSocketHandler
 
     private static async Task<CopilotWebSocketMessage?> ReceiveMessageAsync(WebSocket socket, CancellationToken cancellationToken)
     {
-        var buffer = new byte[16 * 1024];
-        using var assembled = new MemoryStream();
-        WebSocketReceiveResult result;
-        do
+        var buffer = ArrayPool<byte>.Shared.Rent(16 * 1024);
+        try
         {
-            try
+            using var assembled = new MemoryStream();
+            ValueWebSocketReceiveResult result;
+            do
             {
-                result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                return null;
-            }
-            catch (WebSocketException)
-            {
-                return null;
-            }
+                try
+                {
+                    result = await socket.ReceiveAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    return null;
+                }
+                catch (WebSocketException)
+                {
+                    return null;
+                }
 
-            if (result.MessageType == WebSocketMessageType.Close)
-            {
-                return null;
-            }
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    return null;
+                }
 
-            assembled.Write(buffer, 0, result.Count);
+                assembled.Write(buffer, 0, result.Count);
+            }
+            while (!result.EndOfMessage);
+
+            return new CopilotWebSocketMessage(assembled.ToArray(), result.MessageType == WebSocketMessageType.Binary);
         }
-        while (!result.EndOfMessage);
-
-        return new CopilotWebSocketMessage(assembled.ToArray(), result.MessageType == WebSocketMessageType.Binary);
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
     }
 
     private static async Task CloseWebSocketQuietlyAsync(WebSocket socket)
@@ -430,13 +440,34 @@ public class CopilotRequestHandler
 {
     private static readonly HttpClient s_sharedHttpClient = new();
 
+    private readonly HttpClient _httpClient;
+
+    /// <summary>
+    /// Initializes a new instance that issues upstream requests using a shared
+    /// process-wide <see cref="HttpClient"/>.
+    /// </summary>
+    public CopilotRequestHandler()
+        : this(null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance that issues upstream requests using the supplied
+    /// <see cref="HttpClient"/>, or a shared process-wide instance when <paramref name="httpClient"/> is <see langword="null"/>.
+    /// </summary>
+    /// <param name="httpClient">The <see cref="HttpClient"/> to use, or <see langword="null"/> to use the shared instance.</param>
+    public CopilotRequestHandler(HttpClient? httpClient)
+    {
+        _httpClient = httpClient ?? s_sharedHttpClient;
+    }
+
     /// <summary>
     /// Issue the upstream HTTP request. Override to mutate the request before
     /// calling <c>base</c>, mutate the returned response after, or replace the
     /// call entirely.
     /// </summary>
     protected virtual Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, CopilotRequestContext ctx) =>
-        s_sharedHttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ctx.CancellationToken);
+        _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ctx.CancellationToken);
 
     /// <summary>
     /// Open the upstream WebSocket connection. Override to return a custom
@@ -464,7 +495,7 @@ public class CopilotRequestHandler
 
     private static async Task<HttpRequestMessage> BuildHttpRequestAsync(LlmInferenceExchange exchange)
     {
-        var method = new HttpMethod(exchange.Method.ToUpperInvariant());
+        var method = new HttpMethod(exchange.Method);
         var message = new HttpRequestMessage(method, exchange.Context.Url);
 
         var hasBody = method != HttpMethod.Get && method != HttpMethod.Head;
@@ -499,18 +530,10 @@ public class CopilotRequestHandler
             HeadersToMultiMap(response)).ConfigureAwait(false);
 
         var ct = exchange.Context.CancellationToken;
-#if NETSTANDARD2_0
-        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-#else
         using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-#endif
         var buffer = new byte[16 * 1024];
         int read;
-#if NETSTANDARD2_0
-        while ((read = await stream.ReadAsync(buffer, 0, buffer.Length, ct).ConfigureAwait(false)) > 0)
-#else
         while ((read = await stream.ReadAsync(buffer.AsMemory(), ct).ConfigureAwait(false)) > 0)
-#endif
         {
             await exchange.WriteResponseAsync(new ReadOnlyMemory<byte>(buffer, 0, read)).ConfigureAwait(false);
         }
@@ -579,7 +602,7 @@ public class CopilotRequestHandler
         {
             if (chunk.Length > 0)
             {
-                buffer.Write(chunk.ToArray(), 0, chunk.Length);
+                buffer.Write(chunk.Span);
             }
         }
 

--- a/dotnet/src/Polyfills/DownlevelExtensions.cs
+++ b/dotnet/src/Polyfills/DownlevelExtensions.cs
@@ -700,8 +700,13 @@ namespace System.Net.Http
     {
         extension(HttpContent content)
         {
-            public Task<IO.Stream> ReadAsStreamAsync(Threading.CancellationToken cancellationToken) =>
-                content.ReadAsStreamAsync();
+            public Task<IO.Stream> ReadAsStreamAsync(Threading.CancellationToken cancellationToken)
+            {
+                // The underlying netstandard2.0 ReadAsStreamAsync() can't be cancelled,
+                // but honour an already-cancelled token to match the BCL overload.
+                cancellationToken.ThrowIfCancellationRequested();
+                return content.ReadAsStreamAsync();
+            }
         }
     }
 }

--- a/dotnet/src/Polyfills/DownlevelExtensions.cs
+++ b/dotnet/src/Polyfills/DownlevelExtensions.cs
@@ -376,6 +376,25 @@ namespace System.IO
                     totalRead += bytesRead;
                 }
             }
+
+            public void Write(ReadOnlySpan<byte> buffer)
+            {
+                if (buffer.IsEmpty)
+                {
+                    return;
+                }
+
+                var rented = ArrayPool<byte>.Shared.Rent(buffer.Length);
+                try
+                {
+                    buffer.CopyTo(rented);
+                    stream.Write(rented, 0, buffer.Length);
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(rented);
+                }
+            }
         }
 
         private static async ValueTask<int> ReadAsyncSlow(Stream stream, Memory<byte> buffer, Threading.CancellationToken cancellationToken)
@@ -642,6 +661,123 @@ namespace System.Threading.Tasks
             {
                 await ((Task)task).WaitAsync(timeout, cancellationToken).ConfigureAwait(false);
                 return await task.ConfigureAwait(false);
+            }
+        }
+    }
+}
+
+namespace System.Text
+{
+    internal static class DownlevelEncodingExtensions
+    {
+        extension(Encoding encoding)
+        {
+            public string GetString(ReadOnlySpan<byte> bytes)
+            {
+                if (bytes.IsEmpty)
+                {
+                    return string.Empty;
+                }
+
+                var rented = ArrayPool<byte>.Shared.Rent(bytes.Length);
+                try
+                {
+                    bytes.CopyTo(rented);
+                    return encoding.GetString(rented, 0, bytes.Length);
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(rented);
+                }
+            }
+        }
+    }
+}
+
+namespace System.Net.Http
+{
+    internal static class DownlevelHttpContentExtensions
+    {
+        extension(HttpContent content)
+        {
+            public Task<IO.Stream> ReadAsStreamAsync(Threading.CancellationToken cancellationToken) =>
+                content.ReadAsStreamAsync();
+        }
+    }
+}
+
+namespace System.Net.WebSockets
+{
+    /// <summary>
+    /// Polyfill for the <c>System.Net.WebSockets.ValueWebSocketReceiveResult</c>
+    /// struct, which is unavailable on .NET Standard 2.0.
+    /// </summary>
+    internal readonly struct ValueWebSocketReceiveResult
+    {
+        public ValueWebSocketReceiveResult(int count, WebSocketMessageType messageType, bool endOfMessage)
+        {
+            Count = count;
+            MessageType = messageType;
+            EndOfMessage = endOfMessage;
+        }
+
+        public int Count { get; }
+
+        public WebSocketMessageType MessageType { get; }
+
+        public bool EndOfMessage { get; }
+    }
+
+    internal static class DownlevelWebSocketExtensions
+    {
+        extension(WebSocket socket)
+        {
+            public ValueTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, Threading.CancellationToken cancellationToken)
+            {
+                if (Runtime.InteropServices.MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> segment))
+                {
+                    return new ValueTask(socket.SendAsync(segment, messageType, endOfMessage, cancellationToken));
+                }
+
+                return SendAsyncSlow(socket, buffer, messageType, endOfMessage, cancellationToken);
+            }
+
+            public ValueTask<ValueWebSocketReceiveResult> ReceiveAsync(Memory<byte> buffer, Threading.CancellationToken cancellationToken) =>
+                ReceiveAsyncCore(socket, buffer, cancellationToken);
+        }
+
+        private static async ValueTask SendAsyncSlow(WebSocket socket, ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, Threading.CancellationToken cancellationToken)
+        {
+            var rented = ArrayPool<byte>.Shared.Rent(buffer.Length);
+            try
+            {
+                buffer.CopyTo(rented);
+                await socket.SendAsync(new ArraySegment<byte>(rented, 0, buffer.Length), messageType, endOfMessage, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+
+        private static async ValueTask<ValueWebSocketReceiveResult> ReceiveAsyncCore(WebSocket socket, Memory<byte> buffer, Threading.CancellationToken cancellationToken)
+        {
+            if (Runtime.InteropServices.MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> segment))
+            {
+                var result = await socket.ReceiveAsync(segment, cancellationToken).ConfigureAwait(false);
+                return new ValueWebSocketReceiveResult(result.Count, result.MessageType, result.EndOfMessage);
+            }
+
+            var rented = ArrayPool<byte>.Shared.Rent(buffer.Length);
+            try
+            {
+                var result = await socket.ReceiveAsync(new ArraySegment<byte>(rented, 0, buffer.Length), cancellationToken).ConfigureAwait(false);
+                new ReadOnlyMemory<byte>(rented, 0, result.Count).CopyTo(buffer);
+                return new ValueWebSocketReceiveResult(result.Count, result.MessageType, result.EndOfMessage);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
             }
         }
     }

--- a/go/copilot_request_handler.go
+++ b/go/copilot_request_handler.go
@@ -90,14 +90,10 @@ type CopilotWebSocketMessage struct {
 // Text decodes the frame payload as a UTF-8 string.
 func (m CopilotWebSocketMessage) Text() string { return string(m.Data) }
 
-// NewTextMessage creates a text-frame message from a UTF-8 string.
+// NewTextMessage creates a text-frame message from a UTF-8 string. Binary
+// frames are constructed directly with CopilotWebSocketMessage{Data: ..., Binary: true}.
 func NewTextMessage(text string) CopilotWebSocketMessage {
 	return CopilotWebSocketMessage{Data: []byte(text), Binary: false}
-}
-
-// NewBinaryMessage creates a binary-frame message from raw bytes.
-func NewBinaryMessage(data []byte) CopilotWebSocketMessage {
-	return CopilotWebSocketMessage{Data: data, Binary: true}
 }
 
 // CopilotRequestHandler is the idiomatic handler for intercepting or replacing
@@ -227,9 +223,9 @@ func streamResponseToSink(resp *http.Response, sink *responseSink) error {
 	for {
 		n, readErr := resp.Body.Read(buf)
 		if n > 0 {
-			frame := make([]byte, n)
-			copy(frame, buf[:n])
-			if err := sink.writeText(frame); err != nil {
+			// writeText copies eagerly via string(...), so the reused read
+			// buffer can be passed directly without an extra per-chunk alloc.
+			if err := sink.writeText(buf[:n]); err != nil {
 				return err
 			}
 		}

--- a/java/src/main/java/com/github/copilot/CopilotRequestHandler.java
+++ b/java/src/main/java/com/github/copilot/CopilotRequestHandler.java
@@ -143,9 +143,7 @@ public class CopilotRequestHandler {
             int n;
             while ((n = body.read(buffer)) != -1) {
                 if (n > 0) {
-                    byte[] frame = new byte[n];
-                    System.arraycopy(buffer, 0, frame, 0, n);
-                    exchange.writeResponseBinary(frame);
+                    exchange.writeResponseBinary(buffer, 0, n);
                 }
             }
         } catch (IOException e) {

--- a/java/src/main/java/com/github/copilot/CopilotWebSocketMessage.java
+++ b/java/src/main/java/com/github/copilot/CopilotWebSocketMessage.java
@@ -35,18 +35,7 @@ public record CopilotWebSocketMessage(byte[] data, boolean binary) {
      *            the text payload
      * @return a text message
      */
-    public static CopilotWebSocketMessage text(String text) {
+    public static CopilotWebSocketMessage fromText(String text) {
         return new CopilotWebSocketMessage(text.getBytes(StandardCharsets.UTF_8), false);
-    }
-
-    /**
-     * Creates a binary message from raw bytes.
-     *
-     * @param data
-     *            the binary payload
-     * @return a binary message
-     */
-    public static CopilotWebSocketMessage binary(byte[] data) {
-        return new CopilotWebSocketMessage(data, true);
     }
 }

--- a/java/src/main/java/com/github/copilot/LlmInferenceExchange.java
+++ b/java/src/main/java/com/github/copilot/LlmInferenceExchange.java
@@ -6,6 +6,8 @@ package com.github.copilot;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -194,6 +196,11 @@ final class LlmInferenceExchange {
 
     void writeResponseBinary(byte[] data) throws IOException {
         writeChunk(Base64.getEncoder().encodeToString(data), true);
+    }
+
+    void writeResponseBinary(byte[] data, int offset, int length) throws IOException {
+        ByteBuffer encoded = Base64.getEncoder().encode(ByteBuffer.wrap(data, offset, length));
+        writeChunk(new String(encoded.array(), 0, encoded.limit(), StandardCharsets.ISO_8859_1), true);
     }
 
     void endResponse() throws IOException {

--- a/rust/src/copilot_request_handler.rs
+++ b/rust/src/copilot_request_handler.rs
@@ -538,7 +538,11 @@ impl CopilotWebSocketHandler for CopilotWebSocketForwarder {
         let ws_message = if message.binary {
             Message::Binary(message.data)
         } else {
-            Message::Text(String::from_utf8_lossy(&message.data).into_owned())
+            let text = match String::from_utf8(message.data) {
+                Ok(text) => text,
+                Err(err) => String::from_utf8_lossy(err.as_bytes()).into_owned(),
+            };
+            Message::Text(text)
         };
         let mut guard = self.write.lock().await;
         if let Some(write) = guard.as_mut() {

--- a/rust/src/copilot_request_handler.rs
+++ b/rust/src/copilot_request_handler.rs
@@ -209,17 +209,13 @@ pub struct CopilotWebSocketMessage {
 }
 
 impl CopilotWebSocketMessage {
-    /// A UTF-8 text message.
-    pub fn text(data: impl Into<String>) -> Self {
+    /// A UTF-8 text message. Binary messages are constructed directly via the
+    /// public `data` / `binary` fields.
+    pub fn from_text(data: impl Into<String>) -> Self {
         Self {
             data: data.into().into_bytes(),
             binary: false,
         }
-    }
-
-    /// A binary message.
-    pub fn binary(data: Vec<u8>) -> Self {
-        Self { data, binary: true }
     }
 }
 
@@ -477,13 +473,13 @@ impl CopilotWebSocketForwarderBuilder {
                     _ = loop_cancel.cancelled() => break,
                     msg = read.next() => match msg {
                         Some(Ok(Message::Text(text))) => {
-                            let message = CopilotWebSocketMessage::text(text);
+                            let message = CopilotWebSocketMessage::from_text(text);
                             if let Some(out) = apply_transform(&on_response, message) {
                                 let _ = response.send_message(out).await;
                             }
                         }
                         Some(Ok(Message::Binary(data))) => {
-                            let message = CopilotWebSocketMessage::binary(data);
+                            let message = CopilotWebSocketMessage { data, binary: true };
                             if let Some(out) = apply_transform(&on_response, message) {
                                 let _ = response.send_message(out).await;
                             }


### PR DESCRIPTION
Follow-up to #1689 addressing the review comments from @stephentoub. The bulk is .NET; a second commit propagates the applicable naming/efficiency changes to the other language SDKs so the `CopilotRequestHandler` shape stays consistent across all six. No behavior changes to the public callback model.

## Implemented (12 comments)

**CopilotWebSocketMessage**
- Rename Text(...) factory to FromText(...).
- Remove the redundant Binary(...) factory; the public primary constructor CopilotWebSocketMessage(ReadOnlyMemory<byte> data, bool isBinary) already covers binary construction.
- GetText() decodes via Encoding.UTF8.GetString(Data.Span) instead of allocating with .ToArray().

**CopilotRequestHandler**
- New CopilotRequestHandler(HttpClient?) constructor so consumers can supply their own HttpClient, falling back to the shared process-wide instance.
- Forward the original HTTP method casing (drop ToUpperInvariant(); HttpMethod comparison is already case-insensitive).

**Allocation/perf on the hot paths**
- Send WebSocket frames through the ReadOnlyMemory<byte> overload (no ToArray()).
- Receive WebSocket frames through the Memory<byte> overload and rent the receive buffer from ArrayPool.
- Write request-body chunks via buffer.Write(chunk.Span).
- Don't pass the pump's cancellation token to Task.Run itself, so the pump still runs its cleanup if the linked token is already cancelled.

**TFM cleanup**
- Drop the `#if NETSTANDARD2_0` branches in StreamResponseAsync in favour of new netstandard2.0 polyfills in DownlevelExtensions.cs: Encoding.GetString(ReadOnlySpan<byte>), HttpContent.ReadAsStreamAsync(CancellationToken), Stream.Write(ReadOnlySpan<byte>), and WebSocket SendAsync(ReadOnlyMemory)/ReceiveAsync(Memory) plus a ValueWebSocketReceiveResult shim. On net8/net10 the native BCL methods are used; call sites are now TFM-uniform.
- The ns2.0 HttpContent.ReadAsStreamAsync(CancellationToken) polyfill now honors the token (throws if already cancelled before the tokenless BCL call).

## Cross-SDK parity (Go, Rust, Java)

Since these APIs are unshipped, the same renames/cleanups land in the other SDKs using each language's idiom — no two SDKs carry a redundant binary-message factory anymore:

- **Go**: drop the redundant per-chunk copy in `streamResponseToSink` (the sink's `writeText` already copies eagerly via `string(...)`); remove the redundant `NewBinaryMessage` factory (exported `Data`/`Binary` fields make a struct literal sufficient). `NewTextMessage` kept — `New*` is the idiomatic Go constructor name.
- **Rust**: rename `text` -> `from_text`; remove the redundant `binary` associated fn (the `pub data`/`pub binary` fields suffice); construct binary frames via a struct literal.
- **Java**: rename static `text` -> `fromText`; remove the redundant static `binary` factory (the record's canonical constructor suffices).

Node.js and Python are unaffected — they have no message wrapper type (raw `string | Uint8Array` / `str | bytes`) and their forwarding paths are already copy-light.

Two further per-frame copy removals, internal-only (no public API change):

- **Rust**: `send_request_message` now moves the owned payload into `String::from_utf8` (zero-copy on valid UTF-8 — the common case for LLM traffic), falling back to lossy decoding only on invalid bytes, instead of always allocating via `from_utf8_lossy().into_owned()`.
- **Java**: a new internal `LlmInferenceExchange.writeResponseBinary(byte[], offset, length)` overload base64-encodes a subrange directly, so `streamResponse` no longer allocates + arraycopies an exact-length frame per response chunk. The single-arg overload is kept for the WebSocket bridge.

## Validation
- .NET builds clean on net8.0 / net10.0 / netstandard2.0 (TreatWarningsAsErrors, 0 warnings); `CopilotRequest*` e2e pass on net8.0 (5/5) and net472 (4/4, exercises the ns2.0 polyfill assembly at runtime).
- Go: `go build` + e2e green. Rust: build + `cargo fmt --check` + `clippy -D warnings` clean, e2e 4/4. Java: compiles clean (JDK 25).

## Not adopting the BCL WebSocket types (responding to @stephentoub)

**`System.Net.WebSockets.WebSocket` as the base class.** `WebSocket` models one endpoint of one connection: `SendAsync` writes to the peer, `ReceiveAsync` reads from the peer. Our handler is a mediator on a relay with two directions to two different parties:

```csharp
// What a consumer overrides today — direction is explicit, both sides mutable:
public override Task SendRequestMessageAsync(CopilotWebSocketMessage m)  // runtime -> upstream
public override Task SendResponseMessageAsync(CopilotWebSocketMessage m) // upstream -> runtime
```

A `WebSocket` subclass has a single `SendAsync`/`ReceiveAsync` with no notion of which side a frame belongs to, so the relay can't be expressed cleanly. It's also pull-based (the consumer owns a receive loop with buffer management and fragment reassembly), whereas we hand the consumer a fully-assembled `CopilotWebSocketMessage` and pump for them. Deriving from `WebSocket` would also force implementations of `State`, `CloseStatus`, `SubProtocol`, `Abort`, `CloseOutputAsync`, etc. — members with no meaning for a relay hook — and the `Memory` overloads are core-only, reintroducing the netstandard2.0 split this PR just removed.

**`WebSocketCloseStatus` (the enum).** It can't replace `CopilotWebSocketCloseStatus`, which carries `Exception? Error` and `string? ErrorCode` and is mapped to the runtime via end-of-stream / error-with-code — never an RFC numeric close code. Adding it *alongside* what we already have would only change the close code sent to the upstream provider, which providers don't act on, so it solves no consumer problem. A consumer who genuinely needed a specific upstream close can already override `CloseAsync`.


## Deferred — needs maintainer input (not in this PR)
- **Rpc.cs (generated types)** — a question about why generated wire types surface; not a code change.
- **Client.cs `runtimeShutdownCompleted` removal / graceful-shutdown wait reasoning** — these question the shutdown redesign that landed in #1689; reverting would be a significant change, so flagging rather than acting.
