### PR TITLE
fix(rust): backdate extracted CLI mtime to stop build.rs self-invalidation

### DIFF
--- a/rust/build.rs
+++ b/rust/build.rs
@@ -378,6 +378,35 @@ fn extract_to_cache(archive: &[u8], install_dir: &Path, platform: Platform) -> P
         }
     }
 
+    // Backdate the staged binary to the Unix epoch before it lands. We emit
+    // `cargo:rerun-if-changed` on `final_path` (see caller) so a *deleted*
+    // cache binary forces a re-extract — but cargo stamps the build-script
+    // `output` reference when the script is spawned, seconds before this
+    // freshly-downloaded binary is written. A current mtime would therefore
+    // be *newer* than that reference, so the next identical `cargo`
+    // invocation would see the watched file as "changed" and pointlessly
+    // rerun build.rs + recompile the crate + relink every downstream crate.
+    // Pinning to the epoch keeps the file unambiguously older than any real
+    // build reference; `rename` preserves mtime (same inode), so it lands
+    // already-backdated and a no-change rebuild stays a true no-op. The
+    // deleted-file recovery contract is untouched: a missing file can't be
+    // stat'd, so cargo still treats it as stale and reruns regardless.
+    //
+    // Best-effort: a filesystem that refuses the epoch (e.g. FAT's 1980 floor
+    // clamps it — still older than any real reference) or rejects the call
+    // just reverts to the pre-fix redundant-rebuild behaviour, never a broken
+    // build.
+    if let Err(e) = std::fs::File::options()
+        .write(true)
+        .open(&staging_path)
+        .and_then(|f| f.set_modified(std::time::SystemTime::UNIX_EPOCH))
+    {
+        println!(
+            "cargo:warning=Could not backdate {} (a redundant rebuild may occur): {e}",
+            staging_path.display()
+        );
+    }
+
     // Atomic file-replace on both Unix and Windows. If a concurrent build
     // already produced the same file the rename overwrites it; the bytes
     // are SHA-verified-identical so replacement is safe.

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,4 +1,4 @@
-use std::io::Read;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -359,52 +359,56 @@ fn extract_to_cache(archive: &[u8], install_dir: &Path, platform: Platform) -> P
         std::process::id(),
     ));
 
-    if let Err(e) = std::fs::write(&staging_path, &bytes) {
-        let _ = std::fs::remove_file(&staging_path);
-        panic!(
-            "failed to write staging file {}: {e}",
-            staging_path.display()
-        );
-    }
-
-    #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        if let Err(e) =
-            std::fs::set_permissions(&staging_path, std::fs::Permissions::from_mode(0o755))
-        {
+        let mut f = std::fs::File::create(&staging_path).unwrap_or_else(|e| {
             let _ = std::fs::remove_file(&staging_path);
-            panic!("failed to chmod {}: {e}", staging_path.display());
-        }
-    }
+            panic!(
+                "failed to create staging file {}: {e}",
+                staging_path.display()
+            );
+        });
 
-    // Backdate the staged binary to the Unix epoch before it lands. We emit
-    // `cargo:rerun-if-changed` on `final_path` (see caller) so a *deleted*
-    // cache binary forces a re-extract — but cargo stamps the build-script
-    // `output` reference when the script is spawned, seconds before this
-    // freshly-downloaded binary is written. A current mtime would therefore
-    // be *newer* than that reference, so the next identical `cargo`
-    // invocation would see the watched file as "changed" and pointlessly
-    // rerun build.rs + recompile the crate + relink every downstream crate.
-    // Pinning to the epoch keeps the file unambiguously older than any real
-    // build reference; `rename` preserves mtime (same inode), so it lands
-    // already-backdated and a no-change rebuild stays a true no-op. The
-    // deleted-file recovery contract is untouched: a missing file can't be
-    // stat'd, so cargo still treats it as stale and reruns regardless.
-    //
-    // Best-effort: a filesystem that refuses the epoch (e.g. FAT's 1980 floor
-    // clamps it — still older than any real reference) or rejects the call
-    // just reverts to the pre-fix redundant-rebuild behaviour, never a broken
-    // build.
-    if let Err(e) = std::fs::File::options()
-        .write(true)
-        .open(&staging_path)
-        .and_then(|f| f.set_modified(std::time::SystemTime::UNIX_EPOCH))
-    {
-        println!(
-            "cargo:warning=Could not backdate {} (a redundant rebuild may occur): {e}",
-            staging_path.display()
-        );
+        if let Err(e) = f.write_all(&bytes) {
+            let _ = std::fs::remove_file(&staging_path);
+            panic!(
+                "failed to write staging file {}: {e}",
+                staging_path.display()
+            );
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Err(e) = f.set_permissions(std::fs::Permissions::from_mode(0o755)) {
+                let _ = std::fs::remove_file(&staging_path);
+                panic!("failed to chmod {}: {e}", staging_path.display());
+            }
+        }
+
+        // Backdate the staged binary to the Unix epoch before it lands. We emit
+        // `cargo:rerun-if-changed` on `final_path` (see caller) so a *deleted*
+        // cache binary forces a re-extract — but cargo stamps the build-script
+        // `output` reference when the script is spawned, seconds before this
+        // freshly-downloaded binary is written. A current mtime would therefore
+        // be *newer* than that reference, so the next identical `cargo`
+        // invocation would see the watched file as "changed" and pointlessly
+        // rerun build.rs + recompile the crate + relink every downstream crate.
+        // Pinning to the epoch keeps the file unambiguously older than any real
+        // build reference; `rename` preserves mtime (same inode), so it lands
+        // already-backdated and a no-change rebuild stays a true no-op. The
+        // deleted-file recovery contract is untouched: a missing file can't be
+        // stat'd, so cargo still treats it as stale and reruns regardless.
+        //
+        // Best-effort: a filesystem that refuses the epoch (e.g. FAT's 1980 floor
+        // clamps it — still older than any real reference) or rejects the call
+        // just reverts to the pre-fix redundant-rebuild behaviour, never a broken
+        // build.
+        if let Err(e) = f.set_modified(std::time::SystemTime::UNIX_EPOCH) {
+            println!(
+                "cargo:warning=Could not backdate {} (a redundant rebuild may occur): {e}",
+                staging_path.display()
+            );
+        }
     }
 
     // Atomic file-replace on both Unix and Windows. If a concurrent build


### PR DESCRIPTION
## Problem

When the `bundled-cli` cargo feature is **off**, `rust/build.rs` extracts the Copilot CLI binary into a cache dir and emits `cargo:rerun-if-changed=<extracted binary path>` on it. That watch is deliberate: it's how a *deleted* cached binary forces a re-extract, so cargo doesn't replay a stale `has_extracted_cli` cfg and leave runtime resolution failing with `BinaryNotFound` (see `src/resolve.rs::extracted_cli_path`).

The trap: on a **cold cache** the same `build.rs` *creates* that binary mid-build, seconds after a network download + extract. Cargo stamps the build script's `output` reference file when the script is **spawned** — before the binary is written. So the freshly-extracted binary's mtime ends up **newer** than its own `rerun-if-changed` reference. The next identical `cargo` invocation sees the watched file as "changed", reruns build.rs, recompiles the SDK crate, and relinks every downstream crate. A warm cache never reproduces (the file already exists, not created that build) — so it's a cold-cache / CI-only redundant rebuild.

Cargo's own fingerprint log proves it:

```
stale: changed '<cache>/copilot'
  (vs)  '<target>/build/<crate>-<hash>/output'
FileTime{...942} < FileTime{...950}   # output(reference) < binary
```

In a downstream consumer's CI this wasted ~9 minutes (a second cargo invocation in the same job recompiled the SDK + a Tauri backend with unchanged sources).

## Fix

In `extract_to_cache`, after writing + chmod'ing the staged binary but **before** the atomic rename into place, backdate the staged file's mtime to the Unix epoch via `std::fs::File::set_modified(SystemTime::UNIX_EPOCH)`. The same-fs sibling rename preserves the mtime, so the file lands already-backdated and unambiguously older than any real build reference — a second identical invocation becomes a true no-op. Best-effort: on error we emit a `cargo:warning` and continue (worst case = today's redundant-rebuild behaviour, never a broken build).

## Why this is correct for *all* SDK consumers

- **Embed mode (`bundled-cli` on):** unaffected — that path emits no `rerun-if-changed` on any build-created file, so it has no self-invalidation. No change needed there.
- **`COPILOT_CLI_EXTRACT_DIR` set vs default cache dir:** both flow through the same `extract_to_cache`, so one fix covers both.
- **sccache / cross-machine `target/` reuse:** unaffected/helped — the cache binary isn't a compiler input, and an epoch mtime is deterministic across machines.
- **Concurrent/parallel builds:** safe — each build backdates its own PID+nanos staging file before the atomic rename; last rename wins and the final file is epoch-dated regardless.
- **Windows/NTFS (epoch 1601) & FAT (floor 1980):** 1970 is fine on NTFS/APFS/ext4; the platform cache dir is never FAT. A FAT `COPILOT_CLI_EXTRACT_DIR` would clamp to 1980 — still older than any real reference, still benign.
- **Deleted-file recovery + version-bump contract:** preserved — a missing file still can't be stat'd, so cargo still treats it as stale and reruns; the `cli-version.txt` watch and version-keyed cache path are untouched.

## Verification

Reproduced the consumer scenario (`cli-version.txt` present, `--no-default-features`) with a fresh extract dir:

- **Build 1 (cold):** extracts → binary mtime is `1970-01-01 (epoch 0)`.
- **Build 2 (identical):** `Finished in 0.05s`, no `Compiling github-copilot-sdk`, no `stale`/`dirty` in the fingerprint log — a true no-op.

`cargo +nightly fmt --check`, `cargo clippy -D warnings` (the repo's `just lint-rust`), and all non-e2e test targets (173 tests) pass. The e2e suite is unrunnable in this environment (requires `npm install` in `nodejs/` for the CLI) — orthogonal to this change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>