### PR TITLE
Document Java memory section and add Copilot Memory links across SDK READMEs

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -419,6 +419,7 @@ When enabled, sessions emit compaction events:
 ## Memory
 
 Sessions can opt into persistent memory, allowing the agent to read and write memory across turns. Memory is configured per session and applies to both `CreateSessionAsync` and `ResumeSessionAsync`.
+For more background, see [About GitHub Copilot Memory](https://docs.github.com/en/copilot/concepts/agents/copilot-memory).
 
 ```csharp
 var session = await client.CreateSessionAsync(new SessionConfig

--- a/go/README.md
+++ b/go/README.md
@@ -511,6 +511,7 @@ information across turns. Provide a `MemoryConfiguration` on session create or r
 when omitted, the runtime default applies. In the default `ModeCopilotCli` client mode the
 SDK leaves `Memory` unset so the runtime applies its own default, while `ModeEmpty`
 defaults `Memory` to disabled unless you set it explicitly.
+For more background, see [About GitHub Copilot Memory](https://docs.github.com/en/copilot/concepts/agents/copilot-memory).
 
 ```go
 // Enable memory for a session

--- a/java/README.md
+++ b/java/README.md
@@ -120,9 +120,22 @@ public class CopilotSDK {
 }
 ```
 
+## Try it with JBang
+
+You can run the SDK without setting up a full Java project, by using [JBang](https://www.jbang.dev/).
+
+See the full source of [`jbang-example.java`](jbang-example.java) for a complete example with more features like session idle handling and usage info events.
+
+Or run it directly from the repository:
+
+```bash
+jbang https://github.com/github/copilot-sdk/blob/main/java/jbang-example.java
+```
+
 ## Memory
 
 Sessions can opt into persistent memory, allowing the agent to read and write memory across turns. Memory is configured per session and applies to both `createSession` and `resumeSession`.
+For more background, see [About GitHub Copilot Memory](https://docs.github.com/en/copilot/concepts/agents/copilot-memory).
 
 ```java
 import com.github.copilot.rpc.MemoryConfiguration;
@@ -152,18 +165,6 @@ var resumed = client.resumeSession(sessionId, new ResumeSessionConfig()
 ```
 
 When `memory` is left unset, no memory configuration is sent and the runtime default applies. In the default `CopilotClientMode.COPILOT_CLI` the SDK leaves `memory` unset so the runtime applies its own default, while `CopilotClientMode.EMPTY` defaults `memory` to disabled unless you set it explicitly.
-
-## Try it with JBang
-
-You can run the SDK without setting up a full Java project, by using [JBang](https://www.jbang.dev/).
-
-See the full source of [`jbang-example.java`](jbang-example.java) for a complete example with more features like session idle handling and usage info events.
-
-Or run it directly from the repository:
-
-```bash
-jbang https://github.com/github/copilot-sdk/blob/main/java/jbang-example.java
-```
 
 ## Using experimental APIs
 

--- a/java/README.md
+++ b/java/README.md
@@ -126,17 +126,20 @@ Sessions can opt into persistent memory, allowing the agent to read and write me
 
 ```java
 import com.github.copilot.rpc.MemoryConfiguration;
+import com.github.copilot.rpc.PermissionHandler;
 import com.github.copilot.rpc.ResumeSessionConfig;
 import com.github.copilot.rpc.SessionConfig;
 
 // Enable memory for a new session
 var session = client.createSession(new SessionConfig()
+    .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
     .setModel("gpt-5")
     .setMemory(new MemoryConfiguration().setEnabled(true))
 ).get();
 
 // Disable memory for a new session
 var sessionNoMemory = client.createSession(new SessionConfig()
+    .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
     .setModel("gpt-5")
     .setMemory(new MemoryConfiguration().setEnabled(false))
 ).get();

--- a/java/README.md
+++ b/java/README.md
@@ -120,6 +120,36 @@ public class CopilotSDK {
 }
 ```
 
+## Memory
+
+Sessions can opt into persistent memory, allowing the agent to read and write memory across turns. Memory is configured per session and applies to both `createSession` and `resumeSession`.
+
+```java
+import com.github.copilot.rpc.MemoryConfiguration;
+import com.github.copilot.rpc.ResumeSessionConfig;
+import com.github.copilot.rpc.SessionConfig;
+
+// Enable memory for a new session
+var session = client.createSession(new SessionConfig()
+    .setModel("gpt-5")
+    .setMemory(new MemoryConfiguration().setEnabled(true))
+).get();
+
+// Disable memory for a new session
+var sessionNoMemory = client.createSession(new SessionConfig()
+    .setModel("gpt-5")
+    .setMemory(new MemoryConfiguration().setEnabled(false))
+).get();
+
+// Configure memory while resuming
+var resumed = client.resumeSession(sessionId, new ResumeSessionConfig()
+    .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
+    .setMemory(new MemoryConfiguration().setEnabled(true))
+).get();
+```
+
+When `memory` is left unset, no memory configuration is sent and the runtime default applies. In the default `CopilotClientMode.COPILOT_CLI` the SDK leaves `memory` unset so the runtime applies its own default, while `CopilotClientMode.EMPTY` defaults `memory` to disabled unless you set it explicitly.
+
 ## Try it with JBang
 
 You can run the SDK without setting up a full Java project, by using [JBang](https://www.jbang.dev/).
@@ -274,4 +304,3 @@ mvn jacoco:prepare-agent@wire-up-coverage-instrumentation antrun:run@print-test-
 ## License
 
 MIT — see [LICENSE](LICENSE) for details.
-

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -684,6 +684,7 @@ information across turns. Provide a `memory` configuration on session create or 
 when omitted, the runtime default applies. In the default `"copilot-cli"` client mode the
 SDK leaves `memory` unset so the runtime applies its own default, while `"empty"` mode
 defaults `memory` to disabled unless you set it explicitly.
+For more background, see [About GitHub Copilot Memory](https://docs.github.com/en/copilot/concepts/agents/copilot-memory).
 
 ```typescript
 // Enable memory for a session

--- a/python/README.md
+++ b/python/README.md
@@ -505,6 +505,7 @@ When enabled, sessions emit compaction events:
 ## Memory
 
 Sessions can opt into persistent memory, allowing the agent to read and write memory across turns. Memory is configured per session and applies to both `create_session` and `resume_session`.
+For more background, see [About GitHub Copilot Memory](https://docs.github.com/en/copilot/concepts/agents/copilot-memory).
 
 ```python
 async with await client.create_session(

--- a/rust/README.md
+++ b/rust/README.md
@@ -574,6 +574,7 @@ The CLI emits `session.compaction_start` / `session.compaction_complete` events 
 ### Memory
 
 Configure the runtime memory feature for a session:
+For more background, see [About GitHub Copilot Memory](https://docs.github.com/en/copilot/concepts/agents/copilot-memory).
 
 ```rust,ignore
 use github_copilot_sdk::types::{MemoryConfiguration, SessionConfig};


### PR DESCRIPTION
## Summary
- Add a Java SDK `Memory` section with working examples for `createSession` and `resumeSession`
- Keep Java quick-start flow contiguous by placing `Memory` after `Try it with JBang`
- Add an "About GitHub Copilot Memory" link in each SDK Memory section (Node, Python, Go, .NET, Rust, Java)
- Align Java memory examples with runtime requirements by including `PermissionHandler.APPROVE_ALL`

## Testing
- Documentation changes only