### PR TITLE
Clean up HTTP passthrough API

### DIFF
--- a/dotnet/src/CopilotRequestHandler.cs
+++ b/dotnet/src/CopilotRequestHandler.cs
@@ -41,8 +41,28 @@ public enum CopilotRequestTransport
 [Experimental(Diagnostics.Experimental)]
 public sealed class CopilotRequestContext
 {
+    /// <summary>
+    /// Creates an instance of <see cref="CopilotRequestContext"/> by copying the values from another instance.
+    /// </summary>
+    /// <param name="original">A <see cref="CopilotRequestContext"/> instance to copy values from.</param>
+    public CopilotRequestContext(CopilotRequestContext original)
+        : this(original.RequestId, original.Url, original.Headers)
+    {
+        SessionId = original.SessionId;
+        Transport = original.Transport;
+        CancellationToken = original.CancellationToken;
+        WebSocketResponse = original.WebSocketResponse;
+    }
+
+    internal CopilotRequestContext(string requestId, string url, IReadOnlyDictionary<string, IReadOnlyList<string>> headers)
+    {
+        RequestId = requestId;
+        Url = url;
+        Headers = headers;
+    }
+
     /// <summary>Opaque runtime-minted id, stable across the request lifecycle.</summary>
-    public required string RequestId { get; init; }
+    public string RequestId { get; init; }
 
     /// <summary>Runtime session id that triggered the request, if any.</summary>
     public string? SessionId { get; init; }
@@ -50,11 +70,11 @@ public sealed class CopilotRequestContext
     /// <summary>Transport the runtime would otherwise use.</summary>
     public CopilotRequestTransport Transport { get; init; }
 
-    /// <summary>Original request URL.</summary>
-    public required string Url { get; init; }
+    /// <summary>Request URL.</summary>
+    public string Url { get; init; }
 
-    /// <summary>Original request headers.</summary>
-    public required IReadOnlyDictionary<string, IReadOnlyList<string>> Headers { get; init; }
+    /// <summary>Request headers.</summary>
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> Headers { get; init; }
 
     /// <summary>
     /// Cancelled when the runtime aborts this in-flight request. Subclasses that
@@ -199,25 +219,17 @@ public abstract class CopilotWebSocketHandler : IAsyncDisposable
 [Experimental(Diagnostics.Experimental)]
 public class CopilotWebSocketForwarder : CopilotWebSocketHandler
 {
-    private readonly string _url;
-    private readonly IReadOnlyDictionary<string, IReadOnlyList<string>> _headers;
     private WebSocket? _upstream;
     private CancellationTokenSource? _pumpCts;
     private Task? _responsePump;
 
     /// <summary>
     /// Initializes a forwarding handler that will open the upstream socket on
-    /// demand using the supplied URL/headers (or the values from
-    /// <paramref name="context"/> when omitted).
+    /// demand using the supplied URL/headers from <paramref name="context"/>.
     /// </summary>
-    public CopilotWebSocketForwarder(
-        CopilotRequestContext context,
-        string? url = null,
-        IReadOnlyDictionary<string, IReadOnlyList<string>>? headers = null)
+    public CopilotWebSocketForwarder(CopilotRequestContext context)
         : base(context)
     {
-        _url = url ?? context.Url;
-        _headers = headers ?? context.Headers;
     }
 
     /// <summary>
@@ -231,7 +243,7 @@ public class CopilotWebSocketForwarder : CopilotWebSocketHandler
         }
 
         var socket = new ClientWebSocket();
-        foreach (var (name, values) in _headers)
+        foreach (var (name, values) in Context.Headers)
         {
             if (LlmInferenceHeaders.Forbidden.Contains(name))
             {
@@ -248,7 +260,7 @@ public class CopilotWebSocketForwarder : CopilotWebSocketHandler
             }
         }
 
-        await socket.ConnectAsync(ToWebSocketUri(_url), Context.CancellationToken).ConfigureAwait(false);
+        await socket.ConnectAsync(ToWebSocketUri(Context.Url), Context.CancellationToken).ConfigureAwait(false);
         _upstream = socket;
         _pumpCts = CancellationTokenSource.CreateLinkedTokenSource(Context.CancellationToken);
 
@@ -855,13 +867,10 @@ internal sealed class LlmInferenceAdapter(CopilotRequestHandler handler, Func<Se
         // dropping those frames and hanging the body drain.
         var exchange = _pending.GetOrAdd(request.RequestId, id => new LlmInferenceExchange(id, _getServerRpc));
         exchange.Method = request.Method;
-        exchange.Context = new CopilotRequestContext
+        exchange.Context = new CopilotRequestContext(request.RequestId, request.Url, ToReadOnlyHeaders(request.Headers))
         {
-            RequestId = request.RequestId,
             SessionId = request.SessionId,
             Transport = transport,
-            Url = request.Url,
-            Headers = ToReadOnlyHeaders(request.Headers),
             CancellationToken = exchange.Abort.Token,
         };
 

--- a/dotnet/test/E2E/CopilotRequestWebSocketE2ETests.cs
+++ b/dotnet/test/E2E/CopilotRequestWebSocketE2ETests.cs
@@ -116,8 +116,8 @@ internal sealed class ForwardingUpstreamHandler(string upstreamBaseUrl, HandlerC
 
     protected override Task<CopilotWebSocketHandler> OpenWebSocketAsync(CopilotRequestContext ctx)
     {
-        var wsUrl = Rewrite(new Uri(ctx.Url)).ToString();
-        return Task.FromResult<CopilotWebSocketHandler>(new CountingForwardingWebSocketHandler(ctx, wsUrl, counters));
+        ctx = new CopilotRequestContext(ctx) { Url = Rewrite(new Uri(ctx.Url)).ToString() };
+        return Task.FromResult<CopilotWebSocketHandler>(new CountingForwardingWebSocketHandler(ctx, counters));
     }
 
     private Uri Rewrite(Uri original) => new UriBuilder(original)
@@ -133,9 +133,8 @@ internal sealed class ForwardingUpstreamHandler(string upstreamBaseUrl, HandlerC
 /// </summary>
 internal sealed class CountingForwardingWebSocketHandler(
     CopilotRequestContext context,
-    string url,
     HandlerCounters counters)
-    : CopilotWebSocketForwarder(context, url)
+    : CopilotWebSocketForwarder(context)
 {
     public override Task SendRequestMessageAsync(CopilotWebSocketMessage message)
     {

--- a/java/src/main/java/com/github/copilot/CopilotRequestContext.java
+++ b/java/src/main/java/com/github/copilot/CopilotRequestContext.java
@@ -39,6 +39,13 @@ public final class CopilotRequestContext {
         this.cancellation = cancellation;
     }
 
+    private CopilotRequestContext(String requestId, @Nullable String sessionId, CopilotRequestTransport transport,
+            String url, Map<String, List<String>> headers, CompletableFuture<Void> cancellation,
+            LlmWebSocketResponseBridge webSocketResponse) {
+        this(requestId, sessionId, transport, url, headers, cancellation);
+        this.webSocketResponse = webSocketResponse;
+    }
+
     /**
      * Gets the opaque runtime-minted request id, stable across the request
      * lifecycle.
@@ -86,6 +93,30 @@ public final class CopilotRequestContext {
      */
     public Map<String, List<String>> headers() {
         return headers;
+    }
+
+    /**
+     * Returns a copy of this context with a different request URL.
+     *
+     * @param url
+     *            the replacement request URL
+     * @return the copied context
+     */
+    public CopilotRequestContext withUrl(String url) {
+        return new CopilotRequestContext(requestId, sessionId, transport, url, headers, cancellation,
+                webSocketResponse);
+    }
+
+    /**
+     * Returns a copy of this context with different request headers.
+     *
+     * @param headers
+     *            the replacement request headers
+     * @return the copied context
+     */
+    public CopilotRequestContext withHeaders(Map<String, List<String>> headers) {
+        return new CopilotRequestContext(requestId, sessionId, transport, url, headers, cancellation,
+                webSocketResponse);
     }
 
     /**

--- a/java/src/main/java/com/github/copilot/CopilotWebSocketForwarder.java
+++ b/java/src/main/java/com/github/copilot/CopilotWebSocketForwarder.java
@@ -27,9 +27,6 @@ import java.util.concurrent.CompletionStage;
  */
 public class CopilotWebSocketForwarder extends CopilotWebSocketHandler {
 
-    private final String url;
-    private final Map<String, List<String>> headers;
-
     private volatile WebSocket webSocket;
 
     /**
@@ -40,37 +37,7 @@ public class CopilotWebSocketForwarder extends CopilotWebSocketHandler {
      *            the per-request context
      */
     public CopilotWebSocketForwarder(CopilotRequestContext context) {
-        this(context, context.url(), context.headers());
-    }
-
-    /**
-     * Creates a forwarding handler targeting {@code url} with the handshake headers
-     * from {@code context}.
-     *
-     * @param context
-     *            the per-request context
-     * @param url
-     *            the upstream WebSocket URL
-     */
-    public CopilotWebSocketForwarder(CopilotRequestContext context, String url) {
-        this(context, url, context.headers());
-    }
-
-    /**
-     * Creates a forwarding handler targeting {@code url} with the given handshake
-     * headers.
-     *
-     * @param context
-     *            the per-request context
-     * @param url
-     *            the upstream WebSocket URL
-     * @param headers
-     *            the handshake headers, multi-valued
-     */
-    public CopilotWebSocketForwarder(CopilotRequestContext context, String url, Map<String, List<String>> headers) {
         super(context);
-        this.url = url;
-        this.headers = headers;
     }
 
     @Override
@@ -79,6 +46,7 @@ public class CopilotWebSocketForwarder extends CopilotWebSocketHandler {
             return;
         }
         WebSocket.Builder builder = HttpClient.newHttpClient().newWebSocketBuilder();
+        Map<String, List<String>> headers = context.headers();
         if (headers != null) {
             for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
                 if (CopilotRequestHandler.isForbiddenRequestHeader(entry.getKey()) || entry.getValue() == null) {
@@ -90,8 +58,8 @@ public class CopilotWebSocketForwarder extends CopilotWebSocketHandler {
             }
         }
         try {
-            this.webSocket = builder.buildAsync(URI.create(normalizeWebSocketScheme(url)), new ForwardingListener())
-                    .join();
+            this.webSocket = builder
+                    .buildAsync(URI.create(normalizeWebSocketScheme(context.url())), new ForwardingListener()).join();
         } catch (Exception e) {
             throw unwrap(e);
         }

--- a/java/src/test/java/com/github/copilot/CopilotRequestHandlerE2ETest.java
+++ b/java/src/test/java/com/github/copilot/CopilotRequestHandlerE2ETest.java
@@ -123,8 +123,7 @@ public class CopilotRequestHandlerE2ETest {
 
                 @Override
                 protected CopilotWebSocketHandler openWebSocket(CopilotRequestContext rctx) {
-                    String rewritten = rewriteHost(wsBase, URI.create(rctx.url()));
-                    return new CopilotWebSocketForwarder(rctx, rewritten) {
+                    return new CopilotWebSocketForwarder(rctx.withUrl(rewriteHost(wsBase, URI.create(rctx.url())))) {
                         @Override
                         public void sendRequestMessage(CopilotWebSocketMessage message) throws Exception {
                             wsRequestMessages.incrementAndGet();

--- a/nodejs/src/copilotRequestHandler.ts
+++ b/nodejs/src/copilotRequestHandler.ts
@@ -34,8 +34,8 @@ export interface CopilotRequestContext {
     readonly requestId: string;
     readonly sessionId?: string;
     readonly transport: "http" | "websocket";
-    readonly url: string;
-    readonly headers: LlmInferenceHeaders;
+    url: string;
+    headers: LlmInferenceHeaders;
     readonly signal: AbortSignal;
 }
 
@@ -139,12 +139,10 @@ export abstract class CopilotWebSocketHandler implements AsyncDisposable {
  * @experimental
  */
 export class CopilotWebSocketForwarder extends CopilotWebSocketHandler {
-    readonly #url: string;
     #upstream: WebSocket | null = null;
 
-    constructor(context: CopilotRequestContext, url = context.url) {
+    constructor(context: CopilotRequestContext) {
         super(context);
-        this.#url = url;
     }
 
     override sendRequestMessage(data: string | Uint8Array): void {
@@ -159,7 +157,7 @@ export class CopilotWebSocketForwarder extends CopilotWebSocketHandler {
         if (this.#upstream) {
             return;
         }
-        const upstream = new WebSocket(this.#url);
+        const upstream = new WebSocket(this.context.url);
         upstream.binaryType = "arraybuffer";
         this.#upstream = upstream;
         upstream.addEventListener("message", (event) => {

--- a/nodejs/test/e2e/copilot_request_handler.e2e.test.ts
+++ b/nodejs/test/e2e/copilot_request_handler.e2e.test.ts
@@ -184,7 +184,6 @@ function buildResponsesEvents(text: string, id: string): Array<Record<string, un
     ];
 }
 
-/**
 interface Counters {
     httpRequests: number;
     httpResponses: number;

--- a/nodejs/test/e2e/copilot_request_handler.e2e.test.ts
+++ b/nodejs/test/e2e/copilot_request_handler.e2e.test.ts
@@ -5,12 +5,11 @@
 import { createServer, IncomingMessage, Server as HttpServer, ServerResponse } from "http";
 import { AddressInfo } from "net";
 import { afterAll, describe, expect, it } from "vitest";
-import { WebSocket as WsClient, WebSocketServer } from "ws";
+import { WebSocketServer } from "ws";
 import {
     approveAll,
     CopilotRequestHandler,
-    CopilotWebSocketHandler,
-    CopilotWebSocketCloseStatus,
+    CopilotWebSocketForwarder,
     type CopilotRequestContext,
 } from "../../src/index.js";
 import { createSdkTestContext } from "./harness/sdkTestContext.js";
@@ -202,9 +201,9 @@ interface Counters {
  *   `X-Test-Response-Mutated` header on the way back. The test server
  *   echoes the request header into a counter so we can assert it
  *   actually arrived upstream.
- * - WebSocket: rewrites the WS URL similarly, opens with the `ws`
- *   package inside a custom per-connection handler, and observes
- *   message counts in both directions.
+ * - WebSocket: rewrites the WS URL similarly and forwards through the
+ *   default WebSocket forwarder while observing message counts in both
+ *   directions.
  */
 class TestHandler extends CopilotRequestHandler {
     constructor(
@@ -259,70 +258,28 @@ class TestHandler extends CopilotRequestHandler {
 
     protected override async openWebSocket(
         ctx: CopilotRequestContext
-    ): Promise<CopilotWebSocketHandler> {
-        return TestSocketHandler.connect(this.rewriteWsUrl(ctx.url), ctx, this.counters);
+    ): Promise<CopilotWebSocketForwarder> {
+        ctx.url = this.rewriteWsUrl(ctx.url);
+        return new CountingSocketForwarder(ctx, this.counters);
     }
 }
 
-class TestSocketHandler extends CopilotWebSocketHandler {
-    static async connect(
-        url: string,
-        ctx: CopilotRequestContext,
-        counters: Counters
-    ): Promise<TestSocketHandler> {
-        const client = new WsClient(url);
-        await new Promise<void>((resolve, reject) => {
-            client.once("open", () => resolve());
-            client.once("error", (err) => reject(err));
-        });
-        return new TestSocketHandler(client, ctx, counters);
-    }
-
-    private constructor(
-        private readonly client: WsClient,
+class CountingSocketForwarder extends CopilotWebSocketForwarder {
+    constructor(
         ctx: CopilotRequestContext,
         private readonly counters: Counters
     ) {
         super(ctx);
-        this.client.on("message", (data, isBinary) => {
-            this.counters.wsResponseMessages++;
-            void this.sendResponseMessage(isBinary ? (data as Buffer) : data.toString("utf-8"));
-        });
-        this.client.once("close", () => {
-            void this.close();
-        });
-        this.client.once("error", (err) => {
-            void this.close(new CopilotWebSocketCloseStatus(err.message, undefined, err as Error));
-        });
-        const onAbort = (): void => {
-            try {
-                this.client.close();
-            } catch {
-                /* best-effort */
-            }
-        };
-        ctx.signal.addEventListener("abort", onAbort, { once: true });
-        this.client.once("close", () => ctx.signal.removeEventListener("abort", onAbort));
     }
 
     override sendRequestMessage(data: string | Uint8Array): void {
         this.counters.wsRequestMessages++;
-        if (this.client.readyState !== WsClient.OPEN) {
-            return;
-        }
-        this.client.send(data);
+        super.sendRequestMessage(data);
     }
 
-    override async [Symbol.asyncDispose](): Promise<void> {
-        try {
-            await super[Symbol.asyncDispose]();
-        } finally {
-            try {
-                this.client.close();
-            } catch {
-                /* best-effort */
-            }
-        }
+    override async sendResponseMessage(data: string | Uint8Array): Promise<void> {
+        this.counters.wsResponseMessages++;
+        await super.sendResponseMessage(data);
     }
 }
 

--- a/python/copilot/copilot_request_handler.py
+++ b/python/copilot/copilot_request_handler.py
@@ -167,9 +167,8 @@ class CopilotWebSocketHandler:
 class CopilotWebSocketForwarder(CopilotWebSocketHandler):
     """Default pass-through WebSocket handler backed by the ``websockets`` library."""
 
-    def __init__(self, context: CopilotRequestContext, url: str | None = None) -> None:
+    def __init__(self, context: CopilotRequestContext) -> None:
         super().__init__(context)
-        self._url = url or context.url
         self._upstream: Any | None = None
         self._receive_task: asyncio.Task[None] | None = None
 
@@ -195,7 +194,7 @@ class CopilotWebSocketForwarder(CopilotWebSocketHandler):
             if name.lower() not in _FORBIDDEN_REQUEST_HEADERS
             for value in (values or [])
         ]
-        self._upstream = await websockets.connect(self._url, additional_headers=headers)
+        self._upstream = await websockets.connect(self.context.url, additional_headers=headers)
         self._receive_task = asyncio.create_task(self._receive_loop())
 
     async def _receive_loop(self) -> None:

--- a/python/e2e/test_copilot_request_handler_e2e.py
+++ b/python/e2e/test_copilot_request_handler_e2e.py
@@ -167,8 +167,8 @@ async def _start_fake_upstream() -> _Upstream:
 class _CountingSocketHandler(CopilotWebSocketForwarder):
     """Forwarding WebSocket handler that counts messages in both directions."""
 
-    def __init__(self, ctx: CopilotRequestContext, url: str, counters: _Counters) -> None:
-        super().__init__(ctx, url=url)
+    def __init__(self, ctx: CopilotRequestContext, counters: _Counters) -> None:
+        super().__init__(ctx)
         self._counters = counters
 
     async def send_request_message(self, data: str | bytes) -> None:
@@ -213,7 +213,8 @@ class _TestHandler(CopilotRequestHandler):
         return response
 
     async def open_websocket(self, ctx: CopilotRequestContext):
-        return _CountingSocketHandler(ctx, self._rewrite_ws(ctx.url), self._counters)
+        ctx.url = self._rewrite_ws(ctx.url)
+        return _CountingSocketHandler(ctx, self._counters)
 
     async def aclose(self) -> None:
         await self._client.aclose()


### PR DESCRIPTION
The built-in types were sourcing url/header information from two different places which reduced usability of the APIs.