### PR TITLE
Sunbrye/fix azure managed identity tabs

### DIFF
--- a/.github/instructions/docs-style.instructions.md
+++ b/.github/instructions/docs-style.instructions.md
@@ -160,3 +160,67 @@ Body text here.
 
 * [Link text](./relative-path.md): short description
 ```
+
+## Multi-language code examples
+
+When showing the same concept in multiple programming languages, use consecutive `<details>` blocks. The docs-internal normalization pipeline converts these into tabbed language switchers on docs.github.com.
+
+### Rules
+
+* **Only code inside `<details>` blocks.** Shared prose, headings, and explanations must go outside the blocks. Each block should contain only a code fence (and optionally a `<!-- docs-validate: skip -->` comment).
+* **Blocks must be consecutive.** No content (headings, paragraphs) between `<details>` blocks in the same group. Blank lines between blocks are fine.
+* **Use the exact `<summary>` format:** `<summary><strong>LANGUAGE</strong></summary>`. Supported labels: `.NET`, `Python`, `TypeScript`, `Go`, `Java`, `Rust`, `Node.js`, `Shell`.
+* **Need 2+ blocks to form a group.** A single `<details>` block won't be converted and renders as raw HTML on docs.github.com.
+* **Equal content across tabs.** Each tab should show the same concept in a different language. Language-specific extras should be a separate section outside the tabs.
+
+### Correct
+
+Shared prose goes above the group, then each `<details>` block contains only code:
+
+```markdown
+Install the SDK:
+
+<details open>
+<summary><strong>.NET</strong></summary>
+
+<!-- docs-validate: skip -->
+
+```bash
+dotnet add package GitHub.Copilot.SDK
+```
+
+</details>
+<details>
+<summary><strong>Python</strong></summary>
+
+<!-- docs-validate: skip -->
+
+```bash
+pip install github-copilot-sdk
+```
+
+</details>
+```
+
+### Incorrect
+
+Do not put headings, prose, or multiple sections inside a `<details>` block:
+
+```markdown
+<details>
+<summary><strong>Python</strong></summary>
+
+### Prerequisites           ← breaks TOC/anchors
+Install the packages:       ← prose belongs outside
+
+```bash
+pip install github-copilot-sdk
+```
+
+### Basic usage             ← multiple sections in one tab
+```python
+[code]
+```
+
+</details>
+```

--- a/.github/instructions/docs-style.instructions.md
+++ b/.github/instructions/docs-style.instructions.md
@@ -177,7 +177,7 @@ When showing the same concept in multiple programming languages, use consecutive
 
 Shared prose goes above the group, then each `<details>` block contains only code:
 
-````markdown
+```markdown
 Install the SDK:
 
 <details open>
@@ -200,13 +200,13 @@ pip install github-copilot-sdk
 ```
 
 </details>
-````
+```
 
 ### Incorrect
 
 Do not put headings, prose, or multiple sections inside a `<details>` block:
 
-````markdown
+```markdown
 <details>
 <summary><strong>Python</strong></summary>
 
@@ -223,4 +223,4 @@ pip install github-copilot-sdk
 ```
 
 </details>
-````
+```

--- a/.github/instructions/docs-style.instructions.md
+++ b/.github/instructions/docs-style.instructions.md
@@ -177,7 +177,7 @@ When showing the same concept in multiple programming languages, use consecutive
 
 Shared prose goes above the group, then each `<details>` block contains only code:
 
-~~~markdown
+````markdown
 Install the SDK:
 
 <details open>
@@ -200,13 +200,13 @@ pip install github-copilot-sdk
 ```
 
 </details>
-~~~
+````
 
 ### Incorrect
 
 Do not put headings, prose, or multiple sections inside a `<details>` block:
 
-~~~markdown
+````markdown
 <details>
 <summary><strong>Python</strong></summary>
 
@@ -223,4 +223,4 @@ pip install github-copilot-sdk
 ```
 
 </details>
-~~~
+````

--- a/.github/instructions/docs-style.instructions.md
+++ b/.github/instructions/docs-style.instructions.md
@@ -177,7 +177,7 @@ When showing the same concept in multiple programming languages, use consecutive
 
 Shared prose goes above the group, then each `<details>` block contains only code:
 
-```markdown
+~~~markdown
 Install the SDK:
 
 <details open>
@@ -200,13 +200,13 @@ pip install github-copilot-sdk
 ```
 
 </details>
-```
+~~~
 
 ### Incorrect
 
 Do not put headings, prose, or multiple sections inside a `<details>` block:
 
-```markdown
+~~~markdown
 <details>
 <summary><strong>Python</strong></summary>
 
@@ -223,4 +223,4 @@ pip install github-copilot-sdk
 ```
 
 </details>
-```
+~~~

--- a/docs/setup/azure-managed-identity.md
+++ b/docs/setup/azure-managed-identity.md
@@ -67,7 +67,7 @@ npm install @github/copilot-sdk @azure/identity
 
 ### Basic usage
 
-Get a token using `DefaultAzureCredential` and pass it as the `bearer_token` in your provider config:
+Get a token using `DefaultAzureCredential` and pass it as the bearer token in your provider configuration:
 
 <details open>
 <summary><strong>.NET</strong></summary>

--- a/docs/setup/azure-managed-identity.md
+++ b/docs/setup/azure-managed-identity.md
@@ -29,19 +29,48 @@ sequenceDiagram
 
 ## Code samples
 
+### Prerequisites
+
+Install the Azure Identity and Copilot SDK packages for your language:
+
 <details open>
 <summary><strong>.NET</strong></summary>
 
-### Prerequisites
-
-Install the required packages:
+<!-- docs-validate: skip -->
 
 ```bash
 dotnet add package GitHub.Copilot.SDK
 dotnet add package Azure.Core
 ```
 
+</details>
+<details>
+<summary><strong>Python</strong></summary>
+
+<!-- docs-validate: skip -->
+
+```bash
+pip install github-copilot-sdk azure-identity
+```
+
+</details>
+<details>
+<summary><strong>TypeScript</strong></summary>
+
+<!-- docs-validate: skip -->
+
+```bash
+npm install @github/copilot-sdk @azure/identity
+```
+
+</details>
+
 ### Basic usage
+
+Get a token using `DefaultAzureCredential` and pass it as the `bearer_token` in your provider config:
+
+<details open>
+<summary><strong>.NET</strong></summary>
 
 <!-- docs-validate: skip -->
 
@@ -76,19 +105,8 @@ Console.WriteLine(response?.Data.Content);
 ```
 
 </details>
-
 <details>
 <summary><strong>Python</strong></summary>
-
-### Prerequisites
-
-Install the required packages:
-
-```bash
-pip install github-copilot-sdk azure-identity
-```
-
-### Basic usage
 
 <!-- docs-validate: skip -->
 
@@ -133,9 +151,46 @@ async def main():
 asyncio.run(main())
 ```
 
+</details>
+<details>
+<summary><strong>TypeScript</strong></summary>
+
+<!-- docs-validate: skip -->
+
+```typescript
+import { DefaultAzureCredential } from "@azure/identity";
+import { CopilotClient } from "@github/copilot-sdk";
+
+const credential = new DefaultAzureCredential({
+  requiredEnvVars: ["AZURE_TOKEN_CREDENTIALS"],
+});
+const tokenResponse = await credential.getToken(
+  "https://ai.azure.com/.default"
+);
+
+const client = new CopilotClient();
+
+const session = await client.createSession({
+  model: "gpt-5.5",
+  provider: {
+    type: "openai",
+    baseUrl: `${process.env.FOUNDRY_RESOURCE_URL}/openai/v1/`,
+    bearerToken: tokenResponse.token,
+    wireApi: "responses",
+  },
+});
+
+const response = await session.sendAndWait({ prompt: "Hello!" });
+console.log(response?.data.content);
+
+await client.stop();
+```
+
+</details>
+
 ### Token refresh for long-running applications
 
-Bearer tokens expire (typically after ~1 hour). For servers or long-running agents, refresh the token before creating each session:
+Bearer tokens expire (typically after ~1 hour). For servers or long-running agents, refresh the token before creating each session. The following Python example demonstrates this pattern:
 
 <!-- docs-validate: skip -->
 
@@ -180,54 +235,6 @@ class ManagedIdentityCopilotAgent:
 
         return response.data.content if response else ""
 ```
-
-</details>
-
-<details>
-<summary><strong>TypeScript</strong></summary>
-
-### Prerequisites
-
-Install the required packages:
-
-```bash
-npm install @github/copilot-sdk @azure/identity
-```
-
-### Basic usage
-
-<!-- docs-validate: skip -->
-
-```typescript
-import { DefaultAzureCredential } from "@azure/identity";
-import { CopilotClient } from "@github/copilot-sdk";
-
-const credential = new DefaultAzureCredential({
-  requiredEnvVars: ["AZURE_TOKEN_CREDENTIALS"],
-});
-const tokenResponse = await credential.getToken(
-  "https://ai.azure.com/.default"
-);
-
-const client = new CopilotClient();
-
-const session = await client.createSession({
-  model: "gpt-5.5",
-  provider: {
-    type: "openai",
-    baseUrl: `${process.env.FOUNDRY_RESOURCE_URL}/openai/v1/`,
-    bearerToken: tokenResponse.token,
-    wireApi: "responses",
-  },
-});
-
-const response = await session.sendAndWait({ prompt: "Hello!" });
-console.log(response?.data.content);
-
-await client.stop();
-```
-
-</details>
 
 ## Environment configuration
 


### PR DESCRIPTION
## Why

The current `<details>` block structure in `azure-managed-identity.md` puts headings, prose, and multiple code blocks inside each tab. When the docs-internal normalization pipeline converts these to `{% codetabs %}`, this structure breaks  headings don't render in the TOC, anchor links break, and the tabs contain unequal amounts of content.

This also adds documentation to the style guide so future authors know the correct format.

## What's changed

### 1. Restructured `docs/setup/azure-managed-identity.md`

- Moved shared prose ("Install the packages", "Get a token using DefaultAzureCredential") **outside** the `<details>` blocks
- Each `<details>` block now contains **only a code fence**  no headings, no paragraphs
- Two groups of consecutive tabs: one for prerequisites (install commands), one for basic usage (full examples)
- Pulled the Python-only "Token refresh" section out as a standalone section (single-language content doesn't need tabs)

### 2. Added guidance to `.github/instructions/docs-style.instructions.md`

New "Multi-language code examples" section documenting:
- Only code inside `<details>` blocks
- Blocks must be consecutive (no content between them)
- Exact `<summary>` format required
- Need 2+ blocks per group
- Correct and incorrect examples

## Preview

### Before

<img width="1263" height="1106" alt="image" src="https://github.com/user-attachments/assets/2c68f05c-134b-499f-afef-0e086b74e07f" />

### After

<img width="1297" height="1177" alt="image" src="https://github.com/user-attachments/assets/06d8c306-0b43-4749-afc3-07e959ca6e14" />


cc @scottaddie