### PR TITLE
Make abort E2E snapshots tolerate timing variants

### DIFF
--- a/test/snapshots/abort/should_abort_during_active_streaming.yaml
+++ b/test/snapshots/abort/should_abort_during_active_streaming.yaml
@@ -35,3 +35,13 @@ conversations:
         content: Say 'abort_recovery_ok'.
       - role: assistant
         content: abort_recovery_ok
+  - messages:
+      - role: system
+        content: ${system}
+      - role: user
+        content: Write a very long essay about the history of computing, covering every decade from the 1940s to the 2020s in
+          great detail.
+      - role: user
+        content: Say 'abort_recovery_ok'.
+      - role: assistant
+        content: abort_recovery_ok

--- a/test/snapshots/session/should_abort_a_session.yaml
+++ b/test/snapshots/session/should_abort_a_session.yaml
@@ -50,3 +50,31 @@ conversations:
         content: What is 2+2?
       - role: assistant
         content: 2 + 2 = 4
+  - messages:
+      - role: system
+        content: ${system}
+      - role: user
+        content: run the shell command 'sleep 100' (note this works on both bash and PowerShell)
+      - role: assistant
+        content: I'll run the sleep command for 100 seconds.
+        tool_calls:
+          - id: toolcall_0
+            type: function
+            function:
+              name: report_intent
+              arguments: '{"intent":"Running sleep command"}'
+          - id: toolcall_1
+            type: function
+            function:
+              name: ${shell}
+              arguments: '{"command":"sleep 100","description":"Run sleep 100 command","mode":"sync","initial_wait":105}'
+      - role: tool
+        tool_call_id: toolcall_0
+        content: The execution of this tool, or a previous tool was interrupted.
+      - role: tool
+        tool_call_id: toolcall_1
+        content: The execution of this tool, or a previous tool was interrupted.
+      - role: user
+        content: What is 2+2?
+      - role: assistant
+        content: 2 + 2 = 4


### PR DESCRIPTION
Abort E2E tests can produce different valid request histories depending on when `AbortAsync` lands. Runtime PR investigations saw C# replay mismatches where an in-flight tool result was interrupted instead of recorded as a missing tool, and where streaming abort retained the original user prompt while dropping the aborted assistant response.

This updates the affected replay snapshots with those legal alternatives. No production code changes are included: the tests still cover the public contract that abort completes and the session remains usable, while the cassettes stop requiring a single timing-dependent history.

Validation:
- `GITHUB_ACTIONS=true dotnet test dotnet\test\GitHub.Copilot.SDK.Test.csproj --filter "FullyQualifiedName=GitHub.Copilot.Test.E2E.SessionE2ETests.Should_Abort_A_Session|FullyQualifiedName~GitHub.Copilot.Test.E2E.AbortE2ETests"`
- Synthetic replay requests for the two reported CI histories matched the updated snapshots
- `git diff --check`