### PR TITLE
Restrict block-remove-before-merge check to PRs targeting main

### DIFF
--- a/.github/workflows/block-remove-before-merge.yml
+++ b/.github/workflows/block-remove-before-merge.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   check-paths:
     name: "No remove-before-merge directories"
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Check for remove-before-merge paths in PR


### PR DESCRIPTION
Only block merging when the PR base branch is main. PRs targeting other branches (e.g. feature or release branches) are now a no-op for this check.

Fixes #1918 