### PR TITLE
Fix .NET GitHub telemetry forwarding

### DIFF
--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -1802,7 +1802,15 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 _ => null,
             };
             var connectResponse = await InvokeRpcAsync<ConnectResult>(
-                connection.Rpc, "connect", [new ConnectRequest { Token = token }], connection.StderrBuffer, cancellationToken);
+                connection.Rpc,
+                "connect",
+                [new ConnectRequest
+                {
+                    Token = token,
+                    EnableGitHubTelemetryForwarding = _options.OnGitHubTelemetry != null ? true : null,
+                }],
+                connection.StderrBuffer,
+                cancellationToken);
             serverVersion = (int)connectResponse.ProtocolVersion;
         }
         catch (IOException ex) when (ex.InnerException is RemoteRpcException remoteEx && IsUnsupportedConnectMethod(remoteEx))

--- a/dotnet/test/E2E/GitHubTelemetryForwardingE2ETests.cs
+++ b/dotnet/test/E2E/GitHubTelemetryForwardingE2ETests.cs
@@ -43,7 +43,7 @@ public class GitHubTelemetryForwardingE2ETests(E2ETestFixture fixture, ITestOutp
                 timeoutMessage: "Timed out waiting for GitHub telemetry notification.");
 
             Assert.True(notifications.TryPeek(out var notification));
-            Assert.NotEmpty(notification.SessionId);
+            Assert.False(string.IsNullOrEmpty(notification.SessionId));
             Assert.NotNull(notification.Event);
             Assert.NotEmpty(notification.Event.Kind);
             Assert.IsType<bool>(notification.Restricted);

--- a/dotnet/test/E2E/GitHubTelemetryForwardingE2ETests.cs
+++ b/dotnet/test/E2E/GitHubTelemetryForwardingE2ETests.cs
@@ -3,6 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System.Collections.Concurrent;
+using System.Linq;
 using GitHub.Copilot.Rpc;
 using GitHub.Copilot.Test.Harness;
 using Xunit;
@@ -37,13 +38,16 @@ public class GitHubTelemetryForwardingE2ETests(E2ETestFixture fixture, ITestOutp
                 OnPermissionRequest = PermissionHandler.ApproveAll,
             });
 
+            var answer = await session.SendAndWaitAsync(new MessageOptions { Prompt = "What is 2+2?" });
+            Assert.NotNull(answer);
+
             await TestHelper.WaitForConditionAsync(
-                () => !notifications.IsEmpty,
+                () => notifications.Any(notification => string.Equals(notification.SessionId, session.SessionId, StringComparison.Ordinal)),
                 timeout: TimeSpan.FromSeconds(30),
                 timeoutMessage: "Timed out waiting for GitHub telemetry notification.");
 
-            Assert.True(notifications.TryPeek(out var notification));
-            Assert.False(string.IsNullOrEmpty(notification.SessionId));
+            var notification = notifications.First(notification => string.Equals(notification.SessionId, session.SessionId, StringComparison.Ordinal));
+            Assert.Equal(session.SessionId, notification.SessionId);
             Assert.NotNull(notification.Event);
             Assert.NotEmpty(notification.Event.Kind);
             Assert.IsType<bool>(notification.Restricted);

--- a/dotnet/test/E2E/RpcSessionStateExtrasE2ETests.cs
+++ b/dotnet/test/E2E/RpcSessionStateExtrasE2ETests.cs
@@ -64,19 +64,19 @@ public class RpcSessionStateExtrasE2ETests(E2ETestFixture fixture, ITestOutputHe
             var initial = await session.Rpc.Permissions.GetAllowAllAsync();
             Assert.False(initial.Enabled, "Allow-all should be disabled on a fresh session.");
 
-            var enable = await session.Rpc.Permissions.SetAllowAllAsync(true);
+            var enable = await session.Rpc.Permissions.SetAllowAllAsync(enabled: true);
             Assert.True(enable.Success);
             Assert.True(enable.Enabled);
             Assert.True((await session.Rpc.Permissions.GetAllowAllAsync()).Enabled);
 
-            var disable = await session.Rpc.Permissions.SetAllowAllAsync(false);
+            var disable = await session.Rpc.Permissions.SetAllowAllAsync(enabled: false);
             Assert.True(disable.Success);
             Assert.False(disable.Enabled);
             Assert.False((await session.Rpc.Permissions.GetAllowAllAsync()).Enabled);
         }
         finally
         {
-            await session.Rpc.Permissions.SetAllowAllAsync(false);
+            await session.Rpc.Permissions.SetAllowAllAsync(enabled: false);
         }
     }
 

--- a/dotnet/test/Unit/GitHubTelemetryTests.cs
+++ b/dotnet/test/Unit/GitHubTelemetryTests.cs
@@ -18,7 +18,7 @@ namespace GitHub.Copilot.Test.Unit;
 public sealed class GitHubTelemetryTests
 {
     [Fact]
-    public async Task CreateSession_Opts_Into_Forwarding_When_Handler_Provided()
+    public async Task Connect_Opts_Into_Forwarding_When_Handler_Provided()
     {
         await using var server = await FakeTelemetryServer.StartAsync();
         await using var client = new CopilotClient(new CopilotClientOptions
@@ -28,10 +28,8 @@ public sealed class GitHubTelemetryTests
         });
         await client.StartAsync();
 
-        await client.CreateSessionAsync(new SessionConfig { OnPermissionRequest = PermissionHandler.ApproveAll });
-
-        var createParams = server.LastCreateParams ?? throw new InvalidOperationException("session.create was not captured.");
-        Assert.True(createParams.TryGetProperty("enableGitHubTelemetryForwarding", out var flag));
+        var connectParams = server.LastConnectParams ?? throw new InvalidOperationException("connect was not captured.");
+        Assert.True(connectParams.TryGetProperty("enableGitHubTelemetryForwarding", out var flag));
         Assert.True(flag.GetBoolean());
     }
 
@@ -54,7 +52,7 @@ public sealed class GitHubTelemetryTests
     }
 
     [Fact]
-    public async Task CreateSession_Does_Not_Opt_In_Without_Handler()
+    public async Task Connect_Does_Not_Opt_In_Without_Handler()
     {
         await using var server = await FakeTelemetryServer.StartAsync();
         await using var client = new CopilotClient(new CopilotClientOptions
@@ -63,10 +61,8 @@ public sealed class GitHubTelemetryTests
         });
         await client.StartAsync();
 
-        await client.CreateSessionAsync(new SessionConfig { OnPermissionRequest = PermissionHandler.ApproveAll });
-
-        var createParams = server.LastCreateParams ?? throw new InvalidOperationException("session.create was not captured.");
-        var optedIn = createParams.TryGetProperty("enableGitHubTelemetryForwarding", out var flag)
+        var connectParams = server.LastConnectParams ?? throw new InvalidOperationException("connect was not captured.");
+        var optedIn = connectParams.TryGetProperty("enableGitHubTelemetryForwarding", out var flag)
             && flag.ValueKind == JsonValueKind.True;
         Assert.False(optedIn);
     }
@@ -185,6 +181,8 @@ public sealed class GitHubTelemetryTests
 
         public JsonElement? LastCreateParams { get; private set; }
 
+        public JsonElement? LastConnectParams { get; private set; }
+
         public JsonElement? LastResumeParams { get; private set; }
 
         public static Task<FakeTelemetryServer> StartAsync()
@@ -267,12 +265,7 @@ public sealed class GitHubTelemetryTests
 
             object? result = method switch
             {
-                "connect" => new Dictionary<string, object?>
-                {
-                    ["ok"] = true,
-                    ["protocolVersion"] = 3,
-                    ["version"] = "test",
-                },
+                "connect" => CaptureConnect(request),
                 "session.create" => CaptureCreate(request),
                 "session.resume" => CaptureResume(request),
                 "session.send" => new Dictionary<string, object?> { ["messageId"] = "message-1" },
@@ -293,6 +286,17 @@ public sealed class GitHubTelemetryTests
         {
             LastCreateParams = request.TryGetProperty("params", out var p) ? p.Clone() : null;
             return SessionResult(LastCreateParams);
+        }
+
+        private Dictionary<string, object?> CaptureConnect(JsonElement request)
+        {
+            LastConnectParams = request.TryGetProperty("params", out var p) ? p.Clone() : null;
+            return new Dictionary<string, object?>
+            {
+                ["ok"] = true,
+                ["protocolVersion"] = 3,
+                ["version"] = "test",
+            };
         }
 
         private Dictionary<string, object?> CaptureResume(JsonElement request)

--- a/test/snapshots/github_telemetry/should_forward_github_telemetry_for_a_live_session.yaml
+++ b/test/snapshots/github_telemetry/should_forward_github_telemetry_for_a_live_session.yaml
@@ -1,0 +1,10 @@
+models:
+  - claude-sonnet-4.5
+conversations:
+  - messages:
+      - role: system
+        content: ${system}
+      - role: user
+        content: What is 2+2?
+      - role: assistant
+        content: "4"


### PR DESCRIPTION
## Summary
- Send `enableGitHubTelemetryForwarding` during the `connect` handshake, which is where the runtime now negotiates forwarding.
- Harden the .NET GitHub telemetry E2E to drive a real replayed turn and wait for the notification belonging to the live session instead of peeking the first queued event.
- Add unit coverage that asserts the forwarding opt-in is present on `connect`, and add the replay snapshot used by the E2E.

## Validation
- `DOTNET_ROLL_FORWARD=Major dotnet test dotnet/test/GitHub.Copilot.SDK.Test.csproj -f net8.0 --filter "FullyQualifiedName~GitHubTelemetryTests|FullyQualifiedName~GitHubTelemetryForwardingE2ETests|FullyQualifiedName~RpcSessionStateExtrasE2ETests"`
  - Passed locally (13/13).