### PR TITLE
Forward enableManagedSettings in session.create (all SDKs)

### DIFF
--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -1147,6 +1147,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 Models: config.Models,
                 ToolFilterPrecedence: toolFilter.ToolFilterPrecedence,
                 ExpAssignments: config.ExpAssignments,
+                SelfFetchManagedSettings: config.SelfFetchManagedSettings,
                 EnableGitHubTelemetryForwarding: _options.OnGitHubTelemetry != null ? true : null);
 
             var rpcTimestamp = Stopwatch.GetTimestamp();
@@ -1357,6 +1358,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 Models: config.Models,
                 ToolFilterPrecedence: toolFilter.ToolFilterPrecedence,
                 ExpAssignments: config.ExpAssignments,
+                SelfFetchManagedSettings: config.SelfFetchManagedSettings,
                 EnableGitHubTelemetryForwarding: _options.OnGitHubTelemetry != null ? true : null);
 
             var rpcTimestamp = Stopwatch.GetTimestamp();
@@ -2696,6 +2698,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         IList<ProviderModelConfig>? Models = null,
         OptionsUpdateToolFilterPrecedence? ToolFilterPrecedence = null,
         [property: JsonPropertyName("expAssignments")] JsonElement? ExpAssignments = null,
+        [property: JsonPropertyName("selfFetchManagedSettings")] bool? SelfFetchManagedSettings = null,
         bool? EnableGitHubTelemetryForwarding = null);
 #pragma warning restore GHCP001
 
@@ -2796,6 +2799,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         IList<ProviderModelConfig>? Models = null,
         OptionsUpdateToolFilterPrecedence? ToolFilterPrecedence = null,
         [property: JsonPropertyName("expAssignments")] JsonElement? ExpAssignments = null,
+        [property: JsonPropertyName("selfFetchManagedSettings")] bool? SelfFetchManagedSettings = null,
         bool? EnableGitHubTelemetryForwarding = null);
 #pragma warning restore GHCP001
 

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -1147,7 +1147,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 Models: config.Models,
                 ToolFilterPrecedence: toolFilter.ToolFilterPrecedence,
                 ExpAssignments: config.ExpAssignments,
-                SelfFetchManagedSettings: config.SelfFetchManagedSettings,
+                EnableManagedSettings: config.EnableManagedSettings,
                 EnableGitHubTelemetryForwarding: _options.OnGitHubTelemetry != null ? true : null);
 
             var rpcTimestamp = Stopwatch.GetTimestamp();
@@ -1358,7 +1358,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 Models: config.Models,
                 ToolFilterPrecedence: toolFilter.ToolFilterPrecedence,
                 ExpAssignments: config.ExpAssignments,
-                SelfFetchManagedSettings: config.SelfFetchManagedSettings,
+                EnableManagedSettings: config.EnableManagedSettings,
                 EnableGitHubTelemetryForwarding: _options.OnGitHubTelemetry != null ? true : null);
 
             var rpcTimestamp = Stopwatch.GetTimestamp();
@@ -2698,7 +2698,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         IList<ProviderModelConfig>? Models = null,
         OptionsUpdateToolFilterPrecedence? ToolFilterPrecedence = null,
         [property: JsonPropertyName("expAssignments")] JsonElement? ExpAssignments = null,
-        [property: JsonPropertyName("selfFetchManagedSettings")] bool? SelfFetchManagedSettings = null,
+        [property: JsonPropertyName("enableManagedSettings")] bool? EnableManagedSettings = null,
         bool? EnableGitHubTelemetryForwarding = null);
 #pragma warning restore GHCP001
 
@@ -2799,7 +2799,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         IList<ProviderModelConfig>? Models = null,
         OptionsUpdateToolFilterPrecedence? ToolFilterPrecedence = null,
         [property: JsonPropertyName("expAssignments")] JsonElement? ExpAssignments = null,
-        [property: JsonPropertyName("selfFetchManagedSettings")] bool? SelfFetchManagedSettings = null,
+        [property: JsonPropertyName("enableManagedSettings")] bool? EnableManagedSettings = null,
         bool? EnableGitHubTelemetryForwarding = null);
 #pragma warning restore GHCP001
 

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -2861,7 +2861,7 @@ public abstract class SessionConfigBase
         GitHubToken = other.GitHubToken;
         RemoteSession = other.RemoteSession;
         ExpAssignments = other.ExpAssignments;
-        SelfFetchManagedSettings = other.SelfFetchManagedSettings;
+        EnableManagedSettings = other.EnableManagedSettings;
 #pragma warning disable GHCP001
         Canvases = other.Canvases is not null ? [.. other.Canvases] : null;
         RequestCanvasRenderer = other.RequestCanvasRenderer;
@@ -3292,9 +3292,9 @@ public abstract class SessionConfigBase
     /// session's <see cref="GitHubToken"/>. Requires <see cref="GitHubToken"/> to
     /// be set; if omitted, the runtime is expected to reject session creation
     /// (fail-closed). When unset, behaves exactly as before. Serialized on the
-    /// wire as <c>selfFetchManagedSettings</c>.
+    /// wire as <c>enableManagedSettings</c>.
     /// </summary>
-    public bool? SelfFetchManagedSettings { get; set; }
+    public bool? EnableManagedSettings { get; set; }
 
 #pragma warning disable GHCP001
     /// <summary>

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -2861,6 +2861,7 @@ public abstract class SessionConfigBase
         GitHubToken = other.GitHubToken;
         RemoteSession = other.RemoteSession;
         ExpAssignments = other.ExpAssignments;
+        SelfFetchManagedSettings = other.SelfFetchManagedSettings;
 #pragma warning disable GHCP001
         Canvases = other.Canvases is not null ? [.. other.Canvases] : null;
         RequestCanvasRenderer = other.RequestCanvasRenderer;
@@ -3284,6 +3285,16 @@ public abstract class SessionConfigBase
     /// </remarks>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public JsonElement? ExpAssignments { get; set; }
+
+    /// <summary>
+    /// Opt-in: when <c>true</c>, the runtime self-fetches enterprise managed
+    /// settings (bypass-permissions policy) at session bootstrap using the
+    /// session's <see cref="GitHubToken"/>. Requires <see cref="GitHubToken"/> to
+    /// be set; if omitted, the runtime is expected to reject session creation
+    /// (fail-closed). When unset, behaves exactly as before. Serialized on the
+    /// wire as <c>selfFetchManagedSettings</c>.
+    /// </summary>
+    public bool? SelfFetchManagedSettings { get; set; }
 
 #pragma warning disable GHCP001
     /// <summary>

--- a/go/client.go
+++ b/go/client.go
@@ -732,6 +732,7 @@ func (c *Client) CreateSession(ctx context.Context, config *SessionConfig) (*Ses
 	req.ExtensionSDKPath = config.ExtensionSDKPath
 	req.ExtensionInfo = config.ExtensionInfo
 	req.ExpAssignments = config.ExpAssignments
+	req.SelfFetchManagedSettings = config.SelfFetchManagedSettings
 
 	if len(config.Commands) > 0 {
 		cmds := make([]wireCommand, 0, len(config.Commands))
@@ -1095,6 +1096,7 @@ func (c *Client) ResumeSessionWithOptions(ctx context.Context, sessionID string,
 	req.ExtensionSDKPath = config.ExtensionSDKPath
 	req.ExtensionInfo = config.ExtensionInfo
 	req.ExpAssignments = config.ExpAssignments
+	req.SelfFetchManagedSettings = config.SelfFetchManagedSettings
 	if config.OnPermissionRequest != nil {
 		req.RequestPermission = Bool(true)
 	}

--- a/go/client.go
+++ b/go/client.go
@@ -732,7 +732,7 @@ func (c *Client) CreateSession(ctx context.Context, config *SessionConfig) (*Ses
 	req.ExtensionSDKPath = config.ExtensionSDKPath
 	req.ExtensionInfo = config.ExtensionInfo
 	req.ExpAssignments = config.ExpAssignments
-	req.SelfFetchManagedSettings = config.SelfFetchManagedSettings
+	req.EnableManagedSettings = config.EnableManagedSettings
 
 	if len(config.Commands) > 0 {
 		cmds := make([]wireCommand, 0, len(config.Commands))
@@ -1096,7 +1096,7 @@ func (c *Client) ResumeSessionWithOptions(ctx context.Context, sessionID string,
 	req.ExtensionSDKPath = config.ExtensionSDKPath
 	req.ExtensionInfo = config.ExtensionInfo
 	req.ExpAssignments = config.ExpAssignments
-	req.SelfFetchManagedSettings = config.SelfFetchManagedSettings
+	req.EnableManagedSettings = config.EnableManagedSettings
 	if config.OnPermissionRequest != nil {
 		req.RequestPermission = Bool(true)
 	}

--- a/go/types.go
+++ b/go/types.go
@@ -2132,7 +2132,7 @@ type createSessionRequest struct {
 	ExtensionSDKPath                   *string                                `json:"extensionSdkPath,omitempty"`
 	ExtensionInfo                      *ExtensionInfo                         `json:"extensionInfo,omitempty"`
 	ExpAssignments                     any                                    `json:"expAssignments,omitempty"`
-	EnableManagedSettings           *bool                                  `json:"enableManagedSettings,omitempty"`
+	EnableManagedSettings              *bool                                  `json:"enableManagedSettings,omitempty"`
 	Traceparent                        string                                 `json:"traceparent,omitempty"`
 	Tracestate                         string                                 `json:"tracestate,omitempty"`
 }
@@ -2222,7 +2222,7 @@ type resumeSessionRequest struct {
 	ExtensionSDKPath                   *string                                `json:"extensionSdkPath,omitempty"`
 	ExtensionInfo                      *ExtensionInfo                         `json:"extensionInfo,omitempty"`
 	ExpAssignments                     any                                    `json:"expAssignments,omitempty"`
-	EnableManagedSettings           *bool                                  `json:"enableManagedSettings,omitempty"`
+	EnableManagedSettings              *bool                                  `json:"enableManagedSettings,omitempty"`
 	Traceparent                        string                                 `json:"traceparent,omitempty"`
 	Tracestate                         string                                 `json:"tracestate,omitempty"`
 }

--- a/go/types.go
+++ b/go/types.go
@@ -1247,12 +1247,12 @@ type SessionConfig struct {
 	// intended for trusted out-of-process integrators, and is not intended for
 	// general external use.
 	ExpAssignments any
-	// SelfFetchManagedSettings, when set to true, opts the runtime into
+	// EnableManagedSettings, when set to true, opts the runtime into
 	// self-fetching enterprise managed settings (bypass-permissions policy) at
 	// session bootstrap using the session's GitHubToken. Requires GitHubToken to
 	// be set; if omitted, the runtime is expected to reject session creation
 	// (fail-closed). Unset behaves exactly as before.
-	SelfFetchManagedSettings *bool
+	EnableManagedSettings *bool
 }
 
 // ToolDefer controls whether a tool may be deferred (loaded lazily via tool
@@ -1674,10 +1674,10 @@ type ResumeSessionConfig struct {
 	// intended for trusted out-of-process integrators, and is not intended for
 	// general external use.
 	ExpAssignments any
-	// SelfFetchManagedSettings injects the same opt-in flag on resume. See
-	// SessionConfig.SelfFetchManagedSettings. Re-supply on resume so the runtime
+	// EnableManagedSettings injects the same opt-in flag on resume. See
+	// SessionConfig.EnableManagedSettings. Re-supply on resume so the runtime
 	// re-applies the managed-settings self-fetch after a CLI process restart.
-	SelfFetchManagedSettings *bool
+	EnableManagedSettings *bool
 }
 
 // ProviderTokenArgs carries the context passed to a [BearerTokenProvider] callback
@@ -2132,7 +2132,7 @@ type createSessionRequest struct {
 	ExtensionSDKPath                   *string                                `json:"extensionSdkPath,omitempty"`
 	ExtensionInfo                      *ExtensionInfo                         `json:"extensionInfo,omitempty"`
 	ExpAssignments                     any                                    `json:"expAssignments,omitempty"`
-	SelfFetchManagedSettings           *bool                                  `json:"selfFetchManagedSettings,omitempty"`
+	EnableManagedSettings           *bool                                  `json:"enableManagedSettings,omitempty"`
 	Traceparent                        string                                 `json:"traceparent,omitempty"`
 	Tracestate                         string                                 `json:"tracestate,omitempty"`
 }
@@ -2222,7 +2222,7 @@ type resumeSessionRequest struct {
 	ExtensionSDKPath                   *string                                `json:"extensionSdkPath,omitempty"`
 	ExtensionInfo                      *ExtensionInfo                         `json:"extensionInfo,omitempty"`
 	ExpAssignments                     any                                    `json:"expAssignments,omitempty"`
-	SelfFetchManagedSettings           *bool                                  `json:"selfFetchManagedSettings,omitempty"`
+	EnableManagedSettings           *bool                                  `json:"enableManagedSettings,omitempty"`
 	Traceparent                        string                                 `json:"traceparent,omitempty"`
 	Tracestate                         string                                 `json:"tracestate,omitempty"`
 }

--- a/go/types.go
+++ b/go/types.go
@@ -1247,6 +1247,12 @@ type SessionConfig struct {
 	// intended for trusted out-of-process integrators, and is not intended for
 	// general external use.
 	ExpAssignments any
+	// SelfFetchManagedSettings, when set to true, opts the runtime into
+	// self-fetching enterprise managed settings (bypass-permissions policy) at
+	// session bootstrap using the session's GitHubToken. Requires GitHubToken to
+	// be set; if omitted, the runtime is expected to reject session creation
+	// (fail-closed). Unset behaves exactly as before.
+	SelfFetchManagedSettings *bool
 }
 
 // ToolDefer controls whether a tool may be deferred (loaded lazily via tool
@@ -1668,6 +1674,10 @@ type ResumeSessionConfig struct {
 	// intended for trusted out-of-process integrators, and is not intended for
 	// general external use.
 	ExpAssignments any
+	// SelfFetchManagedSettings injects the same opt-in flag on resume. See
+	// SessionConfig.SelfFetchManagedSettings. Re-supply on resume so the runtime
+	// re-applies the managed-settings self-fetch after a CLI process restart.
+	SelfFetchManagedSettings *bool
 }
 
 // ProviderTokenArgs carries the context passed to a [BearerTokenProvider] callback
@@ -2122,6 +2132,7 @@ type createSessionRequest struct {
 	ExtensionSDKPath                   *string                                `json:"extensionSdkPath,omitempty"`
 	ExtensionInfo                      *ExtensionInfo                         `json:"extensionInfo,omitempty"`
 	ExpAssignments                     any                                    `json:"expAssignments,omitempty"`
+	SelfFetchManagedSettings           *bool                                  `json:"selfFetchManagedSettings,omitempty"`
 	Traceparent                        string                                 `json:"traceparent,omitempty"`
 	Tracestate                         string                                 `json:"tracestate,omitempty"`
 }
@@ -2211,6 +2222,7 @@ type resumeSessionRequest struct {
 	ExtensionSDKPath                   *string                                `json:"extensionSdkPath,omitempty"`
 	ExtensionInfo                      *ExtensionInfo                         `json:"extensionInfo,omitempty"`
 	ExpAssignments                     any                                    `json:"expAssignments,omitempty"`
+	SelfFetchManagedSettings           *bool                                  `json:"selfFetchManagedSettings,omitempty"`
 	Traceparent                        string                                 `json:"traceparent,omitempty"`
 	Tracestate                         string                                 `json:"tracestate,omitempty"`
 }

--- a/java/src/main/java/com/github/copilot/SessionRequestBuilder.java
+++ b/java/src/main/java/com/github/copilot/SessionRequestBuilder.java
@@ -185,6 +185,7 @@ final class SessionRequestBuilder {
         request.setRemoteSession(config.getRemoteSession());
         request.setCloud(config.getCloud());
         request.setExpAssignments(config.getExpAssignments());
+        config.getSelfFetchManagedSettings().ifPresent(request::setSelfFetchManagedSettings);
 
         return request;
     }
@@ -306,6 +307,7 @@ final class SessionRequestBuilder {
         request.setGitHubToken(config.getGitHubToken());
         request.setRemoteSession(config.getRemoteSession());
         request.setExpAssignments(config.getExpAssignments());
+        config.getSelfFetchManagedSettings().ifPresent(request::setSelfFetchManagedSettings);
 
         return request;
     }

--- a/java/src/main/java/com/github/copilot/SessionRequestBuilder.java
+++ b/java/src/main/java/com/github/copilot/SessionRequestBuilder.java
@@ -185,7 +185,7 @@ final class SessionRequestBuilder {
         request.setRemoteSession(config.getRemoteSession());
         request.setCloud(config.getCloud());
         request.setExpAssignments(config.getExpAssignments());
-        config.getSelfFetchManagedSettings().ifPresent(request::setSelfFetchManagedSettings);
+        config.getEnableManagedSettings().ifPresent(request::setEnableManagedSettings);
 
         return request;
     }
@@ -307,7 +307,7 @@ final class SessionRequestBuilder {
         request.setGitHubToken(config.getGitHubToken());
         request.setRemoteSession(config.getRemoteSession());
         request.setExpAssignments(config.getExpAssignments());
-        config.getSelfFetchManagedSettings().ifPresent(request::setSelfFetchManagedSettings);
+        config.getEnableManagedSettings().ifPresent(request::setEnableManagedSettings);
 
         return request;
     }

--- a/java/src/main/java/com/github/copilot/rpc/CreateSessionRequest.java
+++ b/java/src/main/java/com/github/copilot/rpc/CreateSessionRequest.java
@@ -212,9 +212,9 @@ public final class CreateSessionRequest {
     @JsonProperty("expAssignments")
     private JsonNode expAssignments;
 
-    @JsonProperty("selfFetchManagedSettings")
+    @JsonProperty("enableManagedSettings")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private Boolean selfFetchManagedSettings;
+    private Boolean enableManagedSettings;
 
     /** Gets the model name. @return the model */
     public String getModel() {
@@ -975,23 +975,22 @@ public final class CreateSessionRequest {
      * Gets the self-fetch managed settings flag. @return the flag, or {@code null}
      * if not set
      */
-    public Boolean getSelfFetchManagedSettings() {
-        return selfFetchManagedSettings;
+    public Boolean getEnableManagedSettings() {
+        return enableManagedSettings;
     }
 
     /**
-     * Sets the self-fetch managed settings flag. @param selfFetchManagedSettings
-     * the flag
+     * Sets the self-fetch managed settings flag. @param enableManagedSettings the
+     * flag
      */
-    public void setSelfFetchManagedSettings(boolean selfFetchManagedSettings) {
-        this.selfFetchManagedSettings = selfFetchManagedSettings;
+    public void setEnableManagedSettings(boolean enableManagedSettings) {
+        this.enableManagedSettings = enableManagedSettings;
     }
 
     /**
-     * Clears the selfFetchManagedSettings setting, reverting to the default
-     * behavior.
+     * Clears the enableManagedSettings setting, reverting to the default behavior.
      */
-    public void clearSelfFetchManagedSettings() {
-        this.selfFetchManagedSettings = null;
+    public void clearEnableManagedSettings() {
+        this.enableManagedSettings = null;
     }
 }

--- a/java/src/main/java/com/github/copilot/rpc/CreateSessionRequest.java
+++ b/java/src/main/java/com/github/copilot/rpc/CreateSessionRequest.java
@@ -212,6 +212,10 @@ public final class CreateSessionRequest {
     @JsonProperty("expAssignments")
     private JsonNode expAssignments;
 
+    @JsonProperty("selfFetchManagedSettings")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean selfFetchManagedSettings;
+
     /** Gets the model name. @return the model */
     public String getModel() {
         return model;
@@ -965,5 +969,29 @@ public final class CreateSessionRequest {
      */
     public void setExpAssignments(JsonNode expAssignments) {
         this.expAssignments = expAssignments;
+    }
+
+    /**
+     * Gets the self-fetch managed settings flag. @return the flag, or {@code null}
+     * if not set
+     */
+    public Boolean getSelfFetchManagedSettings() {
+        return selfFetchManagedSettings;
+    }
+
+    /**
+     * Sets the self-fetch managed settings flag. @param selfFetchManagedSettings
+     * the flag
+     */
+    public void setSelfFetchManagedSettings(boolean selfFetchManagedSettings) {
+        this.selfFetchManagedSettings = selfFetchManagedSettings;
+    }
+
+    /**
+     * Clears the selfFetchManagedSettings setting, reverting to the default
+     * behavior.
+     */
+    public void clearSelfFetchManagedSettings() {
+        this.selfFetchManagedSettings = null;
     }
 }

--- a/java/src/main/java/com/github/copilot/rpc/ResumeSessionConfig.java
+++ b/java/src/main/java/com/github/copilot/rpc/ResumeSessionConfig.java
@@ -102,7 +102,7 @@ public class ResumeSessionConfig {
     private String gitHubToken;
     private String remoteSession;
     private JsonNode expAssignments;
-    private Boolean selfFetchManagedSettings;
+    private Boolean enableManagedSettings;
 
     /**
      * Gets the AI model to use.
@@ -1755,24 +1755,24 @@ public class ResumeSessionConfig {
      *         to use the default behavior
      */
     @JsonIgnore
-    public Optional<Boolean> getSelfFetchManagedSettings() {
-        return Optional.ofNullable(selfFetchManagedSettings);
+    public Optional<Boolean> getEnableManagedSettings() {
+        return Optional.ofNullable(enableManagedSettings);
     }
 
     /**
      * Opts the runtime into self-fetching enterprise managed settings on resume.
      * <p>
-     * See {@link SessionConfig#setSelfFetchManagedSettings(boolean)} for details.
+     * See {@link SessionConfig#setEnableManagedSettings(boolean)} for details.
      * Re-supply on resume so the runtime re-applies the managed-settings self-fetch
      * after a CLI process restart. Serialized on the wire as
-     * {@code selfFetchManagedSettings}.
+     * {@code enableManagedSettings}.
      *
-     * @param selfFetchManagedSettings
+     * @param enableManagedSettings
      *            {@code true} to opt into self-fetching managed settings
      * @return this config for method chaining
      */
-    public ResumeSessionConfig setSelfFetchManagedSettings(boolean selfFetchManagedSettings) {
-        this.selfFetchManagedSettings = selfFetchManagedSettings;
+    public ResumeSessionConfig setEnableManagedSettings(boolean enableManagedSettings) {
+        this.enableManagedSettings = enableManagedSettings;
         return this;
     }
 
@@ -1850,7 +1850,7 @@ public class ResumeSessionConfig {
         copy.gitHubToken = this.gitHubToken;
         copy.remoteSession = this.remoteSession;
         copy.expAssignments = this.expAssignments;
-        copy.selfFetchManagedSettings = this.selfFetchManagedSettings;
+        copy.enableManagedSettings = this.enableManagedSettings;
         return copy;
     }
 }

--- a/java/src/main/java/com/github/copilot/rpc/ResumeSessionConfig.java
+++ b/java/src/main/java/com/github/copilot/rpc/ResumeSessionConfig.java
@@ -102,6 +102,7 @@ public class ResumeSessionConfig {
     private String gitHubToken;
     private String remoteSession;
     private JsonNode expAssignments;
+    private Boolean selfFetchManagedSettings;
 
     /**
      * Gets the AI model to use.
@@ -1746,6 +1747,36 @@ public class ResumeSessionConfig {
     }
 
     /**
+     * Gets whether the runtime self-fetches enterprise managed settings at session
+     * bootstrap on resume.
+     *
+     * @return an {@link java.util.Optional} containing {@code true} to opt into
+     *         self-fetching managed settings, or {@link java.util.Optional#empty()}
+     *         to use the default behavior
+     */
+    @JsonIgnore
+    public Optional<Boolean> getSelfFetchManagedSettings() {
+        return Optional.ofNullable(selfFetchManagedSettings);
+    }
+
+    /**
+     * Opts the runtime into self-fetching enterprise managed settings on resume.
+     * <p>
+     * See {@link SessionConfig#setSelfFetchManagedSettings(boolean)} for details.
+     * Re-supply on resume so the runtime re-applies the managed-settings self-fetch
+     * after a CLI process restart. Serialized on the wire as
+     * {@code selfFetchManagedSettings}.
+     *
+     * @param selfFetchManagedSettings
+     *            {@code true} to opt into self-fetching managed settings
+     * @return this config for method chaining
+     */
+    public ResumeSessionConfig setSelfFetchManagedSettings(boolean selfFetchManagedSettings) {
+        this.selfFetchManagedSettings = selfFetchManagedSettings;
+        return this;
+    }
+
+    /**
      * Creates a shallow clone of this {@code ResumeSessionConfig} instance.
      * <p>
      * Mutable collection properties are copied into new collection instances so
@@ -1819,6 +1850,7 @@ public class ResumeSessionConfig {
         copy.gitHubToken = this.gitHubToken;
         copy.remoteSession = this.remoteSession;
         copy.expAssignments = this.expAssignments;
+        copy.selfFetchManagedSettings = this.selfFetchManagedSettings;
         return copy;
     }
 }

--- a/java/src/main/java/com/github/copilot/rpc/ResumeSessionRequest.java
+++ b/java/src/main/java/com/github/copilot/rpc/ResumeSessionRequest.java
@@ -214,9 +214,9 @@ public final class ResumeSessionRequest {
     @JsonProperty("expAssignments")
     private JsonNode expAssignments;
 
-    @JsonProperty("selfFetchManagedSettings")
+    @JsonProperty("enableManagedSettings")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private Boolean selfFetchManagedSettings;
+    private Boolean enableManagedSettings;
 
     /** Gets the session ID. @return the session ID */
     public String getSessionId() {
@@ -990,23 +990,22 @@ public final class ResumeSessionRequest {
      * Gets the self-fetch managed settings flag. @return the flag, or {@code null}
      * if not set
      */
-    public Boolean getSelfFetchManagedSettings() {
-        return selfFetchManagedSettings;
+    public Boolean getEnableManagedSettings() {
+        return enableManagedSettings;
     }
 
     /**
-     * Sets the self-fetch managed settings flag. @param selfFetchManagedSettings
-     * the flag
+     * Sets the self-fetch managed settings flag. @param enableManagedSettings the
+     * flag
      */
-    public void setSelfFetchManagedSettings(boolean selfFetchManagedSettings) {
-        this.selfFetchManagedSettings = selfFetchManagedSettings;
+    public void setEnableManagedSettings(boolean enableManagedSettings) {
+        this.enableManagedSettings = enableManagedSettings;
     }
 
     /**
-     * Clears the selfFetchManagedSettings setting, reverting to the default
-     * behavior.
+     * Clears the enableManagedSettings setting, reverting to the default behavior.
      */
-    public void clearSelfFetchManagedSettings() {
-        this.selfFetchManagedSettings = null;
+    public void clearEnableManagedSettings() {
+        this.enableManagedSettings = null;
     }
 }

--- a/java/src/main/java/com/github/copilot/rpc/ResumeSessionRequest.java
+++ b/java/src/main/java/com/github/copilot/rpc/ResumeSessionRequest.java
@@ -214,6 +214,10 @@ public final class ResumeSessionRequest {
     @JsonProperty("expAssignments")
     private JsonNode expAssignments;
 
+    @JsonProperty("selfFetchManagedSettings")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean selfFetchManagedSettings;
+
     /** Gets the session ID. @return the session ID */
     public String getSessionId() {
         return sessionId;
@@ -980,5 +984,29 @@ public final class ResumeSessionRequest {
      */
     public void setExpAssignments(JsonNode expAssignments) {
         this.expAssignments = expAssignments;
+    }
+
+    /**
+     * Gets the self-fetch managed settings flag. @return the flag, or {@code null}
+     * if not set
+     */
+    public Boolean getSelfFetchManagedSettings() {
+        return selfFetchManagedSettings;
+    }
+
+    /**
+     * Sets the self-fetch managed settings flag. @param selfFetchManagedSettings
+     * the flag
+     */
+    public void setSelfFetchManagedSettings(boolean selfFetchManagedSettings) {
+        this.selfFetchManagedSettings = selfFetchManagedSettings;
+    }
+
+    /**
+     * Clears the selfFetchManagedSettings setting, reverting to the default
+     * behavior.
+     */
+    public void clearSelfFetchManagedSettings() {
+        this.selfFetchManagedSettings = null;
     }
 }

--- a/java/src/main/java/com/github/copilot/rpc/SessionConfig.java
+++ b/java/src/main/java/com/github/copilot/rpc/SessionConfig.java
@@ -103,7 +103,7 @@ public class SessionConfig {
     private String remoteSession;
     private CloudSessionOptions cloud;
     private JsonNode expAssignments;
-    private Boolean selfFetchManagedSettings;
+    private Boolean enableManagedSettings;
 
     /**
      * Gets the custom session ID.
@@ -1886,8 +1886,8 @@ public class SessionConfig {
      *         to use the default behavior
      */
     @JsonIgnore
-    public Optional<Boolean> getSelfFetchManagedSettings() {
-        return Optional.ofNullable(selfFetchManagedSettings);
+    public Optional<Boolean> getEnableManagedSettings() {
+        return Optional.ofNullable(enableManagedSettings);
     }
 
     /**
@@ -1898,14 +1898,14 @@ public class SessionConfig {
      * the session's {@link #getGitHubToken() gitHubToken}. Requires
      * {@code gitHubToken} to be set; if omitted, the runtime is expected to reject
      * session creation (fail-closed). When unset, behaves exactly as before.
-     * Serialized on the wire as {@code selfFetchManagedSettings}.
+     * Serialized on the wire as {@code enableManagedSettings}.
      *
-     * @param selfFetchManagedSettings
+     * @param enableManagedSettings
      *            {@code true} to opt into self-fetching managed settings
      * @return this config instance for method chaining
      */
-    public SessionConfig setSelfFetchManagedSettings(boolean selfFetchManagedSettings) {
-        this.selfFetchManagedSettings = selfFetchManagedSettings;
+    public SessionConfig setEnableManagedSettings(boolean enableManagedSettings) {
+        this.enableManagedSettings = enableManagedSettings;
         return this;
     }
 
@@ -1988,7 +1988,7 @@ public class SessionConfig {
         copy.remoteSession = this.remoteSession;
         copy.cloud = this.cloud;
         copy.expAssignments = this.expAssignments;
-        copy.selfFetchManagedSettings = this.selfFetchManagedSettings;
+        copy.enableManagedSettings = this.enableManagedSettings;
         return copy;
     }
 }

--- a/java/src/main/java/com/github/copilot/rpc/SessionConfig.java
+++ b/java/src/main/java/com/github/copilot/rpc/SessionConfig.java
@@ -103,6 +103,7 @@ public class SessionConfig {
     private String remoteSession;
     private CloudSessionOptions cloud;
     private JsonNode expAssignments;
+    private Boolean selfFetchManagedSettings;
 
     /**
      * Gets the custom session ID.
@@ -1877,6 +1878,38 @@ public class SessionConfig {
     }
 
     /**
+     * Gets whether the runtime self-fetches enterprise managed settings at session
+     * bootstrap.
+     *
+     * @return an {@link java.util.Optional} containing {@code true} to opt into
+     *         self-fetching managed settings, or {@link java.util.Optional#empty()}
+     *         to use the default behavior
+     */
+    @JsonIgnore
+    public Optional<Boolean> getSelfFetchManagedSettings() {
+        return Optional.ofNullable(selfFetchManagedSettings);
+    }
+
+    /**
+     * Opts the runtime into self-fetching enterprise managed settings
+     * (bypass-permissions policy) at session bootstrap.
+     * <p>
+     * When {@code true}, the runtime self-fetches enterprise managed settings using
+     * the session's {@link #getGitHubToken() gitHubToken}. Requires
+     * {@code gitHubToken} to be set; if omitted, the runtime is expected to reject
+     * session creation (fail-closed). When unset, behaves exactly as before.
+     * Serialized on the wire as {@code selfFetchManagedSettings}.
+     *
+     * @param selfFetchManagedSettings
+     *            {@code true} to opt into self-fetching managed settings
+     * @return this config instance for method chaining
+     */
+    public SessionConfig setSelfFetchManagedSettings(boolean selfFetchManagedSettings) {
+        this.selfFetchManagedSettings = selfFetchManagedSettings;
+        return this;
+    }
+
+    /**
      * Creates a shallow clone of this {@code SessionConfig} instance.
      * <p>
      * Mutable collection properties are copied into new collection instances so
@@ -1955,6 +1988,7 @@ public class SessionConfig {
         copy.remoteSession = this.remoteSession;
         copy.cloud = this.cloud;
         copy.expAssignments = this.expAssignments;
+        copy.selfFetchManagedSettings = this.selfFetchManagedSettings;
         return copy;
     }
 }

--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -1472,6 +1472,7 @@ export class CopilotClient {
                 remoteSession: config.remoteSession,
                 cloud: config.cloud,
                 expAssignments: config.expAssignments,
+                selfFetchManagedSettings: config.selfFetchManagedSettings,
             });
 
             const {
@@ -1683,6 +1684,7 @@ export class CopilotClient {
                 remoteSession: config.remoteSession,
                 openCanvases: config.openCanvases,
                 expAssignments: config.expAssignments,
+                selfFetchManagedSettings: config.selfFetchManagedSettings,
             });
 
             const { workspacePath, capabilities, openCanvases } = response as {

--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -1472,7 +1472,7 @@ export class CopilotClient {
                 remoteSession: config.remoteSession,
                 cloud: config.cloud,
                 expAssignments: config.expAssignments,
-                selfFetchManagedSettings: config.selfFetchManagedSettings,
+                enableManagedSettings: config.enableManagedSettings,
             });
 
             const {
@@ -1684,7 +1684,7 @@ export class CopilotClient {
                 remoteSession: config.remoteSession,
                 openCanvases: config.openCanvases,
                 expAssignments: config.expAssignments,
-                selfFetchManagedSettings: config.selfFetchManagedSettings,
+                enableManagedSettings: config.enableManagedSettings,
             });
 
             const { workspacePath, capabilities, openCanvases } = response as {

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -2195,7 +2195,7 @@ export interface SessionConfigBase {
      * `gitHubToken`. Requires {@link SessionConfigBase.gitHubToken} to be set;
      * if omitted, the runtime is expected to reject session creation (fail-closed).
      */
-    selfFetchManagedSettings?: boolean;
+    enableManagedSettings?: boolean;
 
     /**
      * When true, skips embedding-based retrieval for this session.

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -2190,6 +2190,14 @@ export interface SessionConfigBase {
     gitHubToken?: string;
 
     /**
+     * Opt-in: when true, the runtime self-fetches enterprise managed settings
+     * (bypass-permissions policy) at session bootstrap using the session's
+     * `gitHubToken`. Requires {@link SessionConfigBase.gitHubToken} to be set;
+     * if omitted, the runtime is expected to reject session creation (fail-closed).
+     */
+    selfFetchManagedSettings?: boolean;
+
+    /**
      * When true, skips embedding-based retrieval for this session.
      * Use in multitenant deployments to prevent cross-session information leakage
      * through the shared embedding cache.

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -1756,7 +1756,7 @@ class CopilotClient:
         extension_info: ExtensionInfo | None = None,
         canvas_handler: CanvasHandler | None = None,
         exp_assignments: dict[str, Any] | None = None,
-        self_fetch_managed_settings: bool | None = None,
+        enable_managed_settings: bool | None = None,
     ) -> CopilotSession:
         """
         Create a new conversation session with the Copilot CLI.
@@ -1888,13 +1888,13 @@ class CopilotClient:
                 malformed payloads are dropped by the runtime (fail-open). This
                 is an internal/trusted-integrator option. Sent on the wire as
                 ``expAssignments``.
-            self_fetch_managed_settings: Opt-in flag. When ``True``, the runtime
+            enable_managed_settings: Opt-in flag. When ``True``, the runtime
                 self-fetches enterprise managed settings (bypass-permissions
                 policy) at session bootstrap using the session's ``github_token``.
                 Requires ``github_token`` to be set; if omitted, the runtime is
                 expected to reject session creation (fail-closed). When unset,
                 behaves exactly as before. Sent on the wire as
-                ``selfFetchManagedSettings``.
+                ``enableManagedSettings``.
 
         Returns:
             A :class:`CopilotSession` instance for the new session.
@@ -2027,8 +2027,8 @@ class CopilotClient:
             payload["expAssignments"] = exp_assignments
 
         # Opt the runtime into self-fetching enterprise managed settings
-        if self_fetch_managed_settings is not None:
-            payload["selfFetchManagedSettings"] = self_fetch_managed_settings
+        if enable_managed_settings is not None:
+            payload["enableManagedSettings"] = enable_managed_settings
 
         # Add working directory if provided
         if working_directory:
@@ -2420,7 +2420,7 @@ class CopilotClient:
         canvas_handler: CanvasHandler | None = None,
         open_canvases: list[OpenCanvasInstance] | None = None,
         exp_assignments: dict[str, Any] | None = None,
-        self_fetch_managed_settings: bool | None = None,
+        enable_managed_settings: bool | None = None,
     ) -> CopilotSession:
         """
         Resume an existing conversation session by its ID.
@@ -2553,13 +2553,13 @@ class CopilotClient:
                 malformed payloads are dropped by the runtime (fail-open). This
                 is an internal/trusted-integrator option. Sent on the wire as
                 ``expAssignments``.
-            self_fetch_managed_settings: Opt-in flag. When ``True``, the runtime
+            enable_managed_settings: Opt-in flag. When ``True``, the runtime
                 self-fetches enterprise managed settings (bypass-permissions
                 policy) at session bootstrap using the session's ``github_token``.
                 Requires ``github_token`` to be set; if omitted, the runtime is
                 expected to reject session creation (fail-closed). When unset,
                 behaves exactly as before. Sent on the wire as
-                ``selfFetchManagedSettings``.
+                ``enableManagedSettings``.
 
         Returns:
             A :class:`CopilotSession` instance for the resumed session.
@@ -2716,8 +2716,8 @@ class CopilotClient:
             payload["expAssignments"] = exp_assignments
 
         # Opt the runtime into self-fetching enterprise managed settings
-        if self_fetch_managed_settings is not None:
-            payload["selfFetchManagedSettings"] = self_fetch_managed_settings
+        if enable_managed_settings is not None:
+            payload["enableManagedSettings"] = enable_managed_settings
 
         if working_directory:
             payload["workingDirectory"] = working_directory

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -1756,6 +1756,7 @@ class CopilotClient:
         extension_info: ExtensionInfo | None = None,
         canvas_handler: CanvasHandler | None = None,
         exp_assignments: dict[str, Any] | None = None,
+        self_fetch_managed_settings: bool | None = None,
     ) -> CopilotSession:
         """
         Create a new conversation session with the Copilot CLI.
@@ -1887,6 +1888,13 @@ class CopilotClient:
                 malformed payloads are dropped by the runtime (fail-open). This
                 is an internal/trusted-integrator option. Sent on the wire as
                 ``expAssignments``.
+            self_fetch_managed_settings: Opt-in flag. When ``True``, the runtime
+                self-fetches enterprise managed settings (bypass-permissions
+                policy) at session bootstrap using the session's ``github_token``.
+                Requires ``github_token`` to be set; if omitted, the runtime is
+                expected to reject session creation (fail-closed). When unset,
+                behaves exactly as before. Sent on the wire as
+                ``selfFetchManagedSettings``.
 
         Returns:
             A :class:`CopilotSession` instance for the new session.
@@ -2017,6 +2025,10 @@ class CopilotClient:
         # Add ExP assignment data if provided (opaque JSON, trusted integrator)
         if exp_assignments is not None:
             payload["expAssignments"] = exp_assignments
+
+        # Opt the runtime into self-fetching enterprise managed settings
+        if self_fetch_managed_settings is not None:
+            payload["selfFetchManagedSettings"] = self_fetch_managed_settings
 
         # Add working directory if provided
         if working_directory:
@@ -2408,6 +2420,7 @@ class CopilotClient:
         canvas_handler: CanvasHandler | None = None,
         open_canvases: list[OpenCanvasInstance] | None = None,
         exp_assignments: dict[str, Any] | None = None,
+        self_fetch_managed_settings: bool | None = None,
     ) -> CopilotSession:
         """
         Resume an existing conversation session by its ID.
@@ -2540,6 +2553,13 @@ class CopilotClient:
                 malformed payloads are dropped by the runtime (fail-open). This
                 is an internal/trusted-integrator option. Sent on the wire as
                 ``expAssignments``.
+            self_fetch_managed_settings: Opt-in flag. When ``True``, the runtime
+                self-fetches enterprise managed settings (bypass-permissions
+                policy) at session bootstrap using the session's ``github_token``.
+                Requires ``github_token`` to be set; if omitted, the runtime is
+                expected to reject session creation (fail-closed). When unset,
+                behaves exactly as before. Sent on the wire as
+                ``selfFetchManagedSettings``.
 
         Returns:
             A :class:`CopilotSession` instance for the resumed session.
@@ -2694,6 +2714,10 @@ class CopilotClient:
         # Add ExP assignment data if provided (opaque JSON, trusted integrator)
         if exp_assignments is not None:
             payload["expAssignments"] = exp_assignments
+
+        # Opt the runtime into self-fetching enterprise managed settings
+        if self_fetch_managed_settings is not None:
+            payload["selfFetchManagedSettings"] = self_fetch_managed_settings
 
         if working_directory:
             payload["workingDirectory"] = working_directory

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1770,6 +1770,13 @@ pub struct SessionConfig {
     /// [`with_exp_assignments`](Self::with_exp_assignments).
     #[doc(hidden)]
     pub exp_assignments: Option<Value>,
+    /// Opt-in: when `Some(true)`, the runtime self-fetches enterprise managed
+    /// settings (bypass-permissions policy) at session bootstrap using the
+    /// session's [`github_token`](Self::github_token). Requires `github_token`
+    /// to be set; if omitted, the runtime is expected to reject session creation
+    /// (fail-closed). When `None`, behaves exactly as before. Set via
+    /// [`with_self_fetch_managed_settings`](Self::with_self_fetch_managed_settings).
+    pub self_fetch_managed_settings: Option<bool>,
     /// Custom session filesystem provider for this session. Required when
     /// the [`Client`](crate::Client) was started with
     /// [`ClientOptions::session_fs`](crate::ClientOptions::session_fs) set.
@@ -1906,6 +1913,10 @@ impl std::fmt::Debug for SessionConfig {
             .field("commands", &self.commands)
             .field("exp_assignments", &self.exp_assignments)
             .field(
+                "self_fetch_managed_settings",
+                &self.self_fetch_managed_settings,
+            )
+            .field(
                 "session_fs_provider",
                 &self.session_fs_provider.as_ref().map(|_| "<set>"),
             )
@@ -2010,6 +2021,7 @@ impl Default for SessionConfig {
             include_sub_agent_streaming_events: None,
             commands: None,
             exp_assignments: None,
+            self_fetch_managed_settings: None,
             session_fs_provider: None,
             permission_handler: None,
             elicitation_handler: None,
@@ -2166,6 +2178,7 @@ impl SessionConfig {
             enable_github_telemetry_forwarding: None,
             commands: wire_commands,
             exp_assignments: self.exp_assignments,
+            self_fetch_managed_settings: self.self_fetch_managed_settings,
         };
 
         let runtime = SessionConfigRuntime {
@@ -2732,6 +2745,16 @@ impl SessionConfig {
         self.exp_assignments = Some(assignments);
         self
     }
+
+    /// Opt the runtime into self-fetching enterprise managed settings
+    /// (bypass-permissions policy) at session bootstrap using the session's
+    /// [`github_token`](Self::github_token). Requires `github_token` to be set;
+    /// if omitted, the runtime is expected to reject session creation
+    /// (fail-closed).
+    pub fn with_self_fetch_managed_settings(mut self, enabled: bool) -> Self {
+        self.self_fetch_managed_settings = Some(enabled);
+        self
+    }
 }
 ///
 /// See [`SessionConfig`] for the construction patterns (chained `with_*`
@@ -2900,6 +2923,12 @@ pub struct ResumeSessionConfig {
     /// [`with_exp_assignments`](Self::with_exp_assignments).
     #[doc(hidden)]
     pub exp_assignments: Option<Value>,
+    /// Opt-in flag injected on resume. See
+    /// [`SessionConfig::self_fetch_managed_settings`]. Re-supply on resume so
+    /// the runtime re-applies the managed-settings self-fetch after a CLI
+    /// process restart. Set via
+    /// [`with_self_fetch_managed_settings`](Self::with_self_fetch_managed_settings).
+    pub self_fetch_managed_settings: Option<bool>,
     /// Custom session filesystem provider. Required on resume when the
     /// [`Client`](crate::Client) was started with
     /// [`ClientOptions::session_fs`](crate::ClientOptions::session_fs).
@@ -3028,6 +3057,10 @@ impl std::fmt::Debug for ResumeSessionConfig {
             )
             .field("commands", &self.commands)
             .field("exp_assignments", &self.exp_assignments)
+            .field(
+                "self_fetch_managed_settings",
+                &self.self_fetch_managed_settings,
+            )
             .field(
                 "session_fs_provider",
                 &self.session_fs_provider.as_ref().map(|_| "<set>"),
@@ -3177,6 +3210,7 @@ impl ResumeSessionConfig {
             enable_github_telemetry_forwarding: None,
             commands: wire_commands,
             exp_assignments: self.exp_assignments,
+            self_fetch_managed_settings: self.self_fetch_managed_settings,
             suppress_resume_event: self.suppress_resume_event,
             continue_pending_work: self.continue_pending_work,
         };
@@ -3264,6 +3298,7 @@ impl ResumeSessionConfig {
             include_sub_agent_streaming_events: None,
             commands: None,
             exp_assignments: None,
+            self_fetch_managed_settings: None,
             session_fs_provider: None,
             suppress_resume_event: None,
             continue_pending_work: None,
@@ -3811,6 +3846,13 @@ impl ResumeSessionConfig {
     #[doc(hidden)]
     pub fn with_exp_assignments(mut self, assignments: Value) -> Self {
         self.exp_assignments = Some(assignments);
+        self
+    }
+
+    /// Opt the runtime into self-fetching enterprise managed settings on resume.
+    /// See [`SessionConfig::with_self_fetch_managed_settings`].
+    pub fn with_self_fetch_managed_settings(mut self, enabled: bool) -> Self {
+        self.self_fetch_managed_settings = Some(enabled);
         self
     }
 }

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1775,8 +1775,8 @@ pub struct SessionConfig {
     /// session's [`github_token`](Self::github_token). Requires `github_token`
     /// to be set; if omitted, the runtime is expected to reject session creation
     /// (fail-closed). When `None`, behaves exactly as before. Set via
-    /// [`with_self_fetch_managed_settings`](Self::with_self_fetch_managed_settings).
-    pub self_fetch_managed_settings: Option<bool>,
+    /// [`with_enable_managed_settings`](Self::with_enable_managed_settings).
+    pub enable_managed_settings: Option<bool>,
     /// Custom session filesystem provider for this session. Required when
     /// the [`Client`](crate::Client) was started with
     /// [`ClientOptions::session_fs`](crate::ClientOptions::session_fs) set.
@@ -1913,8 +1913,8 @@ impl std::fmt::Debug for SessionConfig {
             .field("commands", &self.commands)
             .field("exp_assignments", &self.exp_assignments)
             .field(
-                "self_fetch_managed_settings",
-                &self.self_fetch_managed_settings,
+                "enable_managed_settings",
+                &self.enable_managed_settings,
             )
             .field(
                 "session_fs_provider",
@@ -2021,7 +2021,7 @@ impl Default for SessionConfig {
             include_sub_agent_streaming_events: None,
             commands: None,
             exp_assignments: None,
-            self_fetch_managed_settings: None,
+            enable_managed_settings: None,
             session_fs_provider: None,
             permission_handler: None,
             elicitation_handler: None,
@@ -2178,7 +2178,7 @@ impl SessionConfig {
             enable_github_telemetry_forwarding: None,
             commands: wire_commands,
             exp_assignments: self.exp_assignments,
-            self_fetch_managed_settings: self.self_fetch_managed_settings,
+            enable_managed_settings: self.enable_managed_settings,
         };
 
         let runtime = SessionConfigRuntime {
@@ -2751,8 +2751,8 @@ impl SessionConfig {
     /// [`github_token`](Self::github_token). Requires `github_token` to be set;
     /// if omitted, the runtime is expected to reject session creation
     /// (fail-closed).
-    pub fn with_self_fetch_managed_settings(mut self, enabled: bool) -> Self {
-        self.self_fetch_managed_settings = Some(enabled);
+    pub fn with_enable_managed_settings(mut self, enabled: bool) -> Self {
+        self.enable_managed_settings = Some(enabled);
         self
     }
 }
@@ -2924,11 +2924,11 @@ pub struct ResumeSessionConfig {
     #[doc(hidden)]
     pub exp_assignments: Option<Value>,
     /// Opt-in flag injected on resume. See
-    /// [`SessionConfig::self_fetch_managed_settings`]. Re-supply on resume so
+    /// [`SessionConfig::enable_managed_settings`]. Re-supply on resume so
     /// the runtime re-applies the managed-settings self-fetch after a CLI
     /// process restart. Set via
-    /// [`with_self_fetch_managed_settings`](Self::with_self_fetch_managed_settings).
-    pub self_fetch_managed_settings: Option<bool>,
+    /// [`with_enable_managed_settings`](Self::with_enable_managed_settings).
+    pub enable_managed_settings: Option<bool>,
     /// Custom session filesystem provider. Required on resume when the
     /// [`Client`](crate::Client) was started with
     /// [`ClientOptions::session_fs`](crate::ClientOptions::session_fs).
@@ -3058,8 +3058,8 @@ impl std::fmt::Debug for ResumeSessionConfig {
             .field("commands", &self.commands)
             .field("exp_assignments", &self.exp_assignments)
             .field(
-                "self_fetch_managed_settings",
-                &self.self_fetch_managed_settings,
+                "enable_managed_settings",
+                &self.enable_managed_settings,
             )
             .field(
                 "session_fs_provider",
@@ -3210,7 +3210,7 @@ impl ResumeSessionConfig {
             enable_github_telemetry_forwarding: None,
             commands: wire_commands,
             exp_assignments: self.exp_assignments,
-            self_fetch_managed_settings: self.self_fetch_managed_settings,
+            enable_managed_settings: self.enable_managed_settings,
             suppress_resume_event: self.suppress_resume_event,
             continue_pending_work: self.continue_pending_work,
         };
@@ -3298,7 +3298,7 @@ impl ResumeSessionConfig {
             include_sub_agent_streaming_events: None,
             commands: None,
             exp_assignments: None,
-            self_fetch_managed_settings: None,
+            enable_managed_settings: None,
             session_fs_provider: None,
             suppress_resume_event: None,
             continue_pending_work: None,
@@ -3850,9 +3850,9 @@ impl ResumeSessionConfig {
     }
 
     /// Opt the runtime into self-fetching enterprise managed settings on resume.
-    /// See [`SessionConfig::with_self_fetch_managed_settings`].
-    pub fn with_self_fetch_managed_settings(mut self, enabled: bool) -> Self {
-        self.self_fetch_managed_settings = Some(enabled);
+    /// See [`SessionConfig::with_enable_managed_settings`].
+    pub fn with_enable_managed_settings(mut self, enabled: bool) -> Self {
+        self.enable_managed_settings = Some(enabled);
         self
     }
 }

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1912,10 +1912,7 @@ impl std::fmt::Debug for SessionConfig {
             )
             .field("commands", &self.commands)
             .field("exp_assignments", &self.exp_assignments)
-            .field(
-                "enable_managed_settings",
-                &self.enable_managed_settings,
-            )
+            .field("enable_managed_settings", &self.enable_managed_settings)
             .field(
                 "session_fs_provider",
                 &self.session_fs_provider.as_ref().map(|_| "<set>"),
@@ -3057,10 +3054,7 @@ impl std::fmt::Debug for ResumeSessionConfig {
             )
             .field("commands", &self.commands)
             .field("exp_assignments", &self.exp_assignments)
-            .field(
-                "enable_managed_settings",
-                &self.enable_managed_settings,
-            )
+            .field("enable_managed_settings", &self.enable_managed_settings)
             .field(
                 "session_fs_provider",
                 &self.session_fs_provider.as_ref().map(|_| "<set>"),

--- a/rust/src/wire.rs
+++ b/rust/src/wire.rs
@@ -169,6 +169,8 @@ pub(crate) struct SessionCreateWire {
     pub commands: Option<Vec<CommandWireDefinition>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exp_assignments: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub self_fetch_managed_settings: Option<bool>,
 }
 
 /// The exact JSON shape sent on the `session.resume` JSON-RPC request.
@@ -302,4 +304,6 @@ pub(crate) struct SessionResumeWire {
     pub continue_pending_work: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exp_assignments: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub self_fetch_managed_settings: Option<bool>,
 }

--- a/rust/src/wire.rs
+++ b/rust/src/wire.rs
@@ -170,7 +170,7 @@ pub(crate) struct SessionCreateWire {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exp_assignments: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub self_fetch_managed_settings: Option<bool>,
+    pub enable_managed_settings: Option<bool>,
 }
 
 /// The exact JSON shape sent on the `session.resume` JSON-RPC request.
@@ -305,5 +305,5 @@ pub(crate) struct SessionResumeWire {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exp_assignments: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub self_fetch_managed_settings: Option<bool>,
+    pub enable_managed_settings: Option<bool>,
 }


### PR DESCRIPTION
Extends #1846 to **all language SDKs**.

## Forward `enableManagedSettings` in `session.create`

Threads an optional `enableManagedSettings` flag from the SDK session config through the `session.create` / `resumeSession` wire calls, so consumers can opt the runtime into enterprise **managed-settings** enforcement (bypass-permissions policy) at session bootstrap using the session's `gitHubToken`.

> **Note:** the wire field was renamed from `selfFetchManagedSettings` to `enableManagedSettings` by runtime PR github/copilot-agent-runtime#12118. This PR uses the new name.

Per language:
- **nodejs** — `enableManagedSettings?: boolean` on `SessionConfigBase`; forwarded in create/resume payloads. (mirrors #1846)
- **python** — `enable_managed_settings` kwarg on `create_session`/`resume_session`, sent on the wire as `enableManagedSettings`.
- **go** — `EnableManagedSettings *bool` on `SessionConfig`/`ResumeSessionConfig` and the create/resume wire structs; forwarded in `client.go`.
- **dotnet** — `EnableManagedSettings` on `SessionConfigBase` (incl. clone) and both wire records.
- **rust** — `enable_managed_settings: Option<bool>` with `with_enable_managed_settings` builders on both configs and the wire structs.
- **java** — `enableManagedSettings` on `SessionConfig`/`ResumeSessionConfig` (getter/setter + clone), the request classes, and `SessionRequestBuilder`.

Purely additive and opt-in; unset behaves exactly as before. Requires the session `gitHubToken`; the runtime is expected to reject session creation when omitted (fail-closed). Runtime enforcement lives in the runtime PRs.

### Verification
- Go: `go build`, `go vet`, test compile ✓
- Python: syntax parse ✓
- .NET: SDK build + `CloneTests`/`SerializationTests` (76 passed) ✓
- Rust: `cargo build` + `session_config` lib tests (26 passed) ✓
- Java: compile + `ConfigCloneTest`/`SessionRequestBuilderTest` (116 passed), Spotless applied ✓
- Node: `tsc --noEmit` ✓

### Related PRs
- **Node SDK**: #1846
- **Runtime** (implements + enforces): github/copilot-agent-runtime#11604
- **Runtime** (renames flag to `enableManagedSettings`): github/copilot-agent-runtime#12118
- **VS Code** (AHP opts in): microsoft/vscode#323651
