### PR TITLE
Draft: use-after-free guards

### DIFF
--- a/.github/workflows/dotnet-sdk-tests.yml
+++ b/.github/workflows/dotnet-sdk-tests.yml
@@ -37,10 +37,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         transport: ["default", "inprocess"]
-        # TODO: Re-enable after fixing in-process sqlite file locking on shutdown on Windows
-        exclude:
-          - os: windows-latest
-            transport: "inprocess"
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/dotnet-sdk-tests.yml
+++ b/.github/workflows/dotnet-sdk-tests.yml
@@ -88,4 +88,15 @@ jobs:
       - name: Run .NET SDK tests
         env:
           COPILOT_HMAC_KEY: ${{ secrets.COPILOT_DEVELOPER_CLI_INTEGRATION_HMAC_KEY }}
-        run: dotnet test --no-build -v n
+        run: |
+          # In-process (FFI) hosting is only exercised on .NET (Core). The .NET
+          # Framework (net472) target does not add coverage for the in-process
+          # transport, so on Windows restrict the inprocess leg to net8.0. net472
+          # is still covered by the windows default-transport leg.
+          # TODO: Re-enable net472 for inprocess after fixing in-process sqlite
+          # file locking on shutdown on Windows.
+          framework_arg=""
+          if [ "${{ runner.os }}" = "Windows" ] && [ "${{ matrix.transport }}" = "inprocess" ]; then
+            framework_arg="--framework net8.0"
+          fi
+          dotnet test --no-build -v n $framework_arg

--- a/dotnet/src/FfiRuntimeHost.cs
+++ b/dotnet/src/FfiRuntimeHost.cs
@@ -3,6 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -52,12 +53,70 @@ internal sealed partial class FfiRuntimeHost : IDisposable
     private uint _connectionId;
     private bool _disposed;
 
+    // The native outbound callback used to receive `this` as a GCHandle in
+    // user_data and dereference it. Rust can invoke that callback from a tokio
+    // task that outlives Dispose (connection_close/host_shutdown don't join it),
+    // so dereferencing a freed GCHandle crashed the process with an
+    // AccessViolationException. Instead we mint our own integer token, keep a
+    // registry of live hosts, and pass the token as user_data. A callback for a
+    // token we've already removed is logged (visible in CI) and dropped rather
+    // than faulting.
+    private static readonly ConcurrentDictionary<int, FfiRuntimeHost> s_outboundTargets = new();
+    private static int s_nextOutboundToken;
+    private static int s_orphanedOutboundCount;
+    private static volatile ILogger? s_diagnosticLogger;
+    private int _outboundToken;
+
     private FfiRuntimeHost(string libraryPath, string cliEntrypoint, IReadOnlyDictionary<string, string>? environment, ILogger logger)
     {
         _libraryPath = libraryPath;
         _cliEntrypoint = cliEntrypoint;
         _environment = environment;
         _logger = logger;
+        s_diagnosticLogger = logger;
+    }
+
+    private int RegisterOutboundToken()
+    {
+        _outboundToken = Interlocked.Increment(ref s_nextOutboundToken);
+        s_outboundTargets[_outboundToken] = this;
+        return _outboundToken;
+    }
+
+    private void UnregisterOutboundToken()
+    {
+        var token = _outboundToken;
+        if (token != 0)
+        {
+            _outboundToken = 0;
+            s_outboundTargets.TryRemove(token, out _);
+        }
+    }
+
+    private static void RouteOutbound(IntPtr userData, IntPtr bytesPtr, UIntPtr bytesLen)
+    {
+        if (bytesPtr == IntPtr.Zero || bytesLen == UIntPtr.Zero)
+        {
+            return;
+        }
+
+        var token = userData.ToInt32();
+        if (token != 0 && s_outboundTargets.TryGetValue(token, out var self))
+        {
+            self.FeedInbound(bytesPtr, bytesLen);
+            return;
+        }
+
+        var count = Interlocked.Increment(ref s_orphanedOutboundCount);
+        s_diagnosticLogger?.LogWarning(
+            "FfiRuntimeHost: dropped outbound frame for released connection token {Token} "
+            + "(orphaned callback #{Count} after dispose). This indicates the native runtime invoked "
+            + "the outbound callback after connection_close/host_shutdown returned.",
+            token, count);
+        Console.Error.WriteLine(
+            $"FfiRuntimeHost: dropped outbound frame for released connection token {token} "
+            + $"(orphaned callback #{count} after dispose). This indicates the native runtime invoked "
+            + "the outbound callback after connection_close/host_shutdown returned.");
     }
 
     /// <summary>The stream JSON-RPC reads server→client frames from.</summary>
@@ -223,6 +282,11 @@ internal sealed partial class FfiRuntimeHost : IDisposable
         }
         _disposed = true;
 
+        // Stop routing outbound callbacks to this instance before we ask the
+        // native side to close, so any callback the runtime fires during/after
+        // teardown is logged and dropped instead of touching disposed state.
+        UnregisterOutboundToken();
+
         try
         {
             if (_connectionId != 0)
@@ -263,10 +327,6 @@ internal sealed partial class FfiRuntimeHost : IDisposable
     private static bool s_resolverRegistered;
     private static string? s_resolvedLibraryPath;
 
-    // A normal (non-pinned) handle to this instance, passed to the native side as
-    // the callback's user_data so the static outbound callback can route back here.
-    private GCHandle _selfHandle;
-
     /// <summary>
     /// Registers (once) a process-wide <see cref="NativeLibrary.SetDllImportResolver"/>
     /// that maps <see cref="LibraryName"/> to the absolute <c>runtime.node</c> path so the
@@ -306,13 +366,13 @@ internal sealed partial class FfiRuntimeHost : IDisposable
 
     private uint NativeOpenConnection(uint serverId)
     {
-        _selfHandle = GCHandle.Alloc(this);
+        var token = RegisterOutboundToken();
         unsafe
         {
             return ConnectionOpen(
                 serverId,
                 &OnOutboundStatic,
-                GCHandle.ToIntPtr(_selfHandle),
+                (IntPtr)token,
                 null, UIntPtr.Zero,
                 null, UIntPtr.Zero,
                 null, UIntPtr.Zero);
@@ -325,25 +385,12 @@ internal sealed partial class FfiRuntimeHost : IDisposable
 
     private static bool NativeConnectionClose(uint connectionId) => ConnectionClose(connectionId);
 
-    private void DisposeNativeCallback()
-    {
-        if (_selfHandle.IsAllocated)
-        {
-            _selfHandle.Free();
-        }
-    }
+    private void DisposeNativeCallback() => UnregisterOutboundToken();
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
     private static void OnOutboundStatic(IntPtr userData, IntPtr bytesPtr, nuint bytesLen)
     {
-        if (userData == IntPtr.Zero || bytesPtr == IntPtr.Zero || bytesLen == 0)
-        {
-            return;
-        }
-        if (GCHandle.FromIntPtr(userData).Target is FfiRuntimeHost self)
-        {
-            self.FeedInbound(bytesPtr, bytesLen);
-        }
+        RouteOutbound(userData, bytesPtr, (UIntPtr)bytesLen);
     }
 
     [LibraryImport(LibraryName, EntryPoint = "copilot_runtime_host_start")]
@@ -421,9 +468,11 @@ internal sealed partial class FfiRuntimeHost : IDisposable
     private static ConnectionWriteDelegate? s_connectionWrite;
     private static ConnectionCloseDelegate? s_connectionClose;
 
-    // Held for the connection's lifetime so the marshaled function pointer handed to the
-    // native side is not collected while Rust may still invoke it.
-    private OutboundCallbackDelegate? _outboundDelegate;
+    // Held for the process lifetime so the marshaled function pointer handed to the
+    // native side is never collected while Rust may still invoke it. A single static
+    // delegate serves all connections; it routes to the target host by the integer
+    // token passed as user_data (see RouteOutbound).
+    private static readonly OutboundCallbackDelegate s_outboundDelegate = OnOutboundLegacy;
 
     private static void PrepareNativeLibrary(string libraryPath)
     {
@@ -471,11 +520,11 @@ internal sealed partial class FfiRuntimeHost : IDisposable
 
     private uint NativeOpenConnection(uint serverId)
     {
-        _outboundDelegate = OnOutbound;
+        var token = RegisterOutboundToken();
         return s_connectionOpen!(
             serverId,
-            _outboundDelegate,
-            IntPtr.Zero,
+            s_outboundDelegate,
+            (IntPtr)token,
             null, UIntPtr.Zero,
             null, UIntPtr.Zero,
             null, UIntPtr.Zero);
@@ -493,15 +542,11 @@ internal sealed partial class FfiRuntimeHost : IDisposable
 
     private static bool NativeConnectionClose(uint connectionId) => s_connectionClose!(connectionId);
 
-    private void DisposeNativeCallback() => _outboundDelegate = null;
+    private void DisposeNativeCallback() => UnregisterOutboundToken();
 
-    private void OnOutbound(IntPtr userData, IntPtr bytesPtr, UIntPtr bytesLen)
+    private static void OnOutboundLegacy(IntPtr userData, IntPtr bytesPtr, UIntPtr bytesLen)
     {
-        if (bytesPtr == IntPtr.Zero || bytesLen == UIntPtr.Zero)
-        {
-            return;
-        }
-        FeedInbound(bytesPtr, bytesLen);
+        RouteOutbound(userData, bytesPtr, bytesLen);
     }
 
     /// <summary>

--- a/dotnet/src/FfiRuntimeHost.cs
+++ b/dotnet/src/FfiRuntimeHost.cs
@@ -74,6 +74,14 @@ internal sealed partial class FfiRuntimeHost : IDisposable
     // write dereference half-freed shared state and crash the whole process with
     // an AccessViolationException.
     private static readonly ReaderWriterLockSlim s_nativeGate = new(LockRecursionPolicy.NoRecursion);
+
+    // Serializes StartAsync's publish of the native ids against Dispose. host_start
+    // blocks until the embedded child has fully started (or times out), so if a
+    // Dispose races an in-flight StartAsync we must not tear the child down while
+    // it is still booting (that closes the napi-oop provider mid-startup and the
+    // child aborts the shared process with "peer is closed"). Instead, whichever
+    // of the two runs second performs the teardown of the fully-started host.
+    private readonly object _startStopLock = new();
     private static volatile ILogger? s_diagnosticLogger;
     private int _outboundToken;
 
@@ -194,23 +202,44 @@ internal sealed partial class FfiRuntimeHost : IDisposable
             var argvJson = BuildArgvJson(_cliEntrypoint);
             var envJson = BuildEnvJson(_environment);
 
-            _serverId = NativeHostStart(argvJson, envJson);
-            if (_serverId == 0)
+            // host_start blocks until the child signals readiness, so on return the
+            // child has finished loading and its provider is safe to close cleanly.
+            var serverId = NativeHostStart(argvJson, envJson);
+            if (serverId == 0)
             {
                 throw new InvalidOperationException(
                     $"copilot_runtime_host_start failed (library '{_libraryPath}', entrypoint '{_cliEntrypoint}').");
             }
 
-            _connectionId = NativeOpenConnection(_serverId);
-            if (_connectionId == 0)
+            var connectionId = NativeOpenConnection(serverId);
+            if (connectionId == 0)
             {
                 DisposeNativeCallback();
-                NativeHostShutdown(_serverId);
-                _serverId = 0;
+                NativeHostShutdown(serverId);
                 throw new InvalidOperationException("copilot_runtime_connection_open failed.");
             }
 
-            _sendStream = new CallbackSendStream(SendFrame);
+            var sendStream = new CallbackSendStream(SendFrame);
+
+            bool disposedWhileStarting;
+            lock (_startStopLock)
+            {
+                disposedWhileStarting = _disposed;
+                if (!disposedWhileStarting)
+                {
+                    _serverId = serverId;
+                    _connectionId = connectionId;
+                    _sendStream = sendStream;
+                }
+            }
+
+            if (disposedWhileStarting)
+            {
+                // Disposed while host_start was blocking. The child is fully started
+                // now, so tear it down cleanly here (Dispose saw no ids to close).
+                TeardownNative(connectionId, serverId);
+                throw new OperationCanceledException("FfiRuntimeHost was disposed during startup.");
+            }
         }, cancellationToken).ConfigureAwait(false);
 
         if (_logger.IsEnabled(LogLevel.Debug))
@@ -297,29 +326,53 @@ internal sealed partial class FfiRuntimeHost : IDisposable
 
     public void Dispose()
     {
-        if (_disposed)
+        uint connectionId;
+        uint serverId;
+        lock (_startStopLock)
         {
-            return;
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
+
+            // Claim the native ids. If StartAsync hasn't published them yet, these
+            // are 0 and its still-running publish will observe _disposed and perform
+            // the teardown itself once the child has finished starting.
+            connectionId = _connectionId;
+            serverId = _serverId;
+            _connectionId = 0;
+            _serverId = 0;
         }
-        _disposed = true;
 
         // Stop routing outbound callbacks to this instance before we ask the
         // native side to close, so any callback the runtime fires during/after
         // teardown is logged and dropped instead of touching disposed state.
         UnregisterOutboundToken();
 
-        // Hold the exclusive gate across the native teardown so no other host's
-        // connection_write can be executing in native code while this host tears
-        // down the shared runtime/provider state.
+        TeardownNative(connectionId, serverId);
+
+        _receiveStream.Complete();
+    }
+
+    // Closes the connection and shuts the host down under the exclusive native
+    // gate so no other host's connection_write can be executing in native code
+    // while this host tears down the shared runtime/provider state.
+    private void TeardownNative(uint connectionId, uint serverId)
+    {
+        if (connectionId == 0 && serverId == 0)
+        {
+            return;
+        }
+
         s_nativeGate.EnterWriteLock();
         try
         {
             try
             {
-                if (_connectionId != 0)
+                if (connectionId != 0)
                 {
-                    NativeConnectionClose(_connectionId);
-                    _connectionId = 0;
+                    NativeConnectionClose(connectionId);
                 }
             }
             catch (Exception ex)
@@ -329,10 +382,9 @@ internal sealed partial class FfiRuntimeHost : IDisposable
 
             try
             {
-                if (_serverId != 0)
+                if (serverId != 0)
                 {
-                    NativeHostShutdown(_serverId);
-                    _serverId = 0;
+                    NativeHostShutdown(serverId);
                 }
             }
             catch (Exception ex)
@@ -344,9 +396,6 @@ internal sealed partial class FfiRuntimeHost : IDisposable
         {
             s_nativeGate.ExitWriteLock();
         }
-
-        _receiveStream.Complete();
-        DisposeNativeCallback();
     }
 
     /// <summary>Length as the native pointer-sized unsigned integer the ABI expects.</summary>

--- a/dotnet/src/FfiRuntimeHost.cs
+++ b/dotnet/src/FfiRuntimeHost.cs
@@ -64,6 +64,16 @@ internal sealed partial class FfiRuntimeHost : IDisposable
     private static readonly ConcurrentDictionary<int, FfiRuntimeHost> s_outboundTargets = new();
     private static int s_nextOutboundToken;
     private static int s_orphanedOutboundCount;
+
+    // Process-global gate protecting the shared native state (the single loaded
+    // runtime.node, its process-global tokio runtime, and the napi-oop provider
+    // bridge) that ALL in-process hosts share. Inbound writes take the read lock;
+    // a host's native teardown (connection_close + host_shutdown) takes the write
+    // lock. This guarantees no connection_write P/Invoke is executing in native
+    // code while any host tears that shared state down, which otherwise let a live
+    // write dereference half-freed shared state and crash the whole process with
+    // an AccessViolationException.
+    private static readonly ReaderWriterLockSlim s_nativeGate = new(LockRecursionPolicy.NoRecursion);
     private static volatile ILogger? s_diagnosticLogger;
     private int _outboundToken;
 
@@ -259,11 +269,22 @@ internal sealed partial class FfiRuntimeHost : IDisposable
 
     private bool SendFrame(ReadOnlySpan<byte> frame)
     {
-        if (_disposed || _connectionId == 0)
+        // The read lock lets writes from independent connections proceed
+        // concurrently but blocks while any host holds the exclusive write lock
+        // for its native teardown, so a write can never race a teardown.
+        s_nativeGate.EnterReadLock();
+        try
         {
-            return false;
+            if (_disposed || _connectionId == 0)
+            {
+                return false;
+            }
+            return NativeConnectionWrite(_connectionId, frame);
         }
-        return NativeConnectionWrite(_connectionId, frame);
+        finally
+        {
+            s_nativeGate.ExitReadLock();
+        }
     }
 
     private void FeedInbound(IntPtr bytesPtr, UIntPtr bytesLen)
@@ -287,30 +308,41 @@ internal sealed partial class FfiRuntimeHost : IDisposable
         // teardown is logged and dropped instead of touching disposed state.
         UnregisterOutboundToken();
 
+        // Hold the exclusive gate across the native teardown so no other host's
+        // connection_write can be executing in native code while this host tears
+        // down the shared runtime/provider state.
+        s_nativeGate.EnterWriteLock();
         try
         {
-            if (_connectionId != 0)
+            try
             {
-                NativeConnectionClose(_connectionId);
-                _connectionId = 0;
+                if (_connectionId != 0)
+                {
+                    NativeConnectionClose(_connectionId);
+                    _connectionId = 0;
+                }
             }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "FfiRuntimeHost: connection_close failed");
-        }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "FfiRuntimeHost: connection_close failed");
+            }
 
-        try
-        {
-            if (_serverId != 0)
+            try
             {
-                NativeHostShutdown(_serverId);
-                _serverId = 0;
+                if (_serverId != 0)
+                {
+                    NativeHostShutdown(_serverId);
+                    _serverId = 0;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "FfiRuntimeHost: host_shutdown failed");
             }
         }
-        catch (Exception ex)
+        finally
         {
-            _logger.LogDebug(ex, "FfiRuntimeHost: host_shutdown failed");
+            s_nativeGate.ExitWriteLock();
         }
 
         _receiveStream.Complete();

--- a/dotnet/test/Harness/E2ETestContext.cs
+++ b/dotnet/test/Harness/E2ETestContext.cs
@@ -344,7 +344,7 @@ public sealed class E2ETestContext : IAsyncDisposable
         {
             try
             {
-                await StopClientForCleanupAsync(client);
+                await client.StopAsync();
             }
             catch (Exception ex) when (IsTransientCleanupException(ex))
             {
@@ -378,7 +378,7 @@ public sealed class E2ETestContext : IAsyncDisposable
         {
             try
             {
-                await StopClientForCleanupAsync(client);
+                await client.StopAsync();
             }
             catch (Exception ex) when (IsTransientCleanupException(ex))
             {
@@ -437,23 +437,6 @@ public sealed class E2ETestContext : IAsyncDisposable
         if (Directory.Exists(path))
         {
             throw new IOException($"Failed to delete directory '{path}' after {maxAttempts} attempts.", lastException);
-        }
-    }
-
-    // Inproc holds the session-store SQLite handle in-process; graceful StopAsync releases it so the temp-dir delete succeeds on Windows.
-    private static async Task StopClientForCleanupAsync(CopilotClient client)
-    {
-        var isInProcess = string.Equals(
-            Environment.GetEnvironmentVariable("COPILOT_SDK_DEFAULT_CONNECTION"),
-            "inprocess",
-            StringComparison.OrdinalIgnoreCase);
-        if (isInProcess)
-        {
-            await client.StopAsync();
-        }
-        else
-        {
-            await client.ForceStopAsync();
         }
     }
 


### PR DESCRIPTION
## Status

There's a shutdown race that affects .NET+Windows+inproc specifically. This does not seem likely to affect any real application, since real applications typically start up one runtime instance and then only shut it down when the application itself is shutting down. Our E2E tests, on the other hand, start up many hundreds of runtime instances in the same process in quick succession, rapidly creating and destroying them.

This PR adds a set of additional guards in the .NET FFI transport to detect or block use-after-free in both inbound and outbound message cases. But it's still not enough - there's a remaining use-after-free (or similar) in the Rust->napi-oop->Node bridge in certain shutdown cases. This manifests in the build error you can see for this PR:

```
Error: peer is closed
    at Object.call (C:\Users\runneradmin\AppData\Local\copilot\pkg\win32-x64\1.0.69-2\napi-oop-runtime\node_modules\napi-oop-runtime\dist\index.js:68:2418)
    at Proxy.S (C:\Users\runneradmin\AppData\Local\copilot\pkg\win32-x64\1.0.69-2\napi-oop-runtime\node_modules\napi-oop-runtime\dist\index.js:68:3671)
    at t.filterSecrets (file:///C:/Users/runneradmin/AppData/Local/copilot/pkg/win32-x64/1.0.69-2/app.js:92:42580)
    at HC.filterSecrets (file:///C:/Users/runneradmin/AppData/Local/copilot/pkg/win32-x64/1.0.69-2/app.js:92:44685)
    at HC.error (file:///C:/Users/runneradmin/AppData/Local/copilot/pkg/win32-x64/1.0.69-2/app.js:92:46758)
    at HC.writeLog (file:///C:/Users/runneradmin/AppData/Local/copilot/pkg/win32-x64/1.0.69-2/app.js:93:163)
    at qae.logToLevel (file:///C:/Users/runneradmin/AppData/Local/copilot/pkg/win32-x64/1.0.69-2/app.js:61:1536)
    at qae.error (file:///C:/Users/runneradmin/AppData/Local/copilot/pkg/win32-x64/1.0.69-2/app.js:61:1719)
    at t.handleError (file:///C:/Users/runneradmin/AppData/Local/copilot/pkg/win32-x64/1.0.69-2/app.js:5226:625)
    at process.<anonymous> (file:///C:/Users/runneradmin/AppData/Local/copilot/pkg/win32-x64/1.0.69-2/app.js:5226:360)
Node.js v24.16.0
```

It might be that before we get to dealing with this, the problem disappears naturally (in ~2 weeks we hope not to have napi-oop any more). Once we do remove napi-oop, we should see if the .NET+Windows+inproc combination immediately becomes robust when re-enabling its CI leg and then we can simply close this draft PR.

If not, we should consider productizing one or more of the use-after-free guards/locks from this PR.

This PR also temporarily disables the net472 part of the CI leg. That is simply to help diagnose whether issues are specific to .NET Framework or not. We do not plan to remove net472 support.
