### PR TITLE
Make .NET CopilotClient.DisposeAsync graceful

### DIFF
--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -2391,13 +2391,15 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     /// </summary>
     /// <returns>A <see cref="ValueTask"/> representing the asynchronous dispose operation.</returns>
     /// <remarks>
-    /// This method calls <see cref="ForceStopAsync"/> to immediately release all resources.
+    /// This method calls <see cref="StopAsync"/> to gracefully shut down the runtime and
+    /// release all resources. Use <see cref="ForceStopAsync"/> for an immediate hard stop
+    /// that skips graceful runtime shutdown.
     /// </remarks>
     public async ValueTask DisposeAsync()
     {
         if (_disposed) return;
         _disposed = true;
-        await ForceStopAsync();
+        await StopAsync();
     }
 
     private class RpcHandler(CopilotClient client)

--- a/dotnet/test/Unit/ClientSessionLifetimeTests.cs
+++ b/dotnet/test/Unit/ClientSessionLifetimeTests.cs
@@ -33,6 +33,20 @@ public sealed class ClientSessionLifetimeTests
     }
 
     [Fact]
+    public async Task DisposeAsync_Requests_Runtime_Shutdown_For_Owned_Process()
+    {
+        await using var server = await FakeCopilotServer.StartAsync();
+        var client = new CopilotClient(new CopilotClientOptions { Connection = RuntimeConnection.ForUri(server.Url) });
+        await client.StartAsync();
+        using var process = StartExitedProcess();
+        await ReplaceConnectionCliProcessAsync(client, process);
+
+        await client.DisposeAsync();
+
+        Assert.Equal(1, server.RuntimeShutdownCount);
+    }
+
+    [Fact]
     public async Task StopAsync_Does_Not_Throw_When_Runtime_Shutdown_Fails()
     {
         await using var server = await FakeCopilotServer.StartAsync();


### PR DESCRIPTION
## What

Makes the .NET `CopilotClient.DisposeAsync` perform a **graceful** shutdown (`StopAsync`) instead of a hard kill (`ForceStopAsync`), so that `await using` / `Dispose` cleanly shuts down the runtime and releases all resources. `ForceStopAsync` remains available as the opt-in hard stop.

## Why

Idiomatic disposal should release resources cleanly. The other SDKs already do this — this brings .NET into line.

## Cross-language status

The goal is: **idiomatic dispose == graceful stop** in every SDK. Verified state:

| SDK | Idiomatic dispose | Graceful? | Change |
| --- | --- | --- | --- |
| **.NET** | `DisposeAsync` / `await using` | ❌ called `ForceStopAsync` | ✅ now `StopAsync` |
| Node | `[Symbol.asyncDispose]` → `stop()` | ✅ already | none |
| Python | `__aexit__` → `stop()` | ✅ already | none |
| Java | `close()` → `stop()` | ✅ already | none |
| Go | explicit `Stop()` / `ForceStop()` (no implicit dispose) | ✅ `Stop()` graceful | none |
| Rust | `Drop` (synchronous best-effort kill) | n/a — async graceful shutdown needs explicit `stop().await` | none |

All of Node (`stop()`→`runtime.shutdown`), Python, and Java route graceful `stop()` through the `runtime.shutdown` RPC. Rust's `Drop` is synchronous and cannot `await`, so graceful shutdown there remains the explicit `client.stop().await` path (Drop stays a best-effort child kill).

## Tests

Adds `DisposeAsync_Requests_Runtime_Shutdown_For_Owned_Process` (mirrors the existing `StopAsync_...` test) asserting `DisposeAsync` issues exactly one `runtime.shutdown`. `ForceStopAsync_And_External_Stop_Do_Not_Request_Runtime_Shutdown` continues to pass.

## Notes

This is the standalone, broadly-desirable dispose change extracted from the in-process FFI investigation in #1928 (which remains in draft for the use-after-free explorations).
