### PR TITLE
GPT-4.1 is not available anymore

### DIFF
--- a/docs/auth/byok.md
+++ b/docs/auth/byok.md
@@ -529,7 +529,7 @@ import { CopilotClient } from "@github/copilot-sdk";
 
 const client = new CopilotClient();
 const session = await client.createSession({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     provider: {
         type: "azure",
         baseUrl: "https://my-resource.openai.azure.com",
@@ -560,7 +560,7 @@ import { CopilotClient } from "@github/copilot-sdk";
 
 const client = new CopilotClient();
 const session = await client.createSession({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     provider: {
         type: "openai",
         baseUrl: "https://your-resource.openai.azure.com/openai/v1/",

--- a/docs/features/custom-agents.md
+++ b/docs/features/custom-agents.md
@@ -37,7 +37,7 @@ const client = new CopilotClient();
 await client.start();
 
 const session = await client.createSession({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     customAgents: [
         {
             name: "researcher",
@@ -71,7 +71,7 @@ await client.start()
 
 session = await client.create_session(
     on_permission_request=lambda req, inv: PermissionDecisionApproveOnce(),
-    model="gpt-4.1",
+    model="gpt-5.4",
     custom_agents=[
         {
             "name": "researcher",
@@ -112,7 +112,7 @@ func main() {
 	client.Start(ctx)
 
 	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
-		Model: "gpt-4.1",
+		Model: "gpt-5.4",
 		CustomAgents: []copilot.CustomAgentConfig{
 			{
 				Name:        "researcher",
@@ -144,7 +144,7 @@ client := copilot.NewClient(nil)
 client.Start(ctx)
 
 session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
-    Model: "gpt-4.1",
+    Model: "gpt-5.4",
     CustomAgents: []copilot.CustomAgentConfig{
         {
             Name:        "researcher",
@@ -179,7 +179,7 @@ using GitHub.Copilot.Rpc;
 await using var client = new CopilotClient();
 await using var session = await client.CreateSessionAsync(new SessionConfig
 {
-    Model = "gpt-4.1",
+    Model = "gpt-5.4",
     CustomAgents = new List<CustomAgentConfig>
     {
         new()
@@ -219,7 +219,7 @@ try (var client = new CopilotClient()) {
 
     var session = client.createSession(
         new SessionConfig()
-            .setModel("gpt-4.1")
+            .setModel("gpt-5.4")
             .setCustomAgents(List.of(
                 new CustomAgentConfig()
                     .setName("researcher")
@@ -529,7 +529,7 @@ func main() {
 	client.Start(ctx)
 
 	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
-		Model: "gpt-4.1",
+		Model: "gpt-5.4",
 		OnPermissionRequest: func(req copilot.PermissionRequest, inv copilot.PermissionInvocation) (rpc.PermissionDecision, error) {
 			return &rpc.PermissionDecisionApproveOnce{}, nil
 		},

--- a/docs/features/image-input.md
+++ b/docs/features/image-input.md
@@ -47,7 +47,7 @@ const client = new CopilotClient();
 await client.start();
 
 const session = await client.createSession({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     onPermissionRequest: async () => ({ kind: "approve-once" }),
 });
 
@@ -75,7 +75,7 @@ await client.start()
 
 session = await client.create_session(
     on_permission_request=lambda req, inv: PermissionDecisionApproveOnce(),
-    model="gpt-4.1",
+    model="gpt-5.4",
 )
 
 await session.send(
@@ -110,7 +110,7 @@ func main() {
 	client.Start(ctx)
 
 	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
-		Model: "gpt-4.1",
+		Model: "gpt-5.4",
 		OnPermissionRequest: func(req copilot.PermissionRequest, inv copilot.PermissionInvocation) (rpc.PermissionDecision, error) {
 			return &rpc.PermissionDecisionApproveOnce{}, nil
 		},
@@ -136,7 +136,7 @@ client := copilot.NewClient(nil)
 client.Start(ctx)
 
 session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
-    Model: "gpt-4.1",
+    Model: "gpt-5.4",
     OnPermissionRequest: func(req copilot.PermissionRequest, inv copilot.PermissionInvocation) (rpc.PermissionDecision, error) {
         return &rpc.PermissionDecisionApproveOnce{}, nil
     },
@@ -171,7 +171,7 @@ public static class ImageInputExample
         await using var client = new CopilotClient();
         await using var session = await client.CreateSessionAsync(new SessionConfig
         {
-            Model = "gpt-4.1",
+            Model = "gpt-5.4",
             OnPermissionRequest = (req, inv) =>
                 Task.FromResult(PermissionDecision.ApproveOnce()),
         });
@@ -200,7 +200,7 @@ using GitHub.Copilot.Rpc;
 await using var client = new CopilotClient();
 await using var session = await client.CreateSessionAsync(new SessionConfig
 {
-    Model = "gpt-4.1",
+    Model = "gpt-5.4",
     OnPermissionRequest = (req, inv) =>
         Task.FromResult(PermissionDecision.ApproveOnce()),
 });
@@ -234,7 +234,7 @@ try (var client = new CopilotClient()) {
 
     var session = client.createSession(
         new SessionConfig()
-            .setModel("gpt-4.1")
+            .setModel("gpt-5.4")
             .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
     ).get();
 
@@ -263,7 +263,7 @@ const client = new CopilotClient();
 await client.start();
 
 const session = await client.createSession({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     onPermissionRequest: async () => ({ kind: "approve-once" }),
 });
 
@@ -294,7 +294,7 @@ await client.start()
 
 session = await client.create_session(
     on_permission_request=lambda req, inv: PermissionDecisionApproveOnce(),
-    model="gpt-4.1",
+    model="gpt-5.4",
 )
 
 base64_image_data = "..."  # your base64-encoded image
@@ -332,7 +332,7 @@ func main() {
 	client.Start(ctx)
 
 	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
-		Model: "gpt-4.1",
+		Model: "gpt-5.4",
 		OnPermissionRequest: func(req copilot.PermissionRequest, inv copilot.PermissionInvocation) (rpc.PermissionDecision, error) {
 			return &rpc.PermissionDecisionApproveOnce{}, nil
 		},
@@ -387,7 +387,7 @@ public static class BlobAttachmentExample
         await using var client = new CopilotClient();
         await using var session = await client.CreateSessionAsync(new SessionConfig
         {
-            Model = "gpt-4.1",
+            Model = "gpt-5.4",
             OnPermissionRequest = (req, inv) =>
                 Task.FromResult(PermissionDecision.ApproveOnce()),
         });
@@ -442,7 +442,7 @@ try (var client = new CopilotClient()) {
 
     var session = client.createSession(
         new SessionConfig()
-            .setModel("gpt-4.1")
+            .setModel("gpt-5.4")
             .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
     ).get();
 

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -24,7 +24,7 @@ import { CopilotClient } from "@github/copilot-sdk";
 
 const client = new CopilotClient();
 const session = await client.createSession({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     skillDirectories: [
         "./skills/code-review",
         "./skills/documentation",
@@ -50,7 +50,7 @@ async def main():
 
     session = await client.create_session(
         on_permission_request=lambda req, inv: PermissionDecisionApproveOnce(),
-        model="gpt-4.1",
+        model="gpt-5.4",
         skill_directories=[
             "./skills/code-review",
             "./skills/documentation",
@@ -87,7 +87,7 @@ func main() {
     defer client.Stop()
 
     session, err := client.CreateSession(ctx, &copilot.SessionConfig{
-        Model: "gpt-4.1",
+        Model: "gpt-5.4",
         SkillDirectories: []string{
             "./skills/code-review",
             "./skills/documentation",
@@ -122,7 +122,7 @@ using GitHub.Copilot.Rpc;
 await using var client = new CopilotClient();
 await using var session = await client.CreateSessionAsync(new SessionConfig
 {
-    Model = "gpt-4.1",
+    Model = "gpt-5.4",
     SkillDirectories = new List<string>
     {
         "./skills/code-review",
@@ -154,7 +154,7 @@ try (var client = new CopilotClient()) {
 
     var session = client.createSession(
         new SessionConfig()
-            .setModel("gpt-4.1")
+            .setModel("gpt-5.4")
             .setSkillDirectories(List.of(
                 "./skills/code-review",
                 "./skills/documentation"

--- a/docs/features/steering-and-queueing.md
+++ b/docs/features/steering-and-queueing.md
@@ -47,7 +47,7 @@ const client = new CopilotClient();
 await client.start();
 
 const session = await client.createSession({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     onPermissionRequest: async () => ({ kind: "approve-once" }),
 });
 
@@ -77,7 +77,7 @@ async def main():
 
     session = await client.create_session(
         on_permission_request=lambda req, inv: PermissionDecisionApproveOnce(),
-        model="gpt-4.1",
+        model="gpt-5.4",
     )
 
     # Start a long-running task
@@ -118,7 +118,7 @@ func main() {
     defer client.Stop()
 
     session, err := client.CreateSession(ctx, &copilot.SessionConfig{
-        Model: "gpt-4.1",
+        Model: "gpt-5.4",
         OnPermissionRequest: func(req copilot.PermissionRequest, inv copilot.PermissionInvocation) (rpc.PermissionDecision, error) {
             return &rpc.PermissionDecisionApproveOnce{}, nil
         },
@@ -158,7 +158,7 @@ using GitHub.Copilot.Rpc;
 await using var client = new CopilotClient();
 await using var session = await client.CreateSessionAsync(new SessionConfig
 {
-    Model = "gpt-4.1",
+    Model = "gpt-5.4",
     OnPermissionRequest = (req, inv) =>
         Task.FromResult(PermissionDecision.ApproveOnce()),
 });
@@ -191,7 +191,7 @@ try (var client = new CopilotClient()) {
 
     var session = client.createSession(
         new SessionConfig()
-            .setModel("gpt-4.1")
+            .setModel("gpt-5.4")
             .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
     ).get();
 
@@ -234,7 +234,7 @@ const client = new CopilotClient();
 await client.start();
 
 const session = await client.createSession({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     onPermissionRequest: async () => ({ kind: "approve-once" }),
 });
 
@@ -269,7 +269,7 @@ async def main():
 
     session = await client.create_session(
         on_permission_request=lambda req, inv: PermissionDecisionApproveOnce(),
-        model="gpt-4.1",
+        model="gpt-5.4",
     )
 
     # Send an initial task
@@ -311,7 +311,7 @@ func main() {
 	client.Start(ctx)
 
 	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
-		Model: "gpt-4.1",
+		Model: "gpt-5.4",
 		OnPermissionRequest: func(req copilot.PermissionRequest, inv copilot.PermissionInvocation) (rpc.PermissionDecision, error) {
 			return &rpc.PermissionDecisionApproveOnce{}, nil
 		},
@@ -371,7 +371,7 @@ public static class QueueingExample
         await using var client = new CopilotClient();
         await using var session = await client.CreateSessionAsync(new SessionConfig
         {
-            Model = "gpt-4.1",
+            Model = "gpt-5.4",
             OnPermissionRequest = (req, inv) =>
                 Task.FromResult(PermissionDecision.ApproveOnce()),
         });
@@ -434,7 +434,7 @@ try (var client = new CopilotClient()) {
 
     var session = client.createSession(
         new SessionConfig()
-            .setModel("gpt-4.1")
+            .setModel("gpt-5.4")
             .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
     ).get();
 
@@ -475,7 +475,7 @@ You can use both patterns together in a single session. Steering affects the cur
 
 ```typescript
 const session = await client.createSession({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     onPermissionRequest: async () => ({ kind: "approve-once" }),
 });
 
@@ -503,7 +503,7 @@ await session.send({
 ```python
 session = await client.create_session(
     on_permission_request=lambda req, inv: PermissionDecisionApproveOnce(),
-    model="gpt-4.1",
+    model="gpt-5.4",
 )
 
 # Start a task

--- a/docs/features/streaming-events.md
+++ b/docs/features/streaming-events.md
@@ -130,7 +130,7 @@ func main() {
 	client := copilot.NewClient(nil)
 
 	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
-		Model:     "gpt-4.1",
+		Model:     "gpt-5.4",
 		Streaming: copilot.Bool(true),
 		OnPermissionRequest: func(req copilot.PermissionRequest, inv copilot.PermissionInvocation) (rpc.PermissionDecision, error) {
 			return &rpc.PermissionDecisionApproveOnce{}, nil
@@ -306,7 +306,7 @@ Ephemeral. Token usage and cost information for an individual API call.
 
 | Data Field | Type | Required | Description |
 |------------|------|----------|-------------|
-| `model` | `string` | ✅ | Model identifier (e.g., `"gpt-4.1"`) |
+| `model` | `string` | ✅ | Model identifier (e.g., `"gpt-5.4"`) |
 | `inputTokens` | `number` | | Input tokens consumed |
 | `outputTokens` | `number` | | Output tokens produced |
 | `cacheReadTokens` | `number` | | Tokens read from prompt cache |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -150,7 +150,7 @@ Create `index.ts`:
 import { CopilotClient } from "@github/copilot-sdk";
 
 const client = new CopilotClient();
-const session = await client.createSession({ model: "gpt-4.1" });
+const session = await client.createSession({ model: "gpt-5.4" });
 
 const response = await session.sendAndWait({ prompt: "What is 2 + 2?" });
 console.log(response?.data.content);
@@ -181,7 +181,7 @@ async def main():
     client = CopilotClient()
     await client.start()
 
-    session = await client.create_session(on_permission_request=PermissionHandler.approve_all, model="gpt-4.1")
+    session = await client.create_session(on_permission_request=PermissionHandler.approve_all, model="gpt-5.4")
     response = await session.send_and_wait("What is 2 + 2?")
     print(response.data.content)
 
@@ -223,7 +223,7 @@ func main() {
 	}
 	defer client.Stop()
 
-	session, err := client.CreateSession(ctx, &copilot.SessionConfig{Model: "gpt-4.1"})
+	session, err := client.CreateSession(ctx, &copilot.SessionConfig{Model: "gpt-5.4"})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -304,7 +304,7 @@ using GitHub.Copilot;
 await using var client = new CopilotClient();
 await using var session = await client.CreateSessionAsync(new SessionConfig
 {
-    Model = "gpt-4.1",
+    Model = "gpt-5.4",
     OnPermissionRequest = PermissionHandler.ApproveAll
 });
 
@@ -337,7 +337,7 @@ public class HelloCopilot {
 
             var session = client.createSession(
                 new SessionConfig()
-                    .setModel("gpt-4.1")
+                    .setModel("gpt-5.4")
                     .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
             ).get();
 
@@ -383,7 +383,7 @@ import { CopilotClient } from "@github/copilot-sdk";
 
 const client = new CopilotClient();
 const session = await client.createSession({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     streaming: true,
 });
 
@@ -419,7 +419,7 @@ async def main():
     client = CopilotClient()
     await client.start()
 
-    session = await client.create_session(on_permission_request=PermissionHandler.approve_all, model="gpt-4.1", streaming=True)
+    session = await client.create_session(on_permission_request=PermissionHandler.approve_all, model="gpt-5.4", streaming=True)
 
     # Listen for response chunks
     def handle_event(event):
@@ -466,7 +466,7 @@ func main() {
 	defer client.Stop()
 
 	session, err := client.CreateSession(ctx, &copilot.SessionConfig{
-		Model:     "gpt-4.1",
+		Model:     "gpt-5.4",
 		Streaming: copilot.Bool(true),
 	})
 	if err != nil {
@@ -562,7 +562,7 @@ using GitHub.Copilot;
 await using var client = new CopilotClient();
 await using var session = await client.CreateSessionAsync(new SessionConfig
 {
-    Model = "gpt-4.1",
+    Model = "gpt-5.4",
     OnPermissionRequest = PermissionHandler.ApproveAll,
     Streaming = true,
 });
@@ -602,7 +602,7 @@ public class HelloCopilot {
 
             var session = client.createSession(
                 new SessionConfig()
-                    .setModel("gpt-4.1")
+                    .setModel("gpt-5.4")
                     .setStreaming(true)
                     .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
             ).get();
@@ -912,7 +912,7 @@ const getWeather = defineTool("get_weather", {
 
 const client = new CopilotClient();
 const session = await client.createSession({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     streaming: true,
     tools: [getWeather],
 });
@@ -968,7 +968,7 @@ async def main():
     client = CopilotClient()
     await client.start()
 
-    session = await client.create_session(on_permission_request=PermissionHandler.approve_all, model="gpt-4.1", streaming=True, tools=[get_weather])
+    session = await client.create_session(on_permission_request=PermissionHandler.approve_all, model="gpt-5.4", streaming=True, tools=[get_weather])
 
     def handle_event(event):
         if event.type == SessionEventType.ASSISTANT_MESSAGE_DELTA:
@@ -1045,7 +1045,7 @@ func main() {
 	defer client.Stop()
 
 	session, err := client.CreateSession(ctx, &copilot.SessionConfig{
-		Model:     "gpt-4.1",
+		Model:     "gpt-5.4",
 		Streaming: copilot.Bool(true),
 		Tools:     []copilot.Tool{getWeather},
 	})
@@ -1185,7 +1185,7 @@ var getWeather = CopilotTool.DefineTool(
 
 await using var session = await client.CreateSessionAsync(new SessionConfig
 {
-    Model = "gpt-4.1",
+    Model = "gpt-5.4",
     OnPermissionRequest = PermissionHandler.ApproveAll,
     Streaming = true,
     Tools = [getWeather],
@@ -1259,7 +1259,7 @@ public class HelloCopilot {
 
             var session = client.createSession(
                 new SessionConfig()
-                    .setModel("gpt-4.1")
+                    .setModel("gpt-5.4")
                     .setStreaming(true)
                     .setTools(List.of(getWeather))
                     .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
@@ -1316,7 +1316,7 @@ const getWeather = defineTool("get_weather", {
 
 const client = new CopilotClient();
 const session = await client.createSession({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     streaming: true,
     tools: [getWeather],
 });
@@ -1389,7 +1389,7 @@ async def main():
     client = CopilotClient()
     await client.start()
 
-    session = await client.create_session(on_permission_request=PermissionHandler.approve_all, model="gpt-4.1", streaming=True, tools=[get_weather])
+    session = await client.create_session(on_permission_request=PermissionHandler.approve_all, model="gpt-5.4", streaming=True, tools=[get_weather])
 
     def handle_event(event):
         if event.type == SessionEventType.ASSISTANT_MESSAGE_DELTA:
@@ -1482,7 +1482,7 @@ func main() {
 	defer client.Stop()
 
 	session, err := client.CreateSession(ctx, &copilot.SessionConfig{
-		Model:     "gpt-4.1",
+		Model:     "gpt-5.4",
 		Streaming: copilot.Bool(true),
 		Tools:     []copilot.Tool{getWeather},
 	})
@@ -1671,7 +1671,7 @@ var getWeather = CopilotTool.DefineTool(
 await using var client = new CopilotClient();
 await using var session = await client.CreateSessionAsync(new SessionConfig
 {
-    Model = "gpt-4.1",
+    Model = "gpt-5.4",
     OnPermissionRequest = PermissionHandler.ApproveAll,
     Streaming = true,
     Tools = [getWeather]
@@ -1765,7 +1765,7 @@ public class WeatherAssistant {
 
             var session = client.createSession(
                 new SessionConfig()
-                    .setModel("gpt-4.1")
+                    .setModel("gpt-5.4")
                     .setStreaming(true)
                     .setOnPermissionRequest(request ->
                         CompletableFuture.completedFuture(PermissionDecision.allow())

--- a/docs/integrations/microsoft-agent-framework.md
+++ b/docs/integrations/microsoft-agent-framework.md
@@ -123,7 +123,7 @@ var client = new CopilotClient();
 client.start().get();
 
 var session = client.createSession(new SessionConfig()
-    .setModel("gpt-4.1")
+    .setModel("gpt-5.4")
     .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
 ).get();
 
@@ -217,7 +217,7 @@ const getWeather = DefineTool({
 
 const client = new CopilotClient();
 const session = await client.createSession({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     tools: [getWeather],
     onPermissionRequest: async () => ({ kind: "approve-once" }),
 });
@@ -255,7 +255,7 @@ try (var client = new CopilotClient()) {
     client.start().get();
 
     var session = client.createSession(new SessionConfig()
-        .setModel("gpt-4.1")
+        .setModel("gpt-5.4")
         .setTools(List.of(getWeather))
         .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
     ).get();
@@ -296,7 +296,7 @@ AIAgent reviewer = copilotClient.AsAIAgent(new AIAgentOptions
 // Azure OpenAI agent for generating documentation
 AIAgent documentor = AIAgent.FromOpenAI(new OpenAIAgentOptions
 {
-    Model = "gpt-4.1",
+    Model = "gpt-5.4",
     Instructions = "You write clear, concise documentation for code changes.",
 });
 
@@ -330,7 +330,7 @@ async def main():
 
     # OpenAI agent for documentation
     documentor = OpenAIAgent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         instructions="You write clear, concise documentation for code changes.",
     )
 
@@ -360,7 +360,7 @@ client.start().get();
 
 // Step 1: Code review session
 var reviewer = client.createSession(new SessionConfig()
-    .setModel("gpt-4.1")
+    .setModel("gpt-5.4")
     .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
 ).get();
 
@@ -370,7 +370,7 @@ var review = reviewer.sendAndWait(new MessageOptions()
 
 // Step 2: Documentation session using review output
 var documentor = client.createSession(new SessionConfig()
-    .setModel("gpt-4.1")
+    .setModel("gpt-5.4")
     .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
 ).get();
 
@@ -434,12 +434,12 @@ var client = new CopilotClient();
 client.start().get();
 
 var securitySession = client.createSession(new SessionConfig()
-    .setModel("gpt-4.1")
+    .setModel("gpt-5.4")
     .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
 ).get();
 
 var perfSession = client.createSession(new SessionConfig()
-    .setModel("gpt-4.1")
+    .setModel("gpt-5.4")
     .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
 ).get();
 
@@ -518,7 +518,7 @@ import { CopilotClient } from "@github/copilot-sdk";
 
 const client = new CopilotClient();
 const session = await client.createSession({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     streaming: true,
     onPermissionRequest: async () => ({ kind: "approve-once" }),
 });
@@ -544,7 +544,7 @@ var client = new CopilotClient();
 client.start().get();
 
 var session = client.createSession(new SessionConfig()
-    .setModel("gpt-4.1")
+    .setModel("gpt-5.4")
     .setStreaming(true)
     .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
 ).get();
@@ -598,7 +598,7 @@ import { CopilotClient } from "@github/copilot-sdk";
 
 const client = new CopilotClient();
 const session = await client.createSession({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     onPermissionRequest: async () => ({ kind: "approve-once" }),
 });
 const response = await session.sendAndWait({ prompt: "Explain this code" });

--- a/docs/setup/backend-services.md
+++ b/docs/setup/backend-services.md
@@ -134,7 +134,7 @@ const client = new CopilotClient({
 
 const session = await client.createSession({
     sessionId: `user-${userId}-${Date.now()}`,
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     availableTools: ["custom:*"],
     gitHubToken: user.githubToken,
 });
@@ -157,7 +157,7 @@ client = CopilotClient(
 )
 await client.start()
 
-session = await client.create_session(on_permission_request=PermissionHandler.approve_all, model="gpt-4.1", session_id=f"user-{user_id}-{int(time.time())}")
+session = await client.create_session(on_permission_request=PermissionHandler.approve_all, model="gpt-5.4", session_id=f"user-{user_id}-{int(time.time())}")
 
 response = await session.send_and_wait(message)
 ```
@@ -191,7 +191,7 @@ func main() {
 
 	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
 		SessionID: fmt.Sprintf("user-%s-%d", userID, time.Now().Unix()),
-		Model:     "gpt-4.1",
+		Model:     "gpt-5.4",
 	})
 
 	response, _ := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: message})
@@ -209,7 +209,7 @@ defer client.Stop()
 
 session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
     SessionID: fmt.Sprintf("user-%s-%d", userID, time.Now().Unix()),
-    Model:     "gpt-4.1",
+    Model:     "gpt-5.4",
 })
 
 response, _ := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: message})
@@ -235,7 +235,7 @@ var client = new CopilotClient(new CopilotClientOptions
 await using var session = await client.CreateSessionAsync(new SessionConfig
 {
     SessionId = $"user-{userId}-{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}",
-    Model = "gpt-4.1",
+    Model = "gpt-5.4",
 });
 
 var response = await session.SendAndWaitAsync(
@@ -252,7 +252,7 @@ var client = new CopilotClient(new CopilotClientOptions
 await using var session = await client.CreateSessionAsync(new SessionConfig
 {
     SessionId = $"user-{userId}-{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}",
-    Model = "gpt-4.1",
+    Model = "gpt-5.4",
 });
 
 var response = await session.SendAndWaitAsync(
@@ -280,7 +280,7 @@ try {
 
     var session = client.createSession(new SessionConfig()
         .setSessionId(String.format("user-%s-%d", userId, System.currentTimeMillis() / 1000))
-        .setModel("gpt-4.1")
+        .setModel("gpt-5.4")
         .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
     ).get();
 
@@ -332,7 +332,7 @@ const client = new CopilotClient({
 app.post("/chat", authMiddleware, async (req, res) => {
     const session = await client.createSession({
         sessionId: `user-${req.user.id}-chat`,
-        model: "gpt-4.1",
+        model: "gpt-5.4",
         availableTools: ["custom:*"],
         gitHubToken: req.user.githubToken,
     });
@@ -355,7 +355,7 @@ const client = new CopilotClient({
 });
 
 const session = await client.createSession({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     provider: {
         type: "openai",
         baseUrl: "https://api.openai.com/v1",
@@ -407,7 +407,7 @@ app.post("/api/chat", async (req, res) => {
     } catch {
         session = await client.createSession({
             sessionId,
-            model: "gpt-4.1",
+            model: "gpt-5.4",
             availableTools: ["custom:*"],
             gitHubToken: req.user.githubToken,
         });
@@ -436,7 +436,7 @@ const client = new CopilotClient({
 async function processJob(job: Job) {
     const session = await client.createSession({
         sessionId: `job-${job.id}`,
-        model: "gpt-4.1",
+        model: "gpt-5.4",
     });
 
     const response = await session.sendAndWait({

--- a/docs/setup/bundled-cli.md
+++ b/docs/setup/bundled-cli.md
@@ -47,7 +47,7 @@ import { CopilotClient } from "@github/copilot-sdk";
 
 const client = new CopilotClient();
 
-const session = await client.createSession({ model: "gpt-4.1" });
+const session = await client.createSession({ model: "gpt-5.4" });
 const response = await session.sendAndWait({ prompt: "Hello!" });
 console.log(response?.data.content);
 
@@ -66,7 +66,7 @@ from copilot.session import PermissionHandler
 client = CopilotClient()
 await client.start()
 
-session = await client.create_session(on_permission_request=PermissionHandler.approve_all, model="gpt-4.1")
+session = await client.create_session(on_permission_request=PermissionHandler.approve_all, model="gpt-5.4")
 response = await session.send_and_wait("Hello!")
 print(response.data.content)
 
@@ -101,7 +101,7 @@ func main() {
 	}
 	defer client.Stop()
 
-	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{Model: "gpt-4.1"})
+	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{Model: "gpt-5.4"})
 	response, _ := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: "Hello!"})
 	if d, ok := response.Data.(*copilot.AssistantMessageData); ok {
 		fmt.Println(d.Content)
@@ -117,7 +117,7 @@ if err := client.Start(ctx); err != nil {
 }
 defer client.Stop()
 
-session, _ := client.CreateSession(ctx, &copilot.SessionConfig{Model: "gpt-4.1"})
+session, _ := client.CreateSession(ctx, &copilot.SessionConfig{Model: "gpt-5.4"})
 response, _ := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: "Hello!"})
 if d, ok := response.Data.(*copilot.AssistantMessageData); ok {
     fmt.Println(d.Content)
@@ -132,7 +132,7 @@ if d, ok := response.Data.(*copilot.AssistantMessageData); ok {
 ```csharp
 await using var client = new CopilotClient();
 await using var session = await client.CreateSessionAsync(
-    new SessionConfig { Model = "gpt-4.1" });
+    new SessionConfig { Model = "gpt-5.4" });
 
 var response = await session.SendAndWaitAsync(
     new MessageOptions { Prompt = "Hello!" });
@@ -158,7 +158,7 @@ var client = new CopilotClient(new CopilotClientOptions()
 client.start().get();
 
 var session = client.createSession(new SessionConfig()
-    .setModel("gpt-4.1")
+    .setModel("gpt-5.4")
     .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
 ).get();
 
@@ -219,7 +219,7 @@ If you manage your own model provider keys, users don't need GitHub accounts at 
 const client = new CopilotClient();
 
 const session = await client.createSession({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     provider: {
         type: "openai",
         baseUrl: "https://api.openai.com/v1",
@@ -241,7 +241,7 @@ const client = new CopilotClient();
 const sessionId = `project-${projectName}`;
 const session = await client.createSession({
     sessionId,
-    model: "gpt-4.1",
+    model: "gpt-5.4",
 });
 
 // User closes app...

--- a/docs/setup/github-oauth.md
+++ b/docs/setup/github-oauth.md
@@ -133,7 +133,7 @@ function createClientForUser(userToken: string): CopilotClient {
 const client = createClientForUser("gho_user_access_token");
 const session = await client.createSession({
     sessionId: `user-${userId}-session`,
-    model: "gpt-4.1",
+    model: "gpt-5.4",
 });
 
 const response = await session.sendAndWait({ prompt: "Hello!" });
@@ -158,7 +158,7 @@ def create_client_for_user(user_token: str) -> CopilotClient:
 client = create_client_for_user("gho_user_access_token")
 await client.start()
 
-session = await client.create_session(on_permission_request=PermissionHandler.approve_all, model="gpt-4.1", session_id=f"user-{user_id}-session")
+session = await client.create_session(on_permission_request=PermissionHandler.approve_all, model="gpt-5.4", session_id=f"user-{user_id}-session")
 
 response = await session.send_and_wait("Hello!")
 ```
@@ -195,7 +195,7 @@ func main() {
 
 	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
 		SessionID: fmt.Sprintf("user-%s-session", userID),
-		Model:     "gpt-4.1",
+		Model:     "gpt-5.4",
 	})
 	response, _ := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: "Hello!"})
 	_ = response
@@ -218,7 +218,7 @@ defer client.Stop()
 
 session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
     SessionID: fmt.Sprintf("user-%s-session", userID),
-    Model:     "gpt-4.1",
+    Model:     "gpt-5.4",
 })
 response, _ := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: "Hello!"})
 ```
@@ -245,7 +245,7 @@ await using var client = CreateClientForUser("gho_user_access_token");
 await using var session = await client.CreateSessionAsync(new SessionConfig
 {
     SessionId = $"user-{userId}-session",
-    Model = "gpt-4.1",
+    Model = "gpt-5.4",
 });
 
 var response = await session.SendAndWaitAsync(
@@ -266,7 +266,7 @@ await using var client = CreateClientForUser("gho_user_access_token");
 await using var session = await client.CreateSessionAsync(new SessionConfig
 {
     SessionId = $"user-{userId}-session",
-    Model = "gpt-4.1",
+    Model = "gpt-5.4",
 });
 
 var response = await session.SendAndWaitAsync(
@@ -297,7 +297,7 @@ var userId = "user1";
 try (var client = createClientForUser("gho_user_access_token")) {
     var session = client.createSession(new SessionConfig()
         .setSessionId(String.format("user-%s-session", userId))
-        .setModel("gpt-4.1")
+        .setModel("gpt-5.4")
         .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
     ).get();
 

--- a/docs/setup/local-cli.md
+++ b/docs/setup/local-cli.md
@@ -40,7 +40,7 @@ const client = new CopilotClient({
     cliPath: "/usr/local/bin/copilot",
 });
 
-const session = await client.createSession({ model: "gpt-4.1" });
+const session = await client.createSession({ model: "gpt-5.4" });
 const response = await session.sendAndWait({ prompt: "Hello!" });
 console.log(response?.data.content);
 
@@ -62,7 +62,7 @@ client = CopilotClient({
 })
 await client.start()
 
-session = await client.create_session(on_permission_request=PermissionHandler.approve_all, model="gpt-4.1")
+session = await client.create_session(on_permission_request=PermissionHandler.approve_all, model="gpt-5.4")
 response = await session.send_and_wait("Hello!")
 if response:
     match response.data:
@@ -102,7 +102,7 @@ func main() {
 	}
 	defer client.Stop()
 
-	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{Model: "gpt-4.1"})
+	session, _ := client.CreateSession(ctx, &copilot.SessionConfig{Model: "gpt-5.4"})
 	response, _ := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: "Hello!"})
 	if response != nil {
 		if d, ok := response.Data.(*copilot.AssistantMessageData); ok {
@@ -122,7 +122,7 @@ if err := client.Start(ctx); err != nil {
 }
 defer client.Stop()
 
-session, _ := client.CreateSession(ctx, &copilot.SessionConfig{Model: "gpt-4.1"})
+session, _ := client.CreateSession(ctx, &copilot.SessionConfig{Model: "gpt-5.4"})
 response, _ := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: "Hello!"})
 if response != nil {
     if d, ok := response.Data.(*copilot.AssistantMessageData); ok {
@@ -143,7 +143,7 @@ var client = new CopilotClient(new CopilotClientOptions
 });
 
 await using var session = await client.CreateSessionAsync(
-    new SessionConfig { Model = "gpt-4.1" });
+    new SessionConfig { Model = "gpt-5.4" });
 
 var response = await session.SendAndWaitAsync(
     new MessageOptions { Prompt = "Hello!" });
@@ -190,7 +190,7 @@ Sessions default to ephemeral. To create resumable sessions, provide your own se
 // Create a named session
 const session = await client.createSession({
     sessionId: "my-project-analysis",
-    model: "gpt-4.1",
+    model: "gpt-5.4",
 });
 
 // Later, resume it

--- a/docs/setup/multi-tenancy.md
+++ b/docs/setup/multi-tenancy.md
@@ -48,7 +48,7 @@ const client = new CopilotClient({
 
 const session = await client.createSession({
     sessionId: `user-${user.id}-${crypto.randomUUID()}`,
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     availableTools: ["custom:lookupOrder", "custom:createTicket"],
     gitHubToken: user.githubToken,
 });
@@ -73,7 +73,7 @@ await client.start()
 
 session = await client.create_session(
     session_id=f"user-{user.id}-{request_id}",
-    model="gpt-4.1",
+    model="gpt-5.4",
     available_tools=["custom:lookupOrder", "custom:createTicket"],
     github_token=user.github_token,
     on_permission_request=PermissionHandler.approve_all,
@@ -117,7 +117,7 @@ func main() {
 
 	session, err := client.CreateSession(ctx, &copilot.SessionConfig{
 		SessionID:      fmt.Sprintf("user-%s-%s", user.ID, requestID),
-		Model:          "gpt-4.1",
+		Model:          "gpt-5.4",
 		AvailableTools: []string{"custom:lookupOrder", "custom:createTicket"},
 		GitHubToken:    user.GitHubToken,
 	})
@@ -137,7 +137,7 @@ client := copilot.NewClient(&copilot.ClientOptions{
 
 session, err := client.CreateSession(ctx, &copilot.SessionConfig{
     SessionID:      fmt.Sprintf("user-%s-%s", user.ID, requestID),
-    Model:          "gpt-4.1",
+    Model:          "gpt-5.4",
     AvailableTools: []string{"custom:lookupOrder", "custom:createTicket"},
     GitHubToken:    user.GitHubToken,
 })
@@ -168,7 +168,7 @@ var client = new CopilotClient(new CopilotClientOptions
 await using var session = await client.CreateSessionAsync(new SessionConfig
 {
     SessionId = $"user-{user.Id}-{requestId}",
-    Model = "gpt-4.1",
+    Model = "gpt-5.4",
     AvailableTools = ["custom:lookupOrder", "custom:createTicket"],
     GitHubToken = user.GitHubToken,
 });
@@ -187,7 +187,7 @@ var client = new CopilotClient(new CopilotClientOptions
 await using var session = await client.CreateSessionAsync(new SessionConfig
 {
     SessionId = $"user-{user.Id}-{requestId}",
-    Model = "gpt-4.1",
+    Model = "gpt-5.4",
     AvailableTools = ["custom:lookupOrder", "custom:createTicket"],
     GitHubToken = user.GitHubToken,
 });
@@ -223,7 +223,7 @@ public class MultiTenancyExample {
 
         var session = client.createSession(new SessionConfig()
             .setSessionId("user-" + user.id() + "-" + requestId)
-            .setModel("gpt-4.1")
+            .setModel("gpt-5.4")
             .setAvailableTools(List.of("custom:lookupOrder", "custom:createTicket"))
             .setGitHubToken(user.gitHubToken())
         ).get();
@@ -242,7 +242,7 @@ var client = new CopilotClient(new CopilotClientOptions()
 
 var session = client.createSession(new SessionConfig()
     .setSessionId("user-" + user.id() + "-" + requestId)
-    .setModel("gpt-4.1")
+    .setModel("gpt-5.4")
     .setAvailableTools(List.of("custom:lookupOrder", "custom:createTicket"))
     .setGitHubToken(user.gitHubToken())
 ).get();
@@ -276,7 +276,7 @@ let client = Client::start(
 let session = client.create_session(
     SessionConfig::default()
         .with_session_id(format!("user-{}-{request_id}", user.id))
-        .with_model("gpt-4.1")
+        .with_model("gpt-5.4")
         .with_available_tools(["custom:lookupOrder", "custom:createTicket"])
         .with_github_token(user.github_token),
 ).await?;
@@ -366,7 +366,7 @@ Set `gitHubToken` on each session to scope GitHub auth to the requesting user. T
 ```typescript
 const session = await client.createSession({
     sessionId: `user-${user.id}-support`,
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     availableTools: ["custom:*"],
     gitHubToken: user.githubToken,
 });

--- a/docs/setup/scaling.md
+++ b/docs/setup/scaling.md
@@ -324,7 +324,7 @@ app.post("/chat", async (req, res) => {
 
     const session = await client.createSession({
         sessionId: `user-${req.user.id}-chat`,
-        model: "gpt-4.1",
+        model: "gpt-5.4",
     });
 
     const response = await session.sendAndWait({ prompt: req.body.message });
@@ -404,7 +404,7 @@ class SessionManager {
         // Create or resume
         const session = await client.createSession({
             sessionId,
-            model: "gpt-4.1",
+            model: "gpt-5.4",
         });
 
         this.activeSessions.set(sessionId, session);
@@ -450,7 +450,7 @@ For stateless API endpoints where each request is independent:
 ```typescript
 app.post("/api/analyze", async (req, res) => {
     const session = await client.createSession({
-        model: "gpt-4.1",
+        model: "gpt-5.4",
     });
 
     try {
@@ -475,7 +475,7 @@ app.post("/api/chat/start", async (req, res) => {
 
     const session = await client.createSession({
         sessionId,
-        model: "gpt-4.1",
+        model: "gpt-5.4",
         infiniteSessions: {
             enabled: true,
             backgroundCompactionThreshold: 0.80,


### PR DESCRIPTION
gpt-4.1 is not available in the CLI anymore. So when running the getting started sample I get:

```
com.github.copilot.JsonRpcException: Request session.create failed with message: Model "gpt-4.1" is not available
```

I changed it to gpt-5.4