### PR TITLE
fix(dotnet): abort in-flight turns before disposing sessions on in-process shutdown

### DIFF
--- a/.github/workflows/dotnet-sdk-tests.yml
+++ b/.github/workflows/dotnet-sdk-tests.yml
@@ -37,10 +37,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         transport: ["default", "inprocess"]
-        # TODO: Re-enable after fixing in-process sqlite file locking on shutdown on Windows
-        exclude:
-          - os: windows-latest
-            transport: "inprocess"
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -445,19 +445,34 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     /// </example>
     public async Task StopAsync()
     {
-        List<Exception> errors = [];
-
-        foreach (var session in _sessions.Values.ToArray())
+        var disposeErrors = await Task.WhenAll(_sessions.Values.Select(async session =>
         {
             try
             {
+                // TEMPORARY: over the in-process (FFI) transport the runtime shares this
+                // process, so a turn still running when the runtime disposes the session
+                // can leave that session's SQLite session.db handle open — it isn't
+                // reclaimed by terminating a child process, so the file stays locked
+                // (Windows) and the session-state directory can't be removed. Abort any
+                // in-flight turn first so it cancels and releases the handle. Aborting a
+                // session with no active turn is a no-op. Scoped to in-process only:
+                // stdio/tcp runtimes run in a child process that we kill on shutdown
+                // (which frees the handle), and for external servers we don't own the
+                // runtime and aborting would cancel pending work other clients may still
+                // resume. Remove once the runtime cleans up fully on shutdown.
+                if (_connection is InProcessRuntimeConnection)
+                {
+                    await session.AbortAsync();
+                }
                 await session.DisposeAsync();
+                return (Exception?)null;
             }
             catch (Exception ex)
             {
-                errors.Add(new IOException($"Failed to dispose session {session.SessionId}: {ex.Message}", ex));
+                return new IOException($"Failed to dispose session {session.SessionId}: {ex.Message}", ex);
             }
-        }
+        }));
+        List<Exception> errors = [.. disposeErrors.Where(static e => e is not null).Select(static e => e!)];
 
         _sessions.Clear();
 


### PR DESCRIPTION
## What

Cross-SDK parity with the Node.js in-process shutdown fix.

Over the in-process (FFI) transport the runtime shares the SDK process, so a turn still running when a session is disposed can leave that session's SQLite `session.db` handle open. Because there is no child process to terminate, the handle is never reclaimed — on Windows the file stays locked and the session-state temp directory can't be removed.

## Changes

- **`CopilotClient.StopAsync()`** now aborts any in-flight turn (`session.AbortAsync()`) **before** `session.DisposeAsync()`, releasing the handle. Aborting a session with no active turn is a no-op.
  - Scoped to `InProcessRuntimeConnection` only: stdio/tcp runtimes run in a child process we kill on shutdown (which frees the handle), and for external servers we don't own the runtime and aborting would cancel pending work other clients may still resume.
  - Abort + dispose run per-session in a single parallel `Task.WhenAll`.
  - Marked `TEMPORARY` — remove once the runtime cleans up fully on shutdown.
- **CI**: re-enables the `windows-latest` + `inprocess` matrix leg in `dotnet-sdk-tests.yml` (previously excluded pending this fix).

## Context

Follow-up to the equivalent Node.js SDK fix. See https://github.com/github/copilot-sdk/issues/1934 for the broader in-process transport tracking.
