### PR TITLE
rust: use native-tls for the build-time CLI download

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -435,6 +435,7 @@ dependencies = [
  "http",
  "indexmap",
  "libloading",
+ "native-tls",
  "parking_lot",
  "regex",
  "reqwest",
@@ -1229,9 +1230,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
- "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1848,11 +1847,9 @@ checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
  "base64",
  "log",
+ "native-tls",
  "once_cell",
- "rustls",
- "rustls-pki-types",
  "url",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2043,24 +2040,6 @@ checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -97,5 +97,6 @@ flate2 = "1"
 serde_json = "1"
 sha2 = "0.10"
 tar = "0.4"
-ureq = { version = "2", default-features = false, features = ["tls"] }
+ureq = { version = "2", default-features = false, features = ["native-tls"] }
+native-tls = "0.2"
 zip = { version = "2", default-features = false, features = ["deflate"] }

--- a/rust/build/in_process.rs
+++ b/rust/build/in_process.rs
@@ -631,7 +631,12 @@ struct DownloadError {
 }
 
 fn try_download(url: &str) -> Result<Vec<u8>, DownloadError> {
+    let connector = native_tls::TlsConnector::new().map_err(|e| DownloadError {
+        message: format!("native-tls init error: {e}"),
+        transient: false,
+    })?;
     let agent = ureq::AgentBuilder::new()
+        .tls_connector(std::sync::Arc::new(connector))
         .timeout_connect(Duration::from_secs(30))
         .timeout_read(Duration::from_secs(120))
         .build();

--- a/rust/build/out_of_process.rs
+++ b/rust/build/out_of_process.rs
@@ -599,7 +599,12 @@ struct DownloadError {
 }
 
 fn try_download(url: &str) -> Result<Vec<u8>, DownloadError> {
+    let connector = native_tls::TlsConnector::new().map_err(|e| DownloadError {
+        message: format!("native-tls init error: {e}"),
+        transient: false,
+    })?;
     let agent = ureq::AgentBuilder::new()
+        .tls_connector(std::sync::Arc::new(connector))
         .timeout_connect(Duration::from_secs(30))
         .timeout_read(Duration::from_secs(120))
         .build();


### PR DESCRIPTION
Microsoft Component Governance flags ring (MVS-2022-374v-6mvc, Use Discouraged) in projects that consume this SDK. The build script downloads the Copilot CLI over ureq using the rustls (tls) feature, and rustls pulls in ring.

CG's guidance for that advisory is to use native-tls, which wraps the platform's approved crypto libraries: SChannel on Windows, OpenSSL on Linux, Secure Transport on macOS. This switches the ureq build dependency from rustls to native-tls and builds the connector in build.rs.

native-tls adds no extra dependencies on Windows or macOS; on Linux it links against system OpenSSL.