### PR TITLE
Update outdated gpt-4.1 model references in SDK docstrings

### DIFF
--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -1775,15 +1775,15 @@ public sealed partial class CopilotSession : IAsyncDisposable
     /// Changes the model for this session.
     /// The new model takes effect for the next message. Conversation history is preserved.
     /// </summary>
-    /// <param name="model">Model ID to switch to (e.g., "gpt-4.1").</param>
+    /// <param name="model">Model ID to switch to (e.g., "gpt-5.4").</param>
     /// <param name="reasoningEffort">Reasoning effort level (e.g., "low", "medium", "high", "xhigh").</param>
     /// <param name="modelCapabilities">Per-property overrides for model capabilities, deep-merged over runtime defaults.</param>
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <example>
     /// <code>
-    /// await session.SetModelAsync("gpt-4.1");
+    /// await session.SetModelAsync("gpt-5.4");
     /// await session.SetModelAsync("claude-sonnet-4.6", "high");
-    /// await session.SetModelAsync("gpt-4.1", new SetModelOptions { ContextTier = ContextTier.LongContext });
+    /// await session.SetModelAsync("gpt-5.4", new SetModelOptions { ContextTier = ContextTier.LongContext });
     /// </code>
     /// </example>
     public Task SetModelAsync(string model, string? reasoningEffort, ModelCapabilitiesOverride? modelCapabilities = null, CancellationToken cancellationToken = default)
@@ -1802,7 +1802,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
     /// Changes the model for this session.
     /// The new model takes effect for the next message. Conversation history is preserved.
     /// </summary>
-    /// <param name="model">Model ID to switch to (e.g., "gpt-4.1").</param>
+    /// <param name="model">Model ID to switch to (e.g., "gpt-5.4").</param>
     /// <param name="options">Settings for the new model.</param>
     /// <param name="cancellationToken">Optional cancellation token.</param>
     public async Task SetModelAsync(string model, SetModelOptions options, CancellationToken cancellationToken = default)

--- a/go/session.go
+++ b/go/session.go
@@ -1752,7 +1752,7 @@ type SetModelOptions struct {
 //
 // Example:
 //
-//	if err := session.SetModel(context.Background(), "gpt-4.1", nil); err != nil {
+//	if err := session.SetModel(context.Background(), "gpt-5.4", nil); err != nil {
 //	    log.Printf("Failed to set model: %v", err)
 //	}
 //	if err := session.SetModel(context.Background(), "claude-sonnet-4.6", &SetModelOptions{ReasoningEffort: new("high")}); err != nil {

--- a/java/src/main/java/com/github/copilot/CopilotSession.java
+++ b/java/src/main/java/com/github/copilot/CopilotSession.java
@@ -1945,12 +1945,12 @@ public final class CopilotSession implements AutoCloseable {
      * preserved.
      *
      * <pre>{@code
-     * session.setModel("gpt-4.1").get();
+     * session.setModel("gpt-5.4").get();
      * session.setModel("claude-sonnet-4.6", "high").get();
      * }</pre>
      *
      * @param model
-     *            the model ID to switch to (e.g., {@code "gpt-4.1"})
+     *            the model ID to switch to (e.g., {@code "gpt-5.4"})
      * @param reasoningEffort
      *            reasoning effort level (e.g., {@code "low"}, {@code "medium"},
      *            {@code "high"}, {@code "xhigh"}); {@code null} to use default
@@ -1980,7 +1980,7 @@ public final class CopilotSession implements AutoCloseable {
      * }</pre>
      *
      * @param model
-     *            the model ID to switch to (e.g., {@code "gpt-4.1"})
+     *            the model ID to switch to (e.g., {@code "gpt-5.4"})
      * @param reasoningEffort
      *            reasoning effort level (e.g., {@code "low"}, {@code "medium"},
      *            {@code "high"}, {@code "xhigh"}); {@code null} to use default
@@ -2005,7 +2005,7 @@ public final class CopilotSession implements AutoCloseable {
      * preserved.
      *
      * @param model
-     *            the model ID to switch to (e.g., {@code "gpt-4.1"})
+     *            the model ID to switch to (e.g., {@code "gpt-5.4"})
      * @param reasoningEffort
      *            reasoning effort level; {@code null} to use default
      * @param reasoningSummary
@@ -2053,11 +2053,11 @@ public final class CopilotSession implements AutoCloseable {
      * preserved.
      *
      * <pre>{@code
-     * session.setModel("gpt-4.1").get();
+     * session.setModel("gpt-5.4").get();
      * }</pre>
      *
      * @param model
-     *            the model ID to switch to (e.g., {@code "gpt-4.1"})
+     *            the model ID to switch to (e.g., {@code "gpt-5.4"})
      * @return a future that completes when the model switch is acknowledged
      * @throws IllegalStateException
      *             if this session has been terminated

--- a/java/src/main/java/com/github/copilot/package-info.java
+++ b/java/src/main/java/com/github/copilot/package-info.java
@@ -31,7 +31,7 @@
  * try (var client = new CopilotClient()) {
  * 	client.start().get();
  *
- * 	var session = client.createSession(new SessionConfig().setModel("gpt-4.1")).get();
+ * 	var session = client.createSession(new SessionConfig().setModel("gpt-5.4")).get();
  *
  * 	session.on(AssistantMessageEvent.class, msg -> {
  * 		System.out.println(msg.getData().content());

--- a/java/src/main/java/com/github/copilot/rpc/package-info.java
+++ b/java/src/main/java/com/github/copilot/rpc/package-info.java
@@ -80,7 +80,7 @@
  * <h2>Usage Example</h2>
  *
  * <pre>{@code
- * var config = new SessionConfig().setModel("gpt-4.1").setStreaming(true)
+ * var config = new SessionConfig().setModel("gpt-5.4").setStreaming(true)
  * 		.setSystemMessage(new SystemMessageConfig().setMode(SystemMessageMode.APPEND)
  * 				.setContent("Be concise in your responses."))
  * 		.setTools(List.of(ToolDefinition.create("my_tool", "Description", schema, handler)));

--- a/nodejs/src/session.ts
+++ b/nodejs/src/session.ts
@@ -1372,7 +1372,7 @@ export class CopilotSession {
      *
      * @example
      * ```typescript
-     * await session.setModel("gpt-4.1");
+     * await session.setModel("gpt-5.4");
      * await session.setModel("claude-sonnet-4.6", { reasoningEffort: "high" });
      * ```
      */

--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -2892,7 +2892,7 @@ class CopilotSession:
         is preserved.
 
         Args:
-            model: Model ID to switch to (e.g., "gpt-4.1", "claude-sonnet-4").
+            model: Model ID to switch to (e.g., "gpt-5.4", "claude-sonnet-4").
             reasoning_effort: Optional reasoning effort level for the new model
                 (e.g., "low", "medium", "high", "xhigh").
             reasoning_summary: Optional reasoning summary mode for supported
@@ -2906,7 +2906,7 @@ class CopilotSession:
             Exception: If the session has been destroyed or the connection fails.
 
         Example:
-            >>> await session.set_model("gpt-4.1")
+            >>> await session.set_model("gpt-5.4")
             >>> await session.set_model("claude-sonnet-4.6", reasoning_effort="high")
         """
         rpc_caps = None


### PR DESCRIPTION
PR #1952 updated sample/docs code from `gpt-4.1` to `gpt-5.4`, but left behind references in source code docstrings and comments across all SDKs.

This PR updates the remaining 16 occurrences in `SetModel`/`setModel`/`set_model` API documentation:

- **dotnet/src/Session.cs** — 4 XML doc references
- **java/.../CopilotSession.java** — 6 Javadoc references
- **java/.../package-info.java** — 1 Javadoc reference
- **java/.../rpc/package-info.java** — 1 Javadoc reference
- **nodejs/src/session.ts** — 1 JSDoc reference
- **python/copilot/session.py** — 2 docstring references
- **go/session.go** — 1 comment reference

No logic changes, no test changes.