### PR TITLE
docs: apply style guide conventions and fix trailing whitespace

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Copilot SDK 
+# Copilot SDK
 
 Welcome to the GitHub Copilot SDK docs. Whether you're building your first Copilot-powered app or deploying to production, you'll find what you need here.
 

--- a/docs/auth/authenticate.md
+++ b/docs/auth/authenticate.md
@@ -9,7 +9,7 @@ The GitHub Copilot SDK supports multiple authentication methods to fit different
 | [GitHub Signed-in User](#github-signed-in-user) | Interactive apps where users sign in with GitHub | Yes |
 | [OAuth GitHub App](#oauth-github-app) | Apps acting on behalf of users via OAuth | Yes |
 | [Environment Variables](#environment-variables) | CI/CD, automation, server-to-server | Yes |
-| [BYOK (Bring Your Own Key)](./byok.md) | Using your own API keys (Azure AI Foundry, OpenAI, etc.) | No |
+| [BYOK (Bring Your Own Key)](./byok.md) | Using your own API keys (Azure AI Foundry, OpenAI, and more) | No |
 
 ## GitHub signed-in user
 
@@ -221,7 +221,7 @@ client.start().get();
 
 **Supported token types:**
 * `gho_` - OAuth user access tokens
-* `ghu_` - GitHub App user access tokens  
+* `ghu_` - GitHub App user access tokens
 * `github_pat_` - Fine-grained personal access tokens
 
 **Not supported:**
@@ -275,7 +275,7 @@ await client.start()
 </details>
 
 **When to use:**
-* CI/CD pipelines (GitHub Actions, Jenkins, etc.)
+* CI/CD pipelines (GitHub Actions, Jenkins, and more)
 * Automated testing
 * Server-side applications with service accounts
 * Development when you don't want to use interactive login

--- a/docs/features/cloud-sessions.md
+++ b/docs/features/cloud-sessions.md
@@ -235,7 +235,7 @@ Capture the URL by subscribing to `session.info` and filtering by `infoType: "re
 session.on("session.info", (event) => {
   if (event.data?.infoType === "remote" && event.data.url) {
     console.log("Open from web or mobile:", event.data.url);
-    // e.g. surface in your UI as a shareable link or QR code.
+    // For example, surface in your UI as a shareable link or QR code.
   }
 });
 ```

--- a/docs/setup/choosing-a-setup-path.md
+++ b/docs/setup/choosing-a-setup-path.md
@@ -88,7 +88,7 @@ Use this table to find the right guides based on what you need to do:
 | Getting started quickly | [Default Setup (Bundled CLI)](./bundled-cli.md) |
 | Use your own CLI binary or server | [Local CLI](./local-cli.md) |
 | Users sign in with GitHub | [GitHub OAuth](./github-oauth.md) |
-| Use your own model keys (OpenAI, Azure, etc.) | [BYOK](../auth/byok.md) |
+| Use your own model keys (OpenAI, Azure, and more) | [BYOK](../auth/byok.md) |
 | Azure BYOK with Managed Identity (no API keys) | [Azure Managed Identity](./azure-managed-identity.md) |
 | Run the SDK on a server | [Backend Services](./backend-services.md) |
 | Configure SDK options for concurrent users | [Multi-tenancy and server deployments](./multi-tenancy.md) |

--- a/docs/troubleshooting/mcp-debugging.md
+++ b/docs/troubleshooting/mcp-debugging.md
@@ -446,10 +446,10 @@ When opening an issue or asking for help, collect:
 
 * [ ] SDK language and version
 * [ ] CLI version (`copilot --version`)
-* [ ] MCP server type (Node.js, Python, .NET, Go, Rust, etc.)
+* [ ] MCP server type (Node.js, Python, .NET, Go, Rust, and more)
 * [ ] Full MCP server configuration (redact secrets)
 * [ ] Result of manual `initialize` test
-* [ ] Result of manual `tools/list` test  
+* [ ] Result of manual `tools/list` test
 * [ ] Debug logs from SDK
 * [ ] Any error messages
 


### PR DESCRIPTION
Applies the repo's own [docs style guide](https://github.com/github/copilot-sdk/blob/main/.github/instructions/docs-style.instructions.md) to documentation files:

### Style guide word choice fixes

The style guide specifies:
| Use | Avoid |
|---|---|
| \\or example\\ | \\e.g.\\ |
| \\nd similar\\ | \\etc.\\ |

Following existing docs convention (\\nd more\\ is already used in \\docs/README.md\\ and \\docs/auth/README.md\\):

- **docs/auth/authenticate.md** — 2 \\etc.\\ → \\nd more\\
- **docs/features/cloud-sessions.md** — 1 \\e.g.\\ → \\For example\\
- **docs/setup/choosing-a-setup-path.md** — 1 \\etc.\\ → \\nd more\\
- **docs/troubleshooting/mcp-debugging.md** — 1 \\etc.\\ → \\nd more\\

### Trailing whitespace cleanup

- **docs/README.md** — heading trailing space
- **docs/auth/authenticate.md** — list item trailing spaces
- **docs/troubleshooting/mcp-debugging.md** — checklist item trailing spaces

No files that conflict with open PRs were modified.