### PR TITLE
Add custom agent reasoning effort across SDKs

### DIFF
--- a/docs/features/custom-agents.md
+++ b/docs/features/custom-agents.md
@@ -253,9 +253,13 @@ try (var client = new CopilotClient()) {
 | `mcpServers` | `object` | | MCP server configurations specific to this agent |
 | `infer` | `boolean` | | Whether the runtime can auto-select this agent (default: `true`) |
 | `skills` | `string[]` | | Skill names to preload into the agent's context at startup |
+| `model` | `string` | | Model identifier to use while this agent runs |
+| `reasoningEffort` | `string` | | Reasoning effort to use while this agent runs |
 
 > [!TIP]
 > A good `description` helps the runtime match user intent to the right agent. Be specific about the agent's expertise and capabilities.
+
+Set `model` and `reasoningEffort` to override the parent session's model settings while a custom agent runs. Omit either property to leave that setting unspecified; the SDK does not add a per-agent default. Python uses `reasoning_effort`, .NET uses `ReasoningEffort`, Go uses `ReasoningEffort`, Java uses `setReasoningEffort`, and Rust uses `with_reasoning_effort`.
 
 In addition to per-agent configuration above, you can set `agent` on the **session config** itself to pre-select which custom agent is active when the session starts. See [Selecting an Agent at Session Creation](#selecting-an-agent-at-session-creation) below.
 

--- a/docs/features/custom-agents.md
+++ b/docs/features/custom-agents.md
@@ -254,12 +254,12 @@ try (var client = new CopilotClient()) {
 | `infer` | `boolean` | | Whether the runtime can auto-select this agent (default: `true`) |
 | `skills` | `string[]` | | Skill names to preload into the agent's context at startup |
 | `model` | `string` | | Model identifier to use while this agent runs |
-| `reasoningEffort` | `string` | | Reasoning effort to use while this agent runs |
+| `reasoningEffort` | `string` | | Reasoning effort to use while this agent runs. Inherits an explicit parent session effort when omitted |
 
 > [!TIP]
 > A good `description` helps the runtime match user intent to the right agent. Be specific about the agent's expertise and capabilities.
 
-Set `model` and `reasoningEffort` to override the parent session's model settings while a custom agent runs. Omit either property to leave that setting unspecified; the SDK does not add a per-agent default. Python uses `reasoning_effort`, .NET uses `ReasoningEffort`, Go uses `ReasoningEffort`, Java uses `setReasoningEffort`, and Rust uses `with_reasoning_effort`.
+Set `model` and `reasoningEffort` to override the parent session's model settings while a custom agent runs. When `reasoningEffort` is omitted, the runtime currently inherits an explicitly configured parent session effort. If the parent session effort is also omitted, no effort is sent and the backend chooses. The SDK does not add a per-agent default. Python uses `reasoning_effort`, .NET uses `ReasoningEffort`, Go uses `ReasoningEffort`, Java uses `setReasoningEffort`, and Rust uses `with_reasoning_effort`.
 
 In addition to per-agent configuration above, you can set `agent` on the **session config** itself to pre-select which custom agent is active when the session starts. See [Selecting an Agent at Session Creation](#selecting-an-agent-at-session-creation) below.
 

--- a/docs/features/custom-agents.md
+++ b/docs/features/custom-agents.md
@@ -254,12 +254,12 @@ try (var client = new CopilotClient()) {
 | `infer` | `boolean` | | Whether the runtime can auto-select this agent (default: `true`) |
 | `skills` | `string[]` | | Skill names to preload into the agent's context at startup |
 | `model` | `string` | | Model identifier to use while this agent runs |
-| `reasoningEffort` | `string` | | Reasoning effort to use while this agent runs. Inherits an explicit parent session effort when omitted |
+| `reasoningEffort` | `string` | | Reasoning effort to use while this agent runs. When omitted, no override is sent and the backend chooses its default |
 
 > [!TIP]
 > A good `description` helps the runtime match user intent to the right agent. Be specific about the agent's expertise and capabilities.
 
-Set `model` and `reasoningEffort` to override the parent session's model settings while a custom agent runs. When `reasoningEffort` is omitted, the runtime currently inherits an explicitly configured parent session effort. If the parent session effort is also omitted, no effort is sent and the backend chooses. The SDK does not add a per-agent default. Python uses `reasoning_effort`, .NET uses `ReasoningEffort`, Go uses `ReasoningEffort`, Java uses `setReasoningEffort`, and Rust uses `with_reasoning_effort`.
+Set `model` and `reasoningEffort` to override the parent session's model settings while a custom agent runs. When `reasoningEffort` is omitted, the SDK sends no per-agent override and the backend chooses its default. The parent session effort is not inherited, and the SDK does not add a per-agent default. Python uses `reasoning_effort`, .NET uses `ReasoningEffort`, Go uses `ReasoningEffort`, Java uses `setReasoningEffort`, and Rust uses `with_reasoning_effort`.
 
 In addition to per-agent configuration above, you can set `agent` on the **session config** itself to pre-select which custom agent is active when the session starts. See [Selecting an Agent at Session Creation](#selecting-an-agent-at-session-creation) below.
 

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -2660,8 +2660,8 @@ public sealed class CustomAgentConfig
 
     /// <summary>
     /// Reasoning effort level for this agent's model.
-    /// When omitted, the runtime inherits an explicit parent session effort.
-    /// If the parent effort is also omitted, the backend chooses the effort.
+    /// When omitted, no per-agent override is sent and the backend chooses its
+    /// default. The parent session effort is not inherited.
     /// </summary>
     [JsonPropertyName("reasoningEffort")]
     public string? ReasoningEffort { get; set; }

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -2657,6 +2657,13 @@ public sealed class CustomAgentConfig
     /// </summary>
     [JsonPropertyName("model")]
     public string? Model { get; set; }
+
+    /// <summary>
+    /// Reasoning effort level for this agent's model.
+    /// When omitted, no per-agent reasoning effort is sent to the runtime.
+    /// </summary>
+    [JsonPropertyName("reasoningEffort")]
+    public string? ReasoningEffort { get; set; }
 }
 
 /// <summary>

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -2660,7 +2660,8 @@ public sealed class CustomAgentConfig
 
     /// <summary>
     /// Reasoning effort level for this agent's model.
-    /// When omitted, no per-agent reasoning effort is sent to the runtime.
+    /// When omitted, the runtime inherits an explicit parent session effort.
+    /// If the parent effort is also omitted, the backend chooses the effort.
     /// </summary>
     [JsonPropertyName("reasoningEffort")]
     public string? ReasoningEffort { get; set; }

--- a/dotnet/test/Unit/ClientSessionLifetimeTests.cs
+++ b/dotnet/test/Unit/ClientSessionLifetimeTests.cs
@@ -205,6 +205,57 @@ public sealed class ClientSessionLifetimeTests
     }
 
     [Fact]
+    public async Task CreateSessionAsync_Serializes_CustomAgent_ReasoningEffort()
+    {
+        await using var server = await FakeCopilotServer.StartAsync();
+        await using var client = new CopilotClient(new CopilotClientOptions { Connection = RuntimeConnection.ForUri(server.Url) });
+        await client.StartAsync();
+
+        await using var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            CustomAgents =
+            [
+                new CustomAgentConfig
+                {
+                    Name = "reasoning-agent",
+                    Prompt = "Think carefully.",
+                    ReasoningEffort = "high"
+                }
+            ],
+            OnPermissionRequest = PermissionHandler.ApproveAll
+        });
+
+        var request = Assert.Single(server.Requests, request => request.Method == "session.create");
+        var agent = Assert.Single(request.Params.GetProperty("customAgents").EnumerateArray());
+        Assert.Equal("high", agent.GetProperty("reasoningEffort").GetString());
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_Omits_CustomAgent_ReasoningEffort_When_Unset()
+    {
+        await using var server = await FakeCopilotServer.StartAsync();
+        await using var client = new CopilotClient(new CopilotClientOptions { Connection = RuntimeConnection.ForUri(server.Url) });
+        await client.StartAsync();
+
+        await using var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            CustomAgents =
+            [
+                new CustomAgentConfig
+                {
+                    Name = "default-agent",
+                    Prompt = "Use runtime defaults."
+                }
+            ],
+            OnPermissionRequest = PermissionHandler.ApproveAll
+        });
+
+        var request = Assert.Single(server.Requests, request => request.Method == "session.create");
+        var agent = Assert.Single(request.Params.GetProperty("customAgents").EnumerateArray());
+        Assert.False(agent.TryGetProperty("reasoningEffort", out _));
+    }
+
+    [Fact]
     public async Task CreateSessionAsync_Registers_McpAuth_Interest_Only_When_Handler_Configured()
     {
         await using var server = await FakeCopilotServer.StartAsync();

--- a/dotnet/test/Unit/CloneTests.cs
+++ b/dotnet/test/Unit/CloneTests.cs
@@ -82,7 +82,7 @@ public class CloneTests
             IncludeSubAgentStreamingEvents = false,
             McpServers = new Dictionary<string, McpServerConfig> { ["server1"] = new McpStdioServerConfig { Command = "echo" } },
             McpOAuthTokenStorage = McpOAuthTokenStorageMode.Persistent,
-            CustomAgents = [new CustomAgentConfig { Name = "agent1", Model = "claude-haiku-4.5" }],
+            CustomAgents = [new CustomAgentConfig { Name = "agent1", Model = "claude-haiku-4.5", ReasoningEffort = "high" }],
             Agent = "agent1",
             Capi = new CapiSessionOptions { EnableWebSocketResponses = false },
             Cloud = new CloudSessionOptions
@@ -128,6 +128,7 @@ public class CloneTests
         Assert.Equal(original.McpOAuthTokenStorage, clone.McpOAuthTokenStorage);
         Assert.Equal(original.CustomAgents.Count, clone.CustomAgents!.Count);
         Assert.Equal(original.CustomAgents[0].Model, clone.CustomAgents[0].Model);
+        Assert.Equal(original.CustomAgents[0].ReasoningEffort, clone.CustomAgents[0].ReasoningEffort);
         Assert.Equal(original.Agent, clone.Agent);
         Assert.Same(original.Capi, clone.Capi);
         Assert.Same(original.Cloud, clone.Cloud);

--- a/dotnet/test/Unit/SerializationTests.cs
+++ b/dotnet/test/Unit/SerializationTests.cs
@@ -17,37 +17,6 @@ namespace GitHub.Copilot.Test.Unit;
 public class SerializationTests
 {
     [Fact]
-    public void CustomAgentConfig_SerializesReasoningEffort_WithSdkOptions()
-    {
-        var options = GetSerializerOptions();
-        var original = new CustomAgentConfig
-        {
-            Name = "reasoning-agent",
-            Prompt = "Think carefully.",
-            ReasoningEffort = "high"
-        };
-
-        var json = JsonSerializer.Serialize(original, options);
-        using var document = JsonDocument.Parse(json);
-        Assert.Equal("high", document.RootElement.GetProperty("reasoningEffort").GetString());
-    }
-
-    [Fact]
-    public void CustomAgentConfig_OmitsReasoningEffortWhenUnset_WithSdkOptions()
-    {
-        var options = GetSerializerOptions();
-        var original = new CustomAgentConfig
-        {
-            Name = "default-agent",
-            Prompt = "Use runtime defaults."
-        };
-
-        var json = JsonSerializer.Serialize(original, options);
-        using var document = JsonDocument.Parse(json);
-        Assert.False(document.RootElement.TryGetProperty("reasoningEffort", out _));
-    }
-
-    [Fact]
     public void ProviderConfig_CanSerializeHeaders_WithSdkOptions()
     {
         var options = GetSerializerOptions();

--- a/dotnet/test/Unit/SerializationTests.cs
+++ b/dotnet/test/Unit/SerializationTests.cs
@@ -17,6 +17,37 @@ namespace GitHub.Copilot.Test.Unit;
 public class SerializationTests
 {
     [Fact]
+    public void CustomAgentConfig_SerializesReasoningEffort_WithSdkOptions()
+    {
+        var options = GetSerializerOptions();
+        var original = new CustomAgentConfig
+        {
+            Name = "reasoning-agent",
+            Prompt = "Think carefully.",
+            ReasoningEffort = "high"
+        };
+
+        var json = JsonSerializer.Serialize(original, options);
+        using var document = JsonDocument.Parse(json);
+        Assert.Equal("high", document.RootElement.GetProperty("reasoningEffort").GetString());
+    }
+
+    [Fact]
+    public void CustomAgentConfig_OmitsReasoningEffortWhenUnset_WithSdkOptions()
+    {
+        var options = GetSerializerOptions();
+        var original = new CustomAgentConfig
+        {
+            Name = "default-agent",
+            Prompt = "Use runtime defaults."
+        };
+
+        var json = JsonSerializer.Serialize(original, options);
+        using var document = JsonDocument.Parse(json);
+        Assert.False(document.RootElement.TryGetProperty("reasoningEffort", out _));
+    }
+
+    [Fact]
     public void ProviderConfig_CanSerializeHeaders_WithSdkOptions()
     {
         var options = GetSerializerOptions();

--- a/go/types.go
+++ b/go/types.go
@@ -950,7 +950,8 @@ type CustomAgentConfig struct {
 	// falling back to the parent session model if unavailable.
 	Model string `json:"model,omitempty"`
 	// ReasoningEffort is the reasoning effort level for this agent's model.
-	// When empty, no per-agent reasoning effort is sent to the runtime.
+	// When empty, the runtime inherits an explicit parent session effort.
+	// If the parent effort is also empty, the backend chooses the effort.
 	ReasoningEffort string `json:"reasoningEffort,omitempty"`
 }
 

--- a/go/types.go
+++ b/go/types.go
@@ -949,6 +949,9 @@ type CustomAgentConfig struct {
 	// When set, the runtime will attempt to use this model for the agent,
 	// falling back to the parent session model if unavailable.
 	Model string `json:"model,omitempty"`
+	// ReasoningEffort is the reasoning effort level for this agent's model.
+	// When empty, no per-agent reasoning effort is sent to the runtime.
+	ReasoningEffort string `json:"reasoningEffort,omitempty"`
 }
 
 // DefaultAgentConfig configures the default agent (the built-in agent that handles turns when no custom agent is selected).

--- a/go/types.go
+++ b/go/types.go
@@ -950,8 +950,8 @@ type CustomAgentConfig struct {
 	// falling back to the parent session model if unavailable.
 	Model string `json:"model,omitempty"`
 	// ReasoningEffort is the reasoning effort level for this agent's model.
-	// When empty, the runtime inherits an explicit parent session effort.
-	// If the parent effort is also empty, the backend chooses the effort.
+	// When empty, no per-agent override is sent and the backend chooses its
+	// default. The parent session effort is not inherited.
 	ReasoningEffort string `json:"reasoningEffort,omitempty"`
 }
 

--- a/go/types_test.go
+++ b/go/types_test.go
@@ -152,6 +152,28 @@ func TestCustomAgentConfig_JSONIncludesModel(t *testing.T) {
 	}
 }
 
+func TestCustomAgentConfig_JSONIncludesReasoningEffort(t *testing.T) {
+	cfg := CustomAgentConfig{
+		Name:            "reasoning-agent",
+		Prompt:          "Think carefully.",
+		ReasoningEffort: "high",
+	}
+
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("failed to marshal CustomAgentConfig: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal CustomAgentConfig: %v", err)
+	}
+
+	if decoded["reasoningEffort"] != "high" {
+		t.Errorf("expected reasoningEffort 'high', got %v", decoded["reasoningEffort"])
+	}
+}
+
 func TestCustomAgentConfig_JSONIncludesEmptyTools(t *testing.T) {
 	cfg := CustomAgentConfig{
 		Name:   "no-tools-agent",
@@ -272,6 +294,9 @@ func TestCustomAgentConfig_JSONOmitsModelWhenEmpty(t *testing.T) {
 
 	if _, present := decoded["model"]; present {
 		t.Errorf("expected model to be omitted when empty, got %v", decoded["model"])
+	}
+	if _, present := decoded["reasoningEffort"]; present {
+		t.Errorf("expected reasoningEffort to be omitted when empty, got %v", decoded["reasoningEffort"])
 	}
 }
 

--- a/java/src/main/java/com/github/copilot/rpc/CustomAgentConfig.java
+++ b/java/src/main/java/com/github/copilot/rpc/CustomAgentConfig.java
@@ -298,8 +298,8 @@ public class CustomAgentConfig {
     /**
      * Sets the reasoning effort level for this agent's model.
      * <p>
-     * When omitted, the runtime inherits an explicit parent session effort. If the
-     * parent effort is also omitted, the backend chooses the effort.
+     * When omitted, no per-agent override is sent and the backend chooses its
+     * default. The parent session effort is not inherited.
      *
      * @param reasoningEffort
      *            the reasoning effort level

--- a/java/src/main/java/com/github/copilot/rpc/CustomAgentConfig.java
+++ b/java/src/main/java/com/github/copilot/rpc/CustomAgentConfig.java
@@ -298,7 +298,8 @@ public class CustomAgentConfig {
     /**
      * Sets the reasoning effort level for this agent's model.
      * <p>
-     * When omitted, no per-agent reasoning effort is sent to the runtime.
+     * When omitted, the runtime inherits an explicit parent session effort. If the
+     * parent effort is also omitted, the backend chooses the effort.
      *
      * @param reasoningEffort
      *            the reasoning effort level

--- a/java/src/main/java/com/github/copilot/rpc/CustomAgentConfig.java
+++ b/java/src/main/java/com/github/copilot/rpc/CustomAgentConfig.java
@@ -63,6 +63,9 @@ public class CustomAgentConfig {
     @JsonProperty("model")
     private String model;
 
+    @JsonProperty("reasoningEffort")
+    private String reasoningEffort;
+
     /**
      * Gets the unique identifier name for this agent.
      *
@@ -280,6 +283,29 @@ public class CustomAgentConfig {
      */
     public CustomAgentConfig setModel(String model) {
         this.model = model;
+        return this;
+    }
+
+    /**
+     * Gets the reasoning effort level for this agent's model.
+     *
+     * @return the reasoning effort level, or {@code null} if not set
+     */
+    public String getReasoningEffort() {
+        return reasoningEffort;
+    }
+
+    /**
+     * Sets the reasoning effort level for this agent's model.
+     * <p>
+     * When omitted, no per-agent reasoning effort is sent to the runtime.
+     *
+     * @param reasoningEffort
+     *            the reasoning effort level
+     * @return this config for method chaining
+     */
+    public CustomAgentConfig setReasoningEffort(String reasoningEffort) {
+        this.reasoningEffort = reasoningEffort;
         return this;
     }
 }

--- a/java/src/test/java/com/github/copilot/DataObjectCoverageTest.java
+++ b/java/src/test/java/com/github/copilot/DataObjectCoverageTest.java
@@ -186,7 +186,7 @@ class DataObjectCoverageTest {
         assertEquals("session-xyz", input.getSessionId());
     }
 
-    // ===== CustomAgentConfig model field =====
+    // ===== CustomAgentConfig model fields =====
 
     @Test
     void customAgentConfigModelGetterAndSetter() {
@@ -225,6 +225,36 @@ class DataObjectCoverageTest {
 
         var json = mapper.writeValueAsString(cfg);
         assertFalse(json.contains("\"model\""));
+    }
+
+    @Test
+    void customAgentConfigReasoningEffortGetterAndFluentSetter() {
+        var cfg = new CustomAgentConfig();
+        assertNull(cfg.getReasoningEffort());
+
+        var result = cfg.setReasoningEffort("high");
+        assertSame(cfg, result);
+        assertEquals("high", cfg.getReasoningEffort());
+    }
+
+    @Test
+    void customAgentConfigReasoningEffortSerializationRoundTrip() throws Exception {
+        var mapper = JsonRpcClient.getObjectMapper();
+        var cfg = new CustomAgentConfig().setName("reasoning-agent").setReasoningEffort("high");
+
+        var json = mapper.writeValueAsString(cfg);
+        assertTrue(json.contains("\"reasoningEffort\":\"high\""));
+
+        var deserialized = mapper.readValue(json, CustomAgentConfig.class);
+        assertEquals("high", deserialized.getReasoningEffort());
+    }
+
+    @Test
+    void customAgentConfigReasoningEffortOmittedWhenNull() throws Exception {
+        var mapper = JsonRpcClient.getObjectMapper();
+        var json = mapper.writeValueAsString(new CustomAgentConfig().setName("default-agent"));
+
+        assertFalse(json.contains("\"reasoningEffort\""));
     }
 
     // ===== PermissionRequestResult setRules =====

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -1634,7 +1634,8 @@ export interface CustomAgentConfig {
     model?: string;
     /**
      * Reasoning effort level for this agent's model.
-     * When omitted, the SDK does not send a per-agent reasoning effort.
+     * When omitted, the runtime inherits an explicit parent session effort.
+     * If the parent effort is also omitted, the backend chooses the effort.
      */
     reasoningEffort?: ReasoningEffort;
 }

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -1634,8 +1634,8 @@ export interface CustomAgentConfig {
     model?: string;
     /**
      * Reasoning effort level for this agent's model.
-     * When omitted, the runtime inherits an explicit parent session effort.
-     * If the parent effort is also omitted, the backend chooses the effort.
+     * When omitted, no per-agent override is sent and the backend chooses its
+     * default. The parent session effort is not inherited.
      */
     reasoningEffort?: ReasoningEffort;
 }

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -1632,6 +1632,11 @@ export interface CustomAgentConfig {
      * falling back to the parent session model if unavailable.
      */
     model?: string;
+    /**
+     * Reasoning effort level for this agent's model.
+     * When omitted, the SDK does not send a per-agent reasoning effort.
+     */
+    reasoningEffort?: ReasoningEffort;
 }
 
 /**

--- a/nodejs/test/client.test.ts
+++ b/nodejs/test/client.test.ts
@@ -2216,9 +2216,10 @@ describe("CopilotClient", () => {
             const payload = spy.mock.calls.find((c) => c[0] === "session.create")![1] as any;
             expect(payload.agent).toBe("test-agent");
             expect(payload.customAgents).toEqual([expect.objectContaining({ name: "test-agent" })]);
+            expect(payload.customAgents[0].reasoningEffort).toBeUndefined();
         });
 
-        it("forwards custom agent model in session.create request", async () => {
+        it("forwards custom agent model and reasoning effort in session.create request", async () => {
             const client = new CopilotClient();
             await client.start();
             onTestFinished(() => stopClient(client));
@@ -2231,13 +2232,18 @@ describe("CopilotClient", () => {
                         name: "model-agent",
                         prompt: "You are a model agent.",
                         model: "claude-haiku-4.5",
+                        reasoningEffort: "high",
                     },
                 ],
             });
 
             const payload = spy.mock.calls.find((c) => c[0] === "session.create")![1] as any;
             expect(payload.customAgents).toEqual([
-                expect.objectContaining({ name: "model-agent", model: "claude-haiku-4.5" }),
+                expect.objectContaining({
+                    name: "model-agent",
+                    model: "claude-haiku-4.5",
+                    reasoningEffort: "high",
+                }),
             ]);
         });
 

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -3736,6 +3736,8 @@ class CopilotClient:
             wire_agent["skills"] = agent["skills"]
         if "model" in agent:
             wire_agent["model"] = agent["model"]
+        if "reasoning_effort" in agent:
+            wire_agent["reasoningEffort"] = agent["reasoning_effort"]
         return wire_agent
 
     def _convert_default_agent_to_wire_format(

--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -1080,8 +1080,8 @@ class CustomAgentConfig(TypedDict, total=False):
     skills: NotRequired[list[str]]
     # Model identifier (e.g. "claude-haiku-4.5"); runtime falls back to parent model if unavailable
     model: NotRequired[str]
-    # Reasoning effort for this agent's model. When omitted, inherits an explicit
-    # parent session effort; if that is also omitted, the backend chooses.
+    # Reasoning effort for this agent's model. When omitted, no per-agent override
+    # is sent and the backend chooses its default; the parent effort is not inherited.
     reasoning_effort: NotRequired[ReasoningEffort]
 
 

--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -1080,7 +1080,8 @@ class CustomAgentConfig(TypedDict, total=False):
     skills: NotRequired[list[str]]
     # Model identifier (e.g. "claude-haiku-4.5"); runtime falls back to parent model if unavailable
     model: NotRequired[str]
-    # Reasoning effort for this agent's model; omit to leave it unspecified
+    # Reasoning effort for this agent's model. When omitted, inherits an explicit
+    # parent session effort; if that is also omitted, the backend chooses.
     reasoning_effort: NotRequired[ReasoningEffort]
 
 

--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -1080,6 +1080,8 @@ class CustomAgentConfig(TypedDict, total=False):
     skills: NotRequired[list[str]]
     # Model identifier (e.g. "claude-haiku-4.5"); runtime falls back to parent model if unavailable
     model: NotRequired[str]
+    # Reasoning effort for this agent's model; omit to leave it unspecified
+    reasoning_effort: NotRequired[ReasoningEffort]
 
 
 class DefaultAgentConfig(TypedDict, total=False):

--- a/python/test_client.py
+++ b/python/test_client.py
@@ -2245,6 +2245,32 @@ class TestCustomAgentWireFormat:
         wire = client._convert_custom_agent_to_wire_format(agent)
         assert "model" not in wire
 
+    def test_reasoning_effort_is_forwarded_in_camel_case(self):
+        from copilot.client import CopilotClient
+        from copilot.session import CustomAgentConfig
+
+        client = CopilotClient.__new__(CopilotClient)
+        agent: CustomAgentConfig = {
+            "name": "reasoning-agent",
+            "prompt": "Think carefully.",
+            "reasoning_effort": "high",
+        }
+        wire = client._convert_custom_agent_to_wire_format(agent)
+        assert wire["reasoningEffort"] == "high"
+        assert "reasoning_effort" not in wire
+
+    def test_reasoning_effort_is_omitted_when_absent(self):
+        from copilot.client import CopilotClient
+        from copilot.session import CustomAgentConfig
+
+        client = CopilotClient.__new__(CopilotClient)
+        agent: CustomAgentConfig = {
+            "name": "default-agent",
+            "prompt": "Use runtime defaults.",
+        }
+        wire = client._convert_custom_agent_to_wire_format(agent)
+        assert "reasoningEffort" not in wire
+
 
 class TestPostToolUseFailureHookDispatch:
     """Unit tests for the postToolUseFailure handler dispatch."""

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -628,6 +628,11 @@ pub struct CustomAgentConfig {
     /// falling back to the parent session model if unavailable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    /// Reasoning effort level for this agent's model.
+    ///
+    /// When unset, no per-agent reasoning effort is sent to the runtime.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
 }
 
 impl CustomAgentConfig {
@@ -693,6 +698,12 @@ impl CustomAgentConfig {
     /// Set the model identifier for this agent.
     pub fn with_model(mut self, model: impl Into<String>) -> Self {
         self.model = Some(model.into());
+        self
+    }
+
+    /// Set the reasoning effort level for this agent's model.
+    pub fn with_reasoning_effort(mut self, reasoning_effort: impl Into<String>) -> Self {
+        self.reasoning_effort = Some(reasoning_effort.into());
         self
     }
 }
@@ -5467,6 +5478,28 @@ mod tests {
         let agent = CustomAgentConfig::new("no-model-agent", "prompt");
         let wire = serde_json::to_value(&agent).unwrap();
         assert!(wire.get("model").is_none());
+    }
+
+    #[test]
+    fn custom_agent_config_builder_with_reasoning_effort() {
+        let agent =
+            CustomAgentConfig::new("reasoning-agent", "prompt").with_reasoning_effort("high");
+        assert_eq!(agent.reasoning_effort.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn custom_agent_config_serializes_reasoning_effort() {
+        let agent =
+            CustomAgentConfig::new("reasoning-agent", "prompt").with_reasoning_effort("high");
+        let wire = serde_json::to_value(&agent).unwrap();
+        assert_eq!(wire["reasoningEffort"], "high");
+    }
+
+    #[test]
+    fn custom_agent_config_omits_reasoning_effort_when_none() {
+        let agent = CustomAgentConfig::new("default-agent", "prompt");
+        let wire = serde_json::to_value(&agent).unwrap();
+        assert!(wire.get("reasoningEffort").is_none());
     }
 
     #[test]

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -630,7 +630,8 @@ pub struct CustomAgentConfig {
     pub model: Option<String>,
     /// Reasoning effort level for this agent's model.
     ///
-    /// When unset, no per-agent reasoning effort is sent to the runtime.
+    /// When unset, the runtime inherits an explicit parent session effort. If
+    /// the parent effort is also unset, the backend chooses the effort.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<String>,
 }

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -630,8 +630,8 @@ pub struct CustomAgentConfig {
     pub model: Option<String>,
     /// Reasoning effort level for this agent's model.
     ///
-    /// When unset, the runtime inherits an explicit parent session effort. If
-    /// the parent effort is also unset, the backend chooses the effort.
+    /// When unset, no per-agent override is sent and the backend chooses its
+    /// default. The parent session effort is not inherited.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<String>,
 }


### PR DESCRIPTION
## Summary

- add optional per-agent reasoning effort to every SDK binding
- serialize the wire field as `reasoningEffort` without adding an SDK default
- document finalized omission semantics: when per-agent effort is omitted, the SDK sends no override and the backend chooses its default; the parent/session effort is not inherited
- add focused serialization, cloning, builder, and DTO tests

This is SDK-side changes to support https://github.com/github/copilot-agent-runtime/pull/11166 (runtime PR).

Closes github/copilot-sdk-internal#195.

## Validation

- Node.js: Prettier, ESLint, TypeScript typecheck, targeted Vitest (3 passed)
- Python: Ruff, ty, targeted pytest (4 passed)
- Go: gofmt, go vet, targeted go test
- .NET: dotnet format, targeted tests (34 passed)
- Java: Spotless, Checkstyle, targeted Maven verify (27 passed; integration tests skipped)
- Rust: rustfmt, Clippy library target, targeted tests (7 passed)