### PR TITLE
Fix Windows in-process Node E2E cleanup hang

### DIFF
--- a/nodejs/test/e2e/harness/CapiProxy.ts
+++ b/nodejs/test/e2e/harness/CapiProxy.ts
@@ -146,7 +146,11 @@ export class CapiProxy {
         }
 
         if (!(await waitForProcessExit(process, 5000))) {
-            process.kill();
+            try {
+                process.kill();
+            } catch {
+                // Process may have already exited between wait timeout and kill attempt.
+            }
             await waitForProcessExit(process, 5000);
         }
         this.serverProcess = undefined;

--- a/nodejs/test/e2e/harness/CapiProxy.ts
+++ b/nodejs/test/e2e/harness/CapiProxy.ts
@@ -1,4 +1,4 @@
-import { spawn } from "child_process";
+import { ChildProcess, spawn } from "child_process";
 import { resolve } from "path";
 import { createInterface } from "readline";
 import { expect } from "vitest";
@@ -21,6 +21,7 @@ interface ProxyStartupInfo {
 export class CapiProxy {
     private proxyUrl: string | undefined;
     private startupInfo: ProxyStartupInfo | undefined;
+    private serverProcess: ChildProcess | undefined;
 
     /**
      * Returns the URL of the running proxy. Throws if the proxy has not been started.
@@ -37,6 +38,7 @@ export class CapiProxy {
             stdio: ["ignore", "pipe", "inherit"],
             shell: true,
         });
+        this.serverProcess = serverProcess;
 
         this.startupInfo = await new Promise<ProxyStartupInfo>((resolve, reject) => {
             const stdout = serverProcess.stdout!;
@@ -122,11 +124,34 @@ export class CapiProxy {
     }
 
     async stop(skipWritingCache?: boolean): Promise<void> {
+        const process = this.serverProcess;
+        if (!process) {
+            return;
+        }
+
         const url = skipWritingCache
             ? `${this.proxyUrl}/stop?skipWritingCache=true`
             : `${this.proxyUrl}/stop`;
-        const response = await fetch(url, { method: "POST" });
-        expect(response.ok).toBe(true);
+        try {
+            const controller = new AbortController();
+            const timeout = setTimeout(() => controller.abort(), 5000);
+            try {
+                const response = await fetch(url, { method: "POST", signal: controller.signal });
+                expect(response.ok).toBe(true);
+            } finally {
+                clearTimeout(timeout);
+            }
+        } catch {
+            // Best-effort graceful stop; process termination below is the hard guarantee.
+        }
+
+        if (!(await waitForProcessExit(process, 5000))) {
+            process.kill();
+            await waitForProcessExit(process, 5000);
+        }
+        this.serverProcess = undefined;
+        this.proxyUrl = undefined;
+        this.startupInfo = undefined;
     }
 
     /**
@@ -142,6 +167,26 @@ export class CapiProxy {
         });
         expect(res.ok).toBe(true);
     }
+
+}
+
+// Wait for proxy child exit so teardown doesn't leave hanging harness processes.
+async function waitForProcessExit(process: ChildProcess, timeoutMs: number): Promise<boolean> {
+    if (process.exitCode !== null || process.signalCode !== null) {
+        return true;
+    }
+    return await new Promise<boolean>((resolve) => {
+        const onExit = () => {
+            clearTimeout(timer);
+            process.off("exit", onExit);
+            resolve(true);
+        };
+        const timer = setTimeout(() => {
+            process.off("exit", onExit);
+            resolve(false);
+        }, timeoutMs);
+        process.once("exit", onExit);
+    });
 }
 
 function tryParseStartupInfo(line: string): ProxyStartupInfo | undefined {

--- a/nodejs/test/e2e/harness/CapiProxy.ts
+++ b/nodejs/test/e2e/harness/CapiProxy.ts
@@ -146,11 +146,7 @@ export class CapiProxy {
         }
 
         if (!(await waitForProcessExit(process, 5000))) {
-            try {
-                process.kill();
-            } catch {
-                // Process may have already exited between wait timeout and kill attempt.
-            }
+            await terminateProcessTree(process);
             await waitForProcessExit(process, 5000);
         }
         this.serverProcess = undefined;
@@ -191,6 +187,33 @@ async function waitForProcessExit(process: ChildProcess, timeoutMs: number): Pro
         }, timeoutMs);
         process.once("exit", onExit);
     });
+}
+
+async function terminateProcessTree(child: ChildProcess): Promise<void> {
+    if (child.exitCode !== null || child.signalCode !== null) {
+        return;
+    }
+    const pid = child.pid;
+    if (!pid) {
+        return;
+    }
+
+    if (process.platform === "win32") {
+        await new Promise<void>((resolve) => {
+            const taskkill = spawn("taskkill", ["/PID", String(pid), "/T", "/F"], {
+                stdio: "ignore",
+            });
+            taskkill.once("error", () => resolve());
+            taskkill.once("exit", () => resolve());
+        });
+        return;
+    }
+
+    try {
+        child.kill();
+    } catch {
+        // Process may have already exited between wait timeout and kill attempt.
+    }
 }
 
 function tryParseStartupInfo(line: string): ProxyStartupInfo | undefined {

--- a/nodejs/test/e2e/harness/sdkTestContext.ts
+++ b/nodejs/test/e2e/harness/sdkTestContext.ts
@@ -291,7 +291,18 @@ export async function createSdkTestContext({
     });
 
     afterAll(async () => {
-        await copilotClient.stop();
+        const stopResult = await stopClientWithFallback(copilotClient, {
+            timeoutMs: isInProcess && process.platform === "win32" ? 10_000 : undefined,
+        });
+        if (stopResult.timedOut) {
+            console.warn("WARN: Copilot client stop timed out during e2e cleanup; force-stopped.");
+        } else if (stopResult.errors.length > 0) {
+            console.warn(
+                `WARN: Copilot client stop returned ${stopResult.errors.length} cleanup error(s): ${stopResult.errors
+                    .map((error) => error.message)
+                    .join("; ")}`
+            );
+        }
         await openAiEndpoint.stop(anyTestFailed);
         await rmDir("remove e2e test copilotHomeDir", copilotHomeDir);
         await rmDir("remove e2e test homeDir", homeDir);
@@ -333,4 +344,25 @@ async function rmDir(message: string, path: string): Promise<void> {
             `WARN: ${message} failed; leaving temp dir for OS cleanup: ${formatError(error)}`
         );
     }
+}
+
+async function stopClientWithFallback(
+    client: CopilotClient,
+    options: { timeoutMs?: number } = {}
+): Promise<{ timedOut: boolean; errors: Error[] }> {
+    const stopPromise = client.stop();
+    if (!options.timeoutMs) {
+        return { timedOut: false, errors: await stopPromise };
+    }
+
+    const timeoutPromise = new Promise<"timeout">((resolve) =>
+        setTimeout(() => resolve("timeout"), options.timeoutMs)
+    );
+    const result = await Promise.race([stopPromise, timeoutPromise]);
+    if (result === "timeout") {
+        stopPromise.catch(() => undefined);
+        await client.forceStop();
+        return { timedOut: true, errors: [] };
+    }
+    return { timedOut: false, errors: result };
 }

--- a/nodejs/test/e2e/harness/sdkTestContext.ts
+++ b/nodejs/test/e2e/harness/sdkTestContext.ts
@@ -361,14 +361,17 @@ async function stopClientWithFallback(
     const timeoutPromise = new Promise<"timeout">((resolve) => {
         timeoutId = setTimeout(() => resolve("timeout"), options.timeoutMs);
     });
-    const result = await Promise.race([stopPromise, timeoutPromise]);
-    if (timeoutId) {
-        clearTimeout(timeoutId);
+    try {
+        const result = await Promise.race([stopPromise, timeoutPromise]);
+        if (result === "timeout") {
+            stopPromise.catch(() => undefined);
+            await client.forceStop();
+            return { timedOut: true, errors: [] };
+        }
+        return { timedOut: false, errors: result };
+    } finally {
+        if (timeoutId) {
+            clearTimeout(timeoutId);
+        }
     }
-    if (result === "timeout") {
-        stopPromise.catch(() => undefined);
-        await client.forceStop();
-        return { timedOut: true, errors: [] };
-    }
-    return { timedOut: false, errors: result };
 }

--- a/nodejs/test/e2e/harness/sdkTestContext.ts
+++ b/nodejs/test/e2e/harness/sdkTestContext.ts
@@ -292,7 +292,9 @@ export async function createSdkTestContext({
 
     afterAll(async () => {
         const stopResult = await stopClientWithFallback(copilotClient, {
-            timeoutMs: isInProcess && process.platform === "win32" ? 10_000 : undefined,
+            // Keep this above the client's runtime-shutdown timeout (10s) so we only
+            // force-stop if graceful teardown has truly stalled.
+            timeoutMs: isInProcess && process.platform === "win32" ? 12_000 : undefined,
         });
         if (stopResult.timedOut) {
             console.warn("WARN: Copilot client stop timed out during e2e cleanup; force-stopped.");
@@ -355,10 +357,14 @@ async function stopClientWithFallback(
         return { timedOut: false, errors: await stopPromise };
     }
 
-    const timeoutPromise = new Promise<"timeout">((resolve) =>
-        setTimeout(() => resolve("timeout"), options.timeoutMs)
-    );
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<"timeout">((resolve) => {
+        timeoutId = setTimeout(() => resolve("timeout"), options.timeoutMs);
+    });
     const result = await Promise.race([stopPromise, timeoutPromise]);
+    if (timeoutId) {
+        clearTimeout(timeoutId);
+    }
     if (result === "timeout") {
         stopPromise.catch(() => undefined);
         await client.forceStop();


### PR DESCRIPTION
## Summary
- track the Node E2E replay proxy child process in `CapiProxy` and make shutdown deterministic (bounded `/stop` request + process-exit wait + forced kill fallback)
- add a Windows in-process-only fallback in Node E2E harness cleanup to force-stop the SDK client if graceful stop hangs
- keep behavior unchanged for other transports/OSes while preventing `afterAll` teardown deadlocks in `session.e2e.test.ts`

## Validation
- attempted targeted run: `cd nodejs && COPILOT_SDK_DEFAULT_CONNECTION=inprocess npm test -- test/e2e/session.e2e.test.ts`
- blocked locally because dependencies cannot be restored in this environment (`@github/copilot@1.0.71-0` not accessible from packagefeedproxy)
