### PR TITLE
Remove HMAC key authentication method from public SDK auth docs

### DIFF
--- a/docs/auth/README.md
+++ b/docs/auth/README.md
@@ -7,6 +7,6 @@ Choose the authentication method that best fits your deployment scenario for the
 
 ## Authentication priority
 
-When multiple credentials are configured, an explicit SDK token takes priority, followed by HMAC or direct Copilot API environment authentication, environment variable GitHub tokens, stored Copilot CLI credentials, and then GitHub CLI credentials. See [Authenticate Copilot SDK](authenticate.md#authentication-priority) for details.
+When multiple credentials are configured, an explicit SDK token takes priority, followed by direct Copilot API environment authentication, environment variable GitHub tokens, stored Copilot CLI credentials, and then GitHub CLI credentials. See [Authenticate Copilot SDK](authenticate.md#authentication-priority) for details.
 
 For multi-user server mode, pass a per-session `gitHubToken` so each session runs with the correct GitHub identity; see [Multi-user and server deployments](../setup/multi-tenancy.md).

--- a/docs/auth/authenticate.md
+++ b/docs/auth/authenticate.md
@@ -301,7 +301,6 @@ BYOK allows you to use your own API keys from model providers like Azure AI Foun
 When multiple authentication methods are available, the SDK uses them in this priority order:
 
 1. **Explicit `gitHubToken`** - Token passed directly to the SDK client or session configuration
-1. **HMAC key** - `CAPI_HMAC_KEY` or `COPILOT_HMAC_KEY` environment variables
 1. **Direct API token** - `GITHUB_COPILOT_API_TOKEN` with `COPILOT_API_URL`
 1. **Environment variable tokens** - `COPILOT_GITHUB_TOKEN` → `GH_TOKEN` → `GITHUB_TOKEN`
 1. **Stored OAuth credentials** - From previous `copilot` CLI login


### PR DESCRIPTION
## Summary

Removes references to the **HMAC key** authentication method (`CAPI_HMAC_KEY` / `COPILOT_HMAC_KEY`) from the public Copilot SDK authentication docs. This method should not be documented publicly and appears to have been re-added by docs automation.

## Changes
- `docs/auth/authenticate.md` — removed the **HMAC key** entry from the *Authentication priority* list.
- `docs/auth/README.md` — removed "HMAC or" from the authentication-priority summary.

## Verification
- `grep -rni hmac docs/` returns no matches after the change.
- No other files under `docs/` referenced the HMAC key.

Published page affected: https://docs.github.com/en/copilot/how-tos/copilot-sdk/auth/authenticate#authentication-priority

> [!NOTE]
> If automation keeps re-adding this content, the upstream source/generator will also need updating so the change doesn't regress.