### PR TITLE
Rust: Add Scoped Main-Turn Interruption

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -89,7 +89,7 @@ With the default `CliProgram::Resolve`, `Client::start()` resolves the CLI in th
 Created via `Client::create_session` or `Client::resume_session`. Owns an internal event loop that dispatches CLI callbacks to the focused handler traits you install on `SessionConfig`, and broadcasts session events through `subscribe()`.
 
 ```rust,ignore
-use github_copilot_sdk::MessageOptions;
+use github_copilot_sdk::{InterruptMainTurnOptions, MessageOptions};
 
 // Simple send — &str / String convert into MessageOptions automatically.
 // Returns the assigned message ID for correlation with later events.
@@ -107,7 +107,14 @@ let _id = session
 // Message history
 let messages = session.get_events().await?;
 
-// Abort the current agent turn
+// Interrupt only the foreground turn and preserve queued user prompts.
+let result = session
+    .interrupt_main_turn(
+        InterruptMainTurnOptions::default().with_flush_queued(true),
+    )
+    .await?;
+
+// Recursively abort the active turn and all descendant/background work.
 session.abort().await?;
 
 // Model management
@@ -175,6 +182,10 @@ let forked = client
     })
     .await?;
 ```
+
+`interrupt_main_turn` preserves background agents and other independent background work. Its default `flush_queued: false` discards queued prompts; `true` preserves queued user prompts for the next eligible turn, drops hidden system prompts, and resumes normal queue delivery after the interrupted coordinator loop unwinds. A result with `interrupted == false` means the method is supported but no main turn was active. The method never falls back to `session.abort`, whose recursive cancellation also stops descendant and background work.
+
+Check `session.capabilities().interrupt_main_turn` before calling when connected targets may differ: local sessions report `Some(true)`, unsupported remote sessions report `Some(false)`, and older servers omit the capability (`None`). Each `capabilities.changed` event is a complete snapshot, so the SDK replaces the cached capability state wholesale rather than merging omitted fields.
 
 New RPCs land in the namespace immediately as the schema regenerates;
 helpers are added on top only when an ergonomic story is worth the

--- a/rust/src/generated/api_types.rs
+++ b/rust/src/generated/api_types.rs
@@ -177,6 +177,8 @@ pub mod rpc_methods {
     pub const SESSION_SENDMESSAGES: &str = "session.sendMessages";
     /// `session.abort`
     pub const SESSION_ABORT: &str = "session.abort";
+    /// `session.interruptMainTurn`
+    pub const SESSION_INTERRUPTMAINTURN: &str = "session.interruptMainTurn";
     /// `session.shutdown`
     pub const SESSION_SHUTDOWN: &str = "session.shutdown";
     /// `session.gitHubAuth.getStatus`
@@ -587,7 +589,7 @@ pub mod rpc_methods {
     pub const CANVAS_ACTION_INVOKE: &str = "canvas.action.invoke";
 }
 
-/// Parameters for aborting the current turn
+/// Parameters for aborting the active session turn and recursively cancelling its descendant and background work
 ///
 /// <div class="warning">
 ///
@@ -603,7 +605,7 @@ pub struct AbortRequest {
     pub reason: Option<AbortReason>,
 }
 
-/// Result of aborting the current turn
+/// Result of recursively aborting the active session work
 ///
 /// <div class="warning">
 ///
@@ -4312,6 +4314,37 @@ pub struct InstructionSource {
 pub struct InstructionsGetSourcesResult {
     /// Instruction sources for the session
     pub sources: Vec<InstructionSource>,
+}
+
+/// Parameters for interrupting only the active main coordinator turn while preserving background work
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InterruptMainTurnRequest {
+    /// When an active main turn is interrupted, true flushes queued user prompts through to the next eligible turn: it preserves them, drops hidden system prompts, and resumes normal queue delivery after the interrupted loop unwinds (including existing deferred-idle ordering). False or omitted discards all queued prompts. When no main turn is active, this option has no effect.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flush_queued: Option<bool>,
+}
+
+/// Result of interrupting only the active main coordinator turn
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InterruptMainTurnResult {
+    /// True when an active main coordinator turn was interrupted; false only when the method is supported but no main turn was active
+    pub interrupted: bool,
 }
 
 /// A request body chunk or cancellation signal.
@@ -15100,6 +15133,9 @@ pub struct UsageMetricsModelMetricUsage {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UsageMetricsModelMetric {
+    /// Latest known prompt-cache expiration for this model. A timestamp in the past indicates that the observed cache has expired.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_expires_at: Option<String>,
     /// Request count and cost metrics for this model
     pub requests: UsageMetricsModelMetricRequests,
     /// Token count details per type
@@ -16278,7 +16314,7 @@ pub struct SessionSendMessagesResult {
     pub message_ids: Vec<String>,
 }
 
-/// Result of aborting the current turn
+/// Result of recursively aborting the active session work
 ///
 /// <div class="warning">
 ///
@@ -16294,6 +16330,21 @@ pub struct SessionAbortResult {
     pub error: Option<String>,
     /// Whether the abort completed successfully
     pub success: bool,
+}
+
+/// Result of interrupting only the active main coordinator turn
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionInterruptMainTurnResult {
+    /// True when an active main coordinator turn was interrupted; false only when the method is supported but no main turn was active
+    pub interrupted: bool,
 }
 
 /// Identifies the target session.
@@ -20866,6 +20917,9 @@ pub enum HookType {
     /// Runs after the user submits a prompt.
     #[serde(rename = "userPromptSubmitted")]
     UserPromptSubmitted,
+    /// Runs after the runtime transforms the submitted prompt for the model, before it is added to session history.
+    #[serde(rename = "userPromptTransformed")]
+    UserPromptTransformed,
     /// Runs when a session starts.
     #[serde(rename = "sessionStart")]
     SessionStart,

--- a/rust/src/generated/rpc.rs
+++ b/rust/src/generated/rpc.rs
@@ -2920,17 +2920,17 @@ impl<'a> SessionRpc<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
-    /// Aborts the current agent turn.
+    /// Aborts the active session turn and recursively cancels its descendant and background work. Use session.interruptMainTurn when background work must survive.
     ///
     /// Wire method: `session.abort`.
     ///
     /// # Parameters
     ///
-    /// * `params` - Parameters for aborting the current turn
+    /// * `params` - Parameters for aborting the active session turn and recursively cancelling its descendant and background work
     ///
     /// # Returns
     ///
-    /// Result of aborting the current turn
+    /// Result of recursively aborting the active session work
     ///
     /// <div class="warning">
     ///
@@ -2946,6 +2946,39 @@ impl<'a> SessionRpc<'a> {
             .session
             .client()
             .call(rpc_methods::SESSION_ABORT, Some(wire_params))
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Interrupts only the active main coordinator turn while preserving background agents and other background work. Returns interrupted=false only when the method is supported but no main turn is active. Unsupported or older targets return JSON-RPC MethodNotFound; callers must not fall back to session.abort unless recursive cancellation is intended.
+    ///
+    /// Wire method: `session.interruptMainTurn`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Parameters for interrupting only the active main coordinator turn while preserving background work
+    ///
+    /// # Returns
+    ///
+    /// Result of interrupting only the active main coordinator turn
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub async fn interrupt_main_turn(
+        &self,
+        params: InterruptMainTurnRequest,
+    ) -> Result<InterruptMainTurnResult, Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(rpc_methods::SESSION_INTERRUPTMAINTURN, Some(wire_params))
             .await?;
         Ok(serde_json::from_value(_value)?)
     }

--- a/rust/src/generated/session_events.rs
+++ b/rust/src/generated/session_events.rs
@@ -1209,10 +1209,27 @@ pub struct SessionShutdownData {
     pub(crate) total_premium_requests: Option<f64>,
 }
 
+/// Internal prompt-cache expiration state for one model
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct UsageCheckpointModelCacheState {
+    /// Latest known prompt-cache expiration
+    pub cache_expires_at: String,
+    /// Retained cache lifetime in seconds, used to refresh expiration after a cache read
+    #[doc(hidden)]
+    pub(crate) cache_ttl_seconds: i64,
+    /// Model identifier associated with this cache state
+    pub model_id: String,
+}
+
 /// Session event "session.usage_checkpoint". Durable session usage checkpoint for reconstructing aggregate accounting on resume
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionUsageCheckpointData {
+    /// Internal per-model prompt-cache state used to restore expiration tracking on resume
+    #[doc(hidden)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) model_cache_state: Option<Vec<UsageCheckpointModelCacheState>>,
     /// Session-wide accumulated nano-AI units cost at checkpoint time
     pub total_nano_aiu: f64,
     /// Total number of premium API requests used at checkpoint time
@@ -1870,6 +1887,9 @@ pub struct AssistantUsageData {
     /// API endpoint used for this model call, matching CAPI supported_endpoints vocabulary
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_endpoint: Option<AssistantUsageApiEndpoint>,
+    /// Updated prompt-cache expiration for this model call. Present only when the call establishes or refreshes known cache state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_expires_at: Option<String>,
     /// Number of tokens read from prompt cache
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_read_tokens: Option<i64>,
@@ -4042,6 +4062,9 @@ pub struct CapabilitiesChangedUI {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CapabilitiesChangedData {
+    /// Whether scoped main-turn interruption via `session.interruptMainTurn` is supported
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interrupt_main_turn: Option<bool>,
     /// UI capability changes
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ui: Option<CapabilitiesChangedUI>,

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -12,8 +12,8 @@ use tracing::{Instrument, warn};
 
 use crate::canvas::CanvasHandler;
 use crate::generated::api_types::{
-    LogRequest, ModelSwitchToRequest, OpenCanvasInstance, RegisterEventInterestParams,
-    ToolsGetCurrentMetadataResult, rpc_methods,
+    InterruptMainTurnRequest, InterruptMainTurnResult, LogRequest, ModelSwitchToRequest,
+    OpenCanvasInstance, RegisterEventInterestParams, ToolsGetCurrentMetadataResult, rpc_methods,
 };
 use crate::generated::session_events::{
     CommandExecuteData, ElicitationRequestedData, ExternalToolRequestedData, McpOauthRequiredData,
@@ -31,9 +31,9 @@ use crate::trace_context::inject_trace_context;
 use crate::transforms::SystemMessageTransform;
 use crate::types::{
     CommandContext, CommandDefinition, CommandHandler, CreateSessionResult, ElicitationRequest,
-    ElicitationResult, ExitPlanModeData, GetMessagesResponse, MessageOptions,
-    PermissionRequestData, RequestId, ResumeSessionConfig, ResumeSessionResult, SectionOverride,
-    SessionCapabilities, SessionConfig, SessionEvent, SessionId, SetModelOptions,
+    ElicitationResult, ExitPlanModeData, GetMessagesResponse, InterruptMainTurnOptions,
+    MessageOptions, PermissionRequestData, RequestId, ResumeSessionConfig, ResumeSessionResult,
+    SectionOverride, SessionCapabilities, SessionConfig, SessionEvent, SessionId, SetModelOptions,
     SystemMessageConfig, ToolInvocation, ToolResult, ToolResultExpanded, TraceContext,
     UiInputOptions, ensure_attachment_display_names,
 };
@@ -509,7 +509,11 @@ impl Session {
         self.get_events().await
     }
 
-    /// Abort the current agent turn.
+    /// Abort the active session turn and recursively cancel descendant and
+    /// background work.
+    ///
+    /// Use [`interrupt_main_turn`](Self::interrupt_main_turn) when independent
+    /// background work must survive.
     ///
     /// # Cancel safety
     ///
@@ -524,6 +528,30 @@ impl Session {
             )
             .await?;
         Ok(())
+    }
+
+    /// Interrupt only the active foreground/main turn while preserving
+    /// independent background agents and descendants.
+    ///
+    /// This never falls back to [`abort`](Self::abort), which is the recursive
+    /// destructive cancellation API. Check
+    /// [`SessionCapabilities::interrupt_main_turn`] before calling when the
+    /// client may connect to mixed CLI versions; unsupported runtimes return
+    /// JSON-RPC `MethodNotFound`.
+    ///
+    /// # Cancel safety
+    ///
+    /// **Cancel-safe.** Single `session.interruptMainTurn` RPC; the underlying
+    /// [`Client::call`](crate::Client::call) is cancel-safe via the writer actor.
+    pub async fn interrupt_main_turn(
+        &self,
+        options: InterruptMainTurnOptions,
+    ) -> Result<InterruptMainTurnResult, Error> {
+        self.rpc()
+            .interrupt_main_turn(InterruptMainTurnRequest {
+                flush_queued: Some(options.flush_queued),
+            })
+            .await
     }
 
     /// Switch to a different model.

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -539,6 +539,11 @@ impl Session {
     /// client may connect to mixed CLI versions; unsupported runtimes return
     /// JSON-RPC `MethodNotFound`.
     ///
+    /// [`InterruptMainTurnOptions::default`] sends `flush_queued: false` and
+    /// discards queued prompts. Setting it to `true` preserves queued user
+    /// prompts for the next eligible turn, drops hidden system prompts, and
+    /// resumes normal delivery after the interrupted loop unwinds.
+    ///
     /// # Cancel safety
     ///
     /// **Cancel-safe.** Single `session.interruptMainTurn` RPC; the underlying
@@ -1638,7 +1643,9 @@ async fn handle_notification(
     // response to the event observe the new state.
     if event_type == SessionEventType::CapabilitiesChanged {
         match serde_json::from_value::<SessionCapabilities>(notification.event.data.clone()) {
-            Ok(changed) => *capabilities.write() = changed,
+            // Every capabilities.changed payload is a complete snapshot, so
+            // omitted fields intentionally clear values from the prior one.
+            Ok(snapshot) => *capabilities.write() = snapshot,
             Err(e) => warn!(error = %e, "failed to deserialize capabilities.changed payload"),
         }
     }

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -5240,6 +5240,9 @@ pub struct SessionCapabilities {
     /// Whether scoped foreground interruption via
     /// [`Session::interrupt_main_turn`](crate::session::Session::interrupt_main_turn)
     /// is supported by the connected CLI runtime.
+    ///
+    /// Local sessions report `Some(true)`, unsupported remote sessions report
+    /// `Some(false)`, and older servers omit the field (`None`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interrupt_main_turn: Option<bool>,
     /// UI capabilities (elicitation support, etc.).

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -5235,10 +5235,33 @@ pub struct ElicitationRequest {
 /// Updated at runtime via `capabilities.changed` events.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct SessionCapabilities {
+    /// Whether scoped foreground interruption via
+    /// [`Session::interrupt_main_turn`](crate::session::Session::interrupt_main_turn)
+    /// is supported by the connected CLI runtime.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interrupt_main_turn: Option<bool>,
     /// UI capabilities (elicitation support, etc.).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ui: Option<UiCapabilities>,
+}
+
+/// Options for [`Session::interrupt_main_turn`](crate::session::Session::interrupt_main_turn).
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+pub struct InterruptMainTurnOptions {
+    /// Preserve queued user prompts for the next eligible turn. The default
+    /// (`false`) discards queued prompts while interrupting the foreground turn.
+    pub flush_queued: bool,
+}
+
+impl InterruptMainTurnOptions {
+    /// Set whether queued user prompts should be preserved.
+    pub fn with_flush_queued(mut self, flush_queued: bool) -> Self {
+        self.flush_queued = flush_queued;
+        self
+    }
 }
 
 /// UI-specific capabilities for a session.

--- a/rust/tests/e2e/elicitation.rs
+++ b/rust/tests/e2e/elicitation.rs
@@ -380,13 +380,12 @@ async fn elicitation_returns_all_action_shapes() {
 
 #[tokio::test]
 async fn session_capabilities_types_are_properly_structured() {
-    let capabilities = github_copilot_sdk::SessionCapabilities {
-        ui: Some(UiCapabilities {
-            elicitation: Some(true),
-            mcp_apps: None,
-            canvases: None,
-        }),
-    };
+    let mut capabilities = github_copilot_sdk::SessionCapabilities::default();
+    capabilities.ui = Some(UiCapabilities {
+        elicitation: Some(true),
+        mcp_apps: None,
+        canvases: None,
+    });
 
     assert_eq!(
         capabilities.ui.as_ref().and_then(|ui| ui.elicitation),

--- a/rust/tests/session_test.rs
+++ b/rust/tests/session_test.rs
@@ -14,10 +14,10 @@ use github_copilot_sdk::handler::{
 };
 use github_copilot_sdk::rpc::{
     CanvasProviderInvokeActionRequest, CanvasProviderOpenRequest, CanvasProviderOpenResult,
-    OpenCanvasInstance,
+    InterruptMainTurnRequest, OpenCanvasInstance,
 };
 use github_copilot_sdk::session_events::{
-    McpOauthRequiredData, ReasoningSummary, SessionLimitsConfig,
+    CapabilitiesChangedData, McpOauthRequiredData, ReasoningSummary, SessionLimitsConfig,
 };
 use github_copilot_sdk::types::{
     CanvasProviderIdentity, CloudSessionOptions, CloudSessionRepository, CommandContext,
@@ -130,6 +130,16 @@ impl FakeServer {
     async fn respond(&mut self, request: &Value, result: Value) {
         let id = request["id"].as_u64().unwrap();
         let response = serde_json::json!({ "jsonrpc": "2.0", "id": id, "result": result });
+        write_framed(&mut self.write, &serde_json::to_vec(&response).unwrap()).await;
+    }
+
+    async fn respond_error(&mut self, request: &Value, code: i32, message: &str) {
+        let id = request["id"].as_u64().unwrap();
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": { "code": code, "message": message },
+        });
         write_framed(&mut self.write, &serde_json::to_vec(&response).unwrap()).await;
     }
 
@@ -1288,7 +1298,66 @@ async fn session_rpc_methods_send_correct_method_names() {
 }
 
 #[tokio::test]
-async fn interrupt_main_turn_sends_options_and_returns_typed_result() {
+async fn interrupt_main_turn_rpc_omits_default_flush_queued() {
+    let (session, mut server) = create_session_pair().await;
+    let handle = tokio::spawn(async move {
+        session
+            .rpc()
+            .interrupt_main_turn(InterruptMainTurnRequest::default())
+            .await
+    });
+
+    let request = server.read_request().await;
+    assert_eq!(request["method"], "session.interruptMainTurn");
+    assert_eq!(
+        request["params"],
+        serde_json::json!({ "sessionId": server.session_id })
+    );
+    server
+        .respond(&request, serde_json::json!({ "interrupted": true }))
+        .await;
+
+    let result = timeout(TIMEOUT, handle).await.unwrap().unwrap().unwrap();
+    assert!(result.interrupted);
+}
+
+#[tokio::test]
+async fn interrupt_main_turn_sends_false_and_true_and_returns_status() {
+    let (session, mut server) = create_session_pair().await;
+    let session = Arc::new(session);
+
+    for (options, interrupted) in [
+        (InterruptMainTurnOptions::default(), false),
+        (
+            InterruptMainTurnOptions::default().with_flush_queued(true),
+            true,
+        ),
+    ] {
+        let handle = tokio::spawn({
+            let session = session.clone();
+            async move { session.interrupt_main_turn(options).await }
+        });
+
+        let request = server.read_request().await;
+        assert_eq!(request["method"], "session.interruptMainTurn");
+        assert_eq!(
+            request["params"],
+            serde_json::json!({
+                "sessionId": server.session_id,
+                "flushQueued": options.flush_queued,
+            })
+        );
+        server
+            .respond(&request, serde_json::json!({ "interrupted": interrupted }))
+            .await;
+
+        let result = timeout(TIMEOUT, handle).await.unwrap().unwrap().unwrap();
+        assert_eq!(result.interrupted, interrupted);
+    }
+}
+
+#[tokio::test]
+async fn interrupt_main_turn_propagates_method_not_found_without_abort_fallback() {
     let (session, mut server) = create_session_pair().await;
     let handle = tokio::spawn(async move {
         session
@@ -1298,14 +1367,22 @@ async fn interrupt_main_turn_sends_options_and_returns_typed_result() {
 
     let request = server.read_request().await;
     assert_eq!(request["method"], "session.interruptMainTurn");
-    assert_eq!(request["params"]["sessionId"], server.session_id);
-    assert_eq!(request["params"]["flushQueued"], false);
     server
-        .respond(&request, serde_json::json!({ "interrupted": true }))
+        .respond_error(&request, -32601, "Method not found")
         .await;
 
-    let result = timeout(TIMEOUT, handle).await.unwrap().unwrap().unwrap();
-    assert!(result.interrupted);
+    let error = timeout(TIMEOUT, handle)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(error.rpc_code(), Some(-32601));
+
+    let fallback = timeout(Duration::from_millis(100), server.read_request()).await;
+    assert!(
+        fallback.is_err(),
+        "session.interruptMainTurn must not fall back to session.abort"
+    );
 }
 
 #[tokio::test]
@@ -3169,39 +3246,47 @@ async fn capabilities_captured_from_create_response() {
 }
 
 #[tokio::test]
-async fn capabilities_changed_event_updates_session() {
-    let (session, mut server) = create_session_pair().await;
+async fn missing_interrupt_capability_from_older_server_remains_unknown() {
+    let (session, _server) = create_session_pair_with_capabilities(serde_json::json!({
+        "ui": { "elicitation": true }
+    }))
+    .await;
 
-    // Initially no capabilities (create_session_pair doesn't send them)
-    assert!(session.capabilities().interrupt_main_turn.is_none());
-    assert!(session.capabilities().ui.is_none());
+    assert_eq!(session.capabilities().interrupt_main_turn, None);
+}
 
-    // CLI sends capabilities.changed event
+#[tokio::test]
+async fn capabilities_changed_event_replaces_complete_snapshot_and_is_typed() {
+    let (session, mut server) = create_session_pair_with_capabilities(serde_json::json!({
+        "interruptMainTurn": true,
+        "ui": { "elicitation": true }
+    }))
+    .await;
+    let mut events = session.subscribe();
+
     server
         .send_event(
             "capabilities.changed",
-            serde_json::json!({
-                "interruptMainTurn": true,
-                "ui": { "elicitation": true }
-            }),
+            serde_json::json!({ "interruptMainTurn": false }),
         )
         .await;
 
-    // Poll until the event loop processes the notification
-    let caps = timeout(TIMEOUT, async {
-        loop {
-            let caps = session.capabilities();
-            if caps.interrupt_main_turn.is_some() && caps.ui.is_some() {
-                return caps;
-            }
-            tokio::time::sleep(Duration::from_millis(5)).await;
-        }
-    })
-    .await
-    .expect("capabilities should update within timeout");
+    let event = timeout(TIMEOUT, events.recv())
+        .await
+        .expect("capabilities.changed should arrive within timeout")
+        .unwrap();
+    let changed = event
+        .typed_data::<CapabilitiesChangedData>()
+        .expect("capabilities.changed should expose typed data");
+    assert_eq!(changed.interrupt_main_turn, Some(false));
+    assert!(changed.ui.is_none());
 
-    assert_eq!(caps.interrupt_main_turn, Some(true));
-    assert_eq!(caps.ui.as_ref().unwrap().elicitation, Some(true));
+    let caps = session.capabilities();
+    assert_eq!(caps.interrupt_main_turn, Some(false));
+    assert!(
+        caps.ui.is_none(),
+        "each capabilities.changed payload is a complete replacement snapshot"
+    );
 }
 
 #[tokio::test]
@@ -3334,7 +3419,7 @@ async fn env_value_mode_hardcoded_direct_on_create_and_resume() {
 }
 
 #[tokio::test]
-async fn resume_session_sends_canvas_fields_and_captures_open_canvases() {
+async fn resume_session_sends_canvas_fields_and_captures_snapshots() {
     use github_copilot_sdk::types::ResumeSessionConfig;
 
     let (client, mut server_read, mut server_write) = make_client();
@@ -3398,6 +3483,7 @@ async fn resume_session_sends_canvas_fields_and_captures_open_canvases() {
                 "url": "https://example.test/counter"
             }],
             "capabilities": {
+                "interruptMainTurn": false,
                 "ui": { "canvases": true }
             }
         },
@@ -3415,6 +3501,7 @@ async fn resume_session_sends_canvas_fields_and_captures_open_canvases() {
     assert_eq!(open.len(), 1);
     assert_eq!(open[0].instance_id, "counter-1");
     let caps = session.capabilities();
+    assert_eq!(caps.interrupt_main_turn, Some(false));
     assert_eq!(caps.ui.unwrap().canvases, Some(true));
 }
 

--- a/rust/tests/session_test.rs
+++ b/rust/tests/session_test.rs
@@ -22,8 +22,8 @@ use github_copilot_sdk::session_events::{
 use github_copilot_sdk::types::{
     CanvasProviderIdentity, CloudSessionOptions, CloudSessionRepository, CommandContext,
     CommandDefinition, CommandHandler, DeliveryMode, ElicitationRequest, ElicitationResult,
-    ExitPlanModeData, ExtensionInfo, MessageOptions, RequestId, SessionConfig, SessionId,
-    SetModelOptions, Tool, ToolInvocation, ToolResult,
+    ExitPlanModeData, ExtensionInfo, InterruptMainTurnOptions, MessageOptions, RequestId,
+    SessionConfig, SessionId, SetModelOptions, Tool, ToolInvocation, ToolResult,
 };
 use github_copilot_sdk::{Client, ContextTier, ErrorKind, ProtocolErrorKind, tool};
 use serde_json::Value;
@@ -1285,6 +1285,27 @@ async fn session_rpc_methods_send_correct_method_names() {
         server.respond(&request, response).await;
         timeout(TIMEOUT, handle).await.unwrap().unwrap().unwrap();
     }
+}
+
+#[tokio::test]
+async fn interrupt_main_turn_sends_options_and_returns_typed_result() {
+    let (session, mut server) = create_session_pair().await;
+    let handle = tokio::spawn(async move {
+        session
+            .interrupt_main_turn(InterruptMainTurnOptions::default())
+            .await
+    });
+
+    let request = server.read_request().await;
+    assert_eq!(request["method"], "session.interruptMainTurn");
+    assert_eq!(request["params"]["sessionId"], server.session_id);
+    assert_eq!(request["params"]["flushQueued"], false);
+    server
+        .respond(&request, serde_json::json!({ "interrupted": true }))
+        .await;
+
+    let result = timeout(TIMEOUT, handle).await.unwrap().unwrap().unwrap();
+    assert!(result.interrupted);
 }
 
 #[tokio::test]
@@ -3134,6 +3155,7 @@ async fn capabilities_captured_from_create_response() {
         "result": {
             "sessionId": session_id,
             "capabilities": {
+                "interruptMainTurn": true,
                 "ui": { "elicitation": true }
             }
         },
@@ -3142,6 +3164,7 @@ async fn capabilities_captured_from_create_response() {
 
     let session = timeout(TIMEOUT, create_handle).await.unwrap().unwrap();
     let caps = session.capabilities();
+    assert_eq!(caps.interrupt_main_turn, Some(true));
     assert_eq!(caps.ui.as_ref().unwrap().elicitation, Some(true));
 }
 
@@ -3150,6 +3173,7 @@ async fn capabilities_changed_event_updates_session() {
     let (session, mut server) = create_session_pair().await;
 
     // Initially no capabilities (create_session_pair doesn't send them)
+    assert!(session.capabilities().interrupt_main_turn.is_none());
     assert!(session.capabilities().ui.is_none());
 
     // CLI sends capabilities.changed event
@@ -3157,6 +3181,7 @@ async fn capabilities_changed_event_updates_session() {
         .send_event(
             "capabilities.changed",
             serde_json::json!({
+                "interruptMainTurn": true,
                 "ui": { "elicitation": true }
             }),
         )
@@ -3166,7 +3191,7 @@ async fn capabilities_changed_event_updates_session() {
     let caps = timeout(TIMEOUT, async {
         loop {
             let caps = session.capabilities();
-            if caps.ui.is_some() {
+            if caps.interrupt_main_turn.is_some() && caps.ui.is_some() {
                 return caps;
             }
             tokio::time::sleep(Duration::from_millis(5)).await;
@@ -3175,6 +3200,7 @@ async fn capabilities_changed_event_updates_session() {
     .await
     .expect("capabilities should update within timeout");
 
+    assert_eq!(caps.interrupt_main_turn, Some(true));
     assert_eq!(caps.ui.as_ref().unwrap().elicitation, Some(true));
 }
 


### PR DESCRIPTION
## Summary

Canonical Rust SDK consumer lane for github/copilot-agent-runtime#12968 and github/github-app#8664:

```rust
let result = session
    .interrupt_main_turn(InterruptMainTurnOptions::default())
    .await?;
```

- Repository-conventional non-exhaustive `InterruptMainTurnOptions { flush_queued: bool }` with builder API
- Generated typed `session.interruptMainTurn` RPC and `InterruptMainTurnRequest` / `InterruptMainTurnResult`
- `SessionCapabilities::interrupt_main_turn: Option<bool>` on create/resume snapshots
- Generated typed `CapabilitiesChangedData::interrupt_main_turn: Option<bool>` event payload
- Complete `capabilities.changed` snapshots replace the capability cache wholesale by final runtime contract
- No fallback to recursive `Session::abort`; unsupported or old runtimes surface JSON-RPC MethodNotFound

## Parity coverage

Transferred the valuable docs/tests from superseded #2014 while preserving this PR's final-head generated files:

- Exact `flushQueued` omission through `session.rpc().interrupt_main_turn(InterruptMainTurnRequest::default())`
- High-level default serializes `flushQueued: false`; builder serializes `true`
- `interrupted: true` and `false`
- Explicit `-32601` propagation with proof that no `session.abort` follows
- Create `true`, resume/unsupported `false`, old omission `None`
- Full-snapshot replacement plus `event.typed_data::<CapabilitiesChangedData>()`
- README queue semantics, recursive-abort distinction, and capability-state guidance

## Runtime dependency

Originally generated from the feature schemas at runtime commit `9391d2e781b23fc1ebcbd5b4605f848afa40b7d0` in github/copilot-agent-runtime#12968. The runtime integrated current main at `099e4e1ec7548427a58605929d18c668d5399118`, fixed complete capability snapshots at `c7f1c68d9d316c1294d338923b2609d6e2523141`, then hardened attached-session scoping and canonical snapshot documentation at current head `034a636b982daf15340778f0f1b92b9bf30454fc`. Each prior head remains an ancestor. CLI 1.0.71 and current published `@github/copilot` pins do not contain this protocol.

The containing-release gate must now track exact current runtime head `034a636b982daf15340778f0f1b92b9bf30454fc`, not prior heads `c7f1c68d9d`, `099e4e1ec7`, or `9391d2e781`. Keep this PR draft until the first published CLI package containing the current head exists; then update package/version/hash pins through repository conventions and run canonical full codegen. The generated-files freshness check is expected to remain red until that publication gate opens.

## Validation

- `cargo +nightly-2026-04-14 fmt --check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --all-features --test session_test` (119 passed)
- `GITHUB_ACTIONS=true cargo test --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features`
