### PR TITLE
docs: fix EnableConfigDiscovery summary to accurately describe agent discovery behavior

### DIFF
--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -2983,8 +2983,9 @@ public abstract class SessionConfigBase
     /// <see cref="McpServers"/> and <see cref="SkillDirectories"/>, with explicit
     /// values taking precedence on name collision.
     /// <para>
-    /// Custom instruction files (<c>.github/copilot-instructions.md</c>, <c>AGENTS.md</c>, etc.)
-    /// are always loaded from the working directory regardless of this setting.
+    /// Agent discovery (e.g. <c>.github/agents/</c>) is only performed when this is
+    /// <see langword="true"/>. Use <see cref="SkipCustomInstructions"/> to control
+    /// loading of custom instruction files independently.
     /// </para>
     /// </summary>
     public bool? EnableConfigDiscovery { get; set; }

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -2977,16 +2977,8 @@ public abstract class SessionConfigBase
     public string? ConfigDirectory { get; set; }
 
     /// <summary>
-    /// When <see langword="true"/>, automatically discovers MCP server configurations
-    /// (e.g. <c>.mcp.json</c>, <c>.vscode/mcp.json</c>) and skill directories from
-    /// the working directory and merges them with any explicitly provided
-    /// <see cref="McpServers"/> and <see cref="SkillDirectories"/>, with explicit
-    /// values taking precedence on name collision.
-    /// <para>
-    /// Agent discovery (e.g. <c>.github/agents/</c>) is only performed when this is
-    /// <see langword="true"/>. Use <see cref="SkipCustomInstructions"/> to control
-    /// loading of custom instruction files independently.
-    /// </para>
+    /// Enables runtime discovery of supported configuration. Explicitly supplied
+    /// configuration takes precedence over discovered values.
     /// </summary>
     public bool? EnableConfigDiscovery { get; set; }
 

--- a/go/types.go
+++ b/go/types.go
@@ -1052,13 +1052,9 @@ type SessionConfig struct {
 	// ConfigDirectory overrides the default configuration directory location.
 	// When specified, the session will use this directory for storing config and state.
 	ConfigDirectory string
-	// EnableConfigDiscovery, when non-nil, controls automatic discovery of MCP server configurations
-	// (e.g. .mcp.json, .vscode/mcp.json) and skill directories from the working directory
-	// and merges them with any explicitly provided MCPServers and SkillDirectories, with
-	// explicit values taking precedence on name collision.
+	// EnableConfigDiscovery enables runtime discovery of supported configuration.
+	// Explicitly supplied configuration takes precedence over discovered values.
 	// Nil leaves the runtime default unchanged; use Bool(false) to explicitly disable discovery.
-	// Custom instruction files (.github/copilot-instructions.md, AGENTS.md, etc.) are
-	// always loaded from the working directory regardless of this setting.
 	EnableConfigDiscovery *bool
 	// SkipEmbeddingRetrieval, when non-nil, controls embedding-based retrieval
 	// for this session. Use in multitenant deployments to prevent cross-session
@@ -1611,13 +1607,9 @@ type ResumeSessionConfig struct {
 	WorkingDirectory string
 	// ConfigDirectory overrides the default configuration directory location.
 	ConfigDirectory string
-	// EnableConfigDiscovery, when non-nil, controls automatic discovery of MCP server configurations
-	// (e.g. .mcp.json, .vscode/mcp.json) and skill directories from the working directory
-	// and merges them with any explicitly provided MCPServers and SkillDirectories, with
-	// explicit values taking precedence on name collision.
+	// EnableConfigDiscovery enables runtime discovery of supported configuration.
+	// Explicitly supplied configuration takes precedence over discovered values.
 	// Nil leaves the runtime default unchanged; use Bool(false) to explicitly disable discovery.
-	// Custom instruction files (.github/copilot-instructions.md, AGENTS.md, etc.) are
-	// always loaded from the working directory regardless of this setting.
 	EnableConfigDiscovery *bool
 	// SkipEmbeddingRetrieval, when non-nil, controls embedding-based retrieval
 	// for this session. Use in multitenant deployments to prevent cross-session

--- a/java/src/main/java/com/github/copilot/rpc/ResumeSessionConfig.java
+++ b/java/src/main/java/com/github/copilot/rpc/ResumeSessionConfig.java
@@ -848,12 +848,8 @@ public class ResumeSessionConfig {
     }
 
     /**
-     * Sets whether to automatically discover MCP server configurations and skill
-     * directories from the working directory.
-     * <p>
-     * When {@code true}, the CLI scans the working directory for {@code .mcp.json},
-     * {@code .vscode/mcp.json} and skill directories, and merges them with
-     * explicitly provided configurations.
+     * Enables runtime discovery of supported configuration. Explicitly supplied
+     * configuration takes precedence over discovered values.
      *
      * @param enableConfigDiscovery
      *            {@code true} to enable discovery, {@code false} to disable

--- a/java/src/main/java/com/github/copilot/rpc/SessionConfig.java
+++ b/java/src/main/java/com/github/copilot/rpc/SessionConfig.java
@@ -1235,14 +1235,8 @@ public class SessionConfig {
     }
 
     /**
-     * Sets whether to automatically discover MCP server configurations and skill
-     * directories from the working directory.
-     * <p>
-     * When {@code true}, the CLI scans the working directory for {@code .mcp.json},
-     * {@code .vscode/mcp.json} and skill directories, and merges them with
-     * explicitly provided {@link #setMcpServers(Map)} and
-     * {@link #setSkillDirectories(List)}, with explicit values taking precedence on
-     * name collision.
+     * Enables runtime discovery of supported configuration. Explicitly supplied
+     * configuration takes precedence over discovered values.
      *
      * @param enableConfigDiscovery
      *            {@code true} to enable discovery, {@code false} to disable

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -1915,13 +1915,8 @@ export interface SessionConfigBase {
     configDirectory?: string;
 
     /**
-     * When true, automatically discovers MCP server configurations (e.g. `.mcp.json`,
-     * `.vscode/mcp.json`) and skill directories from the working directory and merges
-     * them with any explicitly provided `mcpServers` and `skillDirectories`, with
-     * explicit values taking precedence on name collision.
-     *
-     * Note: custom instruction files (`.github/copilot-instructions.md`, `AGENTS.md`, etc.)
-     * are always loaded from the working directory regardless of this setting.
+     * Enables runtime discovery of supported configuration. Explicitly supplied
+     * configuration takes precedence over discovered values.
      *
      * @default false
      */

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -2088,13 +2088,9 @@ class CopilotClient:
                 including tool visibility controls.
             agent: Agent to use for the session.
             config_directory: Override for the configuration directory.
-            enable_config_discovery: When True, automatically discovers MCP server
-                configurations (e.g. ``.mcp.json``, ``.vscode/mcp.json``) and skill
-                directories from the working directory and merges them with any
-                explicitly provided ``mcp_servers`` and ``skill_directories``, with
-                explicit values taking precedence on name collision. Custom instruction
-                files (``.github/copilot-instructions.md``, ``AGENTS.md``, etc.) are
-                always loaded regardless of this setting.
+            enable_config_discovery: Enables runtime discovery of supported
+                configuration. Explicitly supplied configuration takes precedence
+                over discovered values.
             skip_embedding_retrieval: When True, skips embedding-based retrieval.
             organization_custom_instructions: Organization-level custom instructions.
             enable_on_demand_instruction_discovery: Enables on-demand instruction file
@@ -2761,13 +2757,9 @@ class CopilotClient:
                 including tool visibility controls.
             agent: Agent to use for the session.
             config_directory: Override for the configuration directory.
-            enable_config_discovery: When True, automatically discovers MCP server
-                configurations (e.g. ``.mcp.json``, ``.vscode/mcp.json``) and skill
-                directories from the working directory and merges them with any
-                explicitly provided ``mcp_servers`` and ``skill_directories``, with
-                explicit values taking precedence on name collision. Custom instruction
-                files (``.github/copilot-instructions.md``, ``AGENTS.md``, etc.) are
-                always loaded regardless of this setting.
+            enable_config_discovery: Enables runtime discovery of supported
+                configuration. Explicitly supplied configuration takes precedence
+                over discovered values.
             skip_embedding_retrieval: When True, skips embedding-based retrieval.
             organization_custom_instructions: Organization-level custom instructions.
             enable_on_demand_instruction_discovery: Enables on-demand instruction file

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1724,7 +1724,8 @@ pub struct SessionConfig {
     /// applied automatically at session creation/resume time. `None` means no
     /// explicit value is set and the runtime default takes effect.
     pub mcp_oauth_token_storage: Option<String>,
-    /// When true, the CLI runs config discovery (MCP config files, skills, plugins).
+    /// Enables runtime discovery of supported configuration. Explicitly supplied
+    /// configuration takes precedence over discovered values.
     pub enable_config_discovery: Option<bool>,
     /// When true, skips embedding retrieval for this session.
     pub skip_embedding_retrieval: Option<bool>,
@@ -2579,7 +2580,8 @@ impl SessionConfig {
         self
     }
 
-    /// Enable or disable CLI config discovery (MCP config files, skills, plugins).
+    /// Enables runtime discovery of supported configuration. Explicitly supplied
+    /// configuration takes precedence over discovered values.
     pub fn with_enable_config_discovery(mut self, enable: bool) -> Self {
         self.enable_config_discovery = Some(enable);
         self
@@ -2949,7 +2951,8 @@ pub struct ResumeSessionConfig {
     /// Controls how MCP OAuth tokens are stored for this session.
     /// See [`SessionConfig::mcp_oauth_token_storage`] for details.
     pub mcp_oauth_token_storage: Option<String>,
-    /// Enable config discovery on resume.
+    /// Enables runtime discovery of supported configuration. Explicitly supplied
+    /// configuration takes precedence over discovered values.
     pub enable_config_discovery: Option<bool>,
     /// When true, skips embedding retrieval on resume.
     pub skip_embedding_retrieval: Option<bool>,
@@ -3703,7 +3706,8 @@ impl ResumeSessionConfig {
         self
     }
 
-    /// Enable or disable CLI config discovery on resume.
+    /// Enables runtime discovery of supported configuration. Explicitly supplied
+    /// configuration takes precedence over discovered values.
     pub fn with_enable_config_discovery(mut self, enable: bool) -> Self {
         self.enable_config_discovery = Some(enable);
         self


### PR DESCRIPTION
## Summary

Fixes #1887

The previous documentation for `EnableConfigDiscovery` incorrectly stated that custom instruction files are "always loaded from the working directory regardless of this setting." In practice, agent files (e.g. `.github/agents/`) are only discovered when `EnableConfigDiscovery` is `true`.

## Changes

Updated the XML doc comment on `SessionConfig.EnableConfigDiscovery` in `dotnet/src/Types.cs` to:

1. Clarify that agent discovery is gated by `EnableConfigDiscovery`
2. Reference `SkipCustomInstructions` as the independent control for instruction file loading

**Before:**
```csharp
/// <para>
/// Custom instruction files (.github/copilot-instructions.md, AGENTS.md, etc.)
/// are always loaded from the working directory regardless of this setting.
/// </para>
```

**After:**
```csharp
/// <para>
/// Agent discovery (e.g. .github/agents/) is only performed when this is
/// true. Use SkipCustomInstructions to control
/// loading of custom instruction files independently.
/// </para>
```