### PR TITLE
Harden MCP OAuth cancel E2E tests against create/interest race

### DIFF
--- a/dotnet/test/E2E/McpOAuthE2ETests.cs
+++ b/dotnet/test/E2E/McpOAuthE2ETests.cs
@@ -204,13 +204,13 @@ public class McpOAuthE2ETests(E2ETestFixture fixture, ITestOutputHelper output) 
     {
         await using var oauthServer = await OAuthMcpServer.StartAsync(ExpectedToken);
         var serverName = "oauth-cancelled-mcp";
-        McpAuthContext? observedRequest = null;
+        var authRequest = new TaskCompletionSource<McpAuthContext>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         await using var session = await CreateSessionAsync(new SessionConfig
         {
             OnMcpAuthRequest = request =>
             {
-                observedRequest = request;
+                authRequest.TrySetResult(request);
                 return Task.FromResult<McpAuthResult?>(McpAuthResult.Cancel());
             },
             McpServers = new Dictionary<string, McpServerConfig>
@@ -228,19 +228,13 @@ public class McpOAuthE2ETests(E2ETestFixture fixture, ITestOutputHelper output) 
         // The MCP connection is kicked off by session.create, but the SDK only registers its
         // `mcp.oauth_required` event interest once create returns. If the server's initial 401
         // wins that race, the runtime records `needs-auth` WITHOUT invoking the host callback,
-        // so `observedRequest` is briefly null even after `needs-auth` is observed. A later
-        // auth retry (now that interest is registered) invokes the callback with the same
-        // `Initial` reason. Wait for the callback rather than sampling it the instant
+        // so the callback fires only on a later auth retry (now that interest is registered),
+        // with the same `Initial` reason. Await the callback rather than sampling it the instant
         // `needs-auth` first appears, which is what made this test flaky.
-        await TestHelper.WaitForConditionAsync(
-            () => Task.FromResult(observedRequest is not null),
-            timeout: TimeSpan.FromSeconds(60),
-            pollInterval: TimeSpan.FromMilliseconds(200),
-            timeoutMessage: $"{serverName} OAuth request reaching the host callback");
+        var observedRequest = await authRequest.Task.WaitAsync(TimeSpan.FromSeconds(60));
 
-        Assert.NotNull(observedRequest);
-        Assert.NotEmpty(observedRequest!.RequestId);
-        Assert.Equal(serverName, observedRequest!.ServerName);
+        Assert.NotEmpty(observedRequest.RequestId);
+        Assert.Equal(serverName, observedRequest.ServerName);
         Assert.Equal(McpOauthRequestReason.Initial, observedRequest.Reason);
     }
 

--- a/dotnet/test/E2E/McpOAuthE2ETests.cs
+++ b/dotnet/test/E2E/McpOAuthE2ETests.cs
@@ -225,6 +225,19 @@ public class McpOAuthE2ETests(E2ETestFixture fixture, ITestOutputHelper output) 
 
         await WaitForMcpServerStatusAsync(session, serverName, McpServerStatus.NeedsAuth);
 
+        // The MCP connection is kicked off by session.create, but the SDK only registers its
+        // `mcp.oauth_required` event interest once create returns. If the server's initial 401
+        // wins that race, the runtime records `needs-auth` WITHOUT invoking the host callback,
+        // so `observedRequest` is briefly null even after `needs-auth` is observed. A later
+        // auth retry (now that interest is registered) invokes the callback with the same
+        // `Initial` reason. Wait for the callback rather than sampling it the instant
+        // `needs-auth` first appears, which is what made this test flaky.
+        await TestHelper.WaitForConditionAsync(
+            () => Task.FromResult(observedRequest is not null),
+            timeout: TimeSpan.FromSeconds(60),
+            pollInterval: TimeSpan.FromMilliseconds(200),
+            timeoutMessage: $"{serverName} OAuth request reaching the host callback");
+
         Assert.NotNull(observedRequest);
         Assert.NotEmpty(observedRequest!.RequestId);
         Assert.Equal(serverName, observedRequest!.ServerName);

--- a/go/internal/e2e/mcp_oauth_e2e_test.go
+++ b/go/internal/e2e/mcp_oauth_e2e_test.go
@@ -197,12 +197,17 @@ func TestMCPOAuthE2E(t *testing.T) {
 	t.Run("cancel pending MCP OAuth request", func(t *testing.T) {
 		baseURL := startOAuthMCPServer(t)
 		serverName := "oauth-cancelled-mcp"
+		var mu sync.Mutex
 		var observedRequest copilot.MCPAuthRequest
+		var observed bool
 
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
 			OnMCPAuthRequest: func(request copilot.MCPAuthRequest, _ copilot.MCPAuthInvocation) (*copilot.MCPAuthResult, error) {
+				mu.Lock()
 				observedRequest = request
+				observed = true
+				mu.Unlock()
 				return copilot.MCPAuthResultCancelled(), nil
 			},
 			MCPServers: map[string]copilot.MCPServerConfig{
@@ -218,11 +223,35 @@ func TestMCPOAuthE2E(t *testing.T) {
 		t.Cleanup(func() { session.Disconnect() })
 
 		waitForMCPServerStatus(t, session, serverName, rpc.MCPServerStatusNeedsAuth)
-		if observedRequest.ServerName != serverName {
-			t.Fatalf("Expected serverName %q, got %q", serverName, observedRequest.ServerName)
+
+		// The MCP connection is kicked off by session.create, but the SDK only registers its
+		// `mcp.oauth_required` event interest once create returns. If the server's initial 401
+		// wins that race, the runtime records `needs-auth` WITHOUT invoking the host callback,
+		// so `observedRequest` is briefly unset even after `needs-auth` is observed. A later
+		// auth retry (now that interest is registered) invokes the callback with the same
+		// `Initial` reason. Wait for the callback rather than sampling it the instant
+		// `needs-auth` first appears, which is what made this test flaky.
+		var request copilot.MCPAuthRequest
+		deadline := time.Now().Add(60 * time.Second)
+		for {
+			mu.Lock()
+			got := observed
+			request = observedRequest
+			mu.Unlock()
+			if got {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("%s OAuth request did not reach the host callback", serverName)
+			}
+			time.Sleep(200 * time.Millisecond)
 		}
-		if observedRequest.Reason != copilot.MCPOauthRequestReasonInitial {
-			t.Fatalf("Unexpected auth request reason: %q", observedRequest.Reason)
+
+		if request.ServerName != serverName {
+			t.Fatalf("Expected serverName %q, got %q", serverName, request.ServerName)
+		}
+		if request.Reason != copilot.MCPOauthRequestReasonInitial {
+			t.Fatalf("Unexpected auth request reason: %q", request.Reason)
 		}
 	})
 

--- a/java/src/test/java/com/github/copilot/McpOAuthE2ETest.java
+++ b/java/src/test/java/com/github/copilot/McpOAuthE2ETest.java
@@ -188,12 +188,18 @@ public class McpOAuthE2ETest {
                                             .setUrl(oauthServer.url() + "/mcp").setTools(List.of("*")))))
                             .get()) {
                 waitForMcpServerStatus(session, serverName, McpServerStatus.NEEDS_AUTH, observedRequest);
-            }
 
-            var request = observedRequest.get();
-            assertNotNull(request, "MCP auth handler should be invoked");
-            assertEquals(serverName, request.serverName());
-            assertEquals(McpOauthRequestReason.INITIAL, request.reason());
+                // Race: session.create kicks off the MCP connection, but the SDK
+                // registers its `mcp.oauth_required` interest only after create
+                // returns. If the initial 401 wins, the runtime records
+                // `needs-auth` without invoking the host callback. A later auth
+                // retry (interest now registered) fires the callback with the same
+                // INITIAL reason. Wait for the callback instead of sampling it the
+                // instant `needs-auth` appears, which is what made this test flaky.
+                var request = waitForAuthRequest(observedRequest);
+                assertEquals(serverName, request.serverName());
+                assertEquals(McpOauthRequestReason.INITIAL, request.reason());
+            }
         }
     }
 

--- a/python/e2e/test_mcp_oauth_e2e.py
+++ b/python/e2e/test_mcp_oauth_e2e.py
@@ -326,6 +326,20 @@ class TestMcpOAuth:
             ) as session:
                 await _wait_for_mcp_server_status(session, server_name, McpServerStatus.NEEDS_AUTH)
 
+                # The MCP connection is kicked off by session.create, but the SDK only registers
+                # its `mcp.oauth_required` event interest once create returns. If the server's
+                # initial 401 wins that race, the runtime records `needs-auth` WITHOUT invoking
+                # the host callback, so `observed_request` is briefly None even after `needs-auth`
+                # is observed. A later auth retry (now that interest is registered) invokes the
+                # callback with the same `initial` reason. Wait for the callback rather than
+                # sampling it the instant `needs-auth` first appears, which made this test flaky.
+                await wait_for_condition(
+                    lambda: observed_request is not None,
+                    timeout=60.0,
+                    poll_interval=0.2,
+                    timeout_message=f"{server_name} OAuth request did not reach the host callback",
+                )
+
             assert observed_request is not None
             assert observed_request["serverName"] == server_name
             assert observed_request["reason"] == "initial"

--- a/rust/tests/e2e/mcp_oauth.rs
+++ b/rust/tests/e2e/mcp_oauth.rs
@@ -209,6 +209,18 @@ async fn should_cancel_pending_mcp_oauth_request() {
 
             wait_for_mcp_server_status(&session, server_name, McpServerStatus::NeedsAuth).await;
 
+            // The MCP connection is kicked off by session.create, but the SDK only registers its
+            // `mcp.oauth_required` event interest once create returns. If the server's initial 401
+            // wins that race, the runtime records `needs-auth` WITHOUT invoking the host callback,
+            // so `handler.request` is briefly `None` even after `needs-auth` is observed. A later
+            // auth retry (now that interest is registered) invokes the callback with the same
+            // `Initial` reason. Wait for the callback rather than sampling it the instant
+            // `needs-auth` first appears, which is what made this test flaky.
+            wait_for_condition("MCP OAuth request reaching the host callback", || async {
+                handler.request.lock().is_some()
+            })
+            .await;
+
             let request = handler
                 .request
                 .lock()


### PR DESCRIPTION
## Why

The C# SDK CI leg in `copilot-agent-runtime` has been intermittently failing on `McpOAuthE2ETests.Should_Cancel_Pending_MCP_OAuth_Request` with `observedRequest` being null. Investigation traced this to a race, not a runtime bug: the runtime behaves exactly per its documented contract.

`session.create` kicks off the MCP server connection, but the SDK only registers its `mcp.oauth_required` event interest *after* create returns. When the OAuth server's initial `401` wins that race, the runtime records the server as `needs-auth` **without** invoking the host callback (its documented "no listener" path). The cancel tests then sampled the host callback the instant `needs-auth` was observed, so `observedRequest` was intermittently empty.

## Approach

Wait for the callback to actually be invoked (bounded, reusing each suite's existing wait-for-condition helper) instead of sampling it the moment `needs-auth` first appears. Once interest is registered, the runtime's auth retry re-drives the OAuth flow and invokes the host callback with the same `initial` reason, so all existing assertions stay valid. The cancel path is still genuinely exercised.

Applied uniformly across all five SDK suites that share this pattern:

- **C#** - `TestHelper.WaitForConditionAsync(...)` before the asserts
- **Go** - poll loop plus a `sync.Mutex` guarding the observed request (also fixes a latent data race between the callback goroutine and the test)
- **Python** - `await wait_for_condition(...)` inside the session scope
- **Java** - reuse the existing `waitForAuthRequest(...)` helper, moved inside the session scope
- **Rust** - `wait_for_condition(...)` on `handler.request`

## Notes for reviewers

- This is a test-robustness fix only; no product/runtime or SDK source code changes.
- The `reason == initial` assertion is preserved on purpose: I confirmed in the runtime source that both the initial connect and the later auth retry emit `reason: "initial"` (retry only becomes `reauth` when `forceReauth` is set, which it isn't here).
- Empirical corroboration: `Should_Satisfy` (which waits for `Connected`) has stayed green while only the cancel test's instantaneous assert was flaky, which shows the retry reliably invokes the callback within the test window.
- Validated locally: C# build, `go vet`, Python `py_compile`, Java `test-compile` + `spotless:check`, and Rust `cargo check --tests` all pass. The full E2E suites need a live CLI, a local OAuth server, and the replay proxy, and the rare race cannot be reproduced deterministically, so they were not run end to end.

Generated by Copilot