### PR TITLE
test(java): re-enable ModeHandlers exit_plan_mode E2E assertions

### DIFF
--- a/java/src/test/java/com/github/copilot/ModeHandlersTest.java
+++ b/java/src/test/java/com/github/copilot/ModeHandlersTest.java
@@ -7,13 +7,13 @@ package com.github.copilot;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.github.copilot.generated.ExitPlanModeAction;
@@ -68,7 +68,6 @@ public class ModeHandlersTest {
     }
 
     @Test
-    @Disabled("Snapshot needs re-recording for CLI 1.0.57: https://github.com/github/copilot-sdk/issues/1547")
     void shouldInvokeExitPlanModeHandlerWhenModelUsesTool() throws Exception {
         final String summary = "Greeting file implementation plan";
         configureAuthenticatedUser("should_invoke_exit_plan_mode_handler_when_model_uses_tool");
@@ -103,16 +102,19 @@ public class ModeHandlersTest {
 
             var request = handlerCalled.get(10, TimeUnit.SECONDS);
             assertEquals(summary, request.getSummary());
-            assertNotNull(request.getActions());
-            assertTrue(request.getActions().contains("interactive"));
+            // Canonical action order after CLI 1.0.57+ (aligned with #2023 / other SDKs).
+            assertEquals(List.of("autopilot", "interactive", "exit_only"), request.getActions());
+            assertEquals("interactive", request.getRecommendedAction());
             assertNotNull(request.getPlanContent());
 
             var reqEvent = requestedEvent.get(10, TimeUnit.SECONDS);
             assertEquals(request.getSummary(), reqEvent.getData().summary());
+            assertEquals(ExitPlanModeAction.INTERACTIVE, reqEvent.getData().recommendedAction());
 
             var compEvent = completedEvent.get(10, TimeUnit.SECONDS);
             assertTrue(compEvent.getData().approved());
             assertEquals(ExitPlanModeAction.INTERACTIVE, compEvent.getData().selectedAction());
+            assertEquals("Approved by the Java E2E test", compEvent.getData().feedback());
 
             assertNotNull(response);
 

--- a/java/src/test/java/com/github/copilot/ModeHandlersTest.java
+++ b/java/src/test/java/com/github/copilot/ModeHandlersTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import com.github.copilot.generated.ExitPlanModeAction;
 import com.github.copilot.generated.ExitPlanModeCompletedEvent;
 import com.github.copilot.generated.ExitPlanModeRequestedEvent;
+import com.github.copilot.rpc.AgentMode;
 import com.github.copilot.rpc.AutoModeSwitchRequest;
 import com.github.copilot.rpc.AutoModeSwitchResponse;
 import com.github.copilot.rpc.CopilotClientOptions;
@@ -98,7 +99,7 @@ public class ModeHandlersTest {
 
             var response = session.sendAndWait(new MessageOptions().setPrompt(
                     "Create a brief implementation plan for adding a greeting.txt file, then request approval with exit_plan_mode.")
-                    .setMode("plan")).get(120, TimeUnit.SECONDS);
+                    .setAgentMode(AgentMode.PLAN)).get(120, TimeUnit.SECONDS);
 
             var request = handlerCalled.get(10, TimeUnit.SECONDS);
             assertEquals(summary, request.getSummary());


### PR DESCRIPTION
## Summary

Re-enables `ModeHandlersTest.shouldInvokeExitPlanModeHandlerWhenModelUsesTool`, which was `@Disabled` in https://github.com/github/copilot-sdk/pull/1548 after the CLI 1.0.57 upgrade.

Shared snapshot work landed in https://github.com/github/copilot-sdk/pull/1639 and the other language SDKs were updated for the canonical action order in https://github.com/github/copilot-sdk/pull/2023; Java was still skipped because this test remained disabled.

This PR:
- Removes the `@Disabled` workaround
- Asserts canonical actions `["autopilot", "interactive", "exit_only"]` and `recommendedAction == "interactive"`
- Asserts matching event fields / feedback, aligned with the .NET E2E test

Fixes https://github.com/github/copilot-sdk/issues/1547

## Test plan

- [ ] `cd test/harness && npm ci`
- [ ] `cd java && mvn verify` (local Copilot/GitHub auth as needed for E2E snapshots)
- [ ] Confirm CI Java E2E `ModeHandlersTest` is green


Made with [Cursor](https://cursor.com)