### PR TITLE
Report authoritative cwd in recordContextChange E2E tests

### DIFF
--- a/dotnet/test/E2E/RpcSessionStateE2ETests.cs
+++ b/dotnet/test/E2E/RpcSessionStateE2ETests.cs
@@ -278,7 +278,6 @@ public class RpcSessionStateE2ETests(E2ETestFixture fixture, ITestOutputHelper o
     {
         var firstDirectory = CreateUniqueDirectory();
         var secondDirectory = CreateUniqueDirectory();
-        var contextDirectory = CreateUniqueDirectory();
         var branch = $"rpc-context-{Guid.NewGuid():N}";
         await using var session = await CreateSessionAsync(new SessionConfig
         {
@@ -322,9 +321,12 @@ public class RpcSessionStateE2ETests(E2ETestFixture fixture, ITestOutputHelper o
             TimeSpan.FromSeconds(15),
             timeoutDescription: "session.context_changed event after metadata.recordContextChange");
 
+        // For local sessions the CLI treats the session cwd as authoritative, so a
+        // recordContextChange that reports a divergent cwd is ignored and emits no event.
+        // Report the current working directory (secondDirectory) to observe the change.
         var context = new SessionWorkingDirectoryContext
         {
-            Cwd = contextDirectory,
+            Cwd = secondDirectory,
             GitRoot = firstDirectory,
             Branch = branch,
             Repository = "github/copilot-sdk-e2e",
@@ -338,8 +340,8 @@ public class RpcSessionStateE2ETests(E2ETestFixture fixture, ITestOutputHelper o
         Assert.NotNull(recordResult);
 
         var contextChanged = await contextChangedTask;
-        Assert.True(PathEquals(contextDirectory, contextChanged.Data.Cwd),
-            $"Expected context cwd '{contextDirectory}', actual '{contextChanged.Data.Cwd}'.");
+        Assert.True(PathEquals(secondDirectory, contextChanged.Data.Cwd),
+            $"Expected context cwd '{secondDirectory}', actual '{contextChanged.Data.Cwd}'.");
         Assert.True(PathEquals(firstDirectory, contextChanged.Data.GitRoot),
             $"Expected context git root '{firstDirectory}', actual '{contextChanged.Data.GitRoot}'.");
         Assert.Equal(branch, contextChanged.Data.Branch);

--- a/go/internal/e2e/rpc_session_state_e2e_test.go
+++ b/go/internal/e2e/rpc_session_state_e2e_test.go
@@ -482,7 +482,6 @@ func TestRPCSessionStateE2E(t *testing.T) {
 	t.Run("should call metadata snapshot set working directory and record context change", func(t *testing.T) {
 		firstDirectory := createUniqueRPCWorkDirectory(t, ctx, "rpc-session-state-first")
 		secondDirectory := createUniqueRPCWorkDirectory(t, ctx, "rpc-session-state-second")
-		contextDirectory := createUniqueRPCWorkDirectory(t, ctx, "rpc-session-state-context")
 		branch := "rpc-context-" + randomHex(t)
 
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
@@ -532,9 +531,12 @@ func TestRPCSessionStateE2E(t *testing.T) {
 		hostType := rpc.SessionWorkingDirectoryContextHostTypeGitHub
 		baseCommit := "0000000000000000000000000000000000000000"
 		headCommit := "1111111111111111111111111111111111111111"
+		// For local sessions the CLI treats the session cwd as authoritative, so a
+		// RecordContextChange that reports a divergent cwd is ignored and emits no event.
+		// Report the current working directory (secondDirectory) to observe the change.
 		if _, err := session.RPC.Metadata.RecordContextChange(t.Context(), &rpc.MetadataRecordContextChangeRequest{
 			Context: rpc.SessionWorkingDirectoryContext{
-				Cwd:            contextDirectory,
+				Cwd:            secondDirectory,
 				GitRoot:        &firstDirectory,
 				Branch:         &branch,
 				Repository:     &repo,
@@ -548,7 +550,7 @@ func TestRPCSessionStateE2E(t *testing.T) {
 		}
 		contextChanged := awaitEvent(t, awaitContextChanged)
 		data := contextChanged.Data.(*copilot.SessionContextChangedData)
-		assertRPCPathEqual(t, contextDirectory, data.Cwd)
+		assertRPCPathEqual(t, secondDirectory, data.Cwd)
 		if data.GitRoot == nil {
 			t.Fatal("Expected context changed git root")
 		}

--- a/nodejs/test/e2e/rpc_session_state.e2e.test.ts
+++ b/nodejs/test/e2e/rpc_session_state.e2e.test.ts
@@ -312,7 +312,6 @@ describe("Session-scoped RPC", async () => {
     it("should call metadata snapshot, setWorkingDirectory, and recordContextChange", async () => {
         const firstDirectory = createUniqueDirectory(workDir, "rpc-session-state-first");
         const secondDirectory = createUniqueDirectory(workDir, "rpc-session-state-second");
-        const contextDirectory = createUniqueDirectory(workDir, "rpc-session-state-context");
         const branch = `rpc-context-${randomUUID()}`;
         const session = await client.createSession({
             onPermissionRequest: approveAll,
@@ -353,8 +352,11 @@ describe("Session-scoped RPC", async () => {
                 "session.context_changed event"
             );
 
+            // For local sessions the CLI treats the session cwd as authoritative, so a
+            // recordContextChange that reports a divergent cwd is ignored and emits no event.
+            // Report the current working directory (secondDirectory) to observe the change.
             const context = {
-                cwd: contextDirectory,
+                cwd: secondDirectory,
                 gitRoot: firstDirectory,
                 branch,
                 repository: "github/copilot-sdk-e2e",
@@ -366,7 +368,7 @@ describe("Session-scoped RPC", async () => {
             await session.rpc.metadata.recordContextChange({ context });
 
             const event = await contextChanged;
-            expect(pathsEqual(event.data.cwd, contextDirectory)).toBe(true);
+            expect(pathsEqual(event.data.cwd, secondDirectory)).toBe(true);
             expect(pathsEqual(event.data.gitRoot ?? "", firstDirectory)).toBe(true);
             expect(event.data.branch).toBe(branch);
             expect(event.data.repository).toBe("github/copilot-sdk-e2e");

--- a/python/e2e/test_rpc_session_state_e2e.py
+++ b/python/e2e/test_rpc_session_state_e2e.py
@@ -259,7 +259,6 @@ class TestRpcSessionState:
     ):
         first_dir = _create_unique_directory(ctx, "metadata-first")
         second_dir = _create_unique_directory(ctx, "metadata-second")
-        context_dir = _create_unique_directory(ctx, "metadata-context")
         branch = f"rpc-context-{uuid.uuid4().hex}"
 
         session = await ctx.client.create_session(
@@ -304,10 +303,13 @@ class TestRpcSessionState:
 
             unsubscribe = session.on(on_event)
             try:
+                # For local sessions the CLI treats the session cwd as authoritative, so a
+                # record_context_change that reports a divergent cwd is ignored and emits
+                # no event. Report the current working directory (second_dir) to observe it.
                 result = await session.rpc.metadata.record_context_change(
                     MetadataRecordContextChangeRequest(
                         context=SessionWorkingDirectoryContext(
-                            cwd=context_dir,
+                            cwd=second_dir,
                             git_root=first_dir,
                             branch=branch,
                             repository="github/copilot-sdk-e2e",
@@ -321,7 +323,7 @@ class TestRpcSessionState:
                 assert result is not None
 
                 event = await asyncio.wait_for(context_future, timeout=15.0)
-                assert _path_equals(context_dir, event.data.cwd)
+                assert _path_equals(second_dir, event.data.cwd)
                 assert _path_equals(first_dir, event.data.git_root)
                 assert event.data.branch == branch
                 assert event.data.repository == "github/copilot-sdk-e2e"


### PR DESCRIPTION
## Summary

Fixes a stale E2E expectation exposed by github/copilot-agent-runtime#12896 (merge commit `2654f6e8b3a1b93e7d3122388fb2ab559e4345f3`).

The runtime now treats a **local session's cwd as authoritative**: it is changed via `setWorkingDirectory`, and a `recordContextChange` that reports a *divergent* cwd is intentionally ignored — the RPC still succeeds, but no `session.context_changed` event is emitted.

The RPC session-state E2E tests previously:
1. Set the working directory to a `second` directory via `setWorkingDirectory`, then
2. Called `recordContextChange` with a **third, divergent** `cwd` and waited for a `session.context_changed` event.

Under the updated contract that event is never emitted, so the C# test `RpcSessionStateE2ETests.Should_Call_Metadata_Snapshot_SetWorkingDirectory_And_RecordContextChange` times out with:

> Timeout waiting for session.context_changed event after metadata.recordContextChange

This is observed on copilot-sdk `main` run live against the runtime CLI by the runtime's non-blocking `.github/workflows/copilot-sdk-dotnet-tests.yml` — every sampled main run since #12896 merged fails only this test. It is not related to replay recordings (this test does not invoke the model, so it has no snapshot).

## Fix

Report the authoritative current cwd (`secondDirectory`) in `recordContextChange` so the `session.context_changed` event fires, and assert against it. Applied consistently to the tests that had the divergent-cwd expectation:

- `dotnet/test/E2E/RpcSessionStateE2ETests.cs`
- `nodejs/test/e2e/rpc_session_state.e2e.test.ts`
- `python/e2e/test_rpc_session_state_e2e.py`
- `go/internal/e2e/rpc_session_state_e2e_test.go`

The Rust test (`rust/tests/e2e/rpc_session_state.rs`) already reported the authoritative cwd (reused the same `subdir` for both `set_working_directory` and `record_context_change`), so it is unchanged.

## Validation

- Definitive cross-repo compatibility: built github/copilot-agent-runtime `main` at `98003c01580e7b4af12f7d8ec7a24a02bf1fa28d`, then ran its `script/test-copilot-sdk-dotnet` against this PR head (`1f35e33e8a3f95a573ee73ffc33380ca0fc404eb`): **670 total, 668 passed, 2 skipped, 0 failed**.
- C#: `dotnet build test/GitHub.Copilot.SDK.Test.csproj` succeeds (0 warnings, 0 errors).
- Node: `npm run typecheck` and `prettier --check` pass.
- Python: `ruff check` / `ruff format --check` pass.
- Go: `go vet ./internal/e2e/` and `gofmt` clean.

Related: github/copilot-agent-runtime#12896