### PR TITLE
Use dependency groups for Python dev deps

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,7 +24,7 @@
   - Format all: `just format` | Lint all: `just lint` | Test all: `just test`
 - Per-language:
   - Node: `cd nodejs && npm ci` → `npm test` (Vitest), `npm run generate:session-types` to regenerate session-event types
-  - Python: `cd python && uv pip install -e ".[dev]"` → `uv run pytest` (E2E tests use the test harness)
+  - Python: `cd python && uv pip install -e . --group dev` → `uv run pytest` (E2E tests use the test harness)
   - Go: `cd go && go test ./...`
   - .NET: `cd dotnet && dotnet test test/GitHub.Copilot.SDK.Test.csproj`
   - **.NET testing note:** Never add `InternalsVisibleTo` to any project file when writing tests. Tests must only access public APIs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ This is a multi-language SDK repository. Install the tools for the SDK(s) you pl
 
 1. Install [Python 3.8+](https://www.python.org/downloads/)
 1. Install [uv](https://github.com/astral-sh/uv)
-1. Install dependencies: `cd python && uv pip install -e ".[dev]"`
+1. Install dependencies: `cd python && uv pip install -e . --group dev`
 
 ### Go SDK
 

--- a/justfile
+++ b/justfile
@@ -109,7 +109,7 @@ install-go: install-nodejs install-test-harness
 # Install Python dependencies and prerequisites for tests
 install-python: install-nodejs install-test-harness
     @echo "=== Installing Python dependencies ==="
-    @cd python && uv pip install -e ".[dev]"
+    @cd python && uv pip install -e . --group dev
 
 # Install .NET dependencies and prerequisites for tests
 install-dotnet: install-nodejs install-test-harness

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -35,6 +35,11 @@ Homepage = "https://github.com/github/copilot-sdk"
 Repository = "https://github.com/github/copilot-sdk"
 
 [project.optional-dependencies]
+telemetry = [
+    "opentelemetry-api>=1.0.0",
+]
+
+[dependency-groups]
 dev = [
     "ruff>=0.1.0",
     "ty>=0.0.2,<0.0.25",
@@ -43,9 +48,6 @@ dev = [
     "pytest-timeout>=2.0.0",
     "websockets>=12.0",
     "opentelemetry-sdk>=1.0.0",
-]
-telemetry = [
-    "opentelemetry-api>=1.0.0",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
This change moves the Python development dependencies out of the project optional-dependencies section and into a PEP 735 dependency group in `python/pyproject.toml`.

The repo's Python install guidance now uses `uv pip install -e . --group dev`, so the same dev setup is available through the newer dependency-group mechanism. I also validated the updated install command with `uv`.