### PR TITLE
dotnet: release oversized JSON-RPC receive buffers

### DIFF
--- a/dotnet/src/JsonRpc.cs
+++ b/dotnet/src/JsonRpc.cs
@@ -29,6 +29,8 @@ internal sealed partial class JsonRpc : IDisposable
 {
     private const int ErrorCodeMethodNotFound = -32601;
     private const int ErrorCodeInternalError = -32603;
+    private const int InitialReadBufferSize = 256;
+    private const int MaximumRetainedReadBufferSize = 1024 * 1024;
 
     private readonly Stream _sendStream;
     private readonly Stream _receiveStream;
@@ -259,7 +261,7 @@ internal sealed partial class JsonRpc : IDisposable
 
     private async Task ReadLoopAsync(CancellationToken cancellationToken)
     {
-        var buffer = new byte[256];
+        var buffer = new byte[InitialReadBufferSize];
         int carried = 0; // bytes in buffer carried over from previous read
         try
         {
@@ -296,6 +298,17 @@ internal sealed partial class JsonRpc : IDisposable
                 if (carried > 0)
                 {
                     Buffer.BlockCopy(buffer, contentLength, buffer, 0, carried);
+                }
+
+                if (buffer.Length > MaximumRetainedReadBufferSize)
+                {
+                    var retainedBuffer = new byte[Math.Max(InitialReadBufferSize, carried)];
+                    if (carried > 0)
+                    {
+                        Buffer.BlockCopy(buffer, 0, retainedBuffer, 0, carried);
+                    }
+
+                    buffer = retainedBuffer;
                 }
 
                 if (message is not { } parsed)

--- a/dotnet/test/Unit/JsonRpcTests.cs
+++ b/dotnet/test/Unit/JsonRpcTests.cs
@@ -3,6 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System.Reflection;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using Xunit;
@@ -93,6 +94,41 @@ public class JsonRpcTests
         await Assert.ThrowsAnyAsync<ObjectDisposedException>(() => pending);
     }
 
+    [Fact]
+    public async Task JsonRpc_Does_Not_Retain_Oversized_Receive_Buffer()
+    {
+        using var receiveStream = new FrameThenEofStream(CreateResponseFrame(2 * 1024 * 1024));
+        using var rpc = new JsonRpcReflection(Stream.Null, receiveStream);
+
+        rpc.StartListening();
+
+        var completed = await Task.WhenAny(
+            receiveStream.PostFrameReadBufferSize,
+            Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(receiveStream.PostFrameReadBufferSize, completed);
+        Assert.InRange(await receiveStream.PostFrameReadBufferSize, 1, 1024 * 1024);
+    }
+
+    private static byte[] CreateResponseFrame(int payloadLength)
+    {
+        using var bodyStream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(bodyStream))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("jsonrpc", "2.0");
+            writer.WriteNumber("id", long.MaxValue);
+            writer.WriteString("result", new string('x', payloadLength));
+            writer.WriteEndObject();
+        }
+
+        var body = bodyStream.ToArray();
+        var header = Encoding.ASCII.GetBytes($"Content-Length: {body.Length}\r\n\r\n");
+        var frame = new byte[header.Length + body.Length];
+        header.CopyTo(frame, 0);
+        body.CopyTo(frame, header.Length);
+        return frame;
+    }
+
     private static int GetRemoteErrorCode(Exception exception)
     {
         var property = exception.GetType().GetProperty("ErrorCode", BindingFlags.Instance | BindingFlags.Public);
@@ -170,12 +206,17 @@ public class JsonRpcTests
         private readonly object _instance;
 
         public JsonRpcReflection(Stream stream)
+            : this(stream, stream)
+        {
+        }
+
+        public JsonRpcReflection(Stream sendStream, Stream receiveStream)
         {
             _instance = Activator.CreateInstance(
                 JsonRpcType,
                 BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
                 binder: null,
-                args: [stream, stream, SerializerOptions, null],
+                args: [sendStream, receiveStream, SerializerOptions, null],
                 culture: null)!;
         }
 
@@ -196,6 +237,63 @@ public class JsonRpcTests
         }
 
         public void Dispose() => ((IDisposable)_instance).Dispose();
+    }
+
+    private sealed class FrameThenEofStream(byte[] frame) : Stream
+    {
+        private readonly TaskCompletionSource<int> _postFrameReadBufferSize =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _offset;
+
+        public Task<int> PostFrameReadBufferSize => _postFrameReadBufferSize.Task;
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            ReadCore(buffer.AsMemory(offset, count));
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            Task.FromResult(ReadCore(buffer.AsMemory(offset, count)));
+
+#if NET8_0_OR_GREATER
+        public override
+#else
+        internal
+#endif
+        ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default) =>
+            new(ReadCore(destination));
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        private int ReadCore(Memory<byte> destination)
+        {
+            if (_offset >= frame.Length)
+            {
+                _postFrameReadBufferSize.TrySetResult(destination.Length);
+                return 0;
+            }
+
+            var bytesRead = Math.Min(destination.Length, frame.Length - _offset);
+            frame.AsMemory(_offset, bytesRead).CopyTo(destination);
+            _offset += bytesRead;
+            return bytesRead;
+        }
     }
 
     private sealed class InMemoryDuplexStream : Stream

--- a/dotnet/test/Unit/JsonRpcTests.cs
+++ b/dotnet/test/Unit/JsonRpcTests.cs
@@ -97,32 +97,48 @@ public class JsonRpcTests
     [Fact]
     public async Task JsonRpc_Does_Not_Retain_Oversized_Receive_Buffer()
     {
-        using var receiveStream = new FrameThenEofStream(CreateResponseFrame(2 * 1024 * 1024));
+        var oversizedFrame = CreateResponseFrame(
+            long.MaxValue,
+            "ignored",
+            headerPaddingLength: 1024 * 1024);
+        var carriedFrame = CreateResponseFrame(1, "carried");
+        using var receiveStream = new CoalescedFramesThenWaitStream(oversizedFrame, carriedFrame);
         using var rpc = new JsonRpcReflection(Stream.Null, receiveStream);
 
+        var carriedResponse = rpc.InvokeAsync<string>("pending", args: null);
         rpc.StartListening();
 
-        var completed = await Task.WhenAny(
+        var responseCompleted = await Task.WhenAny(
+            carriedResponse,
+            Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(carriedResponse, responseCompleted);
+        Assert.Equal("carried", await carriedResponse);
+        Assert.True(receiveStream.FramesWereCoalesced);
+
+        var readCompleted = await Task.WhenAny(
             receiveStream.PostFrameReadBufferSize,
             Task.Delay(TimeSpan.FromSeconds(5)));
-        Assert.Same(receiveStream.PostFrameReadBufferSize, completed);
+        Assert.Same(receiveStream.PostFrameReadBufferSize, readCompleted);
         Assert.InRange(await receiveStream.PostFrameReadBufferSize, 1, 1024 * 1024);
     }
 
-    private static byte[] CreateResponseFrame(int payloadLength)
+    private static byte[] CreateResponseFrame(long id, string result, int headerPaddingLength = 0)
     {
         using var bodyStream = new MemoryStream();
         using (var writer = new Utf8JsonWriter(bodyStream))
         {
             writer.WriteStartObject();
             writer.WriteString("jsonrpc", "2.0");
-            writer.WriteNumber("id", long.MaxValue);
-            writer.WriteString("result", new string('x', payloadLength));
+            writer.WriteNumber("id", id);
+            writer.WriteString("result", result);
             writer.WriteEndObject();
         }
 
         var body = bodyStream.ToArray();
-        var header = Encoding.ASCII.GetBytes($"Content-Length: {body.Length}\r\n\r\n");
+        var paddingHeader = headerPaddingLength > 0
+            ? $"X-Padding: {new string('x', headerPaddingLength)}\r\n"
+            : string.Empty;
+        var header = Encoding.ASCII.GetBytes($"{paddingHeader}Content-Length: {body.Length}\r\n\r\n");
         var frame = new byte[header.Length + body.Length];
         header.CopyTo(frame, 0);
         body.CopyTo(frame, header.Length);
@@ -239,11 +255,23 @@ public class JsonRpcTests
         public void Dispose() => ((IDisposable)_instance).Dispose();
     }
 
-    private sealed class FrameThenEofStream(byte[] frame) : Stream
+    private sealed class CoalescedFramesThenWaitStream : Stream
     {
         private readonly TaskCompletionSource<int> _postFrameReadBufferSize =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly byte[] _frames;
+        private readonly int _firstFrameLength;
         private int _offset;
+
+        public CoalescedFramesThenWaitStream(byte[] firstFrame, byte[] secondFrame)
+        {
+            _firstFrameLength = firstFrame.Length;
+            _frames = new byte[firstFrame.Length + secondFrame.Length];
+            firstFrame.CopyTo(_frames, 0);
+            secondFrame.CopyTo(_frames, firstFrame.Length);
+        }
+
+        public bool FramesWereCoalesced { get; private set; }
 
         public Task<int> PostFrameReadBufferSize => _postFrameReadBufferSize.Task;
 
@@ -257,11 +285,10 @@ public class JsonRpcTests
 
         public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
 
-        public override int Read(byte[] buffer, int offset, int count) =>
-            ReadCore(buffer.AsMemory(offset, count));
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
-            Task.FromResult(ReadCore(buffer.AsMemory(offset, count)));
+            ReadCoreAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
 
 #if NET8_0_OR_GREATER
         public override
@@ -269,7 +296,7 @@ public class JsonRpcTests
         internal
 #endif
         ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default) =>
-            new(ReadCore(destination));
+            ReadCoreAsync(destination, cancellationToken);
 
         public override void Flush()
         {
@@ -281,18 +308,26 @@ public class JsonRpcTests
 
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 
-        private int ReadCore(Memory<byte> destination)
+        private ValueTask<int> ReadCoreAsync(Memory<byte> destination, CancellationToken cancellationToken)
         {
-            if (_offset >= frame.Length)
+            if (_offset >= _frames.Length)
             {
                 _postFrameReadBufferSize.TrySetResult(destination.Length);
-                return 0;
+                return new ValueTask<int>(WaitForCancellationAsync(cancellationToken));
             }
 
-            var bytesRead = Math.Min(destination.Length, frame.Length - _offset);
-            frame.AsMemory(_offset, bytesRead).CopyTo(destination);
+            var startingOffset = _offset;
+            var bytesRead = Math.Min(destination.Length, _frames.Length - _offset);
+            _frames.AsMemory(_offset, bytesRead).CopyTo(destination);
             _offset += bytesRead;
-            return bytesRead;
+            FramesWereCoalesced |= startingOffset < _firstFrameLength && _offset == _frames.Length;
+            return new ValueTask<int>(bytesRead);
+        }
+
+        private static async Task<int> WaitForCancellationAsync(CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+            return 0;
         }
     }
 


### PR DESCRIPTION
## Problem

The .NET JSON-RPC read loop reuses the largest receive buffer for the lifetime of the connection. A single multi-megabyte frame therefore remains rooted while the loop waits for the next message.

## Fix

After a completed frame is parsed, replace receive buffers larger than 1 MiB with the smallest buffer needed to preserve any bytes already carried from the next frame. The connection and all sessions remain active.

## Validation

- New regression test observed a 2,097,206-byte next-read buffer before the fix and passes with the bounded buffer afterward.
- 163 .NET unit tests pass on net8.0.
- The regression test passes on net472.
- A real 16 MiB tool-result scenario completed, the same client connection remained healthy, and a post-GC process dump contained no managed byte arrays larger than 10 MB.