### PR TITLE
rust: re-export ModelPolicyState and ModelPickerCategory from crate root

### DIFF
--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -5388,8 +5388,9 @@ impl InputFormat {
 pub use crate::generated::api_types::{
     Model, ModelBilling, ModelBillingTokenPrices, ModelBillingTokenPricesLongContext,
     ModelCapabilities, ModelCapabilitiesLimits, ModelCapabilitiesLimitsVision,
-    ModelCapabilitiesSupports, ModelList, ModelPolicy, PermissionDecision,
-    PermissionDecisionApproveOnce, PermissionDecisionReject, PermissionDecisionUserNotAvailable,
+    ModelCapabilitiesSupports, ModelList, ModelPickerCategory, ModelPolicy, ModelPolicyState,
+    PermissionDecision, PermissionDecisionApproveOnce, PermissionDecisionReject,
+    PermissionDecisionUserNotAvailable,
 };
 
 /// Permission categories the CLI may request approval for.


### PR DESCRIPTION
Closes #1674

\ModelPolicy\ and \Model\ are re-exported at the crate root, but their field-type enums \ModelPolicyState\ and \ModelPickerCategory\ are not. This forces consumers to reach into \copilot::rpc\ for types that logically belong alongside the already-exported structs.

This adds both enums to the curated \pub use\ block in \	ypes.rs\, in alphabetical order.