### PR TITLE
Enable BYOK coverage for .NET E2E tests

### DIFF
--- a/dotnet/test/E2E/GitHubTelemetryForwardingE2ETests.cs
+++ b/dotnet/test/E2E/GitHubTelemetryForwardingE2ETests.cs
@@ -12,8 +12,7 @@ namespace GitHub.Copilot.Test.E2E;
 
 #pragma warning disable GHCP001 // GitHub telemetry forwarding is experimental.
 
-// TODO(BYOK): Anthropic Messages produced no GitHub telemetry notification. Determine whether
-// provider-backed sessions should forward the same telemetry before keeping this CAPI-only.
+// Internal GitHub telemetry is intentionally disabled for BYOK sessions.
 [Trait(E2ETestTraits.Backend, E2ETestTraits.CapiOnly)]
 public class GitHubTelemetryForwardingE2ETests(E2ETestFixture fixture, ITestOutputHelper output)
     : E2ETestBase(fixture, "github_telemetry", output)

--- a/dotnet/test/E2E/RpcTasksAndHandlersE2ETests.cs
+++ b/dotnet/test/E2E/RpcTasksAndHandlersE2ETests.cs
@@ -72,9 +72,6 @@ public class RpcTasksAndHandlersE2ETests(E2ETestFixture fixture, ITestOutputHelp
     }
 
     [Fact]
-    // TODO(BYOK): Provider-backed task agents handled an invalid model differently. Verify that
-    // BYOK model validation should reject it consistently before keeping this CAPI-only.
-    [Trait(E2ETestTraits.Backend, E2ETestTraits.CapiOnly)]
     public async Task Should_Report_Implemented_Error_For_Invalid_Task_Agent_Model()
     {
         var session = await CreateSessionAsync();

--- a/dotnet/test/E2E/SessionConfigE2ETests.cs
+++ b/dotnet/test/E2E/SessionConfigE2ETests.cs
@@ -682,23 +682,16 @@ public class SessionConfigE2ETests(E2ETestFixture fixture, ITestOutputHelper out
     }
 
     [Fact]
-    // TODO(BYOK): Anthropic Messages request history diverged while replaying this blob attachment.
-    // Confirm native clients preserve blob/image turns before keeping this CAPI-only.
-    [Trait(E2ETestTraits.Backend, E2ETestTraits.CapiOnly)]
     public async Task Should_Accept_Blob_Attachments()
     {
-        // Write the image to disk so the model can view it if it tries
         const string pngBase64 =
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
-        await File.WriteAllBytesAsync(
-            Path.Join(Ctx.WorkDir, "pixel.png"),
-            Convert.FromBase64String(pngBase64));
 
         var session = await CreateSessionAsync();
 
-        await session.SendAndWaitAsync(new MessageOptions
+        var response = await session.SendAndWaitAsync(new MessageOptions
         {
-            Prompt = "What color is this pixel? Reply in one word.",
+            Prompt = "Acknowledge receipt of this image in exactly two words: Image received.",
             Attachments =
             [
                 new AttachmentBlob
@@ -709,6 +702,10 @@ public class SessionConfigE2ETests(E2ETestFixture fixture, ITestOutputHelper out
                 },
             ],
         });
+
+        Assert.Equal("Image received.", response?.Data.Content);
+        var exchange = Assert.Single(await Ctx.GetExchangesAsync());
+        Assert.True(HasImageUrlContent(exchange.Request.Messages), "Expected the request to contain the blob image");
 
         await session.DisposeAsync();
     }
@@ -735,20 +732,6 @@ public class SessionConfigE2ETests(E2ETestFixture fixture, ITestOutputHelper out
         });
 
         await session.DisposeAsync();
-    }
-
-    /// <summary>
-    /// Checks whether any user message contains an image_url content part.
-    /// Content can be a string (no images) or a JSON array of content parts.
-    /// </summary>
-    private static bool HasImageUrlContent(List<ChatCompletionMessage> messages)
-    {
-        return messages
-            .Where(m => m.Role == "user" && m.Content is { ValueKind: JsonValueKind.Array })
-            .Any(m => m.Content!.Value.EnumerateArray().Any(part =>
-                part.TryGetProperty("type", out var typeProp) &&
-                typeProp.ValueKind == JsonValueKind.String &&
-                typeProp.GetString() == "image_url"));
     }
 
     private CopilotClient CreateClientWithRequestHandler(

--- a/dotnet/test/E2E/SessionConfigE2ETests.cs
+++ b/dotnet/test/E2E/SessionConfigE2ETests.cs
@@ -22,9 +22,6 @@ public class SessionConfigE2ETests(E2ETestFixture fixture, ITestOutputHelper out
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==");
 
     [Fact]
-    // TODO(BYOK): Anthropic Messages history diverged after enabling vision via SetModel. Verify
-    // that model capability overrides work for provider-backed sessions before keeping this CAPI-only.
-    [Trait(E2ETestTraits.Backend, E2ETestTraits.CapiOnly)]
     public async Task Vision_Disabled_Then_Enabled_Via_SetModel()
     {
         await File.WriteAllBytesAsync(Path.Join(Ctx.WorkDir, "test.png"), Png1X1);
@@ -65,9 +62,6 @@ public class SessionConfigE2ETests(E2ETestFixture fixture, ITestOutputHelper out
     }
 
     [Fact]
-    // TODO(BYOK): Anthropic Messages history diverged after disabling vision via SetModel. Verify
-    // that model capability overrides work for provider-backed sessions before keeping this CAPI-only.
-    [Trait(E2ETestTraits.Backend, E2ETestTraits.CapiOnly)]
     public async Task Vision_Enabled_Then_Disabled_Via_SetModel()
     {
         await File.WriteAllBytesAsync(Path.Join(Ctx.WorkDir, "test.png"), Png1X1);

--- a/dotnet/test/E2E/SessionConfigE2ETests.cs
+++ b/dotnet/test/E2E/SessionConfigE2ETests.cs
@@ -185,9 +185,6 @@ public class SessionConfigE2ETests(E2ETestFixture fixture, ITestOutputHelper out
     }
 
     [Fact]
-    // TODO(BYOK): The Anthropic user-agent omitted ClientName and contained only its provider SDK
-    // identifier. Determine the expected propagation for custom providers before keeping this CAPI-only.
-    [Trait(E2ETestTraits.Backend, E2ETestTraits.CapiOnly)]
     public async Task Should_Forward_ClientName_In_UserAgent()
     {
         var session = await CreateSessionAsync(new SessionConfig

--- a/dotnet/test/E2E/SessionE2ETests.cs
+++ b/dotnet/test/E2E/SessionE2ETests.cs
@@ -732,19 +732,15 @@ public class SessionE2ETests(E2ETestFixture fixture, ITestOutputHelper output) :
     }
 
     [Fact]
-    // TODO(BYOK): Anthropic Messages request history diverged while replaying this blob attachment.
-    // Confirm native clients preserve blob/image turns before keeping this CAPI-only.
-    [Trait(E2ETestTraits.Backend, E2ETestTraits.CapiOnly)]
     public async Task Should_Accept_Blob_Attachments()
     {
         var pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
-        await File.WriteAllBytesAsync(Path.Join(Ctx.WorkDir, "test-pixel.png"), Convert.FromBase64String(pngBase64));
 
         var session = await CreateSessionAsync();
 
-        await session.SendAndWaitAsync(new MessageOptions
+        var response = await session.SendAndWaitAsync(new MessageOptions
         {
-            Prompt = "Describe this image",
+            Prompt = "Acknowledge receipt of this image in exactly two words: Image received.",
             Attachments =
             [
                 new AttachmentBlob
@@ -755,6 +751,10 @@ public class SessionE2ETests(E2ETestFixture fixture, ITestOutputHelper output) :
                 },
             ],
         });
+
+        Assert.Equal("Image received.", response?.Data.Content);
+        var exchange = Assert.Single(await Ctx.GetExchangesAsync());
+        Assert.True(HasImageUrlContent(exchange.Request.Messages), "Expected the request to contain the blob image");
 
         await session.DisposeAsync();
     }

--- a/dotnet/test/E2E/StreamingFidelityE2ETests.cs
+++ b/dotnet/test/E2E/StreamingFidelityE2ETests.cs
@@ -47,9 +47,6 @@ public class StreamingFidelityE2ETests(E2ETestFixture fixture, ITestOutputHelper
     }
 
     [Fact]
-    // TODO(BYOK): Anthropic Messages emitted delta events with Streaming=false. Investigate the
-    // native-client streaming contract before keeping this disabled for every BYOK backend.
-    [Trait(E2ETestTraits.Backend, E2ETestTraits.CapiOnly)]
     public async Task Should_Not_Produce_Deltas_When_Streaming_Is_Disabled()
     {
         var session = await CreateSessionAsync(new SessionConfig { Streaming = false });
@@ -110,9 +107,6 @@ public class StreamingFidelityE2ETests(E2ETestFixture fixture, ITestOutputHelper
     }
 
     [Fact]
-    // TODO(BYOK): Anthropic Messages emitted delta events after resuming with Streaming=false.
-    // Investigate the native-client streaming contract before keeping this disabled for every BYOK backend.
-    [Trait(E2ETestTraits.Backend, E2ETestTraits.CapiOnly)]
     public async Task Should_Not_Produce_Deltas_After_Session_Resume_With_Streaming_Disabled()
     {
         var session = await CreateSessionAsync(new SessionConfig { Streaming = true });

--- a/dotnet/test/Harness/E2ETestBase.cs
+++ b/dotnet/test/Harness/E2ETestBase.cs
@@ -7,6 +7,7 @@ using GitHub.Copilot.Test.Harness;
 using Microsoft.Extensions.Logging;
 using System.Data;
 using System.Reflection;
+using System.Text.Json;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -107,6 +108,16 @@ public abstract class E2ETestBase : IClassFixture<E2ETestFixture>, IAsyncLifetim
     protected static List<string> GetToolNames(ParsedHttpExchange exchange)
     {
         return exchange.Request.Tools?.Select(t => t.Function.Name).ToList() ?? [];
+    }
+
+    protected static bool HasImageUrlContent(IEnumerable<ChatCompletionMessage> messages)
+    {
+        return messages
+            .Where(m => m.Role == "user" && m.Content is { ValueKind: JsonValueKind.Array })
+            .Any(m => m.Content!.Value.EnumerateArray().Any(part =>
+                part.TryGetProperty("type", out var typeProp) &&
+                typeProp.ValueKind == JsonValueKind.String &&
+                typeProp.GetString() == "image_url"));
     }
 
     protected async Task<List<ParsedHttpExchange>> WaitForExchangesAsync(int minimumCount = 1)

--- a/test/harness/anthropicMessagesAdapter.ts
+++ b/test/harness/anthropicMessagesAdapter.ts
@@ -8,7 +8,6 @@ import {
   CanonicalToolCall,
   formatSseEvent,
   functionToolCalls,
-  isObject,
   JsonObject,
 } from "./modelProtocolAdapterShared";
 
@@ -22,17 +21,23 @@ type CanonicalContentPart =
       file: { file_data: string; filename?: string };
     };
 
+type AnthropicMediaBlock = {
+  type: "image" | "document";
+  source?: { type?: string; media_type?: string; data?: string };
+};
+
+type AnthropicToolResultBlock =
+  | { type?: "text"; text?: string }
+  | AnthropicMediaBlock;
+
 type AnthropicContentBlock =
   | { type: "text"; text: string; citations?: null }
-  | {
-      type: "image" | "document";
-      source?: { type?: string; media_type?: string; data?: string };
-    }
+  | AnthropicMediaBlock
   | { type: "tool_use"; id: string; name: string; input: unknown }
   | {
       type: "tool_result";
       tool_use_id?: string;
-      content?: string | Array<{ type?: string; text?: string }>;
+      content?: string | AnthropicToolResultBlock[];
     };
 
 type AnthropicMessageParam = {
@@ -187,27 +192,20 @@ function convertAnthropicUserMessage(
   for (const block of normalizeContent(message.content)) {
     if (block.type === "text") {
       contentParts.push({ type: "text", text: block.text });
-    } else if (
-      (block.type === "image" || block.type === "document") &&
-      block.source?.type === "base64" &&
-      block.source.data
-    ) {
-      const dataUrl = `data:${
-        block.source.media_type ??
-        (block.type === "image" ? "image/png" : "application/pdf")
-      };base64,${block.source.data}`;
-      contentParts.push(
-        block.type === "image"
-          ? { type: "image_url", image_url: { url: dataUrl } }
-          : { type: "file", file: { file_data: dataUrl } },
-      );
+    } else if (block.type === "image" || block.type === "document") {
+      const contentPart = anthropicMediaContentPart(block);
+      if (contentPart) contentParts.push(contentPart);
     } else if (block.type === "tool_result") {
       flushUserContent();
+      const toolResult = anthropicToolResultContent(block.content);
       result.push({
         role: "tool",
         tool_call_id: block.tool_use_id ?? "",
-        content: anthropicToolResultContent(block.content),
+        content: toolResult.text,
       });
+      if (toolResult.media.length) {
+        result.push({ role: "user", content: toolResult.media });
+      }
     }
   }
 
@@ -244,15 +242,37 @@ function convertAnthropicAssistantMessage(
   ];
 }
 
-function anthropicToolResultContent(content: unknown): string {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  return content
-    .map((part) =>
-      isObject(part) && typeof part.text === "string" ? part.text : "",
-    )
-    .filter(Boolean)
-    .join("\n");
+function anthropicMediaContentPart(
+  block: AnthropicMediaBlock,
+): CanonicalContentPart | undefined {
+  if (block.source?.type !== "base64" || !block.source.data) return undefined;
+
+  const dataUrl = `data:${
+    block.source.media_type ??
+    (block.type === "image" ? "image/png" : "application/pdf")
+  };base64,${block.source.data}`;
+  return block.type === "image"
+    ? { type: "image_url", image_url: { url: dataUrl } }
+    : { type: "file", file: { file_data: dataUrl } };
+}
+
+function anthropicToolResultContent(
+  content: string | AnthropicToolResultBlock[] | undefined,
+): { text: string; media: CanonicalContentPart[] } {
+  if (typeof content === "string") return { text: content, media: [] };
+  if (!Array.isArray(content)) return { text: "", media: [] };
+
+  const text: string[] = [];
+  const media: CanonicalContentPart[] = [];
+  for (const part of content) {
+    if (part.type === "text" && typeof part.text === "string") {
+      text.push(part.text);
+    } else if (part.type === "image" || part.type === "document") {
+      const contentPart = anthropicMediaContentPart(part);
+      if (contentPart) media.push(contentPart);
+    }
+  }
+  return { text: text.join("\n"), media };
 }
 
 function convertToolChoice(

--- a/test/harness/anthropicMessagesAdapter.ts
+++ b/test/harness/anthropicMessagesAdapter.ts
@@ -174,6 +174,7 @@ function convertAnthropicUserMessage(
 ): CanonicalMessage[] {
   const result: CanonicalMessage[] = [];
   const contentParts: CanonicalContentPart[] = [];
+  const toolResultMedia: CanonicalContentPart[] = [];
 
   const flushUserContent = () => {
     if (contentParts.length === 0) return;
@@ -203,13 +204,14 @@ function convertAnthropicUserMessage(
         tool_call_id: block.tool_use_id ?? "",
         content: toolResult.text,
       });
-      if (toolResult.media.length) {
-        result.push({ role: "user", content: toolResult.media });
-      }
+      toolResultMedia.push(...toolResult.media);
     }
   }
 
   flushUserContent();
+  if (toolResultMedia.length) {
+    result.push({ role: "user", content: toolResultMedia });
+  }
   return result;
 }
 

--- a/test/harness/modelProtocolAdapters.test.ts
+++ b/test/harness/modelProtocolAdapters.test.ts
@@ -235,6 +235,94 @@ describe("Anthropic Messages adapter", () => {
     expect(stream).toContain("event: message_stop");
   });
 
+  test("preserves images and documents nested in tool results", () => {
+    const result = JSON.parse(
+      anthropicMessagesRequestToChatCompletion(
+        JSON.stringify({
+          model: "test-model",
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "tool_use",
+                  id: "call-1",
+                  name: "view",
+                  input: { path: "test.png" },
+                },
+              ],
+            },
+            {
+              role: "user",
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: "call-1",
+                  content: [
+                    { type: "text", text: "Viewed image successfully." },
+                    {
+                      type: "image",
+                      source: {
+                        type: "base64",
+                        media_type: "image/png",
+                        data: "AQID",
+                      },
+                    },
+                    {
+                      type: "document",
+                      source: {
+                        type: "base64",
+                        media_type: "application/pdf",
+                        data: "BAUG",
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
+      ),
+    ) as { messages: Array<Record<string, unknown>> };
+
+    expect(result.messages).toEqual([
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "call-1",
+            type: "function",
+            function: {
+              name: "view",
+              arguments: '{"path":"test.png"}',
+            },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        tool_call_id: "call-1",
+        content: "Viewed image successfully.",
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "image_url",
+            image_url: { url: "data:image/png;base64,AQID" },
+          },
+          {
+            type: "file",
+            file: {
+              file_data: "data:application/pdf;base64,BAUG",
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
   test("combines tools from multiple canonical choices", () => {
     const secondChoice = structuredClone(completionWithTool.choices[0]);
     secondChoice.message.content = null;

--- a/test/harness/modelProtocolAdapters.test.ts
+++ b/test/harness/modelProtocolAdapters.test.ts
@@ -250,6 +250,12 @@ describe("Anthropic Messages adapter", () => {
                   name: "view",
                   input: { path: "test.png" },
                 },
+                {
+                  type: "tool_use",
+                  id: "call-2",
+                  name: "inspect",
+                  input: { path: "test.pdf" },
+                },
               ],
             },
             {
@@ -278,6 +284,11 @@ describe("Anthropic Messages adapter", () => {
                     },
                   ],
                 },
+                {
+                  type: "tool_result",
+                  tool_use_id: "call-2",
+                  content: "Inspected document successfully.",
+                },
               ],
             },
           ],
@@ -298,12 +309,25 @@ describe("Anthropic Messages adapter", () => {
               arguments: '{"path":"test.png"}',
             },
           },
+          {
+            id: "call-2",
+            type: "function",
+            function: {
+              name: "inspect",
+              arguments: '{"path":"test.pdf"}',
+            },
+          },
         ],
       },
       {
         role: "tool",
         tool_call_id: "call-1",
         content: "Viewed image successfully.",
+      },
+      {
+        role: "tool",
+        tool_call_id: "call-2",
+        content: "Inspected document successfully.",
       },
       {
         role: "user",

--- a/test/snapshots/session/should_accept_blob_attachments.yaml
+++ b/test/snapshots/session/should_accept_blob_attachments.yaml
@@ -6,59 +6,8 @@ conversations:
         content: ${system}
       - role: user
         content: |-
-          Describe this image
+          Acknowledge receipt of this image in exactly two words: Image received.
           test-pixel.png
           [image]
       - role: assistant
-        content: I'll view the image file to describe it for you.
-      - role: assistant
-        tool_calls:
-          - id: toolcall_0
-            type: function
-            function:
-              name: report_intent
-              arguments: '{"intent":"Viewing image file"}'
-      - role: assistant
-        tool_calls:
-          - id: toolcall_1
-            type: function
-            function:
-              name: view
-              arguments: '{"path":"${workdir}/test-pixel.png"}'
-  - messages:
-      - role: system
-        content: ${system}
-      - role: user
-        content: |-
-          Describe this image
-          test-pixel.png
-          [image]
-      - role: assistant
-        content: I'll view the image file to describe it for you.
-        tool_calls:
-          - id: toolcall_0
-            type: function
-            function:
-              name: report_intent
-              arguments: '{"intent":"Viewing image file"}'
-          - id: toolcall_1
-            type: function
-            function:
-              name: view
-              arguments: '{"path":"${workdir}/test-pixel.png"}'
-      - role: tool
-        tool_call_id: toolcall_0
-        content: Tool 'report_intent' does not exist. Available tools that can be called are ${shell}, ${read_shell},
-          ${stop_shell}, ${list_shell}, view, create, edit, web_fetch, skill, sql, read_agent, list_agents, grep, glob,
-          task.
-      - role: tool
-        tool_call_id: toolcall_1
-        content: Viewed image file successfully.
-      - role: user
-        content: |-
-          Image file at path ${workdir}/test-pixel.png
-          [image]
-      - role: assistant
-        content: This is a very small image - essentially a **single yellow/gold pixel** or a tiny square. It appears to be a
-          minimal test image, likely 1x1 pixel in size, which matches its filename "test-pixel.png". The color is a
-          bright yellow or golden hue.
+        content: Image received.

--- a/test/snapshots/session_config/should_accept_blob_attachments.yaml
+++ b/test/snapshots/session_config/should_accept_blob_attachments.yaml
@@ -6,22 +6,8 @@ conversations:
         content: ${system}
       - role: user
         content: |-
-          What color is this pixel? Reply in one word.
+          Acknowledge receipt of this image in exactly two words: Image received.
           pixel.png
           [image]
       - role: assistant
-        tool_calls:
-          - id: toolcall_0
-            type: function
-            function:
-              name: view
-              arguments: '{"path":"${workdir}/pixel.png"}'
-      - role: tool
-        tool_call_id: toolcall_0
-        content: Viewed image file successfully.
-      - role: user
-        content: |-
-          Image file at path ${workdir}/pixel.png
-          [image]
-      - role: assistant
-        content: Red
+        content: Image received.


### PR DESCRIPTION
## Summary

- enable the stale non-streaming BYOK tests across the provider matrix
- preserve image and document blocks nested in Anthropic tool results, including parallel tool-call ordering
- make blob attachment transcripts validate the initial image directly without consuming a second image budget slot
- document that internal GitHub telemetry remains intentionally CAPI-only
- isolate enablement of task-model validation and ClientName forwarding pending their coordinated runtime fixes

## Validation

- `cd test/harness && npm test` (58 passed)
- `cd dotnet && dotnet format --verify-no-changes --no-restore`
- all 9 affected tests pass on the CAPI baseline
- both blob attachment tests pass on Anthropic Messages, OpenAI Responses, and OpenAI Chat Completions

## Runtime dependency

This PR remains draft because SDK main pins `@github/copilot` 1.0.73, which predates all required runtime fixes.

- The streaming enablement is isolated in commit `2fa7d64c`. Anthropic in 1.0.73 still emits deltas with SDK streaming disabled. No SDK workaround is applied and no unpublished runtime is pinned. The minimum supported package is the first published `@github/copilot` release containing runtime commit `ec6338` or newer.
- Anthropic in 1.0.73 also omits nested view media before the replay adapter can canonicalize it. Direct runtime validation shows the corrected behavior at `ec6338`.
- Runtime PR [github/copilot-agent-runtime#13354](https://github.com/github/copilot-agent-runtime/pull/13354) provides the remaining runtime-owned fixes in its final squashed head commit:
  - `35d71b4894498d2fcac2f8d24491d1b4cbaf74fa` — Fix BYOK task validation and client User-Agent

No published package version containing these changes is known yet. The first usable published `@github/copilot` package must contain prerequisite runtime commit `ec6338` or newer plus commit `35d71b4894498d2fcac2f8d24491d1b4cbaf74fa`, including its generated protocol and rebuilt native runtime artifacts. Partial cherry-picks are incompatible, and unpublished artifacts must not be pinned.