### PR TITLE
fix(node): exclude internal events from public union

### DIFF
--- a/nodejs/src/generated/session-events.ts
+++ b/nodejs/src/generated/session-events.ts
@@ -39,7 +39,6 @@ export type SessionEvent =
   | UserMessageEvent
   | PendingMessagesModifiedEvent
   | AssistantTurnStartEvent
-  | AssistantTurnRetryEvent
   | AssistantIntentEvent
   | AssistantServerToolProgressEvent
   | AssistantReasoningEvent
@@ -53,7 +52,6 @@ export type SessionEvent =
   | AssistantIdleEvent
   | AssistantUsageEvent
   | ModelCallFailureEvent
-  | ModelCallStartEvent
   | AbortEvent
   | ToolUserRequestedEvent
   | ToolExecutionStartEvent
@@ -3190,54 +3188,6 @@ export interface AssistantTurnStartData {
   turnId: string;
 }
 /**
- * Session event "assistant.turn_retry". Metadata for an additional model inference attempt within an existing assistant turn
- */
-/** @internal */
-export interface AssistantTurnRetryEvent {
-  /**
-   * Sub-agent instance identifier. Absent for events from the root/main agent and session-level events.
-   */
-  agentId?: string;
-  data: AssistantTurnRetryData;
-  /**
-   * Always true for events that are transient and not persisted to the session event log on disk.
-   */
-  ephemeral: true;
-  /**
-   * Unique event identifier (UUID v4), generated when the event is emitted
-   */
-  id: string;
-  /**
-   * ID of the chronologically preceding event in the session, forming a linked chain. Null for the first event.
-   */
-  parentId: string | null;
-  /**
-   * ISO 8601 timestamp when the event was created
-   */
-  timestamp: string;
-  /**
-   * Type discriminator. Always "assistant.turn_retry".
-   */
-  type: "assistant.turn_retry";
-}
-/**
- * Metadata for an additional model inference attempt within an existing assistant turn
- */
-export interface AssistantTurnRetryData {
-  /**
-   * Model identifier used for this retry, when known
-   */
-  model?: string;
-  /**
-   * Provider or runtime classification that caused the retry, when known
-   */
-  reason?: string;
-  /**
-   * Identifier of the turn whose model inference is being retried
-   */
-  turnId: string;
-}
-/**
  * Session event "assistant.intent". Agent intent description for current activity or plan
  */
 export interface AssistantIntentEvent {
@@ -4332,50 +4282,6 @@ export interface ModelCallFailureRequestFingerprint {
    * Number of "tool" result messages in the request
    */
   toolResultMessageCount: number;
-}
-/**
- * Session event "model.call_start". Model API dispatch metadata for internal telemetry
- */
-/** @internal */
-export interface ModelCallStartEvent {
-  /**
-   * Sub-agent instance identifier. Absent for events from the root/main agent and session-level events.
-   */
-  agentId?: string;
-  data: ModelCallStartData;
-  /**
-   * Always true for events that are transient and not persisted to the session event log on disk.
-   */
-  ephemeral: true;
-  /**
-   * Unique event identifier (UUID v4), generated when the event is emitted
-   */
-  id: string;
-  /**
-   * ID of the chronologically preceding event in the session, forming a linked chain. Null for the first event.
-   */
-  parentId: string | null;
-  /**
-   * ISO 8601 timestamp when the event was created
-   */
-  timestamp: string;
-  /**
-   * Type discriminator. Always "model.call_start".
-   */
-  type: "model.call_start";
-}
-/**
- * Model API dispatch metadata for internal telemetry
- */
-export interface ModelCallStartData {
-  /**
-   * Model identifier used for this API call, when known
-   */
-  model?: string;
-  /**
-   * Identifier of the assistant turn that initiated the model call
-   */
-  turnId: string;
 }
 /**
  * Session event "abort". Turn abort information including the reason for termination

--- a/nodejs/test/session-event-codegen.test.ts
+++ b/nodejs/test/session-event-codegen.test.ts
@@ -5,8 +5,59 @@ import { generateSessionEventsCode as generateCSharpSessionEventsCode } from "..
 import { generateGoSessionEventsCode } from "../../scripts/codegen/go.ts";
 import { generatePythonSessionEventsCode } from "../../scripts/codegen/python.ts";
 import { generateSessionEventsCode as generateRustSessionEventsCode } from "../../scripts/codegen/rust.ts";
+import { generateTypeScriptSessionEventsCode } from "../../scripts/codegen/typescript.ts";
 
 describe("session event codegen", () => {
+    it("excludes internal event wrappers from the public TypeScript union", async () => {
+        const schema: JSONSchema7 = {
+            definitions: {
+                SessionEvent: {
+                    anyOf: [
+                        { $ref: "#/definitions/PublicEvent" },
+                        { $ref: "#/definitions/InternalEvent" },
+                    ],
+                },
+                PublicEvent: {
+                    type: "object",
+                    required: ["type", "data"],
+                    properties: {
+                        type: { const: "session.public" },
+                        data: { $ref: "#/definitions/PublicData" },
+                    },
+                },
+                PublicData: {
+                    type: "object",
+                    required: ["message"],
+                    properties: {
+                        message: { type: "string" },
+                    },
+                },
+                InternalEvent: {
+                    type: "object",
+                    visibility: "internal",
+                    required: ["type", "data"],
+                    properties: {
+                        type: { const: "session.internal" },
+                        data: { $ref: "#/definitions/InternalData" },
+                    },
+                },
+                InternalData: {
+                    type: "object",
+                    required: ["attempt"],
+                    properties: {
+                        attempt: { type: "number" },
+                    },
+                },
+            },
+        };
+
+        const code = await generateTypeScriptSessionEventsCode(schema);
+
+        expect(code).toContain("export interface PublicEvent");
+        expect(code).not.toContain("InternalEvent");
+        expect(code).not.toContain("InternalData");
+    });
+
     it("maps special schema formats to the expected Python types", () => {
         const schema: JSONSchema7 = {
             definitions: {

--- a/scripts/codegen/typescript.ts
+++ b/scripts/codegen/typescript.ts
@@ -338,11 +338,7 @@ export function normalizeSchemaForTypeScript(schema: JSONSchema7): JSONSchema7 {
 
 // ── Session Events ──────────────────────────────────────────────────────────
 
-async function generateSessionEvents(schemaPath?: string): Promise<void> {
-    console.log("TypeScript: generating session-events...");
-
-    const resolvedPath = schemaPath ?? (await getSessionEventsSchemaPath());
-    const schema = (await loadSchemaJson(resolvedPath)) as JSONSchema7;
+export async function generateTypeScriptSessionEventsCode(schema: JSONSchema7): Promise<string> {
     const processed = propagateInternalVisibility(postProcessSchema(schema));
     const definitionCollections = collectDefinitionCollections(processed as Record<string, unknown>);
     const sessionEvent =
@@ -355,7 +351,7 @@ async function generateSessionEvents(schemaPath?: string): Promise<void> {
         const resolvedVariant = resolveSchema(variantSchema, definitionCollections) ?? variantSchema;
         const dataSchema = resolvedVariant.properties?.data as JSONSchema7 | undefined;
         const resolvedData = dataSchema ? resolveSchema(dataSchema, definitionCollections) ?? dataSchema : undefined;
-        if (!isSchemaInternal(resolvedData)) {
+        if (!isSchemaInternal(resolvedVariant) && !isSchemaInternal(resolvedData)) {
             return true;
         }
 
@@ -415,6 +411,15 @@ async function generateSessionEvents(schemaPath?: string): Promise<void> {
             `$1/** @internal */\n$2`
         );
     }
+    return annotatedTs;
+}
+
+async function generateSessionEvents(schemaPath?: string): Promise<void> {
+    console.log("TypeScript: generating session-events...");
+
+    const resolvedPath = schemaPath ?? (await getSessionEventsSchemaPath());
+    const schema = (await loadSchemaJson(resolvedPath)) as JSONSchema7;
+    const annotatedTs = await generateTypeScriptSessionEventsCode(schema);
     const outPath = await writeGeneratedFile("nodejs/src/generated/session-events.ts", annotatedTs);
     console.log(`  ✓ ${outPath}`);
 }


### PR DESCRIPTION
## Summary

Fix the Node SDK's generated public `SessionEvent` declaration after internal event wrappers are stripped from the published package.

The generator already excluded variants whose `data` schema is internal, but `assistant.turn_retry` and `model.call_start` mark the event wrapper itself as internal. Their interfaces were removed by `stripInternal`, while their names remained in the public union. This left the published declaration with unresolved references and caused event payload types to degrade for consumers using `skipLibCheck`.

This change filters variants when either the resolved wrapper or its data schema is internal, regenerates the TypeScript session events, and adds a regression test for the wrapper-internal/data-public case.

Fixes #2078.

## Validation

- `npx vitest run test/*.test.ts` — 243 tests passed
- `npm run build`
- `npm run typecheck`
- `npm run lint` — no errors (3 existing warnings)
- `npm run format:check`
- Compiled `dist/generated/session-events.d.ts` with `skipLibCheck: false`
- `git diff --check`
