### PR TITLE
docs: fix non-compiling Rust session-limits example

### DIFF
--- a/docs/features/session-limits.md
+++ b/docs/features/session-limits.md
@@ -131,7 +131,7 @@ let limits = SessionLimitsConfig {
 
 let session = client
     .create_session(
-        SessionConfig::new()
+        SessionConfig::default()
             .approve_all_permissions()
             .with_session_limits(limits.clone()),
     )


### PR DESCRIPTION
### Summary

The Rust example in the "Configure a session limit" section of
`docs/features/session-limits.md` did not compile: it called
`SessionConfig::new()`, which does not exist. `SessionConfig` is constructed with
`SessionConfig::default()` plus builder methods (the crate uses `default()`
throughout; there is no `SessionConfig::new`). This one-line change makes the
documented snippet compile.

Fixes #2081

### Change

`docs/features/session-limits.md`, Rust tab:

```diff
-        SessionConfig::new()
+        SessionConfig::default()
```

### Root cause

`SessionConfig` (`rust/src/types.rs`) implements `Default` plus builder methods
but has no `new` associated function, so `SessionConfig::new()` fails with
`error[E0599]`. The snippet was a mistranslation of the sibling
TypeScript/Go/Java/.NET tabs, which all construct-then-configure. The block
carries `<!-- docs-validate: skip -->` and Rust is not in the doc-validation
language set, so CI never compiled it. The neighboring resume example already
uses the real `ResumeSessionConfig::new(session_id)` (a different type) and is
left unchanged.

### Verification

Reproducer against the published crate:

`Cargo.toml`:

```toml
[dependencies]
github-copilot-sdk = "*"
tokio = { version = "1", features = ["full"] }
```

`src/main.rs`: the documented snippet wrapped in the minimal
`#[tokio::main] async fn main` the guide implies.

- Before: `cargo build` fails with
  `error[E0599]: no associated function ... named 'new' found for struct 'SessionConfig'`.
- After (`SessionConfig::new()` -> `SessionConfig::default()`): `cargo build`
  finishes clean.
