### PR TITLE
Fix Go telemetry examples: NewClient takes *ClientOptions and returns one value

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2158,7 +2158,7 @@ Install with telemetry extras: `pip install copilot-sdk[telemetry]` (provides `o
 
 <!-- docs-validate: skip -->
 ```go
-client, err := copilot.NewClient(copilot.ClientOptions{
+client := copilot.NewClient(&copilot.ClientOptions{
     Telemetry: &copilot.TelemetryConfig{
         OTLPEndpoint: "http://localhost:4318",
     },

--- a/docs/observability/opentelemetry.md
+++ b/docs/observability/opentelemetry.md
@@ -43,7 +43,7 @@ client = CopilotClient(
 
 <!-- docs-validate: skip -->
 ```go
-client, err := copilot.NewClient(copilot.ClientOptions{
+client := copilot.NewClient(&copilot.ClientOptions{
     Telemetry: &copilot.TelemetryConfig{
         OTLPEndpoint: "http://localhost:4318",
     },

--- a/go/README.md
+++ b/go/README.md
@@ -646,7 +646,7 @@ session, err := client.CreateSession(context.Background(), &copilot.SessionConfi
 The SDK supports OpenTelemetry for distributed tracing. Provide a `Telemetry` config to enable trace export and automatic W3C Trace Context propagation.
 
 ```go
-client, err := copilot.NewClient(copilot.ClientOptions{
+client := copilot.NewClient(&copilot.ClientOptions{
     Telemetry: &copilot.TelemetryConfig{
         OTLPEndpoint: "http://localhost:4318",
     },


### PR DESCRIPTION
Fixes #2085

## What was wrong

The Go OpenTelemetry example did not compile against the published module. It bound two return values and passed `ClientOptions` by value, while `go/client.go` declares:

```go
func NewClient(options *ClientOptions) *Client
```

The same five-line snippet was duplicated byte-for-byte in three files, so all three were broken identically:

- `go/README.md`, under `## Telemetry`
- `docs/observability/opentelemetry.md`, Go tab
- `docs/getting-started.md`, telemetry section, Go tab

## Reproduction

Against the published module:

```bash
mkdir telemetry-repro && cd telemetry-repro
go mod init telemetry-repro
go get github.com/github/copilot-sdk/go@v1.0.8
```

with the documented snippet in `main.go` (plus `_ = client` / `_ = err` so the only errors are the example's own):

```
./main.go:6:17: assignment mismatch: 2 variables but copilot.NewClient returns 1 value
./main.go:6:35: cannot use copilot.ClientOptions{...} (value of struct type copilot.ClientOptions) as *copilot.ClientOptions value in argument to copilot.NewClient
```

## The fix

One line in each of the three copies:

```diff
-client, err := copilot.NewClient(copilot.ClientOptions{
+client := copilot.NewClient(&copilot.ClientOptions{
```

`err` is dropped because `NewClient` returns no error; failures surface later from `Start` and `CreateSession`. This matches `NewClient`'s own doc comment and the pointer form used by the other `ClientOptions` examples in the documentation. No Go source, no public API, and no other line of the snippets changed.

## Verification

- Each corrected block was extracted verbatim from its file and compiled against this branch's `go` module: all three build cleanly. The same three blocks on `main` fail with the two errors above. Repeated in fresh module directories with identical results.
- The reproduction above was also run against the published `v1.0.8` module: the documented snippet fails with those two errors, and the corrected form compiles.
- `cd go && go build ./... && go vet ./... && gofmt -l .` is clean. No Go source is touched by this PR.
- `scripts/docs-validation`: `npm run extract && npm run validate:go` passes (47 Go blocks). The extractor produces identical extracted Go sources before and after this change (`manifest.json` differs only in its generated `extractedAt` timestamp), so no other block's validation state moved.

## Notes

- No automated check currently covers these three lines: `go/README.md` sits outside the docs-validation input directory, and both `docs/` blocks carry `<!-- docs-validate: skip -->` because they are fragments with no imports and no `main`. I left the markers and the validation scripts alone, since widening that coverage looks like a separate change.
- `docs/features/remote-sessions.md` has a different broken Go snippet: `client, _ := copilot.NewClient(&copilot.ClientOptions{Remote: true})`. The pointer is already correct there, but it still binds two values and sets a `Remote` field that does not exist (`ClientOptions` has `EnableRemoteSessions`). That one needs a decision about the intended field, so it is not part of this PR.
