### PR TITLE
Fix the Node.js tool-definition example in the Microsoft Agent Framework guide

### DIFF
--- a/docs/integrations/microsoft-agent-framework.md
+++ b/docs/integrations/microsoft-agent-framework.md
@@ -206,13 +206,19 @@ You can also use Copilot SDK's native tool definition alongside MAF tools:
 <summary><strong>Node.js / TypeScript (standalone SDK)</strong></summary>
 
 ```typescript
-import { CopilotClient, DefineTool } from "@github/copilot-sdk";
+import { CopilotClient, defineTool } from "@github/copilot-sdk";
 
-const getWeather = DefineTool({
-    name: "GetWeather",
+const getWeather = defineTool("GetWeather", {
     description: "Get the current weather for a given location.",
-    parameters: { location: { type: "string", description: "City name" } },
-    execute: async ({ location }) => `The weather in ${location} is sunny, 25°C.`,
+    parameters: {
+        type: "object",
+        properties: {
+            location: { type: "string", description: "City name" },
+        },
+        required: ["location"],
+    },
+    handler: async ({ location }: { location: string }) =>
+        `The weather in ${location} is sunny, 25°C.`,
 });
 
 const client = new CopilotClient();


### PR DESCRIPTION
Fixes #2087

The "Node.js / TypeScript (standalone SDK)" example under **Adding custom tools** in
`docs/integrations/microsoft-agent-framework.md` could not be copied and run. This corrects it.

## What was wrong

Three problems in the same block, all of which had to be fixed for the example to work:

1. It imported `DefineTool`, which `@github/copilot-sdk` does not export. The export is
   `defineTool`. (`DefineTool` is the correct spelling in the Go and .NET SDKs, and the .NET block
   earlier in the same section uses it correctly.)
2. It called the helper with a single config object carrying `name` and `execute`. The signature is
   `defineTool(name, config)`, and the callback key is `handler`. An `execute` key is not registered
   as the tool's handler and is not sent with the tool definition.
3. `parameters` was `{ location: { type: "string", description: "City name" } }`, which as a JSON
   Schema declares no properties. A non-Zod `parameters` value is forwarded unchanged, so the tool
   would have been advertised with no declared `location` property, while its callback destructures
   `location`.

## The change

```diff
-import { CopilotClient, DefineTool } from "@github/copilot-sdk";
+import { CopilotClient, defineTool } from "@github/copilot-sdk";

-const getWeather = DefineTool({
-    name: "GetWeather",
+const getWeather = defineTool("GetWeather", {
     description: "Get the current weather for a given location.",
-    parameters: { location: { type: "string", description: "City name" } },
-    execute: async ({ location }) => `The weather in ${location} is sunny, 25°C.`,
+    parameters: {
+        type: "object",
+        properties: {
+            location: { type: "string", description: "City name" },
+        },
+        required: ["location"],
+    },
+    handler: async ({ location }: { location: string }) =>
+        `The weather in ${location} is sunny, 25°C.`,
 });
```

The schema now matches what the Java example for the same `GetWeather` tool, later in this section,
already declares. The raw JSON Schema form matches the TypeScript tool example in
`docs/getting-started.md`; a Zod schema would work equally well, but keeping raw JSON Schema avoids
adding a dependency to a standalone snippet. The callback argument is annotated because a raw schema,
unlike a Zod schema, does not give the callback's parameter a type under `--strict`.

This is the only hunk. The rest of the example (client construction, `createSession`, `sendAndWait`)
is untouched, and no SDK source changes.

## Verification

Compiling the block extracted from the document by line range, against the published package
`@github/copilot-sdk@1.0.8` with TypeScript 7.0.2 and
`--target ES2022 --module NodeNext --moduleResolution NodeNext --strict --skipLibCheck --noEmit`:

Before:

```
repro.ts(1,25): error TS2724: '"@github/copilot-sdk"' has no exported member named 'DefineTool'. Did you mean 'defineTool'?
repro.ts(7,23): error TS7031: Binding element 'location' implicitly has an 'any' type.
```

Correcting only the casing, to show the call shape is independently wrong:

```
nameonly.ts(3,20): error TS2554: Expected 2 arguments, but got 1.
nameonly.ts(7,23): error TS7031: Binding element 'location' implicitly has an 'any' type.
```

After:

```
(no diagnostics, exit 0)
```

The same before and after checks were also run against a local build of this branch, with the same
results. `node --input-type=module -e 'import { CopilotClient, defineTool } from "@github/copilot-sdk";'`
now resolves, where the previous `DefineTool` import threw.
