### PR TITLE
Fix the plan-mode exit action type name in the fleet mode guide

### DIFF
--- a/docs/features/fleet-mode.md
+++ b/docs/features/fleet-mode.md
@@ -176,7 +176,7 @@ Native typed bindings for fleet mode were verified in Node.js/TypeScript, Python
 Plan-mode UIs can start fleet deployment by returning the `autopilot_fleet` exit action. The generated session event types describe it as:
 
 ```typescript
-type PlanModeExitAction =
+type ExitPlanModeAction =
   | "exit_only"
   | "interactive"
   | "autopilot"


### PR DESCRIPTION
The "From plan mode" section of `docs/features/fleet-mode.md` introduces its snippet with "The
generated session event types describe it as:", and then labels the union `PlanModeExitAction`.
The generated session-event union is `ExitPlanModeAction`; the SDK does not export the
documented name, which appears nowhere in the repository outside that snippet and nowhere in the
published package.

This renames the identifier in that one snippet. The four string values were already correct.

Fixes #2089

## The change

```diff
-type PlanModeExitAction =
+type ExitPlanModeAction =
```

One token, in `docs/features/fleet-mode.md`.

## Why this identifier

- The sentence above the snippet says "generated **session event** types", and
  `ExitPlanModeAction` is declared in `nodejs/src/generated/session-events.ts` and re-exported
  as a type from the package root.
- The generated session-event payloads use it directly for `actions`, `recommendedAction` and
  `selectedAction`.
- The comment the snippet keeps for `autopilot_fleet` matches the one on that declaration.

## Before and after

Against the published package (`@github/copilot-sdk@1.0.8`, TypeScript 5.9.3, `strict`,
`moduleResolution: NodeNext`, `skipLibCheck`):

```console
# the identifier the guide showed
$ npx tsc --project tsconfig.json
old-name.ts(1,15): error TS2305: Module '"@github/copilot-sdk"' has no exported member 'PlanModeExitAction'.

# the identifier the guide now shows
$ npx tsc --project tsconfig.json
$ echo $?
0
```

A value outside the union is still rejected (`error TS2322: Type '"autopilot_swarm"' is not
assignable to type 'ExitPlanModeAction'`), so the corrected name really does resolve to the
four-value union.

## Checks

`npm run extract && npm run validate:ts` in `scripts/docs-validation` passes before and after
this change - the snippet declares its own alias, so it compiled either way. The four values and
their order match `nodejs/src/generated/session-events.ts` exactly.

Only `docs/features/fleet-mode.md` changes; no generated file, binding source, or public API is
touched.
