### PR TITLE
docs: rename Azure AI Foundry to Microsoft Foundry in BYOK guide

### DIFF
--- a/docs/auth/byok.md
+++ b/docs/auth/byok.md
@@ -7,15 +7,15 @@ BYOK allows you to use the Copilot SDK with your own API keys from model provide
 | Provider | Type Value | Notes |
 |----------|------------|-------|
 | OpenAI | `"openai"` | OpenAI API and OpenAI-compatible endpoints |
-| Azure OpenAI / Azure AI Foundry | `"azure"` | Azure-hosted models |
+| Azure OpenAI / Microsoft Foundry | `"azure"` | Azure-hosted models |
 | Anthropic | `"anthropic"` | Claude models |
 | Ollama | `"openai"` | Local models via OpenAI-compatible API |
 | Microsoft Foundry Local | `"openai"` | Run AI models locally on your device via OpenAI-compatible API |
 | Other OpenAI-compatible | `"openai"` | vLLM, LiteLLM, etc. |
 
-## Quick start: Azure AI Foundry
+## Quick start: Microsoft Foundry
 
-Azure AI Foundry (formerly Azure OpenAI) is a common BYOK deployment target for enterprises. Here's a complete example:
+Microsoft Foundry (formerly Azure AI Foundry) is a common BYOK deployment target for enterprises. Here's a complete example:
 
 <details open>
 <summary><strong>Python</strong></summary>
@@ -260,9 +260,9 @@ provider: {
 }
 ```
 
-### Azure AI Foundry (OpenAI-compatible endpoint)
+### Microsoft Foundry (OpenAI-compatible endpoint)
 
-For Azure AI Foundry deployments with `/openai/v1/` endpoints, use `type: "openai"`:
+For Microsoft Foundry deployments with `/openai/v1/` endpoints, use `type: "openai"`:
 
 ```typescript
 provider: {
@@ -514,7 +514,7 @@ Some Copilot features may behave differently with BYOK:
 
 | Provider | Limitations |
 |----------|-------------|
-| Azure AI Foundry | No Entra ID auth; must use API keys |
+| Microsoft Foundry | No Entra ID auth; must use API keys |
 | Ollama | No API key; local only; model support varies |
 | [Microsoft Foundry Local](https://foundrylocal.ai) | Local only; model availability depends on device hardware; no API key required |
 | OpenAI | Subject to OpenAI rate limits and quotas |
@@ -571,7 +571,7 @@ provider: {
 }
 ```
 
-However, if your Azure AI Foundry deployment provides an OpenAI-compatible endpoint path (e.g., `/openai/v1/`), use `type: "openai"`:
+However, if your Microsoft Foundry deployment provides an OpenAI-compatible endpoint path (e.g., `/openai/v1/`), use `type: "openai"`:
 
 <!-- docs-validate: hidden -->
 ```typescript
@@ -589,7 +589,7 @@ const session = await client.createSession({
 <!-- /docs-validate: hidden -->
 
 ```typescript
-// ✅ Correct: OpenAI-compatible Azure AI Foundry endpoint
+// ✅ Correct: OpenAI-compatible Microsoft Foundry endpoint
 provider: {
     type: "openai",
     baseUrl: "https://your-resource.openai.azure.com/openai/v1/",

--- a/docs/auth/byok.md
+++ b/docs/auth/byok.md
@@ -7,7 +7,7 @@ BYOK allows you to use the Copilot SDK with your own API keys from model provide
 | Provider | Type Value | Notes |
 |----------|------------|-------|
 | OpenAI | `"openai"` | OpenAI API and OpenAI-compatible endpoints |
-| Azure OpenAI / Microsoft Foundry | `"azure"` | Azure-hosted models |
+| Microsoft Foundry / Azure OpenAI | `"openai"` or `"azure"` | Use `"openai"` for `/openai/v1/`; use `"azure"` for native Azure endpoints |
 | Anthropic | `"anthropic"` | Claude models |
 | Ollama | `"openai"` | Local models via OpenAI-compatible API |
 | Microsoft Foundry Local | `"openai"` | Run AI models locally on your device via OpenAI-compatible API |

--- a/docs/auth/byok.md
+++ b/docs/auth/byok.md
@@ -493,14 +493,6 @@ Results are cached after the first call, just like the default behavior. The han
 
 ## Limitations
 
-When using BYOK, be aware of these limitations:
-
-### Identity limitations
-
-BYOK authentication uses **static credentials only**.
-
-You must use an API key or static bearer token that you manage yourself.
-
 ### Feature limitations
 
 Some Copilot features may behave differently with BYOK:
@@ -514,9 +506,8 @@ Some Copilot features may behave differently with BYOK:
 
 | Provider | Limitations |
 |----------|-------------|
-| Microsoft Foundry | None |
-| Ollama | No API key; local only; model support varies |
 | [Microsoft Foundry Local](https://foundrylocal.ai) | Local only; model availability depends on device hardware; no API key required |
+| Ollama | No API key; local only; model support varies |
 | OpenAI | Subject to OpenAI rate limits and quotas |
 
 ## Troubleshooting

--- a/docs/auth/byok.md
+++ b/docs/auth/byok.md
@@ -514,7 +514,7 @@ Some Copilot features may behave differently with BYOK:
 
 | Provider | Limitations |
 |----------|-------------|
-| Microsoft Foundry | No Entra ID auth; must use API keys |
+| Microsoft Foundry | None |
 | Ollama | No API key; local only; model support varies |
 | [Microsoft Foundry Local](https://foundrylocal.ai) | Local only; model availability depends on device hardware; no API key required |
 | OpenAI | Subject to OpenAI rate limits and quotas |

--- a/docs/auth/byok.md
+++ b/docs/auth/byok.md
@@ -562,7 +562,7 @@ provider: {
 }
 ```
 
-However, if your Microsoft Foundry deployment provides an OpenAI-compatible endpoint path (e.g., `/openai/v1/`), use `type: "openai"`:
+However, if your Microsoft Foundry deployment provides an OpenAI-compatible endpoint path (for example, `/openai/v1/`), use `type: "openai"`:
 
 <!-- docs-validate: hidden -->
 ```typescript

--- a/docs/auth/byok.md
+++ b/docs/auth/byok.md
@@ -15,7 +15,7 @@ BYOK allows you to use the Copilot SDK with your own API keys from model provide
 
 ## Quick start: Microsoft Foundry
 
-Microsoft Foundry (formerly Azure AI Foundry) is a common BYOK deployment target for enterprises. Here's a complete example:
+Microsoft Foundry is a common BYOK deployment target for enterprises. Here's a complete example:
 
 <details open>
 <summary><strong>Python</strong></summary>


### PR DESCRIPTION
## Why
The BYOK documentation needed to reflect current product naming and remove outdated branding references so readers see consistent terminology.

## What changed
* Replaced Azure AI Foundry references with Microsoft Foundry across `docs/auth/byok.md`. The product was rebranded a while back.
* Updated the quick-start sentence to remove the parenthetical legacy name.
* Removed the `Identity limitations` section.
* Removed the `Microsoft Foundry` row from provider-specific limitations.

## Notes
N/A