### PR TITLE
Fix the Python list_sessions docstring example to use session_id

### DIFF
--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -3386,7 +3386,7 @@ class CopilotClient:
         Example:
             >>> sessions = await client.list_sessions()
             >>> for session in sessions:
-            ...     print(f"Session: {session.sessionId}")
+            ...     print(f"Session: {session.session_id}")
             >>> # Filter sessions by repository
             >>> from copilot.client import SessionListFilter
             >>> filtered = await client.list_sessions(SessionListFilter(repository="owner/repo"))


### PR DESCRIPTION
Fixes #2098

### What was wrong

The `Example:` block in the `CopilotClient.list_sessions` docstring printed `session.sessionId`.
`list_sessions` returns `list[SessionMetadata]`, and that dataclass declares `session_id`;
`sessionId` exists only as the wire key, mapped to `session_id` inside
`SessionMetadata.from_dict` / `to_dict`. There is no `sessionId` property, alias, or
`__getattr__` fallback, so anyone copying the documented example hit `AttributeError`.

### The change

```diff
         Example:
             >>> sessions = await client.list_sessions()
             >>> for session in sessions:
-            ...     print(f"Session: {session.sessionId}")
+            ...     print(f"Session: {session.session_id}")
```

One token, in the docstring text of a hand-written binding source file. No public API, behavior,
schema, or wire format change; no generated file is touched.

### Why `session_id` is the right spelling

- `SessionMetadata` declares `session_id` and never `sessionId`.
- The end-to-end tests assert `session_id` on exactly this return value
  (`python/e2e/test_session_e2e.py`).
- The generated sibling type `SessionMetadataSnapshot` also uses `session_id`, and the Python
  code generator converts every property to snake_case.
- The sibling docstring for `get_session_metadata` already documents the same object correctly,
  as `metadata.start_time`.

The alternatives -- adding a `sessionId` alias, or renaming the dataclass field -- would both
change the public Python API, so correcting the example is the minimal correct fix.

### Reproduction

Against the published package, with no server, model, or credentials:

```bash
pip install github-copilot-sdk
```

```python
from copilot.client import SessionMetadata

wire = {
    "sessionId": "abc-123",
    "startTime": "2026-06-27T10:00:00Z",
    "modifiedTime": "2026-06-27T10:05:00Z",
    "isRemote": False,
    "summary": "demo session",
}
session = SessionMetadata.from_dict(wire)

# The documented example:
print(f"Session: {session.sessionId}")
```

**Before:**

```
Traceback (most recent call last):
  File "repro.py", line 13, in <module>
    print(f"Session: {session.sessionId}")
                      ^^^^^^^^^^^^^^^^^
AttributeError: 'SessionMetadata' object has no attribute 'sessionId'. Did you mean: 'session_id'?
```

**After:** the documented example prints `Session: abc-123`.

I also checked the shipped docstring itself, by parsing the example out of the installed
package's `CopilotClient.list_sessions.__doc__` and executing it: it raises `AttributeError`
before the change and prints the session id after.

### Checks run

From `python/`, matching `.github/workflows/python-sdk-tests.yml`:

- `ruff check .` -- passes.
- `ty check copilot` -- passes (2 pre-existing warnings, neither near this line).
- `ruff format --check copilot/client.py` -- already formatted; the changed line is 59 characters
  against a 100-character limit, so `docstring-code-format` has nothing to reflow.
- `pytest` -- per-test results are identical before and after the change, and
  `test_should_list_sessions` passes. The few end-to-end tests that fail in my local environment
  fail the same way on an unmodified tree.

### Scope

Python only. Go already documents this method as `session.SessionID` (`go/client.go`) and .NET as
`session.SessionId` (`dotnet/src/Client.cs`), so the other bindings are correct as they stand and
no cross-binding change is needed.
