### PR TITLE
docs: correct the delta field the MAF streaming example reads

### DIFF
--- a/docs/integrations/microsoft-agent-framework.md
+++ b/docs/integrations/microsoft-agent-framework.md
@@ -530,7 +530,7 @@ const session = await client.createSession({
 });
 
 session.on("assistant.message_delta", (event) => {
-    process.stdout.write(event.data.delta ?? "");
+    process.stdout.write(event.data.deltaContent ?? "");
 });
 
 await session.sendAndWait({ prompt: "Write a quicksort implementation in TypeScript" });


### PR DESCRIPTION
Fixes #2104

The "Node.js / TypeScript (standalone SDK)" example under **Streaming responses** in the Microsoft Agent Framework guide registered an `assistant.message_delta` handler that read `event.data.delta`. The payload type for that event, `AssistantMessageDeltaData`, declares `deltaContent`; there is no `delta`. The read therefore evaluated to `undefined`, the `?? ""` fallback turned that into an empty string, and the handler wrote nothing for each delta event.

### The change

```diff
 session.on("assistant.message_delta", (event) => {
-    process.stdout.write(event.data.delta ?? "");
+    process.stdout.write(event.data.deltaContent ?? "");
 });
```

`docs/integrations/microsoft-agent-framework.md`, one line. `event.data.delta` appeared exactly once in the repository; it now appears nowhere.

`deltaContent` is required, so the `?? ""` fallback is inert either way. It is kept as-is to hold the change to the single field name.

### Why `deltaContent`

`AssistantMessageDeltaData` (`nodejs/src/generated/session-events.ts`) declares `deltaContent`, `messageId` and an optional deprecated `parentToolCallId`. The generated types for Go, .NET, Java and Python agree on the same wire field, and the Java example in this same section of this same guide already calls `event.getData().deltaContent()`.

### Verification

Extracting the doc block and type-checking it against the SDK source types, with the compiler options `scripts/docs-validation/validate.ts` generates:

- before: `snippet.ts(11,37): error TS2339: Property 'delta' does not exist on type 'AssistantMessageDeltaData'.` (exit 2)
- after: no diagnostics (exit 0)

That is the block's only type error, and this change removes it.

Observed behaviour, using an instrumented handler that accumulates both accessors side by side rather than the doc block verbatim:

```
payload keys:           ["messageId","deltaContent"]
event.data.delta:       ""
event.data.deltaContent: "pong"
```

Checks run in `nodejs/`: `npm run lint`, `npm run typecheck`, `npm run format:check` and `npm test` all pass.
