### PR TITLE
Fix flaky .NET ask-user E2E tests

### DIFF
--- a/dotnet/test/E2E/AskUserE2ETests.cs
+++ b/dotnet/test/E2E/AskUserE2ETests.cs
@@ -30,12 +30,10 @@ public class AskUserE2ETests(E2ETestFixture fixture, ITestOutputHelper output) :
             }
         });
 
-        await session.SendAsync(new MessageOptions
+        await session.SendAndWaitAsync(new MessageOptions
         {
             Prompt = "Ask me to choose between 'Option A' and 'Option B' using the ask_user tool. Wait for my response before continuing."
-        });
-
-        await TestHelper.GetFinalAssistantMessageAsync(session);
+        }, TimeSpan.FromSeconds(120));
 
         // Should have received at least one user input request
         Assert.NotEmpty(userInputRequests);
@@ -62,12 +60,10 @@ public class AskUserE2ETests(E2ETestFixture fixture, ITestOutputHelper output) :
             }
         });
 
-        await session.SendAsync(new MessageOptions
+        await session.SendAndWaitAsync(new MessageOptions
         {
             Prompt = "Use the ask_user tool to ask me to pick between exactly two options: 'Red' and 'Blue'. These should be provided as choices. Wait for my answer."
-        });
-
-        await TestHelper.GetFinalAssistantMessageAsync(session);
+        }, TimeSpan.FromSeconds(120));
 
         // Should have received a request
         Assert.NotEmpty(userInputRequests);

--- a/dotnet/test/E2E/AskUserE2ETests.cs
+++ b/dotnet/test/E2E/AskUserE2ETests.cs
@@ -33,7 +33,7 @@ public class AskUserE2ETests(E2ETestFixture fixture, ITestOutputHelper output) :
         await session.SendAndWaitAsync(new MessageOptions
         {
             Prompt = "Ask me to choose between 'Option A' and 'Option B' using the ask_user tool. Wait for my response before continuing."
-        }, TimeSpan.FromSeconds(120));
+        });
 
         // Should have received at least one user input request
         Assert.NotEmpty(userInputRequests);
@@ -63,7 +63,7 @@ public class AskUserE2ETests(E2ETestFixture fixture, ITestOutputHelper output) :
         await session.SendAndWaitAsync(new MessageOptions
         {
             Prompt = "Use the ask_user tool to ask me to pick between exactly two options: 'Red' and 'Blue'. These should be provided as choices. Wait for my answer."
-        }, TimeSpan.FromSeconds(120));
+        });
 
         // Should have received a request
         Assert.NotEmpty(userInputRequests);


### PR DESCRIPTION
## Summary

- use `SendAndWaitAsync` for the two .NET ask-user callback tests
- install the completion subscription before sending instead of relying on post-send event backfill
- use the standard 60-second `SendAndWaitAsync` timeout

## Failure analysis

[Run 30350279994 / job 90245871596](https://github.com/github/copilot-sdk/actions/runs/30350279994/job/90245871596) failed only on `windows-latest` when `Should_Receive_Choices_In_User_Input_Request` timed out in `TestHelper.GetFinalAssistantMessageAsync`. The triggering commit changed only documentation, the immediately preceding Windows run passed, and the sibling ask-user test completed in one second, so this is a synchronization flake rather than a product regression or generally slow runner.

The tests called `SendAsync` before subscribing for assistant/idle events, leaving a window where completion events had to be recovered through a separate `GetEventsAsync` backfill. `SendAndWaitAsync` subscribes before sending and is already used by the equivalent Node/Python tests and the third C# ask-user test.

## Validation

- `dotnet format --verify-no-changes --no-restore`
- `dotnet build --no-restore`
- 176 .NET unit tests
- all 3 ask-user E2E tests, including 10 consecutive focused runs