### PR TITLE
Fix flaky .NET session resume E2E test

### DIFF
--- a/dotnet/test/E2E/SessionE2ETests.cs
+++ b/dotnet/test/E2E/SessionE2ETests.cs
@@ -245,8 +245,7 @@ public class SessionE2ETests(E2ETestFixture fixture, ITestOutputHelper output) :
         var session1 = await CreateSessionAsync();
         var sessionId = session1.SessionId;
 
-        await session1.SendAsync(new MessageOptions { Prompt = "What is 1+1?" });
-        var answer = await TestHelper.GetFinalAssistantMessageAsync(session1);
+        var answer = await session1.SendAndWaitAsync(new MessageOptions { Prompt = "What is 1+1?" });
         Assert.NotNull(answer);
         Assert.Contains("2", answer!.Data.Content ?? string.Empty);
 


### PR DESCRIPTION
## Summary

- use `SendAndWaitAsync` for the initial message in the .NET session-resume E2E test
- install the completion subscription before sending so fast assistant/idle events cannot be missed
- preserve the existing resume-event and stateful-continuation assertions

## Failure analysis

[Run 30356278419 / job 90265115048](https://github.com/github/copilot-sdk/actions/runs/30356278419/job/90265115048) failed only in `Should_Resume_A_Session_Using_A_New_Client`, which timed out for two minutes in `TestHelper.GetFinalAssistantMessageAsync` while waiting for the initial `1+1` response. The remaining 457 tests passed.

The test called `SendAsync` before installing the helper subscription. A fast response could therefore deliver its assistant and idle events before the subscription existed, leaving completion dependent on a separate post-send `GetEventsAsync` backfill. This is the same synchronization race addressed for the ask-user tests in #2107. `SendAndWaitAsync` subscribes before sending and removes that window.

## Validation

- `dotnet format --verify-no-changes --no-restore`
- `dotnet build --no-restore`
- 178 .NET unit tests