### PR TITLE
chore: bump @github/copilot to ^1.0.75 and regenerate all SDKs

### DIFF
--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -65,7 +65,7 @@ internal sealed class ConnectResult
 [Experimental(Diagnostics.Experimental)]
 internal sealed class ConnectRequest
 {
-    /// <summary>Opt this connection in to GitHub telemetry forwarding for its lifetime. When set, the runtime forwards every internal telemetry event it emits — across all sessions, plus sessionless events — to this connection over the `gitHubTelemetry.event` notification, in addition to the runtime's normal GitHub/CTS emission (dual-write). Intended for first-party hosts that re-emit the events into their own telemetry stores. Both unrestricted and restricted events are forwarded, each tagged with a `restricted` discriminator; a backstop drops restricted events when restricted telemetry is disabled.</summary>
+    /// <summary>Opt this connection in to GitHub telemetry forwarding for its lifetime. When set, the runtime forwards every internal telemetry event it emits — across all sessions, plus sessionless events — to this connection over the `gitHubTelemetry.event` notification. Regular events are also written to the runtime's normal GitHub/CTS path (dual-write); host-only compatibility events are forward-only and intentionally skip that path. Intended for first-party hosts that re-emit the events into their own telemetry stores. Both unrestricted and restricted events are forwarded, each tagged with a `restricted` discriminator; a backstop drops restricted events when restricted telemetry is disabled — using the process-global gate for ordinary events and an explicit session-scoped decision for host-only events.</summary>
     [JsonPropertyName("enableGitHubTelemetryForwarding")]
     public bool? EnableGitHubTelemetryForwarding { get; set; }
 
@@ -2484,6 +2484,87 @@ internal sealed class SessionsListRequest
     public bool? ThrowOnError { get; set; }
 }
 
+/// <summary>Persisted local session metadata, including identifiers, timestamps, summary/name, client, context, detached state, and task ID.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class LocalSessionMetadataValue
+{
+    /// <summary>Runtime client name that created/last resumed this session.</summary>
+    [JsonPropertyName("clientName")]
+    public string? ClientName { get; set; }
+
+    /// <summary>Pre-resolved working-directory context for session startup.</summary>
+    [JsonPropertyName("context")]
+    public SessionContext? Context { get; set; }
+
+    /// <summary>True for detached maintenance sessions that should be hidden from normal resume lists.</summary>
+    [JsonPropertyName("isDetached")]
+    public bool? IsDetached { get; set; }
+
+    /// <summary>Always false for local sessions.</summary>
+    [JsonPropertyName("isRemote")]
+    public bool IsRemote { get; set; }
+
+    /// <summary>GitHub task ID, when this local session is bound to one. Only present for local sessions exported to remote control.</summary>
+    [JsonPropertyName("mcTaskId")]
+    public string? McTaskId { get; set; }
+
+    /// <summary>Last-modified time of the session's persisted state, as ISO 8601.</summary>
+    [JsonPropertyName("modifiedTime")]
+    public string ModifiedTime { get; set; } = string.Empty;
+
+    /// <summary>Optional human-friendly name set via /rename.</summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>Stable session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+
+    /// <summary>Session creation time as an ISO 8601 timestamp.</summary>
+    [JsonPropertyName("startTime")]
+    public string StartTime { get; set; } = string.Empty;
+
+    /// <summary>Short summary of the session, when one has been derived.</summary>
+    [JsonPropertyName("summary")]
+    public string? Summary { get; set; }
+}
+
+/// <summary>Persisted local session metadata when the session exists.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class SessionsGetMetadataResult
+{
+    /// <summary>Local session metadata, omitted when the session does not exist.</summary>
+    [JsonPropertyName("session")]
+    public LocalSessionMetadataValue? Session { get; set; }
+}
+
+/// <summary>Session ID whose persisted metadata should be read.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class SessionsGetMetadataRequest
+{
+    /// <summary>Session ID to inspect.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Recent local session IDs that contain user-visible history.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class SessionsListNonEmptySessionIdsResult
+{
+    /// <summary>Session IDs ordered newest-first.</summary>
+    [JsonPropertyName("sessionIds")]
+    public IList<string> SessionIds { get => field ??= []; set; }
+}
+
+/// <summary>Limit for non-empty local session IDs.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class SessionsListNonEmptySessionIdsRequest
+{
+    /// <summary>Maximum number of session IDs to return.</summary>
+    [JsonPropertyName("limit")]
+    public long? Limit { get; set; }
+}
+
 /// <summary>ID of the local session bound to the given GitHub task, or omitted when none.</summary>
 [Experimental(Diagnostics.Experimental)]
 public sealed class SessionsFindByTaskIDResult
@@ -2634,6 +2715,19 @@ internal sealed class SessionsBulkDeleteRequest
     public IList<string> SessionIds { get => field ??= []; set; }
 }
 
+/// <summary>Session ID to delete from disk.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class SessionsDeleteRequest
+{
+    /// <summary>Session ID to delete.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+
+    /// <summary>Internal resolved session directory path to delete.</summary>
+    [JsonPropertyName("sessionPath")]
+    public string? SessionPath { get; set; }
+}
+
 /// <summary>Outcome of the prune operation: deleted IDs, dry-run candidates, skipped IDs, total bytes freed, and the dry-run flag.</summary>
 [Experimental(Diagnostics.Experimental)]
 public sealed class SessionPruneResult
@@ -2708,51 +2802,6 @@ internal sealed class SessionsReleaseLockRequest
     /// <summary>Session ID whose in-use lock should be released.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
-}
-
-/// <summary>Persisted local session metadata, including identifiers, timestamps, summary/name, client, context, detached state, and task ID.</summary>
-[Experimental(Diagnostics.Experimental)]
-public sealed class LocalSessionMetadataValue
-{
-    /// <summary>Runtime client name that created/last resumed this session.</summary>
-    [JsonPropertyName("clientName")]
-    public string? ClientName { get; set; }
-
-    /// <summary>Pre-resolved working-directory context for session startup.</summary>
-    [JsonPropertyName("context")]
-    public SessionContext? Context { get; set; }
-
-    /// <summary>True for detached maintenance sessions that should be hidden from normal resume lists.</summary>
-    [JsonPropertyName("isDetached")]
-    public bool? IsDetached { get; set; }
-
-    /// <summary>Always false for local sessions.</summary>
-    [JsonPropertyName("isRemote")]
-    public bool IsRemote { get; set; }
-
-    /// <summary>GitHub task ID, when this local session is bound to one. Only present for local sessions exported to remote control.</summary>
-    [JsonPropertyName("mcTaskId")]
-    public string? McTaskId { get; set; }
-
-    /// <summary>Last-modified time of the session's persisted state, as ISO 8601.</summary>
-    [JsonPropertyName("modifiedTime")]
-    public string ModifiedTime { get; set; } = string.Empty;
-
-    /// <summary>Optional human-friendly name set via /rename.</summary>
-    [JsonPropertyName("name")]
-    public string? Name { get; set; }
-
-    /// <summary>Stable session identifier.</summary>
-    [JsonPropertyName("sessionId")]
-    public string SessionId { get; set; } = string.Empty;
-
-    /// <summary>Session creation time as an ISO 8601 timestamp.</summary>
-    [JsonPropertyName("startTime")]
-    public string StartTime { get; set; } = string.Empty;
-
-    /// <summary>Short summary of the session, when one has been derived.</summary>
-    [JsonPropertyName("summary")]
-    public string? Summary { get; set; }
 }
 
 /// <summary>The enriched metadata records, with summary and context fields backfilled where available. Sessions confirmed empty and unnamed are omitted.</summary>
@@ -3451,8 +3500,8 @@ internal sealed class SendRequest
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
 
-    /// <summary>Optional provenance tag copied to the resulting user.message event. Must match one of three forms: the literal `system`, `command-&lt;command-id&gt;` for messages originating from a command (e.g. slash command, Mission Control command), or `schedule-&lt;numeric-id&gt;` for messages originating from a scheduled job.</summary>
-    [RegularExpression("^(system|command-.*|schedule-\\d+)$")]
+    /// <summary>Optional provenance tag copied to the resulting user.message event. Must be `user`, `system`, `command-&lt;command-id&gt;` for command-originated messages, `schedule-&lt;numeric-id&gt;` for scheduled prompts, or `agent-&lt;agent-id&gt;` for prompts sent by another agent.</summary>
+    [RegularExpression("^(user|system|command-.*|schedule-\\d+|agent-.+)$")]
     [JsonInclude]
     [JsonPropertyName("source")]
     internal string? Source { get; set; }
@@ -3504,8 +3553,8 @@ public sealed class SendMessageItem
     [JsonPropertyName("requiredTool")]
     public string? RequiredTool { get; set; }
 
-    /// <summary>Optional provenance tag copied to the resulting user.message event. Must match one of three forms: the literal `system`, `command-&lt;command-id&gt;` for messages originating from a command (e.g. slash command, Mission Control command), or `schedule-&lt;numeric-id&gt;` for messages originating from a scheduled job.</summary>
-    [RegularExpression("^(system|command-.*|schedule-\\d+)$")]
+    /// <summary>Optional provenance tag copied to the resulting user.message event. Must be `user`, `system`, `command-&lt;command-id&gt;` for command-originated messages, `schedule-&lt;numeric-id&gt;` for scheduled prompts, or `agent-&lt;agent-id&gt;` for prompts sent by another agent.</summary>
+    [RegularExpression("^(user|system|command-.*|schedule-\\d+|agent-.+)$")]
     [JsonInclude]
     [JsonPropertyName("source")]
     internal string? Source { get; set; }
@@ -3552,6 +3601,27 @@ internal sealed class SendMessagesRequest
     public bool? Wait { get; set; }
 }
 
+/// <summary>Internal request for sending a system notification.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class SendSystemNotificationRequest
+{
+    /// <summary>Optional structured notification kind.</summary>
+    [JsonPropertyName("kind")]
+    public JsonElement? Kind { get; set; }
+
+    /// <summary>Notification text to deliver to the model.</summary>
+    [JsonPropertyName("message")]
+    public string Message { get; set; } = string.Empty;
+
+    /// <summary>Internal delivery options, including passive policy.</summary>
+    [JsonPropertyName("options")]
+    public JsonElement? Options { get; set; }
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
 /// <summary>Result of aborting the current turn.</summary>
 [Experimental(Diagnostics.Experimental)]
 public sealed class AbortResult
@@ -3573,6 +3643,37 @@ internal sealed class AbortRequest
     [JsonPropertyName("reason")]
     public AbortReason? Reason { get; set; }
 
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Result of interrupting the main agent turn.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class InterruptMainTurnResult
+{
+    /// <summary>Whether an in-flight main agent turn was interrupted. False when the main loop was not processing.</summary>
+    [JsonPropertyName("interrupted")]
+    public bool Interrupted { get; set; }
+}
+
+/// <summary>Parameters for interrupting the main agent turn.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class InterruptMainTurnRequest
+{
+    /// <summary>When true, the user's queued prompts are preserved and run as the next turn once the interrupted turn unwinds; when false (the default), the queue is cleared like a plain abort.</summary>
+    [JsonPropertyName("flushQueued")]
+    public bool? FlushQueued { get; set; }
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Identifies the target session.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class SessionCancelAllBackgroundAgentsRequest
+{
     /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
@@ -4095,6 +4196,7 @@ internal sealed class CanvasActionInvokeRequest
     UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType)]
 [JsonDerivedType(typeof(FactoryRunFailureFactoryLimitReached), "factory_limit_reached")]
 [JsonDerivedType(typeof(FactoryRunFailureFactoryResumeDeclined), "factory_resume_declined")]
+[JsonDerivedType(typeof(FactoryRunFailureFactoryDurableFailure), "factory_durable_failure")]
 public partial class FactoryRunFailure
 {
     /// <summary>The type discriminator.</summary>
@@ -4141,6 +4243,27 @@ public partial class FactoryRunFailureFactoryResumeDeclined : FactoryRunFailure
     public required string RunId { get; set; }
 }
 
+/// <summary>The <c>factory_durable_failure</c> variant of <see cref="FactoryRunFailure"/>.</summary>
+[Experimental(Diagnostics.Experimental)]
+public partial class FactoryRunFailureFactoryDurableFailure : FactoryRunFailure
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Type => "factory_durable_failure";
+
+    /// <summary>Stable failure code.</summary>
+    [JsonPropertyName("code")]
+    public required string Code { get; set; }
+
+    /// <summary>Execution-critical durable operation that failed.</summary>
+    [JsonPropertyName("operation")]
+    public required FactoryDurableOperation Operation { get; set; }
+
+    /// <summary>Factory run identifier.</summary>
+    [JsonPropertyName("runId")]
+    public required string RunId { get; set; }
+}
+
 /// <summary>Complete current or terminal factory run envelope.</summary>
 [Experimental(Diagnostics.Experimental)]
 public sealed class FactoryRunResult
@@ -4178,6 +4301,10 @@ public sealed class FactoryRunResult
 [Experimental(Diagnostics.Experimental)]
 public sealed class FactoryRunLimits
 {
+    /// <summary>Maximum AI credits consumed by factory subagents and their descendants. The post-paid ceiling is soft: parallel turns can settle beyond it before the run stops.</summary>
+    [JsonPropertyName("maxAiCredits")]
+    public double? MaxAiCredits { get; set; }
+
     /// <summary>Maximum number of factory subagents that may run concurrently.</summary>
     [JsonPropertyName("maxConcurrentSubagents")]
     public long? MaxConcurrentSubagents { get; set; }
@@ -4186,9 +4313,9 @@ public sealed class FactoryRunLimits
     [JsonPropertyName("maxTotalSubagents")]
     public long? MaxTotalSubagents { get; set; }
 
-    /// <summary>Factory active-run timeout in milliseconds.</summary>
-    [JsonPropertyName("timeout")]
-    public double? Timeout { get; set; }
+    /// <summary>Maximum accumulated active-execution time in seconds. Active execution includes the entire extension body, subprocess waits, queued-agent waits, and sleeps; time between resumed attempts is not counted.</summary>
+    [JsonPropertyName("timeoutSeconds")]
+    public double? TimeoutSeconds { get; set; }
 }
 
 /// <summary>Options controlling factory invocation.</summary>
@@ -4225,10 +4352,505 @@ internal sealed class FactoryRunRequest
     public string SessionId { get; set; } = string.Empty;
 }
 
+/// <summary>Resolved persisted factory identity and resumed run envelope.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class FactoryResumeResult
+{
+    /// <summary>Persisted factory name resolved for the resumed run.</summary>
+    [JsonPropertyName("factoryName")]
+    public string FactoryName { get; set; } = string.Empty;
+
+    /// <summary>Terminal resumed run envelope.</summary>
+    [JsonPropertyName("run")]
+    public FactoryRunResult Run { get => field ??= new(); set; }
+}
+
+/// <summary>Parameters for resuming a factory run from its persisted identity.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class FactoryResumeRequest
+{
+    /// <summary>Optional per-invocation resource ceiling overrides.</summary>
+    [JsonPropertyName("limits")]
+    public FactoryRunLimits? Limits { get; set; }
+
+    /// <summary>Factory run identifier.</summary>
+    [JsonPropertyName("runId")]
+    public string RunId { get; set; } = string.Empty;
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
 /// <summary>Parameters for retrieving a factory run.</summary>
 [Experimental(Diagnostics.Experimental)]
 internal sealed class FactoryGetRunRequest
 {
+    /// <summary>Factory run identifier.</summary>
+    [JsonPropertyName("runId")]
+    public string RunId { get; set; } = string.Empty;
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Declared or approved factory resource ceilings.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class FactoryDeclaredLimits
+{
+    /// <summary>Gets or sets the <c>maxAiCredits</c> value.</summary>
+    [JsonPropertyName("maxAiCredits")]
+    public double? MaxAiCredits { get; set; }
+
+    /// <summary>Gets or sets the <c>maxConcurrentSubagents</c> value.</summary>
+    [JsonPropertyName("maxConcurrentSubagents")]
+    public long? MaxConcurrentSubagents { get; set; }
+
+    /// <summary>Gets or sets the <c>maxTotalSubagents</c> value.</summary>
+    [JsonPropertyName("maxTotalSubagents")]
+    public long? MaxTotalSubagents { get; set; }
+
+    /// <summary>Gets or sets the <c>timeoutSeconds</c> value.</summary>
+    [JsonPropertyName("timeoutSeconds")]
+    public double? TimeoutSeconds { get; set; }
+}
+
+/// <summary>Durable factory resource consumption.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class FactoryRunConsumed
+{
+    /// <summary>Gets or sets the <c>activeMs</c> value.</summary>
+    [JsonPropertyName("activeMs")]
+    public long ActiveMs { get; set; }
+
+    /// <summary>Gets or sets the <c>nanoAiu</c> value.</summary>
+    [JsonPropertyName("nanoAiu")]
+    public long NanoAiu { get; set; }
+
+    /// <summary>Gets or sets the <c>subagents</c> value.</summary>
+    [JsonPropertyName("subagents")]
+    public long Subagents { get; set; }
+}
+
+/// <summary>Current factory phase identity.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class FactoryCurrentPhase
+{
+    /// <summary>Gets or sets the <c>id</c> value.</summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the <c>ordinal</c> value.</summary>
+    [JsonPropertyName("ordinal")]
+    public long? Ordinal { get; set; }
+}
+
+/// <summary>Prompt-safe terminal factory outcome.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class FactoryRunTerminal
+{
+    /// <summary>Gets or sets the <c>error</c> value.</summary>
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    /// <summary>Gets or sets the <c>failure</c> value.</summary>
+    [JsonPropertyName("failure")]
+    public FactoryRunFailure? Failure { get; set; }
+
+    /// <summary>Gets or sets the <c>reason</c> value.</summary>
+    [JsonPropertyName("reason")]
+    public string? Reason { get; set; }
+
+    /// <summary>Gets or sets the <c>resultPreview</c> value.</summary>
+    [JsonPropertyName("resultPreview")]
+    public string? ResultPreview { get; set; }
+}
+
+/// <summary>Durable factory run summary with read-time live overlays.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class FactoryRunSummary
+{
+    /// <summary>Gets or sets the <c>activeSegmentStartedAt</c> value.</summary>
+    [JsonPropertyName("activeSegmentStartedAt")]
+    public long? ActiveSegmentStartedAt { get; set; }
+
+    /// <summary>Gets or sets the <c>approved</c> value.</summary>
+    [JsonPropertyName("approved")]
+    public FactoryDeclaredLimits? Approved { get; set; }
+
+    /// <summary>Gets or sets the <c>completedAt</c> value.</summary>
+    [JsonPropertyName("completedAt")]
+    public long? CompletedAt { get; set; }
+
+    /// <summary>Gets or sets the <c>consumed</c> value.</summary>
+    [JsonPropertyName("consumed")]
+    public FactoryRunConsumed Consumed { get => field ??= new(); set; }
+
+    /// <summary>Gets or sets the <c>createdAt</c> value.</summary>
+    [JsonPropertyName("createdAt")]
+    public long CreatedAt { get; set; }
+
+    /// <summary>Gets or sets the <c>currentPhase</c> value.</summary>
+    [JsonPropertyName("currentPhase")]
+    public FactoryCurrentPhase? CurrentPhase { get; set; }
+
+    /// <summary>Gets or sets the <c>declaredLimits</c> value.</summary>
+    [JsonPropertyName("declaredLimits")]
+    public FactoryDeclaredLimits DeclaredLimits { get => field ??= new(); set; }
+
+    /// <summary>Gets or sets the <c>declaredPhaseCount</c> value.</summary>
+    [JsonPropertyName("declaredPhaseCount")]
+    public long DeclaredPhaseCount { get; set; }
+
+    /// <summary>Gets or sets the <c>description</c> value.</summary>
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the <c>factoryName</c> value.</summary>
+    [JsonPropertyName("factoryName")]
+    public string FactoryName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the <c>liveAgentCount</c> value.</summary>
+    [JsonPropertyName("liveAgentCount")]
+    public long LiveAgentCount { get; set; }
+
+    /// <summary>Gets or sets the <c>observedAt</c> value.</summary>
+    [JsonPropertyName("observedAt")]
+    public long ObservedAt { get; set; }
+
+    /// <summary>Gets or sets the <c>revision</c> value.</summary>
+    [JsonPropertyName("revision")]
+    public long Revision { get; set; }
+
+    /// <summary>Gets or sets the <c>runId</c> value.</summary>
+    [JsonPropertyName("runId")]
+    public string RunId { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the <c>startedAt</c> value.</summary>
+    [JsonPropertyName("startedAt")]
+    public long? StartedAt { get; set; }
+
+    /// <summary>Gets or sets the <c>status</c> value.</summary>
+    [JsonPropertyName("status")]
+    public FactoryRunStatus Status { get; set; }
+
+    /// <summary>Gets or sets the <c>terminal</c> value.</summary>
+    [JsonPropertyName("terminal")]
+    public FactoryRunTerminal? Terminal { get; set; }
+
+    /// <summary>Gets or sets the <c>totalSpawnedAgentCount</c> value.</summary>
+    [JsonPropertyName("totalSpawnedAgentCount")]
+    public long TotalSpawnedAgentCount { get; set; }
+
+    /// <summary>Gets or sets the <c>updatedAt</c> value.</summary>
+    [JsonPropertyName("updatedAt")]
+    public long UpdatedAt { get; set; }
+}
+
+/// <summary>Factory runs in durable creation order.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class FactoryListRunsResult
+{
+    /// <summary>Gets or sets the <c>runs</c> value.</summary>
+    [JsonPropertyName("runs")]
+    public IList<FactoryRunSummary> Runs { get => field ??= []; set; }
+}
+
+/// <summary>Empty parameters for listing factory runs.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class FactoryListRunsRequest
+{
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Prompt-safe durable identity and live status for a direct factory agent.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class FactoryAgentSummary
+{
+    /// <summary>Gets or sets the <c>activeMs</c> value.</summary>
+    [JsonPropertyName("activeMs")]
+    public long ActiveMs { get; set; }
+
+    /// <summary>Gets or sets the <c>activity</c> value.</summary>
+    [JsonPropertyName("activity")]
+    public string? Activity { get; set; }
+
+    /// <summary>Gets or sets the <c>agentId</c> value.</summary>
+    [JsonPropertyName("agentId")]
+    public string AgentId { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the <c>agentType</c> value.</summary>
+    [JsonPropertyName("agentType")]
+    public string AgentType { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the <c>completedAt</c> value.</summary>
+    [JsonPropertyName("completedAt")]
+    public long? CompletedAt { get; set; }
+
+    /// <summary>Gets or sets the <c>label</c> value.</summary>
+    [JsonPropertyName("label")]
+    public string Label { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the <c>phaseId</c> value.</summary>
+    [JsonPropertyName("phaseId")]
+    public string? PhaseId { get; set; }
+
+    /// <summary>Gets or sets the <c>requestedModel</c> value.</summary>
+    [JsonPropertyName("requestedModel")]
+    public string? RequestedModel { get; set; }
+
+    /// <summary>Gets or sets the <c>resolvedModel</c> value.</summary>
+    [JsonPropertyName("resolvedModel")]
+    public string? ResolvedModel { get; set; }
+
+    /// <summary>Gets or sets the <c>runId</c> value.</summary>
+    [JsonPropertyName("runId")]
+    public string RunId { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the <c>startedAt</c> value.</summary>
+    [JsonPropertyName("startedAt")]
+    public long? StartedAt { get; set; }
+
+    /// <summary>Gets or sets the <c>status</c> value.</summary>
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the <c>toolCallId</c> value.</summary>
+    [JsonPropertyName("toolCallId")]
+    public string ToolCallId { get; set; } = string.Empty;
+}
+
+/// <summary>Durable lifecycle and timing for one factory phase.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class FactoryPhaseObservation
+{
+    /// <summary>Gets or sets the <c>accumulatedActiveMs</c> value.</summary>
+    [JsonPropertyName("accumulatedActiveMs")]
+    public long AccumulatedActiveMs { get; set; }
+
+    /// <summary>Gets or sets the <c>completedAt</c> value.</summary>
+    [JsonPropertyName("completedAt")]
+    public long? CompletedAt { get; set; }
+
+    /// <summary>Gets or sets the <c>currentActiveMs</c> value.</summary>
+    [JsonPropertyName("currentActiveMs")]
+    public long CurrentActiveMs { get; set; }
+
+    /// <summary>Gets or sets the <c>detail</c> value.</summary>
+    [JsonPropertyName("detail")]
+    public string? Detail { get; set; }
+
+    /// <summary>Gets or sets the <c>entryCount</c> value.</summary>
+    [JsonPropertyName("entryCount")]
+    public long EntryCount { get; set; }
+
+    /// <summary>Gets or sets the <c>id</c> value.</summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the <c>lastEnteredRunAttempt</c> value.</summary>
+    [JsonPropertyName("lastEnteredRunAttempt")]
+    public long LastEnteredRunAttempt { get; set; }
+
+    /// <summary>Gets or sets the <c>liveAgentCount</c> value.</summary>
+    [JsonPropertyName("liveAgentCount")]
+    public long LiveAgentCount { get; set; }
+
+    /// <summary>Gets or sets the <c>ordinal</c> value.</summary>
+    [JsonPropertyName("ordinal")]
+    public long? Ordinal { get; set; }
+
+    /// <summary>Gets or sets the <c>startedAt</c> value.</summary>
+    [JsonPropertyName("startedAt")]
+    public long? StartedAt { get; set; }
+
+    /// <summary>Gets or sets the <c>status</c> value.</summary>
+    [JsonPropertyName("status")]
+    public FactoryPhaseStatus Status { get; set; }
+
+    /// <summary>Gets or sets the <c>title</c> value.</summary>
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the <c>totalAgentCount</c> value.</summary>
+    [JsonPropertyName("totalAgentCount")]
+    public long TotalAgentCount { get; set; }
+}
+
+/// <summary>One durable factory progress record.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class FactoryProgressLine
+{
+    /// <summary>Resume attempt that emitted this record.</summary>
+    [JsonPropertyName("attempt")]
+    public long Attempt { get; set; }
+
+    /// <summary>Progress record kind.</summary>
+    [JsonPropertyName("kind")]
+    public FactoryLogLineKind Kind { get; set; }
+
+    /// <summary>Phase active when the record was emitted, or null before any phase.</summary>
+    [JsonPropertyName("phaseId")]
+    public string? PhaseId { get; set; }
+
+    /// <summary>Epoch milliseconds when the record was persisted.</summary>
+    [JsonPropertyName("recordedAt")]
+    public long RecordedAt { get; set; }
+
+    /// <summary>Global monotonic sequence number within the run.</summary>
+    [JsonPropertyName("seq")]
+    public long Seq { get; set; }
+
+    /// <summary>Prompt-safe progress text.</summary>
+    [JsonPropertyName("text")]
+    public string Text { get; set; } = string.Empty;
+}
+
+/// <summary>A bidirectional page of factory progress.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class FactoryProgressPage
+{
+    /// <summary>Gets or sets the <c>hasMoreNewer</c> value.</summary>
+    [JsonPropertyName("hasMoreNewer")]
+    public bool HasMoreNewer { get; set; }
+
+    /// <summary>Gets or sets the <c>hasMoreOlder</c> value.</summary>
+    [JsonPropertyName("hasMoreOlder")]
+    public bool HasMoreOlder { get; set; }
+
+    /// <summary>Gets or sets the <c>newestSeq</c> value.</summary>
+    [JsonPropertyName("newestSeq")]
+    public long? NewestSeq { get; set; }
+
+    /// <summary>Gets or sets the <c>oldestSeq</c> value.</summary>
+    [JsonPropertyName("oldestSeq")]
+    public long? OldestSeq { get; set; }
+
+    /// <summary>Gets or sets the <c>records</c> value.</summary>
+    [JsonPropertyName("records")]
+    public IList<FactoryProgressLine> Records { get => field ??= []; set; }
+
+    /// <summary>Run revision reflected by this page.</summary>
+    [JsonPropertyName("revision")]
+    public long Revision { get; set; }
+}
+
+/// <summary>Full factory run observability detail.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class FactoryRunDetail
+{
+    /// <summary>Gets or sets the <c>activeSegmentStartedAt</c> value.</summary>
+    [JsonPropertyName("activeSegmentStartedAt")]
+    public long? ActiveSegmentStartedAt { get; set; }
+
+    /// <summary>Gets or sets the <c>agents</c> value.</summary>
+    [JsonPropertyName("agents")]
+    public IList<FactoryAgentSummary> Agents { get => field ??= []; set; }
+
+    /// <summary>Gets or sets the <c>approved</c> value.</summary>
+    [JsonPropertyName("approved")]
+    public FactoryDeclaredLimits? Approved { get; set; }
+
+    /// <summary>Gets or sets the <c>completedAt</c> value.</summary>
+    [JsonPropertyName("completedAt")]
+    public long? CompletedAt { get; set; }
+
+    /// <summary>Gets or sets the <c>consumed</c> value.</summary>
+    [JsonPropertyName("consumed")]
+    public FactoryRunConsumed Consumed { get => field ??= new(); set; }
+
+    /// <summary>Gets or sets the <c>createdAt</c> value.</summary>
+    [JsonPropertyName("createdAt")]
+    public long CreatedAt { get; set; }
+
+    /// <summary>Gets or sets the <c>currentPhase</c> value.</summary>
+    [JsonPropertyName("currentPhase")]
+    public FactoryCurrentPhase? CurrentPhase { get; set; }
+
+    /// <summary>Gets or sets the <c>declaredLimits</c> value.</summary>
+    [JsonPropertyName("declaredLimits")]
+    public FactoryDeclaredLimits DeclaredLimits { get => field ??= new(); set; }
+
+    /// <summary>Gets or sets the <c>declaredPhaseCount</c> value.</summary>
+    [JsonPropertyName("declaredPhaseCount")]
+    public long DeclaredPhaseCount { get; set; }
+
+    /// <summary>Gets or sets the <c>description</c> value.</summary>
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the <c>factoryName</c> value.</summary>
+    [JsonPropertyName("factoryName")]
+    public string FactoryName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the <c>liveAgentCount</c> value.</summary>
+    [JsonPropertyName("liveAgentCount")]
+    public long LiveAgentCount { get; set; }
+
+    /// <summary>Gets or sets the <c>observedAt</c> value.</summary>
+    [JsonPropertyName("observedAt")]
+    public long ObservedAt { get; set; }
+
+    /// <summary>Gets or sets the <c>phases</c> value.</summary>
+    [JsonPropertyName("phases")]
+    public IList<FactoryPhaseObservation> Phases { get => field ??= []; set; }
+
+    /// <summary>Gets or sets the <c>progress</c> value.</summary>
+    [JsonPropertyName("progress")]
+    public FactoryProgressPage Progress { get => field ??= new(); set; }
+
+    /// <summary>Gets or sets the <c>revision</c> value.</summary>
+    [JsonPropertyName("revision")]
+    public long Revision { get; set; }
+
+    /// <summary>Gets or sets the <c>runId</c> value.</summary>
+    [JsonPropertyName("runId")]
+    public string RunId { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the <c>startedAt</c> value.</summary>
+    [JsonPropertyName("startedAt")]
+    public long? StartedAt { get; set; }
+
+    /// <summary>Gets or sets the <c>status</c> value.</summary>
+    [JsonPropertyName("status")]
+    public FactoryRunStatus Status { get; set; }
+
+    /// <summary>Gets or sets the <c>terminal</c> value.</summary>
+    [JsonPropertyName("terminal")]
+    public FactoryRunTerminal? Terminal { get; set; }
+
+    /// <summary>Gets or sets the <c>totalSpawnedAgentCount</c> value.</summary>
+    [JsonPropertyName("totalSpawnedAgentCount")]
+    public long TotalSpawnedAgentCount { get; set; }
+
+    /// <summary>Gets or sets the <c>updatedAt</c> value.</summary>
+    [JsonPropertyName("updatedAt")]
+    public long UpdatedAt { get; set; }
+}
+
+/// <summary>Parameters for paging factory progress.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class FactoryGetRunProgressRequest
+{
+    /// <summary>Exclusive forward cursor.</summary>
+    [JsonPropertyName("afterSeq")]
+    public long? AfterSeq { get; set; }
+
+    /// <summary>Exclusive backward cursor.</summary>
+    [JsonPropertyName("beforeSeq")]
+    public long? BeforeSeq { get; set; }
+
+    /// <summary>Maximum records to return. Defaults to 200 and is capped at 500.</summary>
+    [JsonPropertyName("limit")]
+    public int? Limit { get; set; }
+
+    /// <summary>Optional phase identifier used to scope records and cursors.</summary>
+    [JsonPropertyName("phaseId")]
+    public string? PhaseId { get; set; }
+
     /// <summary>Factory run identifier.</summary>
     [JsonPropertyName("runId")]
     public string RunId { get; set; } = string.Empty;
@@ -4278,6 +4900,10 @@ public sealed class FactoryLogLine
 [Experimental(Diagnostics.Experimental)]
 internal sealed class FactoryLogRequest
 {
+    /// <summary>Opaque token identifying the current factory execution attempt.</summary>
+    [JsonPropertyName("executionToken")]
+    public string ExecutionToken { get; set; } = string.Empty;
+
     /// <summary>Ordered progress lines to append.</summary>
     [JsonPropertyName("lines")]
     public IList<FactoryLogLine> Lines { get => field ??= []; set; }
@@ -4321,6 +4947,10 @@ public sealed class FactoryAgentOptions
 [Experimental(Diagnostics.Experimental)]
 internal sealed class FactoryAgentRequest
 {
+    /// <summary>Opaque token identifying the current factory execution attempt.</summary>
+    [JsonPropertyName("executionToken")]
+    public string ExecutionToken { get; set; } = string.Empty;
+
     /// <summary>Factory run identifier that owns the subagent.</summary>
     [JsonPropertyName("factoryRunId")]
     public string FactoryRunId { get; set; } = string.Empty;
@@ -4355,6 +4985,10 @@ public sealed class FactoryJournalGetResult
 [Experimental(Diagnostics.Experimental)]
 internal sealed class FactoryJournalGetRequest
 {
+    /// <summary>Opaque token identifying the current factory execution attempt.</summary>
+    [JsonPropertyName("executionToken")]
+    public string ExecutionToken { get; set; } = string.Empty;
+
     /// <summary>Namespaced journal key.</summary>
     [JsonPropertyName("key")]
     public string Key { get; set; } = string.Empty;
@@ -4372,6 +5006,10 @@ internal sealed class FactoryJournalGetRequest
 [Experimental(Diagnostics.Experimental)]
 internal sealed class FactoryJournalPutRequest
 {
+    /// <summary>Opaque token identifying the current factory execution attempt.</summary>
+    [JsonPropertyName("executionToken")]
+    public string ExecutionToken { get; set; } = string.Empty;
+
     /// <summary>Namespaced journal key.</summary>
     [JsonPropertyName("key")]
     public string Key { get; set; } = string.Empty;
@@ -4895,6 +5533,36 @@ internal sealed class SessionWorkspacesGetWorkspaceRequest
     public string SessionId { get; set; } = string.Empty;
 }
 
+/// <summary>Workspace metadata fields to update.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class WorkspacesUpdateMetadataRequest
+{
+    /// <summary>Opaque workspace context supplied by the session host.</summary>
+    [JsonPropertyName("context")]
+    public JsonElement? Context { get; set; }
+
+    /// <summary>Optional workspace display name override.</summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Optional session context used when creating a local workspace.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class WorkspacesEnsureRequest
+{
+    /// <summary>Opaque workspace context supplied by the session host.</summary>
+    [JsonPropertyName("context")]
+    public JsonElement? Context { get; set; }
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
 /// <summary>Relative paths of files stored in the session workspace files directory.</summary>
 [Experimental(Diagnostics.Experimental)]
 public sealed class WorkspacesListFilesResult
@@ -5004,6 +5672,135 @@ internal sealed class WorkspacesReadCheckpointRequest
     [JsonPropertyName("number")]
     public long Number { get; set; }
 
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>RPC data type for WorkspacesAddSummaryResultSummary operations.</summary>
+public sealed class WorkspacesAddSummaryResultSummary
+{
+}
+
+/// <summary>RPC data type for WorkspacesAddSummaryResultWorkspace operations.</summary>
+public sealed class WorkspacesAddSummaryResultWorkspace
+{
+}
+
+/// <summary>Persisted summary metadata and refreshed workspace metadata.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class WorkspacesAddSummaryResult
+{
+    /// <summary>Gets or sets the <c>summary</c> value.</summary>
+    [JsonPropertyName("summary")]
+    public WorkspacesAddSummaryResultSummary? Summary { get; set; }
+
+    /// <summary>Gets or sets the <c>workspace</c> value.</summary>
+    [JsonPropertyName("workspace")]
+    public WorkspacesAddSummaryResultWorkspace? Workspace { get; set; }
+}
+
+/// <summary>Compaction summary checkpoint to persist.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class WorkspacesAddSummaryRequest
+{
+    /// <summary>Markdown summary content to persist.</summary>
+    [JsonPropertyName("content")]
+    public string Content { get; set; } = string.Empty;
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+
+    /// <summary>Summary title shown in checkpoint listings.</summary>
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = string.Empty;
+}
+
+/// <summary>Rollback point for local workspace summaries.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class WorkspacesTruncateSummariesRequest
+{
+    /// <summary>Number of newest summaries to keep.</summary>
+    [JsonPropertyName("keepCount")]
+    public long KeepCount { get; set; }
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Autopilot objective file content, or null when missing.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class WorkspacesReadAutopilotObjectiveResult
+{
+    /// <summary>Autopilot objective file content, or null when missing.</summary>
+    [JsonPropertyName("content")]
+    public string? Content { get; set; }
+}
+
+/// <summary>Identifies the target session.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class SessionWorkspacesReadAutopilotObjectiveRequest
+{
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Result of writing the autopilot objective file.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class WorkspacesWriteAutopilotObjectiveResult
+{
+    /// <summary>Filesystem operation performed.</summary>
+    [JsonPropertyName("operation")]
+    public string Operation { get; set; } = string.Empty;
+}
+
+/// <summary>Autopilot objective file content to persist.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class WorkspacesWriteAutopilotObjectiveRequest
+{
+    /// <summary>Autopilot objective file content.</summary>
+    [JsonPropertyName("content")]
+    public string Content { get; set; } = string.Empty;
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Result of deleting the autopilot objective file.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class WorkspacesDeleteAutopilotObjectiveResult
+{
+    /// <summary>True when a file was deleted.</summary>
+    [JsonPropertyName("deleted")]
+    public bool Deleted { get; set; }
+}
+
+/// <summary>Identifies the target session.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class SessionWorkspacesDeleteAutopilotObjectiveRequest
+{
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Whether the autopilot objective file exists.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class WorkspacesAutopilotObjectiveExistsResult
+{
+    /// <summary>True when the objective file exists.</summary>
+    [JsonPropertyName("exists")]
+    public bool Exists { get; set; }
+}
+
+/// <summary>Identifies the target session.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class SessionWorkspacesAutopilotObjectiveExistsRequest
+{
     /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
@@ -6583,6 +7380,28 @@ internal sealed class McpOauthLoginRequest
     public string SessionId { get; set; } = string.Empty;
 }
 
+/// <summary>Indicates whether the pending MCP OAuth response was accepted.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class McpOauthRespondResult
+{
+    /// <summary>Whether the response was accepted. False if the request was unknown, timed out, or already resolved.</summary>
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+}
+
+/// <summary>Pending MCP OAuth request id to respond to.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class McpOauthRespondRequest
+{
+    /// <summary>OAuth request identifier from the mcp.oauth_required event.</summary>
+    [JsonPropertyName("requestId")]
+    public string RequestId { get; set; } = string.Empty;
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
 /// <summary>Indicates whether the pending MCP headers refresh response was accepted.</summary>
 [Experimental(Diagnostics.Experimental)]
 public sealed class McpHeadersHandlePendingHeadersRefreshRequestResult
@@ -7746,6 +8565,50 @@ public sealed class SandboxConfig
     public SandboxConfigUserPolicy? UserPolicy { get; set; }
 }
 
+/// <summary>A host-provided script sourced before each built-in shell command when its shell target matches the active shell.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class ShellInitScript
+{
+    /// <summary>Path to the script to source.</summary>
+    [JsonPropertyName("path")]
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>Built-in shell that may source this script.</summary>
+    [JsonPropertyName("shell")]
+    public ShellInitScriptShell Shell { get; set; }
+}
+
+/// <summary>Per-session settings for built-in shell tools.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class ShellOptions
+{
+    /// <summary>Controls automatic non-interactive profile loading where supported. Explicit initScripts are unaffected.</summary>
+    [JsonPropertyName("initProfile")]
+    public ShellInitProfile? InitProfile { get; set; }
+
+    /// <summary>
+    /// Ordered host-provided script paths sourced before each built-in shell command when the
+    /// entry's shell target matches the active shell. Use these for rc files, environment setup scripts,
+    /// or other custom scripts. A script that returns a nonzero status is reported, and later scripts
+    /// and the user command continue while the shell remains running. Because scripts are sourced into
+    /// the command shell, `exit`, `exec`, failures under `set -e`, or other shell-terminating behavior
+    /// can prevent continuation. Script standard output is preserved; Bash script stderr is discarded,
+    /// PowerShell exception messages are replaced, and runtime-generated failure notices omit
+    /// configured script paths. When sandboxing is enabled, each script must already be readable under
+    /// the active sandbox filesystem policy. Pass an empty array to clear the list.
+    /// </summary>
+    [JsonPropertyName("initScripts")]
+    public IList<ShellInitScript>? InitScripts { get; set; }
+
+    /// <summary>
+    /// Flags passed to the active built-in shell process on startup, replacing its default flags.
+    /// When omitted, the built-in Bash shell uses `--norc --noprofile`,
+    /// and the built-in PowerShell shell uses `-NoProfile -NoLogo`.
+    /// </summary>
+    [JsonPropertyName("processFlags")]
+    public IList<string>? ProcessFlags { get; set; }
+}
+
 /// <summary>Patch of mutable session options to apply to the running session.</summary>
 [Experimental(Diagnostics.Experimental)]
 internal sealed class SessionUpdateOptionsParams
@@ -7847,6 +8710,10 @@ internal sealed class SessionUpdateOptionsParams
     [JsonPropertyName("eventsLogDirectory")]
     public string? EventsLogDirectory { get; set; }
 
+    /// <summary>Whether subagent callback events should be forwarded into the session event log sink.</summary>
+    [JsonPropertyName("eventsLogIncludesSubagents")]
+    public bool? EventsLogIncludesSubagents { get; set; }
+
     /// <summary>Built-in subagent names to exclude from this session. Excluded built-ins are hidden from agent discovery and cannot be dispatched unless a custom agent with the same name is available.</summary>
     [JsonPropertyName("excludedBuiltinAgents")]
     public IList<string>? ExcludedBuiltinAgents { get; set; }
@@ -7935,11 +8802,19 @@ internal sealed class SessionUpdateOptionsParams
     [JsonPropertyName("sessionLimits")]
     public SessionLimitsConfig? SessionLimits { get; set; }
 
-    /// <summary>Shell init profile (`None` or `NonInteractive`).</summary>
+    /// <summary>Per-session settings for built-in shell tools.</summary>
+    [JsonPropertyName("shell")]
+    public ShellOptions? Shell { get; set; }
+
+    /// <summary>Use shell.initProfile instead. Shell init profile (`None` or `NonInteractive`).</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#if NET5_0_OR_GREATER
+    [Obsolete("This member is deprecated and will be removed in a future version.", DiagnosticId = "GHCP001")]
+#endif
     [JsonPropertyName("shellInitProfile")]
     public string? ShellInitProfile { get; set; }
 
-    /// <summary>Per-shell process flags (e.g., `pwsh` arguments).</summary>
+    /// <summary>PowerShell process flags applied to built-in and user-requested shell commands.</summary>
     [JsonPropertyName("shellProcessFlags")]
     public IList<string>? ShellProcessFlags { get; set; }
 
@@ -9318,6 +10193,10 @@ public sealed class UIExitPlanModeResponse
     /// <summary>Whether subsequent edits should be auto-approved without confirmation.</summary>
     [JsonPropertyName("autoApproveEdits")]
     public bool? AutoApproveEdits { get; set; }
+
+    /// <summary>When true, the agent is instructed to end its turn without starting implementation so the client can restore the session model and auto-submit a fresh implementation turn on it. Set only when a distinct plan configuration (a different model, reasoning effort, or context tier) actually ran the planning turn.</summary>
+    [JsonPropertyName("deferImplementation")]
+    public bool? DeferImplementation { get; set; }
 
     /// <summary>Feedback from the user when they declined the plan or requested changes.</summary>
     [JsonPropertyName("feedback")]
@@ -11762,6 +12641,119 @@ internal sealed class SessionQueuePendingItemsRequest
     public string SessionId { get; set; } = string.Empty;
 }
 
+/// <summary>Internal snapshot of native queue state for local session orchestration.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class QueueSnapshotResult
+{
+    /// <summary>Insertion orders for queued items, aligned with `items`.</summary>
+    [JsonPropertyName("itemOrders")]
+    public IList<long>? ItemOrders { get; set; }
+
+    /// <summary>User-facing pending items in FIFO order.</summary>
+    [JsonPropertyName("items")]
+    public IList<QueuePendingItems> Items { get => field ??= []; set; }
+
+    /// <summary>Insertion orders for immediate steering messages, aligned with `steeringMessages`.</summary>
+    [JsonPropertyName("steeringMessageOrders")]
+    public IList<long>? SteeringMessageOrders { get; set; }
+
+    /// <summary>Immediate steering messages waiting for an active turn.</summary>
+    [JsonPropertyName("steeringMessages")]
+    public IList<string> SteeringMessages { get => field ??= []; set; }
+}
+
+/// <summary>Identifies the target session.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class SessionQueueSnapshotRequest
+{
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Whether the native queue has pending work.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class QueueHasPendingResult
+{
+    /// <summary>True when queued or immediate native work is pending.</summary>
+    [JsonPropertyName("hasPending")]
+    public bool HasPending { get; set; }
+}
+
+/// <summary>Identifies the target session.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class SessionQueueHasPendingRequest
+{
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Whether a deferred-idle drain should run.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class QueueBeginDeferredIdleDrainResult
+{
+    /// <summary>True when the host should run finishDeferredIdleDrain asynchronously.</summary>
+    [JsonPropertyName("shouldDrain")]
+    public bool ShouldDrain { get; set; }
+}
+
+/// <summary>Inputs for starting a deferred-idle drain.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class QueueBeginDeferredIdleDrainRequest
+{
+    /// <summary>Whether the host still has active background work.</summary>
+    [JsonPropertyName("activeBackgroundWork")]
+    public bool ActiveBackgroundWork { get; set; }
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Action selected by the native deferred-idle drain.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class QueueFinishDeferredIdleDrainResult
+{
+    /// <summary>Whether the deferred idle was caused by an aborted foreground turn.</summary>
+    [JsonPropertyName("aborted")]
+    public bool Aborted { get; set; }
+
+    /// <summary>One of none, processQueue, or emitSessionIdle.</summary>
+    [JsonPropertyName("action")]
+    public string Action { get; set; } = string.Empty;
+}
+
+/// <summary>Inputs for completing a deferred-idle drain.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class QueueFinishDeferredIdleDrainRequest
+{
+    /// <summary>Whether the host still has active background work.</summary>
+    [JsonPropertyName("activeBackgroundWork")]
+    public bool ActiveBackgroundWork { get; set; }
+
+    /// <summary>Whether native queued work remains.</summary>
+    [JsonPropertyName("hasPending")]
+    public bool HasPending { get; set; }
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Inputs for marking session.idle deferred in native state.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class QueueDeferSessionIdleRequest
+{
+    /// <summary>Whether the deferred idle was caused by an aborted foreground turn.</summary>
+    [JsonPropertyName("aborted")]
+    public bool Aborted { get; set; }
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
 /// <summary>Indicates whether a user-facing pending item was removed.</summary>
 [Experimental(Diagnostics.Experimental)]
 public sealed class QueueRemoveMostRecentResult
@@ -11783,6 +12775,46 @@ internal sealed class SessionQueueRemoveMostRecentRequest
 /// <summary>Identifies the target session.</summary>
 [Experimental(Diagnostics.Experimental)]
 internal sealed class SessionQueueClearRequest
+{
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Internal filter for consuming queued system notifications.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class QueueConsumeSystemNotificationsRequest
+{
+    /// <summary>Opaque runtime-owned filter object.</summary>
+    [JsonPropertyName("filter")]
+    public JsonElement Filter { get; set; }
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Result of enqueueing the resume-pending wake item.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class QueueEnqueueResumePendingResult
+{
+    /// <summary>True when a wake item was newly queued.</summary>
+    [JsonPropertyName("queued")]
+    public bool Queued { get; set; }
+}
+
+/// <summary>Identifies the target session.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class SessionQueueEnqueueResumePendingRequest
+{
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Identifies the target session.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class SessionQueueProcessRequest
 {
     /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
@@ -12243,6 +13275,159 @@ internal sealed class SessionScheduleListRequest
     public string SessionId { get; set; } = string.Empty;
 }
 
+/// <summary>Identifies the target session.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class SessionScheduleHydrateRequest
+{
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Whether the session currently has an active self-paced schedule.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class ScheduleHasSelfPacedResult
+{
+    /// <summary>True when at least one active schedule is self-paced.</summary>
+    [JsonPropertyName("hasSelfPaced")]
+    public bool HasSelfPaced { get; set; }
+}
+
+/// <summary>Identifies the target session.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class SessionScheduleHasSelfPacedRequest
+{
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Result of registering or re-arming a scheduled prompt.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class ScheduleAddResult
+{
+    /// <summary>The registered or updated schedule entry.</summary>
+    [JsonPropertyName("entry")]
+    public ScheduleEntry? Entry { get; set; }
+
+    /// <summary>User-facing validation error, when registration failed.</summary>
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+}
+
+/// <summary>Register a relative-interval scheduled prompt.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class ScheduleAddRequest
+{
+    /// <summary>Optional display-only prompt label.</summary>
+    [JsonPropertyName("displayPrompt")]
+    public string? DisplayPrompt { get; set; }
+
+    /// <summary>Human-readable interval such as `30s`, `5m`, or `2h`.</summary>
+    [JsonPropertyName("interval")]
+    public string Interval { get; set; } = string.Empty;
+
+    /// <summary>Prompt text to enqueue when the schedule fires.</summary>
+    [JsonPropertyName("prompt")]
+    public string Prompt { get; set; } = string.Empty;
+
+    /// <summary>Whether the schedule should re-arm after each tick. Defaults to true.</summary>
+    [JsonPropertyName("recurring")]
+    public bool? Recurring { get; set; }
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Register a cron scheduled prompt.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class ScheduleAddCronRequest
+{
+    /// <summary>5-field cron expression.</summary>
+    [JsonPropertyName("cron")]
+    public string Cron { get; set; } = string.Empty;
+
+    /// <summary>Optional display-only prompt label.</summary>
+    [JsonPropertyName("displayPrompt")]
+    public string? DisplayPrompt { get; set; }
+
+    /// <summary>Prompt text to enqueue when the schedule fires.</summary>
+    [JsonPropertyName("prompt")]
+    public string Prompt { get; set; } = string.Empty;
+
+    /// <summary>Whether the schedule should re-arm after each tick. Defaults to true.</summary>
+    [JsonPropertyName("recurring")]
+    public bool? Recurring { get; set; }
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+
+    /// <summary>IANA timezone for evaluating the cron expression.</summary>
+    [JsonPropertyName("tz")]
+    public string? Tz { get; set; }
+}
+
+/// <summary>Register an absolute-time scheduled prompt.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class ScheduleAddAtRequest
+{
+    /// <summary>Epoch milliseconds when the prompt should fire.</summary>
+    [JsonPropertyName("at")]
+    public long At { get; set; }
+
+    /// <summary>Optional display-only prompt label.</summary>
+    [JsonPropertyName("displayPrompt")]
+    public string? DisplayPrompt { get; set; }
+
+    /// <summary>Prompt text to enqueue when the schedule fires.</summary>
+    [JsonPropertyName("prompt")]
+    public string Prompt { get; set; } = string.Empty;
+
+    /// <summary>Whether the schedule should re-arm after each tick. Defaults to false.</summary>
+    [JsonPropertyName("recurring")]
+    public bool? Recurring { get; set; }
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Register a self-paced scheduled prompt.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class ScheduleAddSelfPacedRequest
+{
+    /// <summary>Optional display-only prompt label.</summary>
+    [JsonPropertyName("displayPrompt")]
+    public string? DisplayPrompt { get; set; }
+
+    /// <summary>Prompt text to enqueue when the schedule fires.</summary>
+    [JsonPropertyName("prompt")]
+    public string Prompt { get; set; } = string.Empty;
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Re-arm a self-paced scheduled prompt.</summary>
+[Experimental(Diagnostics.Experimental)]
+internal sealed class ScheduleRearmSelfPacedRequest
+{
+    /// <summary>Epoch milliseconds when the prompt should next fire.</summary>
+    [JsonPropertyName("at")]
+    public long At { get; set; }
+
+    /// <summary>Id of the self-paced scheduled prompt.</summary>
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+}
+
 /// <summary>Remove a scheduled prompt by id. The result entry is omitted if the id was unknown.</summary>
 [Experimental(Diagnostics.Experimental)]
 public sealed class ScheduleStopResult
@@ -12293,7 +13478,7 @@ public sealed class FactoryExecuteResult
 {
     /// <summary>Factory result value.</summary>
     [JsonPropertyName("result")]
-    public JsonElement Result { get; set; }
+    public JsonElement? Result { get; set; }
 }
 
 /// <summary>Parameters sent to the owning extension to execute a factory closure.</summary>
@@ -12303,6 +13488,10 @@ public sealed class FactoryExecuteRequest
     /// <summary>Factory input value.</summary>
     [JsonPropertyName("args")]
     public JsonElement Args { get; set; }
+
+    /// <summary>Opaque token identifying this factory execution attempt.</summary>
+    [JsonPropertyName("executionToken")]
+    public string ExecutionToken { get; set; } = string.Empty;
 
     /// <summary>Registered factory name.</summary>
     [JsonPropertyName("name")]
@@ -12624,7 +13813,7 @@ public sealed class SessionFsSqliteQueryResult
     public long RowsAffected { get; set; }
 }
 
-/// <summary>SQL query, query type, and optional bind parameters for executing a SQLite query against the per-session database.</summary>
+/// <summary>SQL query, query type, and optional bind parameters for executing a SQLite query against the per-session database. The provider applies its SQLite busy timeout for every call.</summary>
 [Experimental(Diagnostics.Experimental)]
 public sealed class SessionFsSqliteQueryRequest
 {
@@ -12643,6 +13832,62 @@ public sealed class SessionFsSqliteQueryRequest
     /// <summary>Target session identifier.</summary>
     [JsonPropertyName("sessionId")]
     public string SessionId { get; set; } = string.Empty;
+}
+
+/// <summary>Classified SQLite transaction failure. busyOrLocked guarantees rollback; postCommitAmbiguous must never be retried.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class SessionFsSqliteTransactionError
+{
+    /// <summary>Gets or sets the <c>errorClass</c> value.</summary>
+    [JsonPropertyName("errorClass")]
+    public SessionFsSqliteTransactionErrorClass ErrorClass { get; set; }
+
+    /// <summary>Gets or sets the <c>message</c> value.</summary>
+    [JsonPropertyName("message")]
+    public string Message { get; set; } = string.Empty;
+}
+
+/// <summary>Per-statement results, or a classified transaction error.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class SessionFsSqliteTransactionResult
+{
+    /// <summary>Gets or sets the <c>error</c> value.</summary>
+    [JsonPropertyName("error")]
+    public SessionFsSqliteTransactionError? Error { get; set; }
+
+    /// <summary>Gets or sets the <c>results</c> value.</summary>
+    [JsonPropertyName("results")]
+    public IList<SessionFsSqliteQueryResult> Results { get => field ??= []; set; }
+}
+
+/// <summary>One statement in an atomic SQLite transaction.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class SessionFsSqliteTransactionStatement
+{
+    /// <summary>Optional named bind parameters.</summary>
+    [JsonPropertyName("params")]
+    public IDictionary<string, JsonElement>? Params { get; set; }
+
+    /// <summary>SQL statement to execute.</summary>
+    [JsonPropertyName("query")]
+    public string Query { get; set; } = string.Empty;
+
+    /// <summary>How to execute the statement.</summary>
+    [JsonPropertyName("queryType")]
+    public SessionFsSqliteQueryType QueryType { get; set; }
+}
+
+/// <summary>Statements to execute atomically. Providers apply busy handling for every call.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed class SessionFsSqliteTransactionRequest
+{
+    /// <summary>Target session identifier.</summary>
+    [JsonPropertyName("sessionId")]
+    public string SessionId { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the <c>statements</c> value.</summary>
+    [JsonPropertyName("statements")]
+    public IList<SessionFsSqliteTransactionStatement> Statements { get => field ??= []; set; }
 }
 
 /// <summary>Indicates whether the per-session SQLite database already exists.</summary>
@@ -15578,8 +16823,11 @@ public readonly struct FactoryRunFailureKind : IEquatable<FactoryRunFailureKind>
     /// <summary>The run admitted the approved maximum total number of subagents.</summary>
     public static FactoryRunFailureKind MaxTotalSubagents { get; } = new("maxTotalSubagents");
 
-    /// <summary>The run reached the approved timeout deadline.</summary>
-    public static FactoryRunFailureKind Timeout { get; } = new("timeout");
+    /// <summary>The run reached the approved accumulated active-execution time in seconds.</summary>
+    public static FactoryRunFailureKind TimeoutSeconds { get; } = new("timeoutSeconds");
+
+    /// <summary>The run's settled subagent model usage exceeded the approved AI-credit ceiling, or no headroom remained for another subagent.</summary>
+    public static FactoryRunFailureKind MaxAiCredits { get; } = new("maxAiCredits");
 
     /// <summary>Returns a value indicating whether two <see cref="FactoryRunFailureKind"/> instances are equivalent.</summary>
     public static bool operator ==(FactoryRunFailureKind left, FactoryRunFailureKind right) => left.Equals(right);
@@ -15613,6 +16861,93 @@ public readonly struct FactoryRunFailureKind : IEquatable<FactoryRunFailureKind>
         public override void Write(Utf8JsonWriter writer, FactoryRunFailureKind value, JsonSerializerOptions options)
         {
             GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(FactoryRunFailureKind));
+        }
+    }
+}
+
+
+/// <summary>Execution-critical factory storage operation.</summary>
+[Experimental(Diagnostics.Experimental)]
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct FactoryDurableOperation : IEquatable<FactoryDurableOperation>
+{
+    private readonly string? _value;
+
+    /// <summary>Initializes a new instance of the <see cref="FactoryDurableOperation"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="FactoryDurableOperation"/>.</param>
+    [JsonConstructor]
+    public FactoryDurableOperation(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        _value = value;
+    }
+
+    /// <summary>Gets the value associated with this <see cref="FactoryDurableOperation"/>.</summary>
+    public string Value => _value ?? string.Empty;
+
+    /// <summary>Creating the durable run and declared phases.</summary>
+    public static FactoryDurableOperation CreateRun { get; } = new("createRun");
+
+    /// <summary>Persisting the transition to running.</summary>
+    public static FactoryDurableOperation MarkRunStarted { get; } = new("markRunStarted");
+
+    /// <summary>Persisting the terminal run envelope.</summary>
+    public static FactoryDurableOperation FinishRun { get; } = new("finishRun");
+
+    /// <summary>Persisting subagent admission accounting.</summary>
+    public static FactoryDurableOperation ReserveAgent { get; } = new("reserveAgent");
+
+    /// <summary>Rolling back an uncommitted subagent admission.</summary>
+    public static FactoryDurableOperation ReleaseAgent { get; } = new("releaseAgent");
+
+    /// <summary>Persisting an idempotent model-usage charge.</summary>
+    public static FactoryDurableOperation ChargeCredit { get; } = new("chargeCredit");
+
+    /// <summary>Persisting active execution time.</summary>
+    public static FactoryDurableOperation AddElapsed { get; } = new("addElapsed");
+
+    /// <summary>Reading the authoritative AI-credit total.</summary>
+    public static FactoryDurableOperation ReconcileCreditTotal { get; } = new("reconcileCreditTotal");
+
+    /// <summary>Reading a journal entry without treating storage failure as a cache miss.</summary>
+    public static FactoryDurableOperation JournalGet { get; } = new("journalGet");
+
+    /// <summary>Persisting a journal entry before reporting success.</summary>
+    public static FactoryDurableOperation JournalPut { get; } = new("journalPut");
+
+    /// <summary>Returns a value indicating whether two <see cref="FactoryDurableOperation"/> instances are equivalent.</summary>
+    public static bool operator ==(FactoryDurableOperation left, FactoryDurableOperation right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="FactoryDurableOperation"/> instances are not equivalent.</summary>
+    public static bool operator !=(FactoryDurableOperation left, FactoryDurableOperation right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is FactoryDurableOperation other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(FactoryDurableOperation other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
+
+    /// <inheritdoc />
+    public override string ToString() => Value;
+
+    /// <summary>Provides a <see cref="JsonConverter{FactoryDurableOperation}"/> for serializing <see cref="FactoryDurableOperation"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<FactoryDurableOperation>
+    {
+        /// <inheritdoc />
+        public override FactoryDurableOperation Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return new(GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, FactoryDurableOperation value, JsonSerializerOptions options)
+        {
+            GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(FactoryDurableOperation));
         }
     }
 }
@@ -15688,6 +17023,75 @@ public readonly struct FactoryRunStatus : IEquatable<FactoryRunStatus>
         public override void Write(Utf8JsonWriter writer, FactoryRunStatus value, JsonSerializerOptions options)
         {
             GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(FactoryRunStatus));
+        }
+    }
+}
+
+
+/// <summary>Derived lifecycle state of a factory phase.</summary>
+[Experimental(Diagnostics.Experimental)]
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct FactoryPhaseStatus : IEquatable<FactoryPhaseStatus>
+{
+    private readonly string? _value;
+
+    /// <summary>Initializes a new instance of the <see cref="FactoryPhaseStatus"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="FactoryPhaseStatus"/>.</param>
+    [JsonConstructor]
+    public FactoryPhaseStatus(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        _value = value;
+    }
+
+    /// <summary>Gets the value associated with this <see cref="FactoryPhaseStatus"/>.</summary>
+    public string Value => _value ?? string.Empty;
+
+    /// <summary>The phase has not been entered yet.</summary>
+    public static FactoryPhaseStatus Pending { get; } = new("pending");
+
+    /// <summary>The phase is currently entered and accumulating active time.</summary>
+    public static FactoryPhaseStatus Active { get; } = new("active");
+
+    /// <summary>The phase was entered and has since been closed.</summary>
+    public static FactoryPhaseStatus Completed { get; } = new("completed");
+
+    /// <summary>The phase was never entered because a later phase was entered or the run reached a terminal state.</summary>
+    public static FactoryPhaseStatus Skipped { get; } = new("skipped");
+
+    /// <summary>Returns a value indicating whether two <see cref="FactoryPhaseStatus"/> instances are equivalent.</summary>
+    public static bool operator ==(FactoryPhaseStatus left, FactoryPhaseStatus right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="FactoryPhaseStatus"/> instances are not equivalent.</summary>
+    public static bool operator !=(FactoryPhaseStatus left, FactoryPhaseStatus right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is FactoryPhaseStatus other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(FactoryPhaseStatus other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
+
+    /// <inheritdoc />
+    public override string ToString() => Value;
+
+    /// <summary>Provides a <see cref="JsonConverter{FactoryPhaseStatus}"/> for serializing <see cref="FactoryPhaseStatus"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<FactoryPhaseStatus>
+    {
+        /// <inheritdoc />
+        public override FactoryPhaseStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return new(GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, FactoryPhaseStatus value, JsonSerializerOptions options)
+        {
+            GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(FactoryPhaseStatus));
         }
     }
 }
@@ -17658,6 +19062,132 @@ public readonly struct SessionCapability : IEquatable<SessionCapability>
 }
 
 
+/// <summary>Controls automatic non-interactive profile loading where supported. Explicit initScripts are unaffected.</summary>
+[Experimental(Diagnostics.Experimental)]
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct ShellInitProfile : IEquatable<ShellInitProfile>
+{
+    private readonly string? _value;
+
+    /// <summary>Initializes a new instance of the <see cref="ShellInitProfile"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="ShellInitProfile"/>.</param>
+    [JsonConstructor]
+    public ShellInitProfile(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        _value = value;
+    }
+
+    /// <summary>Gets the value associated with this <see cref="ShellInitProfile"/>.</summary>
+    public string Value => _value ?? string.Empty;
+
+    /// <summary>Disable automatic non-interactive profile loading. Explicit initScripts still run.</summary>
+    public static ShellInitProfile None { get; } = new("none");
+
+    /// <summary>Allow automatic non-interactive profile loading when supported. Explicit initScripts still run.</summary>
+    public static ShellInitProfile NonInteractive { get; } = new("non-interactive");
+
+    /// <summary>Returns a value indicating whether two <see cref="ShellInitProfile"/> instances are equivalent.</summary>
+    public static bool operator ==(ShellInitProfile left, ShellInitProfile right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="ShellInitProfile"/> instances are not equivalent.</summary>
+    public static bool operator !=(ShellInitProfile left, ShellInitProfile right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is ShellInitProfile other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(ShellInitProfile other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
+
+    /// <inheritdoc />
+    public override string ToString() => Value;
+
+    /// <summary>Provides a <see cref="JsonConverter{ShellInitProfile}"/> for serializing <see cref="ShellInitProfile"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<ShellInitProfile>
+    {
+        /// <inheritdoc />
+        public override ShellInitProfile Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return new(GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, ShellInitProfile value, JsonSerializerOptions options)
+        {
+            GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(ShellInitProfile));
+        }
+    }
+}
+
+
+/// <summary>Supported built-in shells for initialization scripts.</summary>
+[Experimental(Diagnostics.Experimental)]
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct ShellInitScriptShell : IEquatable<ShellInitScriptShell>
+{
+    private readonly string? _value;
+
+    /// <summary>Initializes a new instance of the <see cref="ShellInitScriptShell"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="ShellInitScriptShell"/>.</param>
+    [JsonConstructor]
+    public ShellInitScriptShell(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        _value = value;
+    }
+
+    /// <summary>Gets the value associated with this <see cref="ShellInitScriptShell"/>.</summary>
+    public string Value => _value ?? string.Empty;
+
+    /// <summary>Source the script in the built-in Bash shell on macOS and Linux.</summary>
+    public static ShellInitScriptShell Bash { get; } = new("bash");
+
+    /// <summary>Source the script in the built-in PowerShell shell on Windows.</summary>
+    public static ShellInitScriptShell Powershell { get; } = new("powershell");
+
+    /// <summary>Returns a value indicating whether two <see cref="ShellInitScriptShell"/> instances are equivalent.</summary>
+    public static bool operator ==(ShellInitScriptShell left, ShellInitScriptShell right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="ShellInitScriptShell"/> instances are not equivalent.</summary>
+    public static bool operator !=(ShellInitScriptShell left, ShellInitScriptShell right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is ShellInitScriptShell other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(ShellInitScriptShell other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
+
+    /// <inheritdoc />
+    public override string ToString() => Value;
+
+    /// <summary>Provides a <see cref="JsonConverter{ShellInitScriptShell}"/> for serializing <see cref="ShellInitScriptShell"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<ShellInitScriptShell>
+    {
+        /// <inheritdoc />
+        public override ShellInitScriptShell Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return new(GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, ShellInitScriptShell value, JsonSerializerOptions options)
+        {
+            GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(ShellInitScriptShell));
+        }
+    }
+}
+
+
 /// <summary>Controls how availableTools (allowlist) and excludedTools (denylist) combine when both are set.</summary>
 [Experimental(Diagnostics.Experimental)]
 [JsonConverter(typeof(Converter))]
@@ -19599,6 +21129,72 @@ public readonly struct SessionFsSqliteQueryType : IEquatable<SessionFsSqliteQuer
 }
 
 
+/// <summary>SQLite transaction failure classification.</summary>
+[Experimental(Diagnostics.Experimental)]
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct SessionFsSqliteTransactionErrorClass : IEquatable<SessionFsSqliteTransactionErrorClass>
+{
+    private readonly string? _value;
+
+    /// <summary>Initializes a new instance of the <see cref="SessionFsSqliteTransactionErrorClass"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="SessionFsSqliteTransactionErrorClass"/>.</param>
+    [JsonConstructor]
+    public SessionFsSqliteTransactionErrorClass(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        _value = value;
+    }
+
+    /// <summary>Gets the value associated with this <see cref="SessionFsSqliteTransactionErrorClass"/>.</summary>
+    public string Value => _value ?? string.Empty;
+
+    /// <summary>SQLite reported BUSY or LOCKED before commit; the transaction was rolled back and may be retried.</summary>
+    public static SessionFsSqliteTransactionErrorClass BusyOrLocked { get; } = new("busyOrLocked");
+
+    /// <summary>The statement, database, or provider failed definitively and must not be retried automatically.</summary>
+    public static SessionFsSqliteTransactionErrorClass Fatal { get; } = new("fatal");
+
+    /// <summary>The transport failed after the provider may have committed; retrying could duplicate effects.</summary>
+    public static SessionFsSqliteTransactionErrorClass PostCommitAmbiguous { get; } = new("postCommitAmbiguous");
+
+    /// <summary>Returns a value indicating whether two <see cref="SessionFsSqliteTransactionErrorClass"/> instances are equivalent.</summary>
+    public static bool operator ==(SessionFsSqliteTransactionErrorClass left, SessionFsSqliteTransactionErrorClass right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="SessionFsSqliteTransactionErrorClass"/> instances are not equivalent.</summary>
+    public static bool operator !=(SessionFsSqliteTransactionErrorClass left, SessionFsSqliteTransactionErrorClass right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is SessionFsSqliteTransactionErrorClass other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(SessionFsSqliteTransactionErrorClass other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
+
+    /// <inheritdoc />
+    public override string ToString() => Value;
+
+    /// <summary>Provides a <see cref="JsonConverter{SessionFsSqliteTransactionErrorClass}"/> for serializing <see cref="SessionFsSqliteTransactionErrorClass"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<SessionFsSqliteTransactionErrorClass>
+    {
+        /// <inheritdoc />
+        public override SessionFsSqliteTransactionErrorClass Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return new(GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, SessionFsSqliteTransactionErrorClass value, JsonSerializerOptions options)
+        {
+            GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(SessionFsSqliteTransactionErrorClass));
+        }
+    }
+}
+
+
 /// <summary>Transport the runtime would otherwise use for this request. `http` (the default when absent) covers plain HTTP and SSE responses; `websocket` indicates a full-duplex message channel where each body chunk maps to one WebSocket message and the `binary` flag distinguishes text from binary frames. The SDK consumer uses this to decide whether to service the request with an HTTP client or a WebSocket client. It is the one piece of request metadata the consumer cannot reliably infer from the URL or headers alone.</summary>
 [Experimental(Diagnostics.Experimental)]
 [JsonConverter(typeof(Converter))]
@@ -19685,7 +21281,7 @@ public sealed class ServerRpc
 
     /// <summary>Performs the SDK server connection handshake and validates the optional connection token. Marked internal because this is JSON-RPC transport plumbing invoked automatically by an SDK client's own `connect()` wrapper, not a user-facing method. Stays internal as long as the SDK client owns the handshake; would only become public if the SDK ever exposed the raw schema surface to consumers without a connection wrapper.</summary>
     /// <param name="token">Connection token; required when the server was started with COPILOT_CONNECTION_TOKEN.</param>
-    /// <param name="enableGitHubTelemetryForwarding">Opt this connection in to GitHub telemetry forwarding for its lifetime. When set, the runtime forwards every internal telemetry event it emits — across all sessions, plus sessionless events — to this connection over the `gitHubTelemetry.event` notification, in addition to the runtime's normal GitHub/CTS emission (dual-write). Intended for first-party hosts that re-emit the events into their own telemetry stores. Both unrestricted and restricted events are forwarded, each tagged with a `restricted` discriminator; a backstop drops restricted events when restricted telemetry is disabled.</param>
+    /// <param name="enableGitHubTelemetryForwarding">Opt this connection in to GitHub telemetry forwarding for its lifetime. When set, the runtime forwards every internal telemetry event it emits — across all sessions, plus sessionless events — to this connection over the `gitHubTelemetry.event` notification. Regular events are also written to the runtime's normal GitHub/CTS path (dual-write); host-only compatibility events are forward-only and intentionally skip that path. Intended for first-party hosts that re-emit the events into their own telemetry stores. Both unrestricted and restricted events are forwarded, each tagged with a `restricted` discriminator; a backstop drops restricted events when restricted telemetry is disabled — using the process-global gate for ordinary events and an explicit session-scoped decision for host-only events.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Handshake result reporting the server's protocol version and package version on success.</returns>
     [Experimental(Diagnostics.Experimental)]
@@ -20569,6 +22165,28 @@ public sealed class ServerSessionsApi
         return await CopilotClient.InvokeRpcAsync<SessionList>(_rpc, "sessions.list", [request], cancellationToken);
     }
 
+    /// <summary>Reads lightweight persisted metadata for one local session without opening it.</summary>
+    /// <param name="sessionId">Session ID to inspect.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Persisted local session metadata when the session exists.</returns>
+    internal async Task<SessionsGetMetadataResult> GetMetadataAsync(string sessionId, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(sessionId);
+
+        var request = new SessionsGetMetadataRequest { SessionId = sessionId };
+        return await CopilotClient.InvokeRpcAsync<SessionsGetMetadataResult>(_rpc, "sessions.getMetadata", [request], cancellationToken);
+    }
+
+    /// <summary>Lists recent local session IDs that contain user-visible history, omitting housekeeping-only sessions.</summary>
+    /// <param name="limit">Maximum number of session IDs to return.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Recent local session IDs that contain user-visible history.</returns>
+    internal async Task<SessionsListNonEmptySessionIdsResult> ListNonEmptySessionIdsAsync(long? limit = null, CancellationToken cancellationToken = default)
+    {
+        var request = new SessionsListNonEmptySessionIdsRequest { Limit = limit };
+        return await CopilotClient.InvokeRpcAsync<SessionsListNonEmptySessionIdsResult>(_rpc, "sessions.listNonEmptySessionIds", [request], cancellationToken);
+    }
+
     /// <summary>Finds the local session bound to a GitHub task ID, if any.</summary>
     /// <param name="taskId">GitHub task ID to look up.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
@@ -20669,6 +22287,18 @@ public sealed class ServerSessionsApi
 
         var request = new SessionsBulkDeleteRequest { SessionIds = sessionIds };
         return await CopilotClient.InvokeRpcAsync<SessionBulkDeleteResult>(_rpc, "sessions.bulkDelete", [request], cancellationToken);
+    }
+
+    /// <summary>Deletes one local session from disk after running the same lifecycle hooks as the session manager.</summary>
+    /// <param name="sessionId">Session ID to delete.</param>
+    /// <param name="sessionPath">Internal resolved session directory path to delete.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    internal async Task DeleteAsync(string sessionId, string? sessionPath = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(sessionId);
+
+        var request = new SessionsDeleteRequest { SessionId = sessionId, SessionPath = sessionPath };
+        await CopilotClient.InvokeRpcAsync(_rpc, "sessions.delete", [request], cancellationToken);
     }
 
     /// <summary>Deletes sessions older than the given threshold, with optional dry-run and exclusion list.</summary>
@@ -21129,7 +22759,7 @@ public sealed class SessionRpc
     /// <param name="prepend">If true, adds the message to the front of the queue instead of the end.</param>
     /// <param name="billable">If false, this message will not trigger a Premium Request Unit charge. User messages default to billable.</param>
     /// <param name="requiredTool">If set, the request will fail if the named tool is not available when this message is among the user messages at the start of the current exchange.</param>
-    /// <param name="source">Optional provenance tag copied to the resulting user.message event. Must match one of three forms: the literal `system`, `command-&lt;command-id&gt;` for messages originating from a command (e.g. slash command, Mission Control command), or `schedule-&lt;numeric-id&gt;` for messages originating from a scheduled job.</param>
+    /// <param name="source">Optional provenance tag copied to the resulting user.message event. Must be `user`, `system`, `command-&lt;command-id&gt;` for command-originated messages, `schedule-&lt;numeric-id&gt;` for scheduled prompts, or `agent-&lt;agent-id&gt;` for prompts sent by another agent.</param>
     /// <param name="agentMode">The UI mode the agent was in when this message was sent. Defaults to the session's current mode.</param>
     /// <param name="requestHeaders">Custom HTTP headers to include in outbound model requests for this turn. Merged with session-level provider headers; per-turn headers augment and overwrite session-level headers with the same key.</param>
     /// <param name="traceparent">W3C Trace Context traceparent header for distributed tracing of this agent turn.</param>
@@ -21168,6 +22798,21 @@ public sealed class SessionRpc
         return await CopilotClient.InvokeRpcAsync<SendMessagesResult>(_session.Rpc, "session.sendMessages", [request], cancellationToken);
     }
 
+    /// <summary>Queues or sends an internal system notification to the session according to its passive policy.</summary>
+    /// <param name="message">Notification text to deliver to the model.</param>
+    /// <param name="kind">Optional structured notification kind.</param>
+    /// <param name="options">Internal delivery options, including passive policy.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    [Experimental(Diagnostics.Experimental)]
+    internal async Task SendSystemNotificationAsync(string message, object? kind = null, object? options = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        _session.ThrowIfDisposed();
+
+        var request = new SendSystemNotificationRequest { SessionId = _session.SessionId, Message = message, Kind = CopilotClient.ToJsonElementForWire(kind), Options = CopilotClient.ToJsonElementForWire(options) };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.sendSystemNotification", [request], cancellationToken);
+    }
+
     /// <summary>Aborts the current agent turn.</summary>
     /// <param name="reason">Finite reason code describing why the current turn was aborted.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
@@ -21179,6 +22824,31 @@ public sealed class SessionRpc
 
         var request = new AbortRequest { SessionId = _session.SessionId, Reason = reason };
         return await CopilotClient.InvokeRpcAsync<AbortResult>(_session.Rpc, "session.abort", [request], cancellationToken);
+    }
+
+    /// <summary>Interrupts the current main agent turn while leaving running background work (subagents, sidekicks, and promoted attached shells) alive. No-op when the main loop is not processing.</summary>
+    /// <param name="flushQueued">When true, the user's queued prompts are preserved and run as the next turn once the interrupted turn unwinds; when false (the default), the queue is cleared like a plain abort.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Result of interrupting the main agent turn.</returns>
+    [Experimental(Diagnostics.Experimental)]
+    public async Task<InterruptMainTurnResult> InterruptMainTurnAsync(bool? flushQueued = null, CancellationToken cancellationToken = default)
+    {
+        _session.ThrowIfDisposed();
+
+        var request = new InterruptMainTurnRequest { SessionId = _session.SessionId, FlushQueued = flushQueued };
+        return await CopilotClient.InvokeRpcAsync<InterruptMainTurnResult>(_session.Rpc, "session.interruptMainTurn", [request], cancellationToken);
+    }
+
+    /// <summary>Cancels every running background agent (task-registry subagents plus sidekick agents) without interrupting the main agent loop. Promoted attached shells are left running.</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>The number of running background agents (task-registry agents) that were cancelled.</returns>
+    [Experimental(Diagnostics.Experimental)]
+    public async Task<long> CancelAllBackgroundAgentsAsync(CancellationToken cancellationToken = default)
+    {
+        _session.ThrowIfDisposed();
+
+        var request = new SessionCancelAllBackgroundAgentsRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<long>(_session.Rpc, "session.cancelAllBackgroundAgents", [request], cancellationToken);
     }
 
     /// <summary>Shuts down the session and persists its final state. Awaits any deferred sessionEnd hooks before resolving so user-supplied hook scripts complete before the runtime tears down.</summary>
@@ -21400,6 +23070,20 @@ public sealed class FactoryApi
         return await CopilotClient.InvokeRpcAsync<FactoryRunResult>(_session.Rpc, "session.factory.run", [request], cancellationToken);
     }
 
+    /// <summary>Resumes a factory run using its persisted name, arguments, journal, and accounting.</summary>
+    /// <param name="runId">Factory run identifier.</param>
+    /// <param name="limits">Optional per-invocation resource ceiling overrides.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Resolved persisted factory identity and resumed run envelope.</returns>
+    public async Task<FactoryResumeResult> ResumeAsync(string runId, FactoryRunLimits? limits = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(runId);
+        _session.ThrowIfDisposed();
+
+        var request = new FactoryResumeRequest { SessionId = _session.SessionId, RunId = runId, Limits = limits };
+        return await CopilotClient.InvokeRpcAsync<FactoryResumeResult>(_session.Rpc, "session.factory.resume", [request], cancellationToken);
+    }
+
     /// <summary>Gets the current or settled envelope for a factory run.</summary>
     /// <param name="runId">Factory run identifier.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
@@ -21411,6 +23095,47 @@ public sealed class FactoryApi
 
         var request = new FactoryGetRunRequest { SessionId = _session.SessionId, RunId = runId };
         return await CopilotClient.InvokeRpcAsync<FactoryRunResult>(_session.Rpc, "session.factory.getRun", [request], cancellationToken);
+    }
+
+    /// <summary>Lists durable factory runs for this session in creation order.</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Factory runs in durable creation order.</returns>
+    public async Task<FactoryListRunsResult> ListRunsAsync(CancellationToken cancellationToken = default)
+    {
+        _session.ThrowIfDisposed();
+
+        var request = new FactoryListRunsRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<FactoryListRunsResult>(_session.Rpc, "session.factory.listRuns", [request], cancellationToken);
+    }
+
+    /// <summary>Gets durable and live observability detail for one factory run.</summary>
+    /// <param name="runId">Factory run identifier.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Full factory run observability detail.</returns>
+    public async Task<FactoryRunDetail> GetRunDetailAsync(string runId, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(runId);
+        _session.ThrowIfDisposed();
+
+        var request = new FactoryGetRunRequest { SessionId = _session.SessionId, RunId = runId };
+        return await CopilotClient.InvokeRpcAsync<FactoryRunDetail>(_session.Rpc, "session.factory.getRunDetail", [request], cancellationToken);
+    }
+
+    /// <summary>Pages durable progress for one factory run.</summary>
+    /// <param name="runId">Factory run identifier.</param>
+    /// <param name="phaseId">Optional phase identifier used to scope records and cursors.</param>
+    /// <param name="afterSeq">Exclusive forward cursor.</param>
+    /// <param name="beforeSeq">Exclusive backward cursor.</param>
+    /// <param name="limit">Maximum records to return. Defaults to 200 and is capped at 500.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>A bidirectional page of factory progress.</returns>
+    public async Task<FactoryProgressPage> GetRunProgressAsync(string runId, string? phaseId = null, long? afterSeq = null, long? beforeSeq = null, int? limit = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(runId);
+        _session.ThrowIfDisposed();
+
+        var request = new FactoryGetRunProgressRequest { SessionId = _session.SessionId, RunId = runId, PhaseId = phaseId, AfterSeq = afterSeq, BeforeSeq = beforeSeq, Limit = limit };
+        return await CopilotClient.InvokeRpcAsync<FactoryProgressPage>(_session.Rpc, "session.factory.getRunProgress", [request], cancellationToken);
     }
 
     /// <summary>Requests cancellation of a factory run and returns its run envelope.</summary>
@@ -21428,33 +23153,37 @@ public sealed class FactoryApi
 
     /// <summary>Records a batch of ordered factory progress lines.</summary>
     /// <param name="runId">Factory run identifier.</param>
+    /// <param name="executionToken">Opaque token identifying the current factory execution attempt.</param>
     /// <param name="lines">Ordered progress lines to append.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Acknowledgement that a factory request was accepted.</returns>
-    public async Task<FactoryAckResult> LogAsync(string runId, IList<FactoryLogLine> lines, CancellationToken cancellationToken = default)
+    public async Task<FactoryAckResult> LogAsync(string runId, string executionToken, IList<FactoryLogLine> lines, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(runId);
+        ArgumentNullException.ThrowIfNull(executionToken);
         ArgumentNullException.ThrowIfNull(lines);
         _session.ThrowIfDisposed();
 
-        var request = new FactoryLogRequest { SessionId = _session.SessionId, RunId = runId, Lines = lines };
+        var request = new FactoryLogRequest { SessionId = _session.SessionId, RunId = runId, ExecutionToken = executionToken, Lines = lines };
         return await CopilotClient.InvokeRpcAsync<FactoryAckResult>(_session.Rpc, "session.factory.log", [request], cancellationToken);
     }
 
     /// <summary>Runs one factory-scoped subagent and returns its result.</summary>
     /// <param name="factoryRunId">Factory run identifier that owns the subagent.</param>
+    /// <param name="executionToken">Opaque token identifying the current factory execution attempt.</param>
     /// <param name="prompt">Prompt to send to the subagent.</param>
     /// <param name="opts">Subagent execution options.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Result of one factory-scoped subagent call.</returns>
-    public async Task<FactoryAgentResult> AgentAsync(string factoryRunId, string prompt, FactoryAgentOptions opts, CancellationToken cancellationToken = default)
+    public async Task<FactoryAgentResult> AgentAsync(string factoryRunId, string executionToken, string prompt, FactoryAgentOptions opts, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(factoryRunId);
+        ArgumentNullException.ThrowIfNull(executionToken);
         ArgumentNullException.ThrowIfNull(prompt);
         ArgumentNullException.ThrowIfNull(opts);
         _session.ThrowIfDisposed();
 
-        var request = new FactoryAgentRequest { SessionId = _session.SessionId, FactoryRunId = factoryRunId, Prompt = prompt, Opts = opts };
+        var request = new FactoryAgentRequest { SessionId = _session.SessionId, FactoryRunId = factoryRunId, ExecutionToken = executionToken, Prompt = prompt, Opts = opts };
         return await CopilotClient.InvokeRpcAsync<FactoryAgentResult>(_session.Rpc, "session.factory.agent", [request], cancellationToken);
     }
 
@@ -21478,33 +23207,37 @@ public sealed class FactoryJournalApi
 
     /// <summary>Reads a memoized factory journal entry.</summary>
     /// <param name="runId">Factory run identifier.</param>
+    /// <param name="executionToken">Opaque token identifying the current factory execution attempt.</param>
     /// <param name="key">Namespaced journal key.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Result of reading a factory journal entry.</returns>
-    public async Task<FactoryJournalGetResult> GetAsync(string runId, string key, CancellationToken cancellationToken = default)
+    public async Task<FactoryJournalGetResult> GetAsync(string runId, string executionToken, string key, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(runId);
+        ArgumentNullException.ThrowIfNull(executionToken);
         ArgumentNullException.ThrowIfNull(key);
         _session.ThrowIfDisposed();
 
-        var request = new FactoryJournalGetRequest { SessionId = _session.SessionId, RunId = runId, Key = key };
+        var request = new FactoryJournalGetRequest { SessionId = _session.SessionId, RunId = runId, ExecutionToken = executionToken, Key = key };
         return await CopilotClient.InvokeRpcAsync<FactoryJournalGetResult>(_session.Rpc, "session.factory.journal.get", [request], cancellationToken);
     }
 
     /// <summary>Stores a memoized factory journal entry.</summary>
     /// <param name="runId">Factory run identifier.</param>
+    /// <param name="executionToken">Opaque token identifying the current factory execution attempt.</param>
     /// <param name="key">Namespaced journal key.</param>
     /// <param name="resultJson">JSON result to memoize.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Acknowledgement that a factory request was accepted.</returns>
-    public async Task<FactoryAckResult> PutAsync(string runId, string key, object resultJson, CancellationToken cancellationToken = default)
+    public async Task<FactoryAckResult> PutAsync(string runId, string executionToken, string key, object resultJson, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(runId);
+        ArgumentNullException.ThrowIfNull(executionToken);
         ArgumentNullException.ThrowIfNull(key);
         ArgumentNullException.ThrowIfNull(resultJson);
         _session.ThrowIfDisposed();
 
-        var request = new FactoryJournalPutRequest { SessionId = _session.SessionId, RunId = runId, Key = key, ResultJson = CopilotClient.ToJsonElementForWire(resultJson)!.Value };
+        var request = new FactoryJournalPutRequest { SessionId = _session.SessionId, RunId = runId, ExecutionToken = executionToken, Key = key, ResultJson = CopilotClient.ToJsonElementForWire(resultJson)!.Value };
         return await CopilotClient.InvokeRpcAsync<FactoryAckResult>(_session.Rpc, "session.factory.journal.put", [request], cancellationToken);
     }
 }
@@ -21746,6 +23479,31 @@ public sealed class WorkspacesApi
         return await CopilotClient.InvokeRpcAsync<WorkspacesGetWorkspaceResult>(_session.Rpc, "session.workspaces.getWorkspace", [request], cancellationToken);
     }
 
+    /// <summary>Updates workspace metadata for a local session and returns the refreshed workspace.</summary>
+    /// <param name="context">Opaque workspace context supplied by the session host.</param>
+    /// <param name="name">Optional workspace display name override.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Current workspace metadata for the session, including its absolute filesystem path when available.</returns>
+    public async Task<WorkspacesGetWorkspaceResult> UpdateMetadataAsync(object? context = null, string? name = null, CancellationToken cancellationToken = default)
+    {
+        _session.ThrowIfDisposed();
+
+        var request = new WorkspacesUpdateMetadataRequest { SessionId = _session.SessionId, Context = CopilotClient.ToJsonElementForWire(context), Name = name };
+        return await CopilotClient.InvokeRpcAsync<WorkspacesGetWorkspaceResult>(_session.Rpc, "session.workspaces.updateMetadata", [request], cancellationToken);
+    }
+
+    /// <summary>Ensures a local session workspace exists and returns it.</summary>
+    /// <param name="context">Opaque workspace context supplied by the session host.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Current workspace metadata for the session, including its absolute filesystem path when available.</returns>
+    public async Task<WorkspacesGetWorkspaceResult> EnsureAsync(object? context = null, CancellationToken cancellationToken = default)
+    {
+        _session.ThrowIfDisposed();
+
+        var request = new WorkspacesEnsureRequest { SessionId = _session.SessionId, Context = CopilotClient.ToJsonElementForWire(context) };
+        return await CopilotClient.InvokeRpcAsync<WorkspacesGetWorkspaceResult>(_session.Rpc, "session.workspaces.ensure", [request], cancellationToken);
+    }
+
     /// <summary>Lists files stored in the session workspace files directory.</summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Relative paths of files stored in the session workspace files directory.</returns>
@@ -21805,6 +23563,79 @@ public sealed class WorkspacesApi
 
         var request = new WorkspacesReadCheckpointRequest { SessionId = _session.SessionId, Number = number };
         return await CopilotClient.InvokeRpcAsync<WorkspacesReadCheckpointResult>(_session.Rpc, "session.workspaces.readCheckpoint", [request], cancellationToken);
+    }
+
+    /// <summary>Adds a compaction summary checkpoint to the local session workspace.</summary>
+    /// <param name="title">Summary title shown in checkpoint listings.</param>
+    /// <param name="content">Markdown summary content to persist.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Persisted summary metadata and refreshed workspace metadata.</returns>
+    public async Task<WorkspacesAddSummaryResult> AddSummaryAsync(string title, string content, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(title);
+        ArgumentNullException.ThrowIfNull(content);
+        _session.ThrowIfDisposed();
+
+        var request = new WorkspacesAddSummaryRequest { SessionId = _session.SessionId, Title = title, Content = content };
+        return await CopilotClient.InvokeRpcAsync<WorkspacesAddSummaryResult>(_session.Rpc, "session.workspaces.addSummary", [request], cancellationToken);
+    }
+
+    /// <summary>Truncates local workspace compaction summaries after a rollback.</summary>
+    /// <param name="keepCount">Number of newest summaries to keep.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Current workspace metadata for the session, including its absolute filesystem path when available.</returns>
+    public async Task<WorkspacesGetWorkspaceResult> TruncateSummariesAsync(long keepCount, CancellationToken cancellationToken = default)
+    {
+        _session.ThrowIfDisposed();
+
+        var request = new WorkspacesTruncateSummariesRequest { SessionId = _session.SessionId, KeepCount = keepCount };
+        return await CopilotClient.InvokeRpcAsync<WorkspacesGetWorkspaceResult>(_session.Rpc, "session.workspaces.truncateSummaries", [request], cancellationToken);
+    }
+
+    /// <summary>Reads the autopilot objective state file from the local session workspace.</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Autopilot objective file content, or null when missing.</returns>
+    public async Task<WorkspacesReadAutopilotObjectiveResult> ReadAutopilotObjectiveAsync(CancellationToken cancellationToken = default)
+    {
+        _session.ThrowIfDisposed();
+
+        var request = new SessionWorkspacesReadAutopilotObjectiveRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<WorkspacesReadAutopilotObjectiveResult>(_session.Rpc, "session.workspaces.readAutopilotObjective", [request], cancellationToken);
+    }
+
+    /// <summary>Writes the autopilot objective state file in the local session workspace.</summary>
+    /// <param name="content">Autopilot objective file content.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Result of writing the autopilot objective file.</returns>
+    public async Task<WorkspacesWriteAutopilotObjectiveResult> WriteAutopilotObjectiveAsync(string content, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        _session.ThrowIfDisposed();
+
+        var request = new WorkspacesWriteAutopilotObjectiveRequest { SessionId = _session.SessionId, Content = content };
+        return await CopilotClient.InvokeRpcAsync<WorkspacesWriteAutopilotObjectiveResult>(_session.Rpc, "session.workspaces.writeAutopilotObjective", [request], cancellationToken);
+    }
+
+    /// <summary>Deletes the autopilot objective state file from the local session workspace.</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Result of deleting the autopilot objective file.</returns>
+    public async Task<WorkspacesDeleteAutopilotObjectiveResult> DeleteAutopilotObjectiveAsync(CancellationToken cancellationToken = default)
+    {
+        _session.ThrowIfDisposed();
+
+        var request = new SessionWorkspacesDeleteAutopilotObjectiveRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<WorkspacesDeleteAutopilotObjectiveResult>(_session.Rpc, "session.workspaces.deleteAutopilotObjective", [request], cancellationToken);
+    }
+
+    /// <summary>Checks whether the local session workspace has an autopilot objective state file.</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Whether the autopilot objective file exists.</returns>
+    public async Task<WorkspacesAutopilotObjectiveExistsResult> AutopilotObjectiveExistsAsync(CancellationToken cancellationToken = default)
+    {
+        _session.ThrowIfDisposed();
+
+        var request = new SessionWorkspacesAutopilotObjectiveExistsRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<WorkspacesAutopilotObjectiveExistsResult>(_session.Rpc, "session.workspaces.autopilotObjectiveExists", [request], cancellationToken);
     }
 
     /// <summary>Saves pasted content as a UTF-8 file in the session workspace.</summary>
@@ -22521,6 +24352,19 @@ public sealed class McpOauthApi
         var request = new McpOauthLoginRequest { SessionId = _session.SessionId, ServerName = serverName, ForceReauth = forceReauth, ClientName = clientName, CallbackSuccessMessage = callbackSuccessMessage, ClientId = clientId, ClientSecret = clientSecret, PublicClient = publicClient, GrantType = grantType };
         return await CopilotClient.InvokeRpcAsync<McpOauthLoginResult>(_session.Rpc, "session.mcp.oauth.login", [request], cancellationToken);
     }
+
+    /// <summary>Responds to a pending MCP OAuth authorization request by its request id.</summary>
+    /// <param name="requestId">OAuth request identifier from the mcp.oauth_required event.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Indicates whether the pending MCP OAuth response was accepted.</returns>
+    public async Task<McpOauthRespondResult> RespondAsync(string requestId, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(requestId);
+        _session.ThrowIfDisposed();
+
+        var request = new McpOauthRespondRequest { SessionId = _session.SessionId, RequestId = requestId };
+        return await CopilotClient.InvokeRpcAsync<McpOauthRespondResult>(_session.Rpc, "session.mcp.oauth.respond", [request], cancellationToken);
+    }
 }
 
 /// <summary>Provides session-scoped McpHeaders APIs.</summary>
@@ -22803,8 +24647,9 @@ public sealed class OptionsApi
     /// <param name="excludedBuiltinAgents">Built-in subagent names to exclude from this session. Excluded built-ins are hidden from agent discovery and cannot be dispatched unless a custom agent with the same name is available.</param>
     /// <param name="toolFilterPrecedence">Controls how availableTools (allowlist) and excludedTools (denylist) combine when both are set.</param>
     /// <param name="enableScriptSafety">Whether shell-script safety heuristics are enabled.</param>
-    /// <param name="shellInitProfile">Shell init profile (`None` or `NonInteractive`).</param>
-    /// <param name="shellProcessFlags">Per-shell process flags (e.g., `pwsh` arguments).</param>
+    /// <param name="shell">Per-session settings for built-in shell tools.</param>
+    /// <param name="shellInitProfile">Use shell.initProfile instead. Shell init profile (`None` or `NonInteractive`).</param>
+    /// <param name="shellProcessFlags">PowerShell process flags applied to built-in and user-requested shell commands.</param>
     /// <param name="sandboxConfig">Resolved sandbox configuration.</param>
     /// <param name="logInteractiveShells">Whether interactive shell sessions are logged.</param>
     /// <param name="envValueMode">How env values are passed to MCP servers (`direct` inlines literal values; `indirect` resolves at launch).</param>
@@ -22828,6 +24673,7 @@ public sealed class OptionsApi
     /// <param name="enableReasoningSummaries">Whether to surface reasoning-summary events from the model.</param>
     /// <param name="agentContext">Runtime context discriminator (e.g., `cli`, `actions`).</param>
     /// <param name="eventsLogDirectory">Override directory for the session-events log. When unset, the runtime's default events log directory is used.</param>
+    /// <param name="eventsLogIncludesSubagents">Whether subagent callback events should be forwarded into the session event log sink.</param>
     /// <param name="additionalContentExclusionPolicies">Additional content-exclusion policies to merge into the session's policy set.</param>
     /// <param name="manageScheduleEnabled">Whether to expose the `manage_schedule` tool to the agent. The runtime always owns the per-session schedule registry; this flag only controls tool exposure (typically gated to staff users).</param>
     /// <param name="sessionCapabilities">Replaces the session's capability set with the given list. Use to enable or disable capabilities mid-session (e.g., remove `memory` for reproducible scripted runs). Omit the field to leave the existing capability set unchanged.</param>
@@ -22841,11 +24687,11 @@ public sealed class OptionsApi
     /// <param name="sessionLimits">Optional session limits. Pass null to clear the session limits.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Indicates whether the session options patch was applied successfully.</returns>
-    public async Task<SessionUpdateOptionsResult> UpdateAsync(string? model = null, ModelCapabilitiesOverride? modelCapabilitiesOverrides = null, string? reasoningEffort = null, OptionsUpdateReasoningSummary? reasoningSummary = null, Verbosity? verbosity = null, string? clientName = null, string? lspClientName = null, string? integrationId = null, IDictionary<string, bool>? featureFlags = null, bool? isExperimentalMode = null, ProviderConfig? provider = null, CapiSessionOptions? capi = null, string? workingDirectory = null, IList<string>? availableTools = null, IList<string>? excludedTools = null, IList<string>? includedBuiltinAgents = null, IList<string>? excludedBuiltinAgents = null, OptionsUpdateToolFilterPrecedence? toolFilterPrecedence = null, bool? enableScriptSafety = null, string? shellInitProfile = null, IList<string>? shellProcessFlags = null, SandboxConfig? sandboxConfig = null, bool? logInteractiveShells = null, OptionsUpdateEnvValueMode? envValueMode = null, bool? allowAllMcpServerInstructions = null, IList<string>? skillDirectories = null, IList<string>? disabledSkills = null, bool? enableOnDemandInstructionDiscovery = null, long? maxInlineBinaryBytes = null, IList<SessionInstalledPlugin>? installedPlugins = null, bool? customAgentsLocalOnly = null, bool? suppressCustomAgentPrompt = null, bool? skipCustomInstructions = null, IList<string>? disabledInstructionSources = null, bool? coauthorEnabled = null, string? trajectoryFile = null, bool? enableStreaming = null, string? copilotUrl = null, bool? askUserDisabled = null, bool? continueOnAutoMode = null, bool? runningInInteractiveMode = null, bool? enableReasoningSummaries = null, string? agentContext = null, string? eventsLogDirectory = null, IList<OptionsUpdateAdditionalContentExclusionPolicy>? additionalContentExclusionPolicies = null, bool? manageScheduleEnabled = null, IList<SessionCapability>? sessionCapabilities = null, bool? skipEmbeddingRetrieval = null, string? organizationCustomInstructions = null, bool? enableFileHooks = null, bool? enableHostGitOperations = null, bool? enableSessionStore = null, bool? enableSkills = null, OptionsUpdateContextTier? contextTier = null, SessionLimitsConfig? sessionLimits = null, CancellationToken cancellationToken = default)
+    public async Task<SessionUpdateOptionsResult> UpdateAsync(string? model = null, ModelCapabilitiesOverride? modelCapabilitiesOverrides = null, string? reasoningEffort = null, OptionsUpdateReasoningSummary? reasoningSummary = null, Verbosity? verbosity = null, string? clientName = null, string? lspClientName = null, string? integrationId = null, IDictionary<string, bool>? featureFlags = null, bool? isExperimentalMode = null, ProviderConfig? provider = null, CapiSessionOptions? capi = null, string? workingDirectory = null, IList<string>? availableTools = null, IList<string>? excludedTools = null, IList<string>? includedBuiltinAgents = null, IList<string>? excludedBuiltinAgents = null, OptionsUpdateToolFilterPrecedence? toolFilterPrecedence = null, bool? enableScriptSafety = null, ShellOptions? shell = null, string? shellInitProfile = null, IList<string>? shellProcessFlags = null, SandboxConfig? sandboxConfig = null, bool? logInteractiveShells = null, OptionsUpdateEnvValueMode? envValueMode = null, bool? allowAllMcpServerInstructions = null, IList<string>? skillDirectories = null, IList<string>? disabledSkills = null, bool? enableOnDemandInstructionDiscovery = null, long? maxInlineBinaryBytes = null, IList<SessionInstalledPlugin>? installedPlugins = null, bool? customAgentsLocalOnly = null, bool? suppressCustomAgentPrompt = null, bool? skipCustomInstructions = null, IList<string>? disabledInstructionSources = null, bool? coauthorEnabled = null, string? trajectoryFile = null, bool? enableStreaming = null, string? copilotUrl = null, bool? askUserDisabled = null, bool? continueOnAutoMode = null, bool? runningInInteractiveMode = null, bool? enableReasoningSummaries = null, string? agentContext = null, string? eventsLogDirectory = null, bool? eventsLogIncludesSubagents = null, IList<OptionsUpdateAdditionalContentExclusionPolicy>? additionalContentExclusionPolicies = null, bool? manageScheduleEnabled = null, IList<SessionCapability>? sessionCapabilities = null, bool? skipEmbeddingRetrieval = null, string? organizationCustomInstructions = null, bool? enableFileHooks = null, bool? enableHostGitOperations = null, bool? enableSessionStore = null, bool? enableSkills = null, OptionsUpdateContextTier? contextTier = null, SessionLimitsConfig? sessionLimits = null, CancellationToken cancellationToken = default)
     {
         _session.ThrowIfDisposed();
 
-        var request = new SessionUpdateOptionsParams { SessionId = _session.SessionId, Model = model, ModelCapabilitiesOverrides = modelCapabilitiesOverrides, ReasoningEffort = reasoningEffort, ReasoningSummary = reasoningSummary, Verbosity = verbosity, ClientName = clientName, LspClientName = lspClientName, IntegrationId = integrationId, FeatureFlags = featureFlags, IsExperimentalMode = isExperimentalMode, Provider = provider, Capi = capi, WorkingDirectory = workingDirectory, AvailableTools = availableTools, ExcludedTools = excludedTools, IncludedBuiltinAgents = includedBuiltinAgents, ExcludedBuiltinAgents = excludedBuiltinAgents, ToolFilterPrecedence = toolFilterPrecedence, EnableScriptSafety = enableScriptSafety, ShellInitProfile = shellInitProfile, ShellProcessFlags = shellProcessFlags, SandboxConfig = sandboxConfig, LogInteractiveShells = logInteractiveShells, EnvValueMode = envValueMode, AllowAllMcpServerInstructions = allowAllMcpServerInstructions, SkillDirectories = skillDirectories, DisabledSkills = disabledSkills, EnableOnDemandInstructionDiscovery = enableOnDemandInstructionDiscovery, MaxInlineBinaryBytes = maxInlineBinaryBytes, InstalledPlugins = installedPlugins, CustomAgentsLocalOnly = customAgentsLocalOnly, SuppressCustomAgentPrompt = suppressCustomAgentPrompt, SkipCustomInstructions = skipCustomInstructions, DisabledInstructionSources = disabledInstructionSources, CoauthorEnabled = coauthorEnabled, TrajectoryFile = trajectoryFile, EnableStreaming = enableStreaming, CopilotUrl = copilotUrl, AskUserDisabled = askUserDisabled, ContinueOnAutoMode = continueOnAutoMode, RunningInInteractiveMode = runningInInteractiveMode, EnableReasoningSummaries = enableReasoningSummaries, AgentContext = agentContext, EventsLogDirectory = eventsLogDirectory, AdditionalContentExclusionPolicies = additionalContentExclusionPolicies, ManageScheduleEnabled = manageScheduleEnabled, SessionCapabilities = sessionCapabilities, SkipEmbeddingRetrieval = skipEmbeddingRetrieval, OrganizationCustomInstructions = organizationCustomInstructions, EnableFileHooks = enableFileHooks, EnableHostGitOperations = enableHostGitOperations, EnableSessionStore = enableSessionStore, EnableSkills = enableSkills, ContextTier = contextTier, SessionLimits = sessionLimits };
+        var request = new SessionUpdateOptionsParams { SessionId = _session.SessionId, Model = model, ModelCapabilitiesOverrides = modelCapabilitiesOverrides, ReasoningEffort = reasoningEffort, ReasoningSummary = reasoningSummary, Verbosity = verbosity, ClientName = clientName, LspClientName = lspClientName, IntegrationId = integrationId, FeatureFlags = featureFlags, IsExperimentalMode = isExperimentalMode, Provider = provider, Capi = capi, WorkingDirectory = workingDirectory, AvailableTools = availableTools, ExcludedTools = excludedTools, IncludedBuiltinAgents = includedBuiltinAgents, ExcludedBuiltinAgents = excludedBuiltinAgents, ToolFilterPrecedence = toolFilterPrecedence, EnableScriptSafety = enableScriptSafety, Shell = shell, ShellInitProfile = shellInitProfile, ShellProcessFlags = shellProcessFlags, SandboxConfig = sandboxConfig, LogInteractiveShells = logInteractiveShells, EnvValueMode = envValueMode, AllowAllMcpServerInstructions = allowAllMcpServerInstructions, SkillDirectories = skillDirectories, DisabledSkills = disabledSkills, EnableOnDemandInstructionDiscovery = enableOnDemandInstructionDiscovery, MaxInlineBinaryBytes = maxInlineBinaryBytes, InstalledPlugins = installedPlugins, CustomAgentsLocalOnly = customAgentsLocalOnly, SuppressCustomAgentPrompt = suppressCustomAgentPrompt, SkipCustomInstructions = skipCustomInstructions, DisabledInstructionSources = disabledInstructionSources, CoauthorEnabled = coauthorEnabled, TrajectoryFile = trajectoryFile, EnableStreaming = enableStreaming, CopilotUrl = copilotUrl, AskUserDisabled = askUserDisabled, ContinueOnAutoMode = continueOnAutoMode, RunningInInteractiveMode = runningInInteractiveMode, EnableReasoningSummaries = enableReasoningSummaries, AgentContext = agentContext, EventsLogDirectory = eventsLogDirectory, EventsLogIncludesSubagents = eventsLogIncludesSubagents, AdditionalContentExclusionPolicies = additionalContentExclusionPolicies, ManageScheduleEnabled = manageScheduleEnabled, SessionCapabilities = sessionCapabilities, SkipEmbeddingRetrieval = skipEmbeddingRetrieval, OrganizationCustomInstructions = organizationCustomInstructions, EnableFileHooks = enableFileHooks, EnableHostGitOperations = enableHostGitOperations, EnableSessionStore = enableSessionStore, EnableSkills = enableSkills, ContextTier = contextTier, SessionLimits = sessionLimits };
         return await CopilotClient.InvokeRpcAsync<SessionUpdateOptionsResult>(_session.Rpc, "session.options.update", [request], cancellationToken);
     }
 }
@@ -23967,6 +25813,64 @@ public sealed class QueueApi
         return await CopilotClient.InvokeRpcAsync<QueuePendingItemsResult>(_session.Rpc, "session.queue.pendingItems", [request], cancellationToken);
     }
 
+    /// <summary>Returns the internal native queue snapshot for in-process session orchestration.</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Internal snapshot of native queue state for local session orchestration.</returns>
+    internal async Task<QueueSnapshotResult> SnapshotAsync(CancellationToken cancellationToken = default)
+    {
+        _session.ThrowIfDisposed();
+
+        var request = new SessionQueueSnapshotRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<QueueSnapshotResult>(_session.Rpc, "session.queue.snapshot", [request], cancellationToken);
+    }
+
+    /// <summary>Reports whether the local session has native queued work pending.</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Whether the native queue has pending work.</returns>
+    internal async Task<QueueHasPendingResult> HasPendingAsync(CancellationToken cancellationToken = default)
+    {
+        _session.ThrowIfDisposed();
+
+        var request = new SessionQueueHasPendingRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<QueueHasPendingResult>(_session.Rpc, "session.queue.hasPending", [request], cancellationToken);
+    }
+
+    /// <summary>Begins a native deferred-idle drain when background work has quiesced.</summary>
+    /// <param name="activeBackgroundWork">Whether the host still has active background work.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Whether a deferred-idle drain should run.</returns>
+    internal async Task<QueueBeginDeferredIdleDrainResult> BeginDeferredIdleDrainAsync(bool activeBackgroundWork, CancellationToken cancellationToken = default)
+    {
+        _session.ThrowIfDisposed();
+
+        var request = new QueueBeginDeferredIdleDrainRequest { SessionId = _session.SessionId, ActiveBackgroundWork = activeBackgroundWork };
+        return await CopilotClient.InvokeRpcAsync<QueueBeginDeferredIdleDrainResult>(_session.Rpc, "session.queue.beginDeferredIdleDrain", [request], cancellationToken);
+    }
+
+    /// <summary>Finishes a native deferred-idle drain and reports whether to drain queue work or emit idle.</summary>
+    /// <param name="activeBackgroundWork">Whether the host still has active background work.</param>
+    /// <param name="hasPending">Whether native queued work remains.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Action selected by the native deferred-idle drain.</returns>
+    internal async Task<QueueFinishDeferredIdleDrainResult> FinishDeferredIdleDrainAsync(bool activeBackgroundWork, bool hasPending, CancellationToken cancellationToken = default)
+    {
+        _session.ThrowIfDisposed();
+
+        var request = new QueueFinishDeferredIdleDrainRequest { SessionId = _session.SessionId, ActiveBackgroundWork = activeBackgroundWork, HasPending = hasPending };
+        return await CopilotClient.InvokeRpcAsync<QueueFinishDeferredIdleDrainResult>(_session.Rpc, "session.queue.finishDeferredIdleDrain", [request], cancellationToken);
+    }
+
+    /// <summary>Marks session.idle as deferred by native background work state.</summary>
+    /// <param name="aborted">Whether the deferred idle was caused by an aborted foreground turn.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    internal async Task DeferSessionIdleAsync(bool aborted, CancellationToken cancellationToken = default)
+    {
+        _session.ThrowIfDisposed();
+
+        var request = new QueueDeferSessionIdleRequest { SessionId = _session.SessionId, Aborted = aborted };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.queue.deferSessionIdle", [request], cancellationToken);
+    }
+
     /// <summary>Removes the most recently queued user-facing item (LIFO).</summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Indicates whether a user-facing pending item was removed.</returns>
@@ -23986,6 +25890,40 @@ public sealed class QueueApi
 
         var request = new SessionQueueClearRequest { SessionId = _session.SessionId };
         await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.queue.clear", [request], cancellationToken);
+    }
+
+    /// <summary>Consumes queued native system notifications matching an internal filter.</summary>
+    /// <param name="filter">Opaque runtime-owned filter object.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Indicates whether a user-facing pending item was removed.</returns>
+    internal async Task<QueueRemoveMostRecentResult> ConsumeSystemNotificationsAsync(object filter, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        _session.ThrowIfDisposed();
+
+        var request = new QueueConsumeSystemNotificationsRequest { SessionId = _session.SessionId, Filter = CopilotClient.ToJsonElementForWire(filter)!.Value };
+        return await CopilotClient.InvokeRpcAsync<QueueRemoveMostRecentResult>(_session.Rpc, "session.queue.consumeSystemNotifications", [request], cancellationToken);
+    }
+
+    /// <summary>Enqueues the internal resume-pending wake item when orphan handling needs a follow-up turn.</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Result of enqueueing the resume-pending wake item.</returns>
+    internal async Task<QueueEnqueueResumePendingResult> EnqueueResumePendingAsync(CancellationToken cancellationToken = default)
+    {
+        _session.ThrowIfDisposed();
+
+        var request = new SessionQueueEnqueueResumePendingRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<QueueEnqueueResumePendingResult>(_session.Rpc, "session.queue.enqueueResumePending", [request], cancellationToken);
+    }
+
+    /// <summary>Drains the native local-session work queue for in-process session orchestration.</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    internal async Task ProcessAsync(CancellationToken cancellationToken = default)
+    {
+        _session.ThrowIfDisposed();
+
+        var request = new SessionQueueProcessRequest { SessionId = _session.SessionId };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.queue.process", [request], cancellationToken);
     }
 }
 
@@ -24180,6 +26118,105 @@ public sealed class ScheduleApi
         return await CopilotClient.InvokeRpcAsync<ScheduleList>(_session.Rpc, "session.schedule.list", [request], cancellationToken);
     }
 
+    /// <summary>Hydrates the native schedule registry from persisted session events.</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    internal async Task HydrateAsync(CancellationToken cancellationToken = default)
+    {
+        _session.ThrowIfDisposed();
+
+        var request = new SessionScheduleHydrateRequest { SessionId = _session.SessionId };
+        await CopilotClient.InvokeRpcAsync(_session.Rpc, "session.schedule.hydrate", [request], cancellationToken);
+    }
+
+    /// <summary>Reports whether the session has an active self-paced scheduled prompt.</summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Whether the session currently has an active self-paced schedule.</returns>
+    internal async Task<ScheduleHasSelfPacedResult> HasSelfPacedAsync(CancellationToken cancellationToken = default)
+    {
+        _session.ThrowIfDisposed();
+
+        var request = new SessionScheduleHasSelfPacedRequest { SessionId = _session.SessionId };
+        return await CopilotClient.InvokeRpcAsync<ScheduleHasSelfPacedResult>(_session.Rpc, "session.schedule.hasSelfPaced", [request], cancellationToken);
+    }
+
+    /// <summary>Registers a relative-interval scheduled prompt.</summary>
+    /// <param name="interval">Human-readable interval such as `30s`, `5m`, or `2h`.</param>
+    /// <param name="prompt">Prompt text to enqueue when the schedule fires.</param>
+    /// <param name="recurring">Whether the schedule should re-arm after each tick. Defaults to true.</param>
+    /// <param name="displayPrompt">Optional display-only prompt label.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Result of registering or re-arming a scheduled prompt.</returns>
+    internal async Task<ScheduleAddResult> AddAsync(string interval, string prompt, bool? recurring = null, string? displayPrompt = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(interval);
+        ArgumentNullException.ThrowIfNull(prompt);
+        _session.ThrowIfDisposed();
+
+        var request = new ScheduleAddRequest { SessionId = _session.SessionId, Interval = interval, Prompt = prompt, Recurring = recurring, DisplayPrompt = displayPrompt };
+        return await CopilotClient.InvokeRpcAsync<ScheduleAddResult>(_session.Rpc, "session.schedule.add", [request], cancellationToken);
+    }
+
+    /// <summary>Registers a recurring cron scheduled prompt.</summary>
+    /// <param name="cron">5-field cron expression.</param>
+    /// <param name="prompt">Prompt text to enqueue when the schedule fires.</param>
+    /// <param name="recurring">Whether the schedule should re-arm after each tick. Defaults to true.</param>
+    /// <param name="displayPrompt">Optional display-only prompt label.</param>
+    /// <param name="tz">IANA timezone for evaluating the cron expression.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Result of registering or re-arming a scheduled prompt.</returns>
+    internal async Task<ScheduleAddResult> AddCronAsync(string cron, string prompt, bool? recurring = null, string? displayPrompt = null, string? tz = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(cron);
+        ArgumentNullException.ThrowIfNull(prompt);
+        _session.ThrowIfDisposed();
+
+        var request = new ScheduleAddCronRequest { SessionId = _session.SessionId, Cron = cron, Prompt = prompt, Recurring = recurring, DisplayPrompt = displayPrompt, Tz = tz };
+        return await CopilotClient.InvokeRpcAsync<ScheduleAddResult>(_session.Rpc, "session.schedule.addCron", [request], cancellationToken);
+    }
+
+    /// <summary>Registers an absolute-time scheduled prompt.</summary>
+    /// <param name="at">Epoch milliseconds when the prompt should fire.</param>
+    /// <param name="prompt">Prompt text to enqueue when the schedule fires.</param>
+    /// <param name="recurring">Whether the schedule should re-arm after each tick. Defaults to false.</param>
+    /// <param name="displayPrompt">Optional display-only prompt label.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Result of registering or re-arming a scheduled prompt.</returns>
+    internal async Task<ScheduleAddResult> AddAtAsync(long at, string prompt, bool? recurring = null, string? displayPrompt = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(prompt);
+        _session.ThrowIfDisposed();
+
+        var request = new ScheduleAddAtRequest { SessionId = _session.SessionId, At = at, Prompt = prompt, Recurring = recurring, DisplayPrompt = displayPrompt };
+        return await CopilotClient.InvokeRpcAsync<ScheduleAddResult>(_session.Rpc, "session.schedule.addAt", [request], cancellationToken);
+    }
+
+    /// <summary>Registers a self-paced scheduled prompt.</summary>
+    /// <param name="prompt">Prompt text to enqueue when the schedule fires.</param>
+    /// <param name="displayPrompt">Optional display-only prompt label.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Result of registering or re-arming a scheduled prompt.</returns>
+    internal async Task<ScheduleAddResult> AddSelfPacedAsync(string prompt, string? displayPrompt = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(prompt);
+        _session.ThrowIfDisposed();
+
+        var request = new ScheduleAddSelfPacedRequest { SessionId = _session.SessionId, Prompt = prompt, DisplayPrompt = displayPrompt };
+        return await CopilotClient.InvokeRpcAsync<ScheduleAddResult>(_session.Rpc, "session.schedule.addSelfPaced", [request], cancellationToken);
+    }
+
+    /// <summary>Re-arms an active self-paced scheduled prompt.</summary>
+    /// <param name="id">Id of the self-paced scheduled prompt.</param>
+    /// <param name="at">Epoch milliseconds when the prompt should next fire.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Result of registering or re-arming a scheduled prompt.</returns>
+    internal async Task<ScheduleAddResult> RearmSelfPacedAsync(long id, long at, CancellationToken cancellationToken = default)
+    {
+        _session.ThrowIfDisposed();
+
+        var request = new ScheduleRearmSelfPacedRequest { SessionId = _session.SessionId, Id = id, At = at };
+        return await CopilotClient.InvokeRpcAsync<ScheduleAddResult>(_session.Rpc, "session.schedule.rearmSelfPaced", [request], cancellationToken);
+    }
+
     /// <summary>Removes a scheduled prompt by id.</summary>
     /// <param name="id">Id of the scheduled prompt to remove.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
@@ -24274,11 +26311,16 @@ public interface ISessionFsHandler
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Describes a filesystem error.</returns>
     Task<SessionFsError?> RenameAsync(SessionFsRenameRequest request, CancellationToken cancellationToken = default);
-    /// <summary>Executes a SQLite query against the per-session database.</summary>
-    /// <param name="request">SQL query, query type, and optional bind parameters for executing a SQLite query against the per-session database.</param>
+    /// <summary>Executes a SQLite query against the per-session database. Providers apply busy handling for every call.</summary>
+    /// <param name="request">SQL query, query type, and optional bind parameters for executing a SQLite query against the per-session database. The provider applies its SQLite busy timeout for every call.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
     /// <returns>Query results including rows, columns, and rows affected, or a filesystem error if execution failed.</returns>
     Task<SessionFsSqliteQueryResult> SqliteQueryAsync(SessionFsSqliteQueryRequest request, CancellationToken cancellationToken = default);
+    /// <summary>Executes SQLite statements atomically on the provider-owned connection.</summary>
+    /// <param name="request">Statements to execute atomically. Providers apply busy handling for every call.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
+    /// <returns>Per-statement results, or a classified transaction error.</returns>
+    Task<SessionFsSqliteTransactionResult> SqliteTransactionAsync(SessionFsSqliteTransactionRequest request, CancellationToken cancellationToken = default);
     /// <summary>Checks whether the per-session SQLite database already exists, without creating it.</summary>
     /// <param name="request">Identifies the target session.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
@@ -24415,6 +26457,12 @@ internal static class ClientSessionApiRegistration
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.SqliteQueryAsync(request, cancellationToken);
+        }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("sessionFs.sqliteTransaction", (Func<SessionFsSqliteTransactionRequest, CancellationToken, ValueTask<SessionFsSqliteTransactionResult>>)(async (request, cancellationToken) =>
+        {
+            var handler = getHandlers(request.SessionId).SessionFs;
+            if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
+            return await handler.SqliteTransactionAsync(request, cancellationToken);
         }), singleObjectParam: true);
         rpc.SetLocalRpcMethod("sessionFs.sqliteExists", (Func<SessionFsSqliteExistsRequest, CancellationToken, ValueTask<SessionFsSqliteExistsResult>>)(async (request, cancellationToken) =>
         {
@@ -24638,6 +26686,8 @@ internal static class ClientGlobalApiRegistration
 [JsonSerializable(typeof(GitHub.Copilot.ExternalToolCompletedEvent), TypeInfoPropertyName = "SessionEventsExternalToolCompletedEvent")]
 [JsonSerializable(typeof(GitHub.Copilot.ExternalToolRequestedData), TypeInfoPropertyName = "SessionEventsExternalToolRequestedData")]
 [JsonSerializable(typeof(GitHub.Copilot.ExternalToolRequestedEvent), TypeInfoPropertyName = "SessionEventsExternalToolRequestedEvent")]
+[JsonSerializable(typeof(GitHub.Copilot.FactoryRunUpdatedData), TypeInfoPropertyName = "SessionEventsFactoryRunUpdatedData")]
+[JsonSerializable(typeof(GitHub.Copilot.FactoryRunUpdatedEvent), TypeInfoPropertyName = "SessionEventsFactoryRunUpdatedEvent")]
 [JsonSerializable(typeof(GitHub.Copilot.GitHubRepoRef), TypeInfoPropertyName = "SessionEventsGitHubRepoRef")]
 [JsonSerializable(typeof(GitHub.Copilot.HandoffRepository), TypeInfoPropertyName = "SessionEventsHandoffRepository")]
 [JsonSerializable(typeof(GitHub.Copilot.HandoffSourceType), TypeInfoPropertyName = "SessionEventsHandoffSourceType")]
@@ -24738,6 +26788,7 @@ internal static class ClientGlobalApiRegistration
 [JsonSerializable(typeof(GitHub.Copilot.SamplingCompletedEvent), TypeInfoPropertyName = "SessionEventsSamplingCompletedEvent")]
 [JsonSerializable(typeof(GitHub.Copilot.SamplingRequestedData), TypeInfoPropertyName = "SessionEventsSamplingRequestedData")]
 [JsonSerializable(typeof(GitHub.Copilot.SamplingRequestedEvent), TypeInfoPropertyName = "SessionEventsSamplingRequestedEvent")]
+[JsonSerializable(typeof(GitHub.Copilot.ScheduleOrigin), TypeInfoPropertyName = "SessionEventsScheduleOrigin")]
 [JsonSerializable(typeof(GitHub.Copilot.SessionEvent), TypeInfoPropertyName = "SessionEventsSessionEvent")]
 [JsonSerializable(typeof(GitHub.Copilot.SessionLimitsConfig), TypeInfoPropertyName = "SessionEventsSessionLimitsConfig")]
 [JsonSerializable(typeof(GitHub.Copilot.SessionLimitsExhaustedCompletedData), TypeInfoPropertyName = "SessionEventsSessionLimitsExhaustedCompletedData")]
@@ -24943,19 +26994,34 @@ internal static class ClientGlobalApiRegistration
 [JsonSerializable(typeof(FactoryAgentOptions))]
 [JsonSerializable(typeof(FactoryAgentRequest))]
 [JsonSerializable(typeof(FactoryAgentResult))]
+[JsonSerializable(typeof(FactoryAgentSummary))]
 [JsonSerializable(typeof(FactoryCancelRequest))]
+[JsonSerializable(typeof(FactoryCurrentPhase))]
+[JsonSerializable(typeof(FactoryDeclaredLimits))]
 [JsonSerializable(typeof(FactoryExecuteRequest))]
 [JsonSerializable(typeof(FactoryExecuteResult))]
+[JsonSerializable(typeof(FactoryGetRunProgressRequest))]
 [JsonSerializable(typeof(FactoryGetRunRequest))]
 [JsonSerializable(typeof(FactoryJournalGetRequest))]
 [JsonSerializable(typeof(FactoryJournalGetResult))]
 [JsonSerializable(typeof(FactoryJournalPutRequest))]
+[JsonSerializable(typeof(FactoryListRunsRequest))]
+[JsonSerializable(typeof(FactoryListRunsResult))]
 [JsonSerializable(typeof(FactoryLogLine))]
 [JsonSerializable(typeof(FactoryLogRequest))]
+[JsonSerializable(typeof(FactoryPhaseObservation))]
+[JsonSerializable(typeof(FactoryProgressLine))]
+[JsonSerializable(typeof(FactoryProgressPage))]
+[JsonSerializable(typeof(FactoryResumeRequest))]
+[JsonSerializable(typeof(FactoryResumeResult))]
+[JsonSerializable(typeof(FactoryRunConsumed))]
+[JsonSerializable(typeof(FactoryRunDetail))]
 [JsonSerializable(typeof(FactoryRunFailure))]
 [JsonSerializable(typeof(FactoryRunLimits))]
 [JsonSerializable(typeof(FactoryRunRequest))]
 [JsonSerializable(typeof(FactoryRunResult))]
+[JsonSerializable(typeof(FactoryRunSummary))]
+[JsonSerializable(typeof(FactoryRunTerminal))]
 [JsonSerializable(typeof(FleetStartRequest))]
 [JsonSerializable(typeof(FleetStartResult))]
 [JsonSerializable(typeof(FolderTrustAddParams))]
@@ -24985,6 +27051,8 @@ internal static class ClientGlobalApiRegistration
 [JsonSerializable(typeof(InstructionsDiscoverRequest))]
 [JsonSerializable(typeof(InstructionsGetDiscoveryPathsRequest))]
 [JsonSerializable(typeof(InstructionsGetSourcesResult))]
+[JsonSerializable(typeof(InterruptMainTurnRequest))]
+[JsonSerializable(typeof(InterruptMainTurnResult))]
 [JsonSerializable(typeof(LlmInferenceHttpRequestChunkRequest))]
 [JsonSerializable(typeof(LlmInferenceHttpRequestChunkResult))]
 [JsonSerializable(typeof(LlmInferenceHttpRequestStartRequest))]
@@ -25053,6 +27121,8 @@ internal static class ClientGlobalApiRegistration
 [JsonSerializable(typeof(McpOauthLoginRequest))]
 [JsonSerializable(typeof(McpOauthLoginResult))]
 [JsonSerializable(typeof(McpOauthPendingRequestResponse))]
+[JsonSerializable(typeof(McpOauthRespondRequest))]
+[JsonSerializable(typeof(McpOauthRespondResult))]
 [JsonSerializable(typeof(McpRegisterExternalClientRequest))]
 [JsonSerializable(typeof(McpReloadWithConfigRequest))]
 [JsonSerializable(typeof(McpRemoveGitHubResult))]
@@ -25224,9 +27294,18 @@ internal static class ClientGlobalApiRegistration
 [JsonSerializable(typeof(PushAttachmentSelectionDetailsEnd))]
 [JsonSerializable(typeof(PushAttachmentSelectionDetailsStart))]
 [JsonSerializable(typeof(PushGitHubRepoRef))]
+[JsonSerializable(typeof(QueueBeginDeferredIdleDrainRequest))]
+[JsonSerializable(typeof(QueueBeginDeferredIdleDrainResult))]
+[JsonSerializable(typeof(QueueConsumeSystemNotificationsRequest))]
+[JsonSerializable(typeof(QueueDeferSessionIdleRequest))]
+[JsonSerializable(typeof(QueueEnqueueResumePendingResult))]
+[JsonSerializable(typeof(QueueFinishDeferredIdleDrainRequest))]
+[JsonSerializable(typeof(QueueFinishDeferredIdleDrainResult))]
+[JsonSerializable(typeof(QueueHasPendingResult))]
 [JsonSerializable(typeof(QueuePendingItems))]
 [JsonSerializable(typeof(QueuePendingItemsResult))]
 [JsonSerializable(typeof(QueueRemoveMostRecentResult))]
+[JsonSerializable(typeof(QueueSnapshotResult))]
 [JsonSerializable(typeof(QueuedCommandResult))]
 [JsonSerializable(typeof(RegisterEventInterestParams))]
 [JsonSerializable(typeof(RegisterEventInterestResult))]
@@ -25254,8 +27333,15 @@ internal static class ClientGlobalApiRegistration
 [JsonSerializable(typeof(SandboxConfigUserPolicyFilesystem))]
 [JsonSerializable(typeof(SandboxConfigUserPolicyNetwork))]
 [JsonSerializable(typeof(SandboxConfigUserPolicySeatbelt))]
+[JsonSerializable(typeof(ScheduleAddAtRequest))]
+[JsonSerializable(typeof(ScheduleAddCronRequest))]
+[JsonSerializable(typeof(ScheduleAddRequest))]
+[JsonSerializable(typeof(ScheduleAddResult))]
+[JsonSerializable(typeof(ScheduleAddSelfPacedRequest))]
 [JsonSerializable(typeof(ScheduleEntry))]
+[JsonSerializable(typeof(ScheduleHasSelfPacedResult))]
 [JsonSerializable(typeof(ScheduleList))]
+[JsonSerializable(typeof(ScheduleRearmSelfPacedRequest))]
 [JsonSerializable(typeof(ScheduleStopRequest))]
 [JsonSerializable(typeof(ScheduleStopResult))]
 [JsonSerializable(typeof(SecretsAddFilterValuesRequest))]
@@ -25266,6 +27352,7 @@ internal static class ClientGlobalApiRegistration
 [JsonSerializable(typeof(SendMessagesResult))]
 [JsonSerializable(typeof(SendRequest))]
 [JsonSerializable(typeof(SendResult))]
+[JsonSerializable(typeof(SendSystemNotificationRequest))]
 [JsonSerializable(typeof(ServerAgentList))]
 [JsonSerializable(typeof(ServerInstructionSourceList))]
 [JsonSerializable(typeof(ServerSkill))]
@@ -25277,6 +27364,7 @@ internal static class ClientGlobalApiRegistration
 [JsonSerializable(typeof(SessionAgentReloadRequest))]
 [JsonSerializable(typeof(SessionAuthStatus))]
 [JsonSerializable(typeof(SessionBulkDeleteResult))]
+[JsonSerializable(typeof(SessionCancelAllBackgroundAgentsRequest))]
 [JsonSerializable(typeof(SessionCanvasListOpenRequest))]
 [JsonSerializable(typeof(SessionCanvasListRequest))]
 [JsonSerializable(typeof(SessionCompletionItem))]
@@ -25307,6 +27395,10 @@ internal static class ClientGlobalApiRegistration
 [JsonSerializable(typeof(SessionFsSqliteExistsResult))]
 [JsonSerializable(typeof(SessionFsSqliteQueryRequest))]
 [JsonSerializable(typeof(SessionFsSqliteQueryResult))]
+[JsonSerializable(typeof(SessionFsSqliteTransactionError))]
+[JsonSerializable(typeof(SessionFsSqliteTransactionRequest))]
+[JsonSerializable(typeof(SessionFsSqliteTransactionResult))]
+[JsonSerializable(typeof(SessionFsSqliteTransactionStatement))]
 [JsonSerializable(typeof(SessionFsStatRequest))]
 [JsonSerializable(typeof(SessionFsStatResult))]
 [JsonSerializable(typeof(SessionFsWriteFileRequest))]
@@ -25343,9 +27435,15 @@ internal static class ClientGlobalApiRegistration
 [JsonSerializable(typeof(SessionPluginsListRequest))]
 [JsonSerializable(typeof(SessionPruneResult))]
 [JsonSerializable(typeof(SessionQueueClearRequest))]
+[JsonSerializable(typeof(SessionQueueEnqueueResumePendingRequest))]
+[JsonSerializable(typeof(SessionQueueHasPendingRequest))]
 [JsonSerializable(typeof(SessionQueuePendingItemsRequest))]
+[JsonSerializable(typeof(SessionQueueProcessRequest))]
 [JsonSerializable(typeof(SessionQueueRemoveMostRecentRequest))]
+[JsonSerializable(typeof(SessionQueueSnapshotRequest))]
 [JsonSerializable(typeof(SessionRemoteDisableRequest))]
+[JsonSerializable(typeof(SessionScheduleHasSelfPacedRequest))]
+[JsonSerializable(typeof(SessionScheduleHydrateRequest))]
 [JsonSerializable(typeof(SessionScheduleListRequest))]
 [JsonSerializable(typeof(SessionSetCredentialsParams))]
 [JsonSerializable(typeof(SessionSetCredentialsResult))]
@@ -25380,14 +27478,18 @@ internal static class ClientGlobalApiRegistration
 [JsonSerializable(typeof(SessionUsageGetMetricsRequest))]
 [JsonSerializable(typeof(SessionVisibilityGetRequest))]
 [JsonSerializable(typeof(SessionWorkingDirectoryContext))]
+[JsonSerializable(typeof(SessionWorkspacesAutopilotObjectiveExistsRequest))]
+[JsonSerializable(typeof(SessionWorkspacesDeleteAutopilotObjectiveRequest))]
 [JsonSerializable(typeof(SessionWorkspacesGetWorkspaceRequest))]
 [JsonSerializable(typeof(SessionWorkspacesListCheckpointsRequest))]
 [JsonSerializable(typeof(SessionWorkspacesListFilesRequest))]
+[JsonSerializable(typeof(SessionWorkspacesReadAutopilotObjectiveRequest))]
 [JsonSerializable(typeof(SessionsBulkDeleteRequest))]
 [JsonSerializable(typeof(SessionsCheckInUseRequest))]
 [JsonSerializable(typeof(SessionsCheckInUseResult))]
 [JsonSerializable(typeof(SessionsCloseRequest))]
 [JsonSerializable(typeof(SessionsCloseResult))]
+[JsonSerializable(typeof(SessionsDeleteRequest))]
 [JsonSerializable(typeof(SessionsEnrichMetadataRequest))]
 [JsonSerializable(typeof(SessionsFindByPrefixRequest))]
 [JsonSerializable(typeof(SessionsFindByPrefixResult))]
@@ -25401,8 +27503,12 @@ internal static class ClientGlobalApiRegistration
 [JsonSerializable(typeof(SessionsGetEventFilePathResult))]
 [JsonSerializable(typeof(SessionsGetLastForContextRequest))]
 [JsonSerializable(typeof(SessionsGetLastForContextResult))]
+[JsonSerializable(typeof(SessionsGetMetadataRequest))]
+[JsonSerializable(typeof(SessionsGetMetadataResult))]
 [JsonSerializable(typeof(SessionsGetPersistedRemoteSteerableRequest))]
 [JsonSerializable(typeof(SessionsGetPersistedRemoteSteerableResult))]
+[JsonSerializable(typeof(SessionsListNonEmptySessionIdsRequest))]
+[JsonSerializable(typeof(SessionsListNonEmptySessionIdsResult))]
 [JsonSerializable(typeof(SessionsListRequest))]
 [JsonSerializable(typeof(SessionsLoadDeferredRepoHooksRequest))]
 [JsonSerializable(typeof(SessionsOpenProgress))]
@@ -25424,8 +27530,10 @@ internal static class ClientGlobalApiRegistration
 [JsonSerializable(typeof(ShellExecRequest))]
 [JsonSerializable(typeof(ShellExecResult))]
 [JsonSerializable(typeof(ShellExecuteUserRequestedRequest))]
+[JsonSerializable(typeof(ShellInitScript))]
 [JsonSerializable(typeof(ShellKillRequest))]
 [JsonSerializable(typeof(ShellKillResult))]
+[JsonSerializable(typeof(ShellOptions))]
 [JsonSerializable(typeof(ShutdownRequest))]
 [JsonSerializable(typeof(Skill))]
 [JsonSerializable(typeof(SkillDiscoveryPath))]
@@ -25511,13 +27619,21 @@ internal static class ClientGlobalApiRegistration
 [JsonSerializable(typeof(VisibilitySetResult))]
 [JsonSerializable(typeof(WorkspaceDiffFileChange))]
 [JsonSerializable(typeof(WorkspaceDiffResult))]
+[JsonSerializable(typeof(WorkspacesAddSummaryRequest))]
+[JsonSerializable(typeof(WorkspacesAddSummaryResult))]
+[JsonSerializable(typeof(WorkspacesAddSummaryResultSummary))]
+[JsonSerializable(typeof(WorkspacesAddSummaryResultWorkspace))]
+[JsonSerializable(typeof(WorkspacesAutopilotObjectiveExistsResult))]
 [JsonSerializable(typeof(WorkspacesCheckpoints))]
 [JsonSerializable(typeof(WorkspacesCreateFileRequest))]
+[JsonSerializable(typeof(WorkspacesDeleteAutopilotObjectiveResult))]
 [JsonSerializable(typeof(WorkspacesDiffRequest))]
+[JsonSerializable(typeof(WorkspacesEnsureRequest))]
 [JsonSerializable(typeof(WorkspacesGetWorkspaceResult))]
 [JsonSerializable(typeof(WorkspacesGetWorkspaceResultWorkspace))]
 [JsonSerializable(typeof(WorkspacesListCheckpointsResult))]
 [JsonSerializable(typeof(WorkspacesListFilesResult))]
+[JsonSerializable(typeof(WorkspacesReadAutopilotObjectiveResult))]
 [JsonSerializable(typeof(WorkspacesReadCheckpointRequest))]
 [JsonSerializable(typeof(WorkspacesReadCheckpointResult))]
 [JsonSerializable(typeof(WorkspacesReadFileRequest))]
@@ -25525,4 +27641,8 @@ internal static class ClientGlobalApiRegistration
 [JsonSerializable(typeof(WorkspacesSaveLargePasteRequest))]
 [JsonSerializable(typeof(WorkspacesSaveLargePasteResult))]
 [JsonSerializable(typeof(WorkspacesSaveLargePasteResultSaved))]
+[JsonSerializable(typeof(WorkspacesTruncateSummariesRequest))]
+[JsonSerializable(typeof(WorkspacesUpdateMetadataRequest))]
+[JsonSerializable(typeof(WorkspacesWriteAutopilotObjectiveRequest))]
+[JsonSerializable(typeof(WorkspacesWriteAutopilotObjectiveResult))]
 internal partial class RpcJsonContext : JsonSerializerContext;

--- a/dotnet/src/Generated/SessionEvents.cs
+++ b/dotnet/src/Generated/SessionEvents.cs
@@ -52,6 +52,7 @@ namespace GitHub.Copilot;
 [JsonDerivedType(typeof(ExitPlanModeRequestedEvent), "exit_plan_mode.requested")]
 [JsonDerivedType(typeof(ExternalToolCompletedEvent), "external_tool.completed")]
 [JsonDerivedType(typeof(ExternalToolRequestedEvent), "external_tool.requested")]
+[JsonDerivedType(typeof(FactoryRunUpdatedEvent), "factory.run_updated")]
 [JsonDerivedType(typeof(HookEndEvent), "hook.end")]
 [JsonDerivedType(typeof(HookProgressEvent), "hook.progress")]
 [JsonDerivedType(typeof(HookStartEvent), "hook.start")]
@@ -1444,6 +1445,20 @@ public sealed partial class SessionBackgroundTasksChangedEvent : SessionEvent
     public required SessionBackgroundTasksChangedData Data { get; set; }
 }
 
+/// <summary>Ephemeral invalidation signal for a changed factory run.</summary>
+/// <remarks>Represents the <c>factory.run_updated</c> event.</remarks>
+[Experimental(Diagnostics.Experimental)]
+public sealed partial class FactoryRunUpdatedEvent : SessionEvent
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Type => "factory.run_updated";
+
+    /// <summary>The <c>factory.run_updated</c> event payload.</summary>
+    [JsonPropertyName("data")]
+    public required FactoryRunUpdatedData Data { get; set; }
+}
+
 /// <summary>Payload of `session.skills_loaded` listing resolved skill metadata.</summary>
 /// <remarks>Represents the <c>session.skills_loaded</c> event.</remarks>
 public sealed partial class SessionSkillsLoadedEvent : SessionEvent
@@ -1903,6 +1918,11 @@ public sealed partial class SessionScheduleCreatedData
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("intervalMs")]
     public TimeSpan? Interval { get; set; }
+
+    /// <summary>Who created the schedule (`user` or `model`). Persisted so a resumed session keeps gating non-user schedules from firing skills that opted out of model invocation. Absent on entries created before this field existed; a missing origin fails closed (treated the same as a non-user origin), so such a schedule may not resolve a `disable-model-invocation` skill.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("origin")]
+    public ScheduleOrigin? Origin { get; set; }
 
     /// <summary>Prompt text that gets enqueued on every tick.</summary>
     [JsonPropertyName("prompt")]
@@ -2557,7 +2577,7 @@ public sealed partial class UserMessageData
     [JsonPropertyName("parentAgentTaskId")]
     public string? ParentAgentTaskId { get; set; }
 
-    /// <summary>Origin of this message, used for timeline filtering (e.g., "skill-pdf" for skill-injected messages that should be hidden from the user).</summary>
+    /// <summary>Origin of this message, used for timeline filtering and attribution (e.g., `skill-pdf` for hidden skill injection or `agent-&lt;agent-id&gt;` for an inter-agent prompt).</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("source")]
     public string? Source { get; set; }
@@ -2648,6 +2668,11 @@ public sealed partial class AssistantReasoningData
     /// <summary>Unique identifier for this reasoning block.</summary>
     [JsonPropertyName("reasoningId")]
     public required string ReasoningId { get; set; }
+
+    /// <summary>Gets or sets the <c>rte</c> value.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("rte")]
+    public bool? Rte { get; set; }
 }
 
 /// <summary>Streaming reasoning delta for incremental extended thinking updates.</summary>
@@ -2772,6 +2797,11 @@ public sealed partial class AssistantMessageData
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("requestId")]
     public string? RequestId { get; set; }
+
+    /// <summary>Gets or sets the <c>rte</c> value.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("rte")]
+    public bool? Rte { get; set; }
 
     /// <summary>Neutral provider-tagged server-side tool-use payload (tool search, advisor) for verbatim round-tripping.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -2915,6 +2945,11 @@ public sealed partial class AssistantUsageData
     [JsonPropertyName("inputTokens")]
     public long? InputTokens { get; set; }
 
+    /// <summary>Coarse classification of the interaction that produced this call, mirroring the session's per-request agent context (e.g. `conversation-agent`, `conversation-subagent`, `conversation-sampling`, `conversation-background`, `conversation-compaction`, `conversation-user`). Non-billing; lets consumers attribute a model call to a call class (e.g. sub-agent/sidekick) independently of the billing initiator. Absent when the runtime did not classify the request.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("interactionType")]
+    public string? InteractionType { get; set; }
+
     /// <summary>Average inter-token latency in milliseconds. Only available for streaming requests.</summary>
     [JsonConverter(typeof(MillisecondsTimeSpanConverter))]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -2959,6 +2994,11 @@ public sealed partial class AssistantUsageData
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("reasoningTokens")]
     public long? ReasoningTokens { get; set; }
+
+    /// <summary>Gets or sets the <c>rte</c> value.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("rte")]
+    public bool? Rte { get; set; }
 
     /// <summary>Copilot service request ID (x-copilot-service-request-id header) for CAPI log correlation.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -3067,6 +3107,11 @@ public sealed partial class ModelCallFailureData
     [JsonPropertyName("requestFingerprint")]
     public ModelCallFailureRequestFingerprint? RequestFingerprint { get; set; }
 
+    /// <summary>Gets or sets the <c>rte</c> value.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("rte")]
+    public bool? Rte { get; set; }
+
     /// <summary>Copilot service request ID (x-copilot-service-request-id header) for CAPI log correlation.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("serviceRequestId")]
@@ -3162,6 +3207,11 @@ public sealed partial class ToolExecutionStartData
     [JsonPropertyName("parentToolCallId")]
     public string? ParentToolCallId { get; set; }
 
+    /// <summary>Gets or sets the <c>rte</c> value.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("rte")]
+    public bool? Rte { get; set; }
+
     /// <summary>Shell-tool path hints derived from the command at start time for shell tools (bash/powershell/local_shell). Produced by the same shell-aware extractor as PermissionRequestShell.possiblePaths, so it is present even when the command is auto-approved and no permission request fires. Absent for non-shell tools.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("shellToolInfo")]
@@ -3252,6 +3302,11 @@ public sealed partial class ToolExecutionCompleteData
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("result")]
     public ToolExecutionCompleteResult? Result { get; set; }
+
+    /// <summary>Gets or sets the <c>rte</c> value.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("rte")]
+    public bool? Rte { get; set; }
 
     /// <summary>Whether this tool execution ran inside a sandbox container.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -3566,6 +3621,11 @@ public sealed partial class SystemMessageData
     /// <summary>The system or developer prompt text sent as model input.</summary>
     [JsonPropertyName("content")]
     public required string Content { get; set; }
+
+    /// <summary>Logical interaction identifier for the model run receiving this prompt.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("interactionId")]
+    public string? InteractionId { get; set; }
 
     /// <summary>Metadata about the prompt template and its construction.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -4191,6 +4251,19 @@ public sealed partial class SessionToolsUpdatedData
 /// <summary>Empty payload for `session.background_tasks_changed`, indicating background task state changed.</summary>
 public sealed partial class SessionBackgroundTasksChangedData
 {
+}
+
+/// <summary>Ephemeral invalidation signal for a changed factory run.</summary>
+[Experimental(Diagnostics.Experimental)]
+public sealed partial class FactoryRunUpdatedData
+{
+    /// <summary>Monotonic revision now available for the run.</summary>
+    [JsonPropertyName("revision")]
+    public required long Revision { get; set; }
+
+    /// <summary>Gets or sets the <c>runId</c> value.</summary>
+    [JsonPropertyName("runId")]
+    public required string RunId { get; set; }
 }
 
 /// <summary>Payload of `session.skills_loaded` listing resolved skill metadata.</summary>
@@ -8412,6 +8485,67 @@ public readonly struct Verbosity : IEquatable<Verbosity>
     }
 }
 
+/// <summary>Who created the schedule: `user` (an explicit user action such as `/every` or `/after`) or `model` (the agent via the `manage_schedule` tool). Gates whether a scheduled skill that opted out of model invocation may fire: only user-created schedules may.</summary>
+[JsonConverter(typeof(Converter))]
+[DebuggerDisplay("{Value,nq}")]
+public readonly struct ScheduleOrigin : IEquatable<ScheduleOrigin>
+{
+    private readonly string? _value;
+
+    /// <summary>Initializes a new instance of the <see cref="ScheduleOrigin"/> struct.</summary>
+    /// <param name="value">The value to associate with this <see cref="ScheduleOrigin"/>.</param>
+    [JsonConstructor]
+    public ScheduleOrigin(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        _value = value;
+    }
+
+    /// <summary>Gets the value associated with this <see cref="ScheduleOrigin"/>.</summary>
+    public string Value => _value ?? string.Empty;
+
+    /// <summary>The schedule was created by an explicit user action, such as `/every` or `/after`.</summary>
+    public static ScheduleOrigin User { get; } = new("user");
+
+    /// <summary>The schedule was created by the agent via the `manage_schedule` tool.</summary>
+    public static ScheduleOrigin Model { get; } = new("model");
+
+    /// <summary>Returns a value indicating whether two <see cref="ScheduleOrigin"/> instances are equivalent.</summary>
+    public static bool operator ==(ScheduleOrigin left, ScheduleOrigin right) => left.Equals(right);
+
+    /// <summary>Returns a value indicating whether two <see cref="ScheduleOrigin"/> instances are not equivalent.</summary>
+    public static bool operator !=(ScheduleOrigin left, ScheduleOrigin right) => !(left == right);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is ScheduleOrigin other && Equals(other);
+
+    /// <inheritdoc />
+    public bool Equals(ScheduleOrigin other) => string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value);
+
+    /// <inheritdoc />
+    public override string ToString() => Value;
+
+    /// <summary>Provides a <see cref="JsonConverter{ScheduleOrigin}"/> for serializing <see cref="ScheduleOrigin"/> instances.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class Converter : JsonConverter<ScheduleOrigin>
+    {
+        /// <inheritdoc />
+        public override ScheduleOrigin Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return new(GeneratedStringEnumJson.ReadValue(ref reader, typeToConvert));
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, ScheduleOrigin value, JsonSerializerOptions options)
+        {
+            GeneratedStringEnumJson.WriteValue(writer, value.Value, typeof(ScheduleOrigin));
+        }
+    }
+}
+
 /// <summary>The type of operation performed on the autopilot objective state file.</summary>
 [JsonConverter(typeof(Converter))]
 [DebuggerDisplay("{Value,nq}")]
@@ -11908,6 +12042,8 @@ public readonly struct ExtensionsLoadedExtensionStatus : IEquatable<ExtensionsLo
 [JsonSerializable(typeof(ExternalToolCompletedEvent))]
 [JsonSerializable(typeof(ExternalToolRequestedData))]
 [JsonSerializable(typeof(ExternalToolRequestedEvent))]
+[JsonSerializable(typeof(FactoryRunUpdatedData))]
+[JsonSerializable(typeof(FactoryRunUpdatedEvent))]
 [JsonSerializable(typeof(GitHubRepoRef))]
 [JsonSerializable(typeof(HandoffRepository))]
 [JsonSerializable(typeof(HeaderEntry))]

--- a/dotnet/src/SessionFsProvider.cs
+++ b/dotnet/src/SessionFsProvider.cs
@@ -309,6 +309,24 @@ public abstract class SessionFsProvider : ISessionFsHandler
         }
     }
 
+    Task<SessionFsSqliteTransactionResult> ISessionFsHandler.SqliteTransactionAsync(SessionFsSqliteTransactionRequest request, CancellationToken cancellationToken)
+    {
+        // This SDK's provider interface exposes no atomic-transaction hook, so
+        // the batch is refused outright rather than applied non-atomically.
+        var message = this is ISessionFsSqliteProvider
+            ? "Atomic SQLite transactions are not supported by this SessionFs provider"
+            : "SQLite is not supported by this SessionFs provider";
+
+        return Task.FromResult(new SessionFsSqliteTransactionResult
+        {
+            Error = new SessionFsSqliteTransactionError
+            {
+                ErrorClass = SessionFsSqliteTransactionErrorClass.Fatal,
+                Message = message,
+            },
+        });
+    }
+
     async Task<SessionFsSqliteExistsResult> ISessionFsHandler.SqliteExistsAsync(SessionFsSqliteExistsRequest request, CancellationToken cancellationToken)
     {
         if (this is not ISessionFsSqliteProvider sqliteProvider)

--- a/go/rpc/zrpc.go
+++ b/go/rpc/zrpc.go
@@ -1363,11 +1363,14 @@ type ConnectRemoteSessionParams struct {
 type ConnectRequest struct {
 	// Opt this connection in to GitHub telemetry forwarding for its lifetime. When set, the
 	// runtime forwards every internal telemetry event it emits — across all sessions, plus
-	// sessionless events — to this connection over the `gitHubTelemetry.event` notification, in
-	// addition to the runtime's normal GitHub/CTS emission (dual-write). Intended for
-	// first-party hosts that re-emit the events into their own telemetry stores. Both
-	// unrestricted and restricted events are forwarded, each tagged with a `restricted`
-	// discriminator; a backstop drops restricted events when restricted telemetry is disabled.
+	// sessionless events — to this connection over the `gitHubTelemetry.event` notification.
+	// Regular events are also written to the runtime's normal GitHub/CTS path (dual-write);
+	// host-only compatibility events are forward-only and intentionally skip that path.
+	// Intended for first-party hosts that re-emit the events into their own telemetry stores.
+	// Both unrestricted and restricted events are forwarded, each tagged with a `restricted`
+	// discriminator; a backstop drops restricted events when restricted telemetry is disabled —
+	// using the process-global gate for ordinary events and an explicit session-scoped decision
+	// for host-only events.
 	EnableGitHubTelemetryForwarding *bool `json:"enableGitHubTelemetryForwarding,omitempty"`
 	// Connection token; required when the server was started with COPILOT_CONNECTION_TOKEN
 	Token *string `json:"token,omitempty"`
@@ -2246,6 +2249,8 @@ type FactoryAgentOptions struct {
 // Experimental: FactoryAgentRequest is part of an experimental API and may change or be
 // removed.
 type FactoryAgentRequest struct {
+	// Opaque token identifying the current factory execution attempt.
+	ExecutionToken string `json:"executionToken"`
 	// Factory run identifier that owns the subagent.
 	FactoryRunID string `json:"factoryRunId"`
 	// Subagent execution options.
@@ -2262,6 +2267,25 @@ type FactoryAgentResult struct {
 	Result any `json:"result,omitempty"`
 }
 
+// Prompt-safe durable identity and live status for a direct factory agent.
+// Experimental: FactoryAgentSummary is part of an experimental API and may change or be
+// removed.
+type FactoryAgentSummary struct {
+	ActiveMs       int64   `json:"activeMs"`
+	Activity       *string `json:"activity,omitempty"`
+	AgentID        string  `json:"agentId"`
+	AgentType      string  `json:"agentType"`
+	CompletedAt    *int64  `json:"completedAt,omitempty"`
+	Label          string  `json:"label"`
+	PhaseID        *string `json:"phaseId"`
+	RequestedModel *string `json:"requestedModel,omitempty"`
+	ResolvedModel  *string `json:"resolvedModel,omitempty"`
+	RunID          string  `json:"runId"`
+	StartedAt      *int64  `json:"startedAt,omitempty"`
+	Status         string  `json:"status"`
+	ToolCallID     string  `json:"toolCallId"`
+}
+
 // Parameters for cancelling a factory run.
 // Experimental: FactoryCancelRequest is part of an experimental API and may change or be
 // removed.
@@ -2270,12 +2294,32 @@ type FactoryCancelRequest struct {
 	RunID string `json:"runId"`
 }
 
+// Current factory phase identity.
+// Experimental: FactoryCurrentPhase is part of an experimental API and may change or be
+// removed.
+type FactoryCurrentPhase struct {
+	ID      string `json:"id"`
+	Ordinal *int64 `json:"ordinal"`
+}
+
+// Declared or approved factory resource ceilings.
+// Experimental: FactoryDeclaredLimits is part of an experimental API and may change or be
+// removed.
+type FactoryDeclaredLimits struct {
+	MaxAiCredits           *float64 `json:"maxAiCredits,omitempty"`
+	MaxConcurrentSubagents *int64   `json:"maxConcurrentSubagents,omitempty"`
+	MaxTotalSubagents      *int64   `json:"maxTotalSubagents,omitempty"`
+	TimeoutSeconds         *float64 `json:"timeoutSeconds,omitempty"`
+}
+
 // Parameters sent to the owning extension to execute a factory closure.
 // Experimental: FactoryExecuteRequest is part of an experimental API and may change or be
 // removed.
 type FactoryExecuteRequest struct {
 	// Factory input value.
 	Args any `json:"args"`
+	// Opaque token identifying this factory execution attempt.
+	ExecutionToken string `json:"executionToken"`
 	// Registered factory name.
 	Name string `json:"name"`
 	// Factory run identifier.
@@ -2289,7 +2333,23 @@ type FactoryExecuteRequest struct {
 // removed.
 type FactoryExecuteResult struct {
 	// Factory result value.
-	Result any `json:"result"`
+	Result any `json:"result,omitempty"`
+}
+
+// Parameters for paging factory progress.
+// Experimental: FactoryGetRunProgressRequest is part of an experimental API and may change
+// or be removed.
+type FactoryGetRunProgressRequest struct {
+	// Exclusive forward cursor.
+	AfterSeq *int64 `json:"afterSeq,omitempty"`
+	// Exclusive backward cursor.
+	BeforeSeq *int64 `json:"beforeSeq,omitempty"`
+	// Maximum records to return. Defaults to 200 and is capped at 500.
+	Limit *int32 `json:"limit,omitempty"`
+	// Optional phase identifier used to scope records and cursors.
+	PhaseID *string `json:"phaseId,omitempty"`
+	// Factory run identifier.
+	RunID string `json:"runId"`
 }
 
 // Parameters for retrieving a factory run.
@@ -2304,6 +2364,8 @@ type FactoryGetRunRequest struct {
 // Experimental: FactoryJournalGetRequest is part of an experimental API and may change or
 // be removed.
 type FactoryJournalGetRequest struct {
+	// Opaque token identifying the current factory execution attempt.
+	ExecutionToken string `json:"executionToken"`
 	// Namespaced journal key.
 	Key string `json:"key"`
 	// Factory run identifier.
@@ -2324,12 +2386,27 @@ type FactoryJournalGetResult struct {
 // Experimental: FactoryJournalPutRequest is part of an experimental API and may change or
 // be removed.
 type FactoryJournalPutRequest struct {
+	// Opaque token identifying the current factory execution attempt.
+	ExecutionToken string `json:"executionToken"`
 	// Namespaced journal key.
 	Key string `json:"key"`
 	// JSON result to memoize.
 	ResultJSON any `json:"resultJson"`
 	// Factory run identifier.
 	RunID string `json:"runId"`
+}
+
+// Empty parameters for listing factory runs.
+// Experimental: FactoryListRunsRequest is part of an experimental API and may change or be
+// removed.
+type FactoryListRunsRequest struct {
+}
+
+// Factory runs in durable creation order.
+// Experimental: FactoryListRunsResult is part of an experimental API and may change or be
+// removed.
+type FactoryListRunsResult struct {
+	Runs []FactoryRunSummary `json:"runs"`
 }
 
 // One ordered factory progress line.
@@ -2347,10 +2424,119 @@ type FactoryLogLine struct {
 // Experimental: FactoryLogRequest is part of an experimental API and may change or be
 // removed.
 type FactoryLogRequest struct {
+	// Opaque token identifying the current factory execution attempt.
+	ExecutionToken string `json:"executionToken"`
 	// Ordered progress lines to append.
 	Lines []FactoryLogLine `json:"lines"`
 	// Factory run identifier.
 	RunID string `json:"runId"`
+}
+
+// Durable lifecycle and timing for one factory phase.
+// Experimental: FactoryPhaseObservation is part of an experimental API and may change or be
+// removed.
+type FactoryPhaseObservation struct {
+	AccumulatedActiveMs   int64              `json:"accumulatedActiveMs"`
+	CompletedAt           *int64             `json:"completedAt,omitempty"`
+	CurrentActiveMs       int64              `json:"currentActiveMs"`
+	Detail                *string            `json:"detail,omitempty"`
+	EntryCount            int64              `json:"entryCount"`
+	ID                    string             `json:"id"`
+	LastEnteredRunAttempt int64              `json:"lastEnteredRunAttempt"`
+	LiveAgentCount        int64              `json:"liveAgentCount"`
+	Ordinal               *int64             `json:"ordinal"`
+	StartedAt             *int64             `json:"startedAt,omitempty"`
+	Status                FactoryPhaseStatus `json:"status"`
+	Title                 string             `json:"title"`
+	TotalAgentCount       int64              `json:"totalAgentCount"`
+}
+
+// One durable factory progress record.
+// Experimental: FactoryProgressLine is part of an experimental API and may change or be
+// removed.
+type FactoryProgressLine struct {
+	// Resume attempt that emitted this record.
+	Attempt int64 `json:"attempt"`
+	// Progress record kind.
+	Kind FactoryLogLineKind `json:"kind"`
+	// Phase active when the record was emitted, or null before any phase.
+	PhaseID *string `json:"phaseId"`
+	// Epoch milliseconds when the record was persisted.
+	RecordedAt int64 `json:"recordedAt"`
+	// Global monotonic sequence number within the run.
+	Seq int64 `json:"seq"`
+	// Prompt-safe progress text.
+	Text string `json:"text"`
+}
+
+// A bidirectional page of factory progress.
+// Experimental: FactoryProgressPage is part of an experimental API and may change or be
+// removed.
+type FactoryProgressPage struct {
+	HasMoreNewer bool                  `json:"hasMoreNewer"`
+	HasMoreOlder bool                  `json:"hasMoreOlder"`
+	NewestSeq    *int64                `json:"newestSeq"`
+	OldestSeq    *int64                `json:"oldestSeq"`
+	Records      []FactoryProgressLine `json:"records"`
+	// Run revision reflected by this page.
+	Revision int64 `json:"revision"`
+}
+
+// Parameters for resuming a factory run from its persisted identity.
+// Experimental: FactoryResumeRequest is part of an experimental API and may change or be
+// removed.
+type FactoryResumeRequest struct {
+	// Optional per-invocation resource ceiling overrides.
+	Limits *FactoryRunLimits `json:"limits,omitempty"`
+	// Factory run identifier.
+	RunID string `json:"runId"`
+}
+
+// Resolved persisted factory identity and resumed run envelope.
+// Experimental: FactoryResumeResult is part of an experimental API and may change or be
+// removed.
+type FactoryResumeResult struct {
+	// Persisted factory name resolved for the resumed run.
+	FactoryName string `json:"factoryName"`
+	// Terminal resumed run envelope.
+	Run FactoryRunResult `json:"run"`
+}
+
+// Durable factory resource consumption.
+// Experimental: FactoryRunConsumed is part of an experimental API and may change or be
+// removed.
+type FactoryRunConsumed struct {
+	ActiveMs  int64 `json:"activeMs"`
+	NanoAiu   int64 `json:"nanoAiu"`
+	Subagents int64 `json:"subagents"`
+}
+
+// Full factory run observability detail.
+// Experimental: FactoryRunDetail is part of an experimental API and may change or be
+// removed.
+type FactoryRunDetail struct {
+	ActiveSegmentStartedAt *int64                    `json:"activeSegmentStartedAt"`
+	Agents                 []FactoryAgentSummary     `json:"agents"`
+	Approved               *FactoryDeclaredLimits    `json:"approved"`
+	CompletedAt            *int64                    `json:"completedAt"`
+	Consumed               FactoryRunConsumed        `json:"consumed"`
+	CreatedAt              int64                     `json:"createdAt"`
+	CurrentPhase           *FactoryCurrentPhase      `json:"currentPhase"`
+	DeclaredLimits         FactoryDeclaredLimits     `json:"declaredLimits"`
+	DeclaredPhaseCount     int64                     `json:"declaredPhaseCount"`
+	Description            string                    `json:"description"`
+	FactoryName            string                    `json:"factoryName"`
+	LiveAgentCount         int64                     `json:"liveAgentCount"`
+	ObservedAt             int64                     `json:"observedAt"`
+	Phases                 []FactoryPhaseObservation `json:"phases"`
+	Progress               FactoryProgressPage       `json:"progress"`
+	Revision               int64                     `json:"revision"`
+	RunID                  string                    `json:"runId"`
+	StartedAt              *int64                    `json:"startedAt"`
+	Status                 FactoryRunStatus          `json:"status"`
+	Terminal               *FactoryRunTerminal       `json:"terminal"`
+	TotalSpawnedAgentCount int64                     `json:"totalSpawnedAgentCount"`
+	UpdatedAt              int64                     `json:"updatedAt"`
 }
 
 // Machine-readable factory run failure.
@@ -2369,6 +2555,20 @@ type RawFactoryRunFailureData struct {
 func (RawFactoryRunFailureData) factoryRunFailure() {}
 func (r RawFactoryRunFailureData) Type() FactoryRunFailureType {
 	return r.Discriminator
+}
+
+type FactoryRunFailureFactoryDurableFailure struct {
+	// Stable failure code.
+	Code string `json:"code"`
+	// Execution-critical durable operation that failed.
+	Operation FactoryDurableOperation `json:"operation"`
+	// Factory run identifier.
+	RunID string `json:"runId"`
+}
+
+func (FactoryRunFailureFactoryDurableFailure) factoryRunFailure() {}
+func (FactoryRunFailureFactoryDurableFailure) Type() FactoryRunFailureType {
+	return FactoryRunFailureTypeFactoryDurableFailure
 }
 
 type FactoryRunFailureFactoryLimitReached struct {
@@ -2401,12 +2601,17 @@ func (FactoryRunFailureFactoryResumeDeclined) Type() FactoryRunFailureType {
 // Experimental: FactoryRunLimits is part of an experimental API and may change or be
 // removed.
 type FactoryRunLimits struct {
+	// Maximum AI credits consumed by factory subagents and their descendants. The post-paid
+	// ceiling is soft: parallel turns can settle beyond it before the run stops.
+	MaxAiCredits *float64 `json:"maxAiCredits,omitempty"`
 	// Maximum number of factory subagents that may run concurrently.
 	MaxConcurrentSubagents *int64 `json:"maxConcurrentSubagents,omitempty"`
 	// Maximum total number of factory subagents that may be admitted.
 	MaxTotalSubagents *int64 `json:"maxTotalSubagents,omitempty"`
-	// Factory active-run timeout in milliseconds.
-	Timeout *float64 `json:"timeout,omitempty"`
+	// Maximum accumulated active-execution time in seconds. Active execution includes the
+	// entire extension body, subprocess waits, queued-agent waits, and sleeps; time between
+	// resumed attempts is not counted.
+	TimeoutSeconds *float64 `json:"timeoutSeconds,omitempty"`
 }
 
 // Parameters for invoking a registered factory.
@@ -2439,6 +2644,41 @@ type FactoryRunResult struct {
 	Snapshot any `json:"snapshot,omitempty"`
 	// Current or terminal factory run status.
 	Status FactoryRunStatus `json:"status"`
+}
+
+// Durable factory run summary with read-time live overlays.
+// Experimental: FactoryRunSummary is part of an experimental API and may change or be
+// removed.
+type FactoryRunSummary struct {
+	ActiveSegmentStartedAt *int64                 `json:"activeSegmentStartedAt"`
+	Approved               *FactoryDeclaredLimits `json:"approved"`
+	CompletedAt            *int64                 `json:"completedAt"`
+	Consumed               FactoryRunConsumed     `json:"consumed"`
+	CreatedAt              int64                  `json:"createdAt"`
+	CurrentPhase           *FactoryCurrentPhase   `json:"currentPhase"`
+	DeclaredLimits         FactoryDeclaredLimits  `json:"declaredLimits"`
+	DeclaredPhaseCount     int64                  `json:"declaredPhaseCount"`
+	Description            string                 `json:"description"`
+	FactoryName            string                 `json:"factoryName"`
+	LiveAgentCount         int64                  `json:"liveAgentCount"`
+	ObservedAt             int64                  `json:"observedAt"`
+	Revision               int64                  `json:"revision"`
+	RunID                  string                 `json:"runId"`
+	StartedAt              *int64                 `json:"startedAt"`
+	Status                 FactoryRunStatus       `json:"status"`
+	Terminal               *FactoryRunTerminal    `json:"terminal"`
+	TotalSpawnedAgentCount int64                  `json:"totalSpawnedAgentCount"`
+	UpdatedAt              int64                  `json:"updatedAt"`
+}
+
+// Prompt-safe terminal factory outcome.
+// Experimental: FactoryRunTerminal is part of an experimental API and may change or be
+// removed.
+type FactoryRunTerminal struct {
+	Error         *string           `json:"error,omitempty"`
+	Failure       FactoryRunFailure `json:"failure,omitempty"`
+	Reason        *string           `json:"reason,omitempty"`
+	ResultPreview *string           `json:"resultPreview,omitempty"`
 }
 
 // Content filtering mode to apply to all tools, or a map of tool name to content filtering
@@ -2759,14 +2999,16 @@ type InstalledPluginSource struct {
 	String                      *string
 }
 
-// Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref,
-// and optional subpath.
+// Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref or
+// full commit SHA, and optional subpath.
 // Experimental: InstalledPluginSourceGitHub is part of an experimental API and may change
 // or be removed.
 type InstalledPluginSourceGitHub struct {
 	Path *string `json:"path,omitempty"`
 	Ref  *string `json:"ref,omitempty"`
 	Repo string  `json:"repo"`
+	// Optional full 40-character hexadecimal commit SHA.
+	Sha *string `json:"sha,omitempty"`
 	// Constant value. Always "github".
 	Source InstalledPluginSourceGitHubSource `json:"source"`
 }
@@ -2780,13 +3022,15 @@ type InstalledPluginSourceLocal struct {
 	Source InstalledPluginSourceLocalSource `json:"source"`
 }
 
-// Source descriptor for a direct URL plugin install, with URL, optional ref, and optional
-// subpath.
+// Source descriptor for a direct URL plugin install, with URL, optional ref or full commit
+// SHA, and optional subpath.
 // Experimental: InstalledPluginSourceURL is part of an experimental API and may change or
 // be removed.
 type InstalledPluginSourceURL struct {
 	Path *string `json:"path,omitempty"`
 	Ref  *string `json:"ref,omitempty"`
+	// Optional full 40-character hexadecimal commit SHA.
+	Sha *string `json:"sha,omitempty"`
 	// Constant value. Always "url".
 	Source InstalledPluginSourceURLSource `json:"source"`
 	URL    string                         `json:"url"`
@@ -2881,6 +3125,25 @@ type InstructionSource struct {
 	SourcePath string `json:"sourcePath"`
 	// Category of instruction source — used for merge logic
 	Type InstructionSourceType `json:"type"`
+}
+
+// Parameters for interrupting the main agent turn.
+// Experimental: InterruptMainTurnRequest is part of an experimental API and may change or
+// be removed.
+type InterruptMainTurnRequest struct {
+	// When true, the user's queued prompts are preserved and run as the next turn once the
+	// interrupted turn unwinds; when false (the default), the queue is cleared like a plain
+	// abort.
+	FlushQueued *bool `json:"flushQueued,omitempty"`
+}
+
+// Result of interrupting the main agent turn.
+// Experimental: InterruptMainTurnResult is part of an experimental API and may change or be
+// removed.
+type InterruptMainTurnResult struct {
+	// Whether an in-flight main agent turn was interrupted. False when the main loop was not
+	// processing.
+	Interrupted bool `json:"interrupted"`
 }
 
 // HTTP headers as a map from lowercased header name to a list of values. Multi-valued
@@ -3803,6 +4066,23 @@ type MCPOauthPendingRequestResponseToken struct {
 func (MCPOauthPendingRequestResponseToken) mcpOauthPendingRequestResponse() {}
 func (MCPOauthPendingRequestResponseToken) Kind() MCPOauthPendingRequestResponseKind {
 	return MCPOauthPendingRequestResponseKindToken
+}
+
+// Pending MCP OAuth request id to respond to.
+// Experimental: MCPOauthRespondRequest is part of an experimental API and may change or be
+// removed.
+type MCPOauthRespondRequest struct {
+	// OAuth request identifier from the mcp.oauth_required event
+	RequestID string `json:"requestId"`
+}
+
+// Indicates whether the pending MCP OAuth response was accepted.
+// Experimental: MCPOauthRespondResult is part of an experimental API and may change or be
+// removed.
+type MCPOauthRespondResult struct {
+	// Whether the response was accepted. False if the request was unknown, timed out, or
+	// already resolved.
+	Success bool `json:"success"`
 }
 
 // Registration parameters for an external MCP client.
@@ -6812,6 +7092,30 @@ type PushGitHubRepoRef struct {
 	Owner string `json:"owner"`
 }
 
+// Inputs for starting a deferred-idle drain.
+// Experimental: QueueBeginDeferredIdleDrainRequest is part of an experimental API and may
+// change or be removed.
+type QueueBeginDeferredIdleDrainRequest struct {
+	// Whether the host still has active background work.
+	ActiveBackgroundWork bool `json:"activeBackgroundWork"`
+}
+
+// Whether a deferred-idle drain should run.
+// Experimental: QueueBeginDeferredIdleDrainResult is part of an experimental API and may
+// change or be removed.
+type QueueBeginDeferredIdleDrainResult struct {
+	// True when the host should run finishDeferredIdleDrain asynchronously.
+	ShouldDrain bool `json:"shouldDrain"`
+}
+
+// Internal filter for consuming queued system notifications.
+// Experimental: QueueConsumeSystemNotificationsRequest is part of an experimental API and
+// may change or be removed.
+type QueueConsumeSystemNotificationsRequest struct {
+	// Opaque runtime-owned filter object.
+	Filter any `json:"filter"`
+}
+
 // Result of the queued command execution.
 // Experimental: QueuedCommandResult is part of an experimental API and may change or be
 // removed.
@@ -6847,6 +7151,50 @@ func (QueuedCommandNotHandled) Handled() bool {
 	return false
 }
 
+// Inputs for marking session.idle deferred in native state.
+// Experimental: QueueDeferSessionIdleRequest is part of an experimental API and may change
+// or be removed.
+type QueueDeferSessionIdleRequest struct {
+	// Whether the deferred idle was caused by an aborted foreground turn.
+	Aborted bool `json:"aborted"`
+}
+
+// Result of enqueueing the resume-pending wake item.
+// Experimental: QueueEnqueueResumePendingResult is part of an experimental API and may
+// change or be removed.
+type QueueEnqueueResumePendingResult struct {
+	// True when a wake item was newly queued.
+	Queued bool `json:"queued"`
+}
+
+// Inputs for completing a deferred-idle drain.
+// Experimental: QueueFinishDeferredIdleDrainRequest is part of an experimental API and may
+// change or be removed.
+type QueueFinishDeferredIdleDrainRequest struct {
+	// Whether the host still has active background work.
+	ActiveBackgroundWork bool `json:"activeBackgroundWork"`
+	// Whether native queued work remains.
+	HasPending bool `json:"hasPending"`
+}
+
+// Action selected by the native deferred-idle drain.
+// Experimental: QueueFinishDeferredIdleDrainResult is part of an experimental API and may
+// change or be removed.
+type QueueFinishDeferredIdleDrainResult struct {
+	// Whether the deferred idle was caused by an aborted foreground turn.
+	Aborted bool `json:"aborted"`
+	// One of none, processQueue, or emitSessionIdle.
+	Action string `json:"action"`
+}
+
+// Whether the native queue has pending work.
+// Experimental: QueueHasPendingResult is part of an experimental API and may change or be
+// removed.
+type QueueHasPendingResult struct {
+	// True when queued or immediate native work is pending.
+	HasPending bool `json:"hasPending"`
+}
+
 // User-facing pending queue entry, with kind and display text for a queued message, slash
 // command, or model change.
 // Experimental: QueuePendingItems is part of an experimental API and may change or be
@@ -6877,6 +7225,20 @@ type QueueRemoveMostRecentResult struct {
 	// True if a user-facing pending item was removed (LIFO across both queues); false when no
 	// removable items remained.
 	Removed bool `json:"removed"`
+}
+
+// Internal snapshot of native queue state for local session orchestration.
+// Experimental: QueueSnapshotResult is part of an experimental API and may change or be
+// removed.
+type QueueSnapshotResult struct {
+	// Insertion orders for queued items, aligned with `items`.
+	ItemOrders []int64 `json:"itemOrders,omitzero"`
+	// User-facing pending items in FIFO order.
+	Items []QueuePendingItems `json:"items"`
+	// Insertion orders for immediate steering messages, aligned with `steeringMessages`.
+	SteeringMessageOrders []int64 `json:"steeringMessageOrders,omitzero"`
+	// Immediate steering messages waiting for an active turn.
+	SteeringMessages []string `json:"steeringMessages"`
 }
 
 // Event type to register consumer interest for, used by runtime gating logic.
@@ -7265,6 +7627,70 @@ type SandboxConfigUserPolicySeatbelt struct {
 	KeychainAccess *bool `json:"keychainAccess,omitempty"`
 }
 
+// Register an absolute-time scheduled prompt.
+// Experimental: ScheduleAddAtRequest is part of an experimental API and may change or be
+// removed.
+type ScheduleAddAtRequest struct {
+	// Epoch milliseconds when the prompt should fire.
+	At int64 `json:"at"`
+	// Optional display-only prompt label.
+	DisplayPrompt *string `json:"displayPrompt,omitempty"`
+	// Prompt text to enqueue when the schedule fires.
+	Prompt string `json:"prompt"`
+	// Whether the schedule should re-arm after each tick. Defaults to false.
+	Recurring *bool `json:"recurring,omitempty"`
+}
+
+// Register a cron scheduled prompt.
+// Experimental: ScheduleAddCronRequest is part of an experimental API and may change or be
+// removed.
+type ScheduleAddCronRequest struct {
+	// 5-field cron expression.
+	Cron string `json:"cron"`
+	// Optional display-only prompt label.
+	DisplayPrompt *string `json:"displayPrompt,omitempty"`
+	// Prompt text to enqueue when the schedule fires.
+	Prompt string `json:"prompt"`
+	// Whether the schedule should re-arm after each tick. Defaults to true.
+	Recurring *bool `json:"recurring,omitempty"`
+	// IANA timezone for evaluating the cron expression.
+	Tz *string `json:"tz,omitempty"`
+}
+
+// Register a relative-interval scheduled prompt.
+// Experimental: ScheduleAddRequest is part of an experimental API and may change or be
+// removed.
+type ScheduleAddRequest struct {
+	// Optional display-only prompt label.
+	DisplayPrompt *string `json:"displayPrompt,omitempty"`
+	// Human-readable interval such as `30s`, `5m`, or `2h`.
+	Interval string `json:"interval"`
+	// Prompt text to enqueue when the schedule fires.
+	Prompt string `json:"prompt"`
+	// Whether the schedule should re-arm after each tick. Defaults to true.
+	Recurring *bool `json:"recurring,omitempty"`
+}
+
+// Result of registering or re-arming a scheduled prompt.
+// Experimental: ScheduleAddResult is part of an experimental API and may change or be
+// removed.
+type ScheduleAddResult struct {
+	// The registered or updated schedule entry.
+	Entry *ScheduleEntry `json:"entry,omitempty"`
+	// User-facing validation error, when registration failed.
+	Error *string `json:"error,omitempty"`
+}
+
+// Register a self-paced scheduled prompt.
+// Experimental: ScheduleAddSelfPacedRequest is part of an experimental API and may change
+// or be removed.
+type ScheduleAddSelfPacedRequest struct {
+	// Optional display-only prompt label.
+	DisplayPrompt *string `json:"displayPrompt,omitempty"`
+	// Prompt text to enqueue when the schedule fires.
+	Prompt string `json:"prompt"`
+}
+
 // Scheduled prompt entry with ID, timing (`intervalMs`, `cron`, or `at`), prompt text,
 // recurrence, and next run time.
 // Experimental: ScheduleEntry is part of an experimental API and may change or be removed.
@@ -7294,11 +7720,29 @@ type ScheduleEntry struct {
 	Tz *string `json:"tz,omitempty"`
 }
 
+// Whether the session currently has an active self-paced schedule.
+// Experimental: ScheduleHasSelfPacedResult is part of an experimental API and may change or
+// be removed.
+type ScheduleHasSelfPacedResult struct {
+	// True when at least one active schedule is self-paced.
+	HasSelfPaced bool `json:"hasSelfPaced"`
+}
+
 // Snapshot of the currently active recurring prompts for this session.
 // Experimental: ScheduleList is part of an experimental API and may change or be removed.
 type ScheduleList struct {
 	// Active scheduled prompts, ordered by id.
 	Entries []ScheduleEntry `json:"entries"`
+}
+
+// Re-arm a self-paced scheduled prompt.
+// Experimental: ScheduleRearmSelfPacedRequest is part of an experimental API and may change
+// or be removed.
+type ScheduleRearmSelfPacedRequest struct {
+	// Epoch milliseconds when the prompt should next fire.
+	At int64 `json:"at"`
+	// Id of the self-paced scheduled prompt.
+	ID int64 `json:"id"`
 }
 
 // Identifier of the scheduled prompt to remove.
@@ -7365,10 +7809,9 @@ type SendMessageItem struct {
 	// If set, the request will fail if the named tool is not available when this message is
 	// among the user messages at the start of the current exchange
 	RequiredTool *string `json:"requiredTool,omitempty"`
-	// Optional provenance tag copied to the resulting user.message event. Must match one of
-	// three forms: the literal `system`, `command-<command-id>` for messages originating from a
-	// command (e.g. slash command, Mission Control command), or `schedule-<numeric-id>` for
-	// messages originating from a scheduled job.
+	// Optional provenance tag copied to the resulting user.message event. Must be `user`,
+	// `system`, `command-<command-id>` for command-originated messages, `schedule-<numeric-id>`
+	// for scheduled prompts, or `agent-<agent-id>` for prompts sent by another agent.
 	// Internal: Source is part of the SDK's internal API surface and is not intended for
 	// external use.
 	Source *string `json:"source,omitempty"`
@@ -7442,10 +7885,9 @@ type SendRequest struct {
 	// If set, the request will fail if the named tool is not available when this message is
 	// among the user messages at the start of the current exchange
 	RequiredTool *string `json:"requiredTool,omitempty"`
-	// Optional provenance tag copied to the resulting user.message event. Must match one of
-	// three forms: the literal `system`, `command-<command-id>` for messages originating from a
-	// command (e.g. slash command, Mission Control command), or `schedule-<numeric-id>` for
-	// messages originating from a scheduled job.
+	// Optional provenance tag copied to the resulting user.message event. Must be `user`,
+	// `system`, `command-<command-id>` for command-originated messages, `schedule-<numeric-id>`
+	// for scheduled prompts, or `agent-<agent-id>` for prompts sent by another agent.
 	// Internal: Source is part of the SDK's internal API surface and is not intended for
 	// external use.
 	Source *string `json:"source,omitempty"`
@@ -7464,6 +7906,18 @@ type SendRequest struct {
 type SendResult struct {
 	// Unique identifier assigned to the message
 	MessageID string `json:"messageId"`
+}
+
+// Internal request for sending a system notification.
+// Experimental: SendSystemNotificationRequest is part of an experimental API and may change
+// or be removed.
+type SendSystemNotificationRequest struct {
+	// Optional structured notification kind.
+	Kind any `json:"kind,omitempty"`
+	// Notification text to deliver to the model.
+	Message string `json:"message"`
+	// Internal delivery options, including passive policy.
+	Options any `json:"options,omitempty"`
 }
 
 // Agents discovered across user, project, plugin, and remote sources.
@@ -7555,6 +8009,11 @@ type SessionBulkDeleteResult struct {
 	// not surfaced per-id; check the map for absent IDs to detect them).
 	FreedBytes map[string]int64 `json:"freedBytes"`
 }
+
+// The number of running background agents (task-registry agents) that were cancelled.
+// Experimental: SessionCancelAllBackgroundAgentsResult is part of an experimental API and
+// may change or be removed.
+type SessionCancelAllBackgroundAgentsResult int64
 
 // Experimental: SessionCanvasCloseResult is part of an experimental API and may change or
 // be removed.
@@ -7905,7 +8364,7 @@ type SessionFSSqliteExistsResult struct {
 }
 
 // SQL query, query type, and optional bind parameters for executing a SQLite query against
-// the per-session database.
+// the per-session database. The provider applies its SQLite busy timeout for every call.
 // Experimental: SessionFSSqliteQueryRequest is part of an experimental API and may change
 // or be removed.
 type SessionFSSqliteQueryRequest struct {
@@ -7935,6 +8394,44 @@ type SessionFSSqliteQueryResult struct {
 	Rows []map[string]any `json:"rows"`
 	// Number of rows affected (for INSERT/UPDATE/DELETE)
 	RowsAffected int64 `json:"rowsAffected"`
+}
+
+// Classified SQLite transaction failure. busyOrLocked guarantees rollback;
+// postCommitAmbiguous must never be retried.
+// Experimental: SessionFSSqliteTransactionError is part of an experimental API and may
+// change or be removed.
+type SessionFSSqliteTransactionError struct {
+	ErrorClass SessionFSSqliteTransactionErrorClass `json:"errorClass"`
+	Message    string                               `json:"message"`
+}
+
+// Statements to execute atomically. Providers apply busy handling for every call.
+// Experimental: SessionFSSqliteTransactionRequest is part of an experimental API and may
+// change or be removed.
+type SessionFSSqliteTransactionRequest struct {
+	// Target session identifier
+	SessionID  string                                `json:"sessionId"`
+	Statements []SessionFSSqliteTransactionStatement `json:"statements"`
+}
+
+// Per-statement results, or a classified transaction error.
+// Experimental: SessionFSSqliteTransactionResult is part of an experimental API and may
+// change or be removed.
+type SessionFSSqliteTransactionResult struct {
+	Error   *SessionFSSqliteTransactionError `json:"error,omitempty"`
+	Results []SessionFSSqliteQueryResult     `json:"results"`
+}
+
+// One statement in an atomic SQLite transaction.
+// Experimental: SessionFSSqliteTransactionStatement is part of an experimental API and may
+// change or be removed.
+type SessionFSSqliteTransactionStatement struct {
+	// Optional named bind parameters.
+	Params map[string]any `json:"params,omitzero"`
+	// SQL statement to execute.
+	Query string `json:"query"`
+	// How to execute the statement.
+	QueryType SessionFSSqliteQueryType `json:"queryType"`
 }
 
 // Path whose metadata should be returned from the client-provided session filesystem.
@@ -8010,14 +8507,16 @@ type SessionInstalledPluginSource struct {
 	String                             *string
 }
 
-// Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref,
-// and optional subpath.
+// Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref or
+// full commit SHA, and optional subpath.
 // Experimental: SessionInstalledPluginSourceGitHub is part of an experimental API and may
 // change or be removed.
 type SessionInstalledPluginSourceGitHub struct {
 	Path *string `json:"path,omitempty"`
 	Ref  *string `json:"ref,omitempty"`
 	Repo string  `json:"repo"`
+	// Optional full 40-character hexadecimal commit SHA.
+	Sha *string `json:"sha,omitempty"`
 	// Constant value. Always "github".
 	Source SessionInstalledPluginSourceGitHubSource `json:"source"`
 }
@@ -8031,13 +8530,15 @@ type SessionInstalledPluginSourceLocal struct {
 	Source SessionInstalledPluginSourceLocalSource `json:"source"`
 }
 
-// Source descriptor for a direct URL plugin install, with URL, optional ref, and optional
-// subpath.
+// Source descriptor for a direct URL plugin install, with URL, optional ref or full commit
+// SHA, and optional subpath.
 // Experimental: SessionInstalledPluginSourceURL is part of an experimental API and may
 // change or be removed.
 type SessionInstalledPluginSourceURL struct {
 	Path *string `json:"path,omitempty"`
 	Ref  *string `json:"ref,omitempty"`
+	// Optional full 40-character hexadecimal commit SHA.
+	Sha *string `json:"sha,omitempty"`
 	// Constant value. Always "url".
 	Source SessionInstalledPluginSourceURLSource `json:"source"`
 	URL    string                                `json:"url"`
@@ -8332,6 +8833,8 @@ type SessionOpenOptions struct {
 	EnvValueMode *SessionOpenOptionsEnvValueMode `json:"envValueMode,omitempty"`
 	// Override directory for session event logs.
 	EventsLogDirectory *string `json:"eventsLogDirectory,omitempty"`
+	// Whether subagent callback events should be forwarded into the session event log sink.
+	EventsLogIncludesSubagents *bool `json:"eventsLogIncludesSubagents,omitempty"`
 	// Built-in subagent names to exclude from this session. Excluded built-ins are hidden from
 	// agent discovery and cannot be dispatched unless a custom agent with the same name is
 	// available.
@@ -8402,9 +8905,12 @@ type SessionOpenOptions struct {
 	SessionID *string `json:"sessionId,omitempty"`
 	// Initial session limits.
 	SessionLimits *SessionLimitsConfig `json:"sessionLimits,omitempty"`
-	// Shell init profile.
+	// Per-session settings for built-in shell tools.
+	Shell *ShellOptions `json:"shell,omitempty"`
+	// Use shell.initProfile instead. Shell init profile.
+	// Deprecated: ShellInitProfile is deprecated.
 	ShellInitProfile *string `json:"shellInitProfile,omitempty"`
-	// Per-shell process flags.
+	// PowerShell process flags applied to built-in and user-requested shell commands.
 	ShellProcessFlags []string `json:"shellProcessFlags,omitzero"`
 	// Additional directories to search for skills.
 	SkillDirectories []string `json:"skillDirectories,omitzero"`
@@ -8676,6 +9182,16 @@ type SessionPruneResult struct {
 type SessionQueueClearResult struct {
 }
 
+// Experimental: SessionQueueDeferSessionIdleResult is part of an experimental API and may
+// change or be removed.
+type SessionQueueDeferSessionIdleResult struct {
+}
+
+// Experimental: SessionQueueProcessResult is part of an experimental API and may change or
+// be removed.
+type SessionQueueProcessResult struct {
+}
+
 // Experimental: SessionRemoteDisableResult is part of an experimental API and may change or
 // be removed.
 type SessionRemoteDisableResult struct {
@@ -8706,6 +9222,11 @@ type SessionsCheckInUseResult struct {
 	InUse []string `json:"inUse"`
 }
 
+// Experimental: SessionScheduleHydrateResult is part of an experimental API and may change
+// or be removed.
+type SessionScheduleHydrateResult struct {
+}
+
 // Session ID to close.
 // Experimental: SessionsCloseRequest is part of an experimental API and may change or be
 // removed.
@@ -8725,6 +9246,26 @@ type SessionsCloseResult struct {
 // Experimental: SessionsConfigureSessionExtensionsResult is part of an experimental API and
 // may change or be removed.
 type SessionsConfigureSessionExtensionsResult struct {
+}
+
+// Session ID to delete from disk.
+// Experimental: SessionsDeleteRequest is part of an experimental API and may change or be
+// removed.
+type SessionsDeleteRequest struct {
+	// Session ID to delete
+	SessionID string `json:"sessionId"`
+	// Internal resolved session directory path to delete
+	SessionPath *string `json:"sessionPath,omitempty"`
+}
+
+// Experimental: SessionsDeleteResult is part of an experimental API and may change or be
+// removed.
+type SessionsDeleteResult struct {
+}
+
+// Experimental: SessionSendSystemNotificationResult is part of an experimental API and may
+// change or be removed.
+type SessionSendSystemNotificationResult struct {
 }
 
 // Session metadata records to enrich with summary and context information.
@@ -8976,6 +9517,22 @@ type SessionsGetLastForContextResult struct {
 	SessionID *string `json:"sessionId,omitempty"`
 }
 
+// Session ID whose persisted metadata should be read.
+// Experimental: SessionsGetMetadataRequest is part of an experimental API and may change or
+// be removed.
+type SessionsGetMetadataRequest struct {
+	// Session ID to inspect
+	SessionID string `json:"sessionId"`
+}
+
+// Persisted local session metadata when the session exists.
+// Experimental: SessionsGetMetadataResult is part of an experimental API and may change or
+// be removed.
+type SessionsGetMetadataResult struct {
+	// Local session metadata, omitted when the session does not exist.
+	Session *LocalSessionMetadataValue `json:"session,omitempty"`
+}
+
 // Session ID to look up the persisted remote-steerable flag for.
 // Experimental: SessionsGetPersistedRemoteSteerableRequest is part of an experimental API
 // and may change or be removed.
@@ -9019,6 +9576,22 @@ type SessionSkillsEnableResult struct {
 // Experimental: SessionSkillsEnsureLoadedResult is part of an experimental API and may
 // change or be removed.
 type SessionSkillsEnsureLoadedResult struct {
+}
+
+// Limit for non-empty local session IDs.
+// Experimental: SessionsListNonEmptySessionIDsRequest is part of an experimental API and
+// may change or be removed.
+type SessionsListNonEmptySessionIDsRequest struct {
+	// Maximum number of session IDs to return.
+	Limit *int64 `json:"limit,omitempty"`
+}
+
+// Recent local session IDs that contain user-visible history.
+// Experimental: SessionsListNonEmptySessionIDsResult is part of an experimental API and may
+// change or be removed.
+type SessionsListNonEmptySessionIDsResult struct {
+	// Session IDs ordered newest-first.
+	SessionIDs []string `json:"sessionIds"`
 }
 
 // Optional source filter, metadata-load limit, and context filter applied to the returned
@@ -9278,6 +9851,8 @@ type SessionUpdateOptionsParams struct {
 	// Override directory for the session-events log. When unset, the runtime's default events
 	// log directory is used.
 	EventsLogDirectory *string `json:"eventsLogDirectory,omitempty"`
+	// Whether subagent callback events should be forwarded into the session event log sink.
+	EventsLogIncludesSubagents *bool `json:"eventsLogIncludesSubagents,omitempty"`
 	// Built-in subagent names to exclude from this session. Excluded built-ins are hidden from
 	// agent discovery and cannot be dispatched unless a custom agent with the same name is
 	// available.
@@ -9332,9 +9907,12 @@ type SessionUpdateOptionsParams struct {
 	SessionCapabilities []SessionCapability `json:"sessionCapabilities,omitzero"`
 	// Optional session limits. Pass null to clear the session limits.
 	SessionLimits *SessionLimitsConfig `json:"sessionLimits,omitempty"`
-	// Shell init profile (`None` or `NonInteractive`).
+	// Per-session settings for built-in shell tools.
+	Shell *ShellOptions `json:"shell,omitempty"`
+	// Use shell.initProfile instead. Shell init profile (`None` or `NonInteractive`).
+	// Deprecated: ShellInitProfile is deprecated.
 	ShellInitProfile *string `json:"shellInitProfile,omitempty"`
-	// Per-shell process flags (e.g., `pwsh` arguments).
+	// PowerShell process flags applied to built-in and user-requested shell commands.
 	ShellProcessFlags []string `json:"shellProcessFlags,omitzero"`
 	// Additional directories to search for skills.
 	SkillDirectories []string `json:"skillDirectories,omitzero"`
@@ -9434,6 +10012,16 @@ type ShellExecuteUserRequestedRequest struct {
 	RequestID string `json:"requestId"`
 }
 
+// A host-provided script sourced before each built-in shell command when its shell target
+// matches the active shell.
+// Experimental: ShellInitScript is part of an experimental API and may change or be removed.
+type ShellInitScript struct {
+	// Path to the script to source.
+	Path string `json:"path"`
+	// Built-in shell that may source this script.
+	Shell ShellInitScriptShell `json:"shell"`
+}
+
 // Identifier of a process previously returned by "shell.exec" and the signal to send.
 // Experimental: ShellKillRequest is part of an experimental API and may change or be
 // removed.
@@ -9450,6 +10038,34 @@ type ShellKillRequest struct {
 type ShellKillResult struct {
 	// Whether the signal was sent successfully
 	Killed bool `json:"killed"`
+}
+
+// Per-session settings for built-in shell tools.
+// Experimental: ShellOptions is part of an experimental API and may change or be removed.
+type ShellOptions struct {
+	// Controls automatic non-interactive profile loading where supported. Explicit initScripts
+	// are unaffected.
+	InitProfile *ShellInitProfile `json:"initProfile,omitempty"`
+	// Ordered host-provided script paths sourced before each built-in shell command when the
+	// entry's shell target matches the active shell. Use these for rc files, environment setup
+	// scripts,
+	// or other custom scripts. A script that returns a nonzero status is reported, and later
+	// scripts
+	// and the user command continue while the shell remains running. Because scripts are
+	// sourced into
+	// the command shell, `exit`, `exec`, failures under `set -e`, or other shell-terminating
+	// behavior
+	// can prevent continuation. Script standard output is preserved; Bash script stderr is
+	// discarded,
+	// PowerShell exception messages are replaced, and runtime-generated failure notices omit
+	// configured script paths. When sandboxing is enabled, each script must already be readable
+	// under
+	// the active sandbox filesystem policy. Pass an empty array to clear the list.
+	InitScripts []ShellInitScript `json:"initScripts,omitzero"`
+	// Flags passed to the active built-in shell process on startup, replacing its default flags.
+	// When omitted, the built-in Bash shell uses `--norc --noprofile`,
+	// and the built-in PowerShell shell uses `-NoProfile -NoLogo`.
+	ProcessFlags []string `json:"processFlags,omitzero"`
 }
 
 // Parameters for shutting down the session
@@ -10497,6 +11113,11 @@ type UIExitPlanModeResponse struct {
 	Approved bool `json:"approved"`
 	// Whether subsequent edits should be auto-approved without confirmation.
 	AutoApproveEdits *bool `json:"autoApproveEdits,omitempty"`
+	// When true, the agent is instructed to end its turn without starting implementation so the
+	// client can restore the session model and auto-submit a fresh implementation turn on it.
+	// Set only when a distinct plan configuration (a different model, reasoning effort, or
+	// context tier) actually ran the planning turn.
+	DeferImplementation *bool `json:"deferImplementation,omitempty"`
 	// Feedback from the user when they declined the plan or requested changes.
 	Feedback *string `json:"feedback,omitempty"`
 	// The action the user selected. Defaults to 'autopilot' when autoApproveEdits is true,
@@ -11015,6 +11636,32 @@ type WorkspaceDiffResult struct {
 	RequestedMode WorkspaceDiffMode `json:"requestedMode"`
 }
 
+// Compaction summary checkpoint to persist.
+// Experimental: WorkspacesAddSummaryRequest is part of an experimental API and may change
+// or be removed.
+type WorkspacesAddSummaryRequest struct {
+	// Markdown summary content to persist.
+	Content string `json:"content"`
+	// Summary title shown in checkpoint listings.
+	Title string `json:"title"`
+}
+
+// Persisted summary metadata and refreshed workspace metadata.
+// Experimental: WorkspacesAddSummaryResult is part of an experimental API and may change or
+// be removed.
+type WorkspacesAddSummaryResult struct {
+	Summary   any `json:"summary,omitempty"`
+	Workspace any `json:"workspace,omitempty"`
+}
+
+// Whether the autopilot objective file exists.
+// Experimental: WorkspacesAutopilotObjectiveExistsResult is part of an experimental API and
+// may change or be removed.
+type WorkspacesAutopilotObjectiveExistsResult struct {
+	// True when the objective file exists.
+	Exists bool `json:"exists"`
+}
+
 // Workspace checkpoint metadata with assigned number, human-readable title, and checkpoint
 // filename.
 // Experimental: WorkspacesCheckpoints is part of an experimental API and may change or be
@@ -11038,6 +11685,14 @@ type WorkspacesCreateFileRequest struct {
 	Path string `json:"path"`
 }
 
+// Result of deleting the autopilot objective file.
+// Experimental: WorkspacesDeleteAutopilotObjectiveResult is part of an experimental API and
+// may change or be removed.
+type WorkspacesDeleteAutopilotObjectiveResult struct {
+	// True when a file was deleted.
+	Deleted bool `json:"deleted"`
+}
+
 // Parameters for computing a workspace diff.
 // Experimental: WorkspacesDiffRequest is part of an experimental API and may change or be
 // removed.
@@ -11046,6 +11701,14 @@ type WorkspacesDiffRequest struct {
 	IgnoreWhitespace *bool `json:"ignoreWhitespace,omitempty"`
 	// Diff mode requested by the client.
 	Mode WorkspaceDiffMode `json:"mode"`
+}
+
+// Optional session context used when creating a local workspace.
+// Experimental: WorkspacesEnsureRequest is part of an experimental API and may change or be
+// removed.
+type WorkspacesEnsureRequest struct {
+	// Opaque workspace context supplied by the session host.
+	Context any `json:"context,omitempty"`
 }
 
 // Current workspace metadata for the session, including its absolute filesystem path when
@@ -11095,6 +11758,14 @@ type WorkspacesListCheckpointsResult struct {
 type WorkspacesListFilesResult struct {
 	// Relative file paths in the workspace files directory
 	Files []string `json:"files"`
+}
+
+// Autopilot objective file content, or null when missing.
+// Experimental: WorkspacesReadAutopilotObjectiveResult is part of an experimental API and
+// may change or be removed.
+type WorkspacesReadAutopilotObjectiveResult struct {
+	// Autopilot objective file content, or null when missing.
+	Content *string `json:"content"`
 }
 
 // Checkpoint number to read.
@@ -11155,6 +11826,14 @@ type WorkspacesSaveLargePasteResultSaved struct {
 	SizeBytes int64 `json:"sizeBytes"`
 }
 
+// Rollback point for local workspace summaries.
+// Experimental: WorkspacesTruncateSummariesRequest is part of an experimental API and may
+// change or be removed.
+type WorkspacesTruncateSummariesRequest struct {
+	// Number of newest summaries to keep.
+	KeepCount int64 `json:"keepCount"`
+}
+
 // Public-facing projection of workspace metadata for SDK / TUI consumers
 // Experimental: WorkspaceSummary is part of an experimental API and may change or be
 // removed.
@@ -11179,6 +11858,32 @@ type WorkspaceSummary struct {
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 	// Whether the display name was explicitly set by the user
 	UserNamed *bool `json:"user_named,omitempty"`
+}
+
+// Workspace metadata fields to update.
+// Experimental: WorkspacesUpdateMetadataRequest is part of an experimental API and may
+// change or be removed.
+type WorkspacesUpdateMetadataRequest struct {
+	// Opaque workspace context supplied by the session host.
+	Context any `json:"context,omitempty"`
+	// Optional workspace display name override.
+	Name *string `json:"name,omitempty"`
+}
+
+// Autopilot objective file content to persist.
+// Experimental: WorkspacesWriteAutopilotObjectiveRequest is part of an experimental API and
+// may change or be removed.
+type WorkspacesWriteAutopilotObjectiveRequest struct {
+	// Autopilot objective file content.
+	Content string `json:"content"`
+}
+
+// Result of writing the autopilot objective file.
+// Experimental: WorkspacesWriteAutopilotObjectiveResult is part of an experimental API and
+// may change or be removed.
+type WorkspacesWriteAutopilotObjectiveResult struct {
+	// Filesystem operation performed.
+	Operation string `json:"operation"`
 }
 
 // Finite reason code describing why the current turn was aborted
@@ -11654,6 +12359,34 @@ const (
 	ExternalToolTextResultForLlmContentTypeText         ExternalToolTextResultForLlmContentType = "text"
 )
 
+// Execution-critical factory storage operation.
+// Experimental: FactoryDurableOperation is part of an experimental API and may change or be
+// removed.
+type FactoryDurableOperation string
+
+const (
+	// Persisting active execution time.
+	FactoryDurableOperationAddElapsed FactoryDurableOperation = "addElapsed"
+	// Persisting an idempotent model-usage charge.
+	FactoryDurableOperationChargeCredit FactoryDurableOperation = "chargeCredit"
+	// Creating the durable run and declared phases.
+	FactoryDurableOperationCreateRun FactoryDurableOperation = "createRun"
+	// Persisting the terminal run envelope.
+	FactoryDurableOperationFinishRun FactoryDurableOperation = "finishRun"
+	// Reading a journal entry without treating storage failure as a cache miss.
+	FactoryDurableOperationJournalGet FactoryDurableOperation = "journalGet"
+	// Persisting a journal entry before reporting success.
+	FactoryDurableOperationJournalPut FactoryDurableOperation = "journalPut"
+	// Persisting the transition to running.
+	FactoryDurableOperationMarkRunStarted FactoryDurableOperation = "markRunStarted"
+	// Reading the authoritative AI-credit total.
+	FactoryDurableOperationReconcileCreditTotal FactoryDurableOperation = "reconcileCreditTotal"
+	// Rolling back an uncommitted subagent admission.
+	FactoryDurableOperationReleaseAgent FactoryDurableOperation = "releaseAgent"
+	// Persisting subagent admission accounting.
+	FactoryDurableOperationReserveAgent FactoryDurableOperation = "reserveAgent"
+)
+
 // Kind of factory progress line.
 // Experimental: FactoryLogLineKind is part of an experimental API and may change or be
 // removed.
@@ -11666,22 +12399,43 @@ const (
 	FactoryLogLineKindPhase FactoryLogLineKind = "phase"
 )
 
+// Derived lifecycle state of a factory phase.
+// Experimental: FactoryPhaseStatus is part of an experimental API and may change or be
+// removed.
+type FactoryPhaseStatus string
+
+const (
+	// The phase is currently entered and accumulating active time.
+	FactoryPhaseStatusActive FactoryPhaseStatus = "active"
+	// The phase was entered and has since been closed.
+	FactoryPhaseStatusCompleted FactoryPhaseStatus = "completed"
+	// The phase has not been entered yet.
+	FactoryPhaseStatusPending FactoryPhaseStatus = "pending"
+	// The phase was never entered because a later phase was entered or the run reached a
+	// terminal state.
+	FactoryPhaseStatusSkipped FactoryPhaseStatus = "skipped"
+)
+
 // Cumulative resource ceiling that stopped a factory run.
 // Experimental: FactoryRunFailureKind is part of an experimental API and may change or be
 // removed.
 type FactoryRunFailureKind string
 
 const (
+	// The run's settled subagent model usage exceeded the approved AI-credit ceiling, or no
+	// headroom remained for another subagent.
+	FactoryRunFailureKindMaxAiCredits FactoryRunFailureKind = "maxAiCredits"
 	// The run admitted the approved maximum total number of subagents.
 	FactoryRunFailureKindMaxTotalSubagents FactoryRunFailureKind = "maxTotalSubagents"
-	// The run reached the approved timeout deadline.
-	FactoryRunFailureKindTimeout FactoryRunFailureKind = "timeout"
+	// The run reached the approved accumulated active-execution time in seconds.
+	FactoryRunFailureKindTimeoutSeconds FactoryRunFailureKind = "timeoutSeconds"
 )
 
 // Type discriminator for FactoryRunFailure.
 type FactoryRunFailureType string
 
 const (
+	FactoryRunFailureTypeFactoryDurableFailure FactoryRunFailureType = "factory_durable_failure"
 	FactoryRunFailureTypeFactoryLimitReached   FactoryRunFailureType = "factory_limit_reached"
 	FactoryRunFailureTypeFactoryResumeDeclined FactoryRunFailureType = "factory_resume_declined"
 )
@@ -12714,6 +13468,23 @@ const (
 	SessionFSSqliteQueryTypeRun SessionFSSqliteQueryType = "run"
 )
 
+// SQLite transaction failure classification.
+// Experimental: SessionFSSqliteTransactionErrorClass is part of an experimental API and may
+// change or be removed.
+type SessionFSSqliteTransactionErrorClass string
+
+const (
+	// SQLite reported BUSY or LOCKED before commit; the transaction was rolled back and may be
+	// retried.
+	SessionFSSqliteTransactionErrorClassBusyOrLocked SessionFSSqliteTransactionErrorClass = "busyOrLocked"
+	// The statement, database, or provider failed definitively and must not be retried
+	// automatically.
+	SessionFSSqliteTransactionErrorClassFatal SessionFSSqliteTransactionErrorClass = "fatal"
+	// The transport failed after the provider may have committed; retrying could duplicate
+	// effects.
+	SessionFSSqliteTransactionErrorClassPostCommitAmbiguous SessionFSSqliteTransactionErrorClass = "postCommitAmbiguous"
+)
+
 // Constant value. Always "github".
 type SessionInstalledPluginSourceGitHubSource string
 
@@ -12960,6 +13731,32 @@ const (
 	SessionWorkingDirectoryContextHostTypeADO SessionWorkingDirectoryContextHostType = "ado"
 	// The working directory repository is hosted on GitHub.
 	SessionWorkingDirectoryContextHostTypeGitHub SessionWorkingDirectoryContextHostType = "github"
+)
+
+// Controls automatic non-interactive profile loading where supported. Explicit initScripts
+// are unaffected.
+// Experimental: ShellInitProfile is part of an experimental API and may change or be
+// removed.
+type ShellInitProfile string
+
+const (
+	// Disable automatic non-interactive profile loading. Explicit initScripts still run.
+	ShellInitProfileNone ShellInitProfile = "none"
+	// Allow automatic non-interactive profile loading when supported. Explicit initScripts
+	// still run.
+	ShellInitProfileNonInteractive ShellInitProfile = "non-interactive"
+)
+
+// Supported built-in shells for initialization scripts.
+// Experimental: ShellInitScriptShell is part of an experimental API and may change or be
+// removed.
+type ShellInitScriptShell string
+
+const (
+	// Source the script in the built-in Bash shell on macOS and Linux.
+	ShellInitScriptShellBash ShellInitScriptShell = "bash"
+	// Source the script in the built-in PowerShell shell on Windows.
+	ShellInitScriptShellPowershell ShellInitScriptShell = "powershell"
 )
 
 // Signal to send (default: SIGTERM)
@@ -14849,6 +15646,26 @@ func (a *InternalServerSessionsAPI) ConfigureSessionExtensions(ctx context.Conte
 	return &result, nil
 }
 
+// Deletes one local session from disk after running the same lifecycle hooks as the session
+// manager.
+//
+// RPC method: sessions.delete.
+//
+// Parameters: Session ID to delete from disk.
+// Internal: Delete is part of the SDK's internal handshake/plumbing; external callers
+// should not use it.
+func (a *InternalServerSessionsAPI) Delete(ctx context.Context, params *SessionsDeleteRequest) (*SessionsDeleteResult, error) {
+	raw, err := a.client.Request(ctx, "sessions.delete", params)
+	if err != nil {
+		return nil, err
+	}
+	var result SessionsDeleteResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // GetBoardEntryCount gets the dynamic-context board entry count associated with a session,
 // when available. Internal: this exists solely so CLI telemetry events (`rem_spawn_gate`,
 // `rem_consolidation_complete`) can pair START / END board counts around the detached
@@ -14900,6 +15717,27 @@ func (a *InternalServerSessionsAPI) GetEventFilePath(ctx context.Context, params
 	return &result, nil
 }
 
+// GetMetadata reads lightweight persisted metadata for one local session without opening it.
+//
+// RPC method: sessions.getMetadata.
+//
+// Parameters: Session ID whose persisted metadata should be read.
+//
+// Returns: Persisted local session metadata when the session exists.
+// Internal: GetMetadata is part of the SDK's internal handshake/plumbing; external callers
+// should not use it.
+func (a *InternalServerSessionsAPI) GetMetadata(ctx context.Context, params *SessionsGetMetadataRequest) (*SessionsGetMetadataResult, error) {
+	raw, err := a.client.Request(ctx, "sessions.getMetadata", params)
+	if err != nil {
+		return nil, err
+	}
+	var result SessionsGetMetadataResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // GetPersistedRemoteSteerable returns a session's persisted remote-steerable flag, if any
 // has been recorded. Internal: this is CLI-specific book-keeping used by `--continue` /
 // `--resume` to inherit the prior session's remote-steerable preference. SDK consumers that
@@ -14920,6 +15758,28 @@ func (a *InternalServerSessionsAPI) GetPersistedRemoteSteerable(ctx context.Cont
 		return nil, err
 	}
 	var result SessionsGetPersistedRemoteSteerableResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ListNonEmptySessionIds lists recent local session IDs that contain user-visible history,
+// omitting housekeeping-only sessions.
+//
+// RPC method: sessions.listNonEmptySessionIds.
+//
+// Parameters: Limit for non-empty local session IDs.
+//
+// Returns: Recent local session IDs that contain user-visible history.
+// Internal: ListNonEmptySessionIds is part of the SDK's internal handshake/plumbing;
+// external callers should not use it.
+func (a *InternalServerSessionsAPI) ListNonEmptySessionIds(ctx context.Context, params *SessionsListNonEmptySessionIDsRequest) (*SessionsListNonEmptySessionIDsResult, error) {
+	raw, err := a.client.Request(ctx, "sessions.listNonEmptySessionIds", params)
+	if err != nil {
+		return nil, err
+	}
+	var result SessionsListNonEmptySessionIDsResult
 	if err := json.Unmarshal(raw, &result); err != nil {
 		return nil, err
 	}
@@ -15703,6 +16563,7 @@ type FactoryAPI sessionAPI
 func (a *FactoryAPI) Agent(ctx context.Context, params *FactoryAgentRequest) (*FactoryAgentResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
+		req["executionToken"] = params.ExecutionToken
 		req["factoryRunId"] = params.FactoryRunID
 		req["opts"] = params.Opts
 		req["prompt"] = params.Prompt
@@ -15764,6 +16625,82 @@ func (a *FactoryAPI) GetRun(ctx context.Context, params *FactoryGetRunRequest) (
 	return &result, nil
 }
 
+// GetRunDetail gets durable and live observability detail for one factory run.
+//
+// RPC method: session.factory.getRunDetail.
+//
+// Parameters: Parameters for retrieving a factory run.
+//
+// Returns: Full factory run observability detail.
+func (a *FactoryAPI) GetRunDetail(ctx context.Context, params *FactoryGetRunRequest) (*FactoryRunDetail, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		req["runId"] = params.RunID
+	}
+	raw, err := a.client.Request(ctx, "session.factory.getRunDetail", req)
+	if err != nil {
+		return nil, err
+	}
+	var result FactoryRunDetail
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetRunProgress pages durable progress for one factory run.
+//
+// RPC method: session.factory.getRunProgress.
+//
+// Parameters: Parameters for paging factory progress.
+//
+// Returns: A bidirectional page of factory progress.
+func (a *FactoryAPI) GetRunProgress(ctx context.Context, params *FactoryGetRunProgressRequest) (*FactoryProgressPage, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		if params.AfterSeq != nil {
+			req["afterSeq"] = *params.AfterSeq
+		}
+		if params.BeforeSeq != nil {
+			req["beforeSeq"] = *params.BeforeSeq
+		}
+		if params.Limit != nil {
+			req["limit"] = *params.Limit
+		}
+		if params.PhaseID != nil {
+			req["phaseId"] = *params.PhaseID
+		}
+		req["runId"] = params.RunID
+	}
+	raw, err := a.client.Request(ctx, "session.factory.getRunProgress", req)
+	if err != nil {
+		return nil, err
+	}
+	var result FactoryProgressPage
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ListRuns lists durable factory runs for this session in creation order.
+//
+// RPC method: session.factory.listRuns.
+//
+// Returns: Factory runs in durable creation order.
+func (a *FactoryAPI) ListRuns(ctx context.Context) (*FactoryListRunsResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	raw, err := a.client.Request(ctx, "session.factory.listRuns", req)
+	if err != nil {
+		return nil, err
+	}
+	var result FactoryListRunsResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // Log records a batch of ordered factory progress lines.
 //
 // RPC method: session.factory.log.
@@ -15774,6 +16711,7 @@ func (a *FactoryAPI) GetRun(ctx context.Context, params *FactoryGetRunRequest) (
 func (a *FactoryAPI) Log(ctx context.Context, params *FactoryLogRequest) (*FactoryAckResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
+		req["executionToken"] = params.ExecutionToken
 		req["lines"] = params.Lines
 		req["runId"] = params.RunID
 	}
@@ -15782,6 +16720,32 @@ func (a *FactoryAPI) Log(ctx context.Context, params *FactoryLogRequest) (*Facto
 		return nil, err
 	}
 	var result FactoryAckResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// Resumes a factory run using its persisted name, arguments, journal, and accounting.
+//
+// RPC method: session.factory.resume.
+//
+// Parameters: Parameters for resuming a factory run from its persisted identity.
+//
+// Returns: Resolved persisted factory identity and resumed run envelope.
+func (a *FactoryAPI) Resume(ctx context.Context, params *FactoryResumeRequest) (*FactoryResumeResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		if params.Limits != nil {
+			req["limits"] = *params.Limits
+		}
+		req["runId"] = params.RunID
+	}
+	raw, err := a.client.Request(ctx, "session.factory.resume", req)
+	if err != nil {
+		return nil, err
+	}
+	var result FactoryResumeResult
 	if err := json.Unmarshal(raw, &result); err != nil {
 		return nil, err
 	}
@@ -15828,6 +16792,7 @@ type FactoryJournalAPI sessionAPI
 func (a *FactoryJournalAPI) Get(ctx context.Context, params *FactoryJournalGetRequest) (*FactoryJournalGetResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
+		req["executionToken"] = params.ExecutionToken
 		req["key"] = params.Key
 		req["runId"] = params.RunID
 	}
@@ -15852,6 +16817,7 @@ func (a *FactoryJournalAPI) Get(ctx context.Context, params *FactoryJournalGetRe
 func (a *FactoryJournalAPI) Put(ctx context.Context, params *FactoryJournalPutRequest) (*FactoryAckResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
+		req["executionToken"] = params.ExecutionToken
 		req["key"] = params.Key
 		req["resultJson"] = params.ResultJSON
 		req["runId"] = params.RunID
@@ -16683,6 +17649,29 @@ func (a *MCPOauthAPI) Login(ctx context.Context, params *MCPOauthLoginRequest) (
 	return &result, nil
 }
 
+// Responds to a pending MCP OAuth authorization request by its request id.
+//
+// RPC method: session.mcp.oauth.respond.
+//
+// Parameters: Pending MCP OAuth request id to respond to.
+//
+// Returns: Indicates whether the pending MCP OAuth response was accepted.
+func (a *MCPOauthAPI) Respond(ctx context.Context, params *MCPOauthRespondRequest) (*MCPOauthRespondResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		req["requestId"] = params.RequestID
+	}
+	raw, err := a.client.Request(ctx, "session.mcp.oauth.respond", req)
+	if err != nil {
+		return nil, err
+	}
+	var result MCPOauthRespondResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // Experimental: Oauth returns experimental APIs that may change or be removed.
 func (s *MCPAPI) Oauth() *MCPOauthAPI {
 	return (*MCPOauthAPI)(s)
@@ -17326,6 +18315,9 @@ func (a *OptionsAPI) Update(ctx context.Context, params *SessionUpdateOptionsPar
 		if params.EventsLogDirectory != nil {
 			req["eventsLogDirectory"] = *params.EventsLogDirectory
 		}
+		if params.EventsLogIncludesSubagents != nil {
+			req["eventsLogIncludesSubagents"] = *params.EventsLogIncludesSubagents
+		}
 		if params.ExcludedBuiltinAgents != nil {
 			req["excludedBuiltinAgents"] = params.ExcludedBuiltinAgents
 		}
@@ -17388,6 +18380,9 @@ func (a *OptionsAPI) Update(ctx context.Context, params *SessionUpdateOptionsPar
 		}
 		if params.SessionLimits != nil {
 			req["sessionLimits"] = *params.SessionLimits
+		}
+		if params.Shell != nil {
+			req["shell"] = *params.Shell
 		}
 		if params.ShellInitProfile != nil {
 			req["shellInitProfile"] = *params.ShellInitProfile
@@ -19366,6 +20361,49 @@ func (a *VisibilityAPI) Set(ctx context.Context, params *VisibilitySetRequest) (
 // Experimental: WorkspacesAPI contains experimental APIs that may change or be removed.
 type WorkspacesAPI sessionAPI
 
+// AddSummary adds a compaction summary checkpoint to the local session workspace.
+//
+// RPC method: session.workspaces.addSummary.
+//
+// Parameters: Compaction summary checkpoint to persist.
+//
+// Returns: Persisted summary metadata and refreshed workspace metadata.
+func (a *WorkspacesAPI) AddSummary(ctx context.Context, params *WorkspacesAddSummaryRequest) (*WorkspacesAddSummaryResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		req["content"] = params.Content
+		req["title"] = params.Title
+	}
+	raw, err := a.client.Request(ctx, "session.workspaces.addSummary", req)
+	if err != nil {
+		return nil, err
+	}
+	var result WorkspacesAddSummaryResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// AutopilotObjectiveExists checks whether the local session workspace has an autopilot
+// objective state file.
+//
+// RPC method: session.workspaces.autopilotObjectiveExists.
+//
+// Returns: Whether the autopilot objective file exists.
+func (a *WorkspacesAPI) AutopilotObjectiveExists(ctx context.Context) (*WorkspacesAutopilotObjectiveExistsResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	raw, err := a.client.Request(ctx, "session.workspaces.autopilotObjectiveExists", req)
+	if err != nil {
+		return nil, err
+	}
+	var result WorkspacesAutopilotObjectiveExistsResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // CreateFile creates or overwrites a file in the session workspace files directory.
 //
 // RPC method: session.workspaces.createFile.
@@ -19382,6 +20420,25 @@ func (a *WorkspacesAPI) CreateFile(ctx context.Context, params *WorkspacesCreate
 		return nil, err
 	}
 	var result SessionWorkspacesCreateFileResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeleteAutopilotObjective deletes the autopilot objective state file from the local
+// session workspace.
+//
+// RPC method: session.workspaces.deleteAutopilotObjective.
+//
+// Returns: Result of deleting the autopilot objective file.
+func (a *WorkspacesAPI) DeleteAutopilotObjective(ctx context.Context) (*WorkspacesDeleteAutopilotObjectiveResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	raw, err := a.client.Request(ctx, "session.workspaces.deleteAutopilotObjective", req)
+	if err != nil {
+		return nil, err
+	}
+	var result WorkspacesDeleteAutopilotObjectiveResult
 	if err := json.Unmarshal(raw, &result); err != nil {
 		return nil, err
 	}
@@ -19408,6 +20465,32 @@ func (a *WorkspacesAPI) Diff(ctx context.Context, params *WorkspacesDiffRequest)
 		return nil, err
 	}
 	var result WorkspaceDiffResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// Ensures a local session workspace exists and returns it.
+//
+// RPC method: session.workspaces.ensure.
+//
+// Parameters: Optional session context used when creating a local workspace.
+//
+// Returns: Current workspace metadata for the session, including its absolute filesystem
+// path when available.
+func (a *WorkspacesAPI) Ensure(ctx context.Context, params *WorkspacesEnsureRequest) (*WorkspacesGetWorkspaceResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		if params.Context != nil {
+			req["context"] = params.Context
+		}
+	}
+	raw, err := a.client.Request(ctx, "session.workspaces.ensure", req)
+	if err != nil {
+		return nil, err
+	}
+	var result WorkspacesGetWorkspaceResult
 	if err := json.Unmarshal(raw, &result); err != nil {
 		return nil, err
 	}
@@ -19464,6 +20547,25 @@ func (a *WorkspacesAPI) ListFiles(ctx context.Context) (*WorkspacesListFilesResu
 		return nil, err
 	}
 	var result WorkspacesListFilesResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ReadAutopilotObjective reads the autopilot objective state file from the local session
+// workspace.
+//
+// RPC method: session.workspaces.readAutopilotObjective.
+//
+// Returns: Autopilot objective file content, or null when missing.
+func (a *WorkspacesAPI) ReadAutopilotObjective(ctx context.Context) (*WorkspacesReadAutopilotObjectiveResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	raw, err := a.client.Request(ctx, "session.workspaces.readAutopilotObjective", req)
+	if err != nil {
+		return nil, err
+	}
+	var result WorkspacesReadAutopilotObjectiveResult
 	if err := json.Unmarshal(raw, &result); err != nil {
 		return nil, err
 	}
@@ -19540,6 +20642,84 @@ func (a *WorkspacesAPI) SaveLargePaste(ctx context.Context, params *WorkspacesSa
 	return &result, nil
 }
 
+// TruncateSummaries truncates local workspace compaction summaries after a rollback.
+//
+// RPC method: session.workspaces.truncateSummaries.
+//
+// Parameters: Rollback point for local workspace summaries.
+//
+// Returns: Current workspace metadata for the session, including its absolute filesystem
+// path when available.
+func (a *WorkspacesAPI) TruncateSummaries(ctx context.Context, params *WorkspacesTruncateSummariesRequest) (*WorkspacesGetWorkspaceResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		req["keepCount"] = params.KeepCount
+	}
+	raw, err := a.client.Request(ctx, "session.workspaces.truncateSummaries", req)
+	if err != nil {
+		return nil, err
+	}
+	var result WorkspacesGetWorkspaceResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// UpdateMetadata updates workspace metadata for a local session and returns the refreshed
+// workspace.
+//
+// RPC method: session.workspaces.updateMetadata.
+//
+// Parameters: Workspace metadata fields to update.
+//
+// Returns: Current workspace metadata for the session, including its absolute filesystem
+// path when available.
+func (a *WorkspacesAPI) UpdateMetadata(ctx context.Context, params *WorkspacesUpdateMetadataRequest) (*WorkspacesGetWorkspaceResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		if params.Context != nil {
+			req["context"] = params.Context
+		}
+		if params.Name != nil {
+			req["name"] = *params.Name
+		}
+	}
+	raw, err := a.client.Request(ctx, "session.workspaces.updateMetadata", req)
+	if err != nil {
+		return nil, err
+	}
+	var result WorkspacesGetWorkspaceResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// WriteAutopilotObjective writes the autopilot objective state file in the local session
+// workspace.
+//
+// RPC method: session.workspaces.writeAutopilotObjective.
+//
+// Parameters: Autopilot objective file content to persist.
+//
+// Returns: Result of writing the autopilot objective file.
+func (a *WorkspacesAPI) WriteAutopilotObjective(ctx context.Context, params *WorkspacesWriteAutopilotObjectiveRequest) (*WorkspacesWriteAutopilotObjectiveResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		req["content"] = params.Content
+	}
+	raw, err := a.client.Request(ctx, "session.workspaces.writeAutopilotObjective", req)
+	if err != nil {
+		return nil, err
+	}
+	var result WorkspacesWriteAutopilotObjectiveResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // SessionRPC provides typed session-scoped RPC methods.
 type SessionRPC struct {
 	// Reuse a single struct instead of allocating one for each service on the heap.
@@ -19603,6 +20783,58 @@ func (a *SessionRPC) Abort(ctx context.Context, params *AbortRequest) (*AbortRes
 		return nil, err
 	}
 	var result AbortResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// CancelAllBackgroundAgents cancels every running background agent (task-registry subagents
+// plus sidekick agents) without interrupting the main agent loop. Promoted attached shells
+// are left running.
+//
+// RPC method: session.cancelAllBackgroundAgents.
+//
+// Returns: The number of running background agents (task-registry agents) that were
+// cancelled.
+// Experimental: CancelAllBackgroundAgents is an experimental API and may change or be
+// removed in future versions.
+func (a *SessionRPC) CancelAllBackgroundAgents(ctx context.Context) (*SessionCancelAllBackgroundAgentsResult, error) {
+	req := map[string]any{"sessionId": a.common.sessionID}
+	raw, err := a.common.client.Request(ctx, "session.cancelAllBackgroundAgents", req)
+	if err != nil {
+		return nil, err
+	}
+	var result SessionCancelAllBackgroundAgentsResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// InterruptMainTurn interrupts the current main agent turn while leaving running background
+// work (subagents, sidekicks, and promoted attached shells) alive. No-op when the main loop
+// is not processing.
+//
+// RPC method: session.interruptMainTurn.
+//
+// Parameters: Parameters for interrupting the main agent turn.
+//
+// Returns: Result of interrupting the main agent turn.
+// Experimental: InterruptMainTurn is an experimental API and may change or be removed in
+// future versions.
+func (a *SessionRPC) InterruptMainTurn(ctx context.Context, params *InterruptMainTurnRequest) (*InterruptMainTurnResult, error) {
+	req := map[string]any{"sessionId": a.common.sessionID}
+	if params != nil {
+		if params.FlushQueued != nil {
+			req["flushQueued"] = *params.FlushQueued
+		}
+	}
+	raw, err := a.common.client.Request(ctx, "session.interruptMainTurn", req)
+	if err != nil {
+		return nil, err
+	}
+	var result InterruptMainTurnResult
 	if err := json.Unmarshal(raw, &result); err != nil {
 		return nil, err
 	}
@@ -19969,6 +21201,385 @@ func (a *InternalMCPAPI) UnregisterExternalClient(ctx context.Context, params *M
 	return &result, nil
 }
 
+// Experimental: InternalQueueAPI contains experimental APIs that may change or be removed.
+type InternalQueueAPI internalSessionAPI
+
+// BeginDeferredIdleDrain begins a native deferred-idle drain when background work has
+// quiesced.
+//
+// RPC method: session.queue.beginDeferredIdleDrain.
+//
+// Parameters: Inputs for starting a deferred-idle drain.
+//
+// Returns: Whether a deferred-idle drain should run.
+// Internal: BeginDeferredIdleDrain is part of the SDK's internal handshake/plumbing;
+// external callers should not use it.
+func (a *InternalQueueAPI) BeginDeferredIdleDrain(ctx context.Context, params *QueueBeginDeferredIdleDrainRequest) (*QueueBeginDeferredIdleDrainResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		req["activeBackgroundWork"] = params.ActiveBackgroundWork
+	}
+	raw, err := a.client.Request(ctx, "session.queue.beginDeferredIdleDrain", req)
+	if err != nil {
+		return nil, err
+	}
+	var result QueueBeginDeferredIdleDrainResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ConsumeSystemNotifications consumes queued native system notifications matching an
+// internal filter.
+//
+// RPC method: session.queue.consumeSystemNotifications.
+//
+// Parameters: Internal filter for consuming queued system notifications.
+//
+// Returns: Indicates whether a user-facing pending item was removed.
+// Internal: ConsumeSystemNotifications is part of the SDK's internal handshake/plumbing;
+// external callers should not use it.
+func (a *InternalQueueAPI) ConsumeSystemNotifications(ctx context.Context, params *QueueConsumeSystemNotificationsRequest) (*QueueRemoveMostRecentResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		req["filter"] = params.Filter
+	}
+	raw, err := a.client.Request(ctx, "session.queue.consumeSystemNotifications", req)
+	if err != nil {
+		return nil, err
+	}
+	var result QueueRemoveMostRecentResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeferSessionIdle marks session.idle as deferred by native background work state.
+//
+// RPC method: session.queue.deferSessionIdle.
+//
+// Parameters: Inputs for marking session.idle deferred in native state.
+// Internal: DeferSessionIdle is part of the SDK's internal handshake/plumbing; external
+// callers should not use it.
+func (a *InternalQueueAPI) DeferSessionIdle(ctx context.Context, params *QueueDeferSessionIdleRequest) (*SessionQueueDeferSessionIdleResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		req["aborted"] = params.Aborted
+	}
+	raw, err := a.client.Request(ctx, "session.queue.deferSessionIdle", req)
+	if err != nil {
+		return nil, err
+	}
+	var result SessionQueueDeferSessionIdleResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// EnqueueResumePending enqueues the internal resume-pending wake item when orphan handling
+// needs a follow-up turn.
+//
+// RPC method: session.queue.enqueueResumePending.
+//
+// Returns: Result of enqueueing the resume-pending wake item.
+// Internal: EnqueueResumePending is part of the SDK's internal handshake/plumbing; external
+// callers should not use it.
+func (a *InternalQueueAPI) EnqueueResumePending(ctx context.Context) (*QueueEnqueueResumePendingResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	raw, err := a.client.Request(ctx, "session.queue.enqueueResumePending", req)
+	if err != nil {
+		return nil, err
+	}
+	var result QueueEnqueueResumePendingResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// FinishDeferredIdleDrain finishes a native deferred-idle drain and reports whether to
+// drain queue work or emit idle.
+//
+// RPC method: session.queue.finishDeferredIdleDrain.
+//
+// Parameters: Inputs for completing a deferred-idle drain.
+//
+// Returns: Action selected by the native deferred-idle drain.
+// Internal: FinishDeferredIdleDrain is part of the SDK's internal handshake/plumbing;
+// external callers should not use it.
+func (a *InternalQueueAPI) FinishDeferredIdleDrain(ctx context.Context, params *QueueFinishDeferredIdleDrainRequest) (*QueueFinishDeferredIdleDrainResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		req["activeBackgroundWork"] = params.ActiveBackgroundWork
+		req["hasPending"] = params.HasPending
+	}
+	raw, err := a.client.Request(ctx, "session.queue.finishDeferredIdleDrain", req)
+	if err != nil {
+		return nil, err
+	}
+	var result QueueFinishDeferredIdleDrainResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// HasPending reports whether the local session has native queued work pending.
+//
+// RPC method: session.queue.hasPending.
+//
+// Returns: Whether the native queue has pending work.
+// Internal: HasPending is part of the SDK's internal handshake/plumbing; external callers
+// should not use it.
+func (a *InternalQueueAPI) HasPending(ctx context.Context) (*QueueHasPendingResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	raw, err := a.client.Request(ctx, "session.queue.hasPending", req)
+	if err != nil {
+		return nil, err
+	}
+	var result QueueHasPendingResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// Process drains the native local-session work queue for in-process session orchestration.
+//
+// RPC method: session.queue.process.
+// Internal: Process is part of the SDK's internal handshake/plumbing; external callers
+// should not use it.
+func (a *InternalQueueAPI) Process(ctx context.Context) (*SessionQueueProcessResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	raw, err := a.client.Request(ctx, "session.queue.process", req)
+	if err != nil {
+		return nil, err
+	}
+	var result SessionQueueProcessResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// Snapshot returns the internal native queue snapshot for in-process session orchestration.
+//
+// RPC method: session.queue.snapshot.
+//
+// Returns: Internal snapshot of native queue state for local session orchestration.
+// Internal: Snapshot is part of the SDK's internal handshake/plumbing; external callers
+// should not use it.
+func (a *InternalQueueAPI) Snapshot(ctx context.Context) (*QueueSnapshotResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	raw, err := a.client.Request(ctx, "session.queue.snapshot", req)
+	if err != nil {
+		return nil, err
+	}
+	var result QueueSnapshotResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// Experimental: InternalScheduleAPI contains experimental APIs that may change or be
+// removed.
+type InternalScheduleAPI internalSessionAPI
+
+// Add registers a relative-interval scheduled prompt.
+//
+// RPC method: session.schedule.add.
+//
+// Parameters: Register a relative-interval scheduled prompt.
+//
+// Returns: Result of registering or re-arming a scheduled prompt.
+// Internal: Add is part of the SDK's internal handshake/plumbing; external callers should
+// not use it.
+func (a *InternalScheduleAPI) Add(ctx context.Context, params *ScheduleAddRequest) (*ScheduleAddResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		if params.DisplayPrompt != nil {
+			req["displayPrompt"] = *params.DisplayPrompt
+		}
+		req["interval"] = params.Interval
+		req["prompt"] = params.Prompt
+		if params.Recurring != nil {
+			req["recurring"] = *params.Recurring
+		}
+	}
+	raw, err := a.client.Request(ctx, "session.schedule.add", req)
+	if err != nil {
+		return nil, err
+	}
+	var result ScheduleAddResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// AddAt registers an absolute-time scheduled prompt.
+//
+// RPC method: session.schedule.addAt.
+//
+// Parameters: Register an absolute-time scheduled prompt.
+//
+// Returns: Result of registering or re-arming a scheduled prompt.
+// Internal: AddAt is part of the SDK's internal handshake/plumbing; external callers should
+// not use it.
+func (a *InternalScheduleAPI) AddAt(ctx context.Context, params *ScheduleAddAtRequest) (*ScheduleAddResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		req["at"] = params.At
+		if params.DisplayPrompt != nil {
+			req["displayPrompt"] = *params.DisplayPrompt
+		}
+		req["prompt"] = params.Prompt
+		if params.Recurring != nil {
+			req["recurring"] = *params.Recurring
+		}
+	}
+	raw, err := a.client.Request(ctx, "session.schedule.addAt", req)
+	if err != nil {
+		return nil, err
+	}
+	var result ScheduleAddResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// AddCron registers a recurring cron scheduled prompt.
+//
+// RPC method: session.schedule.addCron.
+//
+// Parameters: Register a cron scheduled prompt.
+//
+// Returns: Result of registering or re-arming a scheduled prompt.
+// Internal: AddCron is part of the SDK's internal handshake/plumbing; external callers
+// should not use it.
+func (a *InternalScheduleAPI) AddCron(ctx context.Context, params *ScheduleAddCronRequest) (*ScheduleAddResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		req["cron"] = params.Cron
+		if params.DisplayPrompt != nil {
+			req["displayPrompt"] = *params.DisplayPrompt
+		}
+		req["prompt"] = params.Prompt
+		if params.Recurring != nil {
+			req["recurring"] = *params.Recurring
+		}
+		if params.Tz != nil {
+			req["tz"] = *params.Tz
+		}
+	}
+	raw, err := a.client.Request(ctx, "session.schedule.addCron", req)
+	if err != nil {
+		return nil, err
+	}
+	var result ScheduleAddResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// AddSelfPaced registers a self-paced scheduled prompt.
+//
+// RPC method: session.schedule.addSelfPaced.
+//
+// Parameters: Register a self-paced scheduled prompt.
+//
+// Returns: Result of registering or re-arming a scheduled prompt.
+// Internal: AddSelfPaced is part of the SDK's internal handshake/plumbing; external callers
+// should not use it.
+func (a *InternalScheduleAPI) AddSelfPaced(ctx context.Context, params *ScheduleAddSelfPacedRequest) (*ScheduleAddResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		if params.DisplayPrompt != nil {
+			req["displayPrompt"] = *params.DisplayPrompt
+		}
+		req["prompt"] = params.Prompt
+	}
+	raw, err := a.client.Request(ctx, "session.schedule.addSelfPaced", req)
+	if err != nil {
+		return nil, err
+	}
+	var result ScheduleAddResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// HasSelfPaced reports whether the session has an active self-paced scheduled prompt.
+//
+// RPC method: session.schedule.hasSelfPaced.
+//
+// Returns: Whether the session currently has an active self-paced schedule.
+// Internal: HasSelfPaced is part of the SDK's internal handshake/plumbing; external callers
+// should not use it.
+func (a *InternalScheduleAPI) HasSelfPaced(ctx context.Context) (*ScheduleHasSelfPacedResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	raw, err := a.client.Request(ctx, "session.schedule.hasSelfPaced", req)
+	if err != nil {
+		return nil, err
+	}
+	var result ScheduleHasSelfPacedResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// Hydrates the native schedule registry from persisted session events.
+//
+// RPC method: session.schedule.hydrate.
+// Internal: Hydrate is part of the SDK's internal handshake/plumbing; external callers
+// should not use it.
+func (a *InternalScheduleAPI) Hydrate(ctx context.Context) (*SessionScheduleHydrateResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	raw, err := a.client.Request(ctx, "session.schedule.hydrate", req)
+	if err != nil {
+		return nil, err
+	}
+	var result SessionScheduleHydrateResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// RearmSelfPaced re-arms an active self-paced scheduled prompt.
+//
+// RPC method: session.schedule.rearmSelfPaced.
+//
+// Parameters: Re-arm a self-paced scheduled prompt.
+//
+// Returns: Result of registering or re-arming a scheduled prompt.
+// Internal: RearmSelfPaced is part of the SDK's internal handshake/plumbing; external
+// callers should not use it.
+func (a *InternalScheduleAPI) RearmSelfPaced(ctx context.Context, params *ScheduleRearmSelfPacedRequest) (*ScheduleAddResult, error) {
+	req := map[string]any{"sessionId": a.sessionID}
+	if params != nil {
+		req["at"] = params.At
+		req["id"] = params.ID
+	}
+	raw, err := a.client.Request(ctx, "session.schedule.rearmSelfPaced", req)
+	if err != nil {
+		return nil, err
+	}
+	var result ScheduleAddResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // Experimental: InternalSettingsAPI contains experimental APIs that may change or be
 // removed.
 type InternalSettingsAPI internalSessionAPI
@@ -20036,13 +21647,49 @@ type InternalSessionRPC struct {
 	common internalSessionAPI
 
 	MCP      *InternalMCPAPI
+	Queue    *InternalQueueAPI
+	Schedule *InternalScheduleAPI
 	Settings *InternalSettingsAPI
+}
+
+// SendSystemNotification queues or sends an internal system notification to the session
+// according to its passive policy.
+//
+// RPC method: session.sendSystemNotification.
+//
+// Parameters: Internal request for sending a system notification.
+// Experimental: SendSystemNotification is an experimental API and may change or be removed
+// in future versions.
+// Internal: SendSystemNotification is part of the SDK's internal handshake/plumbing;
+// external callers should not use it.
+func (a *InternalSessionRPC) SendSystemNotification(ctx context.Context, params *SendSystemNotificationRequest) (*SessionSendSystemNotificationResult, error) {
+	req := map[string]any{"sessionId": a.common.sessionID}
+	if params != nil {
+		if params.Kind != nil {
+			req["kind"] = params.Kind
+		}
+		req["message"] = params.Message
+		if params.Options != nil {
+			req["options"] = params.Options
+		}
+	}
+	raw, err := a.common.client.Request(ctx, "session.sendSystemNotification", req)
+	if err != nil {
+		return nil, err
+	}
+	var result SessionSendSystemNotificationResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 func NewInternalSessionRPC(client *jsonrpc2.Client, sessionID string) *InternalSessionRPC {
 	r := &InternalSessionRPC{}
 	r.common = internalSessionAPI{client: client, sessionID: sessionID}
 	r.MCP = (*InternalMCPAPI)(&r.common)
+	r.Queue = (*InternalQueueAPI)(&r.common)
+	r.Schedule = (*InternalScheduleAPI)(&r.common)
 	r.Settings = (*InternalSettingsAPI)(&r.common)
 	return r
 }
@@ -20202,16 +21849,27 @@ type SessionFSHandler interface {
 	//
 	// Returns: Indicates whether the per-session SQLite database already exists.
 	SqliteExists(request *SessionFSSqliteExistsRequest) (*SessionFSSqliteExistsResult, error)
-	// SqliteQuery executes a SQLite query against the per-session database.
+	// SqliteQuery executes a SQLite query against the per-session database. Providers apply
+	// busy handling for every call.
 	//
 	// RPC method: sessionFs.sqliteQuery.
 	//
 	// Parameters: SQL query, query type, and optional bind parameters for executing a SQLite
-	// query against the per-session database.
+	// query against the per-session database. The provider applies its SQLite busy timeout for
+	// every call.
 	//
 	// Returns: Query results including rows, columns, and rows affected, or a filesystem error
 	// if execution failed.
 	SqliteQuery(request *SessionFSSqliteQueryRequest) (*SessionFSSqliteQueryResult, error)
+	// SqliteTransaction executes SQLite statements atomically on the provider-owned connection.
+	//
+	// RPC method: sessionFs.sqliteTransaction.
+	//
+	// Parameters: Statements to execute atomically. Providers apply busy handling for every
+	// call.
+	//
+	// Returns: Per-statement results, or a classified transaction error.
+	SqliteTransaction(request *SessionFSSqliteTransactionRequest) (*SessionFSSqliteTransactionResult, error)
 	// Stat gets metadata for a path in the client-provided session filesystem.
 	//
 	// RPC method: sessionFs.stat.
@@ -20550,6 +22208,25 @@ func RegisterClientSessionAPIHandlers(client *jsonrpc2.Client, getHandlers func(
 			return nil, &jsonrpc2.Error{Code: -32603, Message: fmt.Sprintf("No sessionFs handler registered for session: %s", request.SessionID)}
 		}
 		result, err := handlers.SessionFS.SqliteQuery(&request)
+		if err != nil {
+			return nil, clientSessionHandlerError(err)
+		}
+		raw, err := json.Marshal(result)
+		if err != nil {
+			return nil, &jsonrpc2.Error{Code: -32603, Message: fmt.Sprintf("Failed to marshal response: %v", err)}
+		}
+		return raw, nil
+	})
+	client.SetRequestHandler("sessionFs.sqliteTransaction", func(params json.RawMessage) (json.RawMessage, *jsonrpc2.Error) {
+		var request SessionFSSqliteTransactionRequest
+		if err := json.Unmarshal(params, &request); err != nil {
+			return nil, &jsonrpc2.Error{Code: -32602, Message: fmt.Sprintf("Invalid params: %v", err)}
+		}
+		handlers := getHandlers(request.SessionID)
+		if handlers == nil || handlers.SessionFS == nil {
+			return nil, &jsonrpc2.Error{Code: -32603, Message: fmt.Sprintf("No sessionFs handler registered for session: %s", request.SessionID)}
+		}
+		result, err := handlers.SessionFS.SqliteTransaction(&request)
 		if err != nil {
 			return nil, clientSessionHandlerError(err)
 		}

--- a/go/rpc/zrpc_encoding.go
+++ b/go/rpc/zrpc_encoding.go
@@ -1075,6 +1075,12 @@ func unmarshalFactoryRunFailure(data []byte) (FactoryRunFailure, error) {
 	}
 
 	switch raw.Type {
+	case FactoryRunFailureTypeFactoryDurableFailure:
+		var d FactoryRunFailureFactoryDurableFailure
+		if err := json.Unmarshal(data, &d); err != nil {
+			return nil, err
+		}
+		return &d, nil
 	case FactoryRunFailureTypeFactoryLimitReached:
 		var d FactoryRunFailureFactoryLimitReached
 		if err := json.Unmarshal(data, &d); err != nil {
@@ -1103,6 +1109,17 @@ func (r RawFactoryRunFailureData) MarshalJSON() ([]byte, error) {
 	})
 }
 
+func (r FactoryRunFailureFactoryDurableFailure) MarshalJSON() ([]byte, error) {
+	type alias FactoryRunFailureFactoryDurableFailure
+	return json.Marshal(struct {
+		Type FactoryRunFailureType `json:"type"`
+		alias
+	}{
+		Type:  r.Type(),
+		alias: alias(r),
+	})
+}
+
 func (r FactoryRunFailureFactoryLimitReached) MarshalJSON() ([]byte, error) {
 	type alias FactoryRunFailureFactoryLimitReached
 	return json.Marshal(struct {
@@ -1123,6 +1140,30 @@ func (r FactoryRunFailureFactoryResumeDeclined) MarshalJSON() ([]byte, error) {
 		Type:  r.Type(),
 		alias: alias(r),
 	})
+}
+
+func (r *FactoryRunTerminal) UnmarshalJSON(data []byte) error {
+	type rawFactoryRunTerminal struct {
+		Error         *string         `json:"error,omitempty"`
+		Failure       json.RawMessage `json:"failure,omitempty"`
+		Reason        *string         `json:"reason,omitempty"`
+		ResultPreview *string         `json:"resultPreview,omitempty"`
+	}
+	var raw rawFactoryRunTerminal
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	r.Error = raw.Error
+	if raw.Failure != nil {
+		value, err := unmarshalFactoryRunFailure(raw.Failure)
+		if err != nil {
+			return err
+		}
+		r.Failure = value
+	}
+	r.Reason = raw.Reason
+	r.ResultPreview = raw.ResultPreview
+	return nil
 }
 
 func (r *FactoryRunResult) UnmarshalJSON(data []byte) error {
@@ -3499,6 +3540,7 @@ func (r *SessionOpenOptions) UnmarshalJSON(data []byte) error {
 		EnableStreaming                        *bool                                                `json:"enableStreaming,omitempty"`
 		EnvValueMode                           *SessionOpenOptionsEnvValueMode                      `json:"envValueMode,omitempty"`
 		EventsLogDirectory                     *string                                              `json:"eventsLogDirectory,omitempty"`
+		EventsLogIncludesSubagents             *bool                                                `json:"eventsLogIncludesSubagents,omitempty"`
 		ExcludedBuiltinAgents                  []string                                             `json:"excludedBuiltinAgents,omitzero"`
 		ExcludedTools                          []string                                             `json:"excludedTools,omitzero"`
 		ExpAssignments                         any                                                  `json:"expAssignments,omitempty"`
@@ -3527,6 +3569,7 @@ func (r *SessionOpenOptions) UnmarshalJSON(data []byte) error {
 		SessionCapabilities                    []SessionCapability                                  `json:"sessionCapabilities,omitzero"`
 		SessionID                              *string                                              `json:"sessionId,omitempty"`
 		SessionLimits                          *SessionLimitsConfig                                 `json:"sessionLimits,omitempty"`
+		Shell                                  *ShellOptions                                        `json:"shell,omitempty"`
 		ShellInitProfile                       *string                                              `json:"shellInitProfile,omitempty"`
 		ShellProcessFlags                      []string                                             `json:"shellProcessFlags,omitzero"`
 		SkillDirectories                       []string                                             `json:"skillDirectories,omitzero"`
@@ -3571,6 +3614,7 @@ func (r *SessionOpenOptions) UnmarshalJSON(data []byte) error {
 	r.EnableStreaming = raw.EnableStreaming
 	r.EnvValueMode = raw.EnvValueMode
 	r.EventsLogDirectory = raw.EventsLogDirectory
+	r.EventsLogIncludesSubagents = raw.EventsLogIncludesSubagents
 	r.ExcludedBuiltinAgents = raw.ExcludedBuiltinAgents
 	r.ExcludedTools = raw.ExcludedTools
 	r.ExpAssignments = raw.ExpAssignments
@@ -3599,6 +3643,7 @@ func (r *SessionOpenOptions) UnmarshalJSON(data []byte) error {
 	r.SessionCapabilities = raw.SessionCapabilities
 	r.SessionID = raw.SessionID
 	r.SessionLimits = raw.SessionLimits
+	r.Shell = raw.Shell
 	r.ShellInitProfile = raw.ShellInitProfile
 	r.ShellProcessFlags = raw.ShellProcessFlags
 	r.SkillDirectories = raw.SkillDirectories

--- a/go/rpc/zsession_encoding.go
+++ b/go/rpc/zsession_encoding.go
@@ -203,6 +203,12 @@ func (e *SessionEvent) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		e.Data = &d
+	case SessionEventTypeFactoryRunUpdated:
+		var d FactoryRunUpdatedData
+		if err := json.Unmarshal(raw.Data, &d); err != nil {
+			return err
+		}
+		e.Data = &d
 	case SessionEventTypeHookEnd:
 		var d HookEndData
 		if err := json.Unmarshal(raw.Data, &d); err != nil {

--- a/go/rpc/zsession_events.go
+++ b/go/rpc/zsession_events.go
@@ -81,24 +81,27 @@ const (
 	SessionEventTypeExitPlanModeRequested       SessionEventType = "exit_plan_mode.requested"
 	SessionEventTypeExternalToolCompleted       SessionEventType = "external_tool.completed"
 	SessionEventTypeExternalToolRequested       SessionEventType = "external_tool.requested"
-	SessionEventTypeHookEnd                     SessionEventType = "hook.end"
-	SessionEventTypeHookProgress                SessionEventType = "hook.progress"
-	SessionEventTypeHookStart                   SessionEventType = "hook.start"
-	SessionEventTypeMCPAppToolCallComplete      SessionEventType = "mcp_app.tool_call_complete"
-	SessionEventTypeMCPHeadersRefreshCompleted  SessionEventType = "mcp.headers_refresh_completed"
-	SessionEventTypeMCPHeadersRefreshRequired   SessionEventType = "mcp.headers_refresh_required"
-	SessionEventTypeMCPOauthCompleted           SessionEventType = "mcp.oauth_completed"
-	SessionEventTypeMCPOauthRequired            SessionEventType = "mcp.oauth_required"
-	SessionEventTypeMCPPromptsListChanged       SessionEventType = "mcp.prompts.list_changed"
-	SessionEventTypeMCPResourcesListChanged     SessionEventType = "mcp.resources.list_changed"
-	SessionEventTypeMCPToolsListChanged         SessionEventType = "mcp.tools.list_changed"
-	SessionEventTypeModelCallFailure            SessionEventType = "model.call_failure"
-	SessionEventTypeModelCallStart              SessionEventType = "model.call_start"
-	SessionEventTypePendingMessagesModified     SessionEventType = "pending_messages.modified"
-	SessionEventTypePermissionCompleted         SessionEventType = "permission.completed"
-	SessionEventTypePermissionRequested         SessionEventType = "permission.requested"
-	SessionEventTypeSamplingCompleted           SessionEventType = "sampling.completed"
-	SessionEventTypeSamplingRequested           SessionEventType = "sampling.requested"
+	// Experimental: SessionEventTypeFactoryRunUpdated identifies an experimental event that may
+	// change or be removed.
+	SessionEventTypeFactoryRunUpdated          SessionEventType = "factory.run_updated"
+	SessionEventTypeHookEnd                    SessionEventType = "hook.end"
+	SessionEventTypeHookProgress               SessionEventType = "hook.progress"
+	SessionEventTypeHookStart                  SessionEventType = "hook.start"
+	SessionEventTypeMCPAppToolCallComplete     SessionEventType = "mcp_app.tool_call_complete"
+	SessionEventTypeMCPHeadersRefreshCompleted SessionEventType = "mcp.headers_refresh_completed"
+	SessionEventTypeMCPHeadersRefreshRequired  SessionEventType = "mcp.headers_refresh_required"
+	SessionEventTypeMCPOauthCompleted          SessionEventType = "mcp.oauth_completed"
+	SessionEventTypeMCPOauthRequired           SessionEventType = "mcp.oauth_required"
+	SessionEventTypeMCPPromptsListChanged      SessionEventType = "mcp.prompts.list_changed"
+	SessionEventTypeMCPResourcesListChanged    SessionEventType = "mcp.resources.list_changed"
+	SessionEventTypeMCPToolsListChanged        SessionEventType = "mcp.tools.list_changed"
+	SessionEventTypeModelCallFailure           SessionEventType = "model.call_failure"
+	SessionEventTypeModelCallStart             SessionEventType = "model.call_start"
+	SessionEventTypePendingMessagesModified    SessionEventType = "pending_messages.modified"
+	SessionEventTypePermissionCompleted        SessionEventType = "permission.completed"
+	SessionEventTypePermissionRequested        SessionEventType = "permission.requested"
+	SessionEventTypeSamplingCompleted          SessionEventType = "sampling.completed"
+	SessionEventTypeSamplingRequested          SessionEventType = "sampling.requested"
 	// Experimental: SessionEventTypeSessionAutoModeResolved identifies an experimental event
 	// that may change or be removed.
 	SessionEventTypeSessionAutoModeResolved          SessionEventType = "session.auto_mode_resolved"
@@ -214,6 +217,7 @@ type AssistantReasoningData struct {
 	Content string `json:"content"`
 	// Unique identifier for this reasoning block
 	ReasoningID string `json:"reasoningId"`
+	Rte         *bool  `json:"rte,omitempty"`
 }
 
 func (*AssistantReasoningData) sessionEventData()      {}
@@ -253,6 +257,7 @@ type AssistantMessageData struct {
 	ReasoningWireField *string `json:"reasoningWireField,omitempty"`
 	// GitHub request tracing ID (x-github-request-id header) for correlating with server-side logs
 	RequestID *string `json:"requestId,omitempty"`
+	Rte       *bool   `json:"rte,omitempty"`
 	// Neutral provider-tagged server-side tool-use payload (tool search, advisor) for verbatim round-tripping
 	ServerTools *AssistantMessageServerTools `json:"serverTools,omitempty"`
 	// Copilot service request ID (x-copilot-service-request-id header) for CAPI log correlation
@@ -622,6 +627,17 @@ func (*SessionManagedSettingsResolvedData) Type() SessionEventType {
 	return SessionEventTypeSessionManagedSettingsResolved
 }
 
+// Ephemeral invalidation signal for a changed factory run.
+// Experimental: FactoryRunUpdatedData is part of an experimental API and may change or be removed.
+type FactoryRunUpdatedData struct {
+	// Monotonic revision now available for the run.
+	Revision int64  `json:"revision"`
+	RunID    string `json:"runId"`
+}
+
+func (*FactoryRunUpdatedData) sessionEventData()      {}
+func (*FactoryRunUpdatedData) Type() SessionEventType { return SessionEventTypeFactoryRunUpdated }
+
 // Ephemeral progress update from a running hook process
 type HookProgressData struct {
 	// Human-readable progress message from the hook process
@@ -733,6 +749,7 @@ type ModelCallFailureData struct {
 	ReasoningEffort *string `json:"reasoningEffort,omitempty"`
 	// Content-free structural summary of the failing request. Contains only counts and shape flags (no prompt content), so it is safe for unrestricted telemetry. Populated only for client-error (4xx) failures.
 	RequestFingerprint *ModelCallFailureRequestFingerprint `json:"requestFingerprint,omitempty"`
+	Rte                *bool                               `json:"rte,omitempty"`
 	// Copilot service request ID (x-copilot-service-request-id header) for CAPI log correlation
 	ServiceRequestID *string `json:"serviceRequestId,omitempty"`
 	// Where the failed model call originated
@@ -818,6 +835,8 @@ type AssistantUsageData struct {
 	Initiator *string `json:"initiator,omitempty"`
 	// Number of input tokens consumed
 	InputTokens *int64 `json:"inputTokens,omitempty"`
+	// Coarse classification of the interaction that produced this call, mirroring the session's per-request agent context (e.g. `conversation-agent`, `conversation-subagent`, `conversation-sampling`, `conversation-background`, `conversation-compaction`, `conversation-user`). Non-billing; lets consumers attribute a model call to a call class (e.g. sub-agent/sidekick) independently of the billing initiator. Absent when the runtime did not classify the request.
+	InteractionType *string `json:"interactionType,omitempty"`
 	// Average inter-token latency in milliseconds. Only available for streaming requests
 	InterTokenLatencyMs *float64 `json:"interTokenLatencyMs,omitempty"`
 	// Model identifier used for this API call
@@ -836,6 +855,7 @@ type AssistantUsageData struct {
 	ReasoningEffort *string `json:"reasoningEffort,omitempty"`
 	// Number of output tokens used for reasoning (e.g., chain-of-thought)
 	ReasoningTokens *int64 `json:"reasoningTokens,omitempty"`
+	Rte             *bool  `json:"rte,omitempty"`
 	// Copilot service request ID (x-copilot-service-request-id header) for CAPI log correlation
 	ServiceRequestID *string `json:"serviceRequestId,omitempty"`
 	// Time to first token in milliseconds. Only available for streaming requests
@@ -1213,7 +1233,7 @@ type UserMessageData struct {
 	NativeDocumentPathFallbackPaths []string `json:"nativeDocumentPathFallbackPaths,omitzero"`
 	// Parent agent task ID for background telemetry correlated to this user turn
 	ParentAgentTaskID *string `json:"parentAgentTaskId,omitempty"`
-	// Origin of this message, used for timeline filtering (e.g., "skill-pdf" for skill-injected messages that should be hidden from the user)
+	// Origin of this message, used for timeline filtering and attribution (e.g., `skill-pdf` for hidden skill injection or `agent-<agent-id>` for an inter-agent prompt)
 	Source *string `json:"source,omitempty"`
 	// Normalized document MIME types that were sent natively instead of through tagged_files XML
 	SupportedNativeDocumentMIMETypes []string `json:"supportedNativeDocumentMimeTypes,omitzero"`
@@ -1438,6 +1458,8 @@ type SessionScheduleCreatedData struct {
 	ID int64 `json:"id"`
 	// Interval between ticks in milliseconds (relative-interval schedules)
 	IntervalMs *int64 `json:"intervalMs,omitempty"`
+	// Who created the schedule (`user` or `model`). Persisted so a resumed session keeps gating non-user schedules from firing skills that opted out of model invocation. Absent on entries created before this field existed; a missing origin fails closed (treated the same as a non-user origin), so such a schedule may not resolve a `disable-model-invocation` skill.
+	Origin *ScheduleOrigin `json:"origin,omitempty"`
 	// Prompt text that gets enqueued on every tick
 	Prompt string `json:"prompt"`
 	// Whether the schedule re-arms after each tick (`/every`) or fires once (`/after`)
@@ -1861,6 +1883,8 @@ func (*SystemNotificationData) Type() SessionEventType { return SessionEventType
 type SystemMessageData struct {
 	// The system or developer prompt text sent as model input
 	Content string `json:"content"`
+	// Logical interaction identifier for the model run receiving this prompt
+	InteractionID *string `json:"interactionId,omitempty"`
 	// Metadata about the prompt template and its construction
 	Metadata *SystemMessageMetadata `json:"metadata,omitempty"`
 	// Optional name identifier for the message source
@@ -1901,6 +1925,7 @@ type ToolExecutionCompleteData struct {
 	ParentToolCallID *string `json:"parentToolCallId,omitempty"`
 	// Tool execution result on success
 	Result *ToolExecutionCompleteResult `json:"result,omitempty"`
+	Rte    *bool                        `json:"rte,omitempty"`
 	// Whether this tool execution ran inside a sandbox container
 	Sandboxed *bool `json:"sandboxed,omitempty"`
 	// Whether the tool execution completed successfully
@@ -1948,6 +1973,7 @@ type ToolExecutionStartData struct {
 	// Tool call ID of the parent tool invocation when this event originates from a sub-agent
 	// Deprecated: ParentToolCallID is deprecated.
 	ParentToolCallID *string `json:"parentToolCallId,omitempty"`
+	Rte              *bool   `json:"rte,omitempty"`
 	// Shell-tool path hints derived from the command at start time for shell tools (bash/powershell/local_shell). Produced by the same shell-aware extractor as PermissionRequestShell.possiblePaths, so it is present even when the command is auto-approved and no permission request fires. Absent for non-shell tools.
 	ShellToolInfo *ToolExecutionStartShellToolInfo `json:"shellToolInfo,omitempty"`
 	// Unique identifier for this tool call
@@ -4276,6 +4302,16 @@ const (
 	PlanChangedOperationDelete PlanChangedOperation = "delete"
 	// The plan file was updated.
 	PlanChangedOperationUpdate PlanChangedOperation = "update"
+)
+
+// Who created the schedule: `user` (an explicit user action such as `/every` or `/after`) or `model` (the agent via the `manage_schedule` tool). Gates whether a scheduled skill that opted out of model invocation may fire: only user-created schedules may.
+type ScheduleOrigin string
+
+const (
+	// The schedule was created by the agent via the `manage_schedule` tool.
+	ScheduleOriginModel ScheduleOrigin = "model"
+	// The schedule was created by an explicit user action, such as `/every` or `/after`.
+	ScheduleOriginUser ScheduleOrigin = "user"
 )
 
 // User action selected for an exhausted session limit.

--- a/go/session_fs_provider.go
+++ b/go/session_fs_provider.go
@@ -230,6 +230,22 @@ func (a *sessionFSAdapter) SqliteQuery(request *rpc.SessionFSSqliteQueryRequest)
 	}, nil
 }
 
+func (a *sessionFSAdapter) SqliteTransaction(request *rpc.SessionFSSqliteTransactionRequest) (*rpc.SessionFSSqliteTransactionResult, error) {
+	// This SDK's provider interface exposes no atomic-transaction hook, so the
+	// batch is refused outright rather than applied non-atomically.
+	msg := "SQLite is not supported by this session filesystem provider"
+	if _, ok := a.provider.(SessionFSSqliteProvider); ok {
+		msg = "Atomic SQLite transactions are not supported by this session filesystem provider"
+	}
+	return &rpc.SessionFSSqliteTransactionResult{
+		Results: []rpc.SessionFSSqliteQueryResult{},
+		Error: &rpc.SessionFSSqliteTransactionError{
+			ErrorClass: rpc.SessionFSSqliteTransactionErrorClassFatal,
+			Message:    msg,
+		},
+	}, nil
+}
+
 func (a *sessionFSAdapter) SqliteExists(request *rpc.SessionFSSqliteExistsRequest) (*rpc.SessionFSSqliteExistsResult, error) {
 	sp, ok := a.provider.(SessionFSSqliteProvider)
 	if !ok {

--- a/go/zsession_events.go
+++ b/go/zsession_events.go
@@ -103,6 +103,7 @@ type (
 	ExtensionsLoadedExtensionStatus                                = rpc.ExtensionsLoadedExtensionStatus
 	ExternalToolCompletedData                                      = rpc.ExternalToolCompletedData
 	ExternalToolRequestedData                                      = rpc.ExternalToolRequestedData
+	FactoryRunUpdatedData                                          = rpc.FactoryRunUpdatedData
 	GitHubRepoRef                                                  = rpc.GitHubRepoRef
 	HandoffRepository                                              = rpc.HandoffRepository
 	HandoffSourceType                                              = rpc.HandoffSourceType
@@ -212,6 +213,7 @@ type (
 	ReasoningSummary                                               = rpc.ReasoningSummary
 	SamplingCompletedData                                          = rpc.SamplingCompletedData
 	SamplingRequestedData                                          = rpc.SamplingRequestedData
+	ScheduleOrigin                                                 = rpc.ScheduleOrigin
 	SessionAutoModeResolvedData                                    = rpc.SessionAutoModeResolvedData
 	SessionAutopilotObjectiveChangedData                           = rpc.SessionAutopilotObjectiveChangedData
 	SessionBackgroundTasksChangedData                              = rpc.SessionBackgroundTasksChangedData
@@ -534,6 +536,8 @@ const (
 	ReasoningSummaryConcise                                            = rpc.ReasoningSummaryConcise
 	ReasoningSummaryDetailed                                           = rpc.ReasoningSummaryDetailed
 	ReasoningSummaryNone                                               = rpc.ReasoningSummaryNone
+	ScheduleOriginModel                                                = rpc.ScheduleOriginModel
+	ScheduleOriginUser                                                 = rpc.ScheduleOriginUser
 	SessionEventTypeAbort                                              = rpc.SessionEventTypeAbort
 	SessionEventTypeAssistantIdle                                      = rpc.SessionEventTypeAssistantIdle
 	SessionEventTypeAssistantIntent                                    = rpc.SessionEventTypeAssistantIntent
@@ -562,6 +566,7 @@ const (
 	SessionEventTypeExitPlanModeRequested                              = rpc.SessionEventTypeExitPlanModeRequested
 	SessionEventTypeExternalToolCompleted                              = rpc.SessionEventTypeExternalToolCompleted
 	SessionEventTypeExternalToolRequested                              = rpc.SessionEventTypeExternalToolRequested
+	SessionEventTypeFactoryRunUpdated                                  = rpc.SessionEventTypeFactoryRunUpdated
 	SessionEventTypeHookEnd                                            = rpc.SessionEventTypeHookEnd
 	SessionEventTypeHookProgress                                       = rpc.SessionEventTypeHookProgress
 	SessionEventTypeHookStart                                          = rpc.SessionEventTypeHookStart

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.0-dev",
             "license": "MIT",
             "dependencies": {
-                "@github/copilot": "^1.0.73",
+                "@github/copilot": "^1.0.75",
                 "koffi": "^3.1.0",
                 "vscode-jsonrpc": "^8.2.1",
                 "zod": "^4.3.6"
@@ -700,9 +700,9 @@
             }
         },
         "node_modules/@github/copilot": {
-            "version": "1.0.73",
-            "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.73.tgz",
-            "integrity": "sha512-8I2Ejg2CX/PQA3c2H8W1zuqhniCeR1q1/bD8CrV53/ZLw8GF7DAV0xQpwa8ELYvFgjXb6AADojafCKwdbVef+A==",
+            "version": "1.0.75",
+            "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.75.tgz",
+            "integrity": "sha512-rn7ZQmhydCZ9XRdG6V78QEhXIdYlChlUvOVAtyJ6KHJGt2O9/71si7PCt84amfmg0N7IXBT2UGRYF4GQDQBt+g==",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "detect-libc": "^2.1.2"
@@ -711,20 +711,20 @@
                 "copilot": "npm-loader.js"
             },
             "optionalDependencies": {
-                "@github/copilot-darwin-arm64": "1.0.73",
-                "@github/copilot-darwin-x64": "1.0.73",
-                "@github/copilot-linux-arm64": "1.0.73",
-                "@github/copilot-linux-x64": "1.0.73",
-                "@github/copilot-linuxmusl-arm64": "1.0.73",
-                "@github/copilot-linuxmusl-x64": "1.0.73",
-                "@github/copilot-win32-arm64": "1.0.73",
-                "@github/copilot-win32-x64": "1.0.73"
+                "@github/copilot-darwin-arm64": "1.0.75",
+                "@github/copilot-darwin-x64": "1.0.75",
+                "@github/copilot-linux-arm64": "1.0.75",
+                "@github/copilot-linux-x64": "1.0.75",
+                "@github/copilot-linuxmusl-arm64": "1.0.75",
+                "@github/copilot-linuxmusl-x64": "1.0.75",
+                "@github/copilot-win32-arm64": "1.0.75",
+                "@github/copilot-win32-x64": "1.0.75"
             }
         },
         "node_modules/@github/copilot-darwin-arm64": {
-            "version": "1.0.73",
-            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.73.tgz",
-            "integrity": "sha512-5jv7t2sw35/zI0cPze38hG6239NT5/q/Emjx6gLibYkolDqMDJjpm17Ps7tc8oafUEOiMQMb+ar7+qi6rSiGJA==",
+            "version": "1.0.75",
+            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.75.tgz",
+            "integrity": "sha512-avt2ganQwtycGkqz9z8JpARoEz2Fzi02O+WitbB8I8iF3jfvEGpQ8k3z9oSCPAAO0rIMBeSl05xEUUV5RJwfRA==",
             "cpu": [
                 "arm64"
             ],
@@ -738,9 +738,9 @@
             }
         },
         "node_modules/@github/copilot-darwin-x64": {
-            "version": "1.0.73",
-            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.73.tgz",
-            "integrity": "sha512-l794k6Ahb11AG2FQT/P4TEWxWblzM1h8aQQCzG8jBWp8dfwjhyYjJ+d+0CWQzM3Fc1ddNUZRjKXCUsfvFjiZhQ==",
+            "version": "1.0.75",
+            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.75.tgz",
+            "integrity": "sha512-eyM5cz83d9h05m6cnnG7tIHR4lSHHXUnxXeQm4rU3nGB1uwHWOa1TH9B4uAaW3zKQgkCkNgm+IlcPJ7geM0KBg==",
             "cpu": [
                 "x64"
             ],
@@ -754,9 +754,9 @@
             }
         },
         "node_modules/@github/copilot-linux-arm64": {
-            "version": "1.0.73",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.73.tgz",
-            "integrity": "sha512-Zu0W5nupJjNeem0brqU/pG+VY0IWr6EWr/FsC90g5SEDiaM4VhVNVWcz8t0E3DQCSYetV6IBaNMtjs/3uIIiDQ==",
+            "version": "1.0.75",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.75.tgz",
+            "integrity": "sha512-PuGjPCy+z7DrD0rkcXQRBzoA8lVxD1WC6UeZxkZaIb9asueE798eqHHMV169zYiA3gsiSegIKu5J/aUeWwhpuQ==",
             "cpu": [
                 "arm64"
             ],
@@ -770,9 +770,9 @@
             }
         },
         "node_modules/@github/copilot-linux-x64": {
-            "version": "1.0.73",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.73.tgz",
-            "integrity": "sha512-k33XIr6/PVp+K+5F/zv3No4PPaNImvHz73mcbIw63oxh5iiacXjgr0WqbBIS5s/rkhOWjNPIkbof/TTPZ7mQjA==",
+            "version": "1.0.75",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.75.tgz",
+            "integrity": "sha512-aGDtUrNyj/ubqLfXOomL4XYZR//1Cs4tDGe7r/464e3Nw4WlNxWPjBbNyOCcUPUMbPHXck6TyxjEvBwwlKCK5w==",
             "cpu": [
                 "x64"
             ],
@@ -786,9 +786,9 @@
             }
         },
         "node_modules/@github/copilot-linuxmusl-arm64": {
-            "version": "1.0.73",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.73.tgz",
-            "integrity": "sha512-HJWzhfD3oaiIgfRAHkNWzp17fELtshqM9HVN5n+lFEmSO2EETCEh0P1lhJc4m+FYfXSJnL0raAqVuyaNMuPoPw==",
+            "version": "1.0.75",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.75.tgz",
+            "integrity": "sha512-4cbjjR/laL+4a0VjMkzjIsprRUxiAHAefWVTppFitKiqNxfgyRuOhfSUPUA5TVxPwfyYXknsxeYSNRL8zu9YDA==",
             "cpu": [
                 "arm64"
             ],
@@ -802,9 +802,9 @@
             }
         },
         "node_modules/@github/copilot-linuxmusl-x64": {
-            "version": "1.0.73",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.73.tgz",
-            "integrity": "sha512-/BpOXSb16wHEu8I1SaKiLszQ4Kvu4+Z4uCn7W0bv4xI4fPZwTEG0u3zgaI2W9Ao3+aBl0XRpPmpWzE9ziYEq+w==",
+            "version": "1.0.75",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.75.tgz",
+            "integrity": "sha512-I4oFPNOULMGxWghGCG/VkiT0a62UiL4XGKSlp6X0rVD9xyoYyiLGlsBmTumrooPbzEvgKICYWIz8PCZjrZTyhA==",
             "cpu": [
                 "x64"
             ],
@@ -818,9 +818,9 @@
             }
         },
         "node_modules/@github/copilot-win32-arm64": {
-            "version": "1.0.73",
-            "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.73.tgz",
-            "integrity": "sha512-DbPeXiYzQjpOy9oboaBvuCzjRwfcL987c3bG09cK1crdCDrKfkTJ7NXpcp1KWRPIRFO1FQm1qToNE89J+L3uvg==",
+            "version": "1.0.75",
+            "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.75.tgz",
+            "integrity": "sha512-wlLDuor+Qm1H43VwZNi03QI4H9FSyZoQzE/YHpGhUay7sKA+4cDJF8ZZNGrtYkyPskfH5HCdNygUn7EEt6lRyQ==",
             "cpu": [
                 "arm64"
             ],
@@ -834,9 +834,9 @@
             }
         },
         "node_modules/@github/copilot-win32-x64": {
-            "version": "1.0.73",
-            "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.73.tgz",
-            "integrity": "sha512-8D3E1l5i+N5Eq8HIOQpx+Zbcb3MXdFxszksM2gqq175Z1S7Zna67oY4GoR3psxlbIpSyHKiLEBWYiaps6ayHWw==",
+            "version": "1.0.75",
+            "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.75.tgz",
+            "integrity": "sha512-TKISaaILkgcOi7ThaTnln1XoasbUIx+HKSb+pf678RvGucIfLohQyLceuq+rTykoynX54KQ0pf9TEUbMVkUNAA==",
             "cpu": [
                 "x64"
             ],

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -56,7 +56,7 @@
     "author": "GitHub",
     "license": "MIT",
     "dependencies": {
-        "@github/copilot": "^1.0.73",
+        "@github/copilot": "^1.0.75",
         "koffi": "^3.1.0",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"

--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -35,6 +35,7 @@ import {
 } from "./generated/rpc.js";
 import type {
     GitHubTelemetryNotification,
+    JsonValue,
     OpenCanvasInstance,
     SessionUpdateOptionsParams,
 } from "./generated/rpc.js";
@@ -2981,7 +2982,7 @@ export class CopilotClient {
         sessionId: string;
         hookType: string;
         input: unknown;
-    }): Promise<{ output?: unknown }> {
+    }): Promise<{ output?: JsonValue }> {
         if (
             !params ||
             typeof params.sessionId !== "string" ||
@@ -2996,7 +2997,7 @@ export class CopilotClient {
         }
 
         const output = await session._handleHooksInvoke(params.hookType, params.input);
-        return { output };
+        return output === undefined ? {} : { output: JSON.parse(JSON.stringify(output)) };
     }
 
     private async handleSystemMessageTransform(params: {

--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -7,6 +7,8 @@ import type { MessageConnection } from "vscode-jsonrpc/node.js";
 
 import type { AbortReason, Attachment, ContextTier, EmbeddedBlobResourceContents, EmbeddedTextResourceContents, McpServerSource, McpServerStatus, PermissionPromptRequest, PermissionRule, ReasoningSummary, SessionEvent, SessionLimitsConfig, SessionMode, ShutdownType, SkillSource, UserToolSessionApproval, Verbosity } from "./session-events.js";
 
+export type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+
 /**
  * Initial authentication info for the session.
  *
@@ -238,6 +240,12 @@ export type AuthInfoType =
   | "token"
   /** Authentication from a Copilot API token. */
   | "copilot-api-token";
+
+/** @experimental */
+export type CanvasJsonSchema = JsonValue;
+
+/** @experimental */
+export type CanvasActionInvokeResult = JsonValue;
 /**
  * Coarse command category for grouping and behavior: runtime built-in, skill-backed command, or SDK/client-owned command
  *
@@ -510,17 +518,53 @@ export type ExternalToolTextResultForLlmContentResourceDetails =
   | EmbeddedTextResourceContents
   | EmbeddedBlobResourceContents;
 /**
- * Kind of factory progress line.
+ * Execution-critical factory storage operation.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "FactoryLogLineKind".
+ * via the `definition` "FactoryDurableOperation".
  */
 /** @experimental */
-export type FactoryLogLineKind =
-  /** A narrator log line. */
-  | "log"
-  /** A named factory phase marker. */
-  | "phase";
+export type FactoryDurableOperation =
+  /** Creating the durable run and declared phases. */
+  | "createRun"
+  /** Persisting the transition to running. */
+  | "markRunStarted"
+  /** Persisting the terminal run envelope. */
+  | "finishRun"
+  /** Persisting subagent admission accounting. */
+  | "reserveAgent"
+  /** Rolling back an uncommitted subagent admission. */
+  | "releaseAgent"
+  /** Persisting an idempotent model-usage charge. */
+  | "chargeCredit"
+  /** Persisting active execution time. */
+  | "addElapsed"
+  /** Reading the authoritative AI-credit total. */
+  | "reconcileCreditTotal"
+  /** Reading a journal entry without treating storage failure as a cache miss. */
+  | "journalGet"
+  /** Persisting a journal entry before reporting success. */
+  | "journalPut";
+/**
+ * Current or terminal state of a factory run.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "FactoryRunStatus".
+ */
+/** @experimental */
+export type FactoryRunStatus =
+  /** The run was minted and is awaiting approval. */
+  | "pending"
+  /** The run is executing. */
+  | "running"
+  /** The run completed successfully. */
+  | "completed"
+  /** The run was interrupted while resource budget remained. */
+  | "halted"
+  /** The run was cancelled before completion. */
+  | "cancelled"
+  /** The factory body failed or reached a cumulative resource ceiling. */
+  | "error";
 /**
  * Machine-readable factory run failure.
  *
@@ -551,6 +595,18 @@ export type FactoryRunFailure =
        */
       reason: string;
       type: "factory_resume_declined";
+    }
+  | {
+      /**
+       * Stable failure code.
+       */
+      code: string;
+      operation: FactoryDurableOperation;
+      /**
+       * Factory run identifier.
+       */
+      runId: string;
+      type: "factory_durable_failure";
     };
 /**
  * Cumulative resource ceiling that stopped a factory run.
@@ -562,28 +618,38 @@ export type FactoryRunFailure =
 export type FactoryRunFailureKind =
   /** The run admitted the approved maximum total number of subagents. */
   | "maxTotalSubagents"
-  /** The run reached the approved timeout deadline. */
-  | "timeout";
+  /** The run reached the approved accumulated active-execution time in seconds. */
+  | "timeoutSeconds"
+  /** The run's settled subagent model usage exceeded the approved AI-credit ceiling, or no headroom remained for another subagent. */
+  | "maxAiCredits";
 /**
- * Current or terminal state of a factory run.
+ * Kind of factory progress line.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "FactoryRunStatus".
+ * via the `definition` "FactoryLogLineKind".
  */
 /** @experimental */
-export type FactoryRunStatus =
-  /** The run was minted and is awaiting approval. */
+export type FactoryLogLineKind =
+  /** A narrator log line. */
+  | "log"
+  /** A named factory phase marker. */
+  | "phase";
+/**
+ * Derived lifecycle state of a factory phase.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "FactoryPhaseStatus".
+ */
+/** @experimental */
+export type FactoryPhaseStatus =
+  /** The phase has not been entered yet. */
   | "pending"
-  /** The run is executing. */
-  | "running"
-  /** The run completed successfully. */
+  /** The phase is currently entered and accumulating active time. */
+  | "active"
+  /** The phase was entered and has since been closed. */
   | "completed"
-  /** The run was interrupted while resource budget remained. */
-  | "halted"
-  /** The run was cancelled before completion. */
-  | "cancelled"
-  /** The factory body failed or reached a cumulative resource ceiling. */
-  | "error";
+  /** The phase was never entered because a later phase was entered or the run reached a terminal state. */
+  | "skipped";
 /**
  * Content filtering mode to apply to all tools, or a map of tool name to content filtering mode.
  *
@@ -1671,6 +1737,20 @@ export type SessionFsSqliteQueryType =
   /** Execute INSERT, UPDATE, or DELETE SQL and return affected-row metadata. */
   | "run";
 /**
+ * SQLite transaction failure classification.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionFsSqliteTransactionErrorClass".
+ */
+/** @experimental */
+export type SessionFsSqliteTransactionErrorClass =
+  /** SQLite reported BUSY or LOCKED before commit; the transaction was rolled back and may be retried. */
+  | "busyOrLocked"
+  /** The statement, database, or provider failed definitively and must not be retried automatically. */
+  | "fatal"
+  /** The transport failed after the provider may have committed; retrying could duplicate effects. */
+  | "postCommitAmbiguous";
+/**
  * Source descriptor for direct repo installs (when marketplace is empty)
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -1762,6 +1842,30 @@ export type SessionOpenOptionsReasoningSummary =
   | "concise"
   /** Request a detailed summary of model reasoning. */
   | "detailed";
+/**
+ * Controls automatic non-interactive profile loading where supported. Explicit initScripts are unaffected.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ShellInitProfile".
+ */
+/** @experimental */
+export type ShellInitProfile =
+  /** Disable automatic non-interactive profile loading. Explicit initScripts still run. */
+  | "none"
+  /** Allow automatic non-interactive profile loading when supported. Explicit initScripts still run. */
+  | "non-interactive";
+/**
+ * Supported built-in shells for initialization scripts.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ShellInitScriptShell".
+ */
+/** @experimental */
+export type ShellInitScriptShell =
+  /** Source the script in the built-in Bash shell on macOS and Linux. */
+  | "bash"
+  /** Source the script in the built-in PowerShell shell on Windows. */
+  | "powershell";
 /**
  * How MCP server environment values are interpreted.
  *
@@ -2240,6 +2344,14 @@ export type WorkspacesWorkspaceDetailsHostType =
  */
 /** @experimental */
 export type AccountGetAllUsersResult = AccountAllUsers[];
+/**
+ * The number of running background agents (task-registry agents) that were cancelled.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionCancelAllBackgroundAgentsResult".
+ */
+/** @experimental */
+export type SessionCancelAllBackgroundAgentsResult = number;
 
 /**
  * Parameters for aborting the current turn
@@ -3035,7 +3147,7 @@ export interface AgentInfo {
    * @experimental
    */
   mcpServers?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
   /**
    * Skill names preloaded into this agent's context. Omitted means none.
@@ -3393,16 +3505,6 @@ export interface CanvasAction {
   inputSchema?: CanvasJsonSchema;
 }
 /**
- * JSON Schema for canvas open input
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "CanvasJsonSchema".
- */
-/** @experimental */
-export interface CanvasJsonSchema {
-  [k: string]: unknown | undefined;
-}
-/**
  * Canvas action invocation parameters.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -3418,22 +3520,7 @@ export interface CanvasActionInvokeRequest {
    * Action name to invoke
    */
   actionName: string;
-  /**
-   * Action input
-   */
-  input?: {
-    [k: string]: unknown | undefined;
-  };
-}
-/**
- * Provider-supplied action result.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "CanvasActionInvokeResult".
- */
-/** @experimental */
-export interface CanvasActionInvokeResult {
-  [k: string]: unknown | undefined;
+  input?: JsonValue;
 }
 /**
  * Canvas close parameters.
@@ -3575,12 +3662,7 @@ export interface OpenCanvasInstance {
    * URL for web-rendered canvases
    */
   url?: string;
-  /**
-   * Input supplied when the instance was opened
-   */
-  input?: {
-    [k: string]: unknown | undefined;
-  };
+  input?: JsonValue;
 }
 /**
  * Canvas open parameters.
@@ -3602,12 +3684,7 @@ export interface CanvasOpenRequest {
    * Caller-supplied stable instance identifier
    */
   instanceId: string;
-  /**
-   * Canvas open input
-   */
-  input?: {
-    [k: string]: unknown | undefined;
-  };
+  input?: JsonValue;
 }
 /**
  * Canvas close parameters sent to the provider.
@@ -3677,12 +3754,7 @@ export interface CanvasProviderInvokeActionRequest {
    * Action name to invoke
    */
   actionName: string;
-  /**
-   * Action input
-   */
-  input?: {
-    [k: string]: unknown | undefined;
-  };
+  input?: JsonValue;
   host?: CanvasHostContext;
   session?: CanvasSessionContext;
 }
@@ -3710,12 +3782,7 @@ export interface CanvasProviderOpenRequest {
    * Stable caller-supplied canvas instance identifier
    */
   instanceId: string;
-  /**
-   * Canvas open input
-   */
-  input?: {
-    [k: string]: unknown | undefined;
-  };
+  input?: JsonValue;
   host?: CanvasHostContext;
   session?: CanvasSessionContext;
 }
@@ -4054,16 +4121,7 @@ export interface ConfigureSessionExtensionsParams {
    * Session to attach the extension controller delegate to.
    */
   sessionId: string;
-  /**
-   * In-process ExtensionController delegate (CLI-only optimization). Marked internal: this field is excluded from the public SDK surface. The post-SDK extension surface exposes list/enable/disable/reload via dedicated RPCs served by the runtime.
-   *
-   * @internal
-   *
-   * @internal
-   */
-  controller?: {
-    [k: string]: unknown | undefined;
-  };
+  controller?: JsonValue;
 }
 /**
  * Metadata for a connected remote session.
@@ -4160,7 +4218,7 @@ export interface ConnectRequest {
    */
   token?: string;
   /**
-   * Opt this connection in to GitHub telemetry forwarding for its lifetime. When set, the runtime forwards every internal telemetry event it emits — across all sessions, plus sessionless events — to this connection over the `gitHubTelemetry.event` notification, in addition to the runtime's normal GitHub/CTS emission (dual-write). Intended for first-party hosts that re-emit the events into their own telemetry stores. Both unrestricted and restricted events are forwarded, each tagged with a `restricted` discriminator; a backstop drops restricted events when restricted telemetry is disabled.
+   * Opt this connection in to GitHub telemetry forwarding for its lifetime. When set, the runtime forwards every internal telemetry event it emits — across all sessions, plus sessionless events — to this connection over the `gitHubTelemetry.event` notification. Regular events are also written to the runtime's normal GitHub/CTS path (dual-write); host-only compatibility events are forward-only and intentionally skip that path. Intended for first-party hosts that re-emit the events into their own telemetry stores. Both unrestricted and restricted events are forwarded, each tagged with a `restricted` discriminator; a backstop drops restricted events when restricted telemetry is disabled — using the process-global gate for ordinary events and an explicit session-scoped decision for host-only events.
    */
   enableGitHubTelemetryForwarding?: boolean;
 }
@@ -4261,7 +4319,7 @@ export interface CurrentToolMetadata {
    * JSON Schema for tool input
    */
   input_schema?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
   /**
    * Whether the tool is loaded on demand via tool search
@@ -4597,12 +4655,7 @@ export interface ExtensionContextPushInput {
    * Human-readable composer pill label
    */
   title: string;
-  /**
-   * Caller-supplied JSON payload (required, may be null but not undefined)
-   */
-  payload: {
-    [k: string]: unknown | undefined;
-  };
+  payload: JsonValue;
 }
 /**
  * Extensions discovered for the session, with their current status.
@@ -4671,7 +4724,7 @@ export interface ExternalToolTextResultForLlm {
    * Optional tool-specific telemetry
    */
   toolTelemetry?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
   /**
    * Base64-encoded binary results returned to the model
@@ -4711,7 +4764,7 @@ export interface ExternalToolTextResultForLlmBinaryResultsForLlm {
    * Optional metadata from the producing tool.
    */
   metadata?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
 }
 /**
@@ -4945,12 +4998,7 @@ export interface FactoryAgentOptions {
    * Optional label distinguishing otherwise identical memoized agent calls.
    */
   label?: string;
-  /**
-   * Optional JSON Schema for structured agent output.
-   */
-  schema?: {
-    [k: string]: unknown | undefined;
-  };
+  schema?: JsonValue;
   /**
    * Optional model identifier for the subagent.
    */
@@ -4969,6 +5017,10 @@ export interface FactoryAgentRequest {
    */
   factoryRunId: string;
   /**
+   * Opaque token identifying the current factory execution attempt.
+   */
+  executionToken: string;
+  /**
    * Prompt to send to the subagent.
    */
   prompt: string;
@@ -4982,12 +5034,29 @@ export interface FactoryAgentRequest {
  */
 /** @experimental */
 export interface FactoryAgentResult {
-  /**
-   * Agent result, omitted when the agent produced no result.
-   */
-  result?: {
-    [k: string]: unknown | undefined;
-  };
+  result?: JsonValue;
+}
+/**
+ * Prompt-safe durable identity and live status for a direct factory agent.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "FactoryAgentSummary".
+ */
+/** @experimental */
+export interface FactoryAgentSummary {
+  agentId: string;
+  toolCallId: string;
+  runId: string;
+  phaseId: string | null;
+  label: string;
+  agentType: string;
+  status: string;
+  requestedModel?: string;
+  resolvedModel?: string;
+  startedAt?: number;
+  completedAt?: number;
+  activeMs: number;
+  activity?: string;
 }
 /**
  * Parameters for cancelling a factory run.
@@ -5001,6 +5070,30 @@ export interface FactoryCancelRequest {
    * Factory run identifier.
    */
   runId: string;
+}
+/**
+ * Current factory phase identity.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "FactoryCurrentPhase".
+ */
+/** @experimental */
+export interface FactoryCurrentPhase {
+  id: string;
+  ordinal: number | null;
+}
+/**
+ * Declared or approved factory resource ceilings.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "FactoryDeclaredLimits".
+ */
+/** @experimental */
+export interface FactoryDeclaredLimits {
+  maxConcurrentSubagents?: number;
+  maxTotalSubagents?: number;
+  timeoutSeconds?: number;
+  maxAiCredits?: number;
 }
 /**
  * Parameters sent to the owning extension to execute a factory closure.
@@ -5023,11 +5116,10 @@ export interface FactoryExecuteRequest {
    */
   runId: string;
   /**
-   * Factory input value.
+   * Opaque token identifying this factory execution attempt.
    */
-  args: {
-    [k: string]: unknown | undefined;
-  };
+  executionToken: string;
+  args: JsonValue;
 }
 /**
  * Result returned by an extension factory closure.
@@ -5037,12 +5129,36 @@ export interface FactoryExecuteRequest {
  */
 /** @experimental */
 export interface FactoryExecuteResult {
+  result?: JsonValue;
+}
+/**
+ * Parameters for paging factory progress.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "FactoryGetRunProgressRequest".
+ */
+/** @experimental */
+export interface FactoryGetRunProgressRequest {
   /**
-   * Factory result value.
+   * Factory run identifier.
    */
-  result: {
-    [k: string]: unknown | undefined;
-  };
+  runId: string;
+  /**
+   * Optional phase identifier used to scope records and cursors.
+   */
+  phaseId?: string;
+  /**
+   * Exclusive forward cursor.
+   */
+  afterSeq?: number;
+  /**
+   * Exclusive backward cursor.
+   */
+  beforeSeq?: number;
+  /**
+   * Maximum records to return. Defaults to 200 and is capped at 500.
+   */
+  limit?: number;
 }
 /**
  * Parameters for retrieving a factory run.
@@ -5070,6 +5186,10 @@ export interface FactoryJournalGetRequest {
    */
   runId: string;
   /**
+   * Opaque token identifying the current factory execution attempt.
+   */
+  executionToken: string;
+  /**
    * Namespaced journal key.
    */
   key: string;
@@ -5086,12 +5206,7 @@ export interface FactoryJournalGetResult {
    * Whether the journal contained the requested key.
    */
   hit: boolean;
-  /**
-   * Cached JSON result. The hit field distinguishes a cached JSON null from a miss.
-   */
-  resultJson?: {
-    [k: string]: unknown | undefined;
-  };
+  resultJson?: JsonValue;
 }
 /**
  * Parameters for storing a factory journal entry.
@@ -5106,15 +5221,85 @@ export interface FactoryJournalPutRequest {
    */
   runId: string;
   /**
+   * Opaque token identifying the current factory execution attempt.
+   */
+  executionToken: string;
+  /**
    * Namespaced journal key.
    */
   key: string;
-  /**
-   * JSON result to memoize.
-   */
-  resultJson: {
-    [k: string]: unknown | undefined;
-  };
+  resultJson: JsonValue;
+}
+/**
+ * Empty parameters for listing factory runs.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "FactoryListRunsRequest".
+ */
+/** @experimental */
+export interface FactoryListRunsRequest {}
+/**
+ * Factory runs in durable creation order.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "FactoryListRunsResult".
+ */
+/** @experimental */
+export interface FactoryListRunsResult {
+  runs: FactoryRunSummary[];
+}
+/**
+ * Durable factory run summary with read-time live overlays.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "FactoryRunSummary".
+ */
+/** @experimental */
+export interface FactoryRunSummary {
+  runId: string;
+  factoryName: string;
+  description: string;
+  status: FactoryRunStatus;
+  revision: number;
+  createdAt: number;
+  startedAt: number | null;
+  updatedAt: number;
+  completedAt: number | null;
+  currentPhase: FactoryCurrentPhase | null;
+  declaredPhaseCount: number;
+  liveAgentCount: number;
+  totalSpawnedAgentCount: number;
+  consumed: FactoryRunConsumed;
+  declaredLimits: FactoryDeclaredLimits;
+  approved: FactoryDeclaredLimits | null;
+  observedAt: number;
+  activeSegmentStartedAt: number | null;
+  terminal: FactoryRunTerminal | null;
+}
+/**
+ * Durable factory resource consumption.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "FactoryRunConsumed".
+ */
+/** @experimental */
+export interface FactoryRunConsumed {
+  activeMs: number;
+  subagents: number;
+  nanoAiu: number;
+}
+/**
+ * Prompt-safe terminal factory outcome.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "FactoryRunTerminal".
+ */
+/** @experimental */
+export interface FactoryRunTerminal {
+  reason?: string;
+  failure?: FactoryRunFailure;
+  error?: string;
+  resultPreview?: string;
 }
 /**
  * One ordered factory progress line.
@@ -5147,9 +5332,97 @@ export interface FactoryLogRequest {
    */
   runId: string;
   /**
+   * Opaque token identifying the current factory execution attempt.
+   */
+  executionToken: string;
+  /**
    * Ordered progress lines to append.
    */
   lines: FactoryLogLine[];
+}
+/**
+ * Durable lifecycle and timing for one factory phase.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "FactoryPhaseObservation".
+ */
+/** @experimental */
+export interface FactoryPhaseObservation {
+  id: string;
+  ordinal: number | null;
+  title: string;
+  detail?: string;
+  status: FactoryPhaseStatus;
+  lastEnteredRunAttempt: number;
+  entryCount: number;
+  startedAt?: number;
+  completedAt?: number;
+  accumulatedActiveMs: number;
+  currentActiveMs: number;
+  totalAgentCount: number;
+  liveAgentCount: number;
+}
+/**
+ * One durable factory progress record.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "FactoryProgressLine".
+ */
+/** @experimental */
+export interface FactoryProgressLine {
+  /**
+   * Global monotonic sequence number within the run.
+   */
+  seq: number;
+  /**
+   * Resume attempt that emitted this record.
+   */
+  attempt: number;
+  /**
+   * Phase active when the record was emitted, or null before any phase.
+   */
+  phaseId: string | null;
+  /**
+   * Epoch milliseconds when the record was persisted.
+   */
+  recordedAt: number;
+  kind: FactoryLogLineKind;
+  /**
+   * Prompt-safe progress text.
+   */
+  text: string;
+}
+/**
+ * A bidirectional page of factory progress.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "FactoryProgressPage".
+ */
+/** @experimental */
+export interface FactoryProgressPage {
+  records: FactoryProgressLine[];
+  oldestSeq: number | null;
+  newestSeq: number | null;
+  hasMoreOlder: boolean;
+  hasMoreNewer: boolean;
+  /**
+   * Run revision reflected by this page.
+   */
+  revision: number;
+}
+/**
+ * Parameters for resuming a factory run from its persisted identity.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "FactoryResumeRequest".
+ */
+/** @experimental */
+export interface FactoryResumeRequest {
+  /**
+   * Factory run identifier.
+   */
+  runId: string;
+  limits?: FactoryRunLimits;
 }
 /**
  * Wire-only per-invocation factory resource ceiling overrides.
@@ -5168,9 +5441,83 @@ export interface FactoryRunLimits {
    */
   maxTotalSubagents?: number;
   /**
-   * Factory active-run timeout in milliseconds.
+   * Maximum accumulated active-execution time in seconds. Active execution includes the entire extension body, subprocess waits, queued-agent waits, and sleeps; time between resumed attempts is not counted.
    */
-  timeout?: number;
+  timeoutSeconds?: number;
+  /**
+   * Maximum AI credits consumed by factory subagents and their descendants. The post-paid ceiling is soft: parallel turns can settle beyond it before the run stops.
+   */
+  maxAiCredits?: number;
+}
+/**
+ * Resolved persisted factory identity and resumed run envelope.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "FactoryResumeResult".
+ */
+/** @experimental */
+export interface FactoryResumeResult {
+  /**
+   * Persisted factory name resolved for the resumed run.
+   */
+  factoryName: string;
+  run: FactoryRunResult;
+}
+/**
+ * Complete current or terminal factory run envelope.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "FactoryRunResult".
+ */
+/** @experimental */
+export interface FactoryRunResult {
+  /**
+   * Factory run identifier.
+   */
+  runId: string;
+  status: FactoryRunStatus;
+  result?: JsonValue;
+  /**
+   * Error message for an errored run.
+   */
+  error?: string;
+  failure?: FactoryRunFailure;
+  /**
+   * Reason for a halted or cancelled run.
+   */
+  reason?: string;
+  snapshot?: JsonValue;
+}
+/**
+ * Full factory run observability detail.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "FactoryRunDetail".
+ */
+/** @experimental */
+export interface FactoryRunDetail {
+  runId: string;
+  factoryName: string;
+  description: string;
+  status: FactoryRunStatus;
+  revision: number;
+  createdAt: number;
+  startedAt: number | null;
+  updatedAt: number;
+  completedAt: number | null;
+  currentPhase: FactoryCurrentPhase | null;
+  declaredPhaseCount: number;
+  liveAgentCount: number;
+  totalSpawnedAgentCount: number;
+  consumed: FactoryRunConsumed;
+  declaredLimits: FactoryDeclaredLimits;
+  approved: FactoryDeclaredLimits | null;
+  observedAt: number;
+  activeSegmentStartedAt: number | null;
+  terminal: FactoryRunTerminal | null;
+  phases: FactoryPhaseObservation[];
+  agents: FactoryAgentSummary[];
+  progress: FactoryProgressPage;
 }
 /**
  * Parameters for invoking a registered factory.
@@ -5184,12 +5531,7 @@ export interface FactoryRunRequest {
    * Registered factory name.
    */
   name: string;
-  /**
-   * Factory input value.
-   */
-  args: {
-    [k: string]: unknown | undefined;
-  };
+  args: JsonValue;
   options?: RunOptions;
 }
 /**
@@ -5205,41 +5547,6 @@ export interface RunOptions {
    * Run identifier whose journal and progress should seed this resumed run.
    */
   resumeFromRunId?: string;
-}
-/**
- * Complete current or terminal factory run envelope.
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "FactoryRunResult".
- */
-/** @experimental */
-export interface FactoryRunResult {
-  /**
-   * Factory run identifier.
-   */
-  runId: string;
-  status: FactoryRunStatus;
-  /**
-   * Completed factory result.
-   */
-  result?: {
-    [k: string]: unknown | undefined;
-  };
-  /**
-   * Error message for an errored run.
-   */
-  error?: string;
-  failure?: FactoryRunFailure;
-  /**
-   * Reason for a halted or cancelled run.
-   */
-  reason?: string;
-  /**
-   * Partial journal and progress snapshot for a halted, cancelled, or errored run.
-   */
-  snapshot?: {
-    [k: string]: unknown | undefined;
-  };
 }
 /**
  * Optional user prompt to combine with the fleet orchestration instructions.
@@ -5604,7 +5911,7 @@ export interface HistoryTruncateResult {
 export interface HookInvokeRequest {
   sessionId: string;
   hookType: HookType;
-  input: unknown;
+  input: JsonValue;
 }
 /**
  * Optional output returned by an SDK callback hook.
@@ -5615,7 +5922,7 @@ export interface HookInvokeRequest {
 /** @experimental */
 /** @internal */
 export interface HookInvokeResponse {
-  output?: unknown;
+  output?: JsonValue;
 }
 /**
  * Installed plugin record from global state, with marketplace, version, install time, enabled state, cache path, and source.
@@ -5652,7 +5959,7 @@ export interface InstalledPlugin {
   source?: InstalledPluginSource;
 }
 /**
- * Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref, and optional subpath.
+ * Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref or full commit SHA, and optional subpath.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "InstalledPluginSourceGitHub".
@@ -5665,10 +5972,14 @@ export interface InstalledPluginSourceGitHub {
   source: "github";
   repo: string;
   ref?: string;
+  /**
+   * Optional full 40-character hexadecimal commit SHA.
+   */
+  sha?: string;
   path?: string;
 }
 /**
- * Source descriptor for a direct URL plugin install, with URL, optional ref, and optional subpath.
+ * Source descriptor for a direct URL plugin install, with URL, optional ref or full commit SHA, and optional subpath.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "InstalledPluginSourceUrl".
@@ -5681,6 +5992,10 @@ export interface InstalledPluginSourceUrl {
   source: "url";
   url: string;
   ref?: string;
+  /**
+   * Optional full 40-character hexadecimal commit SHA.
+   */
+  sha?: string;
   path?: string;
 }
 /**
@@ -5851,6 +6166,32 @@ export interface InstructionSource {
    * The project path this source was discovered from. Only set by sessionless discovery for repository/working-directory sources, where it disambiguates same-named files (e.g. .github/copilot-instructions.md) across multiple workspace roots. The session-scoped getSources leaves it unset.
    */
   projectPath?: string;
+}
+/**
+ * Parameters for interrupting the main agent turn.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "InterruptMainTurnRequest".
+ */
+/** @experimental */
+export interface InterruptMainTurnRequest {
+  /**
+   * When true, the user's queued prompts are preserved and run as the next turn once the interrupted turn unwinds; when false (the default), the queue is cleared like a plain abort.
+   */
+  flushQueued?: boolean;
+}
+/**
+ * Result of interrupting the main agent turn.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "InterruptMainTurnResult".
+ */
+/** @experimental */
+export interface InterruptMainTurnResult {
+  /**
+   * Whether an in-flight main agent turn was interrupted. False when the main loop was not processing.
+   */
+  interrupted: boolean;
 }
 /**
  * HTTP headers as a map from lowercased header name to a list of values. Multi-valued headers (e.g. Set-Cookie) preserve all values.
@@ -6363,7 +6704,7 @@ export interface McpAppsCallToolRequest {
    * Tool arguments
    */
   arguments?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
   /**
    * **Required.** Server whose ui:// view issued the request. Per SEP-1865 ('callable by the app from this server only'), the call is rejected when this differs from `serverName`, and rejected outright when missing.
@@ -6508,7 +6849,7 @@ export interface McpAppsListToolsResult {
    * App-callable tools from the server
    */
   tools: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   }[];
 }
 /**
@@ -6569,7 +6910,7 @@ export interface McpAppsResourceContent {
    * Resource-level metadata (CSP, permissions, etc.)
    */
   _meta?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
 }
 /**
@@ -6829,14 +7170,7 @@ export interface McpConfigUpdateRequest {
 /** @experimental */
 /** @internal */
 export interface McpConfigureGitHubRequest {
-  /**
-   * Opaque runtime auth info for GitHub MCP configuration. Marked internal: an in-process runtime shape (configureGitHubMcp is a no-op over the wire).
-   *
-   * @internal
-   */
-  authInfo: {
-    [k: string]: unknown | undefined;
-  };
+  authInfo: JsonValue;
 }
 /**
  * Result of configuring GitHub MCP.
@@ -6919,12 +7253,7 @@ export interface McpExecuteSamplingParams {
    * Name of the MCP server that initiated the sampling request
    */
   serverName: string;
-  /**
-   * The original MCP JSON-RPC request ID (string or number). Used by the runtime to correlate the inference with the originating MCP request for telemetry; this is distinct from `requestId` (which is the schema-level cancellation handle).
-   */
-  mcpRequestId: {
-    [k: string]: unknown | undefined;
-  };
+  mcpRequestId: JsonValue;
   request: McpExecuteSamplingRequest;
 }
 /**
@@ -7236,6 +7565,32 @@ export interface McpOauthLoginResult {
   authorizationUrl?: string;
 }
 /**
+ * Pending MCP OAuth request id to respond to.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "McpOauthRespondRequest".
+ */
+/** @experimental */
+export interface McpOauthRespondRequest {
+  /**
+   * OAuth request identifier from the mcp.oauth_required event
+   */
+  requestId: string;
+}
+/**
+ * Indicates whether the pending MCP OAuth response was accepted.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "McpOauthRespondResult".
+ */
+/** @experimental */
+export interface McpOauthRespondResult {
+  /**
+   * Whether the response was accepted. False if the request was unknown, timed out, or already resolved.
+   */
+  success: boolean;
+}
+/**
  * Registration parameters for an external MCP client.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -7248,30 +7603,9 @@ export interface McpRegisterExternalClientRequest {
    * Logical server name for the external client
    */
   serverName: string;
-  /**
-   * In-process MCP Client instance. Marked internal: cannot be serialized across the JSON-RPC boundary.
-   *
-   * @internal
-   */
-  client: {
-    [k: string]: unknown | undefined;
-  };
-  /**
-   * In-process MCP Transport instance. Marked internal: cannot be serialized across the JSON-RPC boundary.
-   *
-   * @internal
-   */
-  transport: {
-    [k: string]: unknown | undefined;
-  };
-  /**
-   * In-process server config (MCPServerConfig) paired with the in-process client/transport. Marked internal alongside its companions.
-   *
-   * @internal
-   */
-  config: {
-    [k: string]: unknown | undefined;
-  };
+  client: JsonValue;
+  transport: JsonValue;
+  config: JsonValue;
 }
 /**
  * Opaque MCP reload configuration.
@@ -7282,14 +7616,7 @@ export interface McpRegisterExternalClientRequest {
 /** @experimental */
 /** @internal */
 export interface McpReloadWithConfigRequest {
-  /**
-   * Opaque runtime MCP reload configuration. Marked internal: an in-process runtime shape (reloadMcpServers throws over the wire).
-   *
-   * @internal
-   */
-  config: {
-    [k: string]: unknown | undefined;
-  };
+  config: JsonValue;
 }
 /**
  * Indicates whether the auto-managed `github` MCP server was removed (false when nothing to remove).
@@ -7345,13 +7672,13 @@ export interface McpResource {
    * Resource-level metadata
    */
   _meta?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
   /**
    * Server-provided non-standard descriptor fields preserved from the MCP response
    */
   additionalProperties?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
 }
 /**
@@ -7382,7 +7709,7 @@ export interface McpResourceIcon {
    * Server-provided non-standard icon fields preserved from the MCP response
    */
   additionalProperties?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
 }
 /**
@@ -7409,7 +7736,7 @@ export interface McpResourceAnnotations {
    * Server-provided non-standard annotation fields preserved from the MCP response
    */
   additionalProperties?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
 }
 /**
@@ -7440,7 +7767,7 @@ export interface McpResourceContent {
    * Resource-level metadata (CSP, permissions, etc.)
    */
   _meta?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
 }
 /**
@@ -7548,13 +7875,13 @@ export interface McpResourceTemplate {
    * Resource-template-level metadata
    */
   _meta?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
   /**
    * Server-provided non-standard descriptor fields preserved from the MCP response
    */
   additionalProperties?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
 }
 /**
@@ -8526,7 +8853,7 @@ export interface NameSetRequest {
 /** @experimental */
 export interface OptionsUpdateAdditionalContentExclusionPolicy {
   rules: OptionsUpdateAdditionalContentExclusionPolicyRule[];
-  last_updated_at: unknown;
+  last_updated_at: JsonValue;
   scope: OptionsUpdateAdditionalContentExclusionPolicyScope;
 }
 /**
@@ -9536,7 +9863,7 @@ export interface PermissionRulesSet {
 /** @experimental */
 export interface PermissionsConfigureAdditionalContentExclusionPolicy {
   rules: PermissionsConfigureAdditionalContentExclusionPolicyRule[];
-  last_updated_at: unknown;
+  last_updated_at: JsonValue;
   scope: PermissionsConfigureAdditionalContentExclusionPolicyScope;
 }
 /**
@@ -10371,7 +10698,7 @@ export interface ProviderAddResult {
   /**
    * Synthesized selectable model entries for the newly added BYOK models, each under its provider-qualified selection id (`provider/id`). Empty when only providers were added.
    */
-  models: unknown[];
+  models: JsonValue[];
 }
 /**
  * Custom model-provider configuration (BYOK).
@@ -10983,6 +11310,115 @@ export interface PushAttachmentBlob {
   displayName?: string;
 }
 /**
+ * Inputs for starting a deferred-idle drain.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "QueueBeginDeferredIdleDrainRequest".
+ */
+/** @experimental */
+export interface QueueBeginDeferredIdleDrainRequest {
+  /**
+   * Whether the host still has active background work.
+   */
+  activeBackgroundWork: boolean;
+}
+/**
+ * Whether a deferred-idle drain should run.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "QueueBeginDeferredIdleDrainResult".
+ */
+/** @experimental */
+export interface QueueBeginDeferredIdleDrainResult {
+  /**
+   * True when the host should run finishDeferredIdleDrain asynchronously.
+   */
+  shouldDrain: boolean;
+}
+/**
+ * Internal filter for consuming queued system notifications.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "QueueConsumeSystemNotificationsRequest".
+ */
+/** @experimental */
+export interface QueueConsumeSystemNotificationsRequest {
+  filter: JsonValue;
+}
+/**
+ * Inputs for marking session.idle deferred in native state.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "QueueDeferSessionIdleRequest".
+ */
+/** @experimental */
+export interface QueueDeferSessionIdleRequest {
+  /**
+   * Whether the deferred idle was caused by an aborted foreground turn.
+   */
+  aborted: boolean;
+}
+/**
+ * Result of enqueueing the resume-pending wake item.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "QueueEnqueueResumePendingResult".
+ */
+/** @experimental */
+export interface QueueEnqueueResumePendingResult {
+  /**
+   * True when a wake item was newly queued.
+   */
+  queued: boolean;
+}
+/**
+ * Inputs for completing a deferred-idle drain.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "QueueFinishDeferredIdleDrainRequest".
+ */
+/** @experimental */
+export interface QueueFinishDeferredIdleDrainRequest {
+  /**
+   * Whether the host still has active background work.
+   */
+  activeBackgroundWork: boolean;
+  /**
+   * Whether native queued work remains.
+   */
+  hasPending: boolean;
+}
+/**
+ * Action selected by the native deferred-idle drain.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "QueueFinishDeferredIdleDrainResult".
+ */
+/** @experimental */
+export interface QueueFinishDeferredIdleDrainResult {
+  /**
+   * One of none, processQueue, or emitSessionIdle.
+   */
+  action: string;
+  /**
+   * Whether the deferred idle was caused by an aborted foreground turn.
+   */
+  aborted: boolean;
+}
+/**
+ * Whether the native queue has pending work.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "QueueHasPendingResult".
+ */
+/** @experimental */
+export interface QueueHasPendingResult {
+  /**
+   * True when queued or immediate native work is pending.
+   */
+  hasPending: boolean;
+}
+/**
  * User-facing pending queue entry, with kind and display text for a queued message, slash command, or model change.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -11027,6 +11463,31 @@ export interface QueueRemoveMostRecentResult {
   removed: boolean;
 }
 /**
+ * Internal snapshot of native queue state for local session orchestration.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "QueueSnapshotResult".
+ */
+/** @experimental */
+export interface QueueSnapshotResult {
+  /**
+   * User-facing pending items in FIFO order.
+   */
+  items: QueuePendingItems[];
+  /**
+   * Immediate steering messages waiting for an active turn.
+   */
+  steeringMessages: string[];
+  /**
+   * Insertion orders for queued items, aligned with `items`.
+   */
+  itemOrders?: number[];
+  /**
+   * Insertion orders for immediate steering messages, aligned with `steeringMessages`.
+   */
+  steeringMessageOrders?: number[];
+}
+/**
  * Event type to register consumer interest for, used by runtime gating logic.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -11065,16 +11526,7 @@ export interface RegisterExtensionToolsParams {
    * Session to register extension tools on.
    */
   sessionId: string;
-  /**
-   * In-process ExtensionLoader handle (CLI-only optimization). Marked internal: this field is excluded from the public SDK surface. When the CLI migrates to a process-separated SDK, extension discovery/launch moves entirely into the runtime — the CLI passes pure config (search paths, disabled ids) via SessionOptions instead.
-   *
-   * @internal
-   *
-   * @internal
-   */
-  loader: {
-    [k: string]: unknown | undefined;
-  };
+  loader: JsonValue;
   options?: SessionsRegisterExtensionToolsOnSessionOptions;
 }
 /**
@@ -11085,14 +11537,7 @@ export interface RegisterExtensionToolsParams {
  */
 /** @experimental */
 export interface SessionsRegisterExtensionToolsOnSessionOptions {
-  /**
-   * In-process `() => boolean` gating callback (CLI-only optimization). Marked internal: replaced by runtime-side enable/disable RPCs in the SDK migration.
-   *
-   * @internal
-   */
-  enabled?: {
-    [k: string]: unknown | undefined;
-  };
+  enabled?: JsonValue;
 }
 /**
  * Handle for releasing the extension tool registration.
@@ -11103,16 +11548,7 @@ export interface SessionsRegisterExtensionToolsOnSessionOptions {
 /** @experimental */
 /** @internal */
 export interface RegisterExtensionToolsResult {
-  /**
-   * In-process unsubscribe function (CLI-only optimization). Marked internal: replaced by an explicit `extensions.unregister` RPC in the SDK migration.
-   *
-   * @internal
-   *
-   * @internal
-   */
-  unsubscribe: {
-    [k: string]: unknown | undefined;
-  };
+  unsubscribe: JsonValue;
 }
 /**
  * Opaque handle previously returned by `registerInterest` to release.
@@ -11228,14 +11664,7 @@ export interface RemoteControlStatusActive {
    * Whether the MC session may steer this session.
    */
   isSteerable: boolean;
-  /**
-   * In-process prompt-manager handle (CLI-only optimization). Marked internal: this field is excluded from the public SDK surface. When the CLI migrates to a process-separated SDK, the same bidirectional prompt-routing handshake is expressed via dedicated remote-control RPCs (register/resolve) rather than a shared in-process object.
-   *
-   * @internal
-   */
-  promptManager?: {
-    [k: string]: unknown | undefined;
-  };
+  promptManager?: JsonValue;
   /**
    * True while a read-only/session-sync export is deferred, awaiting the first `user.message` before its MC session exists. Marked internal: this field is excluded from the public SDK surface and is populated only on the CLI in-process path.
    *
@@ -11580,6 +12009,99 @@ export interface SandboxConfigUserPolicyExperimentalSeatbelt {
   keychainAccess?: boolean;
 }
 /**
+ * Register an absolute-time scheduled prompt.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ScheduleAddAtRequest".
+ */
+/** @experimental */
+export interface ScheduleAddAtRequest {
+  /**
+   * Epoch milliseconds when the prompt should fire.
+   */
+  at: number;
+  /**
+   * Prompt text to enqueue when the schedule fires.
+   */
+  prompt: string;
+  /**
+   * Whether the schedule should re-arm after each tick. Defaults to false.
+   */
+  recurring?: boolean;
+  /**
+   * Optional display-only prompt label.
+   */
+  displayPrompt?: string;
+}
+/**
+ * Register a cron scheduled prompt.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ScheduleAddCronRequest".
+ */
+/** @experimental */
+export interface ScheduleAddCronRequest {
+  /**
+   * 5-field cron expression.
+   */
+  cron: string;
+  /**
+   * Prompt text to enqueue when the schedule fires.
+   */
+  prompt: string;
+  /**
+   * Whether the schedule should re-arm after each tick. Defaults to true.
+   */
+  recurring?: boolean;
+  /**
+   * Optional display-only prompt label.
+   */
+  displayPrompt?: string;
+  /**
+   * IANA timezone for evaluating the cron expression.
+   */
+  tz?: string;
+}
+/**
+ * Register a relative-interval scheduled prompt.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ScheduleAddRequest".
+ */
+/** @experimental */
+export interface ScheduleAddRequest {
+  /**
+   * Human-readable interval such as `30s`, `5m`, or `2h`.
+   */
+  interval: string;
+  /**
+   * Prompt text to enqueue when the schedule fires.
+   */
+  prompt: string;
+  /**
+   * Whether the schedule should re-arm after each tick. Defaults to true.
+   */
+  recurring?: boolean;
+  /**
+   * Optional display-only prompt label.
+   */
+  displayPrompt?: string;
+}
+/**
+ * Result of registering or re-arming a scheduled prompt.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ScheduleAddResult".
+ */
+/** @experimental */
+export interface ScheduleAddResult {
+  entry?: ScheduleEntry;
+  /**
+   * User-facing validation error, when registration failed.
+   */
+  error?: string;
+}
+/**
  * Scheduled prompt entry with ID, timing (`intervalMs`, `cron`, or `at`), prompt text, recurrence, and next run time.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -11629,6 +12151,36 @@ export interface ScheduleEntry {
   nextRunAt: string;
 }
 /**
+ * Register a self-paced scheduled prompt.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ScheduleAddSelfPacedRequest".
+ */
+/** @experimental */
+export interface ScheduleAddSelfPacedRequest {
+  /**
+   * Prompt text to enqueue when the schedule fires.
+   */
+  prompt: string;
+  /**
+   * Optional display-only prompt label.
+   */
+  displayPrompt?: string;
+}
+/**
+ * Whether the session currently has an active self-paced schedule.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ScheduleHasSelfPacedResult".
+ */
+/** @experimental */
+export interface ScheduleHasSelfPacedResult {
+  /**
+   * True when at least one active schedule is self-paced.
+   */
+  hasSelfPaced: boolean;
+}
+/**
  * Snapshot of the currently active recurring prompts for this session.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -11640,6 +12192,23 @@ export interface ScheduleList {
    * Active scheduled prompts, ordered by id.
    */
   entries: ScheduleEntry[];
+}
+/**
+ * Re-arm a self-paced scheduled prompt.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ScheduleRearmSelfPacedRequest".
+ */
+/** @experimental */
+export interface ScheduleRearmSelfPacedRequest {
+  /**
+   * Id of the self-paced scheduled prompt.
+   */
+  id: number;
+  /**
+   * Epoch milliseconds when the prompt should next fire.
+   */
+  at: number;
 }
 /**
  * Identifier of the scheduled prompt to remove.
@@ -11738,7 +12307,7 @@ export interface SendMessageItem {
    */
   requiredTool?: string;
   /**
-   * Optional provenance tag copied to the resulting user.message event. Must match one of three forms: the literal `system`, `command-<command-id>` for messages originating from a command (e.g. slash command, Mission Control command), or `schedule-<numeric-id>` for messages originating from a scheduled job.
+   * Optional provenance tag copied to the resulting user.message event. Must be `user`, `system`, `command-<command-id>` for command-originated messages, `schedule-<numeric-id>` for scheduled prompts, or `agent-<agent-id>` for prompts sent by another agent.
    *
    * @internal
    */
@@ -11828,7 +12397,7 @@ export interface SendRequest {
    */
   requiredTool?: string;
   /**
-   * Optional provenance tag copied to the resulting user.message event. Must match one of three forms: the literal `system`, `command-<command-id>` for messages originating from a command (e.g. slash command, Mission Control command), or `schedule-<numeric-id>` for messages originating from a scheduled job.
+   * Optional provenance tag copied to the resulting user.message event. Must be `user`, `system`, `command-<command-id>` for command-originated messages, `schedule-<numeric-id>` for scheduled prompts, or `agent-<agent-id>` for prompts sent by another agent.
    *
    * @internal
    */
@@ -11865,6 +12434,21 @@ export interface SendResult {
    * Unique identifier assigned to the message
    */
   messageId: string;
+}
+/**
+ * Internal request for sending a system notification.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SendSystemNotificationRequest".
+ */
+/** @experimental */
+export interface SendSystemNotificationRequest {
+  /**
+   * Notification text to deliver to the model.
+   */
+  message: string;
+  kind?: JsonValue;
+  options?: JsonValue;
 }
 /**
  * Agents discovered across user, project, plugin, and remote sources.
@@ -12328,7 +12912,7 @@ export interface SessionFsSqliteExistsResult {
   exists: boolean;
 }
 /**
- * SQL query, query type, and optional bind parameters for executing a SQLite query against the per-session database.
+ * SQL query, query type, and optional bind parameters for executing a SQLite query against the per-session database. The provider applies its SQLite busy timeout for every call.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "SessionFsSqliteQueryRequest".
@@ -12348,7 +12932,7 @@ export interface SessionFsSqliteQueryRequest {
    * Optional named bind parameters
    */
   params?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
 }
 /**
@@ -12363,7 +12947,7 @@ export interface SessionFsSqliteQueryResult {
    * For SELECT: array of row objects. For others: empty array.
    */
   rows: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   }[];
   /**
    * Column names from the result set
@@ -12378,6 +12962,62 @@ export interface SessionFsSqliteQueryResult {
    */
   lastInsertRowid?: number;
   error?: SessionFsError;
+}
+/**
+ * Classified SQLite transaction failure. busyOrLocked guarantees rollback; postCommitAmbiguous must never be retried.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionFsSqliteTransactionError".
+ */
+/** @experimental */
+export interface SessionFsSqliteTransactionError {
+  errorClass: SessionFsSqliteTransactionErrorClass;
+  message: string;
+}
+/**
+ * Statements to execute atomically. Providers apply busy handling for every call.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionFsSqliteTransactionRequest".
+ */
+/** @experimental */
+export interface SessionFsSqliteTransactionRequest {
+  /**
+   * Target session identifier
+   */
+  sessionId: string;
+  statements: SessionFsSqliteTransactionStatement[];
+}
+/**
+ * One statement in an atomic SQLite transaction.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionFsSqliteTransactionStatement".
+ */
+/** @experimental */
+export interface SessionFsSqliteTransactionStatement {
+  /**
+   * SQL statement to execute.
+   */
+  query: string;
+  queryType: SessionFsSqliteQueryType;
+  /**
+   * Optional named bind parameters.
+   */
+  params?: {
+    [k: string]: JsonValue | undefined;
+  };
+}
+/**
+ * Per-statement results, or a classified transaction error.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionFsSqliteTransactionResult".
+ */
+/** @experimental */
+export interface SessionFsSqliteTransactionResult {
+  results: SessionFsSqliteQueryResult[];
+  error?: SessionFsSqliteTransactionError;
 }
 /**
  * Path whose metadata should be returned from the client-provided session filesystem.
@@ -12486,7 +13126,7 @@ export interface SessionInstalledPlugin {
   source?: SessionInstalledPluginSource;
 }
 /**
- * Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref, and optional subpath.
+ * Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref or full commit SHA, and optional subpath.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "SessionInstalledPluginSourceGitHub".
@@ -12499,10 +13139,14 @@ export interface SessionInstalledPluginSourceGitHub {
   source: "github";
   repo: string;
   ref?: string;
+  /**
+   * Optional full 40-character hexadecimal commit SHA.
+   */
+  sha?: string;
   path?: string;
 }
 /**
- * Source descriptor for a direct URL plugin install, with URL, optional ref, and optional subpath.
+ * Source descriptor for a direct URL plugin install, with URL, optional ref or full commit SHA, and optional subpath.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
  * via the `definition` "SessionInstalledPluginSourceUrl".
@@ -12515,6 +13159,10 @@ export interface SessionInstalledPluginSourceUrl {
   source: "url";
   url: string;
   ref?: string;
+  /**
+   * Optional full 40-character hexadecimal commit SHA.
+   */
+  sha?: string;
   path?: string;
 }
 /**
@@ -12660,7 +13308,7 @@ export interface SessionModelList {
   /**
    * Available models, ordered with the most preferred default first. Includes both Copilot (CAPI) models and any registry BYOK models; a BYOK model appears under its provider-qualified selection id (`provider/id`).
    */
-  list: unknown[];
+  list: JsonValue[];
   /**
    * Cost categories for the full CAPI catalog, including picker-disabled models that Auto may select. Metadata only; entries absent from `list` are not manually selectable.
    */
@@ -12669,7 +13317,7 @@ export interface SessionModelList {
    * Per-quota snapshots returned alongside the model list, keyed by quota type.
    */
   quotaSnapshots?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
 }
 /**
@@ -12725,14 +13373,7 @@ export interface SessionOpenOptions {
    * Stable integration identifier for analytics.
    */
   integrationId?: string;
-  /**
-   * ExP assignment ('flight') data injected by an SDK integrator, in the same JSON shape the Copilot CLI fetches from the experimentation service (CopilotExpAssignmentResponse). When supplied this is fed into the FeatureFlagService exactly like CLI-fetched assignments and ExP-backed flags wait for it. When absent the session does not block on ExP.
-   *
-   * @internal
-   */
-  expAssignments?: {
-    [k: string]: unknown | undefined;
-  };
+  expAssignments?: JsonValue;
   /**
    * Opt-in: self-fetch and enforce enterprise managed settings at session bootstrap.
    */
@@ -12807,12 +13448,14 @@ export interface SessionOpenOptions {
    * Whether shell-script safety heuristics are enabled.
    */
   enableScriptSafety?: boolean;
+  shell?: ShellOptions;
   /**
-   * Shell init profile.
+   * @deprecated
+   * Use shell.initProfile instead. Shell init profile.
    */
   shellInitProfile?: string;
   /**
-   * Per-shell process flags.
+   * PowerShell process flags applied to built-in and user-requested shell commands.
    */
   shellProcessFlags?: string[];
   sandboxConfig?: SandboxConfig;
@@ -12902,6 +13545,10 @@ export interface SessionOpenOptions {
    */
   eventsLogDirectory?: string;
   /**
+   * Whether subagent callback events should be forwarded into the session event log sink.
+   */
+  eventsLogIncludesSubagents?: boolean;
+  /**
    * Override Copilot configuration directory.
    */
   configDir?: string;
@@ -12918,6 +13565,48 @@ export interface SessionOpenOptions {
   sessionCapabilities?: SessionCapability[];
 }
 /**
+ * Per-session settings for built-in shell tools.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ShellOptions".
+ */
+/** @experimental */
+export interface ShellOptions {
+  initProfile?: ShellInitProfile;
+  /**
+   * Ordered host-provided script paths sourced before each built-in shell command when the
+   * entry's shell target matches the active shell. Use these for rc files, environment setup scripts,
+   * or other custom scripts. A script that returns a nonzero status is reported, and later scripts
+   * and the user command continue while the shell remains running. Because scripts are sourced into
+   * the command shell, `exit`, `exec`, failures under `set -e`, or other shell-terminating behavior
+   * can prevent continuation. Script standard output is preserved; Bash script stderr is discarded,
+   * PowerShell exception messages are replaced, and runtime-generated failure notices omit
+   * configured script paths. When sandboxing is enabled, each script must already be readable under
+   * the active sandbox filesystem policy. Pass an empty array to clear the list.
+   */
+  initScripts?: ShellInitScript[];
+  /**
+   * Flags passed to the active built-in shell process on startup, replacing its default flags.
+   * When omitted, the built-in Bash shell uses `--norc --noprofile`,
+   * and the built-in PowerShell shell uses `-NoProfile -NoLogo`.
+   */
+  processFlags?: string[];
+}
+/**
+ * A host-provided script sourced before each built-in shell command when its shell target matches the active shell.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ShellInitScript".
+ */
+/** @experimental */
+export interface ShellInitScript {
+  /**
+   * Path to the script to source.
+   */
+  path: string;
+  shell: ShellInitScriptShell;
+}
+/**
  * Content-exclusion policy supplied to `sessions.open` options, with rules, last-updated data, and scope.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -12926,7 +13615,7 @@ export interface SessionOpenOptions {
 /** @experimental */
 export interface SessionOpenOptionsAdditionalContentExclusionPolicy {
   rules: SessionOpenOptionsAdditionalContentExclusionPolicyRule[];
-  last_updated_at: unknown;
+  last_updated_at: JsonValue;
   scope: SessionOpenOptionsAdditionalContentExclusionPolicyScope;
 }
 /**
@@ -13070,14 +13759,7 @@ export interface SessionsOpenCloud {
    */
   owner?: string;
   options?: SessionOpenOptions;
-  /**
-   * In-process callback invoked when the cloud task is created (before connection). Marked internal because a function reference cannot cross the JSON-RPC boundary. Disappears in the SDK migration: the field is purely cosmetic (it flips a single CLI phase label from 'creating' to 'connecting') and the wire-clean version just drops the intermediate phase.
-   *
-   * @internal
-   */
-  onTaskCreated?: {
-    [k: string]: unknown | undefined;
-  };
+  onTaskCreated?: JsonValue;
 }
 /**
  * Parameters for fetching a remote session and handing it off to a new local session.
@@ -13094,22 +13776,8 @@ export interface SessionsOpenHandoff {
   metadata: RemoteSessionMetadataValue;
   options?: SessionOpenOptions;
   taskType?: SessionsOpenHandoffTaskType;
-  /**
-   * In-process progress callback `(update) => void` invoked for each handoff step. Marked internal because a function reference cannot cross the JSON-RPC boundary. The host-side `handoffSession` is already declared as `AsyncGenerator<HandoffProgress, HandoffResult>`; the schema layer flattens it because it does not yet support streaming methods. The wire-clean replacement is to expose the AsyncGenerator directly (or use vscode-jsonrpc `$/progress` notifications) once the schema/transport layer supports it.
-   *
-   * @internal
-   */
-  onProgress?: {
-    [k: string]: unknown | undefined;
-  };
-  /**
-   * In-process confirmation callback `(request) => boolean | Promise<boolean>` invoked when the handoff needs the caller to confirm a non-fatal blocker (e.g. a repository mismatch between the current working directory and the remote session). Returning `true` proceeds with the handoff; returning `false` (or omitting the callback) aborts it. Marked internal because a function reference cannot cross the JSON-RPC boundary, for the same reasons as `onProgress`.
-   *
-   * @internal
-   */
-  onConfirm?: {
-    [k: string]: unknown | undefined;
-  };
+  onProgress?: JsonValue;
+  onConfirm?: JsonValue;
 }
 /**
  * Result of opening a session.
@@ -13124,16 +13792,7 @@ export interface SessionOpenResult {
    * Opened session ID. Omitted when status is `not_found`.
    */
   sessionId?: string;
-  /**
-   * In-process SessionClientApi handle for the opened session, returned to CLI callers as a transitional shortcut. Marked internal so the public SDK surface does not expose it; SDK consumers should construct per-session clients from `sessionId` instead.
-   *
-   * @internal
-   *
-   * @internal
-   */
-  sessionApi?: {
-    [k: string]: unknown | undefined;
-  };
+  sessionApi?: JsonValue;
   /**
    * Startup prompts queued by user-level hook configs at session creation. Only populated when status is `created`; resumed sessions return an empty array.
    */
@@ -13252,6 +13911,23 @@ export interface SessionsCloseRequest {
  */
 /** @experimental */
 export interface SessionsCloseResult {}
+/**
+ * Session ID to delete from disk.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsDeleteRequest".
+ */
+/** @experimental */
+export interface SessionsDeleteRequest {
+  /**
+   * Session ID to delete
+   */
+  sessionId: string;
+  /**
+   * Internal resolved session directory path to delete
+   */
+  sessionPath?: string | null;
+}
 /**
  * Session metadata records to enrich with summary and context information.
  *
@@ -13586,6 +14262,29 @@ export interface SessionsGetLastForContextResult {
   sessionId?: string;
 }
 /**
+ * Session ID whose persisted metadata should be read.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsGetMetadataRequest".
+ */
+/** @experimental */
+export interface SessionsGetMetadataRequest {
+  /**
+   * Session ID to inspect
+   */
+  sessionId: string;
+}
+/**
+ * Persisted local session metadata when the session exists.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsGetMetadataResult".
+ */
+/** @experimental */
+export interface SessionsGetMetadataResult {
+  session?: LocalSessionMetadataValue;
+}
+/**
  * Session ID to look up the persisted remote-steerable flag for.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -13625,6 +14324,32 @@ export interface SessionSizes {
   sizes: {
     [k: string]: number | undefined;
   };
+}
+/**
+ * Limit for non-empty local session IDs.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsListNonEmptySessionIdsRequest".
+ */
+/** @experimental */
+export interface SessionsListNonEmptySessionIdsRequest {
+  /**
+   * Maximum number of session IDs to return.
+   */
+  limit?: number;
+}
+/**
+ * Recent local session IDs that contain user-visible history.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "SessionsListNonEmptySessionIdsResult".
+ */
+/** @experimental */
+export interface SessionsListNonEmptySessionIdsResult {
+  /**
+   * Session IDs ordered newest-first.
+   */
+  sessionIds: string[];
 }
 /**
  * Optional source filter, metadata-load limit, and context filter applied to the returned sessions.
@@ -13912,12 +14637,14 @@ export interface SessionUpdateOptionsParams {
    * Whether shell-script safety heuristics are enabled.
    */
   enableScriptSafety?: boolean;
+  shell?: ShellOptions;
   /**
-   * Shell init profile (`None` or `NonInteractive`).
+   * @deprecated
+   * Use shell.initProfile instead. Shell init profile (`None` or `NonInteractive`).
    */
   shellInitProfile?: string;
   /**
-   * Per-shell process flags (e.g., `pwsh` arguments).
+   * PowerShell process flags applied to built-in and user-requested shell commands.
    */
   shellProcessFlags?: string[];
   sandboxConfig?: SandboxConfig;
@@ -14006,6 +14733,10 @@ export interface SessionUpdateOptionsParams {
    * Override directory for the session-events log. When unset, the runtime's default events log directory is used.
    */
   eventsLogDirectory?: string;
+  /**
+   * Whether subagent callback events should be forwarded into the session event log sink.
+   */
+  eventsLogIncludesSubagents?: boolean;
   /**
    * Additional content-exclusion policies to merge into the session's policy set.
    *
@@ -15000,7 +15731,7 @@ export interface Tool {
    * JSON Schema for the tool's input parameters
    */
   parameters?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
   /**
    * Optional instructions for how to use this tool effectively
@@ -15428,22 +16159,8 @@ export interface UIEphemeralQueryRequest {
    * Question to answer from the current conversation context.
    */
   question: string;
-  /**
-   * In-process streaming callback `(text) => void` invoked with each token as the model emits it. Marked internal: excluded from the public SDK surface. In a process-separated SDK this is replaced by a streaming RPC that yields chunks and a final answer.
-   *
-   * @internal
-   */
-  onChunk?: {
-    [k: string]: unknown | undefined;
-  };
-  /**
-   * In-process `AbortSignal` forwarded to the model client to cancel an in-flight request. Marked internal: excluded from the public SDK surface. Replaced by an explicit cancellation token + cancel RPC in the SDK migration.
-   *
-   * @internal
-   */
-  abortSignal?: {
-    [k: string]: unknown | undefined;
-  };
+  onChunk?: JsonValue;
+  abortSignal?: JsonValue;
 }
 /**
  * Transient answer generated from current conversation context.
@@ -15479,6 +16196,10 @@ export interface UIExitPlanModeResponse {
    * Feedback from the user when they declined the plan or requested changes.
    */
   feedback?: string;
+  /**
+   * When true, the agent is instructed to end its turn without starting implementation so the client can restore the session model and auto-submit a fresh implementation turn on it. Set only when a distinct plan configuration (a different model, reasoning effort, or context tier) actually ran the planning turn.
+   */
+  deferImplementation?: boolean;
 }
 /**
  * Request ID of a pending `auto_mode_switch.requested` event and the user's response.
@@ -15887,18 +16608,8 @@ export interface UserRequestedShellCommandResult {
  */
 /** @experimental */
 export interface UserSettingMetadata {
-  /**
-   * The effective value: the user's value if set, otherwise the default.
-   */
-  value: {
-    [k: string]: unknown | undefined;
-  };
-  /**
-   * The centrally-known default for this setting (null when no default is registered).
-   */
-  default: {
-    [k: string]: unknown | undefined;
-  };
+  value: JsonValue;
+  default: JsonValue;
   /**
    * True when the user has not set an explicit value for this setting (i.e. it is left at its default). Reflects whether the user has overridden the key, not whether the effective value happens to equal the default — a key explicitly set to a value identical to the default still reports false.
    */
@@ -15927,12 +16638,7 @@ export interface UserSettingsGetResult {
  */
 /** @experimental */
 export interface UserSettingsSetRequest {
-  /**
-   * Partial user settings to write, as a free-form object keyed by setting name
-   */
-  settings: {
-    [k: string]: unknown | undefined;
-  };
+  settings: JsonValue;
 }
 /**
  * Outcome of writing user settings.
@@ -16043,6 +16749,48 @@ export interface WorkspaceDiffResult {
   isFallback: boolean;
 }
 /**
+ * Compaction summary checkpoint to persist.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "WorkspacesAddSummaryRequest".
+ */
+/** @experimental */
+export interface WorkspacesAddSummaryRequest {
+  /**
+   * Summary title shown in checkpoint listings.
+   */
+  title: string;
+  /**
+   * Markdown summary content to persist.
+   */
+  content: string;
+}
+/**
+ * Persisted summary metadata and refreshed workspace metadata.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "WorkspacesAddSummaryResult".
+ */
+/** @experimental */
+export interface WorkspacesAddSummaryResult {
+  summary?: {};
+  workspace?: {};
+  [k: string]: unknown | undefined;
+}
+/**
+ * Whether the autopilot objective file exists.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "WorkspacesAutopilotObjectiveExistsResult".
+ */
+/** @experimental */
+export interface WorkspacesAutopilotObjectiveExistsResult {
+  /**
+   * True when the objective file exists.
+   */
+  exists: boolean;
+}
+/**
  * Workspace checkpoint metadata with assigned number, human-readable title, and checkpoint filename.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -16081,6 +16829,19 @@ export interface WorkspacesCreateFileRequest {
   content: string;
 }
 /**
+ * Result of deleting the autopilot objective file.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "WorkspacesDeleteAutopilotObjectiveResult".
+ */
+/** @experimental */
+export interface WorkspacesDeleteAutopilotObjectiveResult {
+  /**
+   * True when a file was deleted.
+   */
+  deleted: boolean;
+}
+/**
  * Parameters for computing a workspace diff.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -16093,6 +16854,16 @@ export interface WorkspacesDiffRequest {
    * When true, ignore whitespace-only changes (git `--ignore-all-space`). Defaults to false.
    */
   ignoreWhitespace?: boolean;
+}
+/**
+ * Optional session context used when creating a local workspace.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "WorkspacesEnsureRequest".
+ */
+/** @experimental */
+export interface WorkspacesEnsureRequest {
+  context?: JsonValue;
 }
 /**
  * Current workspace metadata for the session, including its absolute filesystem path when available.
@@ -16154,6 +16925,19 @@ export interface WorkspacesListFilesResult {
    * Relative file paths in the workspace files directory
    */
   files: string[];
+}
+/**
+ * Autopilot objective file content, or null when missing.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "WorkspacesReadAutopilotObjectiveResult".
+ */
+/** @experimental */
+export interface WorkspacesReadAutopilotObjectiveResult {
+  /**
+   * Autopilot objective file content, or null when missing.
+   */
+  content: string | null;
 }
 /**
  * Checkpoint number to read.
@@ -16247,6 +17031,59 @@ export interface WorkspacesSaveLargePasteResult {
   } | null;
 }
 /**
+ * Rollback point for local workspace summaries.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "WorkspacesTruncateSummariesRequest".
+ */
+/** @experimental */
+export interface WorkspacesTruncateSummariesRequest {
+  /**
+   * Number of newest summaries to keep.
+   */
+  keepCount: number;
+}
+/**
+ * Workspace metadata fields to update.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "WorkspacesUpdateMetadataRequest".
+ */
+/** @experimental */
+export interface WorkspacesUpdateMetadataRequest {
+  context?: JsonValue;
+  /**
+   * Optional workspace display name override.
+   */
+  name?: string;
+}
+/**
+ * Autopilot objective file content to persist.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "WorkspacesWriteAutopilotObjectiveRequest".
+ */
+/** @experimental */
+export interface WorkspacesWriteAutopilotObjectiveRequest {
+  /**
+   * Autopilot objective file content.
+   */
+  content: string;
+}
+/**
+ * Result of writing the autopilot objective file.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "WorkspacesWriteAutopilotObjectiveResult".
+ */
+/** @experimental */
+export interface WorkspacesWriteAutopilotObjectiveResult {
+  /**
+   * Filesystem operation performed.
+   */
+  operation: string;
+}
+/**
  * Standard MCP CallToolResult
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -16254,7 +17091,7 @@ export interface WorkspacesSaveLargePasteResult {
  */
 /** @experimental */
 export interface SessionMcpAppsCallToolResult {
-  [k: string]: unknown | undefined;
+  [k: string]: JsonValue | undefined;
 }
 /**
  * Identifies the target session.
@@ -16928,6 +17765,24 @@ export function createInternalServerRpc(connection: MessageConnection) {
         /** @experimental */
         sessions: {
             /**
+             * Reads lightweight persisted metadata for one local session without opening it.
+             *
+             * @param params Session ID whose persisted metadata should be read.
+             *
+             * @returns Persisted local session metadata when the session exists.
+             */
+            getMetadata: async (params: SessionsGetMetadataRequest): Promise<SessionsGetMetadataResult> =>
+                connection.sendRequest("sessions.getMetadata", params),
+            /**
+             * Lists recent local session IDs that contain user-visible history, omitting housekeeping-only sessions.
+             *
+             * @param params Limit for non-empty local session IDs.
+             *
+             * @returns Recent local session IDs that contain user-visible history.
+             */
+            listNonEmptySessionIds: async (params: SessionsListNonEmptySessionIdsRequest): Promise<SessionsListNonEmptySessionIdsResult> =>
+                connection.sendRequest("sessions.listNonEmptySessionIds", params),
+            /**
              * Computes the absolute path to a session's persisted events.jsonl file. Internal: filesystem paths are only meaningful in-process (CLI and runtime share a filesystem). Currently used by the CLI's contribution-graph feature to read historical events directly. Remote SDK consumers must not depend on this; a proper event-query API would replace it if the contribution graph ever needed to work over the wire.
              *
              * @param params Session ID whose event-log file path to compute.
@@ -16945,6 +17800,13 @@ export function createInternalServerRpc(connection: MessageConnection) {
              */
             getPersistedRemoteSteerable: async (params: SessionsGetPersistedRemoteSteerableRequest): Promise<SessionsGetPersistedRemoteSteerableResult> =>
                 connection.sendRequest("sessions.getPersistedRemoteSteerable", params),
+            /**
+             * Deletes one local session from disk after running the same lifecycle hooks as the session manager.
+             *
+             * @param params Session ID to delete from disk.
+             */
+            delete: async (params: SessionsDeleteRequest): Promise<void> =>
+                connection.sendRequest("sessions.delete", params),
             /**
              * Gets the dynamic-context board entry count associated with a session, when available. Internal: this exists solely so CLI telemetry events (`rem_spawn_gate`, `rem_consolidation_complete`) can pair START / END board counts around the detached rem-agent spawn. "Dynamic context board" is a runtime-internal concept that is not part of the public SDK contract; the long-term plan is to relocate the telemetry emission into the runtime so this method can be deleted entirely.
              *
@@ -17017,6 +17879,26 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
          */
         abort: async (params: AbortRequest): Promise<AbortResult> =>
             connection.sendRequest("session.abort", { sessionId, ...params }),
+        /**
+         * Interrupts the current main agent turn while leaving running background work (subagents, sidekicks, and promoted attached shells) alive. No-op when the main loop is not processing.
+         *
+         * @param params Parameters for interrupting the main agent turn.
+         *
+         * @returns Result of interrupting the main agent turn.
+         *
+         * @experimental
+         */
+        interruptMainTurn: async (params: InterruptMainTurnRequest): Promise<InterruptMainTurnResult> =>
+            connection.sendRequest("session.interruptMainTurn", { sessionId, ...params }),
+        /**
+         * Cancels every running background agent (task-registry subagents plus sidekick agents) without interrupting the main agent loop. Promoted attached shells are left running.
+         *
+         * @returns The number of running background agents (task-registry agents) that were cancelled.
+         *
+         * @experimental
+         */
+        cancelAllBackgroundAgents: async (): Promise<SessionCancelAllBackgroundAgentsResult> =>
+            connection.sendRequest("session.cancelAllBackgroundAgents", { sessionId }),
         /**
          * Shuts down the session and persists its final state. Awaits any deferred sessionEnd hooks before resolving so user-supplied hook scripts complete before the runtime tears down.
          *
@@ -17114,6 +17996,15 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
             run: async (params: FactoryRunRequest): Promise<FactoryRunResult> =>
                 connection.sendRequest("session.factory.run", { sessionId, ...params }),
             /**
+             * Resumes a factory run using its persisted name, arguments, journal, and accounting.
+             *
+             * @param params Parameters for resuming a factory run from its persisted identity.
+             *
+             * @returns Resolved persisted factory identity and resumed run envelope.
+             */
+            resume: async (params: FactoryResumeRequest): Promise<FactoryResumeResult> =>
+                connection.sendRequest("session.factory.resume", { sessionId, ...params }),
+            /**
              * Gets the current or settled envelope for a factory run.
              *
              * @param params Parameters for retrieving a factory run.
@@ -17122,6 +18013,31 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              */
             getRun: async (params: FactoryGetRunRequest): Promise<FactoryRunResult> =>
                 connection.sendRequest("session.factory.getRun", { sessionId, ...params }),
+            /**
+             * Lists durable factory runs for this session in creation order.
+             *
+             * @returns Factory runs in durable creation order.
+             */
+            listRuns: async (): Promise<FactoryListRunsResult> =>
+                connection.sendRequest("session.factory.listRuns", { sessionId }),
+            /**
+             * Gets durable and live observability detail for one factory run.
+             *
+             * @param params Parameters for retrieving a factory run.
+             *
+             * @returns Full factory run observability detail.
+             */
+            getRunDetail: async (params: FactoryGetRunRequest): Promise<FactoryRunDetail> =>
+                connection.sendRequest("session.factory.getRunDetail", { sessionId, ...params }),
+            /**
+             * Pages durable progress for one factory run.
+             *
+             * @param params Parameters for paging factory progress.
+             *
+             * @returns A bidirectional page of factory progress.
+             */
+            getRunProgress: async (params: FactoryGetRunProgressRequest): Promise<FactoryProgressPage> =>
+                connection.sendRequest("session.factory.getRunProgress", { sessionId, ...params }),
             /**
              * Requests cancellation of a factory run and returns its run envelope.
              *
@@ -17297,6 +18213,24 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
             getWorkspace: async (): Promise<WorkspacesGetWorkspaceResult> =>
                 connection.sendRequest("session.workspaces.getWorkspace", { sessionId }),
             /**
+             * Updates workspace metadata for a local session and returns the refreshed workspace.
+             *
+             * @param params Workspace metadata fields to update.
+             *
+             * @returns Current workspace metadata for the session, including its absolute filesystem path when available.
+             */
+            updateMetadata: async (params: WorkspacesUpdateMetadataRequest): Promise<WorkspacesGetWorkspaceResult> =>
+                connection.sendRequest("session.workspaces.updateMetadata", { sessionId, ...params }),
+            /**
+             * Ensures a local session workspace exists and returns it.
+             *
+             * @param params Optional session context used when creating a local workspace.
+             *
+             * @returns Current workspace metadata for the session, including its absolute filesystem path when available.
+             */
+            ensure: async (params: WorkspacesEnsureRequest): Promise<WorkspacesGetWorkspaceResult> =>
+                connection.sendRequest("session.workspaces.ensure", { sessionId, ...params }),
+            /**
              * Lists files stored in the session workspace files directory.
              *
              * @returns Relative paths of files stored in the session workspace files directory.
@@ -17335,6 +18269,54 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
              */
             readCheckpoint: async (params: WorkspacesReadCheckpointRequest): Promise<WorkspacesReadCheckpointResult> =>
                 connection.sendRequest("session.workspaces.readCheckpoint", { sessionId, ...params }),
+            /**
+             * Adds a compaction summary checkpoint to the local session workspace.
+             *
+             * @param params Compaction summary checkpoint to persist.
+             *
+             * @returns Persisted summary metadata and refreshed workspace metadata.
+             */
+            addSummary: async (params: WorkspacesAddSummaryRequest): Promise<WorkspacesAddSummaryResult> =>
+                connection.sendRequest("session.workspaces.addSummary", { sessionId, ...params }),
+            /**
+             * Truncates local workspace compaction summaries after a rollback.
+             *
+             * @param params Rollback point for local workspace summaries.
+             *
+             * @returns Current workspace metadata for the session, including its absolute filesystem path when available.
+             */
+            truncateSummaries: async (params: WorkspacesTruncateSummariesRequest): Promise<WorkspacesGetWorkspaceResult> =>
+                connection.sendRequest("session.workspaces.truncateSummaries", { sessionId, ...params }),
+            /**
+             * Reads the autopilot objective state file from the local session workspace.
+             *
+             * @returns Autopilot objective file content, or null when missing.
+             */
+            readAutopilotObjective: async (): Promise<WorkspacesReadAutopilotObjectiveResult> =>
+                connection.sendRequest("session.workspaces.readAutopilotObjective", { sessionId }),
+            /**
+             * Writes the autopilot objective state file in the local session workspace.
+             *
+             * @param params Autopilot objective file content to persist.
+             *
+             * @returns Result of writing the autopilot objective file.
+             */
+            writeAutopilotObjective: async (params: WorkspacesWriteAutopilotObjectiveRequest): Promise<WorkspacesWriteAutopilotObjectiveResult> =>
+                connection.sendRequest("session.workspaces.writeAutopilotObjective", { sessionId, ...params }),
+            /**
+             * Deletes the autopilot objective state file from the local session workspace.
+             *
+             * @returns Result of deleting the autopilot objective file.
+             */
+            deleteAutopilotObjective: async (): Promise<WorkspacesDeleteAutopilotObjectiveResult> =>
+                connection.sendRequest("session.workspaces.deleteAutopilotObjective", { sessionId }),
+            /**
+             * Checks whether the local session workspace has an autopilot objective state file.
+             *
+             * @returns Whether the autopilot objective file exists.
+             */
+            autopilotObjectiveExists: async (): Promise<WorkspacesAutopilotObjectiveExistsResult> =>
+                connection.sendRequest("session.workspaces.autopilotObjectiveExists", { sessionId }),
             /**
              * Saves pasted content as a UTF-8 file in the session workspace.
              *
@@ -17689,6 +18671,15 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                  */
                 login: async (params: McpOauthLoginRequest): Promise<McpOauthLoginResult> =>
                     connection.sendRequest("session.mcp.oauth.login", { sessionId, ...params }),
+                /**
+                 * Responds to a pending MCP OAuth authorization request by its request id.
+                 *
+                 * @param params Pending MCP OAuth request id to respond to.
+                 *
+                 * @returns Indicates whether the pending MCP OAuth response was accepted.
+                 */
+                respond: async (params: McpOauthRespondRequest): Promise<McpOauthRespondResult> =>
+                    connection.sendRequest("session.mcp.oauth.respond", { sessionId, ...params }),
             },
             /** @experimental */
             headers: {
@@ -18589,6 +19580,15 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
  */
 export function createInternalSessionRpc(connection: MessageConnection, sessionId: string) {
     return {
+        /**
+         * Queues or sends an internal system notification to the session according to its passive policy.
+         *
+         * @param params Internal request for sending a system notification.
+         *
+         * @experimental
+         */
+        sendSystemNotification: async (params: SendSystemNotificationRequest): Promise<void> =>
+            connection.sendRequest("session.sendSystemNotification", { sessionId, ...params }),
         /** @experimental */
         mcp: {
             /**
@@ -18642,6 +19642,129 @@ export function createInternalSessionRpc(connection: MessageConnection, sessionI
              */
             evaluatePredicate: async (params: SessionSettingsEvaluatePredicateRequest): Promise<SessionSettingsEvaluatePredicateResult> =>
                 connection.sendRequest("session.settings.evaluatePredicate", { sessionId, ...params }),
+        },
+        /** @experimental */
+        queue: {
+            /**
+             * Returns the internal native queue snapshot for in-process session orchestration.
+             *
+             * @returns Internal snapshot of native queue state for local session orchestration.
+             */
+            snapshot: async (): Promise<QueueSnapshotResult> =>
+                connection.sendRequest("session.queue.snapshot", { sessionId }),
+            /**
+             * Reports whether the local session has native queued work pending.
+             *
+             * @returns Whether the native queue has pending work.
+             */
+            hasPending: async (): Promise<QueueHasPendingResult> =>
+                connection.sendRequest("session.queue.hasPending", { sessionId }),
+            /**
+             * Begins a native deferred-idle drain when background work has quiesced.
+             *
+             * @param params Inputs for starting a deferred-idle drain.
+             *
+             * @returns Whether a deferred-idle drain should run.
+             */
+            beginDeferredIdleDrain: async (params: QueueBeginDeferredIdleDrainRequest): Promise<QueueBeginDeferredIdleDrainResult> =>
+                connection.sendRequest("session.queue.beginDeferredIdleDrain", { sessionId, ...params }),
+            /**
+             * Finishes a native deferred-idle drain and reports whether to drain queue work or emit idle.
+             *
+             * @param params Inputs for completing a deferred-idle drain.
+             *
+             * @returns Action selected by the native deferred-idle drain.
+             */
+            finishDeferredIdleDrain: async (params: QueueFinishDeferredIdleDrainRequest): Promise<QueueFinishDeferredIdleDrainResult> =>
+                connection.sendRequest("session.queue.finishDeferredIdleDrain", { sessionId, ...params }),
+            /**
+             * Marks session.idle as deferred by native background work state.
+             *
+             * @param params Inputs for marking session.idle deferred in native state.
+             */
+            deferSessionIdle: async (params: QueueDeferSessionIdleRequest): Promise<void> =>
+                connection.sendRequest("session.queue.deferSessionIdle", { sessionId, ...params }),
+            /**
+             * Consumes queued native system notifications matching an internal filter.
+             *
+             * @param params Internal filter for consuming queued system notifications.
+             *
+             * @returns Indicates whether a user-facing pending item was removed.
+             */
+            consumeSystemNotifications: async (params: QueueConsumeSystemNotificationsRequest): Promise<QueueRemoveMostRecentResult> =>
+                connection.sendRequest("session.queue.consumeSystemNotifications", { sessionId, ...params }),
+            /**
+             * Enqueues the internal resume-pending wake item when orphan handling needs a follow-up turn.
+             *
+             * @returns Result of enqueueing the resume-pending wake item.
+             */
+            enqueueResumePending: async (): Promise<QueueEnqueueResumePendingResult> =>
+                connection.sendRequest("session.queue.enqueueResumePending", { sessionId }),
+            /**
+             * Drains the native local-session work queue for in-process session orchestration.
+             */
+            process: async (): Promise<void> =>
+                connection.sendRequest("session.queue.process", { sessionId }),
+        },
+        /** @experimental */
+        schedule: {
+            /**
+             * Hydrates the native schedule registry from persisted session events.
+             */
+            hydrate: async (): Promise<void> =>
+                connection.sendRequest("session.schedule.hydrate", { sessionId }),
+            /**
+             * Reports whether the session has an active self-paced scheduled prompt.
+             *
+             * @returns Whether the session currently has an active self-paced schedule.
+             */
+            hasSelfPaced: async (): Promise<ScheduleHasSelfPacedResult> =>
+                connection.sendRequest("session.schedule.hasSelfPaced", { sessionId }),
+            /**
+             * Registers a relative-interval scheduled prompt.
+             *
+             * @param params Register a relative-interval scheduled prompt.
+             *
+             * @returns Result of registering or re-arming a scheduled prompt.
+             */
+            add: async (params: ScheduleAddRequest): Promise<ScheduleAddResult> =>
+                connection.sendRequest("session.schedule.add", { sessionId, ...params }),
+            /**
+             * Registers a recurring cron scheduled prompt.
+             *
+             * @param params Register a cron scheduled prompt.
+             *
+             * @returns Result of registering or re-arming a scheduled prompt.
+             */
+            addCron: async (params: ScheduleAddCronRequest): Promise<ScheduleAddResult> =>
+                connection.sendRequest("session.schedule.addCron", { sessionId, ...params }),
+            /**
+             * Registers an absolute-time scheduled prompt.
+             *
+             * @param params Register an absolute-time scheduled prompt.
+             *
+             * @returns Result of registering or re-arming a scheduled prompt.
+             */
+            addAt: async (params: ScheduleAddAtRequest): Promise<ScheduleAddResult> =>
+                connection.sendRequest("session.schedule.addAt", { sessionId, ...params }),
+            /**
+             * Registers a self-paced scheduled prompt.
+             *
+             * @param params Register a self-paced scheduled prompt.
+             *
+             * @returns Result of registering or re-arming a scheduled prompt.
+             */
+            addSelfPaced: async (params: ScheduleAddSelfPacedRequest): Promise<ScheduleAddResult> =>
+                connection.sendRequest("session.schedule.addSelfPaced", { sessionId, ...params }),
+            /**
+             * Re-arms an active self-paced scheduled prompt.
+             *
+             * @param params Re-arm a self-paced scheduled prompt.
+             *
+             * @returns Result of registering or re-arming a scheduled prompt.
+             */
+            rearmSelfPaced: async (params: ScheduleRearmSelfPacedRequest): Promise<ScheduleAddResult> =>
+                connection.sendRequest("session.schedule.rearmSelfPaced", { sessionId, ...params }),
         },
     };
 }
@@ -18764,13 +19887,21 @@ export interface SessionFsHandler {
      */
     rename(params: SessionFsRenameRequest): Promise<SessionFsError | undefined>;
     /**
-     * Executes a SQLite query against the per-session database.
+     * Executes a SQLite query against the per-session database. Providers apply busy handling for every call.
      *
-     * @param params SQL query, query type, and optional bind parameters for executing a SQLite query against the per-session database.
+     * @param params SQL query, query type, and optional bind parameters for executing a SQLite query against the per-session database. The provider applies its SQLite busy timeout for every call.
      *
      * @returns Query results including rows, columns, and rows affected, or a filesystem error if execution failed.
      */
     sqliteQuery(params: SessionFsSqliteQueryRequest): Promise<SessionFsSqliteQueryResult>;
+    /**
+     * Executes SQLite statements atomically on the provider-owned connection.
+     *
+     * @param params Statements to execute atomically. Providers apply busy handling for every call.
+     *
+     * @returns Per-statement results, or a classified transaction error.
+     */
+    sqliteTransaction(params: SessionFsSqliteTransactionRequest): Promise<SessionFsSqliteTransactionResult>;
     /**
      * Checks whether the per-session SQLite database already exists, without creating it.
      *
@@ -18895,6 +20026,11 @@ export function registerClientSessionApiHandlers(
         const handler = getHandlers(params.sessionId).sessionFs;
         if (!handler) throw new Error(`No sessionFs handler registered for session: ${params.sessionId}`);
         return handler.sqliteQuery(params);
+    });
+    connection.onRequest("sessionFs.sqliteTransaction", async (params: SessionFsSqliteTransactionRequest) => {
+        const handler = getHandlers(params.sessionId).sessionFs;
+        if (!handler) throw new Error(`No sessionFs handler registered for session: ${params.sessionId}`);
+        return handler.sqliteTransaction(params);
     });
     connection.onRequest("sessionFs.sqliteExists", async (params: SessionFsSqliteExistsRequest) => {
         const handler = getHandlers(params.sessionId).sessionFs;

--- a/nodejs/src/generated/session-events.ts
+++ b/nodejs/src/generated/session-events.ts
@@ -1,3 +1,5 @@
+export type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+
 /**
  * AUTO-GENERATED FILE - DO NOT EDIT
  * Generated from: session-events.schema.json
@@ -104,6 +106,7 @@ export type SessionEvent =
   | ExitPlanModeCompletedEvent
   | ToolsUpdatedEvent
   | BackgroundTasksChangedEvent
+  | FactoryRunUpdatedEvent
   | SkillsLoadedEvent
   | CustomAgentsUpdatedEvent
   | McpServersLoadedEvent
@@ -156,6 +159,14 @@ export type Verbosity =
   | "medium"
   /** A more detailed response was requested. */
   | "high";
+/**
+ * Who created the schedule: `user` (an explicit user action such as `/every` or `/after`) or `model` (the agent via the `manage_schedule` tool). Gates whether a scheduled skill that opted out of model invocation may fire: only user-created schedules may.
+ */
+export type ScheduleOrigin =
+  /** The schedule was created by an explicit user action, such as `/every` or `/after`. */
+  | "user"
+  /** The schedule was created by the agent via the `manage_schedule` tool. */
+  | "model";
 /**
  * The type of operation performed on the autopilot objective state file
  */
@@ -595,6 +606,7 @@ export type ElicitationCompletedAction =
   | "decline"
   /** The user dismissed the request. */
   | "cancel";
+export type ElicitationCompletedContent = JsonValue | undefined;
 /**
  * Reason the runtime is requesting host-provided MCP OAuth credentials
  */
@@ -635,6 +647,7 @@ export type McpHeadersRefreshCompletedOutcome =
   | "none"
   /** No response arrived within the bounded window. */
   | "timeout";
+export type CustomNotificationPayload = JsonValue;
 /**
  * The user's auto-mode-switch choice
  */
@@ -1242,6 +1255,7 @@ export interface ScheduleCreatedData {
    * Interval between ticks in milliseconds (relative-interval schedules)
    */
   intervalMs?: number;
+  origin?: ScheduleOrigin;
   /**
    * Prompt text that gets enqueued on every tick
    */
@@ -2656,7 +2670,7 @@ export interface UserMessageData {
    */
   parentAgentTaskId?: string;
   /**
-   * Origin of this message, used for timeline filtering (e.g., "skill-pdf" for skill-injected messages that should be hidden from the user)
+   * Origin of this message, used for timeline filtering and attribution (e.g., `skill-pdf` for hidden skill injection or `agent-<agent-id>` for an inter-agent prompt)
    */
   source?: string;
   /**
@@ -3093,12 +3107,7 @@ export interface AttachmentExtensionContext {
    * Open canvas instance identifier when the push was bound to a canvas instance
    */
   instanceId?: string;
-  /**
-   * Caller-supplied JSON payload
-   */
-  payload?: {
-    [k: string]: unknown | undefined;
-  };
+  payload?: JsonValue;
   /**
    * Human-readable composer pill label
    */
@@ -3365,6 +3374,7 @@ export interface AssistantReasoningData {
    * Unique identifier for this reasoning block
    */
   reasoningId: string;
+  rte?: boolean;
 }
 /**
  * Session event "assistant.reasoning_delta". Streaming reasoning delta for incremental extended thinking updates
@@ -3593,6 +3603,7 @@ export interface AssistantMessageData {
    * GitHub request tracing ID (x-github-request-id header) for correlating with server-side logs
    */
   requestId?: string;
+  rte?: boolean;
   serverTools?: AssistantMessageServerTools;
   /**
    * Copilot service request ID (x-copilot-service-request-id header) for CAPI log correlation
@@ -3672,12 +3683,7 @@ export interface CitationReference {
    */
   citedText?: string;
   location?: CitationLocation;
-  /**
-   * Provider-native citation correlation data (e.g. Anthropic search_result_index / document_index), passed through opaquely for debugging and forward compatibility.
-   */
-  providerMetadata?: {
-    [k: string]: unknown | undefined;
-  };
+  providerMetadata?: JsonValue;
   /**
    * Identifier of the CitationSource this reference points to (CitationSource.id).
    */
@@ -3746,20 +3752,15 @@ export interface AssistantMessageServerTools {
   functionCallNamespaces?: {
     [k: string]: string | undefined;
   };
-  items?: unknown[];
+  items?: JsonValue[];
   provider: string;
-  rawContentBlocks?: unknown[];
+  rawContentBlocks?: JsonValue[];
 }
 /**
  * A tool invocation request from the assistant
  */
 export interface AssistantMessageToolRequest {
-  /**
-   * Arguments to pass to the tool, format depends on the tool
-   */
-  arguments?: {
-    [k: string]: unknown | undefined;
-  };
+  arguments?: JsonValue;
   /**
    * Resolved intention summary describing what this specific call does
    */
@@ -4038,6 +4039,10 @@ export interface AssistantUsageData {
    */
   inputTokens?: number;
   /**
+   * Coarse classification of the interaction that produced this call, mirroring the session's per-request agent context (e.g. `conversation-agent`, `conversation-subagent`, `conversation-sampling`, `conversation-background`, `conversation-compaction`, `conversation-user`). Non-billing; lets consumers attribute a model call to a call class (e.g. sub-agent/sidekick) independently of the billing initiator. Absent when the runtime did not classify the request.
+   */
+  interactionType?: string;
+  /**
    * Average inter-token latency in milliseconds. Only available for streaming requests
    */
   interTokenLatencyMs?: number;
@@ -4074,6 +4079,7 @@ export interface AssistantUsageData {
    * Number of output tokens used for reasoning (e.g., chain-of-thought)
    */
   reasoningTokens?: number;
+  rte?: boolean;
   /**
    * Copilot service request ID (x-copilot-service-request-id header) for CAPI log correlation
    */
@@ -4289,6 +4295,7 @@ export interface ModelCallFailureData {
    */
   reasoningEffort?: string;
   requestFingerprint?: ModelCallFailureRequestFingerprint;
+  rte?: boolean;
   /**
    * Copilot service request ID (x-copilot-service-request-id header) for CAPI log correlation
    */
@@ -4447,12 +4454,7 @@ export interface ToolUserRequestedEvent {
  * User-initiated tool invocation request with tool name and arguments
  */
 export interface ToolUserRequestedData {
-  /**
-   * Arguments for the tool invocation
-   */
-  arguments?: {
-    [k: string]: unknown | undefined;
-  };
+  arguments?: JsonValue;
   /**
    * Unique identifier for this tool call
    */
@@ -4496,12 +4498,7 @@ export interface ToolExecutionStartEvent {
  * Tool execution startup details including MCP server information when applicable
  */
 export interface ToolExecutionStartData {
-  /**
-   * Arguments passed to the tool
-   */
-  arguments?: {
-    [k: string]: unknown | undefined;
-  };
+  arguments?: JsonValue;
   /**
    * When true, the tool output should be displayed expanded (verbatim) in the CLI timeline
    */
@@ -4523,6 +4520,7 @@ export interface ToolExecutionStartData {
    * Tool call ID of the parent tool invocation when this event originates from a sub-agent
    */
   parentToolCallId?: string;
+  rte?: boolean;
   shellToolInfo?: ToolExecutionStartShellToolInfo;
   /**
    * Unique identifier for this tool call
@@ -4713,14 +4711,7 @@ export interface ToolExecutionCompleteData {
    * Whether this tool call was explicitly requested by the user rather than the assistant
    */
   isUserRequested?: boolean;
-  /**
-   * FIDES IFC label projected from tool ingress metadata (MCP `CallToolResult._meta` or synthesized built-in ingress labels). Persisted as `{ ifc: ... }` so the label survives session resume, including model-visible failure results. Experimental.
-   *
-   * @experimental
-   */
-  mcpMeta?: {
-    [k: string]: unknown | undefined;
-  };
+  mcpMeta?: JsonValue;
   /**
    * Model identifier that generated this tool call
    */
@@ -4731,6 +4722,7 @@ export interface ToolExecutionCompleteData {
    */
   parentToolCallId?: string;
   result?: ToolExecutionCompleteResult;
+  rte?: boolean;
   /**
    * Whether this tool execution ran inside a sandbox container
    */
@@ -4748,7 +4740,7 @@ export interface ToolExecutionCompleteData {
    * Tool-specific telemetry data (e.g., CodeQL check counts, grep match counts)
    */
   toolTelemetry?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
   /**
    * Identifier for the agent loop turn this tool was invoked in, matching the corresponding assistant.turn_start event
@@ -4796,20 +4788,8 @@ export interface ToolExecutionCompleteResult {
    * Full detailed tool result for UI/timeline display, preserving complete content such as diffs. Falls back to content when absent.
    */
   detailedContent?: string;
-  /**
-   * FIDES IFC label projected from tool ingress metadata (MCP `CallToolResult._meta` or synthesized built-in ingress labels) — persisted as `{ ifc: ... }` (only the `ifc` key, not the whole `_meta`). Persisted so the FIDES IFC label survives session resume: the engine rehydrates accumulated taint by replaying these on load. Populated for ingress sources when FIDES IFC is on. Experimental.
-   *
-   * @experimental
-   */
-  mcpMeta?: {
-    [k: string]: unknown | undefined;
-  };
-  /**
-   * Structured content (arbitrary JSON) returned verbatim by the MCP tool
-   */
-  structuredContent?: {
-    [k: string]: unknown | undefined;
-  };
+  mcpMeta?: JsonValue;
+  structuredContent?: JsonValue;
   uiResource?: ToolExecutionCompleteUIResource;
 }
 /**
@@ -4828,7 +4808,7 @@ export interface PersistedBinaryImage {
    * Optional metadata from the producing tool.
    */
   metadata?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
   /**
    * MIME type of the binary data
@@ -4853,7 +4833,7 @@ export interface OmittedBinaryResult {
    * Optional metadata from the producing tool.
    */
   metadata?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
   /**
    * MIME type of the omitted binary data
@@ -4883,7 +4863,7 @@ export interface BinaryAssetReference {
    * Optional metadata from the producing tool.
    */
   metadata?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
   /**
    * MIME type of the referenced binary data
@@ -5641,12 +5621,7 @@ export interface HookStartData {
    * Type of hook being invoked (e.g., "preToolUse", "postToolUse", "sessionStart")
    */
   hookType: string;
-  /**
-   * Input data passed to the hook
-   */
-  input?: {
-    [k: string]: unknown | undefined;
-  };
+  input?: JsonValue;
 }
 /**
  * Session event "hook.end". Hook invocation completion details including output, success status, and error information
@@ -5691,12 +5666,7 @@ export interface HookEndData {
    * Type of hook that was invoked (e.g., "preToolUse", "postToolUse", "sessionStart")
    */
   hookType: string;
-  /**
-   * Output data produced by the hook
-   */
-  output?: {
-    [k: string]: unknown | undefined;
-  };
+  output?: JsonValue;
   /**
    * Whether the hook completed successfully
    */
@@ -5817,7 +5787,7 @@ export interface BinaryAssetData {
    * Optional metadata from the producing tool.
    */
   metadata?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
   /**
    * MIME type of the binary asset
@@ -5863,6 +5833,10 @@ export interface SystemMessageData {
    * The system or developer prompt text sent as model input
    */
   content: string;
+  /**
+   * Logical interaction identifier for the model run receiving this prompt
+   */
+  interactionId?: string;
   metadata?: SystemMessageMetadata;
   /**
    * Optional name identifier for the message source
@@ -5882,7 +5856,7 @@ export interface SystemMessageMetadata {
    * Template variables used when constructing the prompt
    */
   variables?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
 }
 /**
@@ -6254,12 +6228,7 @@ export interface PermissionRequestRead {
  * MCP tool invocation permission request
  */
 export interface PermissionRequestMcp {
-  /**
-   * Arguments to pass to the MCP tool
-   */
-  args?: {
-    [k: string]: unknown | undefined;
-  };
+  args?: JsonValue;
   /**
    * Permission kind discriminator
    */
@@ -6349,12 +6318,7 @@ export interface PermissionRequestMemory {
  * Custom tool invocation permission request
  */
 export interface PermissionRequestCustomTool {
-  /**
-   * Arguments to pass to the custom tool
-   */
-  args?: {
-    [k: string]: unknown | undefined;
-  };
+  args?: JsonValue;
   /**
    * Permission kind discriminator
    */
@@ -6384,12 +6348,7 @@ export interface PermissionRequestHook {
    * Permission kind discriminator
    */
   kind: "hook";
-  /**
-   * Arguments of the tool call being gated
-   */
-  toolArgs?: {
-    [k: string]: unknown | undefined;
-  };
+  toolArgs?: JsonValue;
   /**
    * Tool call ID that triggered this permission request
    */
@@ -6561,12 +6520,7 @@ export interface PermissionPromptRequestRead {
  * MCP tool invocation permission prompt
  */
 export interface PermissionPromptRequestMcp {
-  /**
-   * Arguments to pass to the MCP tool
-   */
-  args?: {
-    [k: string]: unknown | undefined;
-  };
+  args?: JsonValue;
   /**
    * Auto-approval judge information for this request; present only when auto mode is enabled.
    *
@@ -6670,12 +6624,7 @@ export interface PermissionPromptRequestMemory {
  * Custom tool invocation permission prompt
  */
 export interface PermissionPromptRequestCustomTool {
-  /**
-   * Arguments to pass to the custom tool
-   */
-  args?: {
-    [k: string]: unknown | undefined;
-  };
+  args?: JsonValue;
   /**
    * Auto-approval judge information for this request; present only when auto mode is enabled.
    *
@@ -6741,12 +6690,7 @@ export interface PermissionPromptRequestHook {
    * Prompt kind discriminator
    */
   kind: "hook";
-  /**
-   * Arguments of the tool call being gated
-   */
-  toolArgs?: {
-    [k: string]: unknown | undefined;
-  };
+  toolArgs?: JsonValue;
   /**
    * Tool call ID that triggered this permission request
    */
@@ -7249,7 +7193,7 @@ export interface ElicitationRequestedSchema {
    * Form field definitions, keyed by field name
    */
   properties: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
   /**
    * List of required field names
@@ -7307,12 +7251,6 @@ export interface ElicitationCompletedData {
   requestId: string;
 }
 /**
- * Opaque JSON value submitted for one field in accepted `elicitation.completed` form content.
- */
-export interface ElicitationCompletedContent {
-  [k: string]: unknown | undefined;
-}
-/**
  * Session event "sampling.requested". Sampling request from an MCP server; contains the server name and a requestId for correlation
  */
 export interface SamplingRequestedEvent {
@@ -7346,12 +7284,7 @@ export interface SamplingRequestedEvent {
  * Sampling request from an MCP server; contains the server name and a requestId for correlation
  */
 export interface SamplingRequestedData {
-  /**
-   * The JSON-RPC request ID from the MCP protocol
-   */
-  mcpRequestId: {
-    [k: string]: unknown | undefined;
-  };
+  mcpRequestId: JsonValue;
   /**
    * Unique identifier for this sampling request; used to respond via session.respondToSampling()
    */
@@ -7701,12 +7634,6 @@ export interface CustomNotificationData {
   version?: number;
 }
 /**
- * Source-defined JSON payload for the custom notification
- */
-export interface CustomNotificationPayload {
-  [k: string]: unknown | undefined;
-}
-/**
  * Optional source-defined string identifiers describing the payload subject
  */
 export interface CustomNotificationSubject {
@@ -7746,12 +7673,7 @@ export interface ExternalToolRequestedEvent {
  * External tool invocation request for client-side tool execution
  */
 export interface ExternalToolRequestedData {
-  /**
-   * Arguments to pass to the external tool
-   */
-  arguments?: {
-    [k: string]: unknown | undefined;
-  };
+  arguments?: JsonValue;
   /**
    * Unique identifier for this request; used to respond via session.respondToExternalTool()
    */
@@ -8257,12 +8179,7 @@ export interface ManagedSettingsResolvedData {
    * Whether the server (account/org) managed-settings layer was present
    */
   serverManaged: boolean;
-  /**
-   * The effective (resolved) managed settings values, so clients can render exactly what is enforced. Absent when no managed policy is in force.
-   */
-  settings?: {
-    [k: string]: unknown | undefined;
-  };
+  settings?: JsonValue;
   source: ManagedSettingsResolvedSource;
 }
 /**
@@ -8598,6 +8515,48 @@ export interface BackgroundTasksChangedEvent {
  * Empty payload for `session.background_tasks_changed`, indicating background task state changed.
  */
 export interface BackgroundTasksChangedData {}
+/**
+ * Session event "factory.run_updated". Ephemeral invalidation signal for a changed factory run.
+ */
+/** @experimental */
+export interface FactoryRunUpdatedEvent {
+  /**
+   * Sub-agent instance identifier. Absent for events from the root/main agent and session-level events.
+   */
+  agentId?: string;
+  data: FactoryRunUpdatedData;
+  /**
+   * Always true for events that are transient and not persisted to the session event log on disk.
+   */
+  ephemeral: true;
+  /**
+   * Unique event identifier (UUID v4), generated when the event is emitted
+   */
+  id: string;
+  /**
+   * ID of the chronologically preceding event in the session, forming a linked chain. Null for the first event.
+   */
+  parentId: string | null;
+  /**
+   * ISO 8601 timestamp when the event was created
+   */
+  timestamp: string;
+  /**
+   * Type discriminator. Always "factory.run_updated".
+   */
+  type: "factory.run_updated";
+}
+/**
+ * Ephemeral invalidation signal for a changed factory run.
+ */
+/** @experimental */
+export interface FactoryRunUpdatedData {
+  /**
+   * Monotonic revision now available for the run.
+   */
+  revision: number;
+  runId: string;
+}
 /**
  * Session event "session.skills_loaded". Payload of `session.skills_loaded` listing resolved skill metadata.
  */
@@ -9063,12 +9022,7 @@ export interface CanvasOpenedData {
    * Host-local PNG path for the canvas icon, when supplied
    */
   icon?: string;
-  /**
-   * Input supplied when the instance was opened
-   */
-  input?: {
-    [k: string]: unknown | undefined;
-  };
+  input?: JsonValue;
   /**
    * Stable caller-supplied canvas instance identifier
    */
@@ -9160,12 +9114,7 @@ export interface CanvasRegistryChangedCanvas {
    * Host-local PNG path for the canvas icon, when supplied
    */
   icon?: string;
-  /**
-   * JSON Schema for canvas open input
-   */
-  inputSchema?: {
-    [k: string]: unknown | undefined;
-  };
+  inputSchema?: JsonValue;
 }
 /**
  * A single action within a canvas declaration, with its name, optional description, and optional input schema.
@@ -9176,12 +9125,7 @@ export interface CanvasRegistryChangedCanvasAction {
    * Action description
    */
   description?: string;
-  /**
-   * JSON Schema for action input
-   */
-  inputSchema?: {
-    [k: string]: unknown | undefined;
-  };
+  inputSchema?: JsonValue;
   /**
    * Action name
    */
@@ -9329,12 +9273,7 @@ export interface CanvasRecordedData {
    * Owning provider identifier
    */
   extensionId: string;
-  /**
-   * Input supplied when the instance was opened
-   */
-  input?: {
-    [k: string]: unknown | undefined;
-  };
+  input?: JsonValue;
   /**
    * Stable caller-supplied canvas instance identifier
    */
@@ -9470,7 +9409,7 @@ export interface McpAppToolCallCompleteData {
    * Arguments passed to the tool by the app view, if any
    */
   arguments?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
   /**
    * Wall-clock duration of the underlying tools/call in milliseconds
@@ -9481,7 +9420,7 @@ export interface McpAppToolCallCompleteData {
    * Standard MCP CallToolResult returned by the server. Present whether or not the call set isError.
    */
   result?: {
-    [k: string]: unknown | undefined;
+    [k: string]: JsonValue | undefined;
   };
   /**
    * Name of the MCP server hosting the tool

--- a/nodejs/src/sessionFsProvider.ts
+++ b/nodejs/src/sessionFsProvider.ts
@@ -9,6 +9,7 @@ import type {
     SessionFsReaddirWithTypesEntry,
     SessionFsSqliteQueryResult as GeneratedSqliteQueryResult,
     SessionFsSqliteQueryType,
+    SessionFsSqliteTransactionStatement,
 } from "./generated/rpc.js";
 
 export type { SessionFsSqliteQueryType };
@@ -44,6 +45,19 @@ export interface SessionFsSqliteProvider {
         query: string,
         params?: Record<string, string | number | null>
     ): Promise<SessionFsSqliteQueryResult | undefined>;
+
+    /**
+     * Execute statements atomically on the provider-owned connection.
+     *
+     * Apply SQLite busy handling for every call and roll back before throwing.
+     *
+     * Optional: a provider that predates this capability, or cannot offer
+     * atomicity, may omit it. Callers then receive a classified `fatal`
+     * transaction error rather than a partially applied batch.
+     */
+    transaction?(
+        statements: SessionFsSqliteTransactionStatement[]
+    ): Promise<SessionFsSqliteQueryResult[]>;
 
     /**
      * Check whether the per-session database already exists, without creating it.
@@ -219,6 +233,35 @@ export function createSessionFsAdapter(provider: SessionFsProvider): SessionFsHa
             );
             return result ?? { rows: [], columns: [], rowsAffected: 0 };
         },
+        sqliteTransaction: async ({ statements }) => {
+            if (!provider.sqlite?.transaction) {
+                return {
+                    results: [],
+                    error: {
+                        errorClass: "fatal",
+                        message: provider.sqlite
+                            ? "Atomic SQLite transactions are not supported by this provider"
+                            : "SQLite is not supported by this provider",
+                    },
+                };
+            }
+            try {
+                const normalized = statements.map((statement) => ({
+                    ...statement,
+                    params: normalizeSqliteParams(statement.params),
+                }));
+                return { results: await provider.sqlite.transaction(normalized) };
+            } catch (err) {
+                const errorClass = sqliteTransactionErrorClass(err);
+                return {
+                    results: [],
+                    error: {
+                        errorClass,
+                        message: err instanceof Error ? err.message : String(err),
+                    },
+                };
+            }
+        },
         sqliteExists: async () => {
             if (!provider.sqlite) {
                 throw new Error("SQLite is not supported by this provider");
@@ -226,6 +269,31 @@ export function createSessionFsAdapter(provider: SessionFsProvider): SessionFsHa
             return { exists: await provider.sqlite.exists() };
         },
     };
+}
+
+function sqliteTransactionErrorClass(
+    err: unknown
+): "busyOrLocked" | "fatal" | "postCommitAmbiguous" {
+    if (typeof err !== "object" || err === null) {
+        return "fatal";
+    }
+    const classified = "errorClass" in err ? err.errorClass : undefined;
+    if (
+        classified === "busyOrLocked" ||
+        classified === "fatal" ||
+        classified === "postCommitAmbiguous"
+    ) {
+        return classified;
+    }
+    const code = "code" in err ? err.code : undefined;
+    const errcode = "errcode" in err ? err.errcode : undefined;
+    return code === "SQLITE_BUSY" ||
+        code === "SQLITE_LOCKED" ||
+        code === "EBUSY" ||
+        errcode === 5 ||
+        errcode === 6
+        ? "busyOrLocked"
+        : "fatal";
 }
 
 function toSessionFsError(err: unknown): SessionFsError {

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -18,6 +18,7 @@ import type {
 import type { CopilotSession } from "./session.js";
 import type {
     GitHubTelemetryNotification,
+    JsonValue,
     ModelBillingTokenPrices,
     OpenCanvasInstance,
     RemoteSessionMode,
@@ -443,7 +444,7 @@ export type ToolBinaryResult = {
     description?: string;
 };
 
-export type ToolTelemetry = Record<string, Record<string, unknown> | undefined>;
+export type ToolTelemetry = Record<string, { [key: string]: JsonValue } | undefined>;
 
 export type ToolResultObject = {
     textResultForLlm: string;

--- a/nodejs/test/e2e/rpc_session_state.e2e.test.ts
+++ b/nodejs/test/e2e/rpc_session_state.e2e.test.ts
@@ -414,22 +414,22 @@ describe("Session-scoped RPC", async () => {
                 }
             );
 
-            await expect(
-                session.rpc.lsp.initialize({
-                    workingDirectory: optionsDirectory,
-                    gitRoot: initialDirectory,
-                    force: true,
-                })
-            ).resolves.toBeNull();
+            // `lsp.initialize` is declared `Promise<void>`, so its resolved value
+            // is not part of the contract — only that the call resolves.
+            await session.rpc.lsp.initialize({
+                workingDirectory: optionsDirectory,
+                gitRoot: initialDirectory,
+                force: true,
+            });
 
-            await expect(
-                session.rpc.telemetry.setFeatureOverrides({
-                    features: {
-                        rpc_session_state_feature: featureName,
-                        rpc_session_state_value: "enabled",
-                    },
-                })
-            ).resolves.toBeNull();
+            // `telemetry.setFeatureOverrides` is declared `Promise<void>`, so its
+            // resolved value is not part of the contract — only that it resolves.
+            await session.rpc.telemetry.setFeatureOverrides({
+                features: {
+                    rpc_session_state_feature: featureName,
+                    rpc_session_state_value: "enabled",
+                },
+            });
 
             await expect(session.rpc.tools.initializeAndValidate()).resolves.toBeDefined();
             expect(

--- a/nodejs/test/session-event-types.test.ts
+++ b/nodejs/test/session-event-types.test.ts
@@ -97,7 +97,7 @@ describe("Session event type exports (#1156)", () => {
 
         expect(data.toolName).toBe("shell");
         expect(data.toolCallId).toBe("call-1");
-        expect(data.arguments?.command).toBe("ls");
+        expect(data.arguments).toEqual({ command: "ls" });
         expect(data.mcpServerName).toBe("filesystem");
         expect(data.mcpToolName).toBe("list_dir");
         expect(data.turnId).toBe("turn-1");

--- a/nodejs/test/typescript-codegen.test.ts
+++ b/nodejs/test/typescript-codegen.test.ts
@@ -2,7 +2,10 @@ import type { JSONSchema7 } from "json-schema";
 import { compile } from "json-schema-to-typescript";
 import { describe, expect, it } from "vitest";
 
-import { normalizeSchemaForTypeScript } from "../../scripts/codegen/typescript.ts";
+import {
+    normalizeSchemaForTypeScript,
+    TYPESCRIPT_JSON_VALUE_DECLARATION,
+} from "../../scripts/codegen/typescript.ts";
 
 describe("typescript schema codegen", () => {
     it("emits JSDoc comments for described enum values", async () => {
@@ -42,5 +45,38 @@ describe("typescript schema codegen", () => {
             'export type SyntheticMode = /** Use alpha mode. */ "alpha" | "beta";'
         );
         expect(code).toContain('inlineMode: /** Use a direct value. */ "direct" | "indirect";');
+    });
+
+    it("maps opaque JSON fields to the recursive JsonValue type", async () => {
+        const schema: JSONSchema7 = {
+            title: "OpaqueContainer",
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                payload: {
+                    "x-opaque-json": true,
+                },
+            },
+            required: ["payload"],
+        };
+
+        const normalized = normalizeSchemaForTypeScript(schema);
+        expect(normalized.properties?.payload).toEqual({
+            tsType: "JsonValue",
+        });
+
+        const code = await compile(normalized, "OpaqueContainer", {
+            bannerComment: "",
+            style: { semi: true, singleQuote: false },
+            additionalProperties: false,
+        });
+
+        expect(`${TYPESCRIPT_JSON_VALUE_DECLARATION}\n\n${code.trim()}`).toBe(
+            `export type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+
+export interface OpaqueContainer {
+  payload: JsonValue;
+}`
+        );
     });
 });

--- a/python/copilot/generated/rpc.py
+++ b/python/copilot/generated/rpc.py
@@ -1244,11 +1244,14 @@ class _ConnectRequest:
     enable_git_hub_telemetry_forwarding: bool | None = None
     """Opt this connection in to GitHub telemetry forwarding for its lifetime. When set, the
     runtime forwards every internal telemetry event it emits — across all sessions, plus
-    sessionless events — to this connection over the `gitHubTelemetry.event` notification, in
-    addition to the runtime's normal GitHub/CTS emission (dual-write). Intended for
-    first-party hosts that re-emit the events into their own telemetry stores. Both
-    unrestricted and restricted events are forwarded, each tagged with a `restricted`
-    discriminator; a backstop drops restricted events when restricted telemetry is disabled.
+    sessionless events — to this connection over the `gitHubTelemetry.event` notification.
+    Regular events are also written to the runtime's normal GitHub/CTS path (dual-write);
+    host-only compatibility events are forward-only and intentionally skip that path.
+    Intended for first-party hosts that re-emit the events into their own telemetry stores.
+    Both unrestricted and restricted events are forwarded, each tagged with a `restricted`
+    discriminator; a backstop drops restricted events when restricted telemetry is disabled —
+    using the process-global gate for ordinary events and an explicit session-scoped decision
+    for host-only events.
     """
     token: str | None = None
     """Connection token; required when the server was started with COPILOT_CONNECTION_TOKEN"""
@@ -2179,6 +2182,65 @@ class FactoryAgentResult:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class FactoryAgentSummary:
+    """Prompt-safe durable identity and live status for a direct factory agent."""
+
+    active_ms: int
+    agent_id: str
+    agent_type: str
+    label: str
+    run_id: str
+    status: str
+    tool_call_id: str
+    activity: str | None = None
+    completed_at: int | None = None
+    phase_id: str | None = None
+    requested_model: str | None = None
+    resolved_model: str | None = None
+    started_at: int | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'FactoryAgentSummary':
+        assert isinstance(obj, dict)
+        active_ms = from_int(obj.get("activeMs"))
+        agent_id = from_str(obj.get("agentId"))
+        agent_type = from_str(obj.get("agentType"))
+        label = from_str(obj.get("label"))
+        run_id = from_str(obj.get("runId"))
+        status = from_str(obj.get("status"))
+        tool_call_id = from_str(obj.get("toolCallId"))
+        activity = from_union([from_str, from_none], obj.get("activity"))
+        completed_at = from_union([from_int, from_none], obj.get("completedAt"))
+        phase_id = from_union([from_none, from_str], obj.get("phaseId"))
+        requested_model = from_union([from_str, from_none], obj.get("requestedModel"))
+        resolved_model = from_union([from_str, from_none], obj.get("resolvedModel"))
+        started_at = from_union([from_int, from_none], obj.get("startedAt"))
+        return FactoryAgentSummary(active_ms, agent_id, agent_type, label, run_id, status, tool_call_id, activity, completed_at, phase_id, requested_model, resolved_model, started_at)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["activeMs"] = from_int(self.active_ms)
+        result["agentId"] = from_str(self.agent_id)
+        result["agentType"] = from_str(self.agent_type)
+        result["label"] = from_str(self.label)
+        result["runId"] = from_str(self.run_id)
+        result["status"] = from_str(self.status)
+        result["toolCallId"] = from_str(self.tool_call_id)
+        if self.activity is not None:
+            result["activity"] = from_union([from_str, from_none], self.activity)
+        if self.completed_at is not None:
+            result["completedAt"] = from_union([from_int, from_none], self.completed_at)
+        result["phaseId"] = from_union([from_none, from_str], self.phase_id)
+        if self.requested_model is not None:
+            result["requestedModel"] = from_union([from_str, from_none], self.requested_model)
+        if self.resolved_model is not None:
+            result["resolvedModel"] = from_union([from_str, from_none], self.resolved_model)
+        if self.started_at is not None:
+            result["startedAt"] = from_union([from_int, from_none], self.started_at)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class FactoryCancelRequest:
     """Parameters for cancelling a factory run."""
 
@@ -2198,11 +2260,83 @@ class FactoryCancelRequest:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class FactoryCurrentPhase:
+    """Current factory phase identity."""
+
+    id: str
+    ordinal: int | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'FactoryCurrentPhase':
+        assert isinstance(obj, dict)
+        id = from_str(obj.get("id"))
+        ordinal = from_union([from_none, from_int], obj.get("ordinal"))
+        return FactoryCurrentPhase(id, ordinal)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["id"] = from_str(self.id)
+        result["ordinal"] = from_union([from_none, from_int], self.ordinal)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class FactoryDeclaredLimits:
+    """Declared or approved factory resource ceilings."""
+
+    max_ai_credits: float | None = None
+    max_concurrent_subagents: int | None = None
+    max_total_subagents: int | None = None
+    timeout_seconds: float | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'FactoryDeclaredLimits':
+        assert isinstance(obj, dict)
+        max_ai_credits = from_union([from_float, from_none], obj.get("maxAiCredits"))
+        max_concurrent_subagents = from_union([from_int, from_none], obj.get("maxConcurrentSubagents"))
+        max_total_subagents = from_union([from_int, from_none], obj.get("maxTotalSubagents"))
+        timeout_seconds = from_union([from_float, from_none], obj.get("timeoutSeconds"))
+        return FactoryDeclaredLimits(max_ai_credits, max_concurrent_subagents, max_total_subagents, timeout_seconds)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.max_ai_credits is not None:
+            result["maxAiCredits"] = from_union([to_float, from_none], self.max_ai_credits)
+        if self.max_concurrent_subagents is not None:
+            result["maxConcurrentSubagents"] = from_union([from_int, from_none], self.max_concurrent_subagents)
+        if self.max_total_subagents is not None:
+            result["maxTotalSubagents"] = from_union([from_int, from_none], self.max_total_subagents)
+        if self.timeout_seconds is not None:
+            result["timeoutSeconds"] = from_union([to_float, from_none], self.timeout_seconds)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+class FactoryDurableOperation(Enum):
+    """Execution-critical factory storage operation.
+
+    Execution-critical durable operation that failed.
+    """
+    ADD_ELAPSED = "addElapsed"
+    CHARGE_CREDIT = "chargeCredit"
+    CREATE_RUN = "createRun"
+    FINISH_RUN = "finishRun"
+    JOURNAL_GET = "journalGet"
+    JOURNAL_PUT = "journalPut"
+    MARK_RUN_STARTED = "markRunStarted"
+    RECONCILE_CREDIT_TOTAL = "reconcileCreditTotal"
+    RELEASE_AGENT = "releaseAgent"
+    RESERVE_AGENT = "reserveAgent"
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class FactoryExecuteRequest:
     """Parameters sent to the owning extension to execute a factory closure."""
 
     args: Any
     """Factory input value."""
+
+    execution_token: str
+    """Opaque token identifying this factory execution attempt."""
 
     name: str
     """Registered factory name."""
@@ -2217,14 +2351,16 @@ class FactoryExecuteRequest:
     def from_dict(obj: Any) -> 'FactoryExecuteRequest':
         assert isinstance(obj, dict)
         args = obj.get("args")
+        execution_token = from_str(obj.get("executionToken"))
         name = from_str(obj.get("name"))
         run_id = from_str(obj.get("runId"))
         session_id = from_str(obj.get("sessionId"))
-        return FactoryExecuteRequest(args, name, run_id, session_id)
+        return FactoryExecuteRequest(args, execution_token, name, run_id, session_id)
 
     def to_dict(self) -> dict:
         result: dict = {}
         result["args"] = self.args
+        result["executionToken"] = from_str(self.execution_token)
         result["name"] = from_str(self.name)
         result["runId"] = from_str(self.run_id)
         result["sessionId"] = from_str(self.session_id)
@@ -2235,7 +2371,7 @@ class FactoryExecuteRequest:
 class FactoryExecuteResult:
     """Result returned by an extension factory closure."""
 
-    result: Any
+    result: Any = None
     """Factory result value."""
 
     @staticmethod
@@ -2246,7 +2382,51 @@ class FactoryExecuteResult:
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["result"] = self.result
+        if self.result is not None:
+            result["result"] = self.result
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class FactoryGetRunProgressRequest:
+    """Parameters for paging factory progress."""
+
+    run_id: str
+    """Factory run identifier."""
+
+    after_seq: int | None = None
+    """Exclusive forward cursor."""
+
+    before_seq: int | None = None
+    """Exclusive backward cursor."""
+
+    limit: int | None = None
+    """Maximum records to return. Defaults to 200 and is capped at 500."""
+
+    phase_id: str | None = None
+    """Optional phase identifier used to scope records and cursors."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'FactoryGetRunProgressRequest':
+        assert isinstance(obj, dict)
+        run_id = from_str(obj.get("runId"))
+        after_seq = from_union([from_int, from_none], obj.get("afterSeq"))
+        before_seq = from_union([from_int, from_none], obj.get("beforeSeq"))
+        limit = from_union([from_int, from_none], obj.get("limit"))
+        phase_id = from_union([from_str, from_none], obj.get("phaseId"))
+        return FactoryGetRunProgressRequest(run_id, after_seq, before_seq, limit, phase_id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["runId"] = from_str(self.run_id)
+        if self.after_seq is not None:
+            result["afterSeq"] = from_union([from_int, from_none], self.after_seq)
+        if self.before_seq is not None:
+            result["beforeSeq"] = from_union([from_int, from_none], self.before_seq)
+        if self.limit is not None:
+            result["limit"] = from_union([from_int, from_none], self.limit)
+        if self.phase_id is not None:
+            result["phaseId"] = from_union([from_str, from_none], self.phase_id)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -2273,6 +2453,9 @@ class FactoryGetRunRequest:
 class FactoryJournalGetRequest:
     """Parameters for reading a factory journal entry."""
 
+    execution_token: str
+    """Opaque token identifying the current factory execution attempt."""
+
     key: str
     """Namespaced journal key."""
 
@@ -2282,12 +2465,14 @@ class FactoryJournalGetRequest:
     @staticmethod
     def from_dict(obj: Any) -> 'FactoryJournalGetRequest':
         assert isinstance(obj, dict)
+        execution_token = from_str(obj.get("executionToken"))
         key = from_str(obj.get("key"))
         run_id = from_str(obj.get("runId"))
-        return FactoryJournalGetRequest(key, run_id)
+        return FactoryJournalGetRequest(execution_token, key, run_id)
 
     def to_dict(self) -> dict:
         result: dict = {}
+        result["executionToken"] = from_str(self.execution_token)
         result["key"] = from_str(self.key)
         result["runId"] = from_str(self.run_id)
         return result
@@ -2322,6 +2507,9 @@ class FactoryJournalGetResult:
 class FactoryJournalPutRequest:
     """Parameters for storing a factory journal entry."""
 
+    execution_token: str
+    """Opaque token identifying the current factory execution attempt."""
+
     key: str
     """Namespaced journal key."""
 
@@ -2334,79 +2522,62 @@ class FactoryJournalPutRequest:
     @staticmethod
     def from_dict(obj: Any) -> 'FactoryJournalPutRequest':
         assert isinstance(obj, dict)
+        execution_token = from_str(obj.get("executionToken"))
         key = from_str(obj.get("key"))
         result_json = obj.get("resultJson")
         run_id = from_str(obj.get("runId"))
-        return FactoryJournalPutRequest(key, result_json, run_id)
+        return FactoryJournalPutRequest(execution_token, key, result_json, run_id)
 
     def to_dict(self) -> dict:
         result: dict = {}
+        result["executionToken"] = from_str(self.execution_token)
         result["key"] = from_str(self.key)
         result["resultJson"] = self.result_json
         result["runId"] = from_str(self.run_id)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
-class FactoryLogLineKind(Enum):
-    """Progress line kind.
-
-    Kind of factory progress line.
-    """
-    LOG = "log"
-    PHASE = "phase"
-
-# Experimental: this type is part of an experimental API and may change or be removed.
-class FactoryRunFailureKind(Enum):
-    """Resource ceiling that stopped the run.
-
-    Cumulative resource ceiling that stopped a factory run.
-    """
-    MAX_TOTAL_SUBAGENTS = "maxTotalSubagents"
-    TIMEOUT = "timeout"
-
-class FactoryRunFailureType(Enum):
-    FACTORY_LIMIT_REACHED = "factory_limit_reached"
-    FACTORY_RESUME_DECLINED = "factory_resume_declined"
-
-# Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
-class FactoryRunLimits:
-    """Wire-only per-invocation factory resource ceiling overrides.
-
-    Per-invocation resource ceiling overrides.
-    """
-    max_concurrent_subagents: int | None = None
-    """Maximum number of factory subagents that may run concurrently."""
-
-    max_total_subagents: int | None = None
-    """Maximum total number of factory subagents that may be admitted."""
-
-    timeout: float | None = None
-    """Factory active-run timeout in milliseconds."""
-
+class FactoryListRunsRequest:
+    """Empty parameters for listing factory runs."""
     @staticmethod
-    def from_dict(obj: Any) -> 'FactoryRunLimits':
+    def from_dict(obj: Any) -> 'FactoryListRunsRequest':
         assert isinstance(obj, dict)
-        max_concurrent_subagents = from_union([from_int, from_none], obj.get("maxConcurrentSubagents"))
-        max_total_subagents = from_union([from_int, from_none], obj.get("maxTotalSubagents"))
-        timeout = from_union([from_float, from_none], obj.get("timeout"))
-        return FactoryRunLimits(max_concurrent_subagents, max_total_subagents, timeout)
+        return FactoryListRunsRequest()
 
     def to_dict(self) -> dict:
         result: dict = {}
-        if self.max_concurrent_subagents is not None:
-            result["maxConcurrentSubagents"] = from_union([from_int, from_none], self.max_concurrent_subagents)
-        if self.max_total_subagents is not None:
-            result["maxTotalSubagents"] = from_union([from_int, from_none], self.max_total_subagents)
-        if self.timeout is not None:
-            result["timeout"] = from_union([to_float, from_none], self.timeout)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class FactoryRunConsumed:
+    """Durable factory resource consumption."""
+
+    active_ms: int
+    nano_aiu: int
+    subagents: int
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'FactoryRunConsumed':
+        assert isinstance(obj, dict)
+        active_ms = from_int(obj.get("activeMs"))
+        nano_aiu = from_int(obj.get("nanoAiu"))
+        subagents = from_int(obj.get("subagents"))
+        return FactoryRunConsumed(active_ms, nano_aiu, subagents)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["activeMs"] = from_int(self.active_ms)
+        result["nanoAiu"] = from_int(self.nano_aiu)
+        result["subagents"] = from_int(self.subagents)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 class FactoryRunStatus(Enum):
-    """Current or terminal factory run status.
+    """Current or terminal state of a factory run.
 
-    Current or terminal state of a factory run.
+    Current or terminal factory run status.
     """
     CANCELLED = "cancelled"
     COMPLETED = "completed"
@@ -2414,6 +2585,87 @@ class FactoryRunStatus(Enum):
     HALTED = "halted"
     PENDING = "pending"
     RUNNING = "running"
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+class FactoryRunFailureKind(Enum):
+    """Resource ceiling that stopped the run.
+
+    Cumulative resource ceiling that stopped a factory run.
+    """
+    MAX_AI_CREDITS = "maxAiCredits"
+    MAX_TOTAL_SUBAGENTS = "maxTotalSubagents"
+    TIMEOUT_SECONDS = "timeoutSeconds"
+
+class FactoryRunFailureType(Enum):
+    FACTORY_DURABLE_FAILURE = "factory_durable_failure"
+    FACTORY_LIMIT_REACHED = "factory_limit_reached"
+    FACTORY_RESUME_DECLINED = "factory_resume_declined"
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+class FactoryLogLineKind(Enum):
+    """Progress line kind.
+
+    Kind of factory progress line.
+
+    Progress record kind.
+    """
+    LOG = "log"
+    PHASE = "phase"
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+class FactoryPhaseStatus(Enum):
+    """Derived lifecycle state of a factory phase."""
+
+    ACTIVE = "active"
+    COMPLETED = "completed"
+    PENDING = "pending"
+    SKIPPED = "skipped"
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class FactoryRunLimits:
+    """Optional per-invocation resource ceiling overrides.
+
+    Wire-only per-invocation factory resource ceiling overrides.
+
+    Per-invocation resource ceiling overrides.
+    """
+    max_ai_credits: float | None = None
+    """Maximum AI credits consumed by factory subagents and their descendants. The post-paid
+    ceiling is soft: parallel turns can settle beyond it before the run stops.
+    """
+    max_concurrent_subagents: int | None = None
+    """Maximum number of factory subagents that may run concurrently."""
+
+    max_total_subagents: int | None = None
+    """Maximum total number of factory subagents that may be admitted."""
+
+    timeout_seconds: float | None = None
+    """Maximum accumulated active-execution time in seconds. Active execution includes the
+    entire extension body, subprocess waits, queued-agent waits, and sleeps; time between
+    resumed attempts is not counted.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'FactoryRunLimits':
+        assert isinstance(obj, dict)
+        max_ai_credits = from_union([from_float, from_none], obj.get("maxAiCredits"))
+        max_concurrent_subagents = from_union([from_int, from_none], obj.get("maxConcurrentSubagents"))
+        max_total_subagents = from_union([from_int, from_none], obj.get("maxTotalSubagents"))
+        timeout_seconds = from_union([from_float, from_none], obj.get("timeoutSeconds"))
+        return FactoryRunLimits(max_ai_credits, max_concurrent_subagents, max_total_subagents, timeout_seconds)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.max_ai_credits is not None:
+            result["maxAiCredits"] = from_union([to_float, from_none], self.max_ai_credits)
+        if self.max_concurrent_subagents is not None:
+            result["maxConcurrentSubagents"] = from_union([from_int, from_none], self.max_concurrent_subagents)
+        if self.max_total_subagents is not None:
+            result["maxTotalSubagents"] = from_union([from_int, from_none], self.max_total_subagents)
+        if self.timeout_seconds is not None:
+            result["timeoutSeconds"] = from_union([to_float, from_none], self.timeout_seconds)
+        return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
@@ -2910,6 +3162,50 @@ class InstructionsGetDiscoveryPathsRequest:
             result["excludeHostInstructions"] = from_union([from_bool, from_none], self.exclude_host_instructions)
         if self.project_paths is not None:
             result["projectPaths"] = from_union([lambda x: from_list(from_str, x), from_none], self.project_paths)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class InterruptMainTurnRequest:
+    """Parameters for interrupting the main agent turn."""
+
+    flush_queued: bool | None = None
+    """When true, the user's queued prompts are preserved and run as the next turn once the
+    interrupted turn unwinds; when false (the default), the queue is cleared like a plain
+    abort.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'InterruptMainTurnRequest':
+        assert isinstance(obj, dict)
+        flush_queued = from_union([from_bool, from_none], obj.get("flushQueued"))
+        return InterruptMainTurnRequest(flush_queued)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.flush_queued is not None:
+            result["flushQueued"] = from_union([from_bool, from_none], self.flush_queued)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class InterruptMainTurnResult:
+    """Result of interrupting the main agent turn."""
+
+    interrupted: bool
+    """Whether an in-flight main agent turn was interrupted. False when the main loop was not
+    processing.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'InterruptMainTurnResult':
+        assert isinstance(obj, dict)
+        interrupted = from_bool(obj.get("interrupted"))
+        return InterruptMainTurnResult(interrupted)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["interrupted"] = from_bool(self.interrupted)
         return result
 
 @dataclass
@@ -4024,6 +4320,46 @@ class MCPOauthLoginResult:
         result: dict = {}
         if self.authorization_url is not None:
             result["authorizationUrl"] = from_union([from_str, from_none], self.authorization_url)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class MCPOauthRespondRequest:
+    """Pending MCP OAuth request id to respond to."""
+
+    request_id: str
+    """OAuth request identifier from the mcp.oauth_required event"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MCPOauthRespondRequest':
+        assert isinstance(obj, dict)
+        request_id = from_str(obj.get("requestId"))
+        return MCPOauthRespondRequest(request_id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["requestId"] = from_str(self.request_id)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class MCPOauthRespondResult:
+    """Indicates whether the pending MCP OAuth response was accepted."""
+
+    success: bool
+    """Whether the response was accepted. False if the request was unknown, timed out, or
+    already resolved.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'MCPOauthRespondResult':
+        assert isinstance(obj, dict)
+        success = from_bool(obj.get("success"))
+        return MCPOauthRespondResult(success)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["success"] = from_bool(self.success)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -6495,6 +6831,168 @@ class PushAttachmentSelectionType(Enum):
     SELECTION = "selection"
 
 # Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class QueueBeginDeferredIdleDrainRequest:
+    """Inputs for starting a deferred-idle drain."""
+
+    active_background_work: bool
+    """Whether the host still has active background work."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'QueueBeginDeferredIdleDrainRequest':
+        assert isinstance(obj, dict)
+        active_background_work = from_bool(obj.get("activeBackgroundWork"))
+        return QueueBeginDeferredIdleDrainRequest(active_background_work)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["activeBackgroundWork"] = from_bool(self.active_background_work)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class QueueBeginDeferredIdleDrainResult:
+    """Whether a deferred-idle drain should run."""
+
+    should_drain: bool
+    """True when the host should run finishDeferredIdleDrain asynchronously."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'QueueBeginDeferredIdleDrainResult':
+        assert isinstance(obj, dict)
+        should_drain = from_bool(obj.get("shouldDrain"))
+        return QueueBeginDeferredIdleDrainResult(should_drain)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["shouldDrain"] = from_bool(self.should_drain)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class QueueConsumeSystemNotificationsRequest:
+    """Internal filter for consuming queued system notifications."""
+
+    filter: Any
+    """Opaque runtime-owned filter object."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'QueueConsumeSystemNotificationsRequest':
+        assert isinstance(obj, dict)
+        filter = obj.get("filter")
+        return QueueConsumeSystemNotificationsRequest(filter)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["filter"] = self.filter
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class QueueDeferSessionIdleRequest:
+    """Inputs for marking session.idle deferred in native state."""
+
+    aborted: bool
+    """Whether the deferred idle was caused by an aborted foreground turn."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'QueueDeferSessionIdleRequest':
+        assert isinstance(obj, dict)
+        aborted = from_bool(obj.get("aborted"))
+        return QueueDeferSessionIdleRequest(aborted)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["aborted"] = from_bool(self.aborted)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class QueueEnqueueResumePendingResult:
+    """Result of enqueueing the resume-pending wake item."""
+
+    queued: bool
+    """True when a wake item was newly queued."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'QueueEnqueueResumePendingResult':
+        assert isinstance(obj, dict)
+        queued = from_bool(obj.get("queued"))
+        return QueueEnqueueResumePendingResult(queued)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["queued"] = from_bool(self.queued)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class QueueFinishDeferredIdleDrainRequest:
+    """Inputs for completing a deferred-idle drain."""
+
+    active_background_work: bool
+    """Whether the host still has active background work."""
+
+    has_pending: bool
+    """Whether native queued work remains."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'QueueFinishDeferredIdleDrainRequest':
+        assert isinstance(obj, dict)
+        active_background_work = from_bool(obj.get("activeBackgroundWork"))
+        has_pending = from_bool(obj.get("hasPending"))
+        return QueueFinishDeferredIdleDrainRequest(active_background_work, has_pending)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["activeBackgroundWork"] = from_bool(self.active_background_work)
+        result["hasPending"] = from_bool(self.has_pending)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class QueueFinishDeferredIdleDrainResult:
+    """Action selected by the native deferred-idle drain."""
+
+    aborted: bool
+    """Whether the deferred idle was caused by an aborted foreground turn."""
+
+    action: str
+    """One of none, processQueue, or emitSessionIdle."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'QueueFinishDeferredIdleDrainResult':
+        assert isinstance(obj, dict)
+        aborted = from_bool(obj.get("aborted"))
+        action = from_str(obj.get("action"))
+        return QueueFinishDeferredIdleDrainResult(aborted, action)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["aborted"] = from_bool(self.aborted)
+        result["action"] = from_str(self.action)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class QueueHasPendingResult:
+    """Whether the native queue has pending work."""
+
+    has_pending: bool
+    """True when queued or immediate native work is pending."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'QueueHasPendingResult':
+        assert isinstance(obj, dict)
+        has_pending = from_bool(obj.get("hasPending"))
+        return QueueHasPendingResult(has_pending)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["hasPending"] = from_bool(self.has_pending)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
 class QueuePendingItemsKind(Enum):
     """Whether this item is a queued user message or a queued slash command / model change"""
 
@@ -7022,8 +7520,124 @@ class SandboxConfigUserPolicySeatbelt:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class ScheduleAddAtRequest:
+    """Register an absolute-time scheduled prompt."""
+
+    at: int
+    """Epoch milliseconds when the prompt should fire."""
+
+    prompt: str
+    """Prompt text to enqueue when the schedule fires."""
+
+    display_prompt: str | None = None
+    """Optional display-only prompt label."""
+
+    recurring: bool | None = None
+    """Whether the schedule should re-arm after each tick. Defaults to false."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ScheduleAddAtRequest':
+        assert isinstance(obj, dict)
+        at = from_int(obj.get("at"))
+        prompt = from_str(obj.get("prompt"))
+        display_prompt = from_union([from_str, from_none], obj.get("displayPrompt"))
+        recurring = from_union([from_bool, from_none], obj.get("recurring"))
+        return ScheduleAddAtRequest(at, prompt, display_prompt, recurring)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["at"] = from_int(self.at)
+        result["prompt"] = from_str(self.prompt)
+        if self.display_prompt is not None:
+            result["displayPrompt"] = from_union([from_str, from_none], self.display_prompt)
+        if self.recurring is not None:
+            result["recurring"] = from_union([from_bool, from_none], self.recurring)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class ScheduleAddCronRequest:
+    """Register a cron scheduled prompt."""
+
+    cron: str
+    """5-field cron expression."""
+
+    prompt: str
+    """Prompt text to enqueue when the schedule fires."""
+
+    display_prompt: str | None = None
+    """Optional display-only prompt label."""
+
+    recurring: bool | None = None
+    """Whether the schedule should re-arm after each tick. Defaults to true."""
+
+    tz: str | None = None
+    """IANA timezone for evaluating the cron expression."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ScheduleAddCronRequest':
+        assert isinstance(obj, dict)
+        cron = from_str(obj.get("cron"))
+        prompt = from_str(obj.get("prompt"))
+        display_prompt = from_union([from_str, from_none], obj.get("displayPrompt"))
+        recurring = from_union([from_bool, from_none], obj.get("recurring"))
+        tz = from_union([from_str, from_none], obj.get("tz"))
+        return ScheduleAddCronRequest(cron, prompt, display_prompt, recurring, tz)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["cron"] = from_str(self.cron)
+        result["prompt"] = from_str(self.prompt)
+        if self.display_prompt is not None:
+            result["displayPrompt"] = from_union([from_str, from_none], self.display_prompt)
+        if self.recurring is not None:
+            result["recurring"] = from_union([from_bool, from_none], self.recurring)
+        if self.tz is not None:
+            result["tz"] = from_union([from_str, from_none], self.tz)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class ScheduleAddRequest:
+    """Register a relative-interval scheduled prompt."""
+
+    interval: str
+    """Human-readable interval such as `30s`, `5m`, or `2h`."""
+
+    prompt: str
+    """Prompt text to enqueue when the schedule fires."""
+
+    display_prompt: str | None = None
+    """Optional display-only prompt label."""
+
+    recurring: bool | None = None
+    """Whether the schedule should re-arm after each tick. Defaults to true."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ScheduleAddRequest':
+        assert isinstance(obj, dict)
+        interval = from_str(obj.get("interval"))
+        prompt = from_str(obj.get("prompt"))
+        display_prompt = from_union([from_str, from_none], obj.get("displayPrompt"))
+        recurring = from_union([from_bool, from_none], obj.get("recurring"))
+        return ScheduleAddRequest(interval, prompt, display_prompt, recurring)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["interval"] = from_str(self.interval)
+        result["prompt"] = from_str(self.prompt)
+        if self.display_prompt is not None:
+            result["displayPrompt"] = from_union([from_str, from_none], self.display_prompt)
+        if self.recurring is not None:
+            result["recurring"] = from_union([from_bool, from_none], self.recurring)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class ScheduleEntry:
-    """Scheduled prompt entry with ID, timing (`intervalMs`, `cron`, or `at`), prompt text,
+    """The registered or updated schedule entry.
+
+    Scheduled prompt entry with ID, timing (`intervalMs`, `cron`, or `at`), prompt text,
     recurrence, and next run time.
 
     The removed entry, or omitted if no entry matched.
@@ -7094,6 +7708,74 @@ class ScheduleEntry:
             result["selfPaced"] = from_union([from_bool, from_none], self.self_paced)
         if self.tz is not None:
             result["tz"] = from_union([from_str, from_none], self.tz)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class ScheduleAddSelfPacedRequest:
+    """Register a self-paced scheduled prompt."""
+
+    prompt: str
+    """Prompt text to enqueue when the schedule fires."""
+
+    display_prompt: str | None = None
+    """Optional display-only prompt label."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ScheduleAddSelfPacedRequest':
+        assert isinstance(obj, dict)
+        prompt = from_str(obj.get("prompt"))
+        display_prompt = from_union([from_str, from_none], obj.get("displayPrompt"))
+        return ScheduleAddSelfPacedRequest(prompt, display_prompt)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["prompt"] = from_str(self.prompt)
+        if self.display_prompt is not None:
+            result["displayPrompt"] = from_union([from_str, from_none], self.display_prompt)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class ScheduleHasSelfPacedResult:
+    """Whether the session currently has an active self-paced schedule."""
+
+    has_self_paced: bool
+    """True when at least one active schedule is self-paced."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ScheduleHasSelfPacedResult':
+        assert isinstance(obj, dict)
+        has_self_paced = from_bool(obj.get("hasSelfPaced"))
+        return ScheduleHasSelfPacedResult(has_self_paced)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["hasSelfPaced"] = from_bool(self.has_self_paced)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class ScheduleRearmSelfPacedRequest:
+    """Re-arm a self-paced scheduled prompt."""
+
+    at: int
+    """Epoch milliseconds when the prompt should next fire."""
+
+    id: int
+    """Id of the self-paced scheduled prompt."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ScheduleRearmSelfPacedRequest':
+        assert isinstance(obj, dict)
+        at = from_int(obj.get("at"))
+        id = from_int(obj.get("id"))
+        return ScheduleRearmSelfPacedRequest(at, id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["at"] = from_int(self.at)
+        result["id"] = from_int(self.id)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -7222,10 +7904,9 @@ class SendMessageItem:
     """
     # Internal: this field is an internal SDK API and is not part of the public surface.
     source: str | None = None
-    """Optional provenance tag copied to the resulting user.message event. Must match one of
-    three forms: the literal `system`, `command-<command-id>` for messages originating from a
-    command (e.g. slash command, Mission Control command), or `schedule-<numeric-id>` for
-    messages originating from a scheduled job.
+    """Optional provenance tag copied to the resulting user.message event. Must be `user`,
+    `system`, `command-<command-id>` for command-originated messages, `schedule-<numeric-id>`
+    for scheduled prompts, or `agent-<agent-id>` for prompts sent by another agent.
     """
 
     @staticmethod
@@ -7303,6 +7984,37 @@ class SendResult:
     def to_dict(self) -> dict:
         result: dict = {}
         result["messageId"] = from_str(self.message_id)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SendSystemNotificationRequest:
+    """Internal request for sending a system notification."""
+
+    message: str
+    """Notification text to deliver to the model."""
+
+    kind: Any = None
+    """Optional structured notification kind."""
+
+    options: Any = None
+    """Internal delivery options, including passive policy."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SendSystemNotificationRequest':
+        assert isinstance(obj, dict)
+        message = from_str(obj.get("message"))
+        kind = obj.get("kind")
+        options = obj.get("options")
+        return SendSystemNotificationRequest(message, kind, options)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["message"] = from_str(self.message)
+        if self.kind is not None:
+            result["kind"] = self.kind
+        if self.options is not None:
+            result["options"] = self.options
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -7779,10 +8491,20 @@ class SessionFSSqliteExistsResult:
 class SessionFSSqliteQueryType(Enum):
     """How to execute the query: 'exec' for DDL/multi-statement (no results), 'query' for SELECT
     (returns rows), 'run' for INSERT/UPDATE/DELETE (returns rowsAffected)
+
+    How to execute the statement.
     """
     EXEC = "exec"
     QUERY = "query"
     RUN = "run"
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+class SessionFSSqliteTransactionErrorClass(Enum):
+    """SQLite transaction failure classification."""
+
+    BUSY_OR_LOCKED = "busyOrLocked"
+    FATAL = "fatal"
+    POST_COMMIT_AMBIGUOUS = "postCommitAmbiguous"
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
@@ -7947,6 +8669,23 @@ class SessionOpenOptionsAdditionalContentExclusionPolicyRuleSource:
         result["name"] = from_str(self.name)
         result["type"] = from_str(self.type)
         return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+class ShellInitProfile(Enum):
+    """Controls automatic non-interactive profile loading where supported. Explicit initScripts
+    are unaffected.
+    """
+    NONE = "none"
+    NON_INTERACTIVE = "non-interactive"
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+class ShellInitScriptShell(Enum):
+    """Built-in shell that may source this script.
+
+    Supported built-in shells for initialization scripts.
+    """
+    BASH = "bash"
+    POWERSHELL = "powershell"
 
 class SessionOpenParamsKind(Enum):
     ATTACH = "attach"
@@ -8509,6 +9248,31 @@ class SessionsCloseResult:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class SessionsDeleteRequest:
+    """Session ID to delete from disk."""
+
+    session_id: str
+    """Session ID to delete"""
+
+    session_path: str | None = None
+    """Internal resolved session directory path to delete"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsDeleteRequest':
+        assert isinstance(obj, dict)
+        session_id = from_str(obj.get("sessionId"))
+        session_path = from_union([from_none, from_str], obj.get("sessionPath"))
+        return SessionsDeleteRequest(session_id, session_path)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["sessionId"] = from_str(self.session_id)
+        if self.session_path is not None:
+            result["sessionPath"] = from_union([from_none, from_str], self.session_path)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class SessionsFindByPrefixRequest:
     """UUID prefix to resolve to a unique session ID."""
 
@@ -8745,6 +9509,25 @@ class SessionsGetLastForContextResult:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class SessionsGetMetadataRequest:
+    """Session ID whose persisted metadata should be read."""
+
+    session_id: str
+    """Session ID to inspect"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsGetMetadataRequest':
+        assert isinstance(obj, dict)
+        session_id = from_str(obj.get("sessionId"))
+        return SessionsGetMetadataRequest(session_id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["sessionId"] = from_str(self.session_id)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class SessionsGetPersistedRemoteSteerableRequest:
     """Session ID to look up the persisted remote-steerable flag for."""
 
@@ -8783,6 +9566,45 @@ class SessionsGetPersistedRemoteSteerableResult:
         result: dict = {}
         if self.remote_steerable is not None:
             result["remoteSteerable"] = from_union([from_bool, from_none], self.remote_steerable)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsListNonEmptySessionIDSRequest:
+    """Limit for non-empty local session IDs."""
+
+    limit: int | None = None
+    """Maximum number of session IDs to return."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsListNonEmptySessionIDSRequest':
+        assert isinstance(obj, dict)
+        limit = from_union([from_int, from_none], obj.get("limit"))
+        return SessionsListNonEmptySessionIDSRequest(limit)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.limit is not None:
+            result["limit"] = from_union([from_int, from_none], self.limit)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsListNonEmptySessionIDSResult:
+    """Recent local session IDs that contain user-visible history."""
+
+    session_ids: list[str]
+    """Session IDs ordered newest-first."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsListNonEmptySessionIDSResult':
+        assert isinstance(obj, dict)
+        session_ids = from_list(from_str, obj.get("sessionIds"))
+        return SessionsListNonEmptySessionIDSResult(session_ids)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["sessionIds"] = from_list(from_str, self.session_ids)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -10532,6 +11354,72 @@ class WorkspaceDiffMode(Enum):
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class WorkspacesAddSummaryRequest:
+    """Compaction summary checkpoint to persist."""
+
+    content: str
+    """Markdown summary content to persist."""
+
+    title: str
+    """Summary title shown in checkpoint listings."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'WorkspacesAddSummaryRequest':
+        assert isinstance(obj, dict)
+        content = from_str(obj.get("content"))
+        title = from_str(obj.get("title"))
+        return WorkspacesAddSummaryRequest(content, title)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["content"] = from_str(self.content)
+        result["title"] = from_str(self.title)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class WorkspacesAddSummaryResult:
+    """Persisted summary metadata and refreshed workspace metadata."""
+
+    summary: dict[str, Any] | None = None
+    workspace: dict[str, Any] | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'WorkspacesAddSummaryResult':
+        assert isinstance(obj, dict)
+        summary = from_union([lambda x: from_dict(lambda x: x, x), from_none], obj.get("summary"))
+        workspace = from_union([lambda x: from_dict(lambda x: x, x), from_none], obj.get("workspace"))
+        return WorkspacesAddSummaryResult(summary, workspace)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.summary is not None:
+            result["summary"] = from_union([lambda x: from_dict(lambda x: x, x), from_none], self.summary)
+        if self.workspace is not None:
+            result["workspace"] = from_union([lambda x: from_dict(lambda x: x, x), from_none], self.workspace)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class WorkspacesAutopilotObjectiveExistsResult:
+    """Whether the autopilot objective file exists."""
+
+    exists: bool
+    """True when the objective file exists."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'WorkspacesAutopilotObjectiveExistsResult':
+        assert isinstance(obj, dict)
+        exists = from_bool(obj.get("exists"))
+        return WorkspacesAutopilotObjectiveExistsResult(exists)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["exists"] = from_bool(self.exists)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class WorkspacesCreateFileRequest:
     """Relative path and UTF-8 content for the workspace file to create or overwrite."""
 
@@ -10556,6 +11444,45 @@ class WorkspacesCreateFileRequest:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class WorkspacesDeleteAutopilotObjectiveResult:
+    """Result of deleting the autopilot objective file."""
+
+    deleted: bool
+    """True when a file was deleted."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'WorkspacesDeleteAutopilotObjectiveResult':
+        assert isinstance(obj, dict)
+        deleted = from_bool(obj.get("deleted"))
+        return WorkspacesDeleteAutopilotObjectiveResult(deleted)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["deleted"] = from_bool(self.deleted)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class WorkspacesEnsureRequest:
+    """Optional session context used when creating a local workspace."""
+
+    context: Any = None
+    """Opaque workspace context supplied by the session host."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'WorkspacesEnsureRequest':
+        assert isinstance(obj, dict)
+        context = obj.get("context")
+        return WorkspacesEnsureRequest(context)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.context is not None:
+            result["context"] = self.context
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class WorkspacesListFilesResult:
     """Relative paths of files stored in the session workspace files directory."""
 
@@ -10571,6 +11498,25 @@ class WorkspacesListFilesResult:
     def to_dict(self) -> dict:
         result: dict = {}
         result["files"] = from_list(from_str, self.files)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class WorkspacesReadAutopilotObjectiveResult:
+    """Autopilot objective file content, or null when missing."""
+
+    content: str | None = None
+    """Autopilot objective file content, or null when missing."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'WorkspacesReadAutopilotObjectiveResult':
+        assert isinstance(obj, dict)
+        content = from_union([from_none, from_str], obj.get("content"))
+        return WorkspacesReadAutopilotObjectiveResult(content)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["content"] = from_union([from_none, from_str], self.content)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -10692,6 +11638,63 @@ class Saved:
         result["filename"] = from_str(self.filename)
         result["filePath"] = from_str(self.file_path)
         result["sizeBytes"] = from_int(self.size_bytes)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class WorkspacesTruncateSummariesRequest:
+    """Rollback point for local workspace summaries."""
+
+    keep_count: int
+    """Number of newest summaries to keep."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'WorkspacesTruncateSummariesRequest':
+        assert isinstance(obj, dict)
+        keep_count = from_int(obj.get("keepCount"))
+        return WorkspacesTruncateSummariesRequest(keep_count)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["keepCount"] = from_int(self.keep_count)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class WorkspacesWriteAutopilotObjectiveRequest:
+    """Autopilot objective file content to persist."""
+
+    content: str
+    """Autopilot objective file content."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'WorkspacesWriteAutopilotObjectiveRequest':
+        assert isinstance(obj, dict)
+        content = from_str(obj.get("content"))
+        return WorkspacesWriteAutopilotObjectiveRequest(content)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["content"] = from_str(self.content)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class WorkspacesWriteAutopilotObjectiveResult:
+    """Result of writing the autopilot objective file."""
+
+    operation: str
+    """Filesystem operation performed."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'WorkspacesWriteAutopilotObjectiveResult':
+        assert isinstance(obj, dict)
+        operation = from_str(obj.get("operation"))
+        return WorkspacesWriteAutopilotObjectiveResult(operation)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["operation"] = from_str(self.operation)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -11953,6 +12956,9 @@ class SlashCommandTextResult:
 class FactoryAgentRequest:
     """Parameters for one factory-scoped subagent call."""
 
+    execution_token: str
+    """Opaque token identifying the current factory execution attempt."""
+
     factory_run_id: str
     """Factory run identifier that owns the subagent."""
 
@@ -11965,16 +12971,74 @@ class FactoryAgentRequest:
     @staticmethod
     def from_dict(obj: Any) -> 'FactoryAgentRequest':
         assert isinstance(obj, dict)
+        execution_token = from_str(obj.get("executionToken"))
         factory_run_id = from_str(obj.get("factoryRunId"))
         opts = FactoryAgentOptions.from_dict(obj.get("opts"))
         prompt = from_str(obj.get("prompt"))
-        return FactoryAgentRequest(factory_run_id, opts, prompt)
+        return FactoryAgentRequest(execution_token, factory_run_id, opts, prompt)
 
     def to_dict(self) -> dict:
         result: dict = {}
+        result["executionToken"] = from_str(self.execution_token)
         result["factoryRunId"] = from_str(self.factory_run_id)
         result["opts"] = to_class(FactoryAgentOptions, self.opts)
         result["prompt"] = from_str(self.prompt)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class FactoryRunFailure:
+    """Machine-readable factory run failure.
+
+    Machine-readable failure details for an errored run.
+    """
+    run_id: str
+    """Factory run identifier.
+
+    Factory run identifier whose changed limits were declined.
+    """
+    type: FactoryRunFailureType
+    kind: FactoryRunFailureKind | None = None
+    """Resource ceiling that stopped the run."""
+
+    value: float | None = None
+    """Approved effective ceiling that was reached."""
+
+    reason: str | None = None
+    """Human-readable reason the resume did not proceed."""
+
+    code: str | None = None
+    """Stable failure code."""
+
+    operation: FactoryDurableOperation | None = None
+    """Execution-critical durable operation that failed."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'FactoryRunFailure':
+        assert isinstance(obj, dict)
+        run_id = from_str(obj.get("runId"))
+        type = FactoryRunFailureType(obj.get("type"))
+        kind = from_union([FactoryRunFailureKind, from_none], obj.get("kind"))
+        value = from_union([from_float, from_none], obj.get("value"))
+        reason = from_union([from_str, from_none], obj.get("reason"))
+        code = from_union([from_str, from_none], obj.get("code"))
+        operation = from_union([FactoryDurableOperation, from_none], obj.get("operation"))
+        return FactoryRunFailure(run_id, type, kind, value, reason, code, operation)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["runId"] = from_str(self.run_id)
+        result["type"] = to_enum(FactoryRunFailureType, self.type)
+        if self.kind is not None:
+            result["kind"] = from_union([lambda x: to_enum(FactoryRunFailureKind, x), from_none], self.kind)
+        if self.value is not None:
+            result["value"] = from_union([to_float, from_none], self.value)
+        if self.reason is not None:
+            result["reason"] = from_union([from_str, from_none], self.reason)
+        if self.code is not None:
+            result["code"] = from_union([from_str, from_none], self.code)
+        if self.operation is not None:
+            result["operation"] = from_union([lambda x: to_enum(FactoryDurableOperation, x), from_none], self.operation)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -12008,46 +13072,128 @@ class FactoryLogLine:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
-class FactoryRunFailure:
-    """Machine-readable factory run failure.
+class FactoryProgressLine:
+    """One durable factory progress record."""
 
-    Machine-readable failure details for an errored run.
-    """
-    run_id: str
-    """Factory run identifier.
+    attempt: int
+    """Resume attempt that emitted this record."""
 
-    Factory run identifier whose changed limits were declined.
-    """
-    type: FactoryRunFailureType
-    kind: FactoryRunFailureKind | None = None
-    """Resource ceiling that stopped the run."""
+    kind: FactoryLogLineKind
+    """Progress record kind."""
 
-    value: float | None = None
-    """Approved effective ceiling that was reached."""
+    recorded_at: int
+    """Epoch milliseconds when the record was persisted."""
 
-    reason: str | None = None
-    """Human-readable reason the resume did not proceed."""
+    seq: int
+    """Global monotonic sequence number within the run."""
+
+    text: str
+    """Prompt-safe progress text."""
+
+    phase_id: str | None = None
+    """Phase active when the record was emitted, or null before any phase."""
 
     @staticmethod
-    def from_dict(obj: Any) -> 'FactoryRunFailure':
+    def from_dict(obj: Any) -> 'FactoryProgressLine':
+        assert isinstance(obj, dict)
+        attempt = from_int(obj.get("attempt"))
+        kind = FactoryLogLineKind(obj.get("kind"))
+        recorded_at = from_int(obj.get("recordedAt"))
+        seq = from_int(obj.get("seq"))
+        text = from_str(obj.get("text"))
+        phase_id = from_union([from_none, from_str], obj.get("phaseId"))
+        return FactoryProgressLine(attempt, kind, recorded_at, seq, text, phase_id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["attempt"] = from_int(self.attempt)
+        result["kind"] = to_enum(FactoryLogLineKind, self.kind)
+        result["recordedAt"] = from_int(self.recorded_at)
+        result["seq"] = from_int(self.seq)
+        result["text"] = from_str(self.text)
+        result["phaseId"] = from_union([from_none, from_str], self.phase_id)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class FactoryPhaseObservation:
+    """Durable lifecycle and timing for one factory phase."""
+
+    accumulated_active_ms: int
+    current_active_ms: int
+    entry_count: int
+    id: str
+    last_entered_run_attempt: int
+    live_agent_count: int
+    status: FactoryPhaseStatus
+    title: str
+    total_agent_count: int
+    completed_at: int | None = None
+    detail: str | None = None
+    ordinal: int | None = None
+    started_at: int | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'FactoryPhaseObservation':
+        assert isinstance(obj, dict)
+        accumulated_active_ms = from_int(obj.get("accumulatedActiveMs"))
+        current_active_ms = from_int(obj.get("currentActiveMs"))
+        entry_count = from_int(obj.get("entryCount"))
+        id = from_str(obj.get("id"))
+        last_entered_run_attempt = from_int(obj.get("lastEnteredRunAttempt"))
+        live_agent_count = from_int(obj.get("liveAgentCount"))
+        status = FactoryPhaseStatus(obj.get("status"))
+        title = from_str(obj.get("title"))
+        total_agent_count = from_int(obj.get("totalAgentCount"))
+        completed_at = from_union([from_int, from_none], obj.get("completedAt"))
+        detail = from_union([from_str, from_none], obj.get("detail"))
+        ordinal = from_union([from_none, from_int], obj.get("ordinal"))
+        started_at = from_union([from_int, from_none], obj.get("startedAt"))
+        return FactoryPhaseObservation(accumulated_active_ms, current_active_ms, entry_count, id, last_entered_run_attempt, live_agent_count, status, title, total_agent_count, completed_at, detail, ordinal, started_at)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["accumulatedActiveMs"] = from_int(self.accumulated_active_ms)
+        result["currentActiveMs"] = from_int(self.current_active_ms)
+        result["entryCount"] = from_int(self.entry_count)
+        result["id"] = from_str(self.id)
+        result["lastEnteredRunAttempt"] = from_int(self.last_entered_run_attempt)
+        result["liveAgentCount"] = from_int(self.live_agent_count)
+        result["status"] = to_enum(FactoryPhaseStatus, self.status)
+        result["title"] = from_str(self.title)
+        result["totalAgentCount"] = from_int(self.total_agent_count)
+        if self.completed_at is not None:
+            result["completedAt"] = from_union([from_int, from_none], self.completed_at)
+        if self.detail is not None:
+            result["detail"] = from_union([from_str, from_none], self.detail)
+        result["ordinal"] = from_union([from_none, from_int], self.ordinal)
+        if self.started_at is not None:
+            result["startedAt"] = from_union([from_int, from_none], self.started_at)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class FactoryResumeRequest:
+    """Parameters for resuming a factory run from its persisted identity."""
+
+    run_id: str
+    """Factory run identifier."""
+
+    limits: FactoryRunLimits | None = None
+    """Optional per-invocation resource ceiling overrides."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'FactoryResumeRequest':
         assert isinstance(obj, dict)
         run_id = from_str(obj.get("runId"))
-        type = FactoryRunFailureType(obj.get("type"))
-        kind = from_union([FactoryRunFailureKind, from_none], obj.get("kind"))
-        value = from_union([from_float, from_none], obj.get("value"))
-        reason = from_union([from_str, from_none], obj.get("reason"))
-        return FactoryRunFailure(run_id, type, kind, value, reason)
+        limits = from_union([FactoryRunLimits.from_dict, from_none], obj.get("limits"))
+        return FactoryResumeRequest(run_id, limits)
 
     def to_dict(self) -> dict:
         result: dict = {}
         result["runId"] = from_str(self.run_id)
-        result["type"] = to_enum(FactoryRunFailureType, self.type)
-        if self.kind is not None:
-            result["kind"] = from_union([lambda x: to_enum(FactoryRunFailureKind, x), from_none], self.kind)
-        if self.value is not None:
-            result["value"] = from_union([to_float, from_none], self.value)
-        if self.reason is not None:
-            result["reason"] = from_union([from_str, from_none], self.reason)
+        if self.limits is not None:
+            result["limits"] = from_union([lambda x: to_class(FactoryRunLimits, x), from_none], self.limits)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -12149,11 +13295,11 @@ class _HookInvokeRequest:
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
 class InstalledPluginSource:
-    """Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref,
-    and optional subpath.
+    """Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref or
+    full commit SHA, and optional subpath.
 
-    Source descriptor for a direct URL plugin install, with URL, optional ref, and optional
-    subpath.
+    Source descriptor for a direct URL plugin install, with URL, optional ref or full commit
+    SHA, and optional subpath.
 
     Source descriptor for a direct local plugin install, with a local filesystem path.
     """
@@ -12167,6 +13313,9 @@ class InstalledPluginSource:
     path: str | None = None
     ref: str | None = None
     repo: str | None = None
+    sha: str | None = None
+    """Optional full 40-character hexadecimal commit SHA."""
+
     url: str | None = None
 
     @staticmethod
@@ -12176,8 +13325,9 @@ class InstalledPluginSource:
         path = from_union([from_str, from_none], obj.get("path"))
         ref = from_union([from_str, from_none], obj.get("ref"))
         repo = from_union([from_str, from_none], obj.get("repo"))
+        sha = from_union([from_str, from_none], obj.get("sha"))
         url = from_union([from_str, from_none], obj.get("url"))
-        return InstalledPluginSource(source, path, ref, repo, url)
+        return InstalledPluginSource(source, path, ref, repo, sha, url)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -12188,6 +13338,8 @@ class InstalledPluginSource:
             result["ref"] = from_union([from_str, from_none], self.ref)
         if self.repo is not None:
             result["repo"] = from_union([from_str, from_none], self.repo)
+        if self.sha is not None:
+            result["sha"] = from_union([from_str, from_none], self.sha)
         if self.url is not None:
             result["url"] = from_union([from_str, from_none], self.url)
         return result
@@ -12195,11 +13347,11 @@ class InstalledPluginSource:
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
 class SessionInstalledPluginSource:
-    """Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref,
-    and optional subpath.
+    """Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref or
+    full commit SHA, and optional subpath.
 
-    Source descriptor for a direct URL plugin install, with URL, optional ref, and optional
-    subpath.
+    Source descriptor for a direct URL plugin install, with URL, optional ref or full commit
+    SHA, and optional subpath.
 
     Source descriptor for a direct local plugin install, with a local filesystem path.
     """
@@ -12213,6 +13365,9 @@ class SessionInstalledPluginSource:
     path: str | None = None
     ref: str | None = None
     repo: str | None = None
+    sha: str | None = None
+    """Optional full 40-character hexadecimal commit SHA."""
+
     url: str | None = None
 
     @staticmethod
@@ -12222,8 +13377,9 @@ class SessionInstalledPluginSource:
         path = from_union([from_str, from_none], obj.get("path"))
         ref = from_union([from_str, from_none], obj.get("ref"))
         repo = from_union([from_str, from_none], obj.get("repo"))
+        sha = from_union([from_str, from_none], obj.get("sha"))
         url = from_union([from_str, from_none], obj.get("url"))
-        return SessionInstalledPluginSource(source, path, ref, repo, url)
+        return SessionInstalledPluginSource(source, path, ref, repo, sha, url)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -12234,6 +13390,8 @@ class SessionInstalledPluginSource:
             result["ref"] = from_union([from_str, from_none], self.ref)
         if self.repo is not None:
             result["repo"] = from_union([from_str, from_none], self.repo)
+        if self.sha is not None:
+            result["sha"] = from_union([from_str, from_none], self.sha)
         if self.url is not None:
             result["url"] = from_union([from_str, from_none], self.url)
         return result
@@ -12241,8 +13399,8 @@ class SessionInstalledPluginSource:
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
 class InstalledPluginSourceGitHub:
-    """Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref,
-    and optional subpath.
+    """Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref or
+    full commit SHA, and optional subpath.
     """
     repo: str
     source: FluffySource
@@ -12250,6 +13408,8 @@ class InstalledPluginSourceGitHub:
 
     path: str | None = None
     ref: str | None = None
+    sha: str | None = None
+    """Optional full 40-character hexadecimal commit SHA."""
 
     @staticmethod
     def from_dict(obj: Any) -> 'InstalledPluginSourceGitHub':
@@ -12258,7 +13418,8 @@ class InstalledPluginSourceGitHub:
         source = FluffySource(obj.get("source"))
         path = from_union([from_str, from_none], obj.get("path"))
         ref = from_union([from_str, from_none], obj.get("ref"))
-        return InstalledPluginSourceGitHub(repo, source, path, ref)
+        sha = from_union([from_str, from_none], obj.get("sha"))
+        return InstalledPluginSourceGitHub(repo, source, path, ref, sha)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -12268,13 +13429,15 @@ class InstalledPluginSourceGitHub:
             result["path"] = from_union([from_str, from_none], self.path)
         if self.ref is not None:
             result["ref"] = from_union([from_str, from_none], self.ref)
+        if self.sha is not None:
+            result["sha"] = from_union([from_str, from_none], self.sha)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
 class SessionInstalledPluginSourceGitHub:
-    """Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref,
-    and optional subpath.
+    """Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref or
+    full commit SHA, and optional subpath.
     """
     repo: str
     source: FluffySource
@@ -12282,6 +13445,8 @@ class SessionInstalledPluginSourceGitHub:
 
     path: str | None = None
     ref: str | None = None
+    sha: str | None = None
+    """Optional full 40-character hexadecimal commit SHA."""
 
     @staticmethod
     def from_dict(obj: Any) -> 'SessionInstalledPluginSourceGitHub':
@@ -12290,7 +13455,8 @@ class SessionInstalledPluginSourceGitHub:
         source = FluffySource(obj.get("source"))
         path = from_union([from_str, from_none], obj.get("path"))
         ref = from_union([from_str, from_none], obj.get("ref"))
-        return SessionInstalledPluginSourceGitHub(repo, source, path, ref)
+        sha = from_union([from_str, from_none], obj.get("sha"))
+        return SessionInstalledPluginSourceGitHub(repo, source, path, ref, sha)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -12300,6 +13466,8 @@ class SessionInstalledPluginSourceGitHub:
             result["path"] = from_union([from_str, from_none], self.path)
         if self.ref is not None:
             result["ref"] = from_union([from_str, from_none], self.ref)
+        if self.sha is not None:
+            result["sha"] = from_union([from_str, from_none], self.sha)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -12349,8 +13517,8 @@ class SessionInstalledPluginSourceLocal:
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
 class InstalledPluginSourceURL:
-    """Source descriptor for a direct URL plugin install, with URL, optional ref, and optional
-    subpath.
+    """Source descriptor for a direct URL plugin install, with URL, optional ref or full commit
+    SHA, and optional subpath.
     """
     source: StickySource
     """Constant value. Always "url"."""
@@ -12358,6 +13526,8 @@ class InstalledPluginSourceURL:
     url: str
     path: str | None = None
     ref: str | None = None
+    sha: str | None = None
+    """Optional full 40-character hexadecimal commit SHA."""
 
     @staticmethod
     def from_dict(obj: Any) -> 'InstalledPluginSourceURL':
@@ -12366,7 +13536,8 @@ class InstalledPluginSourceURL:
         url = from_str(obj.get("url"))
         path = from_union([from_str, from_none], obj.get("path"))
         ref = from_union([from_str, from_none], obj.get("ref"))
-        return InstalledPluginSourceURL(source, url, path, ref)
+        sha = from_union([from_str, from_none], obj.get("sha"))
+        return InstalledPluginSourceURL(source, url, path, ref, sha)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -12376,13 +13547,15 @@ class InstalledPluginSourceURL:
             result["path"] = from_union([from_str, from_none], self.path)
         if self.ref is not None:
             result["ref"] = from_union([from_str, from_none], self.ref)
+        if self.sha is not None:
+            result["sha"] = from_union([from_str, from_none], self.sha)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
 class SessionInstalledPluginSourceURL:
-    """Source descriptor for a direct URL plugin install, with URL, optional ref, and optional
-    subpath.
+    """Source descriptor for a direct URL plugin install, with URL, optional ref or full commit
+    SHA, and optional subpath.
     """
     source: StickySource
     """Constant value. Always "url"."""
@@ -12390,6 +13563,8 @@ class SessionInstalledPluginSourceURL:
     url: str
     path: str | None = None
     ref: str | None = None
+    sha: str | None = None
+    """Optional full 40-character hexadecimal commit SHA."""
 
     @staticmethod
     def from_dict(obj: Any) -> 'SessionInstalledPluginSourceURL':
@@ -12398,7 +13573,8 @@ class SessionInstalledPluginSourceURL:
         url = from_str(obj.get("url"))
         path = from_union([from_str, from_none], obj.get("path"))
         ref = from_union([from_str, from_none], obj.get("ref"))
-        return SessionInstalledPluginSourceURL(source, url, path, ref)
+        sha = from_union([from_str, from_none], obj.get("sha"))
+        return SessionInstalledPluginSourceURL(source, url, path, ref, sha)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -12408,6 +13584,8 @@ class SessionInstalledPluginSourceURL:
             result["path"] = from_union([from_str, from_none], self.path)
         if self.ref is not None:
             result["ref"] = from_union([from_str, from_none], self.ref)
+        if self.sha is not None:
+            result["sha"] = from_union([from_str, from_none], self.sha)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -16536,6 +17714,32 @@ class SandboxConfigUserPolicyExperimental:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class ScheduleAddResult:
+    """Result of registering or re-arming a scheduled prompt."""
+
+    entry: ScheduleEntry | None = None
+    """The registered or updated schedule entry."""
+
+    error: str | None = None
+    """User-facing validation error, when registration failed."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ScheduleAddResult':
+        assert isinstance(obj, dict)
+        entry = from_union([ScheduleEntry.from_dict, from_none], obj.get("entry"))
+        error = from_union([from_str, from_none], obj.get("error"))
+        return ScheduleAddResult(entry, error)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.entry is not None:
+            result["entry"] = from_union([lambda x: to_class(ScheduleEntry, x), from_none], self.entry)
+        if self.error is not None:
+            result["error"] = from_union([from_str, from_none], self.error)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class ScheduleList:
     """Snapshot of the currently active recurring prompts for this session."""
 
@@ -16685,10 +17889,9 @@ class SendRequest:
     """
     # Internal: this field is an internal SDK API and is not part of the public surface.
     source: str | None = None
-    """Optional provenance tag copied to the resulting user.message event. Must match one of
-    three forms: the literal `system`, `command-<command-id>` for messages originating from a
-    command (e.g. slash command, Mission Control command), or `schedule-<numeric-id>` for
-    messages originating from a scheduled job.
+    """Optional provenance tag copied to the resulting user.message event. Must be `user`,
+    `system`, `command-<command-id>` for command-originated messages, `schedule-<numeric-id>`
+    for scheduled prompts, or `agent-<agent-id>` for prompts sent by another agent.
     """
     traceparent: str | None = None
     """W3C Trace Context traceparent header for distributed tracing of this agent turn"""
@@ -16841,7 +18044,7 @@ class SessionFSSetProviderRequest:
 @dataclass
 class SessionFSSqliteQueryRequest:
     """SQL query, query type, and optional bind parameters for executing a SQLite query against
-    the per-session database.
+    the per-session database. The provider applies its SQLite busy timeout for every call.
     """
     query: str
     """SQL query to execute"""
@@ -16876,6 +18079,58 @@ class SessionFSSqliteQueryRequest:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class SessionFSSqliteTransactionStatement:
+    """One statement in an atomic SQLite transaction."""
+
+    query: str
+    """SQL statement to execute."""
+
+    query_type: SessionFSSqliteQueryType
+    """How to execute the statement."""
+
+    params: dict[str, Any] | None = None
+    """Optional named bind parameters."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionFSSqliteTransactionStatement':
+        assert isinstance(obj, dict)
+        query = from_str(obj.get("query"))
+        query_type = SessionFSSqliteQueryType(obj.get("queryType"))
+        params = from_union([lambda x: from_dict(lambda x: x, x), from_none], obj.get("params"))
+        return SessionFSSqliteTransactionStatement(query, query_type, params)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["query"] = from_str(self.query)
+        result["queryType"] = to_enum(SessionFSSqliteQueryType, self.query_type)
+        if self.params is not None:
+            result["params"] = from_union([lambda x: from_dict(lambda x: x, x), from_none], self.params)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionFSSqliteTransactionError:
+    """Classified SQLite transaction failure. busyOrLocked guarantees rollback;
+    postCommitAmbiguous must never be retried.
+    """
+    error_class: SessionFSSqliteTransactionErrorClass
+    message: str
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionFSSqliteTransactionError':
+        assert isinstance(obj, dict)
+        error_class = SessionFSSqliteTransactionErrorClass(obj.get("errorClass"))
+        message = from_str(obj.get("message"))
+        return SessionFSSqliteTransactionError(error_class, message)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["errorClass"] = to_enum(SessionFSSqliteTransactionErrorClass, self.error_class)
+        result["message"] = from_str(self.message)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class SessionOpenOptionsAdditionalContentExclusionPolicyRule:
     """Single content-exclusion rule supplied to `sessions.open` options, with paths, match
     conditions, and source.
@@ -16904,6 +18159,31 @@ class SessionOpenOptionsAdditionalContentExclusionPolicyRule:
             result["ifAnyMatch"] = from_union([lambda x: from_list(from_str, x), from_none], self.if_any_match)
         if self.if_none_match is not None:
             result["ifNoneMatch"] = from_union([lambda x: from_list(from_str, x), from_none], self.if_none_match)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class ShellInitScript:
+    """A host-provided script sourced before each built-in shell command when its shell target
+    matches the active shell.
+    """
+    path: str
+    """Path to the script to source."""
+
+    shell: ShellInitScriptShell
+    """Built-in shell that may source this script."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ShellInitScript':
+        assert isinstance(obj, dict)
+        path = from_str(obj.get("path"))
+        shell = ShellInitScriptShell(obj.get("shell"))
+        return ShellInitScript(path, shell)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["path"] = from_str(self.path)
+        result["shell"] = to_enum(ShellInitScriptShell, self.shell)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -18339,6 +19619,12 @@ class UIExitPlanModeResponse:
     auto_approve_edits: bool | None = None
     """Whether subsequent edits should be auto-approved without confirmation."""
 
+    defer_implementation: bool | None = None
+    """When true, the agent is instructed to end its turn without starting implementation so the
+    client can restore the session model and auto-submit a fresh implementation turn on it.
+    Set only when a distinct plan configuration (a different model, reasoning effort, or
+    context tier) actually ran the planning turn.
+    """
     feedback: str | None = None
     """Feedback from the user when they declined the plan or requested changes."""
 
@@ -18352,15 +19638,18 @@ class UIExitPlanModeResponse:
         assert isinstance(obj, dict)
         approved = from_bool(obj.get("approved"))
         auto_approve_edits = from_union([from_bool, from_none], obj.get("autoApproveEdits"))
+        defer_implementation = from_union([from_bool, from_none], obj.get("deferImplementation"))
         feedback = from_union([from_str, from_none], obj.get("feedback"))
         selected_action = from_union([UIExitPlanModeAction, from_none], obj.get("selectedAction"))
-        return UIExitPlanModeResponse(approved, auto_approve_edits, feedback, selected_action)
+        return UIExitPlanModeResponse(approved, auto_approve_edits, defer_implementation, feedback, selected_action)
 
     def to_dict(self) -> dict:
         result: dict = {}
         result["approved"] = from_bool(self.approved)
         if self.auto_approve_edits is not None:
             result["autoApproveEdits"] = from_union([from_bool, from_none], self.auto_approve_edits)
+        if self.defer_implementation is not None:
+            result["deferImplementation"] = from_union([from_bool, from_none], self.defer_implementation)
         if self.feedback is not None:
             result["feedback"] = from_union([from_str, from_none], self.feedback)
         if self.selected_action is not None:
@@ -19146,33 +20435,42 @@ class ExternalToolTextResultForLlmContentResourceLink:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
-class FactoryLogRequest:
-    """Parameters for recording factory progress."""
+class FactoryRunTerminal:
+    """Prompt-safe terminal factory outcome."""
 
-    lines: list[FactoryLogLine]
-    """Ordered progress lines to append."""
-
-    run_id: str
-    """Factory run identifier."""
+    error: str | None = None
+    failure: FactoryRunFailure | None = None
+    reason: str | None = None
+    result_preview: str | None = None
 
     @staticmethod
-    def from_dict(obj: Any) -> 'FactoryLogRequest':
+    def from_dict(obj: Any) -> 'FactoryRunTerminal':
         assert isinstance(obj, dict)
-        lines = from_list(FactoryLogLine.from_dict, obj.get("lines"))
-        run_id = from_str(obj.get("runId"))
-        return FactoryLogRequest(lines, run_id)
+        error = from_union([from_str, from_none], obj.get("error"))
+        failure = from_union([FactoryRunFailure.from_dict, from_none], obj.get("failure"))
+        reason = from_union([from_str, from_none], obj.get("reason"))
+        result_preview = from_union([from_str, from_none], obj.get("resultPreview"))
+        return FactoryRunTerminal(error, failure, reason, result_preview)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["lines"] = from_list(lambda x: to_class(FactoryLogLine, x), self.lines)
-        result["runId"] = from_str(self.run_id)
+        if self.error is not None:
+            result["error"] = from_union([from_str, from_none], self.error)
+        if self.failure is not None:
+            result["failure"] = from_union([lambda x: to_class(FactoryRunFailure, x), from_none], self.failure)
+        if self.reason is not None:
+            result["reason"] = from_union([from_str, from_none], self.reason)
+        if self.result_preview is not None:
+            result["resultPreview"] = from_union([from_str, from_none], self.result_preview)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
 class FactoryRunResult:
-    """Complete current or terminal factory run envelope."""
+    """Terminal resumed run envelope.
 
+    Complete current or terminal factory run envelope.
+    """
     run_id: str
     """Factory run identifier."""
 
@@ -19220,6 +20518,70 @@ class FactoryRunResult:
             result["result"] = self.result
         if self.snapshot is not None:
             result["snapshot"] = self.snapshot
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class FactoryLogRequest:
+    """Parameters for recording factory progress."""
+
+    execution_token: str
+    """Opaque token identifying the current factory execution attempt."""
+
+    lines: list[FactoryLogLine]
+    """Ordered progress lines to append."""
+
+    run_id: str
+    """Factory run identifier."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'FactoryLogRequest':
+        assert isinstance(obj, dict)
+        execution_token = from_str(obj.get("executionToken"))
+        lines = from_list(FactoryLogLine.from_dict, obj.get("lines"))
+        run_id = from_str(obj.get("runId"))
+        return FactoryLogRequest(execution_token, lines, run_id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["executionToken"] = from_str(self.execution_token)
+        result["lines"] = from_list(lambda x: to_class(FactoryLogLine, x), self.lines)
+        result["runId"] = from_str(self.run_id)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class FactoryProgressPage:
+    """A bidirectional page of factory progress."""
+
+    has_more_newer: bool
+    has_more_older: bool
+    records: list[FactoryProgressLine]
+    revision: int
+    """Run revision reflected by this page."""
+
+    newest_seq: int | None = None
+    oldest_seq: int | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'FactoryProgressPage':
+        assert isinstance(obj, dict)
+        has_more_newer = from_bool(obj.get("hasMoreNewer"))
+        has_more_older = from_bool(obj.get("hasMoreOlder"))
+        records = from_list(FactoryProgressLine.from_dict, obj.get("records"))
+        revision = from_int(obj.get("revision"))
+        newest_seq = from_union([from_int, from_none], obj.get("newestSeq"))
+        oldest_seq = from_union([from_int, from_none], obj.get("oldestSeq"))
+        return FactoryProgressPage(has_more_newer, has_more_older, records, revision, newest_seq, oldest_seq)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["hasMoreNewer"] = from_bool(self.has_more_newer)
+        result["hasMoreOlder"] = from_bool(self.has_more_older)
+        result["records"] = from_list(lambda x: to_class(FactoryProgressLine, x), self.records)
+        result["revision"] = from_int(self.revision)
+        result["newestSeq"] = from_union([from_int, from_none], self.newest_seq)
+        result["oldestSeq"] = from_union([from_int, from_none], self.oldest_seq)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -19401,6 +20763,8 @@ class ServerInstructionSourceList:
 class LocalSessionMetadataValue:
     """Persisted local session metadata, including identifiers, timestamps, summary/name,
     client, context, detached state, and task ID.
+
+    Local session metadata, omitted when the session does not exist.
     """
     is_remote: bool
     """Always false for local sessions."""
@@ -19784,6 +21148,32 @@ class WorkspacesGetWorkspaceResult:
         if self.path is not None:
             result["path"] = from_union([from_str, from_none], self.path)
         result["workspace"] = from_union([lambda x: to_class(Workspace, x), from_none], self.workspace)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class WorkspacesUpdateMetadataRequest:
+    """Workspace metadata fields to update."""
+
+    context: Any = None
+    """Opaque workspace context supplied by the session host."""
+
+    name: str | None = None
+    """Optional workspace display name override."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'WorkspacesUpdateMetadataRequest':
+        assert isinstance(obj, dict)
+        context = obj.get("context")
+        name = from_union([from_str, from_none], obj.get("name"))
+        return WorkspacesUpdateMetadataRequest(context, name)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.context is not None:
+            result["context"] = self.context
+        if self.name is not None:
+            result["name"] = from_union([from_str, from_none], self.name)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -20585,6 +21975,42 @@ class QueuePendingItemsResult:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class QueueSnapshotResult:
+    """Internal snapshot of native queue state for local session orchestration."""
+
+    items: list[QueuePendingItems]
+    """User-facing pending items in FIFO order."""
+
+    steering_messages: list[str]
+    """Immediate steering messages waiting for an active turn."""
+
+    item_orders: list[int] | None = None
+    """Insertion orders for queued items, aligned with `items`."""
+
+    steering_message_orders: list[int] | None = None
+    """Insertion orders for immediate steering messages, aligned with `steeringMessages`."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'QueueSnapshotResult':
+        assert isinstance(obj, dict)
+        items = from_list(QueuePendingItems.from_dict, obj.get("items"))
+        steering_messages = from_list(from_str, obj.get("steeringMessages"))
+        item_orders = from_union([lambda x: from_list(from_int, x), from_none], obj.get("itemOrders"))
+        steering_message_orders = from_union([lambda x: from_list(from_int, x), from_none], obj.get("steeringMessageOrders"))
+        return QueueSnapshotResult(items, steering_messages, item_orders, steering_message_orders)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["items"] = from_list(lambda x: to_class(QueuePendingItems, x), self.items)
+        result["steeringMessages"] = from_list(from_str, self.steering_messages)
+        if self.item_orders is not None:
+            result["itemOrders"] = from_union([lambda x: from_list(from_int, x), from_none], self.item_orders)
+        if self.steering_message_orders is not None:
+            result["steeringMessageOrders"] = from_union([lambda x: from_list(from_int, x), from_none], self.steering_message_orders)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class SessionsStartRemoteControlRequest:
     """Parameters for attaching the remote-control singleton to a session."""
 
@@ -20785,6 +22211,29 @@ class SessionFSStatResult:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class SessionFSSqliteTransactionRequest:
+    """Statements to execute atomically. Providers apply busy handling for every call."""
+
+    session_id: str
+    """Target session identifier"""
+
+    statements: list[SessionFSSqliteTransactionStatement]
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionFSSqliteTransactionRequest':
+        assert isinstance(obj, dict)
+        session_id = from_str(obj.get("sessionId"))
+        statements = from_list(SessionFSSqliteTransactionStatement.from_dict, obj.get("statements"))
+        return SessionFSSqliteTransactionRequest(session_id, statements)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["sessionId"] = from_str(self.session_id)
+        result["statements"] = from_list(lambda x: to_class(SessionFSSqliteTransactionStatement, x), self.statements)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class SessionOpenOptionsAdditionalContentExclusionPolicy:
     """Content-exclusion policy supplied to `sessions.open` options, with rules, last-updated
     data, and scope.
@@ -20809,6 +22258,57 @@ class SessionOpenOptionsAdditionalContentExclusionPolicy:
         result["last_updated_at"] = self.last_updated_at
         result["rules"] = from_list(lambda x: to_class(SessionOpenOptionsAdditionalContentExclusionPolicyRule, x), self.rules)
         result["scope"] = to_enum(AdditionalContentExclusionPolicyScope, self.scope)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class ShellOptions:
+    """Per-session settings for built-in shell tools."""
+
+    init_profile: ShellInitProfile | None = None
+    """Controls automatic non-interactive profile loading where supported. Explicit initScripts
+    are unaffected.
+    """
+    init_scripts: list[ShellInitScript] | None = None
+    """Ordered host-provided script paths sourced before each built-in shell command when the
+    entry's shell target matches the active shell. Use these for rc files, environment setup
+    scripts,
+    or other custom scripts. A script that returns a nonzero status is reported, and later
+    scripts
+    and the user command continue while the shell remains running. Because scripts are
+    sourced into
+    the command shell, `exit`, `exec`, failures under `set -e`, or other shell-terminating
+    behavior
+    can prevent continuation. Script standard output is preserved; Bash script stderr is
+    discarded,
+    PowerShell exception messages are replaced, and runtime-generated failure notices omit
+    configured script paths. When sandboxing is enabled, each script must already be readable
+    under
+    the active sandbox filesystem policy. Pass an empty array to clear the list.
+    """
+    process_flags: list[str] | None = None
+    """Flags passed to the active built-in shell process on startup, replacing its default
+    flags.
+    When omitted, the built-in Bash shell uses `--norc --noprofile`,
+    and the built-in PowerShell shell uses `-NoProfile -NoLogo`.
+    """
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ShellOptions':
+        assert isinstance(obj, dict)
+        init_profile = from_union([ShellInitProfile, from_none], obj.get("initProfile"))
+        init_scripts = from_union([lambda x: from_list(ShellInitScript.from_dict, x), from_none], obj.get("initScripts"))
+        process_flags = from_union([lambda x: from_list(from_str, x), from_none], obj.get("processFlags"))
+        return ShellOptions(init_profile, init_scripts, process_flags)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.init_profile is not None:
+            result["initProfile"] = from_union([lambda x: to_enum(ShellInitProfile, x), from_none], self.init_profile)
+        if self.init_scripts is not None:
+            result["initScripts"] = from_union([lambda x: from_list(lambda x: to_class(ShellInitScript, x), x), from_none], self.init_scripts)
+        if self.process_flags is not None:
+            result["processFlags"] = from_union([lambda x: from_list(from_str, x), from_none], self.process_flags)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -21681,6 +23181,183 @@ class HandlePendingToolCallRequest:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class FactoryRunSummary:
+    """Durable factory run summary with read-time live overlays."""
+
+    consumed: FactoryRunConsumed
+    created_at: int
+    declared_limits: FactoryDeclaredLimits
+    declared_phase_count: int
+    description: str
+    factory_name: str
+    live_agent_count: int
+    observed_at: int
+    revision: int
+    run_id: str
+    status: FactoryRunStatus
+    total_spawned_agent_count: int
+    updated_at: int
+    active_segment_started_at: int | None = None
+    approved: FactoryDeclaredLimits | None = None
+    completed_at: int | None = None
+    current_phase: FactoryCurrentPhase | None = None
+    started_at: int | None = None
+    terminal: FactoryRunTerminal | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'FactoryRunSummary':
+        assert isinstance(obj, dict)
+        consumed = FactoryRunConsumed.from_dict(obj.get("consumed"))
+        created_at = from_int(obj.get("createdAt"))
+        declared_limits = FactoryDeclaredLimits.from_dict(obj.get("declaredLimits"))
+        declared_phase_count = from_int(obj.get("declaredPhaseCount"))
+        description = from_str(obj.get("description"))
+        factory_name = from_str(obj.get("factoryName"))
+        live_agent_count = from_int(obj.get("liveAgentCount"))
+        observed_at = from_int(obj.get("observedAt"))
+        revision = from_int(obj.get("revision"))
+        run_id = from_str(obj.get("runId"))
+        status = FactoryRunStatus(obj.get("status"))
+        total_spawned_agent_count = from_int(obj.get("totalSpawnedAgentCount"))
+        updated_at = from_int(obj.get("updatedAt"))
+        active_segment_started_at = from_union([from_int, from_none], obj.get("activeSegmentStartedAt"))
+        approved = from_union([FactoryDeclaredLimits.from_dict, from_none], obj.get("approved"))
+        completed_at = from_union([from_int, from_none], obj.get("completedAt"))
+        current_phase = from_union([FactoryCurrentPhase.from_dict, from_none], obj.get("currentPhase"))
+        started_at = from_union([from_int, from_none], obj.get("startedAt"))
+        terminal = from_union([FactoryRunTerminal.from_dict, from_none], obj.get("terminal"))
+        return FactoryRunSummary(consumed, created_at, declared_limits, declared_phase_count, description, factory_name, live_agent_count, observed_at, revision, run_id, status, total_spawned_agent_count, updated_at, active_segment_started_at, approved, completed_at, current_phase, started_at, terminal)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["consumed"] = to_class(FactoryRunConsumed, self.consumed)
+        result["createdAt"] = from_int(self.created_at)
+        result["declaredLimits"] = to_class(FactoryDeclaredLimits, self.declared_limits)
+        result["declaredPhaseCount"] = from_int(self.declared_phase_count)
+        result["description"] = from_str(self.description)
+        result["factoryName"] = from_str(self.factory_name)
+        result["liveAgentCount"] = from_int(self.live_agent_count)
+        result["observedAt"] = from_int(self.observed_at)
+        result["revision"] = from_int(self.revision)
+        result["runId"] = from_str(self.run_id)
+        result["status"] = to_enum(FactoryRunStatus, self.status)
+        result["totalSpawnedAgentCount"] = from_int(self.total_spawned_agent_count)
+        result["updatedAt"] = from_int(self.updated_at)
+        result["activeSegmentStartedAt"] = from_union([from_int, from_none], self.active_segment_started_at)
+        result["approved"] = from_union([lambda x: to_class(FactoryDeclaredLimits, x), from_none], self.approved)
+        result["completedAt"] = from_union([from_int, from_none], self.completed_at)
+        result["currentPhase"] = from_union([lambda x: to_class(FactoryCurrentPhase, x), from_none], self.current_phase)
+        result["startedAt"] = from_union([from_int, from_none], self.started_at)
+        result["terminal"] = from_union([lambda x: to_class(FactoryRunTerminal, x), from_none], self.terminal)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class FactoryResumeResult:
+    """Resolved persisted factory identity and resumed run envelope."""
+
+    factory_name: str
+    """Persisted factory name resolved for the resumed run."""
+
+    run: FactoryRunResult
+    """Terminal resumed run envelope."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'FactoryResumeResult':
+        assert isinstance(obj, dict)
+        factory_name = from_str(obj.get("factoryName"))
+        run = FactoryRunResult.from_dict(obj.get("run"))
+        return FactoryResumeResult(factory_name, run)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["factoryName"] = from_str(self.factory_name)
+        result["run"] = to_class(FactoryRunResult, self.run)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class FactoryRunDetail:
+    """Full factory run observability detail."""
+
+    agents: list[FactoryAgentSummary]
+    consumed: FactoryRunConsumed
+    created_at: int
+    declared_limits: FactoryDeclaredLimits
+    declared_phase_count: int
+    description: str
+    factory_name: str
+    live_agent_count: int
+    observed_at: int
+    phases: list[FactoryPhaseObservation]
+    progress: FactoryProgressPage
+    revision: int
+    run_id: str
+    status: FactoryRunStatus
+    total_spawned_agent_count: int
+    updated_at: int
+    active_segment_started_at: int | None = None
+    approved: FactoryDeclaredLimits | None = None
+    completed_at: int | None = None
+    current_phase: FactoryCurrentPhase | None = None
+    started_at: int | None = None
+    terminal: FactoryRunTerminal | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'FactoryRunDetail':
+        assert isinstance(obj, dict)
+        agents = from_list(FactoryAgentSummary.from_dict, obj.get("agents"))
+        consumed = FactoryRunConsumed.from_dict(obj.get("consumed"))
+        created_at = from_int(obj.get("createdAt"))
+        declared_limits = FactoryDeclaredLimits.from_dict(obj.get("declaredLimits"))
+        declared_phase_count = from_int(obj.get("declaredPhaseCount"))
+        description = from_str(obj.get("description"))
+        factory_name = from_str(obj.get("factoryName"))
+        live_agent_count = from_int(obj.get("liveAgentCount"))
+        observed_at = from_int(obj.get("observedAt"))
+        phases = from_list(FactoryPhaseObservation.from_dict, obj.get("phases"))
+        progress = FactoryProgressPage.from_dict(obj.get("progress"))
+        revision = from_int(obj.get("revision"))
+        run_id = from_str(obj.get("runId"))
+        status = FactoryRunStatus(obj.get("status"))
+        total_spawned_agent_count = from_int(obj.get("totalSpawnedAgentCount"))
+        updated_at = from_int(obj.get("updatedAt"))
+        active_segment_started_at = from_union([from_int, from_none], obj.get("activeSegmentStartedAt"))
+        approved = from_union([FactoryDeclaredLimits.from_dict, from_none], obj.get("approved"))
+        completed_at = from_union([from_int, from_none], obj.get("completedAt"))
+        current_phase = from_union([FactoryCurrentPhase.from_dict, from_none], obj.get("currentPhase"))
+        started_at = from_union([from_int, from_none], obj.get("startedAt"))
+        terminal = from_union([FactoryRunTerminal.from_dict, from_none], obj.get("terminal"))
+        return FactoryRunDetail(agents, consumed, created_at, declared_limits, declared_phase_count, description, factory_name, live_agent_count, observed_at, phases, progress, revision, run_id, status, total_spawned_agent_count, updated_at, active_segment_started_at, approved, completed_at, current_phase, started_at, terminal)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["agents"] = from_list(lambda x: to_class(FactoryAgentSummary, x), self.agents)
+        result["consumed"] = to_class(FactoryRunConsumed, self.consumed)
+        result["createdAt"] = from_int(self.created_at)
+        result["declaredLimits"] = to_class(FactoryDeclaredLimits, self.declared_limits)
+        result["declaredPhaseCount"] = from_int(self.declared_phase_count)
+        result["description"] = from_str(self.description)
+        result["factoryName"] = from_str(self.factory_name)
+        result["liveAgentCount"] = from_int(self.live_agent_count)
+        result["observedAt"] = from_int(self.observed_at)
+        result["phases"] = from_list(lambda x: to_class(FactoryPhaseObservation, x), self.phases)
+        result["progress"] = to_class(FactoryProgressPage, self.progress)
+        result["revision"] = from_int(self.revision)
+        result["runId"] = from_str(self.run_id)
+        result["status"] = to_enum(FactoryRunStatus, self.status)
+        result["totalSpawnedAgentCount"] = from_int(self.total_spawned_agent_count)
+        result["updatedAt"] = from_int(self.updated_at)
+        result["activeSegmentStartedAt"] = from_union([from_int, from_none], self.active_segment_started_at)
+        result["approved"] = from_union([lambda x: to_class(FactoryDeclaredLimits, x), from_none], self.approved)
+        result["completedAt"] = from_union([from_int, from_none], self.completed_at)
+        result["currentPhase"] = from_union([lambda x: to_class(FactoryCurrentPhase, x), from_none], self.current_phase)
+        result["startedAt"] = from_union([from_int, from_none], self.started_at)
+        result["terminal"] = from_union([lambda x: to_class(FactoryRunTerminal, x), from_none], self.terminal)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class SessionsSetAdditionalPluginsRequest:
     """Manager-wide additional plugins to register; replaces any previously-configured set."""
 
@@ -21741,6 +23418,26 @@ class SessionsEnrichMetadataRequest:
     def to_dict(self) -> dict:
         result: dict = {}
         result["sessions"] = from_list(lambda x: to_class(LocalSessionMetadataValue, x), self.sessions)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class SessionsGetMetadataResult:
+    """Persisted local session metadata when the session exists."""
+
+    session: LocalSessionMetadataValue | None = None
+    """Local session metadata, omitted when the session does not exist."""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionsGetMetadataResult':
+        assert isinstance(obj, dict)
+        session = from_union([LocalSessionMetadataValue.from_dict, from_none], obj.get("session"))
+        return SessionsGetMetadataResult(session)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        if self.session is not None:
+            result["session"] = from_union([lambda x: to_class(LocalSessionMetadataValue, x), from_none], self.session)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -22185,6 +23882,28 @@ class SandboxConfig:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class SessionFSSqliteTransactionResult:
+    """Per-statement results, or a classified transaction error."""
+
+    results: list[SessionFSSqliteQueryResult]
+    error: SessionFSSqliteTransactionError | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'SessionFSSqliteTransactionResult':
+        assert isinstance(obj, dict)
+        results = from_list(SessionFSSqliteQueryResult.from_dict, obj.get("results"))
+        error = from_union([SessionFSSqliteTransactionError.from_dict, from_none], obj.get("error"))
+        return SessionFSSqliteTransactionResult(results, error)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["results"] = from_list(lambda x: to_class(SessionFSSqliteQueryResult, x), self.results)
+        if self.error is not None:
+            result["error"] = from_union([lambda x: to_class(SessionFSSqliteTransactionError, x), from_none], self.error)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class MCPListToolsResult:
     """Tools exposed by the connected MCP server. Throws when the server is not connected."""
 
@@ -22230,6 +23949,24 @@ class UIElicitationSchema:
         result["type"] = to_enum(UIElicitationSchemaType, self.type)
         if self.required is not None:
             result["required"] = from_union([lambda x: from_list(from_str, x), from_none], self.required)
+        return result
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
+class FactoryListRunsResult:
+    """Factory runs in durable creation order."""
+
+    runs: list[FactoryRunSummary]
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'FactoryListRunsResult':
+        assert isinstance(obj, dict)
+        runs = from_list(FactoryRunSummary.from_dict, obj.get("runs"))
+        return FactoryListRunsResult(runs)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["runs"] = from_list(lambda x: to_class(FactoryRunSummary, x), self.runs)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -22354,6 +24091,9 @@ class SessionOpenOptions:
     events_log_directory: str | None = None
     """Override directory for session event logs."""
 
+    events_log_includes_subagents: bool | None = None
+    """Whether subagent callback events should be forwarded into the session event log sink."""
+
     excluded_builtin_agents: list[str] | None = None
     """Built-in subagent names to exclude from this session. Excluded built-ins are hidden from
     agent discovery and cannot be dispatched unless a custom agent with the same name is
@@ -22449,11 +24189,14 @@ class SessionOpenOptions:
     session_limits: SessionLimitsConfig | None = None
     """Initial session limits."""
 
+    shell: ShellOptions | None = None
+    """Per-session settings for built-in shell tools."""
+
     shell_init_profile: str | None = None
-    """Shell init profile."""
+    """Use shell.initProfile instead. Shell init profile."""
 
     shell_process_flags: list[str] | None = None
-    """Per-shell process flags."""
+    """PowerShell process flags applied to built-in and user-requested shell commands."""
 
     skill_directories: list[str] | None = None
     """Additional directories to search for skills."""
@@ -22501,6 +24244,7 @@ class SessionOpenOptions:
         enable_streaming = from_union([from_bool, from_none], obj.get("enableStreaming"))
         env_value_mode = from_union([MCPSetEnvValueModeDetails, from_none], obj.get("envValueMode"))
         events_log_directory = from_union([from_str, from_none], obj.get("eventsLogDirectory"))
+        events_log_includes_subagents = from_union([from_bool, from_none], obj.get("eventsLogIncludesSubagents"))
         excluded_builtin_agents = from_union([lambda x: from_list(from_str, x), from_none], obj.get("excludedBuiltinAgents"))
         excluded_tools = from_union([lambda x: from_list(from_str, x), from_none], obj.get("excludedTools"))
         exp_assignments = obj.get("expAssignments")
@@ -22529,6 +24273,7 @@ class SessionOpenOptions:
         session_capabilities = from_union([lambda x: from_list(SessionCapability, x), from_none], obj.get("sessionCapabilities"))
         session_id = from_union([from_str, from_none], obj.get("sessionId"))
         session_limits = from_union([SessionLimitsConfig.from_dict, from_none], obj.get("sessionLimits"))
+        shell = from_union([ShellOptions.from_dict, from_none], obj.get("shell"))
         shell_init_profile = from_union([from_str, from_none], obj.get("shellInitProfile"))
         shell_process_flags = from_union([lambda x: from_list(from_str, x), from_none], obj.get("shellProcessFlags"))
         skill_directories = from_union([lambda x: from_list(from_str, x), from_none], obj.get("skillDirectories"))
@@ -22537,7 +24282,7 @@ class SessionOpenOptions:
         verbosity = from_union([Verbosity, from_none], obj.get("verbosity"))
         working_directory = from_union([from_str, from_none], obj.get("workingDirectory"))
         working_directory_context = from_union([SessionContext.from_dict, from_none], obj.get("workingDirectoryContext"))
-        return SessionOpenOptions(additional_content_exclusion_policies, agent_context, allow_all_mcp_server_instructions, ask_user_disabled, auth_info, available_tools, capi, client_kind, client_name, coauthor_enabled, config_dir, continue_on_auto_mode, copilot_url, custom_agents_local_only, detached_from_spawning_parent_engagement_id, detached_from_spawning_parent_session_id, disabled_instruction_sources, disabled_skills, enable_citations, enable_managed_settings, enable_on_demand_instruction_discovery, enable_script_safety, enable_streaming, env_value_mode, events_log_directory, excluded_builtin_agents, excluded_tools, exp_assignments, feature_flags, included_builtin_agents, installed_plugins, integration_id, is_experimental_mode, log_interactive_shells, lsp_client_name, max_inline_binary_bytes, memory, model, model_capabilities_overrides, models, name, provider, providers, reasoning_effort, reasoning_summary, remote_defaulted_on, remote_exporting, remote_steerable, running_in_interactive_mode, sandbox_config, session_capabilities, session_id, session_limits, shell_init_profile, shell_process_flags, skill_directories, skip_custom_instructions, trajectory_file, verbosity, working_directory, working_directory_context)
+        return SessionOpenOptions(additional_content_exclusion_policies, agent_context, allow_all_mcp_server_instructions, ask_user_disabled, auth_info, available_tools, capi, client_kind, client_name, coauthor_enabled, config_dir, continue_on_auto_mode, copilot_url, custom_agents_local_only, detached_from_spawning_parent_engagement_id, detached_from_spawning_parent_session_id, disabled_instruction_sources, disabled_skills, enable_citations, enable_managed_settings, enable_on_demand_instruction_discovery, enable_script_safety, enable_streaming, env_value_mode, events_log_directory, events_log_includes_subagents, excluded_builtin_agents, excluded_tools, exp_assignments, feature_flags, included_builtin_agents, installed_plugins, integration_id, is_experimental_mode, log_interactive_shells, lsp_client_name, max_inline_binary_bytes, memory, model, model_capabilities_overrides, models, name, provider, providers, reasoning_effort, reasoning_summary, remote_defaulted_on, remote_exporting, remote_steerable, running_in_interactive_mode, sandbox_config, session_capabilities, session_id, session_limits, shell, shell_init_profile, shell_process_flags, skill_directories, skip_custom_instructions, trajectory_file, verbosity, working_directory, working_directory_context)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -22591,6 +24336,8 @@ class SessionOpenOptions:
             result["envValueMode"] = from_union([lambda x: to_enum(MCPSetEnvValueModeDetails, x), from_none], self.env_value_mode)
         if self.events_log_directory is not None:
             result["eventsLogDirectory"] = from_union([from_str, from_none], self.events_log_directory)
+        if self.events_log_includes_subagents is not None:
+            result["eventsLogIncludesSubagents"] = from_union([from_bool, from_none], self.events_log_includes_subagents)
         if self.excluded_builtin_agents is not None:
             result["excludedBuiltinAgents"] = from_union([lambda x: from_list(from_str, x), from_none], self.excluded_builtin_agents)
         if self.excluded_tools is not None:
@@ -22647,6 +24394,8 @@ class SessionOpenOptions:
             result["sessionId"] = from_union([from_str, from_none], self.session_id)
         if self.session_limits is not None:
             result["sessionLimits"] = from_union([lambda x: to_class(SessionLimitsConfig, x), from_none], self.session_limits)
+        if self.shell is not None:
+            result["shell"] = from_union([lambda x: to_class(ShellOptions, x), from_none], self.shell)
         if self.shell_init_profile is not None:
             result["shellInitProfile"] = from_union([from_str, from_none], self.shell_init_profile)
         if self.shell_process_flags is not None:
@@ -22752,6 +24501,9 @@ class SessionUpdateOptionsParams:
     """Override directory for the session-events log. When unset, the runtime's default events
     log directory is used.
     """
+    events_log_includes_subagents: bool | None = None
+    """Whether subagent callback events should be forwarded into the session event log sink."""
+
     excluded_builtin_agents: list[str] | None = None
     """Built-in subagent names to exclude from this session. Excluded built-ins are hidden from
     agent discovery and cannot be dispatched unless a custom agent with the same name is
@@ -22827,11 +24579,14 @@ class SessionUpdateOptionsParams:
     session_limits: SessionLimitsConfig | None = None
     """Optional session limits. Pass null to clear the session limits."""
 
+    shell: ShellOptions | None = None
+    """Per-session settings for built-in shell tools."""
+
     shell_init_profile: str | None = None
-    """Shell init profile (`None` or `NonInteractive`)."""
+    """Use shell.initProfile instead. Shell init profile (`None` or `NonInteractive`)."""
 
     shell_process_flags: list[str] | None = None
-    """Per-shell process flags (e.g., `pwsh` arguments)."""
+    """PowerShell process flags applied to built-in and user-requested shell commands."""
 
     skill_directories: list[str] | None = None
     """Additional directories to search for skills."""
@@ -22887,6 +24642,7 @@ class SessionUpdateOptionsParams:
         enable_streaming = from_union([from_bool, from_none], obj.get("enableStreaming"))
         env_value_mode = from_union([MCPSetEnvValueModeDetails, from_none], obj.get("envValueMode"))
         events_log_directory = from_union([from_str, from_none], obj.get("eventsLogDirectory"))
+        events_log_includes_subagents = from_union([from_bool, from_none], obj.get("eventsLogIncludesSubagents"))
         excluded_builtin_agents = from_union([lambda x: from_list(from_str, x), from_none], obj.get("excludedBuiltinAgents"))
         excluded_tools = from_union([lambda x: from_list(from_str, x), from_none], obj.get("excludedTools"))
         feature_flags = from_union([lambda x: from_dict(from_bool, x), from_none], obj.get("featureFlags"))
@@ -22908,6 +24664,7 @@ class SessionUpdateOptionsParams:
         sandbox_config = from_union([SandboxConfig.from_dict, from_none], obj.get("sandboxConfig"))
         session_capabilities = from_union([lambda x: from_list(SessionCapability, x), from_none], obj.get("sessionCapabilities"))
         session_limits = from_union([SessionLimitsConfig.from_dict, from_none], obj.get("sessionLimits"))
+        shell = from_union([ShellOptions.from_dict, from_none], obj.get("shell"))
         shell_init_profile = from_union([from_str, from_none], obj.get("shellInitProfile"))
         shell_process_flags = from_union([lambda x: from_list(from_str, x), from_none], obj.get("shellProcessFlags"))
         skill_directories = from_union([lambda x: from_list(from_str, x), from_none], obj.get("skillDirectories"))
@@ -22918,7 +24675,7 @@ class SessionUpdateOptionsParams:
         trajectory_file = from_union([from_str, from_none], obj.get("trajectoryFile"))
         verbosity = from_union([Verbosity, from_none], obj.get("verbosity"))
         working_directory = from_union([from_str, from_none], obj.get("workingDirectory"))
-        return SessionUpdateOptionsParams(additional_content_exclusion_policies, agent_context, allow_all_mcp_server_instructions, ask_user_disabled, available_tools, capi, client_name, coauthor_enabled, context_tier, continue_on_auto_mode, copilot_url, custom_agents_local_only, disabled_instruction_sources, disabled_skills, enable_file_hooks, enable_host_git_operations, enable_on_demand_instruction_discovery, enable_reasoning_summaries, enable_script_safety, enable_session_store, enable_skills, enable_streaming, env_value_mode, events_log_directory, excluded_builtin_agents, excluded_tools, feature_flags, included_builtin_agents, installed_plugins, integration_id, is_experimental_mode, log_interactive_shells, lsp_client_name, manage_schedule_enabled, max_inline_binary_bytes, model, model_capabilities_overrides, organization_custom_instructions, provider, reasoning_effort, reasoning_summary, running_in_interactive_mode, sandbox_config, session_capabilities, session_limits, shell_init_profile, shell_process_flags, skill_directories, skip_custom_instructions, skip_embedding_retrieval, suppress_custom_agent_prompt, tool_filter_precedence, trajectory_file, verbosity, working_directory)
+        return SessionUpdateOptionsParams(additional_content_exclusion_policies, agent_context, allow_all_mcp_server_instructions, ask_user_disabled, available_tools, capi, client_name, coauthor_enabled, context_tier, continue_on_auto_mode, copilot_url, custom_agents_local_only, disabled_instruction_sources, disabled_skills, enable_file_hooks, enable_host_git_operations, enable_on_demand_instruction_discovery, enable_reasoning_summaries, enable_script_safety, enable_session_store, enable_skills, enable_streaming, env_value_mode, events_log_directory, events_log_includes_subagents, excluded_builtin_agents, excluded_tools, feature_flags, included_builtin_agents, installed_plugins, integration_id, is_experimental_mode, log_interactive_shells, lsp_client_name, manage_schedule_enabled, max_inline_binary_bytes, model, model_capabilities_overrides, organization_custom_instructions, provider, reasoning_effort, reasoning_summary, running_in_interactive_mode, sandbox_config, session_capabilities, session_limits, shell, shell_init_profile, shell_process_flags, skill_directories, skip_custom_instructions, skip_embedding_retrieval, suppress_custom_agent_prompt, tool_filter_precedence, trajectory_file, verbosity, working_directory)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -22970,6 +24727,8 @@ class SessionUpdateOptionsParams:
             result["envValueMode"] = from_union([lambda x: to_enum(MCPSetEnvValueModeDetails, x), from_none], self.env_value_mode)
         if self.events_log_directory is not None:
             result["eventsLogDirectory"] = from_union([from_str, from_none], self.events_log_directory)
+        if self.events_log_includes_subagents is not None:
+            result["eventsLogIncludesSubagents"] = from_union([from_bool, from_none], self.events_log_includes_subagents)
         if self.excluded_builtin_agents is not None:
             result["excludedBuiltinAgents"] = from_union([lambda x: from_list(from_str, x), from_none], self.excluded_builtin_agents)
         if self.excluded_tools is not None:
@@ -23012,6 +24771,8 @@ class SessionUpdateOptionsParams:
             result["sessionCapabilities"] = from_union([lambda x: from_list(lambda x: to_enum(SessionCapability, x), x), from_none], self.session_capabilities)
         if self.session_limits is not None:
             result["sessionLimits"] = from_union([lambda x: to_class(SessionLimitsConfig, x), from_none], self.session_limits)
+        if self.shell is not None:
+            result["shell"] = from_union([lambda x: to_class(ShellOptions, x), from_none], self.shell)
         if self.shell_init_profile is not None:
             result["shellInitProfile"] = from_union([from_str, from_none], self.shell_init_profile)
         if self.shell_process_flags is not None:
@@ -25109,22 +26870,39 @@ class RPC:
     factory_agent_options: FactoryAgentOptions
     factory_agent_request: FactoryAgentRequest
     factory_agent_result: FactoryAgentResult
+    factory_agent_summary: FactoryAgentSummary
     factory_cancel_request: FactoryCancelRequest
+    factory_current_phase: FactoryCurrentPhase
+    factory_declared_limits: FactoryDeclaredLimits
+    factory_durable_operation: FactoryDurableOperation
     factory_execute_request: FactoryExecuteRequest
     factory_execute_result: FactoryExecuteResult
+    factory_get_run_progress_request: FactoryGetRunProgressRequest
     factory_get_run_request: FactoryGetRunRequest
     factory_journal_get_request: FactoryJournalGetRequest
     factory_journal_get_result: FactoryJournalGetResult
     factory_journal_put_request: FactoryJournalPutRequest
+    factory_list_runs_request: FactoryListRunsRequest
+    factory_list_runs_result: FactoryListRunsResult
     factory_log_line: FactoryLogLine
     factory_log_line_kind: FactoryLogLineKind
     factory_log_request: FactoryLogRequest
+    factory_phase_observation: FactoryPhaseObservation
+    factory_phase_status: FactoryPhaseStatus
+    factory_progress_line: FactoryProgressLine
+    factory_progress_page: FactoryProgressPage
+    factory_resume_request: FactoryResumeRequest
+    factory_resume_result: FactoryResumeResult
+    factory_run_consumed: FactoryRunConsumed
+    factory_run_detail: FactoryRunDetail
     factory_run_failure: FactoryRunFailure
     factory_run_failure_kind: FactoryRunFailureKind
     factory_run_limits: FactoryRunLimits
     factory_run_request: FactoryRunRequest
     factory_run_result: FactoryRunResult
     factory_run_status: FactoryRunStatus
+    factory_run_summary: FactoryRunSummary
+    factory_run_terminal: FactoryRunTerminal
     filter_mapping: dict[str, ContentFilterMode] | ContentFilterMode
     fleet_start_request: FleetStartRequest
     fleet_start_result: FleetStartResult
@@ -25165,6 +26943,8 @@ class RPC:
     instruction_source: InstructionSource
     instruction_source_location: InstructionLocation
     instruction_source_type: InstructionSourceType
+    interrupt_main_turn_request: InterruptMainTurnRequest
+    interrupt_main_turn_result: InterruptMainTurnResult
     llm_inference_headers: dict[str, list[str]]
     llm_inference_http_request_chunk_request: LlmInferenceHTTPRequestChunkRequest
     llm_inference_http_request_chunk_result: LlmInferenceHTTPRequestChunkResult
@@ -25244,6 +27024,8 @@ class RPC:
     mcp_oauth_login_request: MCPOauthLoginRequest
     mcp_oauth_login_result: MCPOauthLoginResult
     mcp_oauth_pending_request_response: MCPOauthPendingRequestResponse
+    mcp_oauth_respond_request: MCPOauthRespondRequest
+    mcp_oauth_respond_result: MCPOauthRespondResult
     mcp_register_external_client_request: MCPRegisterExternalClientRequest
     mcp_reload_with_config_request: MCPReloadWithConfigRequest
     mcp_remove_git_hub_result: MCPRemoveGitHubResult
@@ -25499,13 +27281,22 @@ class RPC:
     push_attachment_selection_details_end: PushAttachmentSelectionDetailsEnd
     push_attachment_selection_details_start: PushAttachmentSelectionDetailsStart
     push_git_hub_repo_ref: PushGitHubRepoRef
+    queue_begin_deferred_idle_drain_request: QueueBeginDeferredIdleDrainRequest
+    queue_begin_deferred_idle_drain_result: QueueBeginDeferredIdleDrainResult
+    queue_consume_system_notifications_request: QueueConsumeSystemNotificationsRequest
     queued_command_handled: QueuedCommandHandled
     queued_command_not_handled: QueuedCommandNotHandled
     queued_command_result: QueuedCommandResult
+    queue_defer_session_idle_request: QueueDeferSessionIdleRequest
+    queue_enqueue_resume_pending_result: QueueEnqueueResumePendingResult
+    queue_finish_deferred_idle_drain_request: QueueFinishDeferredIdleDrainRequest
+    queue_finish_deferred_idle_drain_result: QueueFinishDeferredIdleDrainResult
+    queue_has_pending_result: QueueHasPendingResult
     queue_pending_items: QueuePendingItems
     queue_pending_items_kind: QueuePendingItemsKind
     queue_pending_items_result: QueuePendingItemsResult
     queue_remove_most_recent_result: QueueRemoveMostRecentResult
+    queue_snapshot_result: QueueSnapshotResult
     register_event_interest_params: RegisterEventInterestParams
     register_event_interest_result: RegisterEventInterestResult
     register_extension_tools_params: _RegisterExtensionToolsParams
@@ -25539,8 +27330,15 @@ class RPC:
     sandbox_config_user_policy_filesystem: SandboxConfigUserPolicyFilesystem
     sandbox_config_user_policy_network: SandboxConfigUserPolicyNetwork
     sandbox_config_user_policy_seatbelt: SandboxConfigUserPolicySeatbelt
+    schedule_add_at_request: ScheduleAddAtRequest
+    schedule_add_cron_request: ScheduleAddCronRequest
+    schedule_add_request: ScheduleAddRequest
+    schedule_add_result: ScheduleAddResult
+    schedule_add_self_paced_request: ScheduleAddSelfPacedRequest
     schedule_entry: ScheduleEntry
+    schedule_has_self_paced_result: ScheduleHasSelfPacedResult
     schedule_list: ScheduleList
+    schedule_rearm_self_paced_request: ScheduleRearmSelfPacedRequest
     schedule_stop_request: ScheduleStopRequest
     schedule_stop_result: ScheduleStopResult
     secrets_add_filter_values_request: SecretsAddFilterValuesRequest
@@ -25553,6 +27351,7 @@ class RPC:
     send_mode: SendMode
     send_request: SendRequest
     send_result: SendResult
+    send_system_notification_request: SendSystemNotificationRequest
     server_agent_list: ServerAgentList
     server_instruction_source_list: ServerInstructionSourceList
     server_skill: ServerSkill
@@ -25560,6 +27359,7 @@ class RPC:
     session_activity: SessionActivity
     session_auth_status: SessionAuthStatus
     session_bulk_delete_result: SessionBulkDeleteResult
+    session_cancel_all_background_agents_result: int
     session_capability: SessionCapability
     session_completion_item: SessionCompletionItem
     session_context: SessionContext
@@ -25590,6 +27390,11 @@ class RPC:
     session_fs_sqlite_query_request: SessionFSSqliteQueryRequest
     session_fs_sqlite_query_result: SessionFSSqliteQueryResult
     session_fs_sqlite_query_type: SessionFSSqliteQueryType
+    session_fs_sqlite_transaction_error: SessionFSSqliteTransactionError
+    session_fs_sqlite_transaction_error_class: SessionFSSqliteTransactionErrorClass
+    session_fs_sqlite_transaction_request: SessionFSSqliteTransactionRequest
+    session_fs_sqlite_transaction_result: SessionFSSqliteTransactionResult
+    session_fs_sqlite_transaction_statement: SessionFSSqliteTransactionStatement
     session_fs_stat_request: SessionFSStatRequest
     session_fs_stat_result: SessionFSStatResult
     session_fs_write_file_request: SessionFSWriteFileRequest
@@ -25623,6 +27428,7 @@ class RPC:
     sessions_check_in_use_result: SessionsCheckInUseResult
     sessions_close_request: SessionsCloseRequest
     sessions_close_result: SessionsCloseResult
+    sessions_delete_request: SessionsDeleteRequest
     sessions_enrich_metadata_request: SessionsEnrichMetadataRequest
     session_set_credentials_params: SessionSetCredentialsParams
     session_set_credentials_result: SessionSetCredentialsResult
@@ -25648,9 +27454,13 @@ class RPC:
     sessions_get_event_file_path_result: SessionsGetEventFilePathResult
     sessions_get_last_for_context_request: SessionsGetLastForContextRequest
     sessions_get_last_for_context_result: SessionsGetLastForContextResult
+    sessions_get_metadata_request: SessionsGetMetadataRequest
+    sessions_get_metadata_result: SessionsGetMetadataResult
     sessions_get_persisted_remote_steerable_request: SessionsGetPersistedRemoteSteerableRequest
     sessions_get_persisted_remote_steerable_result: SessionsGetPersistedRemoteSteerableResult
     session_sizes: SessionSizes
+    sessions_list_non_empty_session_ids_request: SessionsListNonEmptySessionIDSRequest
+    sessions_list_non_empty_session_ids_result: SessionsListNonEmptySessionIDSResult
     sessions_list_request: SessionsListRequest
     sessions_load_deferred_repo_hooks_request: SessionsLoadDeferredRepoHooksRequest
     sessions_open_attach: SessionsOpenAttach
@@ -25690,9 +27500,13 @@ class RPC:
     shell_exec_request: ShellExecRequest
     shell_exec_result: ShellExecResult
     shell_execute_user_requested_request: ShellExecuteUserRequestedRequest
+    shell_init_profile: ShellInitProfile
+    shell_init_script: ShellInitScript
+    shell_init_script_shell: ShellInitScriptShell
     shell_kill_request: ShellKillRequest
     shell_kill_result: ShellKillResult
     shell_kill_signal: ShellKillSignal
+    shell_options: ShellOptions
     shutdown_request: ShutdownRequest
     skill: Skill
     skill_discovery_path: SkillDiscoveryPath
@@ -25815,20 +27629,30 @@ class RPC:
     workspace_diff_file_change_type: WorkspaceDiffFileChangeType
     workspace_diff_mode: WorkspaceDiffMode
     workspace_diff_result: WorkspaceDiffResult
+    workspaces_add_summary_request: WorkspacesAddSummaryRequest
+    workspaces_add_summary_result: WorkspacesAddSummaryResult
+    workspaces_autopilot_objective_exists_result: WorkspacesAutopilotObjectiveExistsResult
     workspaces_checkpoints: WorkspacesCheckpoints
     workspaces_create_file_request: WorkspacesCreateFileRequest
+    workspaces_delete_autopilot_objective_result: WorkspacesDeleteAutopilotObjectiveResult
     workspaces_diff_request: WorkspacesDiffRequest
+    workspaces_ensure_request: WorkspacesEnsureRequest
     workspaces_get_workspace_result: WorkspacesGetWorkspaceResult
     workspaces_list_checkpoints_result: WorkspacesListCheckpointsResult
     workspaces_list_files_result: WorkspacesListFilesResult
+    workspaces_read_autopilot_objective_result: WorkspacesReadAutopilotObjectiveResult
     workspaces_read_checkpoint_request: WorkspacesReadCheckpointRequest
     workspaces_read_checkpoint_result: WorkspacesReadCheckpointResult
     workspaces_read_file_request: WorkspacesReadFileRequest
     workspaces_read_file_result: WorkspacesReadFileResult
     workspaces_save_large_paste_request: WorkspacesSaveLargePasteRequest
     workspaces_save_large_paste_result: WorkspacesSaveLargePasteResult
+    workspaces_truncate_summaries_request: WorkspacesTruncateSummariesRequest
     workspace_summary_host_type: HostType
+    workspaces_update_metadata_request: WorkspacesUpdateMetadataRequest
     workspaces_workspace_details_host_type: HostType
+    workspaces_write_autopilot_objective_request: WorkspacesWriteAutopilotObjectiveRequest
+    workspaces_write_autopilot_objective_result: WorkspacesWriteAutopilotObjectiveResult
     session_context_attribution: SessionContextAttribution | None = None
     session_context_info: SessionContextInfo | None = None
     subagent_settings: SubagentSettings | None = None
@@ -25982,22 +27806,39 @@ class RPC:
         factory_agent_options = FactoryAgentOptions.from_dict(obj.get("FactoryAgentOptions"))
         factory_agent_request = FactoryAgentRequest.from_dict(obj.get("FactoryAgentRequest"))
         factory_agent_result = FactoryAgentResult.from_dict(obj.get("FactoryAgentResult"))
+        factory_agent_summary = FactoryAgentSummary.from_dict(obj.get("FactoryAgentSummary"))
         factory_cancel_request = FactoryCancelRequest.from_dict(obj.get("FactoryCancelRequest"))
+        factory_current_phase = FactoryCurrentPhase.from_dict(obj.get("FactoryCurrentPhase"))
+        factory_declared_limits = FactoryDeclaredLimits.from_dict(obj.get("FactoryDeclaredLimits"))
+        factory_durable_operation = FactoryDurableOperation(obj.get("FactoryDurableOperation"))
         factory_execute_request = FactoryExecuteRequest.from_dict(obj.get("FactoryExecuteRequest"))
         factory_execute_result = FactoryExecuteResult.from_dict(obj.get("FactoryExecuteResult"))
+        factory_get_run_progress_request = FactoryGetRunProgressRequest.from_dict(obj.get("FactoryGetRunProgressRequest"))
         factory_get_run_request = FactoryGetRunRequest.from_dict(obj.get("FactoryGetRunRequest"))
         factory_journal_get_request = FactoryJournalGetRequest.from_dict(obj.get("FactoryJournalGetRequest"))
         factory_journal_get_result = FactoryJournalGetResult.from_dict(obj.get("FactoryJournalGetResult"))
         factory_journal_put_request = FactoryJournalPutRequest.from_dict(obj.get("FactoryJournalPutRequest"))
+        factory_list_runs_request = FactoryListRunsRequest.from_dict(obj.get("FactoryListRunsRequest"))
+        factory_list_runs_result = FactoryListRunsResult.from_dict(obj.get("FactoryListRunsResult"))
         factory_log_line = FactoryLogLine.from_dict(obj.get("FactoryLogLine"))
         factory_log_line_kind = FactoryLogLineKind(obj.get("FactoryLogLineKind"))
         factory_log_request = FactoryLogRequest.from_dict(obj.get("FactoryLogRequest"))
+        factory_phase_observation = FactoryPhaseObservation.from_dict(obj.get("FactoryPhaseObservation"))
+        factory_phase_status = FactoryPhaseStatus(obj.get("FactoryPhaseStatus"))
+        factory_progress_line = FactoryProgressLine.from_dict(obj.get("FactoryProgressLine"))
+        factory_progress_page = FactoryProgressPage.from_dict(obj.get("FactoryProgressPage"))
+        factory_resume_request = FactoryResumeRequest.from_dict(obj.get("FactoryResumeRequest"))
+        factory_resume_result = FactoryResumeResult.from_dict(obj.get("FactoryResumeResult"))
+        factory_run_consumed = FactoryRunConsumed.from_dict(obj.get("FactoryRunConsumed"))
+        factory_run_detail = FactoryRunDetail.from_dict(obj.get("FactoryRunDetail"))
         factory_run_failure = FactoryRunFailure.from_dict(obj.get("FactoryRunFailure"))
         factory_run_failure_kind = FactoryRunFailureKind(obj.get("FactoryRunFailureKind"))
         factory_run_limits = FactoryRunLimits.from_dict(obj.get("FactoryRunLimits"))
         factory_run_request = FactoryRunRequest.from_dict(obj.get("FactoryRunRequest"))
         factory_run_result = FactoryRunResult.from_dict(obj.get("FactoryRunResult"))
         factory_run_status = FactoryRunStatus(obj.get("FactoryRunStatus"))
+        factory_run_summary = FactoryRunSummary.from_dict(obj.get("FactoryRunSummary"))
+        factory_run_terminal = FactoryRunTerminal.from_dict(obj.get("FactoryRunTerminal"))
         filter_mapping = from_union([lambda x: from_dict(ContentFilterMode, x), ContentFilterMode], obj.get("FilterMapping"))
         fleet_start_request = FleetStartRequest.from_dict(obj.get("FleetStartRequest"))
         fleet_start_result = FleetStartResult.from_dict(obj.get("FleetStartResult"))
@@ -26038,6 +27879,8 @@ class RPC:
         instruction_source = InstructionSource.from_dict(obj.get("InstructionSource"))
         instruction_source_location = InstructionLocation(obj.get("InstructionSourceLocation"))
         instruction_source_type = InstructionSourceType(obj.get("InstructionSourceType"))
+        interrupt_main_turn_request = InterruptMainTurnRequest.from_dict(obj.get("InterruptMainTurnRequest"))
+        interrupt_main_turn_result = InterruptMainTurnResult.from_dict(obj.get("InterruptMainTurnResult"))
         llm_inference_headers = from_dict(lambda x: from_list(from_str, x), obj.get("LlmInferenceHeaders"))
         llm_inference_http_request_chunk_request = LlmInferenceHTTPRequestChunkRequest.from_dict(obj.get("LlmInferenceHttpRequestChunkRequest"))
         llm_inference_http_request_chunk_result = LlmInferenceHTTPRequestChunkResult.from_dict(obj.get("LlmInferenceHttpRequestChunkResult"))
@@ -26117,6 +27960,8 @@ class RPC:
         mcp_oauth_login_request = MCPOauthLoginRequest.from_dict(obj.get("McpOauthLoginRequest"))
         mcp_oauth_login_result = MCPOauthLoginResult.from_dict(obj.get("McpOauthLoginResult"))
         mcp_oauth_pending_request_response = MCPOauthPendingRequestResponse.from_dict(obj.get("McpOauthPendingRequestResponse"))
+        mcp_oauth_respond_request = MCPOauthRespondRequest.from_dict(obj.get("McpOauthRespondRequest"))
+        mcp_oauth_respond_result = MCPOauthRespondResult.from_dict(obj.get("McpOauthRespondResult"))
         mcp_register_external_client_request = MCPRegisterExternalClientRequest.from_dict(obj.get("McpRegisterExternalClientRequest"))
         mcp_reload_with_config_request = MCPReloadWithConfigRequest.from_dict(obj.get("McpReloadWithConfigRequest"))
         mcp_remove_git_hub_result = MCPRemoveGitHubResult.from_dict(obj.get("McpRemoveGitHubResult"))
@@ -26372,13 +28217,22 @@ class RPC:
         push_attachment_selection_details_end = PushAttachmentSelectionDetailsEnd.from_dict(obj.get("PushAttachmentSelectionDetailsEnd"))
         push_attachment_selection_details_start = PushAttachmentSelectionDetailsStart.from_dict(obj.get("PushAttachmentSelectionDetailsStart"))
         push_git_hub_repo_ref = PushGitHubRepoRef.from_dict(obj.get("PushGitHubRepoRef"))
+        queue_begin_deferred_idle_drain_request = QueueBeginDeferredIdleDrainRequest.from_dict(obj.get("QueueBeginDeferredIdleDrainRequest"))
+        queue_begin_deferred_idle_drain_result = QueueBeginDeferredIdleDrainResult.from_dict(obj.get("QueueBeginDeferredIdleDrainResult"))
+        queue_consume_system_notifications_request = QueueConsumeSystemNotificationsRequest.from_dict(obj.get("QueueConsumeSystemNotificationsRequest"))
         queued_command_handled = QueuedCommandHandled.from_dict(obj.get("QueuedCommandHandled"))
         queued_command_not_handled = QueuedCommandNotHandled.from_dict(obj.get("QueuedCommandNotHandled"))
         queued_command_result = _load_QueuedCommandResult(obj.get("QueuedCommandResult"))
+        queue_defer_session_idle_request = QueueDeferSessionIdleRequest.from_dict(obj.get("QueueDeferSessionIdleRequest"))
+        queue_enqueue_resume_pending_result = QueueEnqueueResumePendingResult.from_dict(obj.get("QueueEnqueueResumePendingResult"))
+        queue_finish_deferred_idle_drain_request = QueueFinishDeferredIdleDrainRequest.from_dict(obj.get("QueueFinishDeferredIdleDrainRequest"))
+        queue_finish_deferred_idle_drain_result = QueueFinishDeferredIdleDrainResult.from_dict(obj.get("QueueFinishDeferredIdleDrainResult"))
+        queue_has_pending_result = QueueHasPendingResult.from_dict(obj.get("QueueHasPendingResult"))
         queue_pending_items = QueuePendingItems.from_dict(obj.get("QueuePendingItems"))
         queue_pending_items_kind = QueuePendingItemsKind(obj.get("QueuePendingItemsKind"))
         queue_pending_items_result = QueuePendingItemsResult.from_dict(obj.get("QueuePendingItemsResult"))
         queue_remove_most_recent_result = QueueRemoveMostRecentResult.from_dict(obj.get("QueueRemoveMostRecentResult"))
+        queue_snapshot_result = QueueSnapshotResult.from_dict(obj.get("QueueSnapshotResult"))
         register_event_interest_params = RegisterEventInterestParams.from_dict(obj.get("RegisterEventInterestParams"))
         register_event_interest_result = RegisterEventInterestResult.from_dict(obj.get("RegisterEventInterestResult"))
         register_extension_tools_params = _RegisterExtensionToolsParams.from_dict(obj.get("RegisterExtensionToolsParams"))
@@ -26412,8 +28266,15 @@ class RPC:
         sandbox_config_user_policy_filesystem = SandboxConfigUserPolicyFilesystem.from_dict(obj.get("SandboxConfigUserPolicyFilesystem"))
         sandbox_config_user_policy_network = SandboxConfigUserPolicyNetwork.from_dict(obj.get("SandboxConfigUserPolicyNetwork"))
         sandbox_config_user_policy_seatbelt = SandboxConfigUserPolicySeatbelt.from_dict(obj.get("SandboxConfigUserPolicySeatbelt"))
+        schedule_add_at_request = ScheduleAddAtRequest.from_dict(obj.get("ScheduleAddAtRequest"))
+        schedule_add_cron_request = ScheduleAddCronRequest.from_dict(obj.get("ScheduleAddCronRequest"))
+        schedule_add_request = ScheduleAddRequest.from_dict(obj.get("ScheduleAddRequest"))
+        schedule_add_result = ScheduleAddResult.from_dict(obj.get("ScheduleAddResult"))
+        schedule_add_self_paced_request = ScheduleAddSelfPacedRequest.from_dict(obj.get("ScheduleAddSelfPacedRequest"))
         schedule_entry = ScheduleEntry.from_dict(obj.get("ScheduleEntry"))
+        schedule_has_self_paced_result = ScheduleHasSelfPacedResult.from_dict(obj.get("ScheduleHasSelfPacedResult"))
         schedule_list = ScheduleList.from_dict(obj.get("ScheduleList"))
+        schedule_rearm_self_paced_request = ScheduleRearmSelfPacedRequest.from_dict(obj.get("ScheduleRearmSelfPacedRequest"))
         schedule_stop_request = ScheduleStopRequest.from_dict(obj.get("ScheduleStopRequest"))
         schedule_stop_result = ScheduleStopResult.from_dict(obj.get("ScheduleStopResult"))
         secrets_add_filter_values_request = SecretsAddFilterValuesRequest.from_dict(obj.get("SecretsAddFilterValuesRequest"))
@@ -26426,6 +28287,7 @@ class RPC:
         send_mode = SendMode(obj.get("SendMode"))
         send_request = SendRequest.from_dict(obj.get("SendRequest"))
         send_result = SendResult.from_dict(obj.get("SendResult"))
+        send_system_notification_request = SendSystemNotificationRequest.from_dict(obj.get("SendSystemNotificationRequest"))
         server_agent_list = ServerAgentList.from_dict(obj.get("ServerAgentList"))
         server_instruction_source_list = ServerInstructionSourceList.from_dict(obj.get("ServerInstructionSourceList"))
         server_skill = ServerSkill.from_dict(obj.get("ServerSkill"))
@@ -26433,6 +28295,7 @@ class RPC:
         session_activity = SessionActivity.from_dict(obj.get("SessionActivity"))
         session_auth_status = SessionAuthStatus.from_dict(obj.get("SessionAuthStatus"))
         session_bulk_delete_result = SessionBulkDeleteResult.from_dict(obj.get("SessionBulkDeleteResult"))
+        session_cancel_all_background_agents_result = from_int(obj.get("SessionCancelAllBackgroundAgentsResult"))
         session_capability = SessionCapability(obj.get("SessionCapability"))
         session_completion_item = SessionCompletionItem.from_dict(obj.get("SessionCompletionItem"))
         session_context = SessionContext.from_dict(obj.get("SessionContext"))
@@ -26463,6 +28326,11 @@ class RPC:
         session_fs_sqlite_query_request = SessionFSSqliteQueryRequest.from_dict(obj.get("SessionFsSqliteQueryRequest"))
         session_fs_sqlite_query_result = SessionFSSqliteQueryResult.from_dict(obj.get("SessionFsSqliteQueryResult"))
         session_fs_sqlite_query_type = SessionFSSqliteQueryType(obj.get("SessionFsSqliteQueryType"))
+        session_fs_sqlite_transaction_error = SessionFSSqliteTransactionError.from_dict(obj.get("SessionFsSqliteTransactionError"))
+        session_fs_sqlite_transaction_error_class = SessionFSSqliteTransactionErrorClass(obj.get("SessionFsSqliteTransactionErrorClass"))
+        session_fs_sqlite_transaction_request = SessionFSSqliteTransactionRequest.from_dict(obj.get("SessionFsSqliteTransactionRequest"))
+        session_fs_sqlite_transaction_result = SessionFSSqliteTransactionResult.from_dict(obj.get("SessionFsSqliteTransactionResult"))
+        session_fs_sqlite_transaction_statement = SessionFSSqliteTransactionStatement.from_dict(obj.get("SessionFsSqliteTransactionStatement"))
         session_fs_stat_request = SessionFSStatRequest.from_dict(obj.get("SessionFsStatRequest"))
         session_fs_stat_result = SessionFSStatResult.from_dict(obj.get("SessionFsStatResult"))
         session_fs_write_file_request = SessionFSWriteFileRequest.from_dict(obj.get("SessionFsWriteFileRequest"))
@@ -26496,6 +28364,7 @@ class RPC:
         sessions_check_in_use_result = SessionsCheckInUseResult.from_dict(obj.get("SessionsCheckInUseResult"))
         sessions_close_request = SessionsCloseRequest.from_dict(obj.get("SessionsCloseRequest"))
         sessions_close_result = SessionsCloseResult.from_dict(obj.get("SessionsCloseResult"))
+        sessions_delete_request = SessionsDeleteRequest.from_dict(obj.get("SessionsDeleteRequest"))
         sessions_enrich_metadata_request = SessionsEnrichMetadataRequest.from_dict(obj.get("SessionsEnrichMetadataRequest"))
         session_set_credentials_params = SessionSetCredentialsParams.from_dict(obj.get("SessionSetCredentialsParams"))
         session_set_credentials_result = SessionSetCredentialsResult.from_dict(obj.get("SessionSetCredentialsResult"))
@@ -26521,9 +28390,13 @@ class RPC:
         sessions_get_event_file_path_result = SessionsGetEventFilePathResult.from_dict(obj.get("SessionsGetEventFilePathResult"))
         sessions_get_last_for_context_request = SessionsGetLastForContextRequest.from_dict(obj.get("SessionsGetLastForContextRequest"))
         sessions_get_last_for_context_result = SessionsGetLastForContextResult.from_dict(obj.get("SessionsGetLastForContextResult"))
+        sessions_get_metadata_request = SessionsGetMetadataRequest.from_dict(obj.get("SessionsGetMetadataRequest"))
+        sessions_get_metadata_result = SessionsGetMetadataResult.from_dict(obj.get("SessionsGetMetadataResult"))
         sessions_get_persisted_remote_steerable_request = SessionsGetPersistedRemoteSteerableRequest.from_dict(obj.get("SessionsGetPersistedRemoteSteerableRequest"))
         sessions_get_persisted_remote_steerable_result = SessionsGetPersistedRemoteSteerableResult.from_dict(obj.get("SessionsGetPersistedRemoteSteerableResult"))
         session_sizes = SessionSizes.from_dict(obj.get("SessionSizes"))
+        sessions_list_non_empty_session_ids_request = SessionsListNonEmptySessionIDSRequest.from_dict(obj.get("SessionsListNonEmptySessionIdsRequest"))
+        sessions_list_non_empty_session_ids_result = SessionsListNonEmptySessionIDSResult.from_dict(obj.get("SessionsListNonEmptySessionIdsResult"))
         sessions_list_request = SessionsListRequest.from_dict(obj.get("SessionsListRequest"))
         sessions_load_deferred_repo_hooks_request = SessionsLoadDeferredRepoHooksRequest.from_dict(obj.get("SessionsLoadDeferredRepoHooksRequest"))
         sessions_open_attach = SessionsOpenAttach.from_dict(obj.get("SessionsOpenAttach"))
@@ -26563,9 +28436,13 @@ class RPC:
         shell_exec_request = ShellExecRequest.from_dict(obj.get("ShellExecRequest"))
         shell_exec_result = ShellExecResult.from_dict(obj.get("ShellExecResult"))
         shell_execute_user_requested_request = ShellExecuteUserRequestedRequest.from_dict(obj.get("ShellExecuteUserRequestedRequest"))
+        shell_init_profile = ShellInitProfile(obj.get("ShellInitProfile"))
+        shell_init_script = ShellInitScript.from_dict(obj.get("ShellInitScript"))
+        shell_init_script_shell = ShellInitScriptShell(obj.get("ShellInitScriptShell"))
         shell_kill_request = ShellKillRequest.from_dict(obj.get("ShellKillRequest"))
         shell_kill_result = ShellKillResult.from_dict(obj.get("ShellKillResult"))
         shell_kill_signal = ShellKillSignal(obj.get("ShellKillSignal"))
+        shell_options = ShellOptions.from_dict(obj.get("ShellOptions"))
         shutdown_request = ShutdownRequest.from_dict(obj.get("ShutdownRequest"))
         skill = Skill.from_dict(obj.get("Skill"))
         skill_discovery_path = SkillDiscoveryPath.from_dict(obj.get("SkillDiscoveryPath"))
@@ -26688,26 +28565,36 @@ class RPC:
         workspace_diff_file_change_type = WorkspaceDiffFileChangeType(obj.get("WorkspaceDiffFileChangeType"))
         workspace_diff_mode = WorkspaceDiffMode(obj.get("WorkspaceDiffMode"))
         workspace_diff_result = WorkspaceDiffResult.from_dict(obj.get("WorkspaceDiffResult"))
+        workspaces_add_summary_request = WorkspacesAddSummaryRequest.from_dict(obj.get("WorkspacesAddSummaryRequest"))
+        workspaces_add_summary_result = WorkspacesAddSummaryResult.from_dict(obj.get("WorkspacesAddSummaryResult"))
+        workspaces_autopilot_objective_exists_result = WorkspacesAutopilotObjectiveExistsResult.from_dict(obj.get("WorkspacesAutopilotObjectiveExistsResult"))
         workspaces_checkpoints = WorkspacesCheckpoints.from_dict(obj.get("WorkspacesCheckpoints"))
         workspaces_create_file_request = WorkspacesCreateFileRequest.from_dict(obj.get("WorkspacesCreateFileRequest"))
+        workspaces_delete_autopilot_objective_result = WorkspacesDeleteAutopilotObjectiveResult.from_dict(obj.get("WorkspacesDeleteAutopilotObjectiveResult"))
         workspaces_diff_request = WorkspacesDiffRequest.from_dict(obj.get("WorkspacesDiffRequest"))
+        workspaces_ensure_request = WorkspacesEnsureRequest.from_dict(obj.get("WorkspacesEnsureRequest"))
         workspaces_get_workspace_result = WorkspacesGetWorkspaceResult.from_dict(obj.get("WorkspacesGetWorkspaceResult"))
         workspaces_list_checkpoints_result = WorkspacesListCheckpointsResult.from_dict(obj.get("WorkspacesListCheckpointsResult"))
         workspaces_list_files_result = WorkspacesListFilesResult.from_dict(obj.get("WorkspacesListFilesResult"))
+        workspaces_read_autopilot_objective_result = WorkspacesReadAutopilotObjectiveResult.from_dict(obj.get("WorkspacesReadAutopilotObjectiveResult"))
         workspaces_read_checkpoint_request = WorkspacesReadCheckpointRequest.from_dict(obj.get("WorkspacesReadCheckpointRequest"))
         workspaces_read_checkpoint_result = WorkspacesReadCheckpointResult.from_dict(obj.get("WorkspacesReadCheckpointResult"))
         workspaces_read_file_request = WorkspacesReadFileRequest.from_dict(obj.get("WorkspacesReadFileRequest"))
         workspaces_read_file_result = WorkspacesReadFileResult.from_dict(obj.get("WorkspacesReadFileResult"))
         workspaces_save_large_paste_request = WorkspacesSaveLargePasteRequest.from_dict(obj.get("WorkspacesSaveLargePasteRequest"))
         workspaces_save_large_paste_result = WorkspacesSaveLargePasteResult.from_dict(obj.get("WorkspacesSaveLargePasteResult"))
+        workspaces_truncate_summaries_request = WorkspacesTruncateSummariesRequest.from_dict(obj.get("WorkspacesTruncateSummariesRequest"))
         workspace_summary_host_type = HostType(obj.get("WorkspaceSummaryHostType"))
+        workspaces_update_metadata_request = WorkspacesUpdateMetadataRequest.from_dict(obj.get("WorkspacesUpdateMetadataRequest"))
         workspaces_workspace_details_host_type = HostType(obj.get("WorkspacesWorkspaceDetailsHostType"))
+        workspaces_write_autopilot_objective_request = WorkspacesWriteAutopilotObjectiveRequest.from_dict(obj.get("WorkspacesWriteAutopilotObjectiveRequest"))
+        workspaces_write_autopilot_objective_result = WorkspacesWriteAutopilotObjectiveResult.from_dict(obj.get("WorkspacesWriteAutopilotObjectiveResult"))
         session_context_attribution = from_union([SessionContextAttribution.from_dict, from_none], obj.get("SessionContextAttribution"))
         session_context_info = from_union([SessionContextInfo.from_dict, from_none], obj.get("SessionContextInfo"))
         subagent_settings = from_union([SubagentSettings.from_dict, from_none], obj.get("SubagentSettings"))
         task_progress = from_union([TaskProgress.from_dict, from_none], obj.get("TaskProgress"))
         workspace_summary = from_union([WorkspaceSummary.from_dict, from_none], obj.get("WorkspaceSummary"))
-        return RPC(abort_request, abort_result, account_all_users, account_get_all_users_result, account_get_current_auth_result, account_get_quota_request, account_get_quota_result, account_login_request, account_login_result, account_logout_request, account_logout_result, account_quota_snapshot, adaptive_thinking_support, agent_discovery_path, agent_discovery_path_list, agent_discovery_path_scope, agent_get_current_result, agent_info, agent_info_source, agent_list, agent_registry_live_target_entry, agent_registry_live_target_entry_attention_kind, agent_registry_live_target_entry_kind, agent_registry_live_target_entry_last_terminal_event, agent_registry_live_target_entry_status, agent_registry_log_capture, agent_registry_log_capture_open_error_reason, agent_registry_spawn_error, agent_registry_spawn_permission_mode, agent_registry_spawn_registry_timeout, agent_registry_spawn_request, agent_registry_spawn_result, agent_registry_spawn_spawned, agent_registry_spawn_validation_error, agent_registry_spawn_validation_error_field, agent_registry_spawn_validation_error_reason, agent_reload_result, agents_discover_request, agent_select_request, agent_select_result, agents_get_discovery_paths_request, allow_all_permission_set_result, allow_all_permission_state, api_key_auth_info, auth_info, auth_info_type, cancel_user_requested_shell_command_result, canvas_action, canvas_action_invoke_request, canvas_action_invoke_result, canvas_close_request, canvas_host_context, canvas_host_context_capabilities, canvas_json_schema, canvas_list, canvas_list_open_result, canvas_open_request, canvas_provider_close_request, canvas_provider_invoke_action_request, canvas_provider_open_request, canvas_provider_open_result, canvas_session_context, capi_session_options, command_list, commands_handle_pending_command_request, commands_handle_pending_command_result, commands_invoke_request, commands_list_request, commands_respond_to_queued_command_request, commands_respond_to_queued_command_result, completions_get_trigger_characters_result, completions_request_request, completions_request_result, configure_session_extensions_params, connected_remote_session_metadata, connected_remote_session_metadata_kind, connected_remote_session_metadata_repository, connect_remote_session_params, connect_request, connect_result, content_filter_mode, context_heaviest_message, copilot_api_token_auth_info, copilot_user_response, copilot_user_response_endpoints, copilot_user_response_quota_snapshots, copilot_user_response_quota_snapshots_chat, copilot_user_response_quota_snapshots_completions, copilot_user_response_quota_snapshots_premium_interactions, current_model, current_tool_metadata, debug_collect_logs_collected_entry, debug_collect_logs_destination, debug_collect_logs_entry, debug_collect_logs_entry_kind, debug_collect_logs_include, debug_collect_logs_redaction, debug_collect_logs_request, debug_collect_logs_result, debug_collect_logs_result_kind, debug_collect_logs_skipped_entry, debug_collect_logs_source, discovered_canvas, discovered_mcp_server, discovered_mcp_server_type, enqueue_command_params, enqueue_command_result, env_auth_info, event_log_read_request, event_log_release_interest_result, event_log_tail_result, event_log_types, events_agent_scope, events_cursor_status, events_read_result, execute_command_params, execute_command_result, extension, extension_context_push_input, extension_list, extensions_disable_request, extensions_enable_request, extension_source, extension_status, external_tool_result, external_tool_text_result_for_llm, external_tool_text_result_for_llm_binary_results_for_llm, external_tool_text_result_for_llm_binary_results_for_llm_type, external_tool_text_result_for_llm_content, external_tool_text_result_for_llm_content_audio, external_tool_text_result_for_llm_content_image, external_tool_text_result_for_llm_content_resource, external_tool_text_result_for_llm_content_resource_details, external_tool_text_result_for_llm_content_resource_link, external_tool_text_result_for_llm_content_resource_link_icon, external_tool_text_result_for_llm_content_resource_link_icon_theme, external_tool_text_result_for_llm_content_shell_exit, external_tool_text_result_for_llm_content_terminal, external_tool_text_result_for_llm_content_text, factory_abort_request, factory_ack_result, factory_agent_options, factory_agent_request, factory_agent_result, factory_cancel_request, factory_execute_request, factory_execute_result, factory_get_run_request, factory_journal_get_request, factory_journal_get_result, factory_journal_put_request, factory_log_line, factory_log_line_kind, factory_log_request, factory_run_failure, factory_run_failure_kind, factory_run_limits, factory_run_request, factory_run_result, factory_run_status, filter_mapping, fleet_start_request, fleet_start_result, folder_trust_add_params, folder_trust_check_params, folder_trust_check_result, gh_cli_auth_info, git_hub_telemetry_client_info, git_hub_telemetry_event, git_hub_telemetry_notification, handle_pending_tool_call_request, handle_pending_tool_call_result, history_abort_manual_compaction_result, history_cancel_background_compaction_result, history_compact_context_window, history_compact_request, history_compact_result, history_summarize_for_handoff_result, history_truncate_request, history_truncate_result, hmac_auth_info, hook_invoke_request, hook_invoke_response, hook_type, installed_plugin, installed_plugin_info, installed_plugin_source, installed_plugin_source_git_hub, installed_plugin_source_local, installed_plugin_source_url, instruction_discovery_path, instruction_discovery_path_kind, instruction_discovery_path_list, instruction_discovery_path_location, instructions_discover_request, instructions_get_discovery_paths_request, instructions_get_sources_result, instruction_source, instruction_source_location, instruction_source_type, llm_inference_headers, llm_inference_http_request_chunk_request, llm_inference_http_request_chunk_result, llm_inference_http_request_start_request, llm_inference_http_request_start_result, llm_inference_http_request_start_transport, llm_inference_http_response_chunk_error, llm_inference_http_response_chunk_request, llm_inference_http_response_chunk_result, llm_inference_http_response_start_request, llm_inference_http_response_start_result, llm_inference_set_provider_result, local_session_metadata_value, log_request, log_result, lsp_initialize_request, marketplace_add_result, marketplace_browse_result, marketplace_info, marketplace_list_result, marketplace_plugin_info, marketplace_refresh_entry, marketplace_refresh_result, marketplace_remove_result, mcp_allowed_server, mcp_apps_call_tool_request, mcp_apps_diagnose_capability, mcp_apps_diagnose_request, mcp_apps_diagnose_result, mcp_apps_diagnose_server, mcp_apps_host_context, mcp_apps_host_context_details, mcp_apps_host_context_details_available_display_mode, mcp_apps_host_context_details_display_mode, mcp_apps_host_context_details_platform, mcp_apps_host_context_details_theme, mcp_apps_list_tools_request, mcp_apps_list_tools_result, mcp_apps_read_resource_request, mcp_apps_read_resource_result, mcp_apps_resource_content, mcp_apps_set_host_context_details, mcp_apps_set_host_context_details_available_display_mode, mcp_apps_set_host_context_details_display_mode, mcp_apps_set_host_context_details_platform, mcp_apps_set_host_context_details_theme, mcp_apps_set_host_context_request, mcp_cancel_sampling_execution_params, mcp_cancel_sampling_execution_result, mcp_config_add_request, mcp_config_disable_request, mcp_config_enable_request, mcp_config_list, mcp_config_remove_request, mcp_config_update_request, mcp_configure_git_hub_request, mcp_configure_git_hub_result, mcp_disable_request, mcp_discover_request, mcp_discover_result, mcp_enable_request, mcp_execute_sampling_params, mcp_execute_sampling_request, mcp_execute_sampling_result, mcp_filtered_server, mcp_headers_handle_pending_headers_refresh_request, mcp_headers_handle_pending_headers_refresh_request_request, mcp_headers_handle_pending_headers_refresh_request_result, mcp_host_state, mcp_is_server_running_request, mcp_is_server_running_result, mcp_list_tools_request, mcp_list_tools_result, mcp_oauth_handle_pending_request, mcp_oauth_handle_pending_result, mcp_oauth_login_grant_type, mcp_oauth_login_request, mcp_oauth_login_result, mcp_oauth_pending_request_response, mcp_register_external_client_request, mcp_reload_with_config_request, mcp_remove_git_hub_result, mcp_resource, mcp_resource_annotations, mcp_resource_content, mcp_resource_icon, mcp_resources_list_request, mcp_resources_list_result, mcp_resources_list_templates_request, mcp_resources_list_templates_result, mcp_resources_read_request, mcp_resources_read_result, mcp_resource_template, mcp_restart_server_request, mcp_sampling_execution_action, mcp_sampling_execution_result, mcp_server, mcp_server_auth_config, mcp_server_auth_config_redirect_port, mcp_server_config, mcp_server_config_defer_tools, mcp_server_config_http, mcp_server_config_http_oauth_grant_type, mcp_server_config_http_type, mcp_server_config_stdio, mcp_server_failure_info, mcp_server_list, mcp_server_needs_auth_info, mcp_set_env_value_mode_details, mcp_set_env_value_mode_params, mcp_set_env_value_mode_result, mcp_start_server_request, mcp_start_servers_result, mcp_stop_server_request, mcp_tools, mcp_tool_ui, mcp_tool_ui_visibility, mcp_unregister_external_client_request, memory_configuration, metadata_context_attribution_result, metadata_context_heaviest_messages_request, metadata_context_heaviest_messages_result, metadata_context_info_request, metadata_context_info_result, metadata_is_processing_result, metadata_recompute_context_tokens_request, metadata_recompute_context_tokens_result, metadata_record_context_change_request, metadata_record_context_change_result, metadata_set_working_directory_request, metadata_set_working_directory_result, metadata_snapshot_current_mode, metadata_snapshot_remote_metadata, metadata_snapshot_remote_metadata_repository, metadata_snapshot_remote_metadata_task_type, model, model_billing, model_billing_promo, model_billing_token_prices, model_billing_token_prices_long_context, model_capabilities, model_capabilities_limits, model_capabilities_limits_vision, model_capabilities_override, model_capabilities_override_limits, model_capabilities_override_limits_vision, model_capabilities_override_supports, model_capabilities_supports, model_list, model_list_request, model_picker_category, model_picker_price_category, model_policy, model_policy_state, model_set_reasoning_effort_request, model_set_reasoning_effort_result, models_list_request, model_switch_to_request, model_switch_to_result, mode_set_request, named_provider_config, name_get_result, name_set_auto_request, name_set_auto_result, name_set_request, open_canvas_instance, options_update_additional_content_exclusion_policy, options_update_additional_content_exclusion_policy_rule, options_update_additional_content_exclusion_policy_rule_source, options_update_additional_content_exclusion_policy_scope, options_update_context_tier, options_update_env_value_mode, options_update_reasoning_summary, options_update_tool_filter_precedence, pending_permission_request, pending_permission_request_list, permission_decision, permission_decision_approved, permission_decision_approved_for_location, permission_decision_approved_for_session, permission_decision_approve_for_location, permission_decision_approve_for_location_approval, permission_decision_approve_for_location_approval_commands, permission_decision_approve_for_location_approval_custom_tool, permission_decision_approve_for_location_approval_extension_management, permission_decision_approve_for_location_approval_extension_permission_access, permission_decision_approve_for_location_approval_mcp, permission_decision_approve_for_location_approval_mcp_sampling, permission_decision_approve_for_location_approval_memory, permission_decision_approve_for_location_approval_read, permission_decision_approve_for_location_approval_write, permission_decision_approve_for_session, permission_decision_approve_for_session_approval, permission_decision_approve_for_session_approval_commands, permission_decision_approve_for_session_approval_custom_tool, permission_decision_approve_for_session_approval_extension_management, permission_decision_approve_for_session_approval_extension_permission_access, permission_decision_approve_for_session_approval_mcp, permission_decision_approve_for_session_approval_mcp_sampling, permission_decision_approve_for_session_approval_memory, permission_decision_approve_for_session_approval_read, permission_decision_approve_for_session_approval_write, permission_decision_approve_once, permission_decision_approve_permanently, permission_decision_cancelled, permission_decision_denied_by_content_exclusion_policy, permission_decision_denied_by_permission_request_hook, permission_decision_denied_by_rules, permission_decision_denied_interactively_by_user, permission_decision_denied_no_approval_rule_and_could_not_request_from_user, permission_decision_reject, permission_decision_request, permission_decision_user_not_available, permission_location_add_tool_approval_params, permission_location_apply_params, permission_location_apply_result, permission_location_resolve_params, permission_location_resolve_result, permission_location_type, permission_paths_add_params, permission_paths_allowed_check_params, permission_paths_allowed_check_result, permission_paths_config, permission_paths_list, permission_paths_update_primary_params, permission_paths_workspace_check_params, permission_paths_workspace_check_result, permission_prompt_shown_notification, permission_request_result, permission_rules_set, permissions_allow_all_mode, permissions_configure_additional_content_exclusion_policy, permissions_configure_additional_content_exclusion_policy_rule, permissions_configure_additional_content_exclusion_policy_rule_source, permissions_configure_additional_content_exclusion_policy_scope, permissions_configure_params, permissions_configure_result, permissions_folder_trust_add_trusted_result, permissions_get_allow_all_request, permissions_locations_add_tool_approval_details, permissions_locations_add_tool_approval_details_commands, permissions_locations_add_tool_approval_details_custom_tool, permissions_locations_add_tool_approval_details_extension_management, permissions_locations_add_tool_approval_details_extension_permission_access, permissions_locations_add_tool_approval_details_mcp, permissions_locations_add_tool_approval_details_mcp_sampling, permissions_locations_add_tool_approval_details_memory, permissions_locations_add_tool_approval_details_read, permissions_locations_add_tool_approval_details_write, permissions_locations_add_tool_approval_result, permissions_modify_rules_params, permissions_modify_rules_result, permissions_modify_rules_scope, permissions_notify_prompt_shown_result, permissions_paths_add_result, permissions_paths_list_request, permissions_paths_update_primary_result, permissions_pending_requests_request, permissions_reset_session_approvals_request, permissions_reset_session_approvals_result, permissions_set_allow_all_request, permissions_set_allow_all_source, permissions_set_approve_all_request, permissions_set_approve_all_result, permissions_set_approve_all_source, permissions_set_required_request, permissions_set_required_result, permissions_urls_set_unrestricted_mode_result, permission_urls_config, permission_urls_set_unrestricted_mode_params, ping_request, ping_result, plan_read_result, plan_read_sql_todos_result, plan_read_sql_todos_with_dependencies_result, plan_sql_todo_dependency, plan_sql_todos_row, plan_update_request, plugin, plugin_install_result, plugin_list, plugin_list_result, plugins_disable_request, plugins_enable_request, plugins_install_request, plugins_marketplaces_add_request, plugins_marketplaces_browse_request, plugins_marketplaces_refresh_request, plugins_marketplaces_remove_request, plugins_reload_request, plugins_uninstall_request, plugins_update_request, plugin_update_all_entry, plugin_update_all_result, plugin_update_result, provider_add_request, provider_add_result, provider_config, provider_config_azure, provider_config_transport, provider_config_type, provider_config_wire_api, provider_endpoint, provider_endpoint_transport, provider_endpoint_type, provider_endpoint_wire_api, provider_get_endpoint_request, provider_model_config, provider_session_token, provider_token_acquire_request, provider_token_acquire_result, push_attachment, push_attachment_blob, push_attachment_directory, push_attachment_file, push_attachment_file_line_range, push_attachment_git_hub_actions_job, push_attachment_git_hub_commit, push_attachment_git_hub_file, push_attachment_git_hub_file_diff, push_attachment_git_hub_file_diff_side, push_attachment_git_hub_reference, push_attachment_git_hub_reference_type, push_attachment_git_hub_release, push_attachment_git_hub_repository, push_attachment_git_hub_snippet, push_attachment_git_hub_tree_comparison, push_attachment_git_hub_tree_comparison_side, push_attachment_git_hub_url, push_attachment_selection, push_attachment_selection_details, push_attachment_selection_details_end, push_attachment_selection_details_start, push_git_hub_repo_ref, queued_command_handled, queued_command_not_handled, queued_command_result, queue_pending_items, queue_pending_items_kind, queue_pending_items_result, queue_remove_most_recent_result, register_event_interest_params, register_event_interest_result, register_extension_tools_params, register_extension_tools_result, release_event_interest_params, remote_control_config, remote_control_config_existing_mc_session, remote_control_status, remote_control_status_active, remote_control_status_connecting, remote_control_status_error, remote_control_status_off, remote_control_status_result, remote_control_stop_result, remote_control_transfer_result, remote_enable_request, remote_enable_result, remote_notify_steerable_changed_request, remote_notify_steerable_changed_result, remote_session_connection_result, remote_session_metadata_repository, remote_session_metadata_task_type, remote_session_metadata_value, remote_session_mode, remote_session_repository, run_options, sandbox_config, sandbox_config_user_policy, sandbox_config_user_policy_experimental, sandbox_config_user_policy_experimental_seatbelt, sandbox_config_user_policy_filesystem, sandbox_config_user_policy_network, sandbox_config_user_policy_seatbelt, schedule_entry, schedule_list, schedule_stop_request, schedule_stop_result, secrets_add_filter_values_request, secrets_add_filter_values_result, send_agent_mode, send_attachments_to_message_params, send_message_item, send_messages_request, send_messages_result, send_mode, send_request, send_result, server_agent_list, server_instruction_source_list, server_skill, server_skill_list, session_activity, session_auth_status, session_bulk_delete_result, session_capability, session_completion_item, session_context, session_context_host_type, session_enrich_metadata_result, session_fs_append_file_request, session_fs_error, session_fs_error_code, session_fs_exists_request, session_fs_exists_result, session_fs_mkdir_request, session_fs_readdir_request, session_fs_readdir_result, session_fs_readdir_with_types_entry, session_fs_readdir_with_types_entry_type, session_fs_readdir_with_types_request, session_fs_readdir_with_types_result, session_fs_read_file_request, session_fs_read_file_result, session_fs_rename_request, session_fs_rm_request, session_fs_set_provider_capabilities, session_fs_set_provider_conventions, session_fs_set_provider_request, session_fs_set_provider_result, session_fs_sqlite_exists_request, session_fs_sqlite_exists_result, session_fs_sqlite_query_request, session_fs_sqlite_query_result, session_fs_sqlite_query_type, session_fs_stat_request, session_fs_stat_result, session_fs_write_file_request, session_installed_plugin, session_installed_plugin_source, session_installed_plugin_source_git_hub, session_installed_plugin_source_local, session_installed_plugin_source_url, session_list, session_list_entry, session_list_filter, session_load_deferred_repo_hooks_result, session_log_level, session_mcp_apps_call_tool_result, session_metadata_snapshot, session_mode, session_model_list, session_model_price_category, session_open_options, session_open_options_additional_content_exclusion_policy, session_open_options_additional_content_exclusion_policy_rule, session_open_options_additional_content_exclusion_policy_rule_source, session_open_options_additional_content_exclusion_policy_scope, session_open_options_env_value_mode, session_open_options_reasoning_summary, session_open_params, session_open_result, session_prune_result, sessions_bulk_delete_request, sessions_check_in_use_request, sessions_check_in_use_result, sessions_close_request, sessions_close_result, sessions_enrich_metadata_request, session_set_credentials_params, session_set_credentials_result, session_settings_built_in_tool_availability_snapshot, session_settings_evaluate_predicate_request, session_settings_evaluate_predicate_result, session_settings_job_snapshot, session_settings_model_snapshot, session_settings_online_evaluation_snapshot, session_settings_predicate_name, session_settings_repo_snapshot, session_settings_snapshot, session_settings_validation_snapshot, sessions_find_by_prefix_request, sessions_find_by_prefix_result, sessions_find_by_task_id_request, sessions_find_by_task_id_result, sessions_fork_request, sessions_fork_result, sessions_get_board_entry_count_request, sessions_get_board_entry_count_result, sessions_get_event_file_path_request, sessions_get_event_file_path_result, sessions_get_last_for_context_request, sessions_get_last_for_context_result, sessions_get_persisted_remote_steerable_request, sessions_get_persisted_remote_steerable_result, session_sizes, sessions_list_request, sessions_load_deferred_repo_hooks_request, sessions_open_attach, sessions_open_cloud, sessions_open_create, sessions_open_handoff, sessions_open_handoff_task_type, sessions_open_progress, sessions_open_progress_status, sessions_open_progress_step, sessions_open_remote, sessions_open_resume, sessions_open_resume_last, sessions_open_status, session_source, sessions_prune_old_request, sessions_register_extension_tools_on_session_options, sessions_release_lock_request, sessions_release_lock_result, sessions_reload_plugin_hooks_request, sessions_reload_plugin_hooks_result, sessions_save_request, sessions_save_result, sessions_set_additional_plugins_request, sessions_set_additional_plugins_result, sessions_set_remote_control_steering_request, sessions_start_remote_control_request, sessions_stop_remote_control_request, sessions_transfer_remote_control_request, session_telemetry_engagement, session_update_options_params, session_update_options_result, session_visibility_status, session_working_directory_context, session_working_directory_context_host_type, shell_cancel_user_requested_request, shell_exec_request, shell_exec_result, shell_execute_user_requested_request, shell_kill_request, shell_kill_result, shell_kill_signal, shutdown_request, skill, skill_discovery_path, skill_discovery_path_list, skill_discovery_scope, skill_list, skills_config_set_disabled_skills_request, skills_disable_request, skills_discover_request, skills_enable_request, skills_get_discovery_paths_request, skills_get_invoked_result, skills_invoked_skill, skills_load_diagnostics, slash_command_agent_prompt_result, slash_command_completed_result, slash_command_info, slash_command_input, slash_command_input_choice, slash_command_input_completion, slash_command_invocation_result, slash_command_kind, slash_command_select_subcommand_option, slash_command_select_subcommand_result, slash_command_text_result, subagent_settings_entry, subagent_settings_entry_context_tier, task_agent_info, task_agent_progress, task_execution_mode, task_info, task_list, task_progress_line, tasks_cancel_request, tasks_cancel_result, tasks_get_current_promotable_result, tasks_get_progress_request, tasks_get_progress_result, task_shell_info, task_shell_info_attachment_mode, task_shell_progress, tasks_promote_current_to_background_result, tasks_promote_to_background_request, tasks_promote_to_background_result, tasks_refresh_result, tasks_remove_request, tasks_remove_result, tasks_send_message_request, tasks_send_message_result, tasks_start_agent_request, tasks_start_agent_result, task_status, tasks_wait_for_pending_result, telemetry_set_feature_overrides_request, token_auth_info, tool, tool_list, tools_get_current_metadata_result, tools_initialize_and_validate_result, tools_list_request, tools_update_subagent_settings_result, ui_auto_mode_switch_response, ui_elicitation_array_any_of_field, ui_elicitation_array_any_of_field_items, ui_elicitation_array_any_of_field_items_any_of, ui_elicitation_array_enum_field, ui_elicitation_array_enum_field_items, ui_elicitation_field_value, ui_elicitation_request, ui_elicitation_response, ui_elicitation_response_action, ui_elicitation_response_content, ui_elicitation_result, ui_elicitation_schema, ui_elicitation_schema_property, ui_elicitation_schema_property_boolean, ui_elicitation_schema_property_number, ui_elicitation_schema_property_number_type, ui_elicitation_schema_property_string, ui_elicitation_schema_property_string_format, ui_elicitation_string_enum_field, ui_elicitation_string_one_of_field, ui_elicitation_string_one_of_field_one_of, ui_ephemeral_query_request, ui_ephemeral_query_result, ui_exit_plan_mode_action, ui_exit_plan_mode_response, ui_handle_pending_auto_mode_switch_request, ui_handle_pending_elicitation_request, ui_handle_pending_exit_plan_mode_request, ui_handle_pending_result, ui_handle_pending_sampling_request, ui_handle_pending_sampling_response, ui_handle_pending_session_limits_exhausted_request, ui_handle_pending_user_input_request, ui_register_direct_auto_mode_switch_handler_result, ui_session_limits_exhausted_response, ui_session_limits_exhausted_response_action, ui_unregister_direct_auto_mode_switch_handler_request, ui_unregister_direct_auto_mode_switch_handler_result, ui_user_input_response, update_subagent_settings_request, usage_get_metrics_result, usage_metrics_code_changes, usage_metrics_model_metric, usage_metrics_model_metric_requests, usage_metrics_model_metric_token_detail, usage_metrics_model_metric_usage, usage_metrics_token_detail, user_auth_info, user_requested_shell_command_result, user_setting_metadata, user_settings_get_result, user_settings_set_request, user_settings_set_result, visibility_get_result, visibility_set_request, visibility_set_result, workspace_diff_file_change, workspace_diff_file_change_type, workspace_diff_mode, workspace_diff_result, workspaces_checkpoints, workspaces_create_file_request, workspaces_diff_request, workspaces_get_workspace_result, workspaces_list_checkpoints_result, workspaces_list_files_result, workspaces_read_checkpoint_request, workspaces_read_checkpoint_result, workspaces_read_file_request, workspaces_read_file_result, workspaces_save_large_paste_request, workspaces_save_large_paste_result, workspace_summary_host_type, workspaces_workspace_details_host_type, session_context_attribution, session_context_info, subagent_settings, task_progress, workspace_summary)
+        return RPC(abort_request, abort_result, account_all_users, account_get_all_users_result, account_get_current_auth_result, account_get_quota_request, account_get_quota_result, account_login_request, account_login_result, account_logout_request, account_logout_result, account_quota_snapshot, adaptive_thinking_support, agent_discovery_path, agent_discovery_path_list, agent_discovery_path_scope, agent_get_current_result, agent_info, agent_info_source, agent_list, agent_registry_live_target_entry, agent_registry_live_target_entry_attention_kind, agent_registry_live_target_entry_kind, agent_registry_live_target_entry_last_terminal_event, agent_registry_live_target_entry_status, agent_registry_log_capture, agent_registry_log_capture_open_error_reason, agent_registry_spawn_error, agent_registry_spawn_permission_mode, agent_registry_spawn_registry_timeout, agent_registry_spawn_request, agent_registry_spawn_result, agent_registry_spawn_spawned, agent_registry_spawn_validation_error, agent_registry_spawn_validation_error_field, agent_registry_spawn_validation_error_reason, agent_reload_result, agents_discover_request, agent_select_request, agent_select_result, agents_get_discovery_paths_request, allow_all_permission_set_result, allow_all_permission_state, api_key_auth_info, auth_info, auth_info_type, cancel_user_requested_shell_command_result, canvas_action, canvas_action_invoke_request, canvas_action_invoke_result, canvas_close_request, canvas_host_context, canvas_host_context_capabilities, canvas_json_schema, canvas_list, canvas_list_open_result, canvas_open_request, canvas_provider_close_request, canvas_provider_invoke_action_request, canvas_provider_open_request, canvas_provider_open_result, canvas_session_context, capi_session_options, command_list, commands_handle_pending_command_request, commands_handle_pending_command_result, commands_invoke_request, commands_list_request, commands_respond_to_queued_command_request, commands_respond_to_queued_command_result, completions_get_trigger_characters_result, completions_request_request, completions_request_result, configure_session_extensions_params, connected_remote_session_metadata, connected_remote_session_metadata_kind, connected_remote_session_metadata_repository, connect_remote_session_params, connect_request, connect_result, content_filter_mode, context_heaviest_message, copilot_api_token_auth_info, copilot_user_response, copilot_user_response_endpoints, copilot_user_response_quota_snapshots, copilot_user_response_quota_snapshots_chat, copilot_user_response_quota_snapshots_completions, copilot_user_response_quota_snapshots_premium_interactions, current_model, current_tool_metadata, debug_collect_logs_collected_entry, debug_collect_logs_destination, debug_collect_logs_entry, debug_collect_logs_entry_kind, debug_collect_logs_include, debug_collect_logs_redaction, debug_collect_logs_request, debug_collect_logs_result, debug_collect_logs_result_kind, debug_collect_logs_skipped_entry, debug_collect_logs_source, discovered_canvas, discovered_mcp_server, discovered_mcp_server_type, enqueue_command_params, enqueue_command_result, env_auth_info, event_log_read_request, event_log_release_interest_result, event_log_tail_result, event_log_types, events_agent_scope, events_cursor_status, events_read_result, execute_command_params, execute_command_result, extension, extension_context_push_input, extension_list, extensions_disable_request, extensions_enable_request, extension_source, extension_status, external_tool_result, external_tool_text_result_for_llm, external_tool_text_result_for_llm_binary_results_for_llm, external_tool_text_result_for_llm_binary_results_for_llm_type, external_tool_text_result_for_llm_content, external_tool_text_result_for_llm_content_audio, external_tool_text_result_for_llm_content_image, external_tool_text_result_for_llm_content_resource, external_tool_text_result_for_llm_content_resource_details, external_tool_text_result_for_llm_content_resource_link, external_tool_text_result_for_llm_content_resource_link_icon, external_tool_text_result_for_llm_content_resource_link_icon_theme, external_tool_text_result_for_llm_content_shell_exit, external_tool_text_result_for_llm_content_terminal, external_tool_text_result_for_llm_content_text, factory_abort_request, factory_ack_result, factory_agent_options, factory_agent_request, factory_agent_result, factory_agent_summary, factory_cancel_request, factory_current_phase, factory_declared_limits, factory_durable_operation, factory_execute_request, factory_execute_result, factory_get_run_progress_request, factory_get_run_request, factory_journal_get_request, factory_journal_get_result, factory_journal_put_request, factory_list_runs_request, factory_list_runs_result, factory_log_line, factory_log_line_kind, factory_log_request, factory_phase_observation, factory_phase_status, factory_progress_line, factory_progress_page, factory_resume_request, factory_resume_result, factory_run_consumed, factory_run_detail, factory_run_failure, factory_run_failure_kind, factory_run_limits, factory_run_request, factory_run_result, factory_run_status, factory_run_summary, factory_run_terminal, filter_mapping, fleet_start_request, fleet_start_result, folder_trust_add_params, folder_trust_check_params, folder_trust_check_result, gh_cli_auth_info, git_hub_telemetry_client_info, git_hub_telemetry_event, git_hub_telemetry_notification, handle_pending_tool_call_request, handle_pending_tool_call_result, history_abort_manual_compaction_result, history_cancel_background_compaction_result, history_compact_context_window, history_compact_request, history_compact_result, history_summarize_for_handoff_result, history_truncate_request, history_truncate_result, hmac_auth_info, hook_invoke_request, hook_invoke_response, hook_type, installed_plugin, installed_plugin_info, installed_plugin_source, installed_plugin_source_git_hub, installed_plugin_source_local, installed_plugin_source_url, instruction_discovery_path, instruction_discovery_path_kind, instruction_discovery_path_list, instruction_discovery_path_location, instructions_discover_request, instructions_get_discovery_paths_request, instructions_get_sources_result, instruction_source, instruction_source_location, instruction_source_type, interrupt_main_turn_request, interrupt_main_turn_result, llm_inference_headers, llm_inference_http_request_chunk_request, llm_inference_http_request_chunk_result, llm_inference_http_request_start_request, llm_inference_http_request_start_result, llm_inference_http_request_start_transport, llm_inference_http_response_chunk_error, llm_inference_http_response_chunk_request, llm_inference_http_response_chunk_result, llm_inference_http_response_start_request, llm_inference_http_response_start_result, llm_inference_set_provider_result, local_session_metadata_value, log_request, log_result, lsp_initialize_request, marketplace_add_result, marketplace_browse_result, marketplace_info, marketplace_list_result, marketplace_plugin_info, marketplace_refresh_entry, marketplace_refresh_result, marketplace_remove_result, mcp_allowed_server, mcp_apps_call_tool_request, mcp_apps_diagnose_capability, mcp_apps_diagnose_request, mcp_apps_diagnose_result, mcp_apps_diagnose_server, mcp_apps_host_context, mcp_apps_host_context_details, mcp_apps_host_context_details_available_display_mode, mcp_apps_host_context_details_display_mode, mcp_apps_host_context_details_platform, mcp_apps_host_context_details_theme, mcp_apps_list_tools_request, mcp_apps_list_tools_result, mcp_apps_read_resource_request, mcp_apps_read_resource_result, mcp_apps_resource_content, mcp_apps_set_host_context_details, mcp_apps_set_host_context_details_available_display_mode, mcp_apps_set_host_context_details_display_mode, mcp_apps_set_host_context_details_platform, mcp_apps_set_host_context_details_theme, mcp_apps_set_host_context_request, mcp_cancel_sampling_execution_params, mcp_cancel_sampling_execution_result, mcp_config_add_request, mcp_config_disable_request, mcp_config_enable_request, mcp_config_list, mcp_config_remove_request, mcp_config_update_request, mcp_configure_git_hub_request, mcp_configure_git_hub_result, mcp_disable_request, mcp_discover_request, mcp_discover_result, mcp_enable_request, mcp_execute_sampling_params, mcp_execute_sampling_request, mcp_execute_sampling_result, mcp_filtered_server, mcp_headers_handle_pending_headers_refresh_request, mcp_headers_handle_pending_headers_refresh_request_request, mcp_headers_handle_pending_headers_refresh_request_result, mcp_host_state, mcp_is_server_running_request, mcp_is_server_running_result, mcp_list_tools_request, mcp_list_tools_result, mcp_oauth_handle_pending_request, mcp_oauth_handle_pending_result, mcp_oauth_login_grant_type, mcp_oauth_login_request, mcp_oauth_login_result, mcp_oauth_pending_request_response, mcp_oauth_respond_request, mcp_oauth_respond_result, mcp_register_external_client_request, mcp_reload_with_config_request, mcp_remove_git_hub_result, mcp_resource, mcp_resource_annotations, mcp_resource_content, mcp_resource_icon, mcp_resources_list_request, mcp_resources_list_result, mcp_resources_list_templates_request, mcp_resources_list_templates_result, mcp_resources_read_request, mcp_resources_read_result, mcp_resource_template, mcp_restart_server_request, mcp_sampling_execution_action, mcp_sampling_execution_result, mcp_server, mcp_server_auth_config, mcp_server_auth_config_redirect_port, mcp_server_config, mcp_server_config_defer_tools, mcp_server_config_http, mcp_server_config_http_oauth_grant_type, mcp_server_config_http_type, mcp_server_config_stdio, mcp_server_failure_info, mcp_server_list, mcp_server_needs_auth_info, mcp_set_env_value_mode_details, mcp_set_env_value_mode_params, mcp_set_env_value_mode_result, mcp_start_server_request, mcp_start_servers_result, mcp_stop_server_request, mcp_tools, mcp_tool_ui, mcp_tool_ui_visibility, mcp_unregister_external_client_request, memory_configuration, metadata_context_attribution_result, metadata_context_heaviest_messages_request, metadata_context_heaviest_messages_result, metadata_context_info_request, metadata_context_info_result, metadata_is_processing_result, metadata_recompute_context_tokens_request, metadata_recompute_context_tokens_result, metadata_record_context_change_request, metadata_record_context_change_result, metadata_set_working_directory_request, metadata_set_working_directory_result, metadata_snapshot_current_mode, metadata_snapshot_remote_metadata, metadata_snapshot_remote_metadata_repository, metadata_snapshot_remote_metadata_task_type, model, model_billing, model_billing_promo, model_billing_token_prices, model_billing_token_prices_long_context, model_capabilities, model_capabilities_limits, model_capabilities_limits_vision, model_capabilities_override, model_capabilities_override_limits, model_capabilities_override_limits_vision, model_capabilities_override_supports, model_capabilities_supports, model_list, model_list_request, model_picker_category, model_picker_price_category, model_policy, model_policy_state, model_set_reasoning_effort_request, model_set_reasoning_effort_result, models_list_request, model_switch_to_request, model_switch_to_result, mode_set_request, named_provider_config, name_get_result, name_set_auto_request, name_set_auto_result, name_set_request, open_canvas_instance, options_update_additional_content_exclusion_policy, options_update_additional_content_exclusion_policy_rule, options_update_additional_content_exclusion_policy_rule_source, options_update_additional_content_exclusion_policy_scope, options_update_context_tier, options_update_env_value_mode, options_update_reasoning_summary, options_update_tool_filter_precedence, pending_permission_request, pending_permission_request_list, permission_decision, permission_decision_approved, permission_decision_approved_for_location, permission_decision_approved_for_session, permission_decision_approve_for_location, permission_decision_approve_for_location_approval, permission_decision_approve_for_location_approval_commands, permission_decision_approve_for_location_approval_custom_tool, permission_decision_approve_for_location_approval_extension_management, permission_decision_approve_for_location_approval_extension_permission_access, permission_decision_approve_for_location_approval_mcp, permission_decision_approve_for_location_approval_mcp_sampling, permission_decision_approve_for_location_approval_memory, permission_decision_approve_for_location_approval_read, permission_decision_approve_for_location_approval_write, permission_decision_approve_for_session, permission_decision_approve_for_session_approval, permission_decision_approve_for_session_approval_commands, permission_decision_approve_for_session_approval_custom_tool, permission_decision_approve_for_session_approval_extension_management, permission_decision_approve_for_session_approval_extension_permission_access, permission_decision_approve_for_session_approval_mcp, permission_decision_approve_for_session_approval_mcp_sampling, permission_decision_approve_for_session_approval_memory, permission_decision_approve_for_session_approval_read, permission_decision_approve_for_session_approval_write, permission_decision_approve_once, permission_decision_approve_permanently, permission_decision_cancelled, permission_decision_denied_by_content_exclusion_policy, permission_decision_denied_by_permission_request_hook, permission_decision_denied_by_rules, permission_decision_denied_interactively_by_user, permission_decision_denied_no_approval_rule_and_could_not_request_from_user, permission_decision_reject, permission_decision_request, permission_decision_user_not_available, permission_location_add_tool_approval_params, permission_location_apply_params, permission_location_apply_result, permission_location_resolve_params, permission_location_resolve_result, permission_location_type, permission_paths_add_params, permission_paths_allowed_check_params, permission_paths_allowed_check_result, permission_paths_config, permission_paths_list, permission_paths_update_primary_params, permission_paths_workspace_check_params, permission_paths_workspace_check_result, permission_prompt_shown_notification, permission_request_result, permission_rules_set, permissions_allow_all_mode, permissions_configure_additional_content_exclusion_policy, permissions_configure_additional_content_exclusion_policy_rule, permissions_configure_additional_content_exclusion_policy_rule_source, permissions_configure_additional_content_exclusion_policy_scope, permissions_configure_params, permissions_configure_result, permissions_folder_trust_add_trusted_result, permissions_get_allow_all_request, permissions_locations_add_tool_approval_details, permissions_locations_add_tool_approval_details_commands, permissions_locations_add_tool_approval_details_custom_tool, permissions_locations_add_tool_approval_details_extension_management, permissions_locations_add_tool_approval_details_extension_permission_access, permissions_locations_add_tool_approval_details_mcp, permissions_locations_add_tool_approval_details_mcp_sampling, permissions_locations_add_tool_approval_details_memory, permissions_locations_add_tool_approval_details_read, permissions_locations_add_tool_approval_details_write, permissions_locations_add_tool_approval_result, permissions_modify_rules_params, permissions_modify_rules_result, permissions_modify_rules_scope, permissions_notify_prompt_shown_result, permissions_paths_add_result, permissions_paths_list_request, permissions_paths_update_primary_result, permissions_pending_requests_request, permissions_reset_session_approvals_request, permissions_reset_session_approvals_result, permissions_set_allow_all_request, permissions_set_allow_all_source, permissions_set_approve_all_request, permissions_set_approve_all_result, permissions_set_approve_all_source, permissions_set_required_request, permissions_set_required_result, permissions_urls_set_unrestricted_mode_result, permission_urls_config, permission_urls_set_unrestricted_mode_params, ping_request, ping_result, plan_read_result, plan_read_sql_todos_result, plan_read_sql_todos_with_dependencies_result, plan_sql_todo_dependency, plan_sql_todos_row, plan_update_request, plugin, plugin_install_result, plugin_list, plugin_list_result, plugins_disable_request, plugins_enable_request, plugins_install_request, plugins_marketplaces_add_request, plugins_marketplaces_browse_request, plugins_marketplaces_refresh_request, plugins_marketplaces_remove_request, plugins_reload_request, plugins_uninstall_request, plugins_update_request, plugin_update_all_entry, plugin_update_all_result, plugin_update_result, provider_add_request, provider_add_result, provider_config, provider_config_azure, provider_config_transport, provider_config_type, provider_config_wire_api, provider_endpoint, provider_endpoint_transport, provider_endpoint_type, provider_endpoint_wire_api, provider_get_endpoint_request, provider_model_config, provider_session_token, provider_token_acquire_request, provider_token_acquire_result, push_attachment, push_attachment_blob, push_attachment_directory, push_attachment_file, push_attachment_file_line_range, push_attachment_git_hub_actions_job, push_attachment_git_hub_commit, push_attachment_git_hub_file, push_attachment_git_hub_file_diff, push_attachment_git_hub_file_diff_side, push_attachment_git_hub_reference, push_attachment_git_hub_reference_type, push_attachment_git_hub_release, push_attachment_git_hub_repository, push_attachment_git_hub_snippet, push_attachment_git_hub_tree_comparison, push_attachment_git_hub_tree_comparison_side, push_attachment_git_hub_url, push_attachment_selection, push_attachment_selection_details, push_attachment_selection_details_end, push_attachment_selection_details_start, push_git_hub_repo_ref, queue_begin_deferred_idle_drain_request, queue_begin_deferred_idle_drain_result, queue_consume_system_notifications_request, queued_command_handled, queued_command_not_handled, queued_command_result, queue_defer_session_idle_request, queue_enqueue_resume_pending_result, queue_finish_deferred_idle_drain_request, queue_finish_deferred_idle_drain_result, queue_has_pending_result, queue_pending_items, queue_pending_items_kind, queue_pending_items_result, queue_remove_most_recent_result, queue_snapshot_result, register_event_interest_params, register_event_interest_result, register_extension_tools_params, register_extension_tools_result, release_event_interest_params, remote_control_config, remote_control_config_existing_mc_session, remote_control_status, remote_control_status_active, remote_control_status_connecting, remote_control_status_error, remote_control_status_off, remote_control_status_result, remote_control_stop_result, remote_control_transfer_result, remote_enable_request, remote_enable_result, remote_notify_steerable_changed_request, remote_notify_steerable_changed_result, remote_session_connection_result, remote_session_metadata_repository, remote_session_metadata_task_type, remote_session_metadata_value, remote_session_mode, remote_session_repository, run_options, sandbox_config, sandbox_config_user_policy, sandbox_config_user_policy_experimental, sandbox_config_user_policy_experimental_seatbelt, sandbox_config_user_policy_filesystem, sandbox_config_user_policy_network, sandbox_config_user_policy_seatbelt, schedule_add_at_request, schedule_add_cron_request, schedule_add_request, schedule_add_result, schedule_add_self_paced_request, schedule_entry, schedule_has_self_paced_result, schedule_list, schedule_rearm_self_paced_request, schedule_stop_request, schedule_stop_result, secrets_add_filter_values_request, secrets_add_filter_values_result, send_agent_mode, send_attachments_to_message_params, send_message_item, send_messages_request, send_messages_result, send_mode, send_request, send_result, send_system_notification_request, server_agent_list, server_instruction_source_list, server_skill, server_skill_list, session_activity, session_auth_status, session_bulk_delete_result, session_cancel_all_background_agents_result, session_capability, session_completion_item, session_context, session_context_host_type, session_enrich_metadata_result, session_fs_append_file_request, session_fs_error, session_fs_error_code, session_fs_exists_request, session_fs_exists_result, session_fs_mkdir_request, session_fs_readdir_request, session_fs_readdir_result, session_fs_readdir_with_types_entry, session_fs_readdir_with_types_entry_type, session_fs_readdir_with_types_request, session_fs_readdir_with_types_result, session_fs_read_file_request, session_fs_read_file_result, session_fs_rename_request, session_fs_rm_request, session_fs_set_provider_capabilities, session_fs_set_provider_conventions, session_fs_set_provider_request, session_fs_set_provider_result, session_fs_sqlite_exists_request, session_fs_sqlite_exists_result, session_fs_sqlite_query_request, session_fs_sqlite_query_result, session_fs_sqlite_query_type, session_fs_sqlite_transaction_error, session_fs_sqlite_transaction_error_class, session_fs_sqlite_transaction_request, session_fs_sqlite_transaction_result, session_fs_sqlite_transaction_statement, session_fs_stat_request, session_fs_stat_result, session_fs_write_file_request, session_installed_plugin, session_installed_plugin_source, session_installed_plugin_source_git_hub, session_installed_plugin_source_local, session_installed_plugin_source_url, session_list, session_list_entry, session_list_filter, session_load_deferred_repo_hooks_result, session_log_level, session_mcp_apps_call_tool_result, session_metadata_snapshot, session_mode, session_model_list, session_model_price_category, session_open_options, session_open_options_additional_content_exclusion_policy, session_open_options_additional_content_exclusion_policy_rule, session_open_options_additional_content_exclusion_policy_rule_source, session_open_options_additional_content_exclusion_policy_scope, session_open_options_env_value_mode, session_open_options_reasoning_summary, session_open_params, session_open_result, session_prune_result, sessions_bulk_delete_request, sessions_check_in_use_request, sessions_check_in_use_result, sessions_close_request, sessions_close_result, sessions_delete_request, sessions_enrich_metadata_request, session_set_credentials_params, session_set_credentials_result, session_settings_built_in_tool_availability_snapshot, session_settings_evaluate_predicate_request, session_settings_evaluate_predicate_result, session_settings_job_snapshot, session_settings_model_snapshot, session_settings_online_evaluation_snapshot, session_settings_predicate_name, session_settings_repo_snapshot, session_settings_snapshot, session_settings_validation_snapshot, sessions_find_by_prefix_request, sessions_find_by_prefix_result, sessions_find_by_task_id_request, sessions_find_by_task_id_result, sessions_fork_request, sessions_fork_result, sessions_get_board_entry_count_request, sessions_get_board_entry_count_result, sessions_get_event_file_path_request, sessions_get_event_file_path_result, sessions_get_last_for_context_request, sessions_get_last_for_context_result, sessions_get_metadata_request, sessions_get_metadata_result, sessions_get_persisted_remote_steerable_request, sessions_get_persisted_remote_steerable_result, session_sizes, sessions_list_non_empty_session_ids_request, sessions_list_non_empty_session_ids_result, sessions_list_request, sessions_load_deferred_repo_hooks_request, sessions_open_attach, sessions_open_cloud, sessions_open_create, sessions_open_handoff, sessions_open_handoff_task_type, sessions_open_progress, sessions_open_progress_status, sessions_open_progress_step, sessions_open_remote, sessions_open_resume, sessions_open_resume_last, sessions_open_status, session_source, sessions_prune_old_request, sessions_register_extension_tools_on_session_options, sessions_release_lock_request, sessions_release_lock_result, sessions_reload_plugin_hooks_request, sessions_reload_plugin_hooks_result, sessions_save_request, sessions_save_result, sessions_set_additional_plugins_request, sessions_set_additional_plugins_result, sessions_set_remote_control_steering_request, sessions_start_remote_control_request, sessions_stop_remote_control_request, sessions_transfer_remote_control_request, session_telemetry_engagement, session_update_options_params, session_update_options_result, session_visibility_status, session_working_directory_context, session_working_directory_context_host_type, shell_cancel_user_requested_request, shell_exec_request, shell_exec_result, shell_execute_user_requested_request, shell_init_profile, shell_init_script, shell_init_script_shell, shell_kill_request, shell_kill_result, shell_kill_signal, shell_options, shutdown_request, skill, skill_discovery_path, skill_discovery_path_list, skill_discovery_scope, skill_list, skills_config_set_disabled_skills_request, skills_disable_request, skills_discover_request, skills_enable_request, skills_get_discovery_paths_request, skills_get_invoked_result, skills_invoked_skill, skills_load_diagnostics, slash_command_agent_prompt_result, slash_command_completed_result, slash_command_info, slash_command_input, slash_command_input_choice, slash_command_input_completion, slash_command_invocation_result, slash_command_kind, slash_command_select_subcommand_option, slash_command_select_subcommand_result, slash_command_text_result, subagent_settings_entry, subagent_settings_entry_context_tier, task_agent_info, task_agent_progress, task_execution_mode, task_info, task_list, task_progress_line, tasks_cancel_request, tasks_cancel_result, tasks_get_current_promotable_result, tasks_get_progress_request, tasks_get_progress_result, task_shell_info, task_shell_info_attachment_mode, task_shell_progress, tasks_promote_current_to_background_result, tasks_promote_to_background_request, tasks_promote_to_background_result, tasks_refresh_result, tasks_remove_request, tasks_remove_result, tasks_send_message_request, tasks_send_message_result, tasks_start_agent_request, tasks_start_agent_result, task_status, tasks_wait_for_pending_result, telemetry_set_feature_overrides_request, token_auth_info, tool, tool_list, tools_get_current_metadata_result, tools_initialize_and_validate_result, tools_list_request, tools_update_subagent_settings_result, ui_auto_mode_switch_response, ui_elicitation_array_any_of_field, ui_elicitation_array_any_of_field_items, ui_elicitation_array_any_of_field_items_any_of, ui_elicitation_array_enum_field, ui_elicitation_array_enum_field_items, ui_elicitation_field_value, ui_elicitation_request, ui_elicitation_response, ui_elicitation_response_action, ui_elicitation_response_content, ui_elicitation_result, ui_elicitation_schema, ui_elicitation_schema_property, ui_elicitation_schema_property_boolean, ui_elicitation_schema_property_number, ui_elicitation_schema_property_number_type, ui_elicitation_schema_property_string, ui_elicitation_schema_property_string_format, ui_elicitation_string_enum_field, ui_elicitation_string_one_of_field, ui_elicitation_string_one_of_field_one_of, ui_ephemeral_query_request, ui_ephemeral_query_result, ui_exit_plan_mode_action, ui_exit_plan_mode_response, ui_handle_pending_auto_mode_switch_request, ui_handle_pending_elicitation_request, ui_handle_pending_exit_plan_mode_request, ui_handle_pending_result, ui_handle_pending_sampling_request, ui_handle_pending_sampling_response, ui_handle_pending_session_limits_exhausted_request, ui_handle_pending_user_input_request, ui_register_direct_auto_mode_switch_handler_result, ui_session_limits_exhausted_response, ui_session_limits_exhausted_response_action, ui_unregister_direct_auto_mode_switch_handler_request, ui_unregister_direct_auto_mode_switch_handler_result, ui_user_input_response, update_subagent_settings_request, usage_get_metrics_result, usage_metrics_code_changes, usage_metrics_model_metric, usage_metrics_model_metric_requests, usage_metrics_model_metric_token_detail, usage_metrics_model_metric_usage, usage_metrics_token_detail, user_auth_info, user_requested_shell_command_result, user_setting_metadata, user_settings_get_result, user_settings_set_request, user_settings_set_result, visibility_get_result, visibility_set_request, visibility_set_result, workspace_diff_file_change, workspace_diff_file_change_type, workspace_diff_mode, workspace_diff_result, workspaces_add_summary_request, workspaces_add_summary_result, workspaces_autopilot_objective_exists_result, workspaces_checkpoints, workspaces_create_file_request, workspaces_delete_autopilot_objective_result, workspaces_diff_request, workspaces_ensure_request, workspaces_get_workspace_result, workspaces_list_checkpoints_result, workspaces_list_files_result, workspaces_read_autopilot_objective_result, workspaces_read_checkpoint_request, workspaces_read_checkpoint_result, workspaces_read_file_request, workspaces_read_file_result, workspaces_save_large_paste_request, workspaces_save_large_paste_result, workspaces_truncate_summaries_request, workspace_summary_host_type, workspaces_update_metadata_request, workspaces_workspace_details_host_type, workspaces_write_autopilot_objective_request, workspaces_write_autopilot_objective_result, session_context_attribution, session_context_info, subagent_settings, task_progress, workspace_summary)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -26855,22 +28742,39 @@ class RPC:
         result["FactoryAgentOptions"] = to_class(FactoryAgentOptions, self.factory_agent_options)
         result["FactoryAgentRequest"] = to_class(FactoryAgentRequest, self.factory_agent_request)
         result["FactoryAgentResult"] = to_class(FactoryAgentResult, self.factory_agent_result)
+        result["FactoryAgentSummary"] = to_class(FactoryAgentSummary, self.factory_agent_summary)
         result["FactoryCancelRequest"] = to_class(FactoryCancelRequest, self.factory_cancel_request)
+        result["FactoryCurrentPhase"] = to_class(FactoryCurrentPhase, self.factory_current_phase)
+        result["FactoryDeclaredLimits"] = to_class(FactoryDeclaredLimits, self.factory_declared_limits)
+        result["FactoryDurableOperation"] = to_enum(FactoryDurableOperation, self.factory_durable_operation)
         result["FactoryExecuteRequest"] = to_class(FactoryExecuteRequest, self.factory_execute_request)
         result["FactoryExecuteResult"] = to_class(FactoryExecuteResult, self.factory_execute_result)
+        result["FactoryGetRunProgressRequest"] = to_class(FactoryGetRunProgressRequest, self.factory_get_run_progress_request)
         result["FactoryGetRunRequest"] = to_class(FactoryGetRunRequest, self.factory_get_run_request)
         result["FactoryJournalGetRequest"] = to_class(FactoryJournalGetRequest, self.factory_journal_get_request)
         result["FactoryJournalGetResult"] = to_class(FactoryJournalGetResult, self.factory_journal_get_result)
         result["FactoryJournalPutRequest"] = to_class(FactoryJournalPutRequest, self.factory_journal_put_request)
+        result["FactoryListRunsRequest"] = to_class(FactoryListRunsRequest, self.factory_list_runs_request)
+        result["FactoryListRunsResult"] = to_class(FactoryListRunsResult, self.factory_list_runs_result)
         result["FactoryLogLine"] = to_class(FactoryLogLine, self.factory_log_line)
         result["FactoryLogLineKind"] = to_enum(FactoryLogLineKind, self.factory_log_line_kind)
         result["FactoryLogRequest"] = to_class(FactoryLogRequest, self.factory_log_request)
+        result["FactoryPhaseObservation"] = to_class(FactoryPhaseObservation, self.factory_phase_observation)
+        result["FactoryPhaseStatus"] = to_enum(FactoryPhaseStatus, self.factory_phase_status)
+        result["FactoryProgressLine"] = to_class(FactoryProgressLine, self.factory_progress_line)
+        result["FactoryProgressPage"] = to_class(FactoryProgressPage, self.factory_progress_page)
+        result["FactoryResumeRequest"] = to_class(FactoryResumeRequest, self.factory_resume_request)
+        result["FactoryResumeResult"] = to_class(FactoryResumeResult, self.factory_resume_result)
+        result["FactoryRunConsumed"] = to_class(FactoryRunConsumed, self.factory_run_consumed)
+        result["FactoryRunDetail"] = to_class(FactoryRunDetail, self.factory_run_detail)
         result["FactoryRunFailure"] = to_class(FactoryRunFailure, self.factory_run_failure)
         result["FactoryRunFailureKind"] = to_enum(FactoryRunFailureKind, self.factory_run_failure_kind)
         result["FactoryRunLimits"] = to_class(FactoryRunLimits, self.factory_run_limits)
         result["FactoryRunRequest"] = to_class(FactoryRunRequest, self.factory_run_request)
         result["FactoryRunResult"] = to_class(FactoryRunResult, self.factory_run_result)
         result["FactoryRunStatus"] = to_enum(FactoryRunStatus, self.factory_run_status)
+        result["FactoryRunSummary"] = to_class(FactoryRunSummary, self.factory_run_summary)
+        result["FactoryRunTerminal"] = to_class(FactoryRunTerminal, self.factory_run_terminal)
         result["FilterMapping"] = from_union([lambda x: from_dict(lambda x: to_enum(ContentFilterMode, x), x), lambda x: to_enum(ContentFilterMode, x)], self.filter_mapping)
         result["FleetStartRequest"] = to_class(FleetStartRequest, self.fleet_start_request)
         result["FleetStartResult"] = to_class(FleetStartResult, self.fleet_start_result)
@@ -26911,6 +28815,8 @@ class RPC:
         result["InstructionSource"] = to_class(InstructionSource, self.instruction_source)
         result["InstructionSourceLocation"] = to_enum(InstructionLocation, self.instruction_source_location)
         result["InstructionSourceType"] = to_enum(InstructionSourceType, self.instruction_source_type)
+        result["InterruptMainTurnRequest"] = to_class(InterruptMainTurnRequest, self.interrupt_main_turn_request)
+        result["InterruptMainTurnResult"] = to_class(InterruptMainTurnResult, self.interrupt_main_turn_result)
         result["LlmInferenceHeaders"] = from_dict(lambda x: from_list(from_str, x), self.llm_inference_headers)
         result["LlmInferenceHttpRequestChunkRequest"] = to_class(LlmInferenceHTTPRequestChunkRequest, self.llm_inference_http_request_chunk_request)
         result["LlmInferenceHttpRequestChunkResult"] = to_class(LlmInferenceHTTPRequestChunkResult, self.llm_inference_http_request_chunk_result)
@@ -26990,6 +28896,8 @@ class RPC:
         result["McpOauthLoginRequest"] = to_class(MCPOauthLoginRequest, self.mcp_oauth_login_request)
         result["McpOauthLoginResult"] = to_class(MCPOauthLoginResult, self.mcp_oauth_login_result)
         result["McpOauthPendingRequestResponse"] = to_class(MCPOauthPendingRequestResponse, self.mcp_oauth_pending_request_response)
+        result["McpOauthRespondRequest"] = to_class(MCPOauthRespondRequest, self.mcp_oauth_respond_request)
+        result["McpOauthRespondResult"] = to_class(MCPOauthRespondResult, self.mcp_oauth_respond_result)
         result["McpRegisterExternalClientRequest"] = to_class(MCPRegisterExternalClientRequest, self.mcp_register_external_client_request)
         result["McpReloadWithConfigRequest"] = to_class(MCPReloadWithConfigRequest, self.mcp_reload_with_config_request)
         result["McpRemoveGitHubResult"] = to_class(MCPRemoveGitHubResult, self.mcp_remove_git_hub_result)
@@ -27245,13 +29153,22 @@ class RPC:
         result["PushAttachmentSelectionDetailsEnd"] = to_class(PushAttachmentSelectionDetailsEnd, self.push_attachment_selection_details_end)
         result["PushAttachmentSelectionDetailsStart"] = to_class(PushAttachmentSelectionDetailsStart, self.push_attachment_selection_details_start)
         result["PushGitHubRepoRef"] = to_class(PushGitHubRepoRef, self.push_git_hub_repo_ref)
+        result["QueueBeginDeferredIdleDrainRequest"] = to_class(QueueBeginDeferredIdleDrainRequest, self.queue_begin_deferred_idle_drain_request)
+        result["QueueBeginDeferredIdleDrainResult"] = to_class(QueueBeginDeferredIdleDrainResult, self.queue_begin_deferred_idle_drain_result)
+        result["QueueConsumeSystemNotificationsRequest"] = to_class(QueueConsumeSystemNotificationsRequest, self.queue_consume_system_notifications_request)
         result["QueuedCommandHandled"] = to_class(QueuedCommandHandled, self.queued_command_handled)
         result["QueuedCommandNotHandled"] = to_class(QueuedCommandNotHandled, self.queued_command_not_handled)
         result["QueuedCommandResult"] = (self.queued_command_result).to_dict()
+        result["QueueDeferSessionIdleRequest"] = to_class(QueueDeferSessionIdleRequest, self.queue_defer_session_idle_request)
+        result["QueueEnqueueResumePendingResult"] = to_class(QueueEnqueueResumePendingResult, self.queue_enqueue_resume_pending_result)
+        result["QueueFinishDeferredIdleDrainRequest"] = to_class(QueueFinishDeferredIdleDrainRequest, self.queue_finish_deferred_idle_drain_request)
+        result["QueueFinishDeferredIdleDrainResult"] = to_class(QueueFinishDeferredIdleDrainResult, self.queue_finish_deferred_idle_drain_result)
+        result["QueueHasPendingResult"] = to_class(QueueHasPendingResult, self.queue_has_pending_result)
         result["QueuePendingItems"] = to_class(QueuePendingItems, self.queue_pending_items)
         result["QueuePendingItemsKind"] = to_enum(QueuePendingItemsKind, self.queue_pending_items_kind)
         result["QueuePendingItemsResult"] = to_class(QueuePendingItemsResult, self.queue_pending_items_result)
         result["QueueRemoveMostRecentResult"] = to_class(QueueRemoveMostRecentResult, self.queue_remove_most_recent_result)
+        result["QueueSnapshotResult"] = to_class(QueueSnapshotResult, self.queue_snapshot_result)
         result["RegisterEventInterestParams"] = to_class(RegisterEventInterestParams, self.register_event_interest_params)
         result["RegisterEventInterestResult"] = to_class(RegisterEventInterestResult, self.register_event_interest_result)
         result["RegisterExtensionToolsParams"] = to_class(_RegisterExtensionToolsParams, self.register_extension_tools_params)
@@ -27285,8 +29202,15 @@ class RPC:
         result["SandboxConfigUserPolicyFilesystem"] = to_class(SandboxConfigUserPolicyFilesystem, self.sandbox_config_user_policy_filesystem)
         result["SandboxConfigUserPolicyNetwork"] = to_class(SandboxConfigUserPolicyNetwork, self.sandbox_config_user_policy_network)
         result["SandboxConfigUserPolicySeatbelt"] = to_class(SandboxConfigUserPolicySeatbelt, self.sandbox_config_user_policy_seatbelt)
+        result["ScheduleAddAtRequest"] = to_class(ScheduleAddAtRequest, self.schedule_add_at_request)
+        result["ScheduleAddCronRequest"] = to_class(ScheduleAddCronRequest, self.schedule_add_cron_request)
+        result["ScheduleAddRequest"] = to_class(ScheduleAddRequest, self.schedule_add_request)
+        result["ScheduleAddResult"] = to_class(ScheduleAddResult, self.schedule_add_result)
+        result["ScheduleAddSelfPacedRequest"] = to_class(ScheduleAddSelfPacedRequest, self.schedule_add_self_paced_request)
         result["ScheduleEntry"] = to_class(ScheduleEntry, self.schedule_entry)
+        result["ScheduleHasSelfPacedResult"] = to_class(ScheduleHasSelfPacedResult, self.schedule_has_self_paced_result)
         result["ScheduleList"] = to_class(ScheduleList, self.schedule_list)
+        result["ScheduleRearmSelfPacedRequest"] = to_class(ScheduleRearmSelfPacedRequest, self.schedule_rearm_self_paced_request)
         result["ScheduleStopRequest"] = to_class(ScheduleStopRequest, self.schedule_stop_request)
         result["ScheduleStopResult"] = to_class(ScheduleStopResult, self.schedule_stop_result)
         result["SecretsAddFilterValuesRequest"] = to_class(SecretsAddFilterValuesRequest, self.secrets_add_filter_values_request)
@@ -27299,6 +29223,7 @@ class RPC:
         result["SendMode"] = to_enum(SendMode, self.send_mode)
         result["SendRequest"] = to_class(SendRequest, self.send_request)
         result["SendResult"] = to_class(SendResult, self.send_result)
+        result["SendSystemNotificationRequest"] = to_class(SendSystemNotificationRequest, self.send_system_notification_request)
         result["ServerAgentList"] = to_class(ServerAgentList, self.server_agent_list)
         result["ServerInstructionSourceList"] = to_class(ServerInstructionSourceList, self.server_instruction_source_list)
         result["ServerSkill"] = to_class(ServerSkill, self.server_skill)
@@ -27306,6 +29231,7 @@ class RPC:
         result["SessionActivity"] = to_class(SessionActivity, self.session_activity)
         result["SessionAuthStatus"] = to_class(SessionAuthStatus, self.session_auth_status)
         result["SessionBulkDeleteResult"] = to_class(SessionBulkDeleteResult, self.session_bulk_delete_result)
+        result["SessionCancelAllBackgroundAgentsResult"] = from_int(self.session_cancel_all_background_agents_result)
         result["SessionCapability"] = to_enum(SessionCapability, self.session_capability)
         result["SessionCompletionItem"] = to_class(SessionCompletionItem, self.session_completion_item)
         result["SessionContext"] = to_class(SessionContext, self.session_context)
@@ -27336,6 +29262,11 @@ class RPC:
         result["SessionFsSqliteQueryRequest"] = to_class(SessionFSSqliteQueryRequest, self.session_fs_sqlite_query_request)
         result["SessionFsSqliteQueryResult"] = to_class(SessionFSSqliteQueryResult, self.session_fs_sqlite_query_result)
         result["SessionFsSqliteQueryType"] = to_enum(SessionFSSqliteQueryType, self.session_fs_sqlite_query_type)
+        result["SessionFsSqliteTransactionError"] = to_class(SessionFSSqliteTransactionError, self.session_fs_sqlite_transaction_error)
+        result["SessionFsSqliteTransactionErrorClass"] = to_enum(SessionFSSqliteTransactionErrorClass, self.session_fs_sqlite_transaction_error_class)
+        result["SessionFsSqliteTransactionRequest"] = to_class(SessionFSSqliteTransactionRequest, self.session_fs_sqlite_transaction_request)
+        result["SessionFsSqliteTransactionResult"] = to_class(SessionFSSqliteTransactionResult, self.session_fs_sqlite_transaction_result)
+        result["SessionFsSqliteTransactionStatement"] = to_class(SessionFSSqliteTransactionStatement, self.session_fs_sqlite_transaction_statement)
         result["SessionFsStatRequest"] = to_class(SessionFSStatRequest, self.session_fs_stat_request)
         result["SessionFsStatResult"] = to_class(SessionFSStatResult, self.session_fs_stat_result)
         result["SessionFsWriteFileRequest"] = to_class(SessionFSWriteFileRequest, self.session_fs_write_file_request)
@@ -27369,6 +29300,7 @@ class RPC:
         result["SessionsCheckInUseResult"] = to_class(SessionsCheckInUseResult, self.sessions_check_in_use_result)
         result["SessionsCloseRequest"] = to_class(SessionsCloseRequest, self.sessions_close_request)
         result["SessionsCloseResult"] = to_class(SessionsCloseResult, self.sessions_close_result)
+        result["SessionsDeleteRequest"] = to_class(SessionsDeleteRequest, self.sessions_delete_request)
         result["SessionsEnrichMetadataRequest"] = to_class(SessionsEnrichMetadataRequest, self.sessions_enrich_metadata_request)
         result["SessionSetCredentialsParams"] = to_class(SessionSetCredentialsParams, self.session_set_credentials_params)
         result["SessionSetCredentialsResult"] = to_class(SessionSetCredentialsResult, self.session_set_credentials_result)
@@ -27394,9 +29326,13 @@ class RPC:
         result["SessionsGetEventFilePathResult"] = to_class(SessionsGetEventFilePathResult, self.sessions_get_event_file_path_result)
         result["SessionsGetLastForContextRequest"] = to_class(SessionsGetLastForContextRequest, self.sessions_get_last_for_context_request)
         result["SessionsGetLastForContextResult"] = to_class(SessionsGetLastForContextResult, self.sessions_get_last_for_context_result)
+        result["SessionsGetMetadataRequest"] = to_class(SessionsGetMetadataRequest, self.sessions_get_metadata_request)
+        result["SessionsGetMetadataResult"] = to_class(SessionsGetMetadataResult, self.sessions_get_metadata_result)
         result["SessionsGetPersistedRemoteSteerableRequest"] = to_class(SessionsGetPersistedRemoteSteerableRequest, self.sessions_get_persisted_remote_steerable_request)
         result["SessionsGetPersistedRemoteSteerableResult"] = to_class(SessionsGetPersistedRemoteSteerableResult, self.sessions_get_persisted_remote_steerable_result)
         result["SessionSizes"] = to_class(SessionSizes, self.session_sizes)
+        result["SessionsListNonEmptySessionIdsRequest"] = to_class(SessionsListNonEmptySessionIDSRequest, self.sessions_list_non_empty_session_ids_request)
+        result["SessionsListNonEmptySessionIdsResult"] = to_class(SessionsListNonEmptySessionIDSResult, self.sessions_list_non_empty_session_ids_result)
         result["SessionsListRequest"] = to_class(SessionsListRequest, self.sessions_list_request)
         result["SessionsLoadDeferredRepoHooksRequest"] = to_class(SessionsLoadDeferredRepoHooksRequest, self.sessions_load_deferred_repo_hooks_request)
         result["SessionsOpenAttach"] = to_class(SessionsOpenAttach, self.sessions_open_attach)
@@ -27436,9 +29372,13 @@ class RPC:
         result["ShellExecRequest"] = to_class(ShellExecRequest, self.shell_exec_request)
         result["ShellExecResult"] = to_class(ShellExecResult, self.shell_exec_result)
         result["ShellExecuteUserRequestedRequest"] = to_class(ShellExecuteUserRequestedRequest, self.shell_execute_user_requested_request)
+        result["ShellInitProfile"] = to_enum(ShellInitProfile, self.shell_init_profile)
+        result["ShellInitScript"] = to_class(ShellInitScript, self.shell_init_script)
+        result["ShellInitScriptShell"] = to_enum(ShellInitScriptShell, self.shell_init_script_shell)
         result["ShellKillRequest"] = to_class(ShellKillRequest, self.shell_kill_request)
         result["ShellKillResult"] = to_class(ShellKillResult, self.shell_kill_result)
         result["ShellKillSignal"] = to_enum(ShellKillSignal, self.shell_kill_signal)
+        result["ShellOptions"] = to_class(ShellOptions, self.shell_options)
         result["ShutdownRequest"] = to_class(ShutdownRequest, self.shutdown_request)
         result["Skill"] = to_class(Skill, self.skill)
         result["SkillDiscoveryPath"] = to_class(SkillDiscoveryPath, self.skill_discovery_path)
@@ -27561,20 +29501,30 @@ class RPC:
         result["WorkspaceDiffFileChangeType"] = to_enum(WorkspaceDiffFileChangeType, self.workspace_diff_file_change_type)
         result["WorkspaceDiffMode"] = to_enum(WorkspaceDiffMode, self.workspace_diff_mode)
         result["WorkspaceDiffResult"] = to_class(WorkspaceDiffResult, self.workspace_diff_result)
+        result["WorkspacesAddSummaryRequest"] = to_class(WorkspacesAddSummaryRequest, self.workspaces_add_summary_request)
+        result["WorkspacesAddSummaryResult"] = to_class(WorkspacesAddSummaryResult, self.workspaces_add_summary_result)
+        result["WorkspacesAutopilotObjectiveExistsResult"] = to_class(WorkspacesAutopilotObjectiveExistsResult, self.workspaces_autopilot_objective_exists_result)
         result["WorkspacesCheckpoints"] = to_class(WorkspacesCheckpoints, self.workspaces_checkpoints)
         result["WorkspacesCreateFileRequest"] = to_class(WorkspacesCreateFileRequest, self.workspaces_create_file_request)
+        result["WorkspacesDeleteAutopilotObjectiveResult"] = to_class(WorkspacesDeleteAutopilotObjectiveResult, self.workspaces_delete_autopilot_objective_result)
         result["WorkspacesDiffRequest"] = to_class(WorkspacesDiffRequest, self.workspaces_diff_request)
+        result["WorkspacesEnsureRequest"] = to_class(WorkspacesEnsureRequest, self.workspaces_ensure_request)
         result["WorkspacesGetWorkspaceResult"] = to_class(WorkspacesGetWorkspaceResult, self.workspaces_get_workspace_result)
         result["WorkspacesListCheckpointsResult"] = to_class(WorkspacesListCheckpointsResult, self.workspaces_list_checkpoints_result)
         result["WorkspacesListFilesResult"] = to_class(WorkspacesListFilesResult, self.workspaces_list_files_result)
+        result["WorkspacesReadAutopilotObjectiveResult"] = to_class(WorkspacesReadAutopilotObjectiveResult, self.workspaces_read_autopilot_objective_result)
         result["WorkspacesReadCheckpointRequest"] = to_class(WorkspacesReadCheckpointRequest, self.workspaces_read_checkpoint_request)
         result["WorkspacesReadCheckpointResult"] = to_class(WorkspacesReadCheckpointResult, self.workspaces_read_checkpoint_result)
         result["WorkspacesReadFileRequest"] = to_class(WorkspacesReadFileRequest, self.workspaces_read_file_request)
         result["WorkspacesReadFileResult"] = to_class(WorkspacesReadFileResult, self.workspaces_read_file_result)
         result["WorkspacesSaveLargePasteRequest"] = to_class(WorkspacesSaveLargePasteRequest, self.workspaces_save_large_paste_request)
         result["WorkspacesSaveLargePasteResult"] = to_class(WorkspacesSaveLargePasteResult, self.workspaces_save_large_paste_result)
+        result["WorkspacesTruncateSummariesRequest"] = to_class(WorkspacesTruncateSummariesRequest, self.workspaces_truncate_summaries_request)
         result["WorkspaceSummaryHostType"] = to_enum(HostType, self.workspace_summary_host_type)
+        result["WorkspacesUpdateMetadataRequest"] = to_class(WorkspacesUpdateMetadataRequest, self.workspaces_update_metadata_request)
         result["WorkspacesWorkspaceDetailsHostType"] = to_enum(HostType, self.workspaces_workspace_details_host_type)
+        result["WorkspacesWriteAutopilotObjectiveRequest"] = to_class(WorkspacesWriteAutopilotObjectiveRequest, self.workspaces_write_autopilot_objective_request)
+        result["WorkspacesWriteAutopilotObjectiveResult"] = to_class(WorkspacesWriteAutopilotObjectiveResult, self.workspaces_write_autopilot_objective_result)
         result["SessionContextAttribution"] = from_union([lambda x: to_class(SessionContextAttribution, x), from_none], self.session_context_attribution)
         result["SessionContextInfo"] = from_union([lambda x: to_class(SessionContextInfo, x), from_none], self.session_context_info)
         result["SubagentSettings"] = from_union([lambda x: to_class(SubagentSettings, x), from_none], self.subagent_settings)
@@ -27847,6 +29797,7 @@ ProviderEndpointTransport = ProviderTransport
 ProviderEndpointType = ProviderType
 ProviderEndpointWireApi = ProviderWireAPI
 RemoteSessionMetadataTaskType = TaskType
+SessionCancelAllBackgroundAgentsResult = int
 SessionContextHostType = HostType
 SessionFsReaddirWithTypesEntryType = DebugCollectLogsEntryKind
 SessionMcpAppsCallToolResult = dict
@@ -28370,6 +30321,16 @@ class _InternalServerSessionsApi:
     def __init__(self, client: "JsonRpcClient"):
         self._client = client
 
+    async def _get_metadata(self, params: SessionsGetMetadataRequest, *, timeout: float | None = None) -> SessionsGetMetadataResult:
+        "Reads lightweight persisted metadata for one local session without opening it.\n\nArgs:\n    params: Session ID whose persisted metadata should be read.\n\nReturns:\n    Persisted local session metadata when the session exists.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        return SessionsGetMetadataResult.from_dict(await self._client.request("sessions.getMetadata", params_dict, **_timeout_kwargs(timeout)))
+
+    async def _list_non_empty_session_ids(self, params: SessionsListNonEmptySessionIDSRequest, *, timeout: float | None = None) -> SessionsListNonEmptySessionIDSResult:
+        "Lists recent local session IDs that contain user-visible history, omitting housekeeping-only sessions.\n\nArgs:\n    params: Limit for non-empty local session IDs.\n\nReturns:\n    Recent local session IDs that contain user-visible history.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        return SessionsListNonEmptySessionIDSResult.from_dict(await self._client.request("sessions.listNonEmptySessionIds", params_dict, **_timeout_kwargs(timeout)))
+
     async def _get_event_file_path(self, params: SessionsGetEventFilePathRequest, *, timeout: float | None = None) -> SessionsGetEventFilePathResult:
         "Computes the absolute path to a session's persisted events.jsonl file. Internal: filesystem paths are only meaningful in-process (CLI and runtime share a filesystem). Currently used by the CLI's contribution-graph feature to read historical events directly. Remote SDK consumers must not depend on this; a proper event-query API would replace it if the contribution graph ever needed to work over the wire.\n\nArgs:\n    params: Session ID whose event-log file path to compute.\n\nReturns:\n    Absolute path to the session's events.jsonl file on disk.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
@@ -28379,6 +30340,11 @@ class _InternalServerSessionsApi:
         "Returns a session's persisted remote-steerable flag, if any has been recorded. Internal: this is CLI-specific book-keeping used by `--continue` / `--resume` to inherit the prior session's remote-steerable preference. SDK consumers that want similar behavior should manage their own persistence around start/stop calls rather than relying on this runtime-side flag.\n\nArgs:\n    params: Session ID to look up the persisted remote-steerable flag for.\n\nReturns:\n    The session's persisted remote-steerable flag, or omitted when no value has been persisted.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return SessionsGetPersistedRemoteSteerableResult.from_dict(await self._client.request("sessions.getPersistedRemoteSteerable", params_dict, **_timeout_kwargs(timeout)))
+
+    async def _delete(self, params: SessionsDeleteRequest, *, timeout: float | None = None) -> None:
+        "Deletes one local session from disk after running the same lifecycle hooks as the session manager.\n\nArgs:\n    params: Session ID to delete from disk.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        await self._client.request("sessions.delete", params_dict, **_timeout_kwargs(timeout))
 
     async def _get_board_entry_count(self, params: SessionsGetBoardEntryCountRequest, *, timeout: float | None = None) -> SessionsGetBoardEntryCountResult:
         "Gets the dynamic-context board entry count associated with a session, when available. Internal: this exists solely so CLI telemetry events (`rem_spawn_gate`, `rem_consolidation_complete`) can pair START / END board counts around the detached rem-agent spawn. \"Dynamic context board\" is a runtime-internal concept that is not part of the public SDK contract; the long-term plan is to relocate the telemetry emission into the runtime so this method can be deleted entirely.\n\nArgs:\n    params: Session ID whose board entry count should be returned.\n\nReturns:\n    Dynamic-context board entry count, when available.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
@@ -28511,11 +30477,33 @@ class FactoryApi:
         params_dict["sessionId"] = self._session_id
         return FactoryRunResult.from_dict(await self._client.request("session.factory.run", params_dict, **_timeout_kwargs(timeout)))
 
+    async def resume(self, params: FactoryResumeRequest, *, timeout: float | None = None) -> FactoryResumeResult:
+        "Resumes a factory run using its persisted name, arguments, journal, and accounting.\n\nArgs:\n    params: Parameters for resuming a factory run from its persisted identity.\n\nReturns:\n    Resolved persisted factory identity and resumed run envelope."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return FactoryResumeResult.from_dict(await self._client.request("session.factory.resume", params_dict, **_timeout_kwargs(timeout)))
+
     async def get_run(self, params: FactoryGetRunRequest, *, timeout: float | None = None) -> FactoryRunResult:
         "Gets the current or settled envelope for a factory run.\n\nArgs:\n    params: Parameters for retrieving a factory run.\n\nReturns:\n    Complete current or terminal factory run envelope."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return FactoryRunResult.from_dict(await self._client.request("session.factory.getRun", params_dict, **_timeout_kwargs(timeout)))
+
+    async def list_runs(self, *, timeout: float | None = None) -> FactoryListRunsResult:
+        "Lists durable factory runs for this session in creation order.\n\nReturns:\n    Factory runs in durable creation order."
+        return FactoryListRunsResult.from_dict(await self._client.request("session.factory.listRuns", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def get_run_detail(self, params: FactoryGetRunRequest, *, timeout: float | None = None) -> FactoryRunDetail:
+        "Gets durable and live observability detail for one factory run.\n\nArgs:\n    params: Parameters for retrieving a factory run.\n\nReturns:\n    Full factory run observability detail."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return FactoryRunDetail.from_dict(await self._client.request("session.factory.getRunDetail", params_dict, **_timeout_kwargs(timeout)))
+
+    async def get_run_progress(self, params: FactoryGetRunProgressRequest, *, timeout: float | None = None) -> FactoryProgressPage:
+        "Pages durable progress for one factory run.\n\nArgs:\n    params: Parameters for paging factory progress.\n\nReturns:\n    A bidirectional page of factory progress."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return FactoryProgressPage.from_dict(await self._client.request("session.factory.getRunProgress", params_dict, **_timeout_kwargs(timeout)))
 
     async def cancel(self, params: FactoryCancelRequest, *, timeout: float | None = None) -> FactoryRunResult:
         "Requests cancellation of a factory run and returns its run envelope.\n\nArgs:\n    params: Parameters for cancelling a factory run.\n\nReturns:\n    Complete current or terminal factory run envelope."
@@ -28644,6 +30632,18 @@ class WorkspacesApi:
         "Gets current workspace metadata for the session.\n\nReturns:\n    Current workspace metadata for the session, including its absolute filesystem path when available."
         return WorkspacesGetWorkspaceResult.from_dict(await self._client.request("session.workspaces.getWorkspace", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
+    async def update_metadata(self, params: WorkspacesUpdateMetadataRequest, *, timeout: float | None = None) -> WorkspacesGetWorkspaceResult:
+        "Updates workspace metadata for a local session and returns the refreshed workspace.\n\nArgs:\n    params: Workspace metadata fields to update.\n\nReturns:\n    Current workspace metadata for the session, including its absolute filesystem path when available."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return WorkspacesGetWorkspaceResult.from_dict(await self._client.request("session.workspaces.updateMetadata", params_dict, **_timeout_kwargs(timeout)))
+
+    async def ensure(self, params: WorkspacesEnsureRequest, *, timeout: float | None = None) -> WorkspacesGetWorkspaceResult:
+        "Ensures a local session workspace exists and returns it.\n\nArgs:\n    params: Optional session context used when creating a local workspace.\n\nReturns:\n    Current workspace metadata for the session, including its absolute filesystem path when available."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return WorkspacesGetWorkspaceResult.from_dict(await self._client.request("session.workspaces.ensure", params_dict, **_timeout_kwargs(timeout)))
+
     async def list_files(self, *, timeout: float | None = None) -> WorkspacesListFilesResult:
         "Lists files stored in the session workspace files directory.\n\nReturns:\n    Relative paths of files stored in the session workspace files directory."
         return WorkspacesListFilesResult.from_dict(await self._client.request("session.workspaces.listFiles", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
@@ -28669,6 +30669,36 @@ class WorkspacesApi:
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return WorkspacesReadCheckpointResult.from_dict(await self._client.request("session.workspaces.readCheckpoint", params_dict, **_timeout_kwargs(timeout)))
+
+    async def add_summary(self, params: WorkspacesAddSummaryRequest, *, timeout: float | None = None) -> WorkspacesAddSummaryResult:
+        "Adds a compaction summary checkpoint to the local session workspace.\n\nArgs:\n    params: Compaction summary checkpoint to persist.\n\nReturns:\n    Persisted summary metadata and refreshed workspace metadata."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return WorkspacesAddSummaryResult.from_dict(await self._client.request("session.workspaces.addSummary", params_dict, **_timeout_kwargs(timeout)))
+
+    async def truncate_summaries(self, params: WorkspacesTruncateSummariesRequest, *, timeout: float | None = None) -> WorkspacesGetWorkspaceResult:
+        "Truncates local workspace compaction summaries after a rollback.\n\nArgs:\n    params: Rollback point for local workspace summaries.\n\nReturns:\n    Current workspace metadata for the session, including its absolute filesystem path when available."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return WorkspacesGetWorkspaceResult.from_dict(await self._client.request("session.workspaces.truncateSummaries", params_dict, **_timeout_kwargs(timeout)))
+
+    async def read_autopilot_objective(self, *, timeout: float | None = None) -> WorkspacesReadAutopilotObjectiveResult:
+        "Reads the autopilot objective state file from the local session workspace.\n\nReturns:\n    Autopilot objective file content, or null when missing."
+        return WorkspacesReadAutopilotObjectiveResult.from_dict(await self._client.request("session.workspaces.readAutopilotObjective", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def write_autopilot_objective(self, params: WorkspacesWriteAutopilotObjectiveRequest, *, timeout: float | None = None) -> WorkspacesWriteAutopilotObjectiveResult:
+        "Writes the autopilot objective state file in the local session workspace.\n\nArgs:\n    params: Autopilot objective file content to persist.\n\nReturns:\n    Result of writing the autopilot objective file."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return WorkspacesWriteAutopilotObjectiveResult.from_dict(await self._client.request("session.workspaces.writeAutopilotObjective", params_dict, **_timeout_kwargs(timeout)))
+
+    async def delete_autopilot_objective(self, *, timeout: float | None = None) -> WorkspacesDeleteAutopilotObjectiveResult:
+        "Deletes the autopilot objective state file from the local session workspace.\n\nReturns:\n    Result of deleting the autopilot objective file."
+        return WorkspacesDeleteAutopilotObjectiveResult.from_dict(await self._client.request("session.workspaces.deleteAutopilotObjective", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def autopilot_objective_exists(self, *, timeout: float | None = None) -> WorkspacesAutopilotObjectiveExistsResult:
+        "Checks whether the local session workspace has an autopilot objective state file.\n\nReturns:\n    Whether the autopilot objective file exists."
+        return WorkspacesAutopilotObjectiveExistsResult.from_dict(await self._client.request("session.workspaces.autopilotObjectiveExists", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
 
     async def save_large_paste(self, params: WorkspacesSaveLargePasteRequest, *, timeout: float | None = None) -> WorkspacesSaveLargePasteResult:
         "Saves pasted content as a UTF-8 file in the session workspace.\n\nArgs:\n    params: Pasted content to save as a UTF-8 file in the session workspace.\n\nReturns:\n    Descriptor for the saved paste file, or null when the workspace is unavailable."
@@ -28868,6 +30898,12 @@ class McpOauthApi:
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
         return MCPOauthLoginResult.from_dict(await self._client.request("session.mcp.oauth.login", params_dict, **_timeout_kwargs(timeout)))
+
+    async def respond(self, params: MCPOauthRespondRequest, *, timeout: float | None = None) -> MCPOauthRespondResult:
+        "Responds to a pending MCP OAuth authorization request by its request id.\n\nArgs:\n    params: Pending MCP OAuth request id to respond to.\n\nReturns:\n    Indicates whether the pending MCP OAuth response was accepted."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return MCPOauthRespondResult.from_dict(await self._client.request("session.mcp.oauth.respond", params_dict, **_timeout_kwargs(timeout)))
 
 
 # Experimental: this API group is experimental and may change or be removed.
@@ -29730,6 +31766,16 @@ class SessionRpc:
         params_dict["sessionId"] = self._session_id
         return AbortResult.from_dict(await self._client.request("session.abort", params_dict, **_timeout_kwargs(timeout)))
 
+    async def interrupt_main_turn(self, params: InterruptMainTurnRequest, *, timeout: float | None = None) -> InterruptMainTurnResult:
+        "Interrupts the current main agent turn while leaving running background work (subagents, sidekicks, and promoted attached shells) alive. No-op when the main loop is not processing.\n\nArgs:\n    params: Parameters for interrupting the main agent turn.\n\nReturns:\n    Result of interrupting the main agent turn.\n\n.. warning:: This API is experimental and may change or be removed in future versions."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return InterruptMainTurnResult.from_dict(await self._client.request("session.interruptMainTurn", params_dict, **_timeout_kwargs(timeout)))
+
+    async def cancel_all_background_agents(self, *, timeout: float | None = None) -> int:
+        "Cancels every running background agent (task-registry subagents plus sidekick agents) without interrupting the main agent loop. Promoted attached shells are left running.\n\nReturns:\n    The number of running background agents (task-registry agents) that were cancelled.\n\n.. warning:: This API is experimental and may change or be removed in future versions."
+        return int(await self._client.request("session.cancelAllBackgroundAgents", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
     async def shutdown(self, params: ShutdownRequest, *, timeout: float | None = None) -> None:
         "Shuts down the session and persists its final state. Awaits any deferred sessionEnd hooks before resolving so user-supplied hook scripts complete before the runtime tears down.\n\nArgs:\n    params: Parameters for shutting down the session\n\n.. warning:: This API is experimental and may change or be removed in future versions."
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
@@ -29791,6 +31837,98 @@ class _InternalSettingsApi:
         return SessionSettingsEvaluatePredicateResult.from_dict(await self._client.request("session.settings.evaluatePredicate", params_dict, **_timeout_kwargs(timeout)))
 
 
+# Experimental: this API group is experimental and may change or be removed.
+class _InternalQueueApi:
+    def __init__(self, client: "JsonRpcClient", session_id: str):
+        self._client = client
+        self._session_id = session_id
+
+    async def _snapshot(self, *, timeout: float | None = None) -> QueueSnapshotResult:
+        "Returns the internal native queue snapshot for in-process session orchestration.\n\nReturns:\n    Internal snapshot of native queue state for local session orchestration.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        return QueueSnapshotResult.from_dict(await self._client.request("session.queue.snapshot", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def _has_pending(self, *, timeout: float | None = None) -> QueueHasPendingResult:
+        "Reports whether the local session has native queued work pending.\n\nReturns:\n    Whether the native queue has pending work.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        return QueueHasPendingResult.from_dict(await self._client.request("session.queue.hasPending", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def _begin_deferred_idle_drain(self, params: QueueBeginDeferredIdleDrainRequest, *, timeout: float | None = None) -> QueueBeginDeferredIdleDrainResult:
+        "Begins a native deferred-idle drain when background work has quiesced.\n\nArgs:\n    params: Inputs for starting a deferred-idle drain.\n\nReturns:\n    Whether a deferred-idle drain should run.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return QueueBeginDeferredIdleDrainResult.from_dict(await self._client.request("session.queue.beginDeferredIdleDrain", params_dict, **_timeout_kwargs(timeout)))
+
+    async def _finish_deferred_idle_drain(self, params: QueueFinishDeferredIdleDrainRequest, *, timeout: float | None = None) -> QueueFinishDeferredIdleDrainResult:
+        "Finishes a native deferred-idle drain and reports whether to drain queue work or emit idle.\n\nArgs:\n    params: Inputs for completing a deferred-idle drain.\n\nReturns:\n    Action selected by the native deferred-idle drain.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return QueueFinishDeferredIdleDrainResult.from_dict(await self._client.request("session.queue.finishDeferredIdleDrain", params_dict, **_timeout_kwargs(timeout)))
+
+    async def _defer_session_idle(self, params: QueueDeferSessionIdleRequest, *, timeout: float | None = None) -> None:
+        "Marks session.idle as deferred by native background work state.\n\nArgs:\n    params: Inputs for marking session.idle deferred in native state.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        await self._client.request("session.queue.deferSessionIdle", params_dict, **_timeout_kwargs(timeout))
+
+    async def _consume_system_notifications(self, params: QueueConsumeSystemNotificationsRequest, *, timeout: float | None = None) -> QueueRemoveMostRecentResult:
+        "Consumes queued native system notifications matching an internal filter.\n\nArgs:\n    params: Internal filter for consuming queued system notifications.\n\nReturns:\n    Indicates whether a user-facing pending item was removed.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return QueueRemoveMostRecentResult.from_dict(await self._client.request("session.queue.consumeSystemNotifications", params_dict, **_timeout_kwargs(timeout)))
+
+    async def _enqueue_resume_pending(self, *, timeout: float | None = None) -> QueueEnqueueResumePendingResult:
+        "Enqueues the internal resume-pending wake item when orphan handling needs a follow-up turn.\n\nReturns:\n    Result of enqueueing the resume-pending wake item.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        return QueueEnqueueResumePendingResult.from_dict(await self._client.request("session.queue.enqueueResumePending", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def _process(self, *, timeout: float | None = None) -> None:
+        "Drains the native local-session work queue for in-process session orchestration.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        await self._client.request("session.queue.process", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
+
+
+# Experimental: this API group is experimental and may change or be removed.
+class _InternalScheduleApi:
+    def __init__(self, client: "JsonRpcClient", session_id: str):
+        self._client = client
+        self._session_id = session_id
+
+    async def _hydrate(self, *, timeout: float | None = None) -> None:
+        "Hydrates the native schedule registry from persisted session events.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        await self._client.request("session.schedule.hydrate", {"sessionId": self._session_id}, **_timeout_kwargs(timeout))
+
+    async def _has_self_paced(self, *, timeout: float | None = None) -> ScheduleHasSelfPacedResult:
+        "Reports whether the session has an active self-paced scheduled prompt.\n\nReturns:\n    Whether the session currently has an active self-paced schedule.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        return ScheduleHasSelfPacedResult.from_dict(await self._client.request("session.schedule.hasSelfPaced", {"sessionId": self._session_id}, **_timeout_kwargs(timeout)))
+
+    async def _add(self, params: ScheduleAddRequest, *, timeout: float | None = None) -> ScheduleAddResult:
+        "Registers a relative-interval scheduled prompt.\n\nArgs:\n    params: Register a relative-interval scheduled prompt.\n\nReturns:\n    Result of registering or re-arming a scheduled prompt.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return ScheduleAddResult.from_dict(await self._client.request("session.schedule.add", params_dict, **_timeout_kwargs(timeout)))
+
+    async def _add_cron(self, params: ScheduleAddCronRequest, *, timeout: float | None = None) -> ScheduleAddResult:
+        "Registers a recurring cron scheduled prompt.\n\nArgs:\n    params: Register a cron scheduled prompt.\n\nReturns:\n    Result of registering or re-arming a scheduled prompt.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return ScheduleAddResult.from_dict(await self._client.request("session.schedule.addCron", params_dict, **_timeout_kwargs(timeout)))
+
+    async def _add_at(self, params: ScheduleAddAtRequest, *, timeout: float | None = None) -> ScheduleAddResult:
+        "Registers an absolute-time scheduled prompt.\n\nArgs:\n    params: Register an absolute-time scheduled prompt.\n\nReturns:\n    Result of registering or re-arming a scheduled prompt.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return ScheduleAddResult.from_dict(await self._client.request("session.schedule.addAt", params_dict, **_timeout_kwargs(timeout)))
+
+    async def _add_self_paced(self, params: ScheduleAddSelfPacedRequest, *, timeout: float | None = None) -> ScheduleAddResult:
+        "Registers a self-paced scheduled prompt.\n\nArgs:\n    params: Register a self-paced scheduled prompt.\n\nReturns:\n    Result of registering or re-arming a scheduled prompt.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return ScheduleAddResult.from_dict(await self._client.request("session.schedule.addSelfPaced", params_dict, **_timeout_kwargs(timeout)))
+
+    async def _rearm_self_paced(self, params: ScheduleRearmSelfPacedRequest, *, timeout: float | None = None) -> ScheduleAddResult:
+        "Re-arms an active self-paced scheduled prompt.\n\nArgs:\n    params: Re-arm a self-paced scheduled prompt.\n\nReturns:\n    Result of registering or re-arming a scheduled prompt.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        return ScheduleAddResult.from_dict(await self._client.request("session.schedule.rearmSelfPaced", params_dict, **_timeout_kwargs(timeout)))
+
+
 class _InternalSessionRpc:
     """Internal SDK session-scoped RPC methods. Not part of the public API."""
     def __init__(self, client: "JsonRpcClient", session_id: str):
@@ -29798,6 +31936,14 @@ class _InternalSessionRpc:
         self._session_id = session_id
         self.mcp = _InternalMcpApi(client, session_id)
         self.settings = _InternalSettingsApi(client, session_id)
+        self.queue = _InternalQueueApi(client, session_id)
+        self.schedule = _InternalScheduleApi(client, session_id)
+
+    async def _send_system_notification(self, params: SendSystemNotificationRequest, *, timeout: float | None = None) -> None:
+        "Queues or sends an internal system notification to the session according to its passive policy.\n\nArgs:\n    params: Internal request for sending a system notification.\n\n.. warning:: This API is experimental and may change or be removed in future versions.\n\n:meta private:\n\nInternal SDK API; not part of the public surface."
+        params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict["sessionId"] = self._session_id
+        await self._client.request("session.sendSystemNotification", params_dict, **_timeout_kwargs(timeout))
 
 
 # Experimental: this API group is experimental and may change or be removed.
@@ -29848,7 +31994,10 @@ class SessionFsHandler(Protocol):
         "Renames or moves a path in the client-provided session filesystem.\n\nArgs:\n    params: Source and destination paths for renaming or moving an entry in the client-provided session filesystem.\n\nReturns:\n    Describes a filesystem error."
         pass
     async def sqlite_query(self, params: SessionFSSqliteQueryRequest) -> SessionFSSqliteQueryResult:
-        "Executes a SQLite query against the per-session database.\n\nArgs:\n    params: SQL query, query type, and optional bind parameters for executing a SQLite query against the per-session database.\n\nReturns:\n    Query results including rows, columns, and rows affected, or a filesystem error if execution failed."
+        "Executes a SQLite query against the per-session database. Providers apply busy handling for every call.\n\nArgs:\n    params: SQL query, query type, and optional bind parameters for executing a SQLite query against the per-session database. The provider applies its SQLite busy timeout for every call.\n\nReturns:\n    Query results including rows, columns, and rows affected, or a filesystem error if execution failed."
+        pass
+    async def sqlite_transaction(self, params: SessionFSSqliteTransactionRequest) -> SessionFSSqliteTransactionResult:
+        "Executes SQLite statements atomically on the provider-owned connection.\n\nArgs:\n    params: Statements to execute atomically. Providers apply busy handling for every call.\n\nReturns:\n    Per-statement results, or a classified transaction error."
         pass
     async def sqlite_exists(self, params: SessionFSSqliteExistsRequest) -> SessionFSSqliteExistsResult:
         "Checks whether the per-session SQLite database already exists, without creating it.\n\nArgs:\n    params: Identifies the target session.\n\nReturns:\n    Indicates whether the per-session SQLite database already exists."
@@ -29976,6 +32125,13 @@ def register_client_session_api_handlers(
         result = await handler.sqlite_query(request)
         return result.to_dict()
     client.set_request_handler("sessionFs.sqliteQuery", handle_session_fs_sqlite_query)
+    async def handle_session_fs_sqlite_transaction(params: dict) -> dict | None:
+        request = SessionFSSqliteTransactionRequest.from_dict(params)
+        handler = get_handlers(request.session_id).session_fs
+        if handler is None: raise RuntimeError(f"No session_fs handler registered for session: {request.session_id}")
+        result = await handler.sqlite_transaction(request)
+        return result.to_dict()
+    client.set_request_handler("sessionFs.sqliteTransaction", handle_session_fs_sqlite_transaction)
     async def handle_session_fs_sqlite_exists(params: dict) -> dict | None:
         request = SessionFSSqliteExistsRequest.from_dict(params)
         handler = get_handlers(request.session_id).session_fs
@@ -30244,19 +32400,34 @@ __all__ = [
     "FactoryAgentOptions",
     "FactoryAgentRequest",
     "FactoryAgentResult",
+    "FactoryAgentSummary",
     "FactoryApi",
     "FactoryCancelRequest",
+    "FactoryCurrentPhase",
+    "FactoryDeclaredLimits",
+    "FactoryDurableOperation",
     "FactoryExecuteRequest",
     "FactoryExecuteResult",
+    "FactoryGetRunProgressRequest",
     "FactoryGetRunRequest",
     "FactoryHandler",
     "FactoryJournalApi",
     "FactoryJournalGetRequest",
     "FactoryJournalGetResult",
     "FactoryJournalPutRequest",
+    "FactoryListRunsRequest",
+    "FactoryListRunsResult",
     "FactoryLogLine",
     "FactoryLogLineKind",
     "FactoryLogRequest",
+    "FactoryPhaseObservation",
+    "FactoryPhaseStatus",
+    "FactoryProgressLine",
+    "FactoryProgressPage",
+    "FactoryResumeRequest",
+    "FactoryResumeResult",
+    "FactoryRunConsumed",
+    "FactoryRunDetail",
     "FactoryRunFailure",
     "FactoryRunFailureKind",
     "FactoryRunFailureType",
@@ -30264,6 +32435,8 @@ __all__ = [
     "FactoryRunRequest",
     "FactoryRunResult",
     "FactoryRunStatus",
+    "FactoryRunSummary",
+    "FactoryRunTerminal",
     "FilterMapping",
     "FleetApi",
     "FleetStartRequest",
@@ -30313,6 +32486,8 @@ __all__ = [
     "InstructionsDiscoverRequest",
     "InstructionsGetDiscoveryPathsRequest",
     "InstructionsGetSourcesResult",
+    "InterruptMainTurnRequest",
+    "InterruptMainTurnResult",
     "KindEnum",
     "LlmInferenceHTTPRequestChunkRequest",
     "LlmInferenceHTTPRequestChunkResult",
@@ -30381,6 +32556,8 @@ __all__ = [
     "MCPOauthLoginResult",
     "MCPOauthPendingRequestResponse",
     "MCPOauthPendingRequestResponseKind",
+    "MCPOauthRespondRequest",
+    "MCPOauthRespondResult",
     "MCPRegisterExternalClientRequest",
     "MCPReloadWithConfigRequest",
     "MCPRemoveGitHubResult",
@@ -30720,10 +32897,19 @@ __all__ = [
     "PushAttachmentType",
     "PushGitHubRepoRef",
     "QueueApi",
+    "QueueBeginDeferredIdleDrainRequest",
+    "QueueBeginDeferredIdleDrainResult",
+    "QueueConsumeSystemNotificationsRequest",
+    "QueueDeferSessionIdleRequest",
+    "QueueEnqueueResumePendingResult",
+    "QueueFinishDeferredIdleDrainRequest",
+    "QueueFinishDeferredIdleDrainResult",
+    "QueueHasPendingResult",
     "QueuePendingItems",
     "QueuePendingItemsKind",
     "QueuePendingItemsResult",
     "QueueRemoveMostRecentResult",
+    "QueueSnapshotResult",
     "QueuedCommandHandled",
     "QueuedCommandNotHandled",
     "QueuedCommandResult",
@@ -30766,9 +32952,16 @@ __all__ = [
     "SandboxConfigUserPolicyNetwork",
     "SandboxConfigUserPolicySeatbelt",
     "Saved",
+    "ScheduleAddAtRequest",
+    "ScheduleAddCronRequest",
+    "ScheduleAddRequest",
+    "ScheduleAddResult",
+    "ScheduleAddSelfPacedRequest",
     "ScheduleApi",
     "ScheduleEntry",
+    "ScheduleHasSelfPacedResult",
     "ScheduleList",
+    "ScheduleRearmSelfPacedRequest",
     "ScheduleStopRequest",
     "ScheduleStopResult",
     "SecretsAddFilterValuesRequest",
@@ -30781,6 +32974,7 @@ __all__ = [
     "SendMode",
     "SendRequest",
     "SendResult",
+    "SendSystemNotificationRequest",
     "ServerAccountApi",
     "ServerAgentList",
     "ServerAgentRegistryApi",
@@ -30809,6 +33003,7 @@ __all__ = [
     "SessionActivity",
     "SessionAuthStatus",
     "SessionBulkDeleteResult",
+    "SessionCancelAllBackgroundAgentsResult",
     "SessionCapability",
     "SessionCompletionItem",
     "SessionContext",
@@ -30840,6 +33035,11 @@ __all__ = [
     "SessionFSSqliteQueryRequest",
     "SessionFSSqliteQueryResult",
     "SessionFSSqliteQueryType",
+    "SessionFSSqliteTransactionError",
+    "SessionFSSqliteTransactionErrorClass",
+    "SessionFSSqliteTransactionRequest",
+    "SessionFSSqliteTransactionResult",
+    "SessionFSSqliteTransactionStatement",
     "SessionFSStatRequest",
     "SessionFSStatResult",
     "SessionFSWriteFileRequest",
@@ -30896,6 +33096,7 @@ __all__ = [
     "SessionsCheckInUseResult",
     "SessionsCloseRequest",
     "SessionsCloseResult",
+    "SessionsDeleteRequest",
     "SessionsEnrichMetadataRequest",
     "SessionsFindByPrefixRequest",
     "SessionsFindByPrefixResult",
@@ -30909,8 +33110,12 @@ __all__ = [
     "SessionsGetEventFilePathResult",
     "SessionsGetLastForContextRequest",
     "SessionsGetLastForContextResult",
+    "SessionsGetMetadataRequest",
+    "SessionsGetMetadataResult",
     "SessionsGetPersistedRemoteSteerableRequest",
     "SessionsGetPersistedRemoteSteerableResult",
+    "SessionsListNonEmptySessionIDSRequest",
+    "SessionsListNonEmptySessionIDSResult",
     "SessionsListRequest",
     "SessionsLoadDeferredRepoHooksRequest",
     "SessionsOpenAttach",
@@ -30951,9 +33156,13 @@ __all__ = [
     "ShellExecRequest",
     "ShellExecResult",
     "ShellExecuteUserRequestedRequest",
+    "ShellInitProfile",
+    "ShellInitScript",
+    "ShellInitScriptShell",
     "ShellKillRequest",
     "ShellKillResult",
     "ShellKillSignal",
+    "ShellOptions",
     "ShutdownRequest",
     "Skill",
     "SkillDiscoveryPath",
@@ -31106,20 +33315,30 @@ __all__ = [
     "WorkspaceDiffResult",
     "WorkspaceSummary",
     "WorkspaceSummaryHostType",
+    "WorkspacesAddSummaryRequest",
+    "WorkspacesAddSummaryResult",
     "WorkspacesApi",
+    "WorkspacesAutopilotObjectiveExistsResult",
     "WorkspacesCheckpoints",
     "WorkspacesCreateFileRequest",
+    "WorkspacesDeleteAutopilotObjectiveResult",
     "WorkspacesDiffRequest",
+    "WorkspacesEnsureRequest",
     "WorkspacesGetWorkspaceResult",
     "WorkspacesListCheckpointsResult",
     "WorkspacesListFilesResult",
+    "WorkspacesReadAutopilotObjectiveResult",
     "WorkspacesReadCheckpointRequest",
     "WorkspacesReadCheckpointResult",
     "WorkspacesReadFileRequest",
     "WorkspacesReadFileResult",
     "WorkspacesSaveLargePasteRequest",
     "WorkspacesSaveLargePasteResult",
+    "WorkspacesTruncateSummariesRequest",
+    "WorkspacesUpdateMetadataRequest",
     "WorkspacesWorkspaceDetailsHostType",
+    "WorkspacesWriteAutopilotObjectiveRequest",
+    "WorkspacesWriteAutopilotObjectiveResult",
     "rpc_from_dict",
     "rpc_to_dict",
 ]

--- a/python/copilot/generated/session_events.py
+++ b/python/copilot/generated/session_events.py
@@ -223,6 +223,8 @@ class SessionEventType(Enum):
     EXIT_PLAN_MODE_COMPLETED = "exit_plan_mode.completed"
     SESSION_TOOLS_UPDATED = "session.tools_updated"
     SESSION_BACKGROUND_TASKS_CHANGED = "session.background_tasks_changed"
+    # Experimental: this event is part of an experimental API and may change or be removed.
+    FACTORY_RUN_UPDATED = "factory.run_updated"
     SESSION_SKILLS_LOADED = "session.skills_loaded"
     SESSION_CUSTOM_AGENTS_UPDATED = "session.custom_agents_updated"
     SESSION_MCP_SERVERS_LOADED = "session.mcp_servers_loaded"
@@ -776,6 +778,30 @@ class Citations:
 
 # Experimental: this type is part of an experimental API and may change or be removed.
 @dataclass
+class FactoryRunUpdatedData:
+    "Ephemeral invalidation signal for a changed factory run."
+    revision: int
+    run_id: str
+
+    @staticmethod
+    def from_dict(obj: Any) -> "FactoryRunUpdatedData":
+        assert isinstance(obj, dict)
+        revision = from_int(obj.get("revision"))
+        run_id = from_str(obj.get("runId"))
+        return FactoryRunUpdatedData(
+            revision=revision,
+            run_id=run_id,
+        )
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["revision"] = to_int(self.revision)
+        result["runId"] = from_str(self.run_id)
+        return result
+
+
+# Experimental: this type is part of an experimental API and may change or be removed.
+@dataclass
 class OmittedBinaryResult:
     "A binary result whose data was omitted from persistence due to the inline size limit"
     byte_length: int
@@ -1246,6 +1272,7 @@ class AssistantMessageData:
     reasoning_text: str | None = None
     reasoning_wire_field: str | None = None
     request_id: str | None = None
+    rte: bool | None = None
     server_tools: AssistantMessageServerTools | None = None
     service_request_id: str | None = None
     tool_requests: list[AssistantMessageToolRequest] | None = None
@@ -1269,6 +1296,7 @@ class AssistantMessageData:
         reasoning_text = from_union([from_none, from_str], obj.get("reasoningText"))
         reasoning_wire_field = from_union([from_none, from_str], obj.get("reasoningWireField"))
         request_id = from_union([from_none, from_str], obj.get("requestId"))
+        rte = from_union([from_none, from_bool], obj.get("rte"))
         server_tools = from_union([from_none, AssistantMessageServerTools.from_dict], obj.get("serverTools"))
         service_request_id = from_union([from_none, from_str], obj.get("serviceRequestId"))
         tool_requests = from_union([from_none, lambda x: from_list(AssistantMessageToolRequest.from_dict, x)], obj.get("toolRequests"))
@@ -1289,6 +1317,7 @@ class AssistantMessageData:
             reasoning_text=reasoning_text,
             reasoning_wire_field=reasoning_wire_field,
             request_id=request_id,
+            rte=rte,
             server_tools=server_tools,
             service_request_id=service_request_id,
             tool_requests=tool_requests,
@@ -1325,6 +1354,8 @@ class AssistantMessageData:
             result["reasoningWireField"] = from_union([from_none, from_str], self.reasoning_wire_field)
         if self.request_id is not None:
             result["requestId"] = from_union([from_none, from_str], self.request_id)
+        if self.rte is not None:
+            result["rte"] = from_union([from_none, from_bool], self.rte)
         if self.server_tools is not None:
             result["serverTools"] = from_union([from_none, lambda x: to_class(AssistantMessageServerTools, x)], self.server_tools)
         if self.service_request_id is not None:
@@ -1447,21 +1478,26 @@ class AssistantReasoningData:
     "Assistant reasoning content for timeline display with complete thinking text"
     content: str
     reasoning_id: str
+    rte: bool | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "AssistantReasoningData":
         assert isinstance(obj, dict)
         content = from_str(obj.get("content"))
         reasoning_id = from_str(obj.get("reasoningId"))
+        rte = from_union([from_none, from_bool], obj.get("rte"))
         return AssistantReasoningData(
             content=content,
             reasoning_id=reasoning_id,
+            rte=rte,
         )
 
     def to_dict(self) -> dict:
         result: dict = {}
         result["content"] = from_str(self.content)
         result["reasoningId"] = from_str(self.reasoning_id)
+        if self.rte is not None:
+            result["rte"] = from_union([from_none, from_bool], self.rte)
         return result
 
 
@@ -1722,6 +1758,7 @@ class AssistantUsageData:
     finish_reason: str | None = None
     initiator: str | None = None
     input_tokens: int | None = None
+    interaction_type: str | None = None
     inter_token_latency: timedelta | None = None
     output_tokens: int | None = None
     # Deprecated: this field is deprecated.
@@ -1731,6 +1768,7 @@ class AssistantUsageData:
     _quota_snapshots: dict[str, _AssistantUsageQuotaSnapshot] | None = None
     reasoning_effort: str | None = None
     reasoning_tokens: int | None = None
+    rte: bool | None = None
     service_request_id: str | None = None
     time_to_first_token: timedelta | None = None
 
@@ -1750,6 +1788,7 @@ class AssistantUsageData:
         finish_reason = from_union([from_none, from_str], obj.get("finishReason"))
         initiator = from_union([from_none, from_str], obj.get("initiator"))
         input_tokens = from_union([from_none, from_int], obj.get("inputTokens"))
+        interaction_type = from_union([from_none, from_str], obj.get("interactionType"))
         inter_token_latency = from_union([from_none, from_timedelta], obj.get("interTokenLatencyMs"))
         output_tokens = from_union([from_none, from_int], obj.get("outputTokens"))
         parent_tool_call_id = from_union([from_none, from_str], obj.get("parentToolCallId"))
@@ -1757,6 +1796,7 @@ class AssistantUsageData:
         _quota_snapshots = from_union([from_none, lambda x: from_dict(_AssistantUsageQuotaSnapshot.from_dict, x)], obj.get("quotaSnapshots"))
         reasoning_effort = from_union([from_none, from_str], obj.get("reasoningEffort"))
         reasoning_tokens = from_union([from_none, from_int], obj.get("reasoningTokens"))
+        rte = from_union([from_none, from_bool], obj.get("rte"))
         service_request_id = from_union([from_none, from_str], obj.get("serviceRequestId"))
         time_to_first_token = from_union([from_none, from_timedelta], obj.get("timeToFirstTokenMs"))
         return AssistantUsageData(
@@ -1773,6 +1813,7 @@ class AssistantUsageData:
             finish_reason=finish_reason,
             initiator=initiator,
             input_tokens=input_tokens,
+            interaction_type=interaction_type,
             inter_token_latency=inter_token_latency,
             output_tokens=output_tokens,
             parent_tool_call_id=parent_tool_call_id,
@@ -1780,6 +1821,7 @@ class AssistantUsageData:
             _quota_snapshots=_quota_snapshots,
             reasoning_effort=reasoning_effort,
             reasoning_tokens=reasoning_tokens,
+            rte=rte,
             service_request_id=service_request_id,
             time_to_first_token=time_to_first_token,
         )
@@ -1811,6 +1853,8 @@ class AssistantUsageData:
             result["initiator"] = from_union([from_none, from_str], self.initiator)
         if self.input_tokens is not None:
             result["inputTokens"] = from_union([from_none, to_int], self.input_tokens)
+        if self.interaction_type is not None:
+            result["interactionType"] = from_union([from_none, from_str], self.interaction_type)
         if self.inter_token_latency is not None:
             result["interTokenLatencyMs"] = from_union([from_none, to_timedelta], self.inter_token_latency)
         if self.output_tokens is not None:
@@ -1825,6 +1869,8 @@ class AssistantUsageData:
             result["reasoningEffort"] = from_union([from_none, from_str], self.reasoning_effort)
         if self.reasoning_tokens is not None:
             result["reasoningTokens"] = from_union([from_none, to_int], self.reasoning_tokens)
+        if self.rte is not None:
+            result["rte"] = from_union([from_none, from_bool], self.rte)
         if self.service_request_id is not None:
             result["serviceRequestId"] = from_union([from_none, from_str], self.service_request_id)
         if self.time_to_first_token is not None:
@@ -3956,6 +4002,7 @@ class ModelCallFailureData:
     _quota_snapshots: dict[str, _AssistantUsageQuotaSnapshot] | None = None
     reasoning_effort: str | None = None
     request_fingerprint: ModelCallFailureRequestFingerprint | None = None
+    rte: bool | None = None
     service_request_id: str | None = None
     status_code: int | None = None
     transport: ModelCallFailureTransport | None = None
@@ -3982,6 +4029,7 @@ class ModelCallFailureData:
         _quota_snapshots = from_union([from_none, lambda x: from_dict(_AssistantUsageQuotaSnapshot.from_dict, x)], obj.get("quotaSnapshots"))
         reasoning_effort = from_union([from_none, from_str], obj.get("reasoningEffort"))
         request_fingerprint = from_union([from_none, ModelCallFailureRequestFingerprint.from_dict], obj.get("requestFingerprint"))
+        rte = from_union([from_none, from_bool], obj.get("rte"))
         service_request_id = from_union([from_none, from_str], obj.get("serviceRequestId"))
         status_code = from_union([from_none, from_int], obj.get("statusCode"))
         transport = from_union([from_none, lambda x: parse_enum(ModelCallFailureTransport, x)], obj.get("transport"))
@@ -4005,6 +4053,7 @@ class ModelCallFailureData:
             _quota_snapshots=_quota_snapshots,
             reasoning_effort=reasoning_effort,
             request_fingerprint=request_fingerprint,
+            rte=rte,
             service_request_id=service_request_id,
             status_code=status_code,
             transport=transport,
@@ -4049,6 +4098,8 @@ class ModelCallFailureData:
             result["reasoningEffort"] = from_union([from_none, from_str], self.reasoning_effort)
         if self.request_fingerprint is not None:
             result["requestFingerprint"] = from_union([from_none, lambda x: to_class(ModelCallFailureRequestFingerprint, x)], self.request_fingerprint)
+        if self.rte is not None:
+            result["rte"] = from_union([from_none, from_bool], self.rte)
         if self.service_request_id is not None:
             result["serviceRequestId"] = from_union([from_none, from_str], self.service_request_id)
         if self.status_code is not None:
@@ -6404,6 +6455,7 @@ class SessionScheduleCreatedData:
     cron: str | None = None
     display_prompt: str | None = None
     interval: timedelta | None = None
+    origin: ScheduleOrigin | None = None
     recurring: bool | None = None
     self_paced: bool | None = None
     tz: str | None = None
@@ -6417,6 +6469,7 @@ class SessionScheduleCreatedData:
         cron = from_union([from_none, from_str], obj.get("cron"))
         display_prompt = from_union([from_none, from_str], obj.get("displayPrompt"))
         interval = from_union([from_none, from_timedelta], obj.get("intervalMs"))
+        origin = from_union([from_none, lambda x: parse_enum(ScheduleOrigin, x)], obj.get("origin"))
         recurring = from_union([from_none, from_bool], obj.get("recurring"))
         self_paced = from_union([from_none, from_bool], obj.get("selfPaced"))
         tz = from_union([from_none, from_str], obj.get("tz"))
@@ -6427,6 +6480,7 @@ class SessionScheduleCreatedData:
             cron=cron,
             display_prompt=display_prompt,
             interval=interval,
+            origin=origin,
             recurring=recurring,
             self_paced=self_paced,
             tz=tz,
@@ -6444,6 +6498,8 @@ class SessionScheduleCreatedData:
             result["displayPrompt"] = from_union([from_none, from_str], self.display_prompt)
         if self.interval is not None:
             result["intervalMs"] = from_union([from_none, to_timedelta_int], self.interval)
+        if self.origin is not None:
+            result["origin"] = from_union([from_none, lambda x: to_enum(ScheduleOrigin, x)], self.origin)
         if self.recurring is not None:
             result["recurring"] = from_union([from_none, from_bool], self.recurring)
         if self.self_paced is not None:
@@ -7407,6 +7463,7 @@ class SystemMessageData:
     "System/developer instruction content with role and optional template metadata"
     content: str
     role: SystemMessageRole
+    interaction_id: str | None = None
     metadata: SystemMessageMetadata | None = None
     name: str | None = None
 
@@ -7415,11 +7472,13 @@ class SystemMessageData:
         assert isinstance(obj, dict)
         content = from_str(obj.get("content"))
         role = parse_enum(SystemMessageRole, obj.get("role"))
+        interaction_id = from_union([from_none, from_str], obj.get("interactionId"))
         metadata = from_union([from_none, SystemMessageMetadata.from_dict], obj.get("metadata"))
         name = from_union([from_none, from_str], obj.get("name"))
         return SystemMessageData(
             content=content,
             role=role,
+            interaction_id=interaction_id,
             metadata=metadata,
             name=name,
         )
@@ -7428,6 +7487,8 @@ class SystemMessageData:
         result: dict = {}
         result["content"] = from_str(self.content)
         result["role"] = to_enum(SystemMessageRole, self.role)
+        if self.interaction_id is not None:
+            result["interactionId"] = from_union([from_none, from_str], self.interaction_id)
         if self.metadata is not None:
             result["metadata"] = from_union([from_none, lambda x: to_class(SystemMessageMetadata, x)], self.metadata)
         if self.name is not None:
@@ -7906,6 +7967,7 @@ class ToolExecutionCompleteData:
     # Deprecated: this field is deprecated.
     parent_tool_call_id: str | None = None
     result: ToolExecutionCompleteResult | None = None
+    rte: bool | None = None
     sandboxed: bool | None = None
     tool_description: ToolExecutionCompleteToolDescription | None = None
     tool_telemetry: dict[str, Any] | None = None
@@ -7923,6 +7985,7 @@ class ToolExecutionCompleteData:
         model = from_union([from_none, from_str], obj.get("model"))
         parent_tool_call_id = from_union([from_none, from_str], obj.get("parentToolCallId"))
         result = from_union([from_none, ToolExecutionCompleteResult.from_dict], obj.get("result"))
+        rte = from_union([from_none, from_bool], obj.get("rte"))
         sandboxed = from_union([from_none, from_bool], obj.get("sandboxed"))
         tool_description = from_union([from_none, ToolExecutionCompleteToolDescription.from_dict], obj.get("toolDescription"))
         tool_telemetry = from_union([from_none, lambda x: from_dict(lambda x: x, x)], obj.get("toolTelemetry"))
@@ -7937,6 +8000,7 @@ class ToolExecutionCompleteData:
             model=model,
             parent_tool_call_id=parent_tool_call_id,
             result=result,
+            rte=rte,
             sandboxed=sandboxed,
             tool_description=tool_description,
             tool_telemetry=tool_telemetry,
@@ -7961,6 +8025,8 @@ class ToolExecutionCompleteData:
             result["parentToolCallId"] = from_union([from_none, from_str], self.parent_tool_call_id)
         if self.result is not None:
             result["result"] = from_union([from_none, lambda x: to_class(ToolExecutionCompleteResult, x)], self.result)
+        if self.rte is not None:
+            result["rte"] = from_union([from_none, from_bool], self.rte)
         if self.sandboxed is not None:
             result["sandboxed"] = from_union([from_none, from_bool], self.sandboxed)
         if self.tool_description is not None:
@@ -8396,6 +8462,7 @@ class ToolExecutionStartData:
     model: str | None = None
     # Deprecated: this field is deprecated.
     parent_tool_call_id: str | None = None
+    rte: bool | None = None
     shell_tool_info: ToolExecutionStartShellToolInfo | None = None
     tool_description: ToolExecutionStartToolDescription | None = None
     turn_id: str | None = None
@@ -8411,6 +8478,7 @@ class ToolExecutionStartData:
         mcp_tool_name = from_union([from_none, from_str], obj.get("mcpToolName"))
         model = from_union([from_none, from_str], obj.get("model"))
         parent_tool_call_id = from_union([from_none, from_str], obj.get("parentToolCallId"))
+        rte = from_union([from_none, from_bool], obj.get("rte"))
         shell_tool_info = from_union([from_none, ToolExecutionStartShellToolInfo.from_dict], obj.get("shellToolInfo"))
         tool_description = from_union([from_none, ToolExecutionStartToolDescription.from_dict], obj.get("toolDescription"))
         turn_id = from_union([from_none, from_str], obj.get("turnId"))
@@ -8423,6 +8491,7 @@ class ToolExecutionStartData:
             mcp_tool_name=mcp_tool_name,
             model=model,
             parent_tool_call_id=parent_tool_call_id,
+            rte=rte,
             shell_tool_info=shell_tool_info,
             tool_description=tool_description,
             turn_id=turn_id,
@@ -8444,6 +8513,8 @@ class ToolExecutionStartData:
             result["model"] = from_union([from_none, from_str], self.model)
         if self.parent_tool_call_id is not None:
             result["parentToolCallId"] = from_union([from_none, from_str], self.parent_tool_call_id)
+        if self.rte is not None:
+            result["rte"] = from_union([from_none, from_bool], self.rte)
         if self.shell_tool_info is not None:
             result["shellToolInfo"] = from_union([from_none, lambda x: to_class(ToolExecutionStartShellToolInfo, x)], self.shell_tool_info)
         if self.tool_description is not None:
@@ -9562,6 +9633,14 @@ class ReasoningSummary(Enum):
     DETAILED = "detailed"
 
 
+class ScheduleOrigin(Enum):
+    "Who created the schedule: `user` (an explicit user action such as `/every` or `/after`) or `model` (the agent via the `manage_schedule` tool). Gates whether a scheduled skill that opted out of model invocation may fire: only user-created schedules may."
+    # The schedule was created by an explicit user action, such as `/every` or `/after`.
+    USER = "user"
+    # The schedule was created by the agent via the `manage_schedule` tool.
+    MODEL = "model"
+
+
 class SessionLimitsExhaustedResponseAction(Enum):
     "User action selected for an exhausted session limit."
     # Increase the current max by an exact AI Credits amount.
@@ -9708,7 +9787,7 @@ class WorkspaceFileChangedOperation(Enum):
     UPDATE = "update"
 
 
-SessionEventData = SessionStartData | SessionResumeData | SessionRemoteSteerableChangedData | SessionErrorData | SessionIdleData | SessionTitleChangedData | SessionScheduleCreatedData | SessionScheduleCancelledData | SessionScheduleRearmedData | SessionAutopilotObjectiveChangedData | SessionInfoData | SessionWarningData | SessionModelChangeData | SessionModeChangedData | SessionSessionLimitsChangedData | SessionPermissionsChangedData | SessionPlanChangedData | SessionTodosChangedData | SessionWorkspaceFileChangedData | SessionHandoffData | SessionTruncationData | SessionSnapshotRewindData | SessionShutdownData | SessionUsageCheckpointData | SessionContextChangedData | SessionUsageInfoData | SessionCompactionStartData | SessionCompactionCompleteData | SessionTaskCompleteData | UserMessageData | PendingMessagesModifiedData | AssistantTurnStartData | AssistantTurnRetryData | AssistantIntentData | AssistantServerToolProgressData | AssistantReasoningData | AssistantReasoningDeltaData | AssistantToolCallDeltaData | AssistantStreamingDeltaData | AssistantMessageData | AssistantMessageStartData | AssistantMessageDeltaData | AssistantTurnEndData | AssistantIdleData | AssistantUsageData | ModelCallFailureData | ModelCallStartData | AbortData | ToolUserRequestedData | ToolExecutionStartData | ToolExecutionPartialResultData | ToolExecutionProgressData | ToolExecutionCompleteData | ToolSearchActivatedData | SkillInvokedData | SubagentStartedData | SubagentCompletedData | SubagentFailedData | SubagentSelectedData | SubagentDeselectedData | HookStartData | HookEndData | HookProgressData | SessionBinaryAssetData | SystemMessageData | SystemNotificationData | PermissionRequestedData | PermissionCompletedData | UserInputRequestedData | UserInputCompletedData | ElicitationRequestedData | ElicitationCompletedData | SamplingRequestedData | SamplingCompletedData | McpOauthRequiredData | McpOauthCompletedData | McpHeadersRefreshRequiredData | McpHeadersRefreshCompletedData | SessionCustomNotificationData | ExternalToolRequestedData | ExternalToolCompletedData | CommandQueuedData | CommandExecuteData | CommandCompletedData | AutoModeSwitchRequestedData | AutoModeSwitchCompletedData | SessionLimitsExhaustedRequestedData | SessionLimitsExhaustedCompletedData | SessionAutoModeResolvedData | SessionManagedSettingsResolvedData | SessionManagedSettingsEnforcedData | CommandsChangedData | CapabilitiesChangedData | ExitPlanModeRequestedData | ExitPlanModeCompletedData | SessionToolsUpdatedData | SessionBackgroundTasksChangedData | SessionSkillsLoadedData | SessionCustomAgentsUpdatedData | SessionMcpServersLoadedData | SessionMcpServerStatusChangedData | McpToolsListChangedData | McpResourcesListChangedData | McpPromptsListChangedData | SessionExtensionsLoadedData | SessionCanvasOpenedData | SessionCanvasRegistryChangedData | SessionCanvasClosedData | SessionCanvasUnavailableData | SessionCanvasRecordedData | SessionCanvasRemovedData | SessionExtensionsAttachmentsPushedData | McpAppToolCallCompleteData | RawSessionEventData | Data
+SessionEventData = SessionStartData | SessionResumeData | SessionRemoteSteerableChangedData | SessionErrorData | SessionIdleData | SessionTitleChangedData | SessionScheduleCreatedData | SessionScheduleCancelledData | SessionScheduleRearmedData | SessionAutopilotObjectiveChangedData | SessionInfoData | SessionWarningData | SessionModelChangeData | SessionModeChangedData | SessionSessionLimitsChangedData | SessionPermissionsChangedData | SessionPlanChangedData | SessionTodosChangedData | SessionWorkspaceFileChangedData | SessionHandoffData | SessionTruncationData | SessionSnapshotRewindData | SessionShutdownData | SessionUsageCheckpointData | SessionContextChangedData | SessionUsageInfoData | SessionCompactionStartData | SessionCompactionCompleteData | SessionTaskCompleteData | UserMessageData | PendingMessagesModifiedData | AssistantTurnStartData | AssistantTurnRetryData | AssistantIntentData | AssistantServerToolProgressData | AssistantReasoningData | AssistantReasoningDeltaData | AssistantToolCallDeltaData | AssistantStreamingDeltaData | AssistantMessageData | AssistantMessageStartData | AssistantMessageDeltaData | AssistantTurnEndData | AssistantIdleData | AssistantUsageData | ModelCallFailureData | ModelCallStartData | AbortData | ToolUserRequestedData | ToolExecutionStartData | ToolExecutionPartialResultData | ToolExecutionProgressData | ToolExecutionCompleteData | ToolSearchActivatedData | SkillInvokedData | SubagentStartedData | SubagentCompletedData | SubagentFailedData | SubagentSelectedData | SubagentDeselectedData | HookStartData | HookEndData | HookProgressData | SessionBinaryAssetData | SystemMessageData | SystemNotificationData | PermissionRequestedData | PermissionCompletedData | UserInputRequestedData | UserInputCompletedData | ElicitationRequestedData | ElicitationCompletedData | SamplingRequestedData | SamplingCompletedData | McpOauthRequiredData | McpOauthCompletedData | McpHeadersRefreshRequiredData | McpHeadersRefreshCompletedData | SessionCustomNotificationData | ExternalToolRequestedData | ExternalToolCompletedData | CommandQueuedData | CommandExecuteData | CommandCompletedData | AutoModeSwitchRequestedData | AutoModeSwitchCompletedData | SessionLimitsExhaustedRequestedData | SessionLimitsExhaustedCompletedData | SessionAutoModeResolvedData | SessionManagedSettingsResolvedData | SessionManagedSettingsEnforcedData | CommandsChangedData | CapabilitiesChangedData | ExitPlanModeRequestedData | ExitPlanModeCompletedData | SessionToolsUpdatedData | SessionBackgroundTasksChangedData | FactoryRunUpdatedData | SessionSkillsLoadedData | SessionCustomAgentsUpdatedData | SessionMcpServersLoadedData | SessionMcpServerStatusChangedData | McpToolsListChangedData | McpResourcesListChangedData | McpPromptsListChangedData | SessionExtensionsLoadedData | SessionCanvasOpenedData | SessionCanvasRegistryChangedData | SessionCanvasClosedData | SessionCanvasUnavailableData | SessionCanvasRecordedData | SessionCanvasRemovedData | SessionExtensionsAttachmentsPushedData | McpAppToolCallCompleteData | RawSessionEventData | Data
 
 
 @dataclass
@@ -9831,6 +9910,7 @@ class SessionEvent:
             case SessionEventType.EXIT_PLAN_MODE_COMPLETED: data = ExitPlanModeCompletedData.from_dict(data_obj)
             case SessionEventType.SESSION_TOOLS_UPDATED: data = SessionToolsUpdatedData.from_dict(data_obj)
             case SessionEventType.SESSION_BACKGROUND_TASKS_CHANGED: data = SessionBackgroundTasksChangedData.from_dict(data_obj)
+            case SessionEventType.FACTORY_RUN_UPDATED: data = FactoryRunUpdatedData.from_dict(data_obj)
             case SessionEventType.SESSION_SKILLS_LOADED: data = SessionSkillsLoadedData.from_dict(data_obj)
             case SessionEventType.SESSION_CUSTOM_AGENTS_UPDATED: data = SessionCustomAgentsUpdatedData.from_dict(data_obj)
             case SessionEventType.SESSION_MCP_SERVERS_LOADED: data = SessionMcpServersLoadedData.from_dict(data_obj)
@@ -9975,6 +10055,7 @@ __all__ = [
     "ExtensionsLoadedExtensionStatus",
     "ExternalToolCompletedData",
     "ExternalToolRequestedData",
+    "FactoryRunUpdatedData",
     "GitHubRepoRef",
     "HandoffRepository",
     "HandoffSourceType",
@@ -10070,6 +10151,7 @@ __all__ = [
     "ReasoningSummary",
     "SamplingCompletedData",
     "SamplingRequestedData",
+    "ScheduleOrigin",
     "SessionAutoModeResolvedData",
     "SessionAutopilotObjectiveChangedData",
     "SessionBackgroundTasksChangedData",

--- a/python/copilot/session_fs_provider.py
+++ b/python/copilot/session_fs_provider.py
@@ -34,6 +34,9 @@ from .generated.rpc import (
     SessionFSReadFileResult,
     SessionFSSqliteExistsResult,
     SessionFSSqliteQueryType,
+    SessionFSSqliteTransactionError,
+    SessionFSSqliteTransactionErrorClass,
+    SessionFSSqliteTransactionResult,
     SessionFSStatResult,
 )
 from .generated.rpc import (
@@ -292,6 +295,21 @@ class _SessionFsAdapter:
             rows=result.rows,
             rows_affected=result.rows_affected,
             last_insert_rowid=result.last_insert_rowid,
+        )
+
+    async def sqlite_transaction(self, params: Any) -> SessionFSSqliteTransactionResult:
+        # This SDK's provider interface exposes no atomic-transaction hook, so
+        # the batch is refused outright rather than applied non-atomically.
+        return SessionFSSqliteTransactionResult(
+            results=[],
+            error=SessionFSSqliteTransactionError(
+                error_class=SessionFSSqliteTransactionErrorClass.FATAL,
+                message=(
+                    "Atomic SQLite transactions are not supported by this SessionFs provider"
+                    if isinstance(self._p, SessionFsSqliteProvider)
+                    else "SQLite is not supported by this SessionFs provider"
+                ),
+            ),
         )
 
     async def sqlite_exists(self, params: Any) -> SessionFSSqliteExistsResult:

--- a/rust/src/generated/api_types.rs
+++ b/rust/src/generated/api_types.rs
@@ -118,6 +118,10 @@ pub mod rpc_methods {
     pub const SESSIONS_CONNECT: &str = "sessions.connect";
     /// `sessions.list`
     pub const SESSIONS_LIST: &str = "sessions.list";
+    /// `sessions.getMetadata`
+    pub const SESSIONS_GETMETADATA: &str = "sessions.getMetadata";
+    /// `sessions.listNonEmptySessionIds`
+    pub const SESSIONS_LISTNONEMPTYSESSIONIDS: &str = "sessions.listNonEmptySessionIds";
     /// `sessions.findByTaskId`
     pub const SESSIONS_FINDBYTASKID: &str = "sessions.findByTaskId";
     /// `sessions.findByPrefix`
@@ -136,6 +140,8 @@ pub mod rpc_methods {
     pub const SESSIONS_CLOSE: &str = "sessions.close";
     /// `sessions.bulkDelete`
     pub const SESSIONS_BULKDELETE: &str = "sessions.bulkDelete";
+    /// `sessions.delete`
+    pub const SESSIONS_DELETE: &str = "sessions.delete";
     /// `sessions.pruneOld`
     pub const SESSIONS_PRUNEOLD: &str = "sessions.pruneOld";
     /// `sessions.save`
@@ -175,8 +181,14 @@ pub mod rpc_methods {
     pub const SESSION_SEND: &str = "session.send";
     /// `session.sendMessages`
     pub const SESSION_SENDMESSAGES: &str = "session.sendMessages";
+    /// `session.sendSystemNotification`
+    pub const SESSION_SENDSYSTEMNOTIFICATION: &str = "session.sendSystemNotification";
     /// `session.abort`
     pub const SESSION_ABORT: &str = "session.abort";
+    /// `session.interruptMainTurn`
+    pub const SESSION_INTERRUPTMAINTURN: &str = "session.interruptMainTurn";
+    /// `session.cancelAllBackgroundAgents`
+    pub const SESSION_CANCELALLBACKGROUNDAGENTS: &str = "session.cancelAllBackgroundAgents";
     /// `session.shutdown`
     pub const SESSION_SHUTDOWN: &str = "session.shutdown";
     /// `session.gitHubAuth.getStatus`
@@ -197,8 +209,16 @@ pub mod rpc_methods {
     pub const SESSION_CANVAS_ACTION_INVOKE: &str = "session.canvas.action.invoke";
     /// `session.factory.run`
     pub const SESSION_FACTORY_RUN: &str = "session.factory.run";
+    /// `session.factory.resume`
+    pub const SESSION_FACTORY_RESUME: &str = "session.factory.resume";
     /// `session.factory.getRun`
     pub const SESSION_FACTORY_GETRUN: &str = "session.factory.getRun";
+    /// `session.factory.listRuns`
+    pub const SESSION_FACTORY_LISTRUNS: &str = "session.factory.listRuns";
+    /// `session.factory.getRunDetail`
+    pub const SESSION_FACTORY_GETRUNDETAIL: &str = "session.factory.getRunDetail";
+    /// `session.factory.getRunProgress`
+    pub const SESSION_FACTORY_GETRUNPROGRESS: &str = "session.factory.getRunProgress";
     /// `session.factory.cancel`
     pub const SESSION_FACTORY_CANCEL: &str = "session.factory.cancel";
     /// `session.factory.log`
@@ -240,6 +260,10 @@ pub mod rpc_methods {
         "session.plan.readSqlTodosWithDependencies";
     /// `session.workspaces.getWorkspace`
     pub const SESSION_WORKSPACES_GETWORKSPACE: &str = "session.workspaces.getWorkspace";
+    /// `session.workspaces.updateMetadata`
+    pub const SESSION_WORKSPACES_UPDATEMETADATA: &str = "session.workspaces.updateMetadata";
+    /// `session.workspaces.ensure`
+    pub const SESSION_WORKSPACES_ENSURE: &str = "session.workspaces.ensure";
     /// `session.workspaces.listFiles`
     pub const SESSION_WORKSPACES_LISTFILES: &str = "session.workspaces.listFiles";
     /// `session.workspaces.readFile`
@@ -250,6 +274,22 @@ pub mod rpc_methods {
     pub const SESSION_WORKSPACES_LISTCHECKPOINTS: &str = "session.workspaces.listCheckpoints";
     /// `session.workspaces.readCheckpoint`
     pub const SESSION_WORKSPACES_READCHECKPOINT: &str = "session.workspaces.readCheckpoint";
+    /// `session.workspaces.addSummary`
+    pub const SESSION_WORKSPACES_ADDSUMMARY: &str = "session.workspaces.addSummary";
+    /// `session.workspaces.truncateSummaries`
+    pub const SESSION_WORKSPACES_TRUNCATESUMMARIES: &str = "session.workspaces.truncateSummaries";
+    /// `session.workspaces.readAutopilotObjective`
+    pub const SESSION_WORKSPACES_READAUTOPILOTOBJECTIVE: &str =
+        "session.workspaces.readAutopilotObjective";
+    /// `session.workspaces.writeAutopilotObjective`
+    pub const SESSION_WORKSPACES_WRITEAUTOPILOTOBJECTIVE: &str =
+        "session.workspaces.writeAutopilotObjective";
+    /// `session.workspaces.deleteAutopilotObjective`
+    pub const SESSION_WORKSPACES_DELETEAUTOPILOTOBJECTIVE: &str =
+        "session.workspaces.deleteAutopilotObjective";
+    /// `session.workspaces.autopilotObjectiveExists`
+    pub const SESSION_WORKSPACES_AUTOPILOTOBJECTIVEEXISTS: &str =
+        "session.workspaces.autopilotObjectiveExists";
     /// `session.workspaces.saveLargePaste`
     pub const SESSION_WORKSPACES_SAVELARGEPASTE: &str = "session.workspaces.saveLargePaste";
     /// `session.workspaces.diff`
@@ -347,6 +387,8 @@ pub mod rpc_methods {
         "session.mcp.oauth.handlePendingRequest";
     /// `session.mcp.oauth.login`
     pub const SESSION_MCP_OAUTH_LOGIN: &str = "session.mcp.oauth.login";
+    /// `session.mcp.oauth.respond`
+    pub const SESSION_MCP_OAUTH_RESPOND: &str = "session.mcp.oauth.respond";
     /// `session.mcp.headers.handlePendingHeadersRefreshRequest`
     pub const SESSION_MCP_HEADERS_HANDLEPENDINGHEADERSREFRESHREQUEST: &str =
         "session.mcp.headers.handlePendingHeadersRefreshRequest";
@@ -539,10 +581,27 @@ pub mod rpc_methods {
     pub const SESSION_HISTORY_SUMMARIZEFORHANDOFF: &str = "session.history.summarizeForHandoff";
     /// `session.queue.pendingItems`
     pub const SESSION_QUEUE_PENDINGITEMS: &str = "session.queue.pendingItems";
+    /// `session.queue.snapshot`
+    pub const SESSION_QUEUE_SNAPSHOT: &str = "session.queue.snapshot";
+    /// `session.queue.hasPending`
+    pub const SESSION_QUEUE_HASPENDING: &str = "session.queue.hasPending";
+    /// `session.queue.beginDeferredIdleDrain`
+    pub const SESSION_QUEUE_BEGINDEFERREDIDLEDRAIN: &str = "session.queue.beginDeferredIdleDrain";
+    /// `session.queue.finishDeferredIdleDrain`
+    pub const SESSION_QUEUE_FINISHDEFERREDIDLEDRAIN: &str = "session.queue.finishDeferredIdleDrain";
+    /// `session.queue.deferSessionIdle`
+    pub const SESSION_QUEUE_DEFERSESSIONIDLE: &str = "session.queue.deferSessionIdle";
     /// `session.queue.removeMostRecent`
     pub const SESSION_QUEUE_REMOVEMOSTRECENT: &str = "session.queue.removeMostRecent";
     /// `session.queue.clear`
     pub const SESSION_QUEUE_CLEAR: &str = "session.queue.clear";
+    /// `session.queue.consumeSystemNotifications`
+    pub const SESSION_QUEUE_CONSUMESYSTEMNOTIFICATIONS: &str =
+        "session.queue.consumeSystemNotifications";
+    /// `session.queue.enqueueResumePending`
+    pub const SESSION_QUEUE_ENQUEUERESUMEPENDING: &str = "session.queue.enqueueResumePending";
+    /// `session.queue.process`
+    pub const SESSION_QUEUE_PROCESS: &str = "session.queue.process";
     /// `session.eventLog.read`
     pub const SESSION_EVENTLOG_READ: &str = "session.eventLog.read";
     /// `session.eventLog.tail`
@@ -565,6 +624,20 @@ pub mod rpc_methods {
     pub const SESSION_VISIBILITY_SET: &str = "session.visibility.set";
     /// `session.schedule.list`
     pub const SESSION_SCHEDULE_LIST: &str = "session.schedule.list";
+    /// `session.schedule.hydrate`
+    pub const SESSION_SCHEDULE_HYDRATE: &str = "session.schedule.hydrate";
+    /// `session.schedule.hasSelfPaced`
+    pub const SESSION_SCHEDULE_HASSELFPACED: &str = "session.schedule.hasSelfPaced";
+    /// `session.schedule.add`
+    pub const SESSION_SCHEDULE_ADD: &str = "session.schedule.add";
+    /// `session.schedule.addCron`
+    pub const SESSION_SCHEDULE_ADDCRON: &str = "session.schedule.addCron";
+    /// `session.schedule.addAt`
+    pub const SESSION_SCHEDULE_ADDAT: &str = "session.schedule.addAt";
+    /// `session.schedule.addSelfPaced`
+    pub const SESSION_SCHEDULE_ADDSELFPACED: &str = "session.schedule.addSelfPaced";
+    /// `session.schedule.rearmSelfPaced`
+    pub const SESSION_SCHEDULE_REARMSELFPACED: &str = "session.schedule.rearmSelfPaced";
     /// `session.schedule.stop`
     pub const SESSION_SCHEDULE_STOP: &str = "session.schedule.stop";
     /// `providerToken.getToken`
@@ -595,6 +668,8 @@ pub mod rpc_methods {
     pub const SESSIONFS_RENAME: &str = "sessionFs.rename";
     /// `sessionFs.sqliteQuery`
     pub const SESSIONFS_SQLITEQUERY: &str = "sessionFs.sqliteQuery";
+    /// `sessionFs.sqliteTransaction`
+    pub const SESSIONFS_SQLITETRANSACTION: &str = "sessionFs.sqliteTransaction";
     /// `sessionFs.sqliteExists`
     pub const SESSIONFS_SQLITEEXISTS: &str = "sessionFs.sqliteExists";
     /// `canvas.open`
@@ -2853,7 +2928,7 @@ pub struct ConnectRemoteSessionParams {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ConnectRequest {
-    /// Opt this connection in to GitHub telemetry forwarding for its lifetime. When set, the runtime forwards every internal telemetry event it emits — across all sessions, plus sessionless events — to this connection over the `gitHubTelemetry.event` notification, in addition to the runtime's normal GitHub/CTS emission (dual-write). Intended for first-party hosts that re-emit the events into their own telemetry stores. Both unrestricted and restricted events are forwarded, each tagged with a `restricted` discriminator; a backstop drops restricted events when restricted telemetry is disabled.
+    /// Opt this connection in to GitHub telemetry forwarding for its lifetime. When set, the runtime forwards every internal telemetry event it emits — across all sessions, plus sessionless events — to this connection over the `gitHubTelemetry.event` notification. Regular events are also written to the runtime's normal GitHub/CTS path (dual-write); host-only compatibility events are forward-only and intentionally skip that path. Intended for first-party hosts that re-emit the events into their own telemetry stores. Both unrestricted and restricted events are forwarded, each tagged with a `restricted` discriminator; a backstop drops restricted events when restricted telemetry is disabled — using the process-global gate for ordinary events and an explicit session-scoped decision for host-only events.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enable_git_hub_telemetry_forwarding: Option<bool>,
     /// Connection token; required when the server was started with COPILOT_CONNECTION_TOKEN
@@ -3724,6 +3799,8 @@ pub struct FactoryAgentOptions {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FactoryAgentRequest {
+    /// Opaque token identifying the current factory execution attempt.
+    pub execution_token: String,
     /// Factory run identifier that owns the subagent.
     pub factory_run_id: String,
     /// Subagent execution options.
@@ -3748,6 +3825,37 @@ pub struct FactoryAgentResult {
     pub result: Option<serde_json::Value>,
 }
 
+/// Prompt-safe durable identity and live status for a direct factory agent.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FactoryAgentSummary {
+    pub active_ms: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub activity: Option<String>,
+    pub agent_id: String,
+    pub agent_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<i64>,
+    pub label: String,
+    pub phase_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_model: Option<String>,
+    pub run_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<i64>,
+    pub status: String,
+    pub tool_call_id: String,
+}
+
 /// Parameters for cancelling a factory run.
 ///
 /// <div class="warning">
@@ -3761,6 +3869,42 @@ pub struct FactoryAgentResult {
 pub struct FactoryCancelRequest {
     /// Factory run identifier.
     pub run_id: String,
+}
+
+/// Current factory phase identity.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FactoryCurrentPhase {
+    pub id: String,
+    pub ordinal: Option<i64>,
+}
+
+/// Declared or approved factory resource ceilings.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FactoryDeclaredLimits {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_ai_credits: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_concurrent_subagents: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_total_subagents: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_seconds: Option<f64>,
 }
 
 /// Parameters sent to the owning extension to execute a factory closure.
@@ -3780,6 +3924,8 @@ pub struct FactoryExecuteRequest {
     pub name: String,
     /// Factory run identifier.
     pub run_id: String,
+    /// Opaque token identifying this factory execution attempt.
+    pub execution_token: String,
     /// Factory input value.
     pub args: serde_json::Value,
 }
@@ -3796,7 +3942,35 @@ pub struct FactoryExecuteRequest {
 #[serde(rename_all = "camelCase")]
 pub struct FactoryExecuteResult {
     /// Factory result value.
-    pub result: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+}
+
+/// Parameters for paging factory progress.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FactoryGetRunProgressRequest {
+    /// Exclusive forward cursor.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after_seq: Option<i64>,
+    /// Exclusive backward cursor.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before_seq: Option<i64>,
+    /// Maximum records to return. Defaults to 200 and is capped at 500.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<i32>,
+    /// Optional phase identifier used to scope records and cursors.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phase_id: Option<String>,
+    /// Factory run identifier.
+    pub run_id: String,
 }
 
 /// Parameters for retrieving a factory run.
@@ -3825,6 +3999,8 @@ pub struct FactoryGetRunRequest {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FactoryJournalGetRequest {
+    /// Opaque token identifying the current factory execution attempt.
+    pub execution_token: String,
     /// Namespaced journal key.
     pub key: String,
     /// Factory run identifier.
@@ -3860,12 +4036,109 @@ pub struct FactoryJournalGetResult {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FactoryJournalPutRequest {
+    /// Opaque token identifying the current factory execution attempt.
+    pub execution_token: String,
     /// Namespaced journal key.
     pub key: String,
     /// JSON result to memoize.
     pub result_json: serde_json::Value,
     /// Factory run identifier.
     pub run_id: String,
+}
+
+/// Empty parameters for listing factory runs.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FactoryListRunsRequest {}
+
+/// Durable factory resource consumption.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FactoryRunConsumed {
+    pub active_ms: i64,
+    pub nano_aiu: i64,
+    pub subagents: i64,
+}
+
+/// Prompt-safe terminal factory outcome.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FactoryRunTerminal {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_preview: Option<String>,
+}
+
+/// Durable factory run summary with read-time live overlays.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FactoryRunSummary {
+    pub active_segment_started_at: Option<i64>,
+    pub approved: Option<FactoryDeclaredLimits>,
+    pub completed_at: Option<i64>,
+    pub consumed: FactoryRunConsumed,
+    pub created_at: i64,
+    pub current_phase: Option<FactoryCurrentPhase>,
+    pub declared_limits: FactoryDeclaredLimits,
+    pub declared_phase_count: i64,
+    pub description: String,
+    pub factory_name: String,
+    pub live_agent_count: i64,
+    pub observed_at: i64,
+    pub revision: i64,
+    pub run_id: String,
+    pub started_at: Option<i64>,
+    pub status: FactoryRunStatus,
+    pub terminal: Option<FactoryRunTerminal>,
+    pub total_spawned_agent_count: i64,
+    pub updated_at: i64,
+}
+
+/// Factory runs in durable creation order.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FactoryListRunsResult {
+    pub runs: Vec<FactoryRunSummary>,
 }
 
 /// One ordered factory progress line.
@@ -3898,10 +4171,86 @@ pub struct FactoryLogLine {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FactoryLogRequest {
+    /// Opaque token identifying the current factory execution attempt.
+    pub execution_token: String,
     /// Ordered progress lines to append.
     pub lines: Vec<FactoryLogLine>,
     /// Factory run identifier.
     pub run_id: String,
+}
+
+/// Durable lifecycle and timing for one factory phase.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FactoryPhaseObservation {
+    pub accumulated_active_ms: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<i64>,
+    pub current_active_ms: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    pub entry_count: i64,
+    pub id: String,
+    pub last_entered_run_attempt: i64,
+    pub live_agent_count: i64,
+    pub ordinal: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<i64>,
+    pub status: FactoryPhaseStatus,
+    pub title: String,
+    pub total_agent_count: i64,
+}
+
+/// One durable factory progress record.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FactoryProgressLine {
+    /// Resume attempt that emitted this record.
+    pub attempt: i64,
+    /// Progress record kind.
+    pub kind: FactoryLogLineKind,
+    /// Phase active when the record was emitted, or null before any phase.
+    pub phase_id: Option<String>,
+    /// Epoch milliseconds when the record was persisted.
+    pub recorded_at: i64,
+    /// Global monotonic sequence number within the run.
+    pub seq: i64,
+    /// Prompt-safe progress text.
+    pub text: String,
+}
+
+/// A bidirectional page of factory progress.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FactoryProgressPage {
+    pub has_more_newer: bool,
+    pub has_more_older: bool,
+    pub newest_seq: Option<i64>,
+    pub oldest_seq: Option<i64>,
+    pub records: Vec<FactoryProgressLine>,
+    /// Run revision reflected by this page.
+    pub revision: i64,
 }
 
 /// Wire-only per-invocation factory resource ceiling overrides.
@@ -3915,15 +4264,120 @@ pub struct FactoryLogRequest {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FactoryRunLimits {
+    /// Maximum AI credits consumed by factory subagents and their descendants. The post-paid ceiling is soft: parallel turns can settle beyond it before the run stops.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_ai_credits: Option<f64>,
     /// Maximum number of factory subagents that may run concurrently.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_concurrent_subagents: Option<i64>,
     /// Maximum total number of factory subagents that may be admitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_total_subagents: Option<i64>,
-    /// Factory active-run timeout in milliseconds.
+    /// Maximum accumulated active-execution time in seconds. Active execution includes the entire extension body, subprocess waits, queued-agent waits, and sleeps; time between resumed attempts is not counted.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub timeout: Option<f64>,
+    pub timeout_seconds: Option<f64>,
+}
+
+/// Parameters for resuming a factory run from its persisted identity.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FactoryResumeRequest {
+    /// Optional per-invocation resource ceiling overrides.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limits: Option<FactoryRunLimits>,
+    /// Factory run identifier.
+    pub run_id: String,
+}
+
+/// Complete current or terminal factory run envelope.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FactoryRunResult {
+    /// Error message for an errored run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// Machine-readable failure details for an errored run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure: Option<serde_json::Value>,
+    /// Reason for a halted or cancelled run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Completed factory result.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    /// Factory run identifier.
+    pub run_id: String,
+    /// Partial journal and progress snapshot for a halted, cancelled, or errored run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snapshot: Option<serde_json::Value>,
+    /// Current or terminal factory run status.
+    pub status: FactoryRunStatus,
+}
+
+/// Resolved persisted factory identity and resumed run envelope.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FactoryResumeResult {
+    /// Persisted factory name resolved for the resumed run.
+    pub factory_name: String,
+    /// Terminal resumed run envelope.
+    pub run: FactoryRunResult,
+}
+
+/// Full factory run observability detail.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FactoryRunDetail {
+    pub active_segment_started_at: Option<i64>,
+    pub agents: Vec<FactoryAgentSummary>,
+    pub approved: Option<FactoryDeclaredLimits>,
+    pub completed_at: Option<i64>,
+    pub consumed: FactoryRunConsumed,
+    pub created_at: i64,
+    pub current_phase: Option<FactoryCurrentPhase>,
+    pub declared_limits: FactoryDeclaredLimits,
+    pub declared_phase_count: i64,
+    pub description: String,
+    pub factory_name: String,
+    pub live_agent_count: i64,
+    pub observed_at: i64,
+    pub phases: Vec<FactoryPhaseObservation>,
+    pub progress: FactoryProgressPage,
+    pub revision: i64,
+    pub run_id: String,
+    pub started_at: Option<i64>,
+    pub status: FactoryRunStatus,
+    pub terminal: Option<FactoryRunTerminal>,
+    pub total_spawned_agent_count: i64,
+    pub updated_at: i64,
 }
 
 /// Options controlling factory invocation.
@@ -3963,38 +4417,6 @@ pub struct FactoryRunRequest {
     /// Factory invocation options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<RunOptions>,
-}
-
-/// Complete current or terminal factory run envelope.
-///
-/// <div class="warning">
-///
-/// **Experimental.** This type is part of an experimental wire-protocol surface
-/// and may change or be removed in future SDK or CLI releases.
-///
-/// </div>
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FactoryRunResult {
-    /// Error message for an errored run.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-    /// Machine-readable failure details for an errored run.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub failure: Option<serde_json::Value>,
-    /// Reason for a halted or cancelled run.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reason: Option<String>,
-    /// Completed factory result.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub result: Option<serde_json::Value>,
-    /// Factory run identifier.
-    pub run_id: String,
-    /// Partial journal and progress snapshot for a halted, cancelled, or errored run.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub snapshot: Option<serde_json::Value>,
-    /// Current or terminal factory run status.
-    pub status: FactoryRunStatus,
 }
 
 /// Optional user prompt to combine with the fleet orchestration instructions.
@@ -4482,7 +4904,7 @@ pub struct InstalledPluginInfo {
     pub version: Option<String>,
 }
 
-/// Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref, and optional subpath.
+/// Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref or full commit SHA, and optional subpath.
 ///
 /// <div class="warning">
 ///
@@ -4498,6 +4920,9 @@ pub struct InstalledPluginSourceGitHub {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub r#ref: Option<String>,
     pub repo: String,
+    /// Optional full 40-character hexadecimal commit SHA.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha: Option<String>,
     /// Constant value. Always "github".
     pub source: InstalledPluginSourceGitHubSource,
 }
@@ -4518,7 +4943,7 @@ pub struct InstalledPluginSourceLocal {
     pub source: InstalledPluginSourceLocalSource,
 }
 
-/// Source descriptor for a direct URL plugin install, with URL, optional ref, and optional subpath.
+/// Source descriptor for a direct URL plugin install, with URL, optional ref or full commit SHA, and optional subpath.
 ///
 /// <div class="warning">
 ///
@@ -4533,6 +4958,9 @@ pub struct InstalledPluginSourceUrl {
     pub path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub r#ref: Option<String>,
+    /// Optional full 40-character hexadecimal commit SHA.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha: Option<String>,
     /// Constant value. Always "url".
     pub source: InstalledPluginSourceUrlSource,
     pub url: String,
@@ -4665,6 +5093,37 @@ pub struct InstructionSource {
 pub struct InstructionsGetSourcesResult {
     /// Instruction sources for the session
     pub sources: Vec<InstructionSource>,
+}
+
+/// Parameters for interrupting the main agent turn.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InterruptMainTurnRequest {
+    /// When true, the user's queued prompts are preserved and run as the next turn once the interrupted turn unwinds; when false (the default), the queue is cleared like a plain abort.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flush_queued: Option<bool>,
+}
+
+/// Result of interrupting the main agent turn.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InterruptMainTurnResult {
+    /// Whether an in-flight main agent turn was interrupted. False when the main loop was not processing.
+    pub interrupted: bool,
 }
 
 /// A request body chunk or cancellation signal.
@@ -5992,6 +6451,36 @@ pub struct McpOauthLoginResult {
     /// URL the caller should open in a browser to complete OAuth. Omitted when cached tokens were still valid and no browser interaction was needed — the server is already reconnected in that case. When present, the runtime starts the callback listener before returning and continues the flow in the background; completion is signaled via session.mcp_server_status_changed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authorization_url: Option<String>,
+}
+
+/// Pending MCP OAuth request id to respond to.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpOauthRespondRequest {
+    /// OAuth request identifier from the mcp.oauth_required event
+    pub request_id: RequestId,
+}
+
+/// Indicates whether the pending MCP OAuth response was accepted.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpOauthRespondResult {
+    /// Whether the response was accepted. False if the request was unknown, timed out, or already resolved.
+    pub success: bool,
 }
 
 /// Registration parameters for an external MCP client.
@@ -10214,6 +10703,51 @@ pub struct PushAttachmentSelection {
     pub r#type: PushAttachmentSelectionType,
 }
 
+/// Inputs for starting a deferred-idle drain.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueueBeginDeferredIdleDrainRequest {
+    /// Whether the host still has active background work.
+    pub active_background_work: bool,
+}
+
+/// Whether a deferred-idle drain should run.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueueBeginDeferredIdleDrainResult {
+    /// True when the host should run finishDeferredIdleDrain asynchronously.
+    pub should_drain: bool,
+}
+
+/// Internal filter for consuming queued system notifications.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueueConsumeSystemNotificationsRequest {
+    /// Opaque runtime-owned filter object.
+    pub filter: serde_json::Value,
+}
+
 /// Queued-command response indicating the host executed the command, with an optional flag to stop queue processing.
 ///
 /// <div class="warning">
@@ -10245,6 +10779,85 @@ pub struct QueuedCommandHandled {
 pub struct QueuedCommandNotHandled {
     /// The host did not execute the queued command. Unblocks the queue without claiming the command was processed (e.g. when the handler threw before completing).
     pub handled: bool,
+}
+
+/// Inputs for marking session.idle deferred in native state.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueueDeferSessionIdleRequest {
+    /// Whether the deferred idle was caused by an aborted foreground turn.
+    pub aborted: bool,
+}
+
+/// Result of enqueueing the resume-pending wake item.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueueEnqueueResumePendingResult {
+    /// True when a wake item was newly queued.
+    pub queued: bool,
+}
+
+/// Inputs for completing a deferred-idle drain.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueueFinishDeferredIdleDrainRequest {
+    /// Whether the host still has active background work.
+    pub active_background_work: bool,
+    /// Whether native queued work remains.
+    pub has_pending: bool,
+}
+
+/// Action selected by the native deferred-idle drain.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueueFinishDeferredIdleDrainResult {
+    /// Whether the deferred idle was caused by an aborted foreground turn.
+    pub aborted: bool,
+    /// One of none, processQueue, or emitSessionIdle.
+    pub action: String,
+}
+
+/// Whether the native queue has pending work.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueueHasPendingResult {
+    /// True when queued or immediate native work is pending.
+    pub has_pending: bool,
 }
 
 /// User-facing pending queue entry, with kind and display text for a queued message, slash command, or model change.
@@ -10294,6 +10907,29 @@ pub struct QueuePendingItemsResult {
 pub struct QueueRemoveMostRecentResult {
     /// True if a user-facing pending item was removed (LIFO across both queues); false when no removable items remained.
     pub removed: bool,
+}
+
+/// Internal snapshot of native queue state for local session orchestration.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueueSnapshotResult {
+    /// Insertion orders for queued items, aligned with `items`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub item_orders: Option<Vec<i64>>,
+    /// User-facing pending items in FIFO order.
+    pub items: Vec<QueuePendingItems>,
+    /// Insertion orders for immediate steering messages, aligned with `steeringMessages`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub steering_message_orders: Option<Vec<i64>>,
+    /// Immediate steering messages waiting for an active turn.
+    pub steering_messages: Vec<String>,
 }
 
 /// Event type to register consumer interest for, used by runtime gating logic.
@@ -10880,6 +11516,78 @@ pub struct SandboxConfig {
     pub user_policy: Option<SandboxConfigUserPolicy>,
 }
 
+/// Register an absolute-time scheduled prompt.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScheduleAddAtRequest {
+    /// Epoch milliseconds when the prompt should fire.
+    pub at: i64,
+    /// Optional display-only prompt label.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_prompt: Option<String>,
+    /// Prompt text to enqueue when the schedule fires.
+    pub prompt: String,
+    /// Whether the schedule should re-arm after each tick. Defaults to false.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recurring: Option<bool>,
+}
+
+/// Register a cron scheduled prompt.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScheduleAddCronRequest {
+    /// 5-field cron expression.
+    pub cron: String,
+    /// Optional display-only prompt label.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_prompt: Option<String>,
+    /// Prompt text to enqueue when the schedule fires.
+    pub prompt: String,
+    /// Whether the schedule should re-arm after each tick. Defaults to true.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recurring: Option<bool>,
+    /// IANA timezone for evaluating the cron expression.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tz: Option<String>,
+}
+
+/// Register a relative-interval scheduled prompt.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScheduleAddRequest {
+    /// Optional display-only prompt label.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_prompt: Option<String>,
+    /// Human-readable interval such as `30s`, `5m`, or `2h`.
+    pub interval: String,
+    /// Prompt text to enqueue when the schedule fires.
+    pub prompt: String,
+    /// Whether the schedule should re-arm after each tick. Defaults to true.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recurring: Option<bool>,
+}
+
 /// Scheduled prompt entry with ID, timing (`intervalMs`, `cron`, or `at`), prompt text, recurrence, and next run time.
 ///
 /// <div class="warning">
@@ -10919,6 +11627,58 @@ pub struct ScheduleEntry {
     pub tz: Option<String>,
 }
 
+/// Result of registering or re-arming a scheduled prompt.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScheduleAddResult {
+    /// The registered or updated schedule entry.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entry: Option<ScheduleEntry>,
+    /// User-facing validation error, when registration failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Register a self-paced scheduled prompt.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScheduleAddSelfPacedRequest {
+    /// Optional display-only prompt label.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_prompt: Option<String>,
+    /// Prompt text to enqueue when the schedule fires.
+    pub prompt: String,
+}
+
+/// Whether the session currently has an active self-paced schedule.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScheduleHasSelfPacedResult {
+    /// True when at least one active schedule is self-paced.
+    pub has_self_paced: bool,
+}
+
 /// Snapshot of the currently active recurring prompts for this session.
 ///
 /// <div class="warning">
@@ -10932,6 +11692,23 @@ pub struct ScheduleEntry {
 pub struct ScheduleList {
     /// Active scheduled prompts, ordered by id.
     pub entries: Vec<ScheduleEntry>,
+}
+
+/// Re-arm a self-paced scheduled prompt.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScheduleRearmSelfPacedRequest {
+    /// Epoch milliseconds when the prompt should next fire.
+    pub at: i64,
+    /// Id of the self-paced scheduled prompt.
+    pub id: i64,
 }
 
 /// Identifier of the scheduled prompt to remove.
@@ -11039,7 +11816,7 @@ pub struct SendMessageItem {
     /// If set, the request will fail if the named tool is not available when this message is among the user messages at the start of the current exchange
     #[serde(skip_serializing_if = "Option::is_none")]
     pub required_tool: Option<String>,
-    /// Optional provenance tag copied to the resulting user.message event. Must match one of three forms: the literal `system`, `command-<command-id>` for messages originating from a command (e.g. slash command, Mission Control command), or `schedule-<numeric-id>` for messages originating from a scheduled job.
+    /// Optional provenance tag copied to the resulting user.message event. Must be `user`, `system`, `command-<command-id>` for command-originated messages, `schedule-<numeric-id>` for scheduled prompts, or `agent-<agent-id>` for prompts sent by another agent.
     #[doc(hidden)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) source: Option<String>,
@@ -11133,7 +11910,7 @@ pub struct SendRequest {
     /// If set, the request will fail if the named tool is not available when this message is among the user messages at the start of the current exchange
     #[serde(skip_serializing_if = "Option::is_none")]
     pub required_tool: Option<String>,
-    /// Optional provenance tag copied to the resulting user.message event. Must match one of three forms: the literal `system`, `command-<command-id>` for messages originating from a command (e.g. slash command, Mission Control command), or `schedule-<numeric-id>` for messages originating from a scheduled job.
+    /// Optional provenance tag copied to the resulting user.message event. Must be `user`, `system`, `command-<command-id>` for command-originated messages, `schedule-<numeric-id>` for scheduled prompts, or `agent-<agent-id>` for prompts sent by another agent.
     #[doc(hidden)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) source: Option<String>,
@@ -11161,6 +11938,27 @@ pub struct SendRequest {
 pub struct SendResult {
     /// Unique identifier assigned to the message
     pub message_id: String,
+}
+
+/// Internal request for sending a system notification.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendSystemNotificationRequest {
+    /// Optional structured notification kind.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<serde_json::Value>,
+    /// Notification text to deliver to the model.
+    pub message: String,
+    /// Internal delivery options, including passive policy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<serde_json::Value>,
 }
 
 /// Agents discovered across user, project, plugin, and remote sources.
@@ -11726,7 +12524,7 @@ pub struct SessionFsSqliteExistsResult {
     pub exists: bool,
 }
 
-/// SQL query, query type, and optional bind parameters for executing a SQLite query against the per-session database.
+/// SQL query, query type, and optional bind parameters for executing a SQLite query against the per-session database. The provider applies its SQLite busy timeout for every call.
 ///
 /// <div class="warning">
 ///
@@ -11771,6 +12569,73 @@ pub struct SessionFsSqliteQueryResult {
     pub rows: Vec<HashMap<String, serde_json::Value>>,
     /// Number of rows affected (for INSERT/UPDATE/DELETE)
     pub rows_affected: i64,
+}
+
+/// Classified SQLite transaction failure. busyOrLocked guarantees rollback; postCommitAmbiguous must never be retried.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionFsSqliteTransactionError {
+    pub error_class: SessionFsSqliteTransactionErrorClass,
+    pub message: String,
+}
+
+/// One statement in an atomic SQLite transaction.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionFsSqliteTransactionStatement {
+    /// Optional named bind parameters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<HashMap<String, serde_json::Value>>,
+    /// SQL statement to execute.
+    pub query: String,
+    /// How to execute the statement.
+    pub query_type: SessionFsSqliteQueryType,
+}
+
+/// Statements to execute atomically. Providers apply busy handling for every call.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionFsSqliteTransactionRequest {
+    /// Target session identifier
+    pub session_id: SessionId,
+    pub statements: Vec<SessionFsSqliteTransactionStatement>,
+}
+
+/// Per-statement results, or a classified transaction error.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionFsSqliteTransactionResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<SessionFsSqliteTransactionError>,
+    pub results: Vec<SessionFsSqliteQueryResult>,
 }
 
 /// Path whose metadata should be returned from the client-provided session filesystem.
@@ -11869,7 +12734,7 @@ pub struct SessionInstalledPlugin {
     pub version: Option<String>,
 }
 
-/// Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref, and optional subpath.
+/// Source descriptor for a direct GitHub plugin install, with `owner/repo`, optional ref or full commit SHA, and optional subpath.
 ///
 /// <div class="warning">
 ///
@@ -11885,6 +12750,9 @@ pub struct SessionInstalledPluginSourceGitHub {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub r#ref: Option<String>,
     pub repo: String,
+    /// Optional full 40-character hexadecimal commit SHA.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha: Option<String>,
     /// Constant value. Always "github".
     pub source: SessionInstalledPluginSourceGitHubSource,
 }
@@ -11905,7 +12773,7 @@ pub struct SessionInstalledPluginSourceLocal {
     pub source: SessionInstalledPluginSourceLocalSource,
 }
 
-/// Source descriptor for a direct URL plugin install, with URL, optional ref, and optional subpath.
+/// Source descriptor for a direct URL plugin install, with URL, optional ref or full commit SHA, and optional subpath.
 ///
 /// <div class="warning">
 ///
@@ -11920,6 +12788,9 @@ pub struct SessionInstalledPluginSourceUrl {
     pub path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub r#ref: Option<String>,
+    /// Optional full 40-character hexadecimal commit SHA.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha: Option<String>,
     /// Constant value. Always "url".
     pub source: SessionInstalledPluginSourceUrlSource,
     pub url: String,
@@ -12154,6 +13025,55 @@ pub struct SessionOpenOptionsAdditionalContentExclusionPolicy {
     pub scope: SessionOpenOptionsAdditionalContentExclusionPolicyScope,
 }
 
+/// A host-provided script sourced before each built-in shell command when its shell target matches the active shell.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShellInitScript {
+    /// Path to the script to source.
+    pub path: String,
+    /// Built-in shell that may source this script.
+    pub shell: ShellInitScriptShell,
+}
+
+/// Per-session settings for built-in shell tools.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShellOptions {
+    /// Controls automatic non-interactive profile loading where supported. Explicit initScripts are unaffected.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub init_profile: Option<ShellInitProfile>,
+    /// Ordered host-provided script paths sourced before each built-in shell command when the
+    /// entry's shell target matches the active shell. Use these for rc files, environment setup scripts,
+    /// or other custom scripts. A script that returns a nonzero status is reported, and later scripts
+    /// and the user command continue while the shell remains running. Because scripts are sourced into
+    /// the command shell, `exit`, `exec`, failures under `set -e`, or other shell-terminating behavior
+    /// can prevent continuation. Script standard output is preserved; Bash script stderr is discarded,
+    /// PowerShell exception messages are replaced, and runtime-generated failure notices omit
+    /// configured script paths. When sandboxing is enabled, each script must already be readable under
+    /// the active sandbox filesystem policy. Pass an empty array to clear the list.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub init_scripts: Option<Vec<ShellInitScript>>,
+    /// Flags passed to the active built-in shell process on startup, replacing its default flags.
+    /// When omitted, the built-in Bash shell uses `--norc --noprofile`,
+    /// and the built-in PowerShell shell uses `-NoProfile -NoLogo`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub process_flags: Option<Vec<String>>,
+}
+
 /// Session construction options.
 ///
 /// <div class="warning">
@@ -12255,6 +13175,9 @@ pub struct SessionOpenOptions {
     /// Override directory for session event logs.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub events_log_directory: Option<String>,
+    /// Whether subagent callback events should be forwarded into the session event log sink.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub events_log_includes_subagents: Option<bool>,
     /// Built-in subagent names to exclude from this session. Excluded built-ins are hidden from agent discovery and cannot be dispatched unless a custom agent with the same name is available.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub excluded_builtin_agents: Option<Vec<String>>,
@@ -12354,10 +13277,15 @@ pub struct SessionOpenOptions {
     /// Initial session limits.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_limits: Option<SessionLimitsConfig>,
-    /// Shell init profile.
+    /// Per-session settings for built-in shell tools.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shell: Option<ShellOptions>,
+    /// Use shell.initProfile instead. Shell init profile.
+    #[doc(hidden)]
+    #[deprecated]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shell_init_profile: Option<String>,
-    /// Per-shell process flags.
+    /// PowerShell process flags applied to built-in and user-requested shell commands.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shell_process_flags: Option<Vec<String>>,
     /// Additional directories to search for skills.
@@ -12698,6 +13626,24 @@ pub struct SessionsCloseRequest {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionsCloseResult {}
+
+/// Session ID to delete from disk.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionsDeleteRequest {
+    /// Session ID to delete
+    pub session_id: SessionId,
+    /// Internal resolved session directory path to delete
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_path: Option<String>,
+}
 
 /// Session metadata records to enrich with summary and context information.
 ///
@@ -13142,6 +14088,37 @@ pub struct SessionsGetLastForContextResult {
     pub session_id: Option<SessionId>,
 }
 
+/// Session ID whose persisted metadata should be read.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionsGetMetadataRequest {
+    /// Session ID to inspect
+    pub session_id: SessionId,
+}
+
+/// Persisted local session metadata when the session exists.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionsGetMetadataResult {
+    /// Local session metadata, omitted when the session does not exist.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session: Option<LocalSessionMetadataValue>,
+}
+
 /// Session ID to look up the persisted remote-steerable flag for.
 ///
 /// <div class="warning">
@@ -13186,6 +14163,37 @@ pub struct SessionsGetPersistedRemoteSteerableResult {
 pub struct SessionSizes {
     /// Map of sessionId -> on-disk size in bytes for the session's workspace directory
     pub sizes: HashMap<String, i64>,
+}
+
+/// Limit for non-empty local session IDs.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionsListNonEmptySessionIdsRequest {
+    /// Maximum number of session IDs to return.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<i64>,
+}
+
+/// Recent local session IDs that contain user-visible history.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionsListNonEmptySessionIdsResult {
+    /// Session IDs ordered newest-first.
+    pub session_ids: Vec<String>,
 }
 
 /// Optional source filter, metadata-load limit, and context filter applied to the returned sessions.
@@ -13542,6 +14550,9 @@ pub struct SessionUpdateOptionsParams {
     /// Override directory for the session-events log. When unset, the runtime's default events log directory is used.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub events_log_directory: Option<String>,
+    /// Whether subagent callback events should be forwarded into the session event log sink.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub events_log_includes_subagents: Option<bool>,
     /// Built-in subagent names to exclude from this session. Excluded built-ins are hidden from agent discovery and cannot be dispatched unless a custom agent with the same name is available.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub excluded_builtin_agents: Option<Vec<String>>,
@@ -13605,10 +14616,15 @@ pub struct SessionUpdateOptionsParams {
     /// Optional session limits. Pass null to clear the session limits.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_limits: Option<SessionLimitsConfig>,
-    /// Shell init profile (`None` or `NonInteractive`).
+    /// Per-session settings for built-in shell tools.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shell: Option<ShellOptions>,
+    /// Use shell.initProfile instead. Shell init profile (`None` or `NonInteractive`).
+    #[doc(hidden)]
+    #[deprecated]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shell_init_profile: Option<String>,
-    /// Per-shell process flags (e.g., `pwsh` arguments).
+    /// PowerShell process flags applied to built-in and user-requested shell commands.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shell_process_flags: Option<Vec<String>>,
     /// Additional directories to search for skills.
@@ -15126,6 +16142,9 @@ pub struct UIExitPlanModeResponse {
     /// Whether subsequent edits should be auto-approved without confirmation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auto_approve_edits: Option<bool>,
+    /// When true, the agent is instructed to end its turn without starting implementation so the client can restore the session model and auto-submit a fresh implementation turn on it. Set only when a distinct plan configuration (a different model, reasoning effort, or context tier) actually ran the planning turn.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub defer_implementation: Option<bool>,
     /// Feedback from the user when they declined the plan or requested changes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub feedback: Option<String>,
@@ -15753,6 +16772,55 @@ pub struct WorkspaceDiffResult {
     pub requested_mode: WorkspaceDiffMode,
 }
 
+/// Compaction summary checkpoint to persist.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspacesAddSummaryRequest {
+    /// Markdown summary content to persist.
+    pub content: String,
+    /// Summary title shown in checkpoint listings.
+    pub title: String,
+}
+
+/// Persisted summary metadata and refreshed workspace metadata.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspacesAddSummaryResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace: Option<serde_json::Value>,
+}
+
+/// Whether the autopilot objective file exists.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspacesAutopilotObjectiveExistsResult {
+    /// True when the objective file exists.
+    pub exists: bool,
+}
+
 /// Workspace checkpoint metadata with assigned number, human-readable title, and checkpoint filename.
 ///
 /// <div class="warning">
@@ -15789,6 +16857,21 @@ pub struct WorkspacesCreateFileRequest {
     pub path: String,
 }
 
+/// Result of deleting the autopilot objective file.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspacesDeleteAutopilotObjectiveResult {
+    /// True when a file was deleted.
+    pub deleted: bool,
+}
+
 /// Parameters for computing a workspace diff.
 ///
 /// <div class="warning">
@@ -15805,6 +16888,22 @@ pub struct WorkspacesDiffRequest {
     pub ignore_whitespace: Option<bool>,
     /// Diff mode requested by the client.
     pub mode: WorkspaceDiffMode,
+}
+
+/// Optional session context used when creating a local workspace.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspacesEnsureRequest {
+    /// Opaque workspace context supplied by the session host.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -15895,6 +16994,21 @@ pub struct WorkspacesListCheckpointsResult {
 pub struct WorkspacesListFilesResult {
     /// Relative file paths in the workspace files directory
     pub files: Vec<String>,
+}
+
+/// Autopilot objective file content, or null when missing.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspacesReadAutopilotObjectiveResult {
+    /// Autopilot objective file content, or null when missing.
+    pub content: Option<String>,
 }
 
 /// Checkpoint number to read.
@@ -15998,6 +17112,21 @@ pub struct WorkspacesSaveLargePasteResult {
     pub saved: Option<WorkspacesSaveLargePasteResultSaved>,
 }
 
+/// Rollback point for local workspace summaries.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspacesTruncateSummariesRequest {
+    /// Number of newest summaries to keep.
+    pub keep_count: i64,
+}
+
 /// Public-facing workspace metadata for this session, or null if the session has no associated workspace. Excludes runtime-internal fields (GitHub IDs, summary count, internal flags).
 ///
 /// <div class="warning">
@@ -16038,6 +17167,55 @@ pub struct WorkspaceSummary {
     /// Whether the display name was explicitly set by the user
     #[serde(rename = "user_named", skip_serializing_if = "Option::is_none")]
     pub user_named: Option<bool>,
+}
+
+/// Workspace metadata fields to update.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspacesUpdateMetadataRequest {
+    /// Opaque workspace context supplied by the session host.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<serde_json::Value>,
+    /// Optional workspace display name override.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+/// Autopilot objective file content to persist.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspacesWriteAutopilotObjectiveRequest {
+    /// Autopilot objective file content.
+    pub content: String,
+}
+
+/// Result of writing the autopilot objective file.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspacesWriteAutopilotObjectiveResult {
+    /// Filesystem operation performed.
+    pub operation: String,
 }
 
 /// List of Copilot models available to the resolved user, including capabilities and billing metadata.
@@ -16670,6 +17848,36 @@ pub struct SessionAbortResult {
     pub success: bool,
 }
 
+/// Result of interrupting the main agent turn.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionInterruptMainTurnResult {
+    /// Whether an in-flight main agent turn was interrupted. False when the main loop was not processing.
+    pub interrupted: bool,
+}
+
+/// Identifies the target session.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionCancelAllBackgroundAgentsParams {
+    /// Target session identifier
+    pub session_id: SessionId,
+}
+
 /// Identifies the target session.
 ///
 /// <div class="warning">
@@ -16900,6 +18108,23 @@ pub struct SessionFactoryRunResult {
     pub status: FactoryRunStatus,
 }
 
+/// Resolved persisted factory identity and resumed run envelope.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionFactoryResumeResult {
+    /// Persisted factory name resolved for the resumed run.
+    pub factory_name: String,
+    /// Terminal resumed run envelope.
+    pub run: FactoryRunResult,
+}
+
 /// Complete current or terminal factory run envelope.
 ///
 /// <div class="warning">
@@ -16930,6 +18155,75 @@ pub struct SessionFactoryGetRunResult {
     pub snapshot: Option<serde_json::Value>,
     /// Current or terminal factory run status.
     pub status: FactoryRunStatus,
+}
+
+/// Factory runs in durable creation order.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionFactoryListRunsResult {
+    pub runs: Vec<FactoryRunSummary>,
+}
+
+/// Full factory run observability detail.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionFactoryGetRunDetailResult {
+    pub active_segment_started_at: Option<i64>,
+    pub agents: Vec<FactoryAgentSummary>,
+    pub approved: Option<FactoryDeclaredLimits>,
+    pub completed_at: Option<i64>,
+    pub consumed: FactoryRunConsumed,
+    pub created_at: i64,
+    pub current_phase: Option<FactoryCurrentPhase>,
+    pub declared_limits: FactoryDeclaredLimits,
+    pub declared_phase_count: i64,
+    pub description: String,
+    pub factory_name: String,
+    pub live_agent_count: i64,
+    pub observed_at: i64,
+    pub phases: Vec<FactoryPhaseObservation>,
+    pub progress: FactoryProgressPage,
+    pub revision: i64,
+    pub run_id: String,
+    pub started_at: Option<i64>,
+    pub status: FactoryRunStatus,
+    pub terminal: Option<FactoryRunTerminal>,
+    pub total_spawned_agent_count: i64,
+    pub updated_at: i64,
+}
+
+/// A bidirectional page of factory progress.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionFactoryGetRunProgressResult {
+    pub has_more_newer: bool,
+    pub has_more_older: bool,
+    pub newest_seq: Option<i64>,
+    pub oldest_seq: Option<i64>,
+    pub records: Vec<FactoryProgressLine>,
+    /// Run revision reflected by this page.
+    pub revision: i64,
 }
 
 /// Complete current or terminal factory run envelope.
@@ -17357,6 +18651,126 @@ pub struct SessionWorkspacesGetWorkspaceResult {
     pub workspace: Option<SessionWorkspacesGetWorkspaceResultWorkspace>,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionWorkspacesUpdateMetadataResultWorkspace {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(
+        rename = "chronicle_sync_dismissed",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub chronicle_sync_dismissed: Option<bool>,
+    #[serde(rename = "client_name", skip_serializing_if = "Option::is_none")]
+    pub client_name: Option<String>,
+    #[serde(rename = "created_at", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(rename = "git_root", skip_serializing_if = "Option::is_none")]
+    pub git_root: Option<String>,
+    /// Allowed values for the `WorkspacesWorkspaceDetailsHostType` enumeration.
+    #[serde(rename = "host_type", skip_serializing_if = "Option::is_none")]
+    pub host_type: Option<WorkspacesWorkspaceDetailsHostType>,
+    pub id: String,
+    #[serde(rename = "mc_last_event_id", skip_serializing_if = "Option::is_none")]
+    pub mc_last_event_id: Option<String>,
+    #[serde(rename = "mc_session_id", skip_serializing_if = "Option::is_none")]
+    pub mc_session_id: Option<String>,
+    #[serde(rename = "mc_task_id", skip_serializing_if = "Option::is_none")]
+    pub mc_task_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "remote_steerable", skip_serializing_if = "Option::is_none")]
+    pub remote_steerable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository: Option<String>,
+    #[serde(rename = "summary_count", skip_serializing_if = "Option::is_none")]
+    pub summary_count: Option<i64>,
+    #[serde(rename = "updated_at", skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+    #[serde(rename = "user_named", skip_serializing_if = "Option::is_none")]
+    pub user_named: Option<bool>,
+}
+
+/// Current workspace metadata for the session, including its absolute filesystem path when available.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionWorkspacesUpdateMetadataResult {
+    /// Absolute filesystem path to the workspace directory. Omitted when the session has no workspace (e.g. remote sessions).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// Current workspace metadata, or null if not available
+    pub workspace: Option<SessionWorkspacesUpdateMetadataResultWorkspace>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionWorkspacesEnsureResultWorkspace {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(
+        rename = "chronicle_sync_dismissed",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub chronicle_sync_dismissed: Option<bool>,
+    #[serde(rename = "client_name", skip_serializing_if = "Option::is_none")]
+    pub client_name: Option<String>,
+    #[serde(rename = "created_at", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(rename = "git_root", skip_serializing_if = "Option::is_none")]
+    pub git_root: Option<String>,
+    /// Allowed values for the `WorkspacesWorkspaceDetailsHostType` enumeration.
+    #[serde(rename = "host_type", skip_serializing_if = "Option::is_none")]
+    pub host_type: Option<WorkspacesWorkspaceDetailsHostType>,
+    pub id: String,
+    #[serde(rename = "mc_last_event_id", skip_serializing_if = "Option::is_none")]
+    pub mc_last_event_id: Option<String>,
+    #[serde(rename = "mc_session_id", skip_serializing_if = "Option::is_none")]
+    pub mc_session_id: Option<String>,
+    #[serde(rename = "mc_task_id", skip_serializing_if = "Option::is_none")]
+    pub mc_task_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "remote_steerable", skip_serializing_if = "Option::is_none")]
+    pub remote_steerable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository: Option<String>,
+    #[serde(rename = "summary_count", skip_serializing_if = "Option::is_none")]
+    pub summary_count: Option<i64>,
+    #[serde(rename = "updated_at", skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+    #[serde(rename = "user_named", skip_serializing_if = "Option::is_none")]
+    pub user_named: Option<bool>,
+}
+
+/// Current workspace metadata for the session, including its absolute filesystem path when available.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionWorkspacesEnsureResult {
+    /// Absolute filesystem path to the workspace directory. Omitted when the session has no workspace (e.g. remote sessions).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// Current workspace metadata, or null if not available
+    pub workspace: Option<SessionWorkspacesEnsureResultWorkspace>,
+}
+
 /// Identifies the target session.
 ///
 /// <div class="warning">
@@ -17445,6 +18859,188 @@ pub struct SessionWorkspacesListCheckpointsResult {
 pub struct SessionWorkspacesReadCheckpointResult {
     /// Checkpoint content as a UTF-8 string, or null when the checkpoint or workspace is missing
     pub content: Option<String>,
+}
+
+/// Persisted summary metadata and refreshed workspace metadata.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionWorkspacesAddSummaryResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionWorkspacesTruncateSummariesResultWorkspace {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(
+        rename = "chronicle_sync_dismissed",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub chronicle_sync_dismissed: Option<bool>,
+    #[serde(rename = "client_name", skip_serializing_if = "Option::is_none")]
+    pub client_name: Option<String>,
+    #[serde(rename = "created_at", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(rename = "git_root", skip_serializing_if = "Option::is_none")]
+    pub git_root: Option<String>,
+    /// Allowed values for the `WorkspacesWorkspaceDetailsHostType` enumeration.
+    #[serde(rename = "host_type", skip_serializing_if = "Option::is_none")]
+    pub host_type: Option<WorkspacesWorkspaceDetailsHostType>,
+    pub id: String,
+    #[serde(rename = "mc_last_event_id", skip_serializing_if = "Option::is_none")]
+    pub mc_last_event_id: Option<String>,
+    #[serde(rename = "mc_session_id", skip_serializing_if = "Option::is_none")]
+    pub mc_session_id: Option<String>,
+    #[serde(rename = "mc_task_id", skip_serializing_if = "Option::is_none")]
+    pub mc_task_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "remote_steerable", skip_serializing_if = "Option::is_none")]
+    pub remote_steerable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository: Option<String>,
+    #[serde(rename = "summary_count", skip_serializing_if = "Option::is_none")]
+    pub summary_count: Option<i64>,
+    #[serde(rename = "updated_at", skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+    #[serde(rename = "user_named", skip_serializing_if = "Option::is_none")]
+    pub user_named: Option<bool>,
+}
+
+/// Current workspace metadata for the session, including its absolute filesystem path when available.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionWorkspacesTruncateSummariesResult {
+    /// Absolute filesystem path to the workspace directory. Omitted when the session has no workspace (e.g. remote sessions).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// Current workspace metadata, or null if not available
+    pub workspace: Option<SessionWorkspacesTruncateSummariesResultWorkspace>,
+}
+
+/// Identifies the target session.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionWorkspacesReadAutopilotObjectiveParams {
+    /// Target session identifier
+    pub session_id: SessionId,
+}
+
+/// Autopilot objective file content, or null when missing.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionWorkspacesReadAutopilotObjectiveResult {
+    /// Autopilot objective file content, or null when missing.
+    pub content: Option<String>,
+}
+
+/// Result of writing the autopilot objective file.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionWorkspacesWriteAutopilotObjectiveResult {
+    /// Filesystem operation performed.
+    pub operation: String,
+}
+
+/// Identifies the target session.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionWorkspacesDeleteAutopilotObjectiveParams {
+    /// Target session identifier
+    pub session_id: SessionId,
+}
+
+/// Result of deleting the autopilot objective file.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionWorkspacesDeleteAutopilotObjectiveResult {
+    /// True when a file was deleted.
+    pub deleted: bool,
+}
+
+/// Identifies the target session.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionWorkspacesAutopilotObjectiveExistsParams {
+    /// Target session identifier
+    pub session_id: SessionId,
+}
+
+/// Whether the autopilot objective file exists.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionWorkspacesAutopilotObjectiveExistsResult {
+    /// True when the objective file exists.
+    pub exists: bool,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -18274,6 +19870,21 @@ pub struct SessionMcpOauthLoginResult {
     /// URL the caller should open in a browser to complete OAuth. Omitted when cached tokens were still valid and no browser interaction was needed — the server is already reconnected in that case. When present, the runtime starts the callback listener before returning and continues the flow in the background; completion is signaled via session.mcp_server_status_changed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authorization_url: Option<String>,
+}
+
+/// Indicates whether the pending MCP OAuth response was accepted.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionMcpOauthRespondResult {
+    /// Whether the response was accepted. False if the request was unknown, timed out, or already resolved.
+    pub success: bool,
 }
 
 /// Indicates whether the pending MCP headers refresh response was accepted.
@@ -19885,6 +21496,106 @@ pub struct SessionQueuePendingItemsResult {
 /// </div>
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct SessionQueueSnapshotParams {
+    /// Target session identifier
+    pub session_id: SessionId,
+}
+
+/// Internal snapshot of native queue state for local session orchestration.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionQueueSnapshotResult {
+    /// Insertion orders for queued items, aligned with `items`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub item_orders: Option<Vec<i64>>,
+    /// User-facing pending items in FIFO order.
+    pub items: Vec<QueuePendingItems>,
+    /// Insertion orders for immediate steering messages, aligned with `steeringMessages`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub steering_message_orders: Option<Vec<i64>>,
+    /// Immediate steering messages waiting for an active turn.
+    pub steering_messages: Vec<String>,
+}
+
+/// Identifies the target session.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionQueueHasPendingParams {
+    /// Target session identifier
+    pub session_id: SessionId,
+}
+
+/// Whether the native queue has pending work.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionQueueHasPendingResult {
+    /// True when queued or immediate native work is pending.
+    pub has_pending: bool,
+}
+
+/// Whether a deferred-idle drain should run.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionQueueBeginDeferredIdleDrainResult {
+    /// True when the host should run finishDeferredIdleDrain asynchronously.
+    pub should_drain: bool,
+}
+
+/// Action selected by the native deferred-idle drain.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionQueueFinishDeferredIdleDrainResult {
+    /// Whether the deferred idle was caused by an aborted foreground turn.
+    pub aborted: bool,
+    /// One of none, processQueue, or emitSessionIdle.
+    pub action: String,
+}
+
+/// Identifies the target session.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SessionQueueRemoveMostRecentParams {
     /// Target session identifier
     pub session_id: SessionId,
@@ -19916,6 +21627,66 @@ pub struct SessionQueueRemoveMostRecentResult {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionQueueClearParams {
+    /// Target session identifier
+    pub session_id: SessionId,
+}
+
+/// Indicates whether a user-facing pending item was removed.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionQueueConsumeSystemNotificationsResult {
+    /// True if a user-facing pending item was removed (LIFO across both queues); false when no removable items remained.
+    pub removed: bool,
+}
+
+/// Identifies the target session.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionQueueEnqueueResumePendingParams {
+    /// Target session identifier
+    pub session_id: SessionId,
+}
+
+/// Result of enqueueing the resume-pending wake item.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionQueueEnqueueResumePendingResult {
+    /// True when a wake item was newly queued.
+    pub queued: bool,
+}
+
+/// Identifies the target session.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionQueueProcessParams {
     /// Target session identifier
     pub session_id: SessionId,
 }
@@ -20186,6 +21957,146 @@ pub struct SessionScheduleListResult {
     pub entries: Vec<ScheduleEntry>,
 }
 
+/// Identifies the target session.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionScheduleHydrateParams {
+    /// Target session identifier
+    pub session_id: SessionId,
+}
+
+/// Identifies the target session.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionScheduleHasSelfPacedParams {
+    /// Target session identifier
+    pub session_id: SessionId,
+}
+
+/// Whether the session currently has an active self-paced schedule.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionScheduleHasSelfPacedResult {
+    /// True when at least one active schedule is self-paced.
+    pub has_self_paced: bool,
+}
+
+/// Result of registering or re-arming a scheduled prompt.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionScheduleAddResult {
+    /// The registered or updated schedule entry.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entry: Option<ScheduleEntry>,
+    /// User-facing validation error, when registration failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Result of registering or re-arming a scheduled prompt.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionScheduleAddCronResult {
+    /// The registered or updated schedule entry.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entry: Option<ScheduleEntry>,
+    /// User-facing validation error, when registration failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Result of registering or re-arming a scheduled prompt.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionScheduleAddAtResult {
+    /// The registered or updated schedule entry.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entry: Option<ScheduleEntry>,
+    /// User-facing validation error, when registration failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Result of registering or re-arming a scheduled prompt.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionScheduleAddSelfPacedResult {
+    /// The registered or updated schedule entry.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entry: Option<ScheduleEntry>,
+    /// User-facing validation error, when registration failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Result of registering or re-arming a scheduled prompt.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionScheduleRearmSelfPacedResult {
+    /// The registered or updated schedule entry.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entry: Option<ScheduleEntry>,
+    /// User-facing validation error, when registration failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 /// Remove a scheduled prompt by id. The result entry is omitted if the id was unknown.
 ///
 /// <div class="warning">
@@ -20305,6 +22216,16 @@ pub type UIElicitationResponseContent = HashMap<String, serde_json::Value>;
 ///
 /// </div>
 pub type AccountGetAllUsersResult = Vec<AccountAllUsers>;
+
+/// The number of running background agents (task-registry agents) that were cancelled.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+pub type SessionCancelAllBackgroundAgentsResult = i64;
 
 /// Standard MCP CallToolResult
 ///
@@ -21364,7 +23285,7 @@ pub enum ExternalToolTextResultForLlmContentTextType {
     Text,
 }
 
-/// Kind of factory progress line.
+/// Execution-critical factory storage operation.
 ///
 /// <div class="warning">
 ///
@@ -21373,35 +23294,37 @@ pub enum ExternalToolTextResultForLlmContentTextType {
 ///
 /// </div>
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub enum FactoryLogLineKind {
-    /// A narrator log line.
-    #[serde(rename = "log")]
-    Log,
-    /// A named factory phase marker.
-    #[serde(rename = "phase")]
-    Phase,
-    /// Unknown variant for forward compatibility.
-    #[default]
-    #[serde(other)]
-    Unknown,
-}
-
-/// Cumulative resource ceiling that stopped a factory run.
-///
-/// <div class="warning">
-///
-/// **Experimental.** This type is part of an experimental wire-protocol surface
-/// and may change or be removed in future SDK or CLI releases.
-///
-/// </div>
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub enum FactoryRunFailureKind {
-    /// The run admitted the approved maximum total number of subagents.
-    #[serde(rename = "maxTotalSubagents")]
-    MaxTotalSubagents,
-    /// The run reached the approved timeout deadline.
-    #[serde(rename = "timeout")]
-    Timeout,
+pub enum FactoryDurableOperation {
+    /// Creating the durable run and declared phases.
+    #[serde(rename = "createRun")]
+    CreateRun,
+    /// Persisting the transition to running.
+    #[serde(rename = "markRunStarted")]
+    MarkRunStarted,
+    /// Persisting the terminal run envelope.
+    #[serde(rename = "finishRun")]
+    FinishRun,
+    /// Persisting subagent admission accounting.
+    #[serde(rename = "reserveAgent")]
+    ReserveAgent,
+    /// Rolling back an uncommitted subagent admission.
+    #[serde(rename = "releaseAgent")]
+    ReleaseAgent,
+    /// Persisting an idempotent model-usage charge.
+    #[serde(rename = "chargeCredit")]
+    ChargeCredit,
+    /// Persisting active execution time.
+    #[serde(rename = "addElapsed")]
+    AddElapsed,
+    /// Reading the authoritative AI-credit total.
+    #[serde(rename = "reconcileCreditTotal")]
+    ReconcileCreditTotal,
+    /// Reading a journal entry without treating storage failure as a cache miss.
+    #[serde(rename = "journalGet")]
+    JournalGet,
+    /// Persisting a journal entry before reporting success.
+    #[serde(rename = "journalPut")]
+    JournalPut,
     /// Unknown variant for forward compatibility.
     #[default]
     #[serde(other)]
@@ -21436,6 +23359,81 @@ pub enum FactoryRunStatus {
     /// The factory body failed or reached a cumulative resource ceiling.
     #[serde(rename = "error")]
     Error,
+    /// Unknown variant for forward compatibility.
+    #[default]
+    #[serde(other)]
+    Unknown,
+}
+
+/// Kind of factory progress line.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FactoryLogLineKind {
+    /// A narrator log line.
+    #[serde(rename = "log")]
+    Log,
+    /// A named factory phase marker.
+    #[serde(rename = "phase")]
+    Phase,
+    /// Unknown variant for forward compatibility.
+    #[default]
+    #[serde(other)]
+    Unknown,
+}
+
+/// Derived lifecycle state of a factory phase.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FactoryPhaseStatus {
+    /// The phase has not been entered yet.
+    #[serde(rename = "pending")]
+    Pending,
+    /// The phase is currently entered and accumulating active time.
+    #[serde(rename = "active")]
+    Active,
+    /// The phase was entered and has since been closed.
+    #[serde(rename = "completed")]
+    Completed,
+    /// The phase was never entered because a later phase was entered or the run reached a terminal state.
+    #[serde(rename = "skipped")]
+    Skipped,
+    /// Unknown variant for forward compatibility.
+    #[default]
+    #[serde(other)]
+    Unknown,
+}
+
+/// Cumulative resource ceiling that stopped a factory run.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FactoryRunFailureKind {
+    /// The run admitted the approved maximum total number of subagents.
+    #[serde(rename = "maxTotalSubagents")]
+    MaxTotalSubagents,
+    /// The run reached the approved accumulated active-execution time in seconds.
+    #[serde(rename = "timeoutSeconds")]
+    TimeoutSeconds,
+    /// The run's settled subagent model usage exceeded the approved AI-credit ceiling, or no headroom remained for another subagent.
+    #[serde(rename = "maxAiCredits")]
+    MaxAiCredits,
     /// Unknown variant for forward compatibility.
     #[default]
     #[serde(other)]
@@ -23508,6 +25506,31 @@ pub enum SessionFsSqliteQueryType {
     Unknown,
 }
 
+/// SQLite transaction failure classification.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SessionFsSqliteTransactionErrorClass {
+    /// SQLite reported BUSY or LOCKED before commit; the transaction was rolled back and may be retried.
+    #[serde(rename = "busyOrLocked")]
+    BusyOrLocked,
+    /// The statement, database, or provider failed definitively and must not be retried automatically.
+    #[serde(rename = "fatal")]
+    Fatal,
+    /// The transport failed after the provider may have committed; retrying could duplicate effects.
+    #[serde(rename = "postCommitAmbiguous")]
+    PostCommitAmbiguous,
+    /// Unknown variant for forward compatibility.
+    #[default]
+    #[serde(other)]
+    Unknown,
+}
+
 /// Constant value. Always "github".
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SessionInstalledPluginSourceGitHubSource {
@@ -23617,6 +25640,50 @@ pub enum SessionOpenOptionsReasoningSummary {
     /// Request a detailed summary of model reasoning.
     #[serde(rename = "detailed")]
     Detailed,
+    /// Unknown variant for forward compatibility.
+    #[default]
+    #[serde(other)]
+    Unknown,
+}
+
+/// Controls automatic non-interactive profile loading where supported. Explicit initScripts are unaffected.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ShellInitProfile {
+    /// Disable automatic non-interactive profile loading. Explicit initScripts still run.
+    #[serde(rename = "none")]
+    None,
+    /// Allow automatic non-interactive profile loading when supported. Explicit initScripts still run.
+    #[serde(rename = "non-interactive")]
+    NonInteractive,
+    /// Unknown variant for forward compatibility.
+    #[default]
+    #[serde(other)]
+    Unknown,
+}
+
+/// Supported built-in shells for initialization scripts.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ShellInitScriptShell {
+    /// Source the script in the built-in Bash shell on macOS and Linux.
+    #[serde(rename = "bash")]
+    Bash,
+    /// Source the script in the built-in PowerShell shell on Windows.
+    #[serde(rename = "powershell")]
+    Powershell,
     /// Unknown variant for forward compatibility.
     #[default]
     #[serde(other)]

--- a/rust/src/generated/rpc.rs
+++ b/rust/src/generated/rpc.rs
@@ -1569,6 +1569,71 @@ impl<'a> ClientRpcSessions<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Reads lightweight persisted metadata for one local session without opening it.
+    ///
+    /// Wire method: `sessions.getMetadata`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Session ID whose persisted metadata should be read.
+    ///
+    /// # Returns
+    ///
+    /// Persisted local session metadata when the session exists.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub(crate) async fn get_metadata(
+        &self,
+        params: SessionsGetMetadataRequest,
+    ) -> Result<SessionsGetMetadataResult, Error> {
+        let wire_params = serde_json::to_value(params)?;
+        let _value = self
+            .client
+            .call(rpc_methods::SESSIONS_GETMETADATA, Some(wire_params))
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Lists recent local session IDs that contain user-visible history, omitting housekeeping-only sessions.
+    ///
+    /// Wire method: `sessions.listNonEmptySessionIds`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Limit for non-empty local session IDs.
+    ///
+    /// # Returns
+    ///
+    /// Recent local session IDs that contain user-visible history.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub(crate) async fn list_non_empty_session_ids(
+        &self,
+        params: SessionsListNonEmptySessionIdsRequest,
+    ) -> Result<SessionsListNonEmptySessionIdsResult, Error> {
+        let wire_params = serde_json::to_value(params)?;
+        let _value = self
+            .client
+            .call(
+                rpc_methods::SESSIONS_LISTNONEMPTYSESSIONIDS,
+                Some(wire_params),
+            )
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
     /// Finds the local session bound to a GitHub task ID, if any.
     ///
     /// Wire method: `sessions.findByTaskId`.
@@ -1839,6 +1904,30 @@ impl<'a> ClientRpcSessions<'a> {
             .call(rpc_methods::SESSIONS_BULKDELETE, Some(wire_params))
             .await?;
         Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Deletes one local session from disk after running the same lifecycle hooks as the session manager.
+    ///
+    /// Wire method: `sessions.delete`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Session ID to delete from disk.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub(crate) async fn delete(&self, params: SessionsDeleteRequest) -> Result<(), Error> {
+        let wire_params = serde_json::to_value(params)?;
+        let _value = self
+            .client
+            .call(rpc_methods::SESSIONS_DELETE, Some(wire_params))
+            .await?;
+        Ok(())
     }
 
     /// Deletes sessions older than the given threshold, with optional dry-run and exclusion list.
@@ -2927,6 +3016,38 @@ impl<'a> SessionRpc<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Queues or sends an internal system notification to the session according to its passive policy.
+    ///
+    /// Wire method: `session.sendSystemNotification`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Internal request for sending a system notification.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub(crate) async fn send_system_notification(
+        &self,
+        params: SendSystemNotificationRequest,
+    ) -> Result<(), Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(
+                rpc_methods::SESSION_SENDSYSTEMNOTIFICATION,
+                Some(wire_params),
+            )
+            .await?;
+        Ok(())
+    }
+
     /// Aborts the current agent turn.
     ///
     /// Wire method: `session.abort`.
@@ -2953,6 +3074,69 @@ impl<'a> SessionRpc<'a> {
             .session
             .client()
             .call(rpc_methods::SESSION_ABORT, Some(wire_params))
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Interrupts the current main agent turn while leaving running background work (subagents, sidekicks, and promoted attached shells) alive. No-op when the main loop is not processing.
+    ///
+    /// Wire method: `session.interruptMainTurn`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Parameters for interrupting the main agent turn.
+    ///
+    /// # Returns
+    ///
+    /// Result of interrupting the main agent turn.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub async fn interrupt_main_turn(
+        &self,
+        params: InterruptMainTurnRequest,
+    ) -> Result<InterruptMainTurnResult, Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(rpc_methods::SESSION_INTERRUPTMAINTURN, Some(wire_params))
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Cancels every running background agent (task-registry subagents plus sidekick agents) without interrupting the main agent loop. Promoted attached shells are left running.
+    ///
+    /// Wire method: `session.cancelAllBackgroundAgents`.
+    ///
+    /// # Returns
+    ///
+    /// The number of running background agents (task-registry agents) that were cancelled.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub async fn cancel_all_background_agents(
+        &self,
+    ) -> Result<SessionCancelAllBackgroundAgentsResult, Error> {
+        let wire_params = serde_json::json!({ "sessionId": self.session.id() });
+        let _value = self
+            .session
+            .client()
+            .call(
+                rpc_methods::SESSION_CANCELALLBACKGROUNDAGENTS,
+                Some(wire_params),
+            )
             .await?;
         Ok(serde_json::from_value(_value)?)
     }
@@ -3976,6 +4160,36 @@ impl<'a> SessionRpcFactory<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Resumes a factory run using its persisted name, arguments, journal, and accounting.
+    ///
+    /// Wire method: `session.factory.resume`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Parameters for resuming a factory run from its persisted identity.
+    ///
+    /// # Returns
+    ///
+    /// Resolved persisted factory identity and resumed run envelope.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub async fn resume(&self, params: FactoryResumeRequest) -> Result<FactoryResumeResult, Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(rpc_methods::SESSION_FACTORY_RESUME, Some(wire_params))
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
     /// Gets the current or settled envelope for a factory run.
     ///
     /// Wire method: `session.factory.getRun`.
@@ -4002,6 +4216,100 @@ impl<'a> SessionRpcFactory<'a> {
             .session
             .client()
             .call(rpc_methods::SESSION_FACTORY_GETRUN, Some(wire_params))
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Lists durable factory runs for this session in creation order.
+    ///
+    /// Wire method: `session.factory.listRuns`.
+    ///
+    /// # Returns
+    ///
+    /// Factory runs in durable creation order.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub async fn list_runs(&self) -> Result<FactoryListRunsResult, Error> {
+        let wire_params = serde_json::json!({ "sessionId": self.session.id() });
+        let _value = self
+            .session
+            .client()
+            .call(rpc_methods::SESSION_FACTORY_LISTRUNS, Some(wire_params))
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Gets durable and live observability detail for one factory run.
+    ///
+    /// Wire method: `session.factory.getRunDetail`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Parameters for retrieving a factory run.
+    ///
+    /// # Returns
+    ///
+    /// Full factory run observability detail.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub async fn get_run_detail(
+        &self,
+        params: FactoryGetRunRequest,
+    ) -> Result<FactoryRunDetail, Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(rpc_methods::SESSION_FACTORY_GETRUNDETAIL, Some(wire_params))
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Pages durable progress for one factory run.
+    ///
+    /// Wire method: `session.factory.getRunProgress`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Parameters for paging factory progress.
+    ///
+    /// # Returns
+    ///
+    /// A bidirectional page of factory progress.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub async fn get_run_progress(
+        &self,
+        params: FactoryGetRunProgressRequest,
+    ) -> Result<FactoryProgressPage, Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(
+                rpc_methods::SESSION_FACTORY_GETRUNPROGRESS,
+                Some(wire_params),
+            )
             .await?;
         Ok(serde_json::from_value(_value)?)
     }
@@ -5383,6 +5691,39 @@ impl<'a> SessionRpcMcpOauth<'a> {
             .session
             .client()
             .call(rpc_methods::SESSION_MCP_OAUTH_LOGIN, Some(wire_params))
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Responds to a pending MCP OAuth authorization request by its request id.
+    ///
+    /// Wire method: `session.mcp.oauth.respond`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Pending MCP OAuth request id to respond to.
+    ///
+    /// # Returns
+    ///
+    /// Indicates whether the pending MCP OAuth response was accepted.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub async fn respond(
+        &self,
+        params: McpOauthRespondRequest,
+    ) -> Result<McpOauthRespondResult, Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(rpc_methods::SESSION_MCP_OAUTH_RESPOND, Some(wire_params))
             .await?;
         Ok(serde_json::from_value(_value)?)
     }
@@ -7275,6 +7616,160 @@ impl<'a> SessionRpcQueue<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Returns the internal native queue snapshot for in-process session orchestration.
+    ///
+    /// Wire method: `session.queue.snapshot`.
+    ///
+    /// # Returns
+    ///
+    /// Internal snapshot of native queue state for local session orchestration.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub(crate) async fn snapshot(&self) -> Result<QueueSnapshotResult, Error> {
+        let wire_params = serde_json::json!({ "sessionId": self.session.id() });
+        let _value = self
+            .session
+            .client()
+            .call(rpc_methods::SESSION_QUEUE_SNAPSHOT, Some(wire_params))
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Reports whether the local session has native queued work pending.
+    ///
+    /// Wire method: `session.queue.hasPending`.
+    ///
+    /// # Returns
+    ///
+    /// Whether the native queue has pending work.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub(crate) async fn has_pending(&self) -> Result<QueueHasPendingResult, Error> {
+        let wire_params = serde_json::json!({ "sessionId": self.session.id() });
+        let _value = self
+            .session
+            .client()
+            .call(rpc_methods::SESSION_QUEUE_HASPENDING, Some(wire_params))
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Begins a native deferred-idle drain when background work has quiesced.
+    ///
+    /// Wire method: `session.queue.beginDeferredIdleDrain`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Inputs for starting a deferred-idle drain.
+    ///
+    /// # Returns
+    ///
+    /// Whether a deferred-idle drain should run.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub(crate) async fn begin_deferred_idle_drain(
+        &self,
+        params: QueueBeginDeferredIdleDrainRequest,
+    ) -> Result<QueueBeginDeferredIdleDrainResult, Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(
+                rpc_methods::SESSION_QUEUE_BEGINDEFERREDIDLEDRAIN,
+                Some(wire_params),
+            )
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Finishes a native deferred-idle drain and reports whether to drain queue work or emit idle.
+    ///
+    /// Wire method: `session.queue.finishDeferredIdleDrain`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Inputs for completing a deferred-idle drain.
+    ///
+    /// # Returns
+    ///
+    /// Action selected by the native deferred-idle drain.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub(crate) async fn finish_deferred_idle_drain(
+        &self,
+        params: QueueFinishDeferredIdleDrainRequest,
+    ) -> Result<QueueFinishDeferredIdleDrainResult, Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(
+                rpc_methods::SESSION_QUEUE_FINISHDEFERREDIDLEDRAIN,
+                Some(wire_params),
+            )
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Marks session.idle as deferred by native background work state.
+    ///
+    /// Wire method: `session.queue.deferSessionIdle`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Inputs for marking session.idle deferred in native state.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub(crate) async fn defer_session_idle(
+        &self,
+        params: QueueDeferSessionIdleRequest,
+    ) -> Result<(), Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(
+                rpc_methods::SESSION_QUEUE_DEFERSESSIONIDLE,
+                Some(wire_params),
+            )
+            .await?;
+        Ok(())
+    }
+
     /// Removes the most recently queued user-facing item (LIFO).
     ///
     /// Wire method: `session.queue.removeMostRecent`.
@@ -7320,6 +7815,93 @@ impl<'a> SessionRpcQueue<'a> {
             .session
             .client()
             .call(rpc_methods::SESSION_QUEUE_CLEAR, Some(wire_params))
+            .await?;
+        Ok(())
+    }
+
+    /// Consumes queued native system notifications matching an internal filter.
+    ///
+    /// Wire method: `session.queue.consumeSystemNotifications`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Internal filter for consuming queued system notifications.
+    ///
+    /// # Returns
+    ///
+    /// Indicates whether a user-facing pending item was removed.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub(crate) async fn consume_system_notifications(
+        &self,
+        params: QueueConsumeSystemNotificationsRequest,
+    ) -> Result<QueueRemoveMostRecentResult, Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(
+                rpc_methods::SESSION_QUEUE_CONSUMESYSTEMNOTIFICATIONS,
+                Some(wire_params),
+            )
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Enqueues the internal resume-pending wake item when orphan handling needs a follow-up turn.
+    ///
+    /// Wire method: `session.queue.enqueueResumePending`.
+    ///
+    /// # Returns
+    ///
+    /// Result of enqueueing the resume-pending wake item.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub(crate) async fn enqueue_resume_pending(
+        &self,
+    ) -> Result<QueueEnqueueResumePendingResult, Error> {
+        let wire_params = serde_json::json!({ "sessionId": self.session.id() });
+        let _value = self
+            .session
+            .client()
+            .call(
+                rpc_methods::SESSION_QUEUE_ENQUEUERESUMEPENDING,
+                Some(wire_params),
+            )
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Drains the native local-session work queue for in-process session orchestration.
+    ///
+    /// Wire method: `session.queue.process`.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub(crate) async fn process(&self) -> Result<(), Error> {
+        let wire_params = serde_json::json!({ "sessionId": self.session.id() });
+        let _value = self
+            .session
+            .client()
+            .call(rpc_methods::SESSION_QUEUE_PROCESS, Some(wire_params))
             .await?;
         Ok(())
     }
@@ -7448,6 +8030,223 @@ impl<'a> SessionRpcSchedule<'a> {
             .session
             .client()
             .call(rpc_methods::SESSION_SCHEDULE_LIST, Some(wire_params))
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Hydrates the native schedule registry from persisted session events.
+    ///
+    /// Wire method: `session.schedule.hydrate`.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub(crate) async fn hydrate(&self) -> Result<(), Error> {
+        let wire_params = serde_json::json!({ "sessionId": self.session.id() });
+        let _value = self
+            .session
+            .client()
+            .call(rpc_methods::SESSION_SCHEDULE_HYDRATE, Some(wire_params))
+            .await?;
+        Ok(())
+    }
+
+    /// Reports whether the session has an active self-paced scheduled prompt.
+    ///
+    /// Wire method: `session.schedule.hasSelfPaced`.
+    ///
+    /// # Returns
+    ///
+    /// Whether the session currently has an active self-paced schedule.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub(crate) async fn has_self_paced(&self) -> Result<ScheduleHasSelfPacedResult, Error> {
+        let wire_params = serde_json::json!({ "sessionId": self.session.id() });
+        let _value = self
+            .session
+            .client()
+            .call(
+                rpc_methods::SESSION_SCHEDULE_HASSELFPACED,
+                Some(wire_params),
+            )
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Registers a relative-interval scheduled prompt.
+    ///
+    /// Wire method: `session.schedule.add`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Register a relative-interval scheduled prompt.
+    ///
+    /// # Returns
+    ///
+    /// Result of registering or re-arming a scheduled prompt.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub(crate) async fn add(&self, params: ScheduleAddRequest) -> Result<ScheduleAddResult, Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(rpc_methods::SESSION_SCHEDULE_ADD, Some(wire_params))
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Registers a recurring cron scheduled prompt.
+    ///
+    /// Wire method: `session.schedule.addCron`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Register a cron scheduled prompt.
+    ///
+    /// # Returns
+    ///
+    /// Result of registering or re-arming a scheduled prompt.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub(crate) async fn add_cron(
+        &self,
+        params: ScheduleAddCronRequest,
+    ) -> Result<ScheduleAddResult, Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(rpc_methods::SESSION_SCHEDULE_ADDCRON, Some(wire_params))
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Registers an absolute-time scheduled prompt.
+    ///
+    /// Wire method: `session.schedule.addAt`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Register an absolute-time scheduled prompt.
+    ///
+    /// # Returns
+    ///
+    /// Result of registering or re-arming a scheduled prompt.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub(crate) async fn add_at(
+        &self,
+        params: ScheduleAddAtRequest,
+    ) -> Result<ScheduleAddResult, Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(rpc_methods::SESSION_SCHEDULE_ADDAT, Some(wire_params))
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Registers a self-paced scheduled prompt.
+    ///
+    /// Wire method: `session.schedule.addSelfPaced`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Register a self-paced scheduled prompt.
+    ///
+    /// # Returns
+    ///
+    /// Result of registering or re-arming a scheduled prompt.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub(crate) async fn add_self_paced(
+        &self,
+        params: ScheduleAddSelfPacedRequest,
+    ) -> Result<ScheduleAddResult, Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(
+                rpc_methods::SESSION_SCHEDULE_ADDSELFPACED,
+                Some(wire_params),
+            )
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Re-arms an active self-paced scheduled prompt.
+    ///
+    /// Wire method: `session.schedule.rearmSelfPaced`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Re-arm a self-paced scheduled prompt.
+    ///
+    /// # Returns
+    ///
+    /// Result of registering or re-arming a scheduled prompt.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub(crate) async fn rearm_self_paced(
+        &self,
+        params: ScheduleRearmSelfPacedRequest,
+    ) -> Result<ScheduleAddResult, Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(
+                rpc_methods::SESSION_SCHEDULE_REARMSELFPACED,
+                Some(wire_params),
+            )
             .await?;
         Ok(serde_json::from_value(_value)?)
     }
@@ -8875,6 +9674,75 @@ impl<'a> SessionRpcWorkspaces<'a> {
         Ok(serde_json::from_value(_value)?)
     }
 
+    /// Updates workspace metadata for a local session and returns the refreshed workspace.
+    ///
+    /// Wire method: `session.workspaces.updateMetadata`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Workspace metadata fields to update.
+    ///
+    /// # Returns
+    ///
+    /// Current workspace metadata for the session, including its absolute filesystem path when available.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub async fn update_metadata(
+        &self,
+        params: WorkspacesUpdateMetadataRequest,
+    ) -> Result<WorkspacesGetWorkspaceResult, Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(
+                rpc_methods::SESSION_WORKSPACES_UPDATEMETADATA,
+                Some(wire_params),
+            )
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Ensures a local session workspace exists and returns it.
+    ///
+    /// Wire method: `session.workspaces.ensure`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Optional session context used when creating a local workspace.
+    ///
+    /// # Returns
+    ///
+    /// Current workspace metadata for the session, including its absolute filesystem path when available.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub async fn ensure(
+        &self,
+        params: WorkspacesEnsureRequest,
+    ) -> Result<WorkspacesGetWorkspaceResult, Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(rpc_methods::SESSION_WORKSPACES_ENSURE, Some(wire_params))
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
     /// Lists files stored in the session workspace files directory.
     ///
     /// Wire method: `session.workspaces.listFiles`.
@@ -9020,6 +9888,204 @@ impl<'a> SessionRpcWorkspaces<'a> {
             .client()
             .call(
                 rpc_methods::SESSION_WORKSPACES_READCHECKPOINT,
+                Some(wire_params),
+            )
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Adds a compaction summary checkpoint to the local session workspace.
+    ///
+    /// Wire method: `session.workspaces.addSummary`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Compaction summary checkpoint to persist.
+    ///
+    /// # Returns
+    ///
+    /// Persisted summary metadata and refreshed workspace metadata.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub async fn add_summary(
+        &self,
+        params: WorkspacesAddSummaryRequest,
+    ) -> Result<WorkspacesAddSummaryResult, Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(
+                rpc_methods::SESSION_WORKSPACES_ADDSUMMARY,
+                Some(wire_params),
+            )
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Truncates local workspace compaction summaries after a rollback.
+    ///
+    /// Wire method: `session.workspaces.truncateSummaries`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Rollback point for local workspace summaries.
+    ///
+    /// # Returns
+    ///
+    /// Current workspace metadata for the session, including its absolute filesystem path when available.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub async fn truncate_summaries(
+        &self,
+        params: WorkspacesTruncateSummariesRequest,
+    ) -> Result<WorkspacesGetWorkspaceResult, Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(
+                rpc_methods::SESSION_WORKSPACES_TRUNCATESUMMARIES,
+                Some(wire_params),
+            )
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Reads the autopilot objective state file from the local session workspace.
+    ///
+    /// Wire method: `session.workspaces.readAutopilotObjective`.
+    ///
+    /// # Returns
+    ///
+    /// Autopilot objective file content, or null when missing.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub async fn read_autopilot_objective(
+        &self,
+    ) -> Result<WorkspacesReadAutopilotObjectiveResult, Error> {
+        let wire_params = serde_json::json!({ "sessionId": self.session.id() });
+        let _value = self
+            .session
+            .client()
+            .call(
+                rpc_methods::SESSION_WORKSPACES_READAUTOPILOTOBJECTIVE,
+                Some(wire_params),
+            )
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Writes the autopilot objective state file in the local session workspace.
+    ///
+    /// Wire method: `session.workspaces.writeAutopilotObjective`.
+    ///
+    /// # Parameters
+    ///
+    /// * `params` - Autopilot objective file content to persist.
+    ///
+    /// # Returns
+    ///
+    /// Result of writing the autopilot objective file.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub async fn write_autopilot_objective(
+        &self,
+        params: WorkspacesWriteAutopilotObjectiveRequest,
+    ) -> Result<WorkspacesWriteAutopilotObjectiveResult, Error> {
+        let mut wire_params = serde_json::to_value(params)?;
+        wire_params["sessionId"] = serde_json::Value::String(self.session.id().to_string());
+        let _value = self
+            .session
+            .client()
+            .call(
+                rpc_methods::SESSION_WORKSPACES_WRITEAUTOPILOTOBJECTIVE,
+                Some(wire_params),
+            )
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Deletes the autopilot objective state file from the local session workspace.
+    ///
+    /// Wire method: `session.workspaces.deleteAutopilotObjective`.
+    ///
+    /// # Returns
+    ///
+    /// Result of deleting the autopilot objective file.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub async fn delete_autopilot_objective(
+        &self,
+    ) -> Result<WorkspacesDeleteAutopilotObjectiveResult, Error> {
+        let wire_params = serde_json::json!({ "sessionId": self.session.id() });
+        let _value = self
+            .session
+            .client()
+            .call(
+                rpc_methods::SESSION_WORKSPACES_DELETEAUTOPILOTOBJECTIVE,
+                Some(wire_params),
+            )
+            .await?;
+        Ok(serde_json::from_value(_value)?)
+    }
+
+    /// Checks whether the local session workspace has an autopilot objective state file.
+    ///
+    /// Wire method: `session.workspaces.autopilotObjectiveExists`.
+    ///
+    /// # Returns
+    ///
+    /// Whether the autopilot objective file exists.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This API is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases. Pin both the
+    /// SDK and CLI versions if your code depends on it.
+    ///
+    /// </div>
+    pub async fn autopilot_objective_exists(
+        &self,
+    ) -> Result<WorkspacesAutopilotObjectiveExistsResult, Error> {
+        let wire_params = serde_json::json!({ "sessionId": self.session.id() });
+        let _value = self
+            .session
+            .client()
+            .call(
+                rpc_methods::SESSION_WORKSPACES_AUTOPILOTOBJECTIVEEXISTS,
                 Some(wire_params),
             )
             .await?;

--- a/rust/src/generated/session_events.rs
+++ b/rust/src/generated/session_events.rs
@@ -233,6 +233,15 @@ pub enum SessionEventType {
     SessionToolsUpdated,
     #[serde(rename = "session.background_tasks_changed")]
     SessionBackgroundTasksChanged,
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This type is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases.
+    ///
+    /// </div>
+    #[serde(rename = "factory.run_updated")]
+    FactoryRunUpdated,
     #[serde(rename = "session.skills_loaded")]
     SessionSkillsLoaded,
     #[serde(rename = "session.custom_agents_updated")]
@@ -534,6 +543,15 @@ pub enum SessionEventData {
     SessionToolsUpdated(SessionToolsUpdatedData),
     #[serde(rename = "session.background_tasks_changed")]
     SessionBackgroundTasksChanged(SessionBackgroundTasksChangedData),
+    ///
+    /// <div class="warning">
+    ///
+    /// **Experimental.** This type is part of an experimental wire-protocol surface
+    /// and may change or be removed in future SDK or CLI releases.
+    ///
+    /// </div>
+    #[serde(rename = "factory.run_updated")]
+    FactoryRunUpdated(FactoryRunUpdatedData),
     #[serde(rename = "session.skills_loaded")]
     SessionSkillsLoaded(SessionSkillsLoadedData),
     #[serde(rename = "session.custom_agents_updated")]
@@ -841,6 +859,9 @@ pub struct SessionScheduleCreatedData {
     /// Interval between ticks in milliseconds (relative-interval schedules)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interval_ms: Option<i64>,
+    /// Who created the schedule (`user` or `model`). Persisted so a resumed session keeps gating non-user schedules from firing skills that opted out of model invocation. Absent on entries created before this field existed; a missing origin fails closed (treated the same as a non-user origin), so such a schedule may not resolve a `disable-model-invocation` skill.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin: Option<ScheduleOrigin>,
     /// Prompt text that gets enqueued on every tick
     pub prompt: String,
     /// Whether the schedule re-arms after each tick (`/every`) or fires once (`/after`)
@@ -1492,7 +1513,7 @@ pub struct UserMessageData {
     /// Parent agent task ID for background telemetry correlated to this user turn
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_agent_task_id: Option<String>,
-    /// Origin of this message, used for timeline filtering (e.g., "skill-pdf" for skill-injected messages that should be hidden from the user)
+    /// Origin of this message, used for timeline filtering and attribution (e.g., `skill-pdf` for hidden skill injection or `agent-<agent-id>` for an inter-agent prompt)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
     /// Normalized document MIME types that were sent natively instead of through tagged_files XML
@@ -1564,6 +1585,8 @@ pub struct AssistantReasoningData {
     pub content: String,
     /// Unique identifier for this reasoning block
     pub reasoning_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rte: Option<bool>,
 }
 
 /// Session event "assistant.reasoning_delta". Streaming reasoning delta for incremental extended thinking updates
@@ -1792,6 +1815,8 @@ pub struct AssistantMessageData {
     /// GitHub request tracing ID (x-github-request-id header) for correlating with server-side logs
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_id: Option<RequestId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rte: Option<bool>,
     /// Neutral provider-tagged server-side tool-use payload (tool search, advisor) for verbatim round-tripping
     #[serde(skip_serializing_if = "Option::is_none")]
     pub server_tools: Option<AssistantMessageServerTools>,
@@ -1968,6 +1993,9 @@ pub struct AssistantUsageData {
     /// Number of input tokens consumed
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_tokens: Option<i64>,
+    /// Coarse classification of the interaction that produced this call, mirroring the session's per-request agent context (e.g. `conversation-agent`, `conversation-subagent`, `conversation-sampling`, `conversation-background`, `conversation-compaction`, `conversation-user`). Non-billing; lets consumers attribute a model call to a call class (e.g. sub-agent/sidekick) independently of the billing initiator. Absent when the runtime did not classify the request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interaction_type: Option<String>,
     /// Average inter-token latency in milliseconds. Only available for streaming requests
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inter_token_latency_ms: Option<f64>,
@@ -1994,6 +2022,8 @@ pub struct AssistantUsageData {
     /// Number of output tokens used for reasoning (e.g., chain-of-thought)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_tokens: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rte: Option<bool>,
     /// Copilot service request ID (x-copilot-service-request-id header) for CAPI log correlation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_request_id: Option<String>,
@@ -2082,6 +2112,8 @@ pub struct ModelCallFailureData {
     /// Content-free structural summary of the failing request. Contains only counts and shape flags (no prompt content), so it is safe for unrestricted telemetry. Populated only for client-error (4xx) failures.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_fingerprint: Option<ModelCallFailureRequestFingerprint>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rte: Option<bool>,
     /// Copilot service request ID (x-copilot-service-request-id header) for CAPI log correlation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_request_id: Option<String>,
@@ -2196,6 +2228,8 @@ pub struct ToolExecutionStartData {
     #[deprecated]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_tool_call_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rte: Option<bool>,
     /// Shell-tool path hints derived from the command at start time for shell tools (bash/powershell/local_shell). Produced by the same shell-aware extractor as PermissionRequestShell.possiblePaths, so it is present even when the command is auto-approved and no permission request fires. Absent for non-shell tools.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shell_tool_info: Option<ToolExecutionStartShellToolInfo>,
@@ -2636,6 +2670,8 @@ pub struct ToolExecutionCompleteData {
     /// Tool execution result on success
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<ToolExecutionCompleteResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rte: Option<bool>,
     /// Whether this tool execution ran inside a sandbox container
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sandboxed: Option<bool>,
@@ -2877,6 +2913,9 @@ pub struct SystemMessageMetadata {
 pub struct SystemMessageData {
     /// The system or developer prompt text sent as model input
     pub content: String,
+    /// Logical interaction identifier for the model run receiving this prompt
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interaction_id: Option<String>,
     /// Metadata about the prompt template and its construction
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<SystemMessageMetadata>,
@@ -4229,6 +4268,22 @@ pub struct SessionToolsUpdatedData {
 #[serde(rename_all = "camelCase")]
 pub struct SessionBackgroundTasksChangedData {}
 
+/// Session event "factory.run_updated". Ephemeral invalidation signal for a changed factory run.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FactoryRunUpdatedData {
+    /// Monotonic revision now available for the run.
+    pub revision: i64,
+    pub run_id: String,
+}
+
 /// A single resolved skill in `session.skills_loaded`, including source, invocability, enabled state, path, and argument hint.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -4697,6 +4752,21 @@ pub enum Verbosity {
     /// A more detailed response was requested.
     #[serde(rename = "high")]
     High,
+    /// Unknown variant for forward compatibility.
+    #[default]
+    #[serde(other)]
+    Unknown,
+}
+
+/// Who created the schedule: `user` (an explicit user action such as `/every` or `/after`) or `model` (the agent via the `manage_schedule` tool). Gates whether a scheduled skill that opted out of model invocation may fire: only user-created schedules may.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ScheduleOrigin {
+    /// The schedule was created by an explicit user action, such as `/every` or `/after`.
+    #[serde(rename = "user")]
+    User,
+    /// The schedule was created by the agent via the `manage_schedule` tool.
+    #[serde(rename = "model")]
+    Model,
     /// Unknown variant for forward compatibility.
     #[default]
     #[serde(other)]

--- a/rust/tests/e2e/rpc_tasks_and_handlers.rs
+++ b/rust/tests/e2e/rpc_tasks_and_handlers.rs
@@ -322,6 +322,7 @@ async fn should_return_expected_results_for_missing_pending_handler_requestids()
                         response: UIExitPlanModeResponse {
                             approved: false,
                             auto_approve_edits: None,
+                            defer_implementation: None,
                             feedback: Some("not now".to_string()),
                             selected_action: None,
                         },

--- a/scripts/codegen/typescript.ts
+++ b/scripts/codegen/typescript.ts
@@ -38,9 +38,10 @@ import {
     isVoidSchema,
     isSchemaExperimental,
     isSchemaInternal,
+    isOpaqueJson,
+    stripOpaqueJsonMarker,
     appendPropertyMarkerTagsToDescriptions,
     getEnumValueDescriptions,
-    stripOpaqueJsonMarker,
     loadSchemaJson,
     fixBrandCasing,
     type ApiSchema,
@@ -52,6 +53,8 @@ const TS_EXPERIMENTAL_JSDOC = "/** @experimental */";
 const EXTERNAL_SCHEMA_TS_IMPORT: Record<string, string> = {
     "session-events.schema.json": "./session-events.js",
 };
+export const TYPESCRIPT_JSON_VALUE_DECLARATION =
+    "export type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };";
 
 function tsExperimentalJSDoc(indent = ""): string {
     return `${indent}${TS_EXPERIMENTAL_JSDOC}`;
@@ -252,6 +255,30 @@ function collectRpcMethods(node: Record<string, unknown>): RpcMethod[] {
     return results;
 }
 
+/**
+ * JSON Schema keywords that describe real structure. A node carrying any of
+ * these is not an unconstrained value, even when it is also marked
+ * `x-opaque-json`.
+ */
+const STRUCTURAL_SCHEMA_KEYWORDS = [
+    "anyOf",
+    "oneOf",
+    "allOf",
+    "not",
+    "type",
+    "properties",
+    "patternProperties",
+    "items",
+    "prefixItems",
+    "enum",
+    "const",
+    "$ref",
+] as const;
+
+function hasStructuralConstraints(schema: Record<string, unknown>): boolean {
+    return STRUCTURAL_SCHEMA_KEYWORDS.some((keyword) => schema[keyword] !== undefined);
+}
+
 export function normalizeSchemaForTypeScript(schema: JSONSchema7): JSONSchema7 {
     const root = structuredClone(schema) as JSONSchema7 & {
         definitions?: Record<string, unknown>;
@@ -286,11 +313,17 @@ export function normalizeSchemaForTypeScript(schema: JSONSchema7): JSONSchema7 {
             Object.entries(value as Record<string, unknown>).map(([key, child]) => [key, rewrite(child)])
         ) as Record<string, unknown>;
 
-        // The TypeScript codegen doesn't distinguish opaque JSON from any
-        // other unconstrained value, so drop the marker before feeding the
-        // schema to json-schema-to-typescript. C# codegen reads the marker
-        // from its own (un-normalized) view of the schema and emits
-        // `JsonElement` instead.
+        // Only a genuinely unconstrained opaque node becomes `JsonValue`. Many
+        // schemas carry `x-opaque-json` alongside real structure (an `anyOf`
+        // union, or `type`/`properties`) so that codegens which model opaque
+        // JSON natively can do so without discarding that structure; collapsing
+        // those to `JsonValue` would silently erase public contracts such as
+        // `McpServerConfig` or `ExternalToolResult`. For those, drop the marker
+        // and let json-schema-to-typescript emit the real shape, exactly as
+        // this codegen did before opaque JSON was representable.
+        if (isOpaqueJson(rewritten as JSONSchema7) && !hasStructuralConstraints(rewritten)) {
+            return { tsType: "JsonValue" };
+        }
         stripOpaqueJsonMarker(rewritten);
 
         const enumValueDescriptions = getEnumValueDescriptions(rewritten as JSONSchema7);
@@ -394,7 +427,7 @@ async function generateSessionEvents(schemaPath?: string): Promise<void> {
         strictIndexSignatures: true,
     });
 
-    let annotatedTs = annotateTypeScriptTypes(ts, experimentalDefinitionNames(definitionCollections), TS_EXPERIMENTAL_JSDOC);
+    let annotatedTs = `${TYPESCRIPT_JSON_VALUE_DECLARATION}\n\n${annotateTypeScriptTypes(ts, experimentalDefinitionNames(definitionCollections), TS_EXPERIMENTAL_JSDOC)}`;
     // Add @internal JSDoc annotations for session-event types marked
     // `visibility: "internal"` in the schema. The tag drives `stripInternal`
     // so the whole type is dropped from the published .d.ts.
@@ -546,6 +579,8 @@ import type { MessageConnection } from "vscode-jsonrpc/node.js";
     if (externalSchemaRefs.size > 0) {
         lines.push("");
     }
+    lines.push(TYPESCRIPT_JSON_VALUE_DECLARATION);
+    lines.push("");
 
     const allMethods = [...collectRpcMethods(schema.server || {}), ...collectRpcMethods(schema.session || {})];
     const clientSessionMethods = collectRpcMethods(schema.clientSession || {});


### PR DESCRIPTION
## Why

Split out of #2114 so the Agent Factories authoring surface can be reviewed on its own. This half is almost entirely machine-generated: of ~12.1k added lines, roughly 200 are hand-written, and every one of those exists because the new schemas force it.

Bumping `@github/copilot` from `^1.0.73` to `^1.0.75` is also useful independently of factories — 1.0.75 is the first published runtime carrying the full factory wire surface, but the regeneration picks up everything else that landed alongside it.

## What

**Generated types** — regenerated for Node.js, Python, Go, .NET, and Rust from the 1.0.75 schemas.

**Codegen: narrow the opaque-JSON conversion.** `x-opaque-json` was being applied to every annotated definition, but only 1 of the 14 (`CanvasJsonSchema`) is genuinely unconstrained; the other 13 carry `anyOf` or `type` + `properties`. Blanket-converting them threw away the structure of `McpServerConfig`, `ExternalToolResult`, `EventLogTypes`, and `UIElicitationSchemaProperty`. The conversion now requires the absence of any structural keyword. Genuinely opaque nodes emit `JsonValue` rather than `unknown`, which is a global tightening.

**Fallout the new schemas force:**

- `sessionFs` gained `sqliteTransaction`, so every hand-written provider adapter must implement it. Node forwards to an optional provider hook and classifies failures; Python, Go, and .NET have no transaction hook in their provider interfaces, so they refuse the batch with a classified `fatal` error rather than applying it non-atomically. **This is the deliberate call worth a look** — refusing is safer than silently running a "transaction" that isn't atomic.
- `UIExitPlanModeResponse` gained `deferImplementation`, so a Rust e2e struct literal has to name it.
- `lsp.initialize` and `telemetry.setFeatureOverrides` are declared `Promise<void>` and now resolve with `{}` rather than `null`, so two e2e assertions no longer pin the resolved value.
- The `JsonValue` tightening reaches `ToolTelemetry`, the hooks-invoke response, and `data.arguments` in a session-event type test.

## Verification

Verified standalone on this branch (not just as part of #2114): Node typecheck clean, lint 0 errors, 675 unit tests passing; `cargo check --all-targets` clean; `go build ./...` and `go vet ./...` clean; `dotnet build` clean with 0 warnings.

## Notes for reviewers

The generated files are the bulk of the diff and are reproducible — `cd scripts/codegen && npm run generate` should be a no-op on this branch. The review that matters is the ~200 hand-written lines listed under *Fallout* above, plus the codegen predicate change in `scripts/codegen/typescript.ts`.

#2114 depends on this and will rebase onto it once this merges.
