### PR TITLE
python: decode boolean-discriminated unions

### DIFF
--- a/python/copilot/generated/rpc.py
+++ b/python/copilot/generated/rpc.py
@@ -6528,7 +6528,7 @@ class QueuedCommandHandled:
     """Queued-command response indicating the host executed the command, with an optional flag
     to stop queue processing.
     """
-    handled: ClassVar[str] = "true"
+    handled: ClassVar[bool] = True
     """The host actually executed the queued command."""
 
     stop_processing_queue: bool | None = None
@@ -6555,7 +6555,7 @@ class QueuedCommandNotHandled:
     """Queued-command response indicating the host did not execute the command and the queue may
     continue.
     """
-    handled: ClassVar[str] = "false"
+    handled: ClassVar[bool] = False
     """The host did not execute the queued command. Unblocks the queue without claiming the
     command was processed (e.g. when the handler threw before completing).
     """
@@ -27742,8 +27742,8 @@ def _load_QueuedCommandResult(obj: Any) -> "QueuedCommandResult":
     assert isinstance(obj, dict)
     kind = obj.get("handled")
     match kind:
-        case "true": return QueuedCommandHandled.from_dict(obj)
-        case "false": return QueuedCommandNotHandled.from_dict(obj)
+        case True: return QueuedCommandHandled.from_dict(obj)
+        case False: return QueuedCommandNotHandled.from_dict(obj)
         case _: raise ValueError(f"Unknown QueuedCommandResult handled: {kind!r}")
 
 # State of the runtime-managed remote-control singleton.
@@ -27766,8 +27766,8 @@ def _load_SessionListEntry(obj: Any) -> "SessionListEntry":
     assert isinstance(obj, dict)
     kind = obj.get("isRemote")
     match kind:
-        case "false": return LocalSessionMetadataValue.from_dict(obj)
-        case "true": return RemoteSessionMetadataValue.from_dict(obj)
+        case False: return LocalSessionMetadataValue.from_dict(obj)
+        case True: return RemoteSessionMetadataValue.from_dict(obj)
         case _: raise ValueError(f"Unknown SessionListEntry isRemote: {kind!r}")
 
 # Open a session by creating, resuming, attaching, connecting to a remote, or handing off.

--- a/python/e2e/test_rpc_server_e2e.py
+++ b/python/e2e/test_rpc_server_e2e.py
@@ -6,7 +6,6 @@ Mirrors ``dotnet/test/RpcServerTests.cs`` (snapshot category ``rpc_server``).
 
 from __future__ import annotations
 
-import asyncio
 import os
 import uuid
 from datetime import UTC, datetime
@@ -56,7 +55,7 @@ from copilot.rpc import (
 )
 from copilot.session import PermissionHandler
 
-from .testharness import E2ETestContext
+from .testharness import E2ETestContext, wait_for_condition
 
 pytestmark = pytest.mark.asyncio(loop_scope="module")
 
@@ -307,16 +306,33 @@ class TestRpcServer:
             await session.send(
                 "Record a turn for sessions.list discriminator coverage", mode="enqueue"
             )
-            await asyncio.sleep(0.2)
-            save = await client.rpc.sessions.save(SessionsSaveRequest(session_id=session_id))
-            assert save is not None
 
-            listed = await client.rpc.sessions.list(
-                SessionsListRequest(
-                    filter=SessionListFilter(cwd=str(working_directory)),
-                    metadata_limit=0,
+            listed = None
+
+            async def session_is_listed() -> bool:
+                nonlocal listed
+                # Re-save on every attempt: on slower runners the enqueued turn is not
+                # necessarily recorded yet when the first save runs, so a single save
+                # followed by a fixed sleep races the CLI's own persistence.
+                save = await client.rpc.sessions.save(SessionsSaveRequest(session_id=session_id))
+                assert save is not None
+                listed = await client.rpc.sessions.list(
+                    SessionsListRequest(
+                        filter=SessionListFilter(cwd=str(working_directory)),
+                        metadata_limit=0,
+                    )
                 )
+                return any(item.session_id == session_id for item in listed.sessions or [])
+
+            await wait_for_condition(
+                session_is_listed,
+                timeout=60.0,
+                timeout_message=(
+                    "Timed out waiting for the saved session to be returned by sessions.list."
+                ),
             )
+
+            assert listed is not None
             assert listed.sessions is not None
             assert len(listed.sessions) >= 1
             matching = [item for item in listed.sessions if item.session_id == session_id]

--- a/python/e2e/test_rpc_server_e2e.py
+++ b/python/e2e/test_rpc_server_e2e.py
@@ -304,7 +304,9 @@ class TestRpcServer:
                 on_permission_request=PermissionHandler.approve_all,
             )
 
-            await session.send("Record a turn for sessions.list discriminator coverage", mode="enqueue")
+            await session.send(
+                "Record a turn for sessions.list discriminator coverage", mode="enqueue"
+            )
             await asyncio.sleep(0.2)
             save = await client.rpc.sessions.save(SessionsSaveRequest(session_id=session_id))
             assert save is not None
@@ -358,6 +360,9 @@ class TestRpcServer:
             try:
                 await client.stop()
             except ExceptionGroup:
+                # Intentional: shutting down the per-test client can race the
+                # CLI's own teardown and surface as an aggregated cancellation
+                # error from anyio. We don't want it to fail the test.
                 pass
 
     async def test_should_enrich_basic_session_metadata(self, ctx: E2ETestContext):

--- a/python/e2e/test_rpc_server_e2e.py
+++ b/python/e2e/test_rpc_server_e2e.py
@@ -6,6 +6,7 @@ Mirrors ``dotnet/test/RpcServerTests.cs`` (snapshot category ``rpc_server``).
 
 from __future__ import annotations
 
+import asyncio
 import os
 import uuid
 from datetime import UTC, datetime
@@ -282,30 +283,44 @@ class TestRpcServer:
                 # error from anyio. We don't want it to fail the test.
                 pass
 
-    async def test_should_list_find_and_inspect_persisted_session_state(self, ctx: E2ETestContext):
+    async def test_should_list_find_and_inspect_persisted_session_state(
+        self, authed_ctx: E2ETestContext
+    ):
+        token = os.environ.get("GITHUB_TOKEN", "fakevalue")
+        await _configure_user(authed_ctx, token)
+        client = _make_authed_client(authed_ctx, token)
+
         session_id = str(uuid.uuid4())
-        working_directory = Path(ctx.work_dir) / f"server-rpc-list-{uuid.uuid4().hex}"
+        working_directory = Path(authed_ctx.work_dir) / f"server-rpc-list-{uuid.uuid4().hex}"
         working_directory.mkdir(parents=True, exist_ok=True)
         missing_task_id = f"missing-task-{uuid.uuid4().hex}"
         missing_session_id = str(uuid.uuid4())
-
-        session = await ctx.client.create_session(
-            session_id=session_id,
-            working_directory=str(working_directory),
-            on_permission_request=PermissionHandler.approve_all,
-        )
+        session = None
         try:
-            await session.log("SERVER_RPC_LIST_READY")
-            save = await ctx.client.rpc.sessions.save(SessionsSaveRequest(session_id=session_id))
+            await client.start()
+            session = await client.create_session(
+                session_id=session_id,
+                working_directory=str(working_directory),
+                on_permission_request=PermissionHandler.approve_all,
+            )
+
+            await session.send("Record a turn for sessions.list discriminator coverage", mode="enqueue")
+            await asyncio.sleep(0.2)
+            save = await client.rpc.sessions.save(SessionsSaveRequest(session_id=session_id))
             assert save is not None
 
-            listed = await ctx.client.rpc.sessions.list(
+            listed = await client.rpc.sessions.list(
                 SessionsListRequest(
                     filter=SessionListFilter(cwd=str(working_directory)),
                     metadata_limit=0,
                 )
             )
             assert listed.sessions is not None
+            assert len(listed.sessions) >= 1
+            matching = [item for item in listed.sessions if item.session_id == session_id]
+            assert len(matching) == 1
+            assert isinstance(matching[0], LocalSessionMetadataValue)
+            assert matching[0].is_remote is False
             assert all(
                 item.context is None
                 or os.path.normcase(os.path.abspath(item.context.cwd))
@@ -313,32 +328,37 @@ class TestRpcServer:
                 for item in listed.sessions
             )
 
-            by_prefix = await ctx.client.rpc.sessions.find_by_prefix(
+            by_prefix = await client.rpc.sessions.find_by_prefix(
                 SessionsFindByPrefixRequest(prefix=session_id[:8])
             )
             assert by_prefix.session_id in (None, session_id)
 
-            by_task = await ctx.client.rpc.sessions.find_by_task_id(
+            by_task = await client.rpc.sessions.find_by_task_id(
                 SessionsFindByTaskIDRequest(task_id=missing_task_id)
             )
             assert by_task.session_id is None
 
-            last_for_context = await ctx.client.rpc.sessions.get_last_for_context(
+            last_for_context = await client.rpc.sessions.get_last_for_context(
                 SessionsGetLastForContextRequest(context=SessionContext(cwd=str(working_directory)))
             )
             assert last_for_context.session_id in (None, session_id)
 
-            sizes = await ctx.client.rpc.sessions.get_sizes()
+            sizes = await client.rpc.sessions.get_sizes()
             assert sizes.sizes is not None
             if session_id in sizes.sizes:
                 assert sizes.sizes[session_id] >= 0
 
-            in_use = await ctx.client.rpc.sessions.check_in_use(
+            in_use = await client.rpc.sessions.check_in_use(
                 SessionsCheckInUseRequest(session_ids=[session_id, missing_session_id])
             )
             assert missing_session_id not in in_use.in_use
         finally:
-            await session.disconnect()
+            if session is not None:
+                await session.disconnect()
+            try:
+                await client.stop()
+            except ExceptionGroup:
+                pass
 
     async def test_should_enrich_basic_session_metadata(self, ctx: E2ETestContext):
         session_id = str(uuid.uuid4())

--- a/python/test_rpc_generated.py
+++ b/python/test_rpc_generated.py
@@ -1,5 +1,6 @@
 """Tests for generated RPC method behavior."""
 
+import json
 from unittest.mock import AsyncMock
 
 import pytest
@@ -7,6 +8,14 @@ import pytest
 from copilot.rpc import (
     CommandsApi,
     CommandsInvokeRequest,
+    CommandsRespondToQueuedCommandRequest,
+    LocalSessionMetadataValue,
+    QueuedCommandHandled,
+    QueuedCommandNotHandled,
+    RemoteControlStatusOff,
+    RemoteControlStatusResult,
+    RemoteSessionMetadataValue,
+    SessionList,
     SlashCommandTextResult,
 )
 
@@ -22,3 +31,77 @@ async def test_commands_invoke_deserializes_slash_command_result():
     assert isinstance(result, SlashCommandTextResult)
     assert result.text == "hello"
     assert result.markdown is True
+
+
+def test_remote_control_status_deserializes_string_discriminated_union():
+    result = RemoteControlStatusResult.from_dict({"status": {"state": "off"}})
+
+    assert isinstance(result.status, RemoteControlStatusOff)
+    assert result.status.state == "off"
+    assert result.status.to_dict() == {"state": "off"}
+
+
+def test_session_list_deserializes_boolean_discriminated_entries():
+    payload = {
+        "sessions": [
+            {
+                "sessionId": "example-local",
+                "startTime": "2026-07-26T10:00:00.000Z",
+                "modifiedTime": "2026-07-26T10:05:00.000Z",
+                "isRemote": False,
+            },
+            {
+                "sessionId": "example-remote",
+                "startTime": "2026-07-26T11:00:00.000Z",
+                "modifiedTime": "2026-07-26T11:05:00.000Z",
+                "isRemote": True,
+                "remoteSessionIds": ["example-remote"],
+                "repository": {"owner": "github", "name": "copilot-sdk", "branch": "main"},
+            },
+        ]
+    }
+
+    result = SessionList.from_dict(payload)
+
+    local, remote = result.sessions
+    assert isinstance(local, LocalSessionMetadataValue)
+    assert local.session_id == "example-local"
+    assert local.is_remote is False
+    assert isinstance(remote, RemoteSessionMetadataValue)
+    assert remote.session_id == "example-remote"
+    assert remote.is_remote is True
+    assert remote.repository.owner == "github"
+
+
+@pytest.mark.parametrize(
+    ("handled", "expected_type"),
+    [(True, QueuedCommandHandled), (False, QueuedCommandNotHandled)],
+)
+def test_queued_command_result_deserializes_boolean_discriminator(handled, expected_type):
+    request = CommandsRespondToQueuedCommandRequest.from_dict(
+        {"requestId": "example-request", "result": {"handled": handled}}
+    )
+
+    assert isinstance(request.result, expected_type)
+
+
+@pytest.mark.parametrize(
+    ("variant", "expected_handled", "expected_json"),
+    [
+        (QueuedCommandHandled(), True, '{"handled": true}'),
+        (QueuedCommandNotHandled(), False, '{"handled": false}'),
+    ],
+)
+def test_queued_command_result_serializes_boolean_discriminator(
+    variant, expected_handled, expected_json
+):
+    encoded = variant.to_dict()
+
+    assert encoded["handled"] is expected_handled
+    assert json.dumps(encoded) == expected_json
+
+    request = CommandsRespondToQueuedCommandRequest(request_id="example-request", result=variant)
+    round_tripped = CommandsRespondToQueuedCommandRequest.from_dict(request.to_dict())
+
+    assert request.to_dict()["result"]["handled"] is expected_handled
+    assert isinstance(round_tripped.result, type(variant))

--- a/scripts/codegen/python.ts
+++ b/scripts/codegen/python.ts
@@ -273,6 +273,39 @@ function postProcessExternalUnionAliasesForPython(code: string, aliases: Map<str
 }
 
 /**
+ * Literal value of a union discriminator. The API schema discriminates on
+ * string `const`s (`kind: "text"`) and on boolean ones
+ * (`SessionListEntry.isRemote`, `QueuedCommandResult.handled`), so the JSON
+ * type has to survive codegen: coercing `true` to `"true"` emits a dispatcher
+ * arm that the decoded Python `True` can never match. Mirrors
+ * `GoDiscriminatorValue` in `go.ts`.
+ */
+type PyDiscriminatorValue = string | boolean;
+
+/**
+ * Capture a schema `const` as a discriminator value, keeping booleans as
+ * booleans and stringifying everything else.
+ */
+function pyDiscriminatorValue(constValue: unknown): PyDiscriminatorValue {
+    return typeof constValue === "boolean" ? constValue : String(constValue);
+}
+
+/**
+ * Render a discriminator value as a Python literal. Booleans need Python's
+ * `True` / `False` spelling, since the JSON `true` would parse as a capture
+ * pattern in a `match` arm rather than as a literal.
+ */
+function pyDiscriminatorValueExpr(value: PyDiscriminatorValue): string {
+    if (typeof value === "boolean") return value ? "True" : "False";
+    return JSON.stringify(value);
+}
+
+/** Python type of a discriminator constant, for its `ClassVar` annotation. */
+function pyDiscriminatorValueType(value: PyDiscriminatorValue): string {
+    return typeof value === "boolean" ? "bool" : "str";
+}
+
+/**
  * Replace flat-merged dataclasses emitted by quicktype for $ref-based
  * discriminated unions with proper Python unions: a `Name = VariantA | ...`
  * alias plus a `_load_Name(obj)` dispatcher. Rewrites `Name.from_dict(x)` and
@@ -293,7 +326,7 @@ function postProcessExternalUnionAliasesForPython(code: string, aliases: Map<str
 interface ResolvedRefBasedUnion {
     aliasName: string;
     discriminatorProp: string;
-    dispatch: Array<{ value: string; typeName: string }>;
+    dispatch: Array<{ value: PyDiscriminatorValue; typeName: string }>;
 }
 function postProcessRefBasedDiscriminatedUnionsForPython(
     code: string,
@@ -304,7 +337,7 @@ function postProcessRefBasedDiscriminatedUnionsForPython(
         aliasName: string;
         variantNames: string[];
         discriminatorProp: string;
-        dispatch: Array<{ value: string; typeName: string }>;
+        dispatch: Array<{ value: PyDiscriminatorValue; typeName: string }>;
         description: string | undefined;
     }
     const unions: UnionInfo[] = [];
@@ -334,7 +367,7 @@ function postProcessRefBasedDiscriminatedUnionsForPython(
                 discriminator.property
             ];
             return {
-                value: String(discProp.const),
+                value: pyDiscriminatorValue(discProp.const),
                 typeName: toPascalCase(variantRefNames[i]),
             };
         });
@@ -387,7 +420,7 @@ function postProcessRefBasedDiscriminatedUnionsForPython(
     for (const union of unions) {
         const actualAliasName = resolveActualName(union.aliasName);
         const actualVariantNames: string[] = [];
-        const actualDispatch: Array<{ value: string; typeName: string }> = [];
+        const actualDispatch: Array<{ value: PyDiscriminatorValue; typeName: string }> = [];
         let allResolved = true;
         for (let i = 0; i < union.variantNames.length; i++) {
             const actual = resolveActualName(union.variantNames[i]);
@@ -450,7 +483,7 @@ function postProcessRefBasedDiscriminatedUnionsForPython(
         dispatcherLines.push(`    kind = obj.get(${JSON.stringify(union.discriminatorProp)})`);
         dispatcherLines.push(`    match kind:`);
         for (const m of actualDispatch) {
-            dispatcherLines.push(`        case ${JSON.stringify(m.value)}: return ${m.typeName}.from_dict(obj)`);
+            dispatcherLines.push(`        case ${pyDiscriminatorValueExpr(m.value)}: return ${m.typeName}.from_dict(obj)`);
         }
         dispatcherLines.push(
             `        case _: raise ValueError(f"Unknown ${actualAliasName} ${union.discriminatorProp}: {kind!r}")`
@@ -500,7 +533,7 @@ function postProcessDiscriminatorDefaultsForPython(
     unions: ResolvedRefBasedUnion[]
 ): string {
     // Build variant lookup: variant class name → { prop, value }.
-    const variantInfo = new Map<string, { prop: string; value: string }>();
+    const variantInfo = new Map<string, { prop: string; value: PyDiscriminatorValue }>();
     for (const union of unions) {
         for (const d of union.dispatch) {
             // First-wins; multiple unions referencing the same variant share a
@@ -571,9 +604,9 @@ function postProcessDiscriminatorDefaultsForPython(
             continue;
         }
         const fieldIndent = (block[fieldIdx].match(/^(\s+)/) ?? ["", ""])[1];
-        const literal = JSON.stringify(info.value);
+        const literal = pyDiscriminatorValueExpr(info.value);
         // Replace the field with a class-level constant.
-        block[fieldIdx] = `${fieldIndent}${info.prop}: ClassVar[str] = ${literal}`;
+        block[fieldIdx] = `${fieldIndent}${info.prop}: ClassVar[${pyDiscriminatorValueType(info.value)}] = ${literal}`;
         usedClassVar = true;
 
         // Drop any field-trailing docstring lines that immediately followed the
@@ -1590,7 +1623,7 @@ function tryEmitPyRefBasedDiscriminatedUnion(
     if (!discriminator) return undefined;
 
     const variantTypeNames: string[] = [];
-    const dispatch: Array<{ value: string; typeName: string }> = [];
+    const dispatch: Array<{ value: PyDiscriminatorValue; typeName: string }> = [];
     for (let i = 0; i < variants.length; i++) {
         const variantTypeName = toPascalCase(variantRefNames[i]);
         const variantSchema = resolveObjectSchema(variants[i], ctx.definitions);
@@ -1599,7 +1632,7 @@ function tryEmitPyRefBasedDiscriminatedUnion(
         }
         variantTypeNames.push(variantTypeName);
         const discProp = resolvedVariants[i].properties?.[discriminator.property] as JSONSchema7;
-        dispatch.push({ value: String(discProp.const), typeName: variantTypeName });
+        dispatch.push({ value: pyDiscriminatorValue(discProp.const), typeName: variantTypeName });
     }
 
     if (!ctx.aliasesByName.has(aliasName)) {
@@ -1627,7 +1660,7 @@ function tryEmitPyRefBasedDiscriminatedUnion(
         lines.push(`    match kind:`);
         for (const m of dispatch) {
             lines.push(
-                `        case ${JSON.stringify(m.value)}: return ${m.typeName}.from_dict(obj)`
+                `        case ${pyDiscriminatorValueExpr(m.value)}: return ${m.typeName}.from_dict(obj)`
             );
         }
         lines.push(


### PR DESCRIPTION
Fixes #2122

## The problem

`scripts/codegen/python.ts` captured a union discriminator's JSON Schema `const` with `String(...)`, so a boolean const became the JavaScript string `"true"` / `"false"` before any emitter ran. The dispatch table was typed `Array<{ value: string; typeName: string }>`, so the type could not survive even if it had been captured.

The generated Python therefore matched strings:

```python
def _load_SessionListEntry(obj: Any) -> "SessionListEntry":
    kind = obj.get("isRemote")
    match kind:
        case "false": return LocalSessionMetadataValue.from_dict(obj)
        case "true": return RemoteSessionMetadataValue.from_dict(obj)
        case _: raise ValueError(f"Unknown SessionListEntry isRemote: {kind!r}")
```

A JSON boolean decodes to Python `True`, which never equals `"true"`, so both boolean-discriminated unions in the schema fell through to `raise ValueError`:

- `sessions.list()` raised `ValueError: Unknown SessionListEntry isRemote: False` for any non-empty session list.
- `QueuedCommandResult` failed to decode, and `QueuedCommandHandled.to_dict()` emitted `{"handled": "true"}` where the schema declares `{"type": "boolean", "const": true}` with `additionalProperties: false`.

## The fix

Keep the const's JSON type through codegen and render it as a Python literal.

- `PyDiscriminatorValue = string | boolean`, with the capture keeping booleans as booleans and stringifying everything else exactly as before.
- A literal renderer emits `True` / `False` for booleans. `JSON.stringify` cannot be reused here: it yields lowercase `true`, which Python parses as a capture pattern rather than a literal, and in a multi-arm `match` that is a hard `SyntaxError`.
- The discriminator `ClassVar` is annotated `bool` when the const is boolean, so the encode direction puts a real JSON boolean on the wire.

This mirrors `scripts/codegen/go.ts`, which already models discriminator values as `string | boolean` and is unaffected by the bug.

Regenerating changes six lines of `python/copilot/generated/rpc.py`:

```diff
-    handled: ClassVar[str] = "true"
+    handled: ClassVar[bool] = True
-    handled: ClassVar[str] = "false"
+    handled: ClassVar[bool] = False

 def _load_QueuedCommandResult(obj: Any) -> "QueuedCommandResult":
-        case "true": return QueuedCommandHandled.from_dict(obj)
-        case "false": return QueuedCommandNotHandled.from_dict(obj)
+        case True: return QueuedCommandHandled.from_dict(obj)
+        case False: return QueuedCommandNotHandled.from_dict(obj)

 def _load_SessionListEntry(obj: Any) -> "SessionListEntry":
-        case "false": return LocalSessionMetadataValue.from_dict(obj)
-        case "true": return RemoteSessionMetadataValue.from_dict(obj)
+        case False: return LocalSessionMetadataValue.from_dict(obj)
+        case True: return RemoteSessionMetadataValue.from_dict(obj)
```

No other generated file changes, in any language.

## Scope

Deliberately left alone:

- `findPyDiscriminator`'s `mapping.set(String(...))`. Those keys feed only the variant-count validity check and the flat-union path, which both boolean unions bypass because they are `$ref`-based. No union in the schema reaches it today.
- The `ClassVar` collapse pass's field lookup, which builds its regex from the raw schema property name (`isRemote`) and so never matches the snake_cased `is_remote`. That is a separate defect, and it is currently load-bearing: it is why `LocalSessionMetadataValue` keeps a real `is_remote: bool` field that already encodes correctly. Changing it would drop a required constructor parameter.

## Verification

Against the published 1.0.8 wheel, the reproducer raises `ValueError: Unknown SessionListEntry isRemote: False` and exits 1. Against this branch it exits 0:

```
SessionList(sessions=[LocalSessionMetadataValue(is_remote=False, modified_time='2026-07-26T10:05:00.000Z', session_id='example-local', start_time='2026-07-26T10:00:00.000Z', client_name=None, context=None, is_detached=None, mc_task_id=None, name=None, summary=None)])
```

Also verified in a scratch environment against the built branch:

| probe | before | after |
| --- | --- | --- |
| one local session | `ValueError` | `LocalSessionMetadataValue` |
| one remote session | `ValueError` | `RemoteSessionMetadataValue` |
| mixed local + remote list | `ValueError` | both variants, round-trips to `"isRemote": false/true` |
| `_load_QueuedCommandResult` on `true` / `false` | `ValueError` | `QueuedCommandHandled` / `QueuedCommandNotHandled` |
| `json.dumps(QueuedCommandHandled().to_dict())` | `{"handled": "true"}` | `{"handled": true}` |
| `handled: "true"` (a string) | silently dispatched to `QueuedCommandHandled` | `ValueError` |
| `isRemote` missing / `None` / `"yes"` / `1` / `0` | `ValueError` (or `AssertionError`) | `ValueError` |

`case True:` compiles to an identity comparison, so `1` and `0` do not match it despite `True == 1`. The error path stays intact.

## Tests

`python/test_rpc_generated.py` gains coverage for both unions, routed through the real dispatchers rather than the variant classes (a variant's `from_dict` ignores the discriminator, so calling it directly would pass even with the bug present):

- `SessionList.from_dict` decodes a local and a remote entry in one payload to the right variants.
- `CommandsRespondToQueuedCommandRequest.from_dict` decodes both `handled` values.
- The encode direction asserts `is True` / `is False` identity and that `json.dumps` produces `{"handled": true}` / `{"handled": false}`.
- A string-discriminated union case guards against a regression on that path.

The new tests fail against the pre-fix generated file and pass after it.

## Checks run

- `npm run generate` for all five languages plus the pinned nightly `cargo fmt` step, leaving the tree byte-clean apart from the six intended Python lines.
- `uv run ruff format --check .`, `uv run ruff check`, `uv run ty check copilot` (two pre-existing warnings in unrelated hand-written files, exit 0).
- `uv run pytest test_rpc_generated.py -v`: 7 passed, repeated across runs and on Python 3.11.
- The offline Python test set: 291 passed.
- Docs validation: 56 files passed.
