### PR TITLE
docs: fix non-compiling Rust external-transport example

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2053,6 +2053,7 @@ let mut options = ClientOptions::default();
 options.transport = Transport::External {
     host: "localhost".to_string(),
     port: 4321,
+    connection_token: None,
 };
 let client = Client::start(options).await?;
 


### PR DESCRIPTION
The Rust example under "Connecting to an external CLI server" in `docs/getting-started.md` constructed `Transport::External { host, port }` and omitted the variant's third required field, so the documented example did not compile. This adds `connection_token: None,`.

Fixes #2141

## Why `None`

- The server the section tells you to start has no token: `copilot --headless --port 4321`, which on startup reports `No COPILOT_CONNECTION_TOKEN was set, so connections will be accepted from any client`.
- None of the sibling language tabs in the same example pass a token.
- The only other Rust example that constructs this variant, in `docs/setup/multi-tenancy.md`, already passes `connection_token: None`.

## Before and after

Against the published crate, installed the way the guide instructs (`cargo add github-copilot-sdk --features derive`, which resolves to 1.0.8), with the example pasted into an async `main` as the guide's own complete examples do:

Before:

```console
$ cargo build
error[E0063]: missing field `connection_token` in initializer of `github_copilot_sdk::Transport`
 --> src/main.rs:9:25
  |
9 |     options.transport = Transport::External {
  |                         ^^^^^^^^^^^^^^^^^^^ missing `connection_token`

error: could not compile `copilot-demo` (bin "copilot-demo") due to 1 previous error
```

After:

```console
$ cargo build
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.62s
```

The fixed example was also run against a real `copilot --headless --port 4321` server: it connects and creates a session, and fails with `ConnectionRefused` once the server is stopped, so the connection is genuinely going to the external server.

## Checks

- Every Rust fence in `docs/getting-started.md` was compiled before and after. This change removes the file's only compile error and introduces none.
- `just validate-docs` gives the same per-language results before and after; the only difference is a one-line shift in generated block metadata.
- No Rust source changed, so the Rust build, formatting and lint results are identical to base.

## No regression test

There is no test to add: `scripts/docs-validation/extract.ts` has no `rust` entry in `LANGUAGE_MAP`, so Rust fences under `docs/` are never extracted and no validator covers them. That is also why this drifted unnoticed. Adding Rust coverage needs a validator and a workflow job, so I have left it out of this change.

## Out of scope

Noted while here, kept separate: the TypeScript tab in this same section is separately stale, as it passes `cliUrl`, which is no longer a `CopilotClientOptions` field.
