### PR TITLE
docs: correct the Python and Go event data model tip

### DIFF
--- a/.github/instructions/docs-style.instructions.md
+++ b/.github/instructions/docs-style.instructions.md
@@ -49,7 +49,7 @@ When a callout applies to a specific language, put the qualifier as bold text in
 
 ```markdown
 > [!TIP]
-> **(Python / Go)** These SDKs use a single `Data` class/struct with all fields optional.
+> **(Python / Go)** These SDKs use separate, per-event data types.
 ```
 
 ## Lists

--- a/docs/features/streaming-events.md
+++ b/docs/features/streaming-events.md
@@ -210,7 +210,7 @@ session.on(AssistantMessageDeltaEvent.class, event ->
 </details>
 
 > [!TIP]
-> **(Python / Go)** These SDKs use a single `Data` class/struct with all possible fields as optional/nullable. Only the fields listed in the tables below are populated for each event type—the rest will be `None` / `nil`.
+> **(Python / Go)** These SDKs use separate, per-event data types (e.g., `AssistantMessageDeltaData`), so only the relevant fields exist on each type.
 >
 > [!TIP]
 > **(.NET)** The .NET SDK uses separate, strongly-typed data classes per event (e.g., `AssistantMessageDeltaData`), so only the relevant fields exist on each type.

--- a/docs/features/streaming-events.md
+++ b/docs/features/streaming-events.md
@@ -210,7 +210,7 @@ session.on(AssistantMessageDeltaEvent.class, event ->
 </details>
 
 > [!TIP]
-> **(Python / Go)** These SDKs use separate, per-event data types (e.g., `AssistantMessageDeltaData`), so only the relevant fields exist on each type.
+> **(Python / Go)** These SDKs use separate, per-event data types (for example, `AssistantMessageDeltaData`), so only the relevant fields exist on each type.
 >
 > [!TIP]
 > **(.NET)** The .NET SDK uses separate, strongly-typed data classes per event (e.g., `AssistantMessageDeltaData`), so only the relevant fields exist on each type.


### PR DESCRIPTION
## What

`docs/features/streaming-events.md` told Python and Go users that session event payloads use a single `Data` class/struct with every field optional, and that fields not populated for an event come back as `None`/`nil`. Both bindings use a separate data type per event, so neither behaves that way.

Fixes #2159

## Why the old text was wrong

**Go.** `event.Data` is the `SessionEventData` interface (`go/rpc/zsession_events.go`), which carries no data fields, so reading one off it does not compile:

```
./main.go:41:35: event.Data.ToolName undefined (type rpc.SessionEventData has no field or method ToolName)
```

`toolName` is listed in the doc's own `tool.execution_start` table, so this is a field the tip said was readable for that event.

**Python.** `event.data` is a per-event dataclass, so reading a field that belongs to a different event raises instead of returning `None`:

```
AttributeError: 'ToolExecutionStartData' object has no attribute 'delta_content'
```

The class named `Data` still exists in the Python binding, but it is a shim for manually constructed payloads with no declared fields; event delivery never produces it, and unrecognized events fall back to `RawSessionEventData`.

The tip was accurate when it was written. Go moved to per-event data structs in https://github.com/github/copilot-sdk/pull/1037 and Python in https://github.com/github/copilot-sdk/pull/1063. The Go change updated this file's Go example and left the prose behind. Docs validation extracts and compiles fenced code blocks only, so nothing checks prose, which is why this file's own Go example uses `event.Data.(*copilot.AssistantMessageDeltaData)` about sixty lines above a tip saying that is unnecessary.

## What changed

- `docs/features/streaming-events.md` - the Python/Go tip now describes per-event data types, using the wording the file already uses for the .NET tip directly below it.
- `.github/instructions/docs-style.instructions.md` - the same sentence is used there as the example of a language-qualified callout, so it carried the same incorrect claim.

Prose only. No code, generated files, codegen templates, schemas, samples or tests.

## Verification

- Programs written to follow the corrected tip compile and run in both Go and Python against a build of this branch. Programs written to follow the old tip still fail with the errors above.
- `npm run validate:go` (48/48) and `npm run validate:py` (57/57) pass, and the extracted code corpus is byte-identical to `main` since only prose changed.
- The corrected tip renders as a Tip callout.

## Not included

Java uses per-event classes and Rust exposes the payload as untyped JSON. Neither has a tip in this section today and this change does not add one.
