### PR TITLE
docs: correct the ephemeral labels on four persisted session events

### DIFF
--- a/docs/features/streaming-events.md
+++ b/docs/features/streaming-events.md
@@ -661,7 +661,7 @@ These events are emitted when the agent needs approval or input from the user be
 
 ### `permission.requested`
 
-Ephemeral. The agent needs permission to perform an action (run a command, write a file, etc.).
+The agent needs permission to perform an action (run a command, write a file, etc.).
 
 | Data Field | Type | Required | Description |
 |------------|------|----------|-------------|
@@ -684,7 +684,7 @@ All `kind` variants also include an optional `toolCallId` linking back to the to
 
 ### `permission.completed`
 
-Ephemeral. A permission request was resolved.
+A permission request was resolved.
 
 | Data Field | Type | Required | Description |
 |------------|------|----------|-------------|
@@ -835,7 +835,7 @@ A system or developer prompt was injected into the conversation.
 
 ### `external_tool.requested`
 
-Ephemeral. The agent wants to invoke an external tool (one provided by the SDK consumer).
+The agent wants to invoke an external tool (one provided by the SDK consumer).
 
 | Data Field | Type | Required | Description |
 |------------|------|----------|-------------|
@@ -847,7 +847,7 @@ Ephemeral. The agent wants to invoke an external tool (one provided by the SDK c
 
 ### `external_tool.completed`
 
-Ephemeral. An external tool request was resolved.
+An external tool request was resolved.
 
 | Data Field | Type | Required | Description |
 |------------|------|----------|-------------|
@@ -925,8 +925,8 @@ assistant.turn_start          → Turn begins
 ├── assistant.usage           → Token usage for this API call (ephemeral)
 │
 ├── [If tools were requested:]
-│   ├── permission.requested  → Needs user approval (ephemeral)
-│   ├── permission.completed  → Approval result (ephemeral)
+│   ├── permission.requested  → Needs user approval
+│   ├── permission.completed  → Approval result
 │   ├── tool.execution_start  → Tool begins
 │   ├── tool.execution_partial_result  → Streaming tool output (ephemeral, repeated)
 │   ├── tool.execution_progress        → Progress updates (ephemeral, repeated)
@@ -969,8 +969,8 @@ This table lists key `data` payload fields. Common envelope fields are documente
 | `session.usage_checkpoint` | | Session | `totalNanoAiu`, `totalPremiumRequests?` |
 | `session.task_complete` | | Session | `summary?` |
 | `session.shutdown` | | Session | `shutdownType`, `codeChanges`, `modelMetrics` |
-| `permission.requested` | ✅ | Permission | `requestId`, `permissionRequest` |
-| `permission.completed` | ✅ | Permission | `requestId`, `result.kind` |
+| `permission.requested` | | Permission | `requestId`, `permissionRequest` |
+| `permission.completed` | | Permission | `requestId`, `result.kind` |
 | `user_input.requested` | ✅ | User Input | `requestId`, `question`, `choices?` |
 | `user_input.completed` | ✅ | User Input | `requestId` |
 | `elicitation.requested` | ✅ | User Input | `requestId`, `message`, `requestedSchema` |
@@ -984,8 +984,8 @@ This table lists key `data` payload fields. Common envelope fields are documente
 | `abort` | | Control | `reason` |
 | `user.message` | | User | `content`, `attachments?`, `agentMode?` |
 | `system.message` | | System | `content`, `role` |
-| `external_tool.requested` | ✅ | External Tool | `requestId`, `toolName`, `arguments?` |
-| `external_tool.completed` | ✅ | External Tool | `requestId` |
+| `external_tool.requested` | | External Tool | `requestId`, `toolName`, `arguments?` |
+| `external_tool.completed` | | External Tool | `requestId` |
 | `command.queued` | ✅ | Command | `requestId`, `command` |
 | `command.completed` | ✅ | Command | `requestId` |
 | `session_limits_exhausted.requested` | ✅ | Session | `requestId`, `maxAiCredits`, `usedAiCredits` |


### PR DESCRIPTION
`docs/features/streaming-events.md` marks four events as **"Ephemeral."** although all four are persisted to the session event log and are still present in a resumed session's history. This removes the incorrect classification.

The affected events are `permission.requested`, `permission.completed`, `external_tool.requested` and `external_tool.completed`.

Fixes #2171

## Why these four are persisted

The file defines the term itself, which is what makes the label falsifiable:

> | **Ephemeral event** | Transient; streamed in real time but **not** persisted to the session log. Not replayed on session resume. |

and gives the operational rule in the event-envelope table:

> | `ephemeral` | `boolean?` | `true` for transient events; absent or `false` for persisted events |

None of the four carried the field in the sessions I ran, so by the file's own rule they are persisted. The generated event types agree. A genuinely ephemeral event declares a **required** literal (`IdleEvent`: `ephemeral: true`); three of these four declare the ordinary `ephemeral?: boolean` used by every other persisted event such as `assistant.turn_start`, and `ExternalToolCompletedEvent` declares `ephemeral?: true` — an optional literal, the only one in the generated types, which constrains the value only when the field is present. Current sessions do not emit it.

The labels were correct when the guide was added in #717. #1177 regenerated the types and moved all four off the required-literal shape in one commit; the prose was not updated with them.

## What changed

Ten lines in one file, all deletions of the classification. Nothing else in the file was touched.

- The four event sections drop the leading `Ephemeral. `. The file's existing convention is that persisted events carry no marker, so this matches the 24 sections that are already unmarked, and no new wording is introduced.
- The two `permission.*` entries of the "agentic turn flow" diagram drop the trailing `(ephemeral)`, matching the diagram's unannotated persisted entries.
- The four corresponding rows of the "All event types at a glance" table have the `Ephemeral` column cleared, matching the empty cell every persisted row already uses.

Before:

```
### `permission.requested`

Ephemeral. The agent needs permission to perform an action (run a command, write a file, etc.).
```

After:

```
### `permission.requested`

The agent needs permission to perform an action (run a command, write a file, etc.).
```

The glossary and the envelope table are untouched: they are the definitions these labels contradicted. The other 20 events marked "Ephemeral." in the file are correct and are unchanged.

## Verification

A differential over the whole file compares three surfaces — every event section, every summary-table row, and every entry of the turn-flow diagram — against the `ephemeral` shape in the schema shipped with the pinned `@github/copilot` dependency, classifying an event as ephemeral only when the property is `const: true` **and** listed in the envelope's `required`.

| | Sections | Table | Diagram |
| --- | --- | --- | --- |
| Before | 4 mismatches | 4 mismatches | 2 mismatches |
| After | 0 | 0 | 0 |

The mismatches before the change are exactly the four events above; no other event is affected in either direction. The check is deterministic across repeated runs.

Behaviour was confirmed separately with real sessions run against a local build of this branch: all four events appear in the session's event log and in the resumed session's history, while the `session.idle` and `assistant.message_delta` controls are correctly absent from both.

Documentation validation passes (`scripts/docs-validation`: TypeScript, Python, Go and C# all green locally; the Java leg needs Maven, which was unavailable in my environment). The change touches no extracted code block — the only fenced block it edits is the untagged diagram, which the extractor ignores — and the file's line count is unchanged, so no extracted block's reported line number moves.

## Scope

Documentation only. No code, no generated file, no schema, no sample and no public API is affected.

One thing this does not do: nothing detects this kind of drift. The extractor only validates fenced code blocks, so prose claims about the event contract are unchecked and can go stale again the next time the classification changes. Comparing this file's `Ephemeral` column against the schema that already ships with the pinned dependency would be a small check, and I am happy to follow up with one if that is wanted.
