### PR TITLE
Update .NET extension reload E2E contract

### DIFF
--- a/dotnet/test/E2E/RpcExtensionsLoadedE2ETests.cs
+++ b/dotnet/test/E2E/RpcExtensionsLoadedE2ETests.cs
@@ -321,7 +321,7 @@ public class RpcExtensionsLoadedE2ETests(E2ETestFixture fixture, ITestOutputHelp
     }
 
     [Fact]
-    public async Task Reload_Preserves_Disabled_State_Across_Calls()
+    public async Task Reload_Restores_Globally_Enabled_State()
     {
         var extName = CreateUserExtension(prefix: "persistent-disable");
         var extId = $"user:{extName}";
@@ -339,11 +339,12 @@ public class RpcExtensionsLoadedE2ETests(E2ETestFixture fixture, ITestOutputHelp
         await session.Rpc.Extensions.DisableAsync(extId);
         await WaitForExtensionAsync(session, extId, ExtensionStatus.Disabled);
 
-        // Reload re-runs discovery and respects the per-session disabled set,
-        // so the extension stays disabled and is not re-launched.
+        // Reload re-reads persisted global settings, where the extension remains enabled,
+        // so the session-local disabled state is cleared and the extension is re-launched.
         await session.Rpc.Extensions.ReloadAsync();
 
-        var afterReload = await WaitForExtensionAsync(session, extId, ExtensionStatus.Disabled);
-        Assert.Null(afterReload.Pid);
+        var afterReload = await WaitForExtensionAsync(session, extId, ExtensionStatus.Running);
+        Assert.NotNull(afterReload.Pid);
+        Assert.True(afterReload.Pid > 0);
     }
 }


### PR DESCRIPTION
## Summary

- update the loaded-extension E2E contract for `session.extensions.reload`
- verify reload re-reads persisted global settings and clears a session-local disable when the global default remains enabled
- assert the relaunched extension is running with a PID

Depends on github/copilot-agent-runtime#13831. The current SDK CI runtime still implements the previous session-local reload behavior, so this contract test becomes green when that runtime change is available.

## Validation

- `git diff --check`
- .NET test execution unavailable locally because this environment has no `dotnet` toolchain