### PR TITLE
docs: correct the remote sessions client option name

### DIFF
--- a/docs/features/remote-sessions.md
+++ b/docs/features/remote-sessions.md
@@ -13,7 +13,7 @@ For running sessions on GitHub-hosted compute, see [Cloud Sessions](./cloud-sess
 
 ### Always-on (client-level)
 
-Set `remote: true` when creating the client. Every session in a GitHub repo automatically gets a remote URL.
+Set `enableRemoteSessions: true` when creating the client. Every session in a GitHub repo automatically gets a remote URL.
 
 <!-- tabs:start -->
 
@@ -23,7 +23,7 @@ Set `remote: true` when creating the client. Every session in a GitHub repo auto
 ```typescript
 import { CopilotClient } from "@github/copilot-sdk";
 
-const client = new CopilotClient({ remote: true });
+const client = new CopilotClient({ enableRemoteSessions: true });
 const session = await client.createSession({
   workingDirectory: "/path/to/github-repo",
   onPermissionRequest: async () => ({ allowed: true }),
@@ -59,7 +59,7 @@ session.on(on_event)
 
 <!-- docs-validate: skip -->
 ```go
-client, _ := copilot.NewClient(&copilot.ClientOptions{Remote: true})
+client := copilot.NewClient(&copilot.ClientOptions{EnableRemoteSessions: true})
 session, _ := client.CreateSession(ctx, &copilot.SessionConfig{
     WorkingDirectory: "/path/to/github-repo",
     OnPermissionRequest: func(req copilot.PermissionRequest, inv copilot.PermissionInvocation) (rpc.PermissionDecision, error) {
@@ -78,7 +78,7 @@ session.On(func(event copilot.SessionEvent) {
 
 <!-- docs-validate: skip -->
 ```csharp
-var client = new CopilotClient(new CopilotClientOptions { Remote = true });
+var client = new CopilotClient(new CopilotClientOptions { EnableRemoteSessions = true });
 var session = await client.CreateSessionAsync(new SessionConfig
 {
     WorkingDirectory = "/path/to/github-repo",
@@ -201,6 +201,6 @@ The remote URL can be rendered as a QR code for easy mobile access. The SDK prov
 
 ## Notes
 
-* The `remote` client option only applies when the SDK spawns the CLI process. It is ignored when connecting to an external server via `cliUrl`.
+* The `enableRemoteSessions` client option applies when the SDK starts the runtime, either as a child process or as an in-process host. It is ignored when connecting to an already-running runtime.
 * If the working directory is not a GitHub repository, remote setup is silently skipped (always-on mode) or returns an error (on-demand mode).
 * Remote sessions require authentication. Ensure `gitHubToken` or `useLoggedInUser` is configured.


### PR DESCRIPTION
Fixes #2178

## What was wrong

`docs/features/remote-sessions.md` documented a client option named `remote` (TypeScript) / `Remote` (Go, C#) for enabling Mission Control remote sessions. No such option exists. It was renamed to `enableRemoteSessions` / `EnableRemoteSessions` for cross-SDK consistency during the per-language API reviews (C# in #1343, TypeScript in #1357, Go in #1360), and none of those updated this guide. The Rust (#1367) and Python (#1376) reviews updated their own tabs in it, which is why 2 of the 5 language tabs were already correct and 3 were not.

Because every fenced block in this file carries `<!-- docs-validate: skip -->`, the documentation validation never compiled these snippets.

## What this changes

Five lines in one file:

- The section lead-in and the TypeScript, Go and C# examples now name the option that actually ships.
- The Go example's return arity is corrected on the same line: `NewClient` returns a single value, so `client, _ := copilot.NewClient(...)` was a second, independent compile error. `go build` reports both errors together, so fixing only the option name would have left that example broken.
- The `## Notes` bullet named the same nonexistent option and also claimed the option "only applies when the SDK spawns the CLI process". The option is honored on both the child-process path and the in-process host path, and is ignored only when connecting to an already-running runtime, so the bullet is corrected rather than merely renamed.

The Python and Rust tabs are untouched; they were already correct.

## Verification

Each corrected client-construction expression was extracted verbatim from the edited file and compiled against a local build of the affected binding, together with the pre-fix expression as a negative control:

| Tab | Before | After |
| --- | --- | --- |
| TypeScript | `TS2353 ... 'remote' does not exist in type 'CopilotClientOptions'` | `tsc --noEmit` exit 0 |
| Go | `assignment mismatch: 2 variables but copilot.NewClient returns 1 value` and `unknown field Remote in struct literal of type copilot.ClientOptions` | `go build` exit 0 |
| C# | `CS0117: 'CopilotClientOptions' does not contain a definition for 'Remote'` | `dotnet build` succeeded |

The TypeScript case was additionally reproduced against the published `@github/copilot-sdk@1.0.8`.

The corrected `## Notes` wording is pinned by the shipped sources: the option is turned into the same runtime flag on the child-process path and on the in-process host path in all five bindings, and it has no effect on any other path.

## Not included

- The remaining examples in this guide have separate, unrelated problems (the TypeScript and Python permission handlers, the Go event-type comparison, and the Rust snippet). This change does not address them, so the fenced blocks still do not compile as whole programs. The claim above is limited to the client-construction expressions that changed.
- The C# and Rust doc comments for this option carry the same "only when the SDK spawns the runtime" inaccuracy that the `## Notes` bullet had. They are left for a separate change.
- `docs/features/cloud-sessions.md` also refers to the old option name.
