### PR TITLE
Fix CAPI reasoning E2E fixtures

### DIFF
--- a/dotnet/test/E2E/SessionE2ETests.cs
+++ b/dotnet/test/E2E/SessionE2ETests.cs
@@ -615,10 +615,10 @@ public class SessionE2ETests(E2ETestFixture fixture, ITestOutputHelper output) :
 
         var modelChangedTask = TestHelper.GetNextEventOfTypeAsync<SessionModelChangeEvent>(session);
 
-        await session.SetModelAsync("gpt-4.1", "high");
+        await session.SetModelAsync("gpt-5.4", "high");
 
         var modelChanged = await modelChangedTask;
-        Assert.Equal("gpt-4.1", modelChanged.Data.NewModel);
+        Assert.Equal("gpt-5.4", modelChanged.Data.NewModel);
         Assert.Equal("high", modelChanged.Data.ReasoningEffort);
     }
 

--- a/dotnet/test/E2E/SessionE2ETests.cs
+++ b/dotnet/test/E2E/SessionE2ETests.cs
@@ -611,7 +611,10 @@ public class SessionE2ETests(E2ETestFixture fixture, ITestOutputHelper output) :
     [Fact]
     public async Task Should_Set_Model_With_ReasoningEffort()
     {
-        var session = await CreateSessionAsync();
+        await using var isolatedCtx = await E2ETestContext.CreateAsync();
+        await isolatedCtx.ConfigureForTestAsync("session", nameof(Should_Set_Model_With_ReasoningEffort));
+        var isolatedClient = isolatedCtx.CreateClient();
+        await using var session = await isolatedCtx.CreateSessionAsync(isolatedClient);
 
         var modelChangedTask = TestHelper.GetNextEventOfTypeAsync<SessionModelChangeEvent>(session);
 

--- a/dotnet/test/E2E/StreamingFidelityE2ETests.cs
+++ b/dotnet/test/E2E/StreamingFidelityE2ETests.cs
@@ -152,6 +152,7 @@ public class StreamingFidelityE2ETests(E2ETestFixture fixture, ITestOutputHelper
         // the streaming pipeline — deltas still arrive and complete successfully.
         var session = await CreateSessionAsync(new SessionConfig
         {
+            Model = "gpt-5.4",
             Streaming = true,
             ReasoningEffort = "high",
         });

--- a/dotnet/test/E2E/StreamingFidelityE2ETests.cs
+++ b/dotnet/test/E2E/StreamingFidelityE2ETests.cs
@@ -150,7 +150,10 @@ public class StreamingFidelityE2ETests(E2ETestFixture fixture, ITestOutputHelper
     {
         // Verifies that setting ReasoningEffort alongside Streaming=true does not break
         // the streaming pipeline — deltas still arrive and complete successfully.
-        var session = await CreateSessionAsync(new SessionConfig
+        await using var isolatedCtx = await E2ETestContext.CreateAsync();
+        await isolatedCtx.ConfigureForTestAsync("streaming_fidelity", nameof(Should_Emit_Streaming_Deltas_With_Reasoning_Effort_Configured));
+        var isolatedClient = isolatedCtx.CreateClient();
+        await using var session = await isolatedCtx.CreateSessionAsync(isolatedClient, new SessionConfig
         {
             Model = "gpt-5.4",
             Streaming = true,
@@ -178,8 +181,6 @@ public class StreamingFidelityE2ETests(E2ETestFixture fixture, ITestOutputHelper
         var messages = await session.GetEventsAsync();
         var startEvent = Assert.Single(messages.OfType<SessionStartEvent>());
         Assert.Equal("high", startEvent.Data.ReasoningEffort);
-
-        await session.DisposeAsync();
     }
 
     [Fact]

--- a/go/internal/e2e/session_e2e_test.go
+++ b/go/internal/e2e/session_e2e_test.go
@@ -1047,7 +1047,12 @@ func getSystemMessage(exchange testharness.ParsedHttpExchange) string {
 }
 
 func TestSetModelWithReasoningEffortE2E(t *testing.T) {
+	t.Run("should set model with reasoningeffort", runSetModelWithReasoningEffortE2E)
+}
+
+func runSetModelWithReasoningEffortE2E(t *testing.T) {
 	ctx := testharness.NewTestContext(t)
+	ctx.ConfigureForTest(t)
 	client := ctx.NewClient()
 	t.Cleanup(func() { client.ForceStop() })
 

--- a/go/internal/e2e/session_e2e_test.go
+++ b/go/internal/e2e/session_e2e_test.go
@@ -1072,15 +1072,15 @@ func TestSetModelWithReasoningEffortE2E(t *testing.T) {
 		}
 	})
 
-	if err := session.SetModel(t.Context(), "gpt-4.1", &copilot.SetModelOptions{ReasoningEffort: copilot.String("high")}); err != nil {
+	if err := session.SetModel(t.Context(), "gpt-5.4", &copilot.SetModelOptions{ReasoningEffort: copilot.String("high")}); err != nil {
 		t.Fatalf("SetModel returned error: %v", err)
 	}
 
 	select {
 	case evt := <-modelChanged:
 		md, mdOk := evt.Data.(*copilot.SessionModelChangeData)
-		if !mdOk || md.NewModel != "gpt-4.1" {
-			t.Errorf("Expected newModel 'gpt-4.1', got %v", evt.Data)
+		if !mdOk || md.NewModel != "gpt-5.4" {
+			t.Errorf("Expected newModel 'gpt-5.4', got %v", evt.Data)
 		}
 		if !mdOk || md.ReasoningEffort == nil || *md.ReasoningEffort != "high" {
 			t.Errorf("Expected reasoningEffort 'high', got %v", evt.Data)

--- a/go/internal/e2e/streaming_fidelity_e2e_test.go
+++ b/go/internal/e2e/streaming_fidelity_e2e_test.go
@@ -291,6 +291,7 @@ func TestStreamingFidelityE2E(t *testing.T) {
 		// the streaming pipeline — deltas still arrive and complete successfully.
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+			Model:               "gpt-5.4",
 			Streaming:           copilot.Bool(true),
 			ReasoningEffort:     "high",
 		})

--- a/go/internal/e2e/streaming_fidelity_e2e_test.go
+++ b/go/internal/e2e/streaming_fidelity_e2e_test.go
@@ -285,11 +285,14 @@ func TestStreamingFidelityE2E(t *testing.T) {
 	})
 
 	t.Run("should emit streaming deltas with reasoning effort configured", func(t *testing.T) {
-		ctx.ConfigureForTest(t)
+		reasoningCtx := testharness.NewTestContext(t)
+		reasoningCtx.ConfigureForTest(t)
+		reasoningClient := reasoningCtx.NewClient()
+		t.Cleanup(func() { reasoningClient.ForceStop() })
 
 		// Verifies that setting ReasoningEffort alongside Streaming=true does not break
 		// the streaming pipeline — deltas still arrive and complete successfully.
-		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
+		session, err := reasoningClient.CreateSession(t.Context(), &copilot.SessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
 			Model:               "gpt-5.4",
 			Streaming:           copilot.Bool(true),

--- a/java/src/test/java/com/github/copilot/StreamingFidelityTest.java
+++ b/java/src/test/java/com/github/copilot/StreamingFidelityTest.java
@@ -254,7 +254,7 @@ public class StreamingFidelityTest {
         try (CopilotClient client = ctx.createClient()) {
             CopilotSession session = client
                     .createSession(new SessionConfig().setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
-                            .setStreaming(true).setReasoningEffort("high"))
+                            .setModel("gpt-5.4").setStreaming(true).setReasoningEffort("high"))
                     .get();
 
             List<SessionEvent> events = new ArrayList<>();

--- a/nodejs/test/e2e/session.e2e.test.ts
+++ b/nodejs/test/e2e/session.e2e.test.ts
@@ -969,10 +969,10 @@ describe("Send Blocking Behavior", async () => {
 
         const modelChangePromise = getNextEventOfType(session, "session.model_change");
 
-        await session.setModel("gpt-4.1", { reasoningEffort: "high" });
+        await session.setModel("gpt-5.4", { reasoningEffort: "high" });
 
         const event = await modelChangePromise;
-        expect(event.data.newModel).toBe("gpt-4.1");
+        expect(event.data.newModel).toBe("gpt-5.4");
         expect(event.data.reasoningEffort).toBe("high");
     });
 });

--- a/nodejs/test/e2e/session.e2e.test.ts
+++ b/nodejs/test/e2e/session.e2e.test.ts
@@ -964,15 +964,21 @@ describe("Send Blocking Behavior", async () => {
         expect(event.data.newModel).toBe("gpt-4.1");
     });
 
-    it("should set model with reasoningEffort", async () => {
-        await using session = await client.createSession({ onPermissionRequest: approveAll });
+    describe("reasoning effort model switch (isolated to avoid models cache contamination)", async () => {
+        const { copilotClient: reasoningClient } = await createSdkTestContext();
 
-        const modelChangePromise = getNextEventOfType(session, "session.model_change");
+        it("should set model with reasoningEffort", async () => {
+            await using session = await reasoningClient.createSession({
+                onPermissionRequest: approveAll,
+            });
 
-        await session.setModel("gpt-5.4", { reasoningEffort: "high" });
+            const modelChangePromise = getNextEventOfType(session, "session.model_change");
 
-        const event = await modelChangePromise;
-        expect(event.data.newModel).toBe("gpt-5.4");
-        expect(event.data.reasoningEffort).toBe("high");
+            await session.setModel("gpt-5.4", { reasoningEffort: "high" });
+
+            const event = await modelChangePromise;
+            expect(event.data.newModel).toBe("gpt-5.4");
+            expect(event.data.reasoningEffort).toBe("high");
+        });
     });
 });

--- a/nodejs/test/e2e/streaming_fidelity.e2e.test.ts
+++ b/nodejs/test/e2e/streaming_fidelity.e2e.test.ts
@@ -146,7 +146,9 @@ describe("Streaming Fidelity", async () => {
     });
 
     it("should emit streaming deltas with reasoning effort configured", async () => {
-        const session = await client.createSession({
+        const reasoningClient = createClient();
+        onTestFinished(() => reasoningClient.stop());
+        const session = await reasoningClient.createSession({
             onPermissionRequest: approveAll,
             model: "gpt-5.4",
             streaming: true,

--- a/nodejs/test/e2e/streaming_fidelity.e2e.test.ts
+++ b/nodejs/test/e2e/streaming_fidelity.e2e.test.ts
@@ -148,6 +148,7 @@ describe("Streaming Fidelity", async () => {
     it("should emit streaming deltas with reasoning effort configured", async () => {
         const session = await client.createSession({
             onPermissionRequest: approveAll,
+            model: "gpt-5.4",
             streaming: true,
             reasoningEffort: "high",
         });

--- a/nodejs/test/e2e/streaming_fidelity.e2e.test.ts
+++ b/nodejs/test/e2e/streaming_fidelity.e2e.test.ts
@@ -145,35 +145,37 @@ describe("Streaming Fidelity", async () => {
         await session2.disconnect();
     });
 
-    it("should emit streaming deltas with reasoning effort configured", async () => {
-        const reasoningClient = createClient();
-        onTestFinished(() => reasoningClient.stop());
-        const session = await reasoningClient.createSession({
-            onPermissionRequest: approveAll,
-            model: "gpt-5.4",
-            streaming: true,
-            reasoningEffort: "high",
+    describe("reasoning effort (isolated to avoid models cache contamination)", async () => {
+        const { copilotClient: reasoningClient } = await createSdkTestContext();
+
+        it("should emit streaming deltas with reasoning effort configured", async () => {
+            const session = await reasoningClient.createSession({
+                onPermissionRequest: approveAll,
+                model: "gpt-5.4",
+                streaming: true,
+                reasoningEffort: "high",
+            });
+
+            const events: SessionEvent[] = [];
+            session.on((event) => events.push(event));
+
+            await session.sendAndWait({ prompt: "What is 15 * 17?" });
+
+            const deltaEvents = events.filter((e) => e.type === "assistant.message_delta");
+            expect(deltaEvents.length).toBeGreaterThanOrEqual(1);
+
+            const assistantEvents = events.filter((e) => e.type === "assistant.message");
+            expect(assistantEvents.length).toBeGreaterThanOrEqual(1);
+            const lastAssistant = assistantEvents[assistantEvents.length - 1]!;
+            expect(lastAssistant.data.content).toContain("255");
+
+            // Verify the session was created with reasoning effort via getMessages
+            const messages = await session.getEvents();
+            const startEvent = messages.find((m) => m.type === "session.start");
+            expect(startEvent).toBeDefined();
+            expect(startEvent!.data.reasoningEffort).toBe("high");
+
+            await session.disconnect();
         });
-
-        const events: SessionEvent[] = [];
-        session.on((event) => events.push(event));
-
-        await session.sendAndWait({ prompt: "What is 15 * 17?" });
-
-        const deltaEvents = events.filter((e) => e.type === "assistant.message_delta");
-        expect(deltaEvents.length).toBeGreaterThanOrEqual(1);
-
-        const assistantEvents = events.filter((e) => e.type === "assistant.message");
-        expect(assistantEvents.length).toBeGreaterThanOrEqual(1);
-        const lastAssistant = assistantEvents[assistantEvents.length - 1]!;
-        expect(lastAssistant.data.content).toContain("255");
-
-        // Verify the session was created with reasoning effort via getMessages
-        const messages = await session.getEvents();
-        const startEvent = messages.find((m) => m.type === "session.start");
-        expect(startEvent).toBeDefined();
-        expect(startEvent!.data.reasoningEffort).toBe("high");
-
-        await session.disconnect();
     });
 });

--- a/python/e2e/test_session_e2e.py
+++ b/python/e2e/test_session_e2e.py
@@ -695,10 +695,10 @@ class TestSessions:
 
         session.on(on_event)
 
-        await session.set_model("gpt-4.1", reasoning_effort="high")
+        await session.set_model("gpt-5.4", reasoning_effort="high")
 
         data = await asyncio.wait_for(model_change_event, timeout=30)
-        assert data.new_model == "gpt-4.1"
+        assert data.new_model == "gpt-5.4"
         assert data.reasoning_effort == "high"
 
     async def test_should_accept_blob_attachments(self, ctx: E2ETestContext):

--- a/python/e2e/test_session_e2e.py
+++ b/python/e2e/test_session_e2e.py
@@ -679,27 +679,36 @@ class TestSessions:
         """Test that setModel passes reasoningEffort and it appears in the model_change event."""
         import asyncio
 
-        session = await ctx.client.create_session(
-            on_permission_request=PermissionHandler.approve_all
-        )
+        isolated_ctx = E2ETestContext()
+        await isolated_ctx.setup()
+        try:
+            await isolated_ctx.configure_for_test(
+                "session", "should_set_model_with_reasoningeffort"
+            )
+            session = await isolated_ctx.client.create_session(
+                on_permission_request=PermissionHandler.approve_all
+            )
 
-        model_change_event = asyncio.get_event_loop().create_future()
+            model_change_event = asyncio.get_event_loop().create_future()
 
-        def on_event(event):
-            if model_change_event.done():
-                return
+            def on_event(event):
+                if model_change_event.done():
+                    return
 
-            match event.data:
-                case SessionModelChangeData() as data:
-                    model_change_event.set_result(data)
+                match event.data:
+                    case SessionModelChangeData() as data:
+                        model_change_event.set_result(data)
 
-        session.on(on_event)
+            session.on(on_event)
 
-        await session.set_model("gpt-5.4", reasoning_effort="high")
+            await session.set_model("gpt-5.4", reasoning_effort="high")
 
-        data = await asyncio.wait_for(model_change_event, timeout=30)
-        assert data.new_model == "gpt-5.4"
-        assert data.reasoning_effort == "high"
+            data = await asyncio.wait_for(model_change_event, timeout=30)
+            assert data.new_model == "gpt-5.4"
+            assert data.reasoning_effort == "high"
+            await session.disconnect()
+        finally:
+            await isolated_ctx.teardown()
 
     async def test_should_accept_blob_attachments(self, ctx: E2ETestContext):
         # Write the image to disk so the model can view it

--- a/python/e2e/test_streaming_fidelity_e2e.py
+++ b/python/e2e/test_streaming_fidelity_e2e.py
@@ -163,6 +163,7 @@ class TestStreamingFidelity:
 
         session = await ctx.client.create_session(
             on_permission_request=PermissionHandler.approve_all,
+            model="gpt-5.4",
             streaming=True,
             reasoning_effort="high",
         )

--- a/python/e2e/test_streaming_fidelity_e2e.py
+++ b/python/e2e/test_streaming_fidelity_e2e.py
@@ -155,35 +155,44 @@ class TestStreamingFidelity:
         finally:
             await new_client.force_stop()
 
-    async def test_should_emit_streaming_deltas_with_reasoning_effort_configured(
-        self, ctx: E2ETestContext
-    ):
+    async def test_should_emit_streaming_deltas_with_reasoning_effort_configured(self):
         """Streaming + reasoning_effort produces delta events and session.start shows effort."""
         from copilot.session_events import SessionStartData
 
-        session = await ctx.client.create_session(
-            on_permission_request=PermissionHandler.approve_all,
-            model="gpt-5.4",
-            streaming=True,
-            reasoning_effort="high",
-        )
-
-        events = []
-        session.on(lambda event: events.append(event))
-
+        isolated_ctx = E2ETestContext()
+        await isolated_ctx.setup()
         try:
-            await session.send_and_wait("What is 15 * 17?", timeout=60.0)
+            await isolated_ctx.configure_for_test(
+                "streaming_fidelity",
+                "should_emit_streaming_deltas_with_reasoning_effort_configured",
+            )
+            session = await isolated_ctx.client.create_session(
+                on_permission_request=PermissionHandler.approve_all,
+                model="gpt-5.4",
+                streaming=True,
+                reasoning_effort="high",
+            )
 
-            delta_events = [e for e in events if e.type.value == "assistant.message_delta"]
-            assert len(delta_events) >= 1, "Expected delta events with streaming=True"
+            events = []
+            session.on(lambda event: events.append(event))
 
-            assistant_events = [e for e in events if e.type.value == "assistant.message"]
-            assert len(assistant_events) >= 1, "Expected final assistant.message"
+            try:
+                await session.send_and_wait("What is 15 * 17?", timeout=60.0)
 
-            # Check session.start event (from get_events) has reasoning_effort
-            all_msgs = await session.get_events()
-            start_event = next((e for e in all_msgs if isinstance(e.data, SessionStartData)), None)
-            assert start_event is not None, "Expected session.start event"
-            assert start_event.data.reasoning_effort == "high"
+                delta_events = [e for e in events if e.type.value == "assistant.message_delta"]
+                assert len(delta_events) >= 1, "Expected delta events with streaming=True"
+
+                assistant_events = [e for e in events if e.type.value == "assistant.message"]
+                assert len(assistant_events) >= 1, "Expected final assistant.message"
+
+                # Check session.start event (from get_events) has reasoning_effort
+                all_msgs = await session.get_events()
+                start_event = next(
+                    (e for e in all_msgs if isinstance(e.data, SessionStartData)), None
+                )
+                assert start_event is not None, "Expected session.start event"
+                assert start_event.data.reasoning_effort == "high"
+            finally:
+                await session.disconnect()
         finally:
-            await session.disconnect()
+            await isolated_ctx.teardown()

--- a/rust/tests/e2e/session.rs
+++ b/rust/tests/e2e/session.rs
@@ -967,7 +967,7 @@ async fn should_set_model_with_reasoningeffort() {
 
             session
                 .set_model(
-                    "gpt-4.1",
+                    "gpt-5.4",
                     Some(SetModelOptions::default().with_reasoning_effort("high")),
                 )
                 .await
@@ -976,7 +976,7 @@ async fn should_set_model_with_reasoningeffort() {
             let data = event
                 .typed_data::<SessionModelChangeData>()
                 .expect("session.model_change data");
-            assert_eq!(data.new_model, "gpt-4.1");
+            assert_eq!(data.new_model, "gpt-5.4");
             assert_eq!(data.reasoning_effort.as_deref(), Some("high"));
 
             session.disconnect().await.expect("disconnect session");

--- a/rust/tests/e2e/streaming_fidelity.rs
+++ b/rust/tests/e2e/streaming_fidelity.rs
@@ -237,6 +237,7 @@ async fn should_emit_streaming_deltas_with_reasoning_effort_configured() {
                 let session = client
                     .create_session(
                         ctx.approve_all_session_config()
+                            .with_model("gpt-5.4")
                             .with_streaming(true)
                             .with_reasoning_effort("high"),
                     )

--- a/test/snapshots/session/should_set_model_with_reasoningeffort.yaml
+++ b/test/snapshots/session/should_set_model_with_reasoningeffort.yaml
@@ -1,5 +1,6 @@
 models:
   - claude-sonnet-4.5
+  - gpt-5.4
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/streaming_fidelity/should_emit_streaming_deltas_with_reasoning_effort_configured.yaml
+++ b/test/snapshots/streaming_fidelity/should_emit_streaming_deltas_with_reasoning_effort_configured.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - gpt-5.4
 conversations:
   - messages:
       - role: system


### PR DESCRIPTION
## Summary

The C# CAPI E2E fixtures configured explicit `high` reasoning effort with models that do not support configurable reasoning:

- `StreamingFidelityE2ETests.Should_Emit_Streaming_Deltas_With_Reasoning_Effort_Configured` inherited the fixture default, `claude-sonnet-4.5`.
- `SessionE2ETests.Should_Set_Model_With_ReasoningEffort` switched to `gpt-4.1`.

Both tests now use the reasoning-capable `gpt-5.4` model. The streaming replay fixture also advertises `gpt-5.4` so the recorded CAPI model catalog matches the test configuration. Assertions that verify `high` reasoning effort propagation remain unchanged.

This preserves the intended runtime contract introduced by github/copilot-agent-runtime commit `6c6125edb8` / PR #12016: explicit unsupported CAPI reasoning efforts fail instead of being silently discarded or clamped.

## Validation

- `dotnet test dotnet/test/GitHub.Copilot.SDK.Test.csproj --no-restore --filter 'FullyQualifiedName~StreamingFidelityE2ETests.Should_Emit_Streaming_Deltas_With_Reasoning_Effort_Configured|FullyQualifiedName~SessionE2ETests.Should_Set_Model_With_ReasoningEffort'` (2 passed)
- `dotnet format dotnet/test/GitHub.Copilot.SDK.Test.csproj --verify-no-changes --no-restore`
