### PR TITLE
Test extension canvas forwarding

### DIFF
--- a/nodejs/test/extension.test.ts
+++ b/nodejs/test/extension.test.ts
@@ -57,4 +57,25 @@ describe("joinSession", () => {
 
         expect(canvas.declaration.id).toBe("counter");
     });
+
+    it("forwards canvas providers when joining as an extension", async () => {
+        process.env.SESSION_ID = "session-123";
+        const resumeForExtension = vi
+            .spyOn(CopilotClient.prototype, "resumeSessionForExtension")
+            .mockResolvedValue({} as any);
+        const canvas = createCanvas({
+            id: "counter",
+            displayName: "Counter",
+            description: "A counter canvas",
+            open: () => ({ url: "https://example.test/counter" }),
+        });
+
+        await joinSession({ canvases: [canvas] });
+
+        expect(resumeForExtension).toHaveBeenCalledWith(
+            "session-123",
+            expect.objectContaining({ canvases: [canvas] }),
+            undefined
+        );
+    });
 });


### PR DESCRIPTION
A canvas registration regression in Copilot CLI 1.0.76-5 initially appeared to originate in the SDK extension path. The investigation confirmed that `joinSession({ canvases })` forwards canvas providers correctly; the actual failure is an agent-runtime connection identity race.

This adds focused coverage for the SDK boundary so future regressions cannot silently drop canvases before `resumeSessionForExtension`.

This PR is test-only and does not fix the runtime issue. The production fix belongs in `copilot-agent-runtime`, where extension identity must be published before the first JSON-RPC request is dispatched. Runtime PR github/copilot-agent-runtime#13958 implements that ordering.