### PR TITLE
Fix active Node and Rust replay E2E flakes

### DIFF
--- a/.github/workflows/dotnet-sdk-tests.yml
+++ b/.github/workflows/dotnet-sdk-tests.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   test:
-    name: ".NET SDK Tests (${{ matrix.os }}, ${{ matrix.transport }}, ${{ matrix.backend }}, ${{ matrix.shard }})"
+    name: ".NET SDK Tests (${{ matrix.os }}, ${{ matrix.framework }}, ${{ matrix.transport }}, ${{ matrix.backend }}, ${{ matrix.shard }})"
     if: github.event.repository.fork == false
     env:
       POWERSHELL_UPDATECHECK: Off
@@ -22,6 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        framework: [net8.0]
         transport: ["default", "inprocess"]
         backend: [capi]
         shard: [full]
@@ -34,26 +35,41 @@ jobs:
             shard: full
         include:
           # Keep xUnit serial within each process, but split the slow Windows
-          # default-transport suite across two isolated test hosts.
+          # default-transport suite across isolated test hosts.
           - os: windows-latest
+            framework: net8.0
             transport: default
             backend: capi
             shard: "1"
           - os: windows-latest
+            framework: net8.0
+            transport: default
+            backend: capi
+            shard: "2"
+          - os: windows-latest
+            framework: net472
+            transport: default
+            backend: capi
+            shard: "1"
+          - os: windows-latest
+            framework: net472
             transport: default
             backend: capi
             shard: "2"
           - os: ubuntu-latest
+            framework: net8.0
             transport: inprocess
             backend: anthropic-messages
             shard: full
             test-filter: "FullyQualifiedName~GitHub.Copilot.Test.E2E&E2EBackend!=SelfConfiguredBackend&E2EBackend!=CapiOnly"
           - os: ubuntu-latest
+            framework: net8.0
             transport: inprocess
             backend: openai-responses
             shard: full
             test-filter: "FullyQualifiedName~GitHub.Copilot.Test.E2E&E2EBackend!=SelfConfiguredBackend&E2EBackend!=CapiOnly"
           - os: ubuntu-latest
+            framework: net8.0
             transport: inprocess
             backend: openai-completions
             shard: full
@@ -111,7 +127,7 @@ jobs:
           COPILOT_HMAC_KEY: ${{ secrets.COPILOT_DEVELOPER_CLI_INTEGRATION_HMAC_KEY }}
           DOTNET_TEST_SHARD: ${{ matrix.shard }}
         run: |
-          args=(--no-build -v n)
+          args=(--no-build -v n --framework "${{ matrix.framework }}")
 
           filter="$DOTNET_TEST_FILTER"
           if [[ "$DOTNET_TEST_SHARD" != "full" ]]; then
@@ -135,4 +151,4 @@ jobs:
           if [[ -n "$filter" ]]; then
             args+=(--filter "$filter")
           fi
-          dotnet test "${args[@]}"
+          dotnet test test/GitHub.Copilot.SDK.Test.csproj "${args[@]}"

--- a/.github/workflows/dotnet-sdk-tests.yml
+++ b/.github/workflows/dotnet-sdk-tests.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   test:
-    name: ".NET SDK Tests (${{ matrix.os }}, ${{ matrix.framework }}, ${{ matrix.transport }}, ${{ matrix.backend }}, ${{ matrix.shard }})"
+    name: ".NET SDK Tests (${{ matrix.os }}, ${{ matrix.transport }}, ${{ matrix.backend }}, ${{ matrix.shard }})"
     if: github.event.repository.fork == false
     env:
       POWERSHELL_UPDATECHECK: Off
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        framework: [net8.0]
         transport: ["default", "inprocess"]
         backend: [capi]
         shard: [full]
@@ -35,41 +34,28 @@ jobs:
             shard: full
         include:
           # Keep xUnit serial within each process, but split the slow Windows
-          # default-transport suite across isolated test hosts.
+          # default-transport suite across two isolated test hosts. Keep both
+          # target frameworks in each shard: separate framework jobs did not
+          # shorten the critical path and doubled the Windows job count.
           - os: windows-latest
-            framework: net8.0
             transport: default
             backend: capi
             shard: "1"
           - os: windows-latest
-            framework: net8.0
-            transport: default
-            backend: capi
-            shard: "2"
-          - os: windows-latest
-            framework: net472
-            transport: default
-            backend: capi
-            shard: "1"
-          - os: windows-latest
-            framework: net472
             transport: default
             backend: capi
             shard: "2"
           - os: ubuntu-latest
-            framework: net8.0
             transport: inprocess
             backend: anthropic-messages
             shard: full
             test-filter: "FullyQualifiedName~GitHub.Copilot.Test.E2E&E2EBackend!=SelfConfiguredBackend&E2EBackend!=CapiOnly"
           - os: ubuntu-latest
-            framework: net8.0
             transport: inprocess
             backend: openai-responses
             shard: full
             test-filter: "FullyQualifiedName~GitHub.Copilot.Test.E2E&E2EBackend!=SelfConfiguredBackend&E2EBackend!=CapiOnly"
           - os: ubuntu-latest
-            framework: net8.0
             transport: inprocess
             backend: openai-completions
             shard: full
@@ -127,7 +113,7 @@ jobs:
           COPILOT_HMAC_KEY: ${{ secrets.COPILOT_DEVELOPER_CLI_INTEGRATION_HMAC_KEY }}
           DOTNET_TEST_SHARD: ${{ matrix.shard }}
         run: |
-          args=(--no-build -v n --framework "${{ matrix.framework }}")
+          args=(--no-build -v n)
 
           filter="$DOTNET_TEST_FILTER"
           if [[ "$DOTNET_TEST_SHARD" != "full" ]]; then
@@ -151,4 +137,4 @@ jobs:
           if [[ -n "$filter" ]]; then
             args+=(--filter "$filter")
           fi
-          dotnet test test/GitHub.Copilot.SDK.Test.csproj "${args[@]}"
+          dotnet test "${args[@]}"

--- a/nodejs/vitest.config.ts
+++ b/nodejs/vitest.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig } from "vitest/config";
 
+const integrationTestTimeout = process.platform === "win32" ? 60000 : 30000;
+
 export default defineConfig({
     test: {
         globals: true,
         environment: "node",
-        testTimeout: 30000, // 30 seconds for integration tests
-        hookTimeout: 30000,
+        testTimeout: integrationTestTimeout,
+        hookTimeout: integrationTestTimeout,
         teardownTimeout: 10000,
         isolate: true, // Run each test file in isolation
         pool: "forks", // Use process forking for better isolation

--- a/rust/tests/e2e/rpc_session_state.rs
+++ b/rust/tests/e2e/rpc_session_state.rs
@@ -1098,11 +1098,11 @@ async fn should_report_implemented_errors_for_unsupported_session_rpc_paths() {
 }
 
 #[tokio::test]
-async fn should_compact_session_history_after_messages() {
+async fn should_report_processing_and_context_metadata() {
     super::support::with_shared_e2e_context(
         &E2E,
         "rpc_session_state",
-        "should_compact_session_history_after_messages",
+        "should_report_processing_and_context_metadata",
         |ctx| {
             Box::pin(async move {
                 ctx.set_default_copilot_user();

--- a/test/snapshots/rpc_session_state/should_report_processing_and_context_metadata.yaml
+++ b/test/snapshots/rpc_session_state/should_report_processing_and_context_metadata.yaml
@@ -1,0 +1,10 @@
+models:
+  - claude-sonnet-4.5
+conversations:
+  - messages:
+      - role: system
+        content: ${system}
+      - role: user
+        content: "Reply with exactly: RUST_CONTEXT_INFO"
+      - role: assistant
+        content: RUST_CONTEXT_INFO


### PR DESCRIPTION
July CI runs exposed two hermetic test failures: arbitrary Node E2E tests exhausted the fixed Windows timeout budget, and a repurposed Rust metadata test still selected an unrelated compaction snapshot.

This change:

- gives Node tests and hooks a 60-second budget on Windows while retaining 30 seconds elsewhere, covering both default and in-process transports;
- gives the Rust processing/context metadata test a dedicated snapshot matching its `RUST_CONTEXT_INFO` prompt, while preserving the shared compaction fixture used by Python.

The branch was rebased onto #2251. The earlier .NET target-framework split was removed: measured Windows critical-path time changed only from 21.9 to 21.8 minutes while doubling the Windows job count. The class-level process sharding merged in #2251 provides the meaningful latency reduction and continues to run both target frameworks in each shard.

Validation included workflow and TypeScript formatting, Node type checking, Rust formatting, Rust E2E test-target compilation, and commit whitespace checks.