### PR TITLE
docs: fix non-compiling attachment examples in the .NET README

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -296,9 +296,9 @@ The SDK supports image attachments via the `Attachments` parameter. You can atta
 await session.SendAsync(new MessageOptions
 {
     Prompt = "What's in this image?",
-    Attachments = new List<UserMessageDataAttachmentsItem>
+    Attachments = new List<Attachment>
     {
-        new UserMessageDataAttachmentsItemFile
+        new AttachmentFile
         {
             Path = "/path/to/image.jpg",
             DisplayName = "image.jpg",
@@ -310,9 +310,9 @@ await session.SendAsync(new MessageOptions
 await session.SendAsync(new MessageOptions
 {
     Prompt = "What's in this image?",
-    Attachments = new List<UserMessageDataAttachmentsItem>
+    Attachments = new List<Attachment>
     {
-        new UserMessageDataAttachmentsItemBlob
+        new AttachmentBlob
         {
             Data = base64ImageData,
             MimeType = "image/png",
@@ -721,11 +721,10 @@ await session2.SendAsync(new MessageOptions { Prompt = "Hello from session 2" })
 await session.SendAsync(new MessageOptions
 {
     Prompt = "Analyze this file",
-    Attachments = new List<UserMessageDataAttachmentsItem>
+    Attachments = new List<Attachment>
     {
-        new UserMessageDataAttachmentsItem
+        new AttachmentFile
         {
-            Type = UserMessageDataAttachmentsItemType.File,
             Path = "/path/to/file.cs",
             DisplayName = "My File"
         }


### PR DESCRIPTION
Fixes #2196

### Problem

The three attachment examples in `dotnet/README.md` reference a type family that is no longer in the SDK - `UserMessageDataAttachmentsItem`, `UserMessageDataAttachmentsItemFile`, `UserMessageDataAttachmentsItemBlob`, and the enum `UserMessageDataAttachmentsItemType`. Copying any of them yields `CS0246`/`CS0103`.

This file is packed as the package README, so it is also the [`GitHub.Copilot.SDK`](https://www.nuget.org/packages/GitHub.Copilot.SDK) NuGet page. The published `1.0.8` package ships these broken snippets today.

Attachments moved to a polymorphic model and the types were later renamed to `Attachment*`. The feature guide under `docs/` was updated; this README was not, and documentation validation never compiles it because extraction is scoped to the `docs/` directory (`scripts/docs-validation/extract.ts` resolves `DOCS_DIR` to `docs` and globs `**/*.md` relative to it).

### Fix

Update the three examples to the shipped public API, aligning them with the C# blocks in `docs/features/image-input.md` that documentation validation already compiles:

- `new List<UserMessageDataAttachmentsItem>` becomes `new List<Attachment>`
- `new UserMessageDataAttachmentsItemFile` becomes `new AttachmentFile`
- `new UserMessageDataAttachmentsItemBlob` becomes `new AttachmentBlob`
- in `### File Attachments`, the base type plus `Type = UserMessageDataAttachmentsItemType.File` becomes `new AttachmentFile`, and the discriminator assignment is dropped

Property sets are unchanged: `AttachmentFile` requires `Path` and `DisplayName`, both already present, and `AttachmentBlob` requires `MimeType`, also already present.

The discriminator line is removed rather than translated because the concrete subclass already carries it. `AttachmentFile.Type` is a get-only override that always returns `"file"` and is `[JsonIgnore]`d; the wire discriminator is emitted from `[JsonPolymorphic]`/`[JsonDerivedType]`. An explicit assignment would compile but be silently ignored, which is worse than not showing it.

Markdown only - no source, public API, schema, generated file, or codegen template is touched.

### Verification

The examples were extracted from the README programmatically (not retyped) and compiled before and after:

Before, against published `1.0.8`:

```
error CS0246: The type or namespace name 'UserMessageDataAttachmentsItem' could not be found
error CS0246: The type or namespace name 'UserMessageDataAttachmentsItemFile' could not be found
error CS0246: The type or namespace name 'UserMessageDataAttachmentsItemBlob' could not be found
error CS0103: The name 'UserMessageDataAttachmentsItemType' does not exist in the current context
Build FAILED.    7 Error(s)
```

After:

```
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

Green against both a local build of this branch and the published `1.0.8` package, on `netstandard2.0`, `net8.0` and `net10.0`. The complete `## Image Support` fence also compiles as a single paste. Removing `DisplayName` from the corrected file example fails with `CS9035`, confirming the required-member check is live rather than vacuous.

Also verified: zero remaining occurrences of the old names in `dotnet/README.md`; the markdown token stream is unchanged apart from the one deleted line; `dotnet format --verify-no-changes` passes; and documentation validation still passes (55 C# files).

Round-tripping the corrected initializers through the real serializer gives `{"type":"file",...}` and `{"type":"blob",...}` and deserializes back to `AttachmentFile`/`AttachmentBlob`, confirming the dropped discriminator is supplied by the concrete type.

### Scope

Deliberately limited to `dotnet/README.md` to keep this markdown-only.

`dotnet/src/Session.cs` has a related but distinct defect in the `SendAsync` XML `<example>`: `new()` inside a `List<Attachment>` initializer target-types to the base `Attachment`, which has no `Path` (`CS0117`), and it omits the required `DisplayName`. It uses current type names, so it is a different bug from the stale names fixed here. Happy to follow up on it, or on widening documentation validation to cover the per-binding READMEs, in separate PRs.
