### PR TITLE
fix(dotnet): tolerate numeric ping timestamps

### DIFF
--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -31,6 +31,7 @@ public sealed class PingResult
     public long ProtocolVersion { get; set; }
 
     /// <summary>ISO 8601 timestamp when the server handled the ping.</summary>
+    [JsonConverter(typeof(GitHub.Copilot.UnixMillisecondsDateTimeOffsetConverter))]
     [JsonPropertyName("timestamp")]
     public DateTimeOffset Timestamp { get; set; }
 }

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -3845,6 +3845,7 @@ public sealed class PingResponse
     /// <summary>
     /// ISO 8601 timestamp when the ping was processed.
     /// </summary>
+    [JsonConverter(typeof(UnixMillisecondsDateTimeOffsetConverter))]
     public DateTimeOffset Timestamp { get; set; }
     /// <summary>
     /// Protocol version supported by the server.

--- a/dotnet/src/UnixMillisecondsDateTimeOffsetConverter.cs
+++ b/dotnet/src/UnixMillisecondsDateTimeOffsetConverter.cs
@@ -3,18 +3,30 @@
  *--------------------------------------------------------------------------------------------*/
 
 using System.ComponentModel;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace GitHub.Copilot;
 
-/// <summary>Converts between JSON numeric milliseconds-since-Unix-epoch and <see cref="DateTimeOffset"/>.</summary>
+/// <summary>Converts JSON numeric milliseconds-since-Unix-epoch or ISO 8601 strings to <see cref="DateTimeOffset"/>.</summary>
 [EditorBrowsable(EditorBrowsableState.Never)]
 public sealed class UnixMillisecondsDateTimeOffsetConverter : JsonConverter<DateTimeOffset>
 {
     /// <inheritdoc />
     public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            string? value = reader.GetString();
+            if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out long milliseconds))
+            {
+                return DateTimeOffset.FromUnixTimeMilliseconds(milliseconds);
+            }
+
+            return reader.GetDateTimeOffset();
+        }
+
         // The CLI may serialize the epoch-millisecond timestamp as a JSON integer
         // or as a floating-point number (e.g. 1700000000000.0). GetInt64 throws on a
         // fractional token, so fall back to reading a double and truncating.

--- a/dotnet/test/Unit/SerializationTests.cs
+++ b/dotnet/test/Unit/SerializationTests.cs
@@ -914,6 +914,82 @@ public class SerializationTests
     }
 
     [Fact]
+    public void PingResponse_DeserializesIsoTimestamp_WithSdkOptions()
+    {
+        var options = GetSerializerOptions();
+        var response = JsonSerializer.Deserialize<GitHub.Copilot.PingResponse>(
+            """{"message":"pong","timestamp":"2026-05-21T08:29:54.042Z","protocolVersion":3}""",
+            options);
+
+        Assert.NotNull(response);
+        Assert.Equal("pong", response.Message);
+        Assert.Equal(3, response.ProtocolVersion);
+        Assert.Equal(DateTimeOffset.Parse("2026-05-21T08:29:54.042Z"), response.Timestamp);
+    }
+
+    [Fact]
+    public void PingResponse_DeserializesEpochMillisecondsTimestamp_WithSdkOptions()
+    {
+        var options = GetSerializerOptions();
+        var response = JsonSerializer.Deserialize<GitHub.Copilot.PingResponse>(
+            """{"message":"pong","timestamp":1779352370134,"protocolVersion":3}""",
+            options);
+
+        Assert.NotNull(response);
+        Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1779352370134), response.Timestamp);
+    }
+
+    [Fact]
+    public void PingResponse_DeserializesStringEpochMillisecondsTimestamp_WithSdkOptions()
+    {
+        var options = GetSerializerOptions();
+        var response = JsonSerializer.Deserialize<GitHub.Copilot.PingResponse>(
+            """{"message":"pong","timestamp":"1779352370134","protocolVersion":3}""",
+            options);
+
+        Assert.NotNull(response);
+        Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1779352370134), response.Timestamp);
+    }
+
+    [Fact]
+    public void RpcPingResult_DeserializesIsoTimestamp_WithSdkOptions()
+    {
+        var options = GetSerializerOptions();
+        var result = JsonSerializer.Deserialize<PingResult>(
+            """{"message":"pong","timestamp":"2026-05-21T08:29:54.042Z","protocolVersion":3}""",
+            options);
+
+        Assert.NotNull(result);
+        Assert.Equal("pong", result.Message);
+        Assert.Equal(3, result.ProtocolVersion);
+        Assert.Equal(DateTimeOffset.Parse("2026-05-21T08:29:54.042Z"), result.Timestamp);
+    }
+
+    [Fact]
+    public void RpcPingResult_DeserializesEpochMillisecondsTimestamp_WithSdkOptions()
+    {
+        var options = GetSerializerOptions();
+        var result = JsonSerializer.Deserialize<PingResult>(
+            """{"message":"pong","timestamp":1779352370134,"protocolVersion":3}""",
+            options);
+
+        Assert.NotNull(result);
+        Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1779352370134), result.Timestamp);
+    }
+
+    [Fact]
+    public void RpcPingResult_DeserializesStringEpochMillisecondsTimestamp_WithSdkOptions()
+    {
+        var options = GetSerializerOptions();
+        var result = JsonSerializer.Deserialize<PingResult>(
+            """{"message":"pong","timestamp":"1779352370134","protocolVersion":3}""",
+            options);
+
+        Assert.NotNull(result);
+        Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1779352370134), result.Timestamp);
+    }
+
+    [Fact]
     public void AgentStopHookOutput_SerializesBlockDecision_WithSdkOptions()
     {
         var options = GetSerializerOptions();

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -492,6 +492,9 @@ function isMillisecondsDurationProperty(propName: string | undefined, schema: JS
     return isDurationProperty(schema) && !isSecondsDurationPropertyName(propName);
 }
 
+function isFlexiblePingTimestampProperty(className: string, propName: string, schema: JSONSchema7): boolean {
+    return className === "PingResult" && propName === "timestamp" && schema.format === "date-time";
+}
 
 const COPYRIGHT = `/*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
@@ -1736,6 +1739,9 @@ function emitRpcClass(
         if (isSchemaDeprecated(prop)) pushObsoleteAttributes(lines, "    ");
         if (isSchemaExperimental(prop)) pushExperimentalAttribute(lines, "    ");
         if (isMillisecondsDurationProperty(propName, prop)) lines.push(`    [JsonConverter(typeof(MillisecondsTimeSpanConverter))]`);
+        if (isFlexiblePingTimestampProperty(inlineTypeParentName, propName, prop)) {
+            lines.push(`    [JsonConverter(typeof(GitHub.Copilot.UnixMillisecondsDateTimeOffsetConverter))]`);
+        }
         const propVisibility = pushCSharpInternalAttribute(lines, prop);
         lines.push(`    [JsonPropertyName("${propName}")]`);
 


### PR DESCRIPTION
Fixes #2091.

## Summary
- apply the existing DateTimeOffset timestamp converter to `PingResponse.Timestamp`
- extend that converter to accept ISO-8601 strings, numeric epoch milliseconds, and stringified epoch milliseconds
- apply the same converter to generated `Rpc.PingResult.Timestamp` through the C# generator and current generated output
- add serialization tests for both public and typed RPC ping result shapes

## Root cause
`PingResponse.Timestamp` and generated `Rpc.PingResult.Timestamp` used the default `DateTimeOffset` JSON converter, which expects a string and rejects older numeric epoch-millisecond payloads from some CLI builds. Since ping is used during startup protocol verification, that deserialization error prevents the .NET client from starting.

## Validation
- Not run: `dotnet test test/GitHub.Copilot.SDK.Test.csproj --filter SerializationTests` could not run because `dotnet` is not installed in this environment (`zsh:1: command not found: dotnet`).
