### PR TITLE
Serialize tool results with Pydantic's JSON mode

### DIFF
--- a/python/copilot/tools.py
+++ b/python/copilot/tools.py
@@ -351,7 +351,11 @@ def _normalize_result(result: Any) -> ToolResult:
     # Everything else gets JSON-serialized (with Pydantic model support)
     def default(obj: Any) -> Any:
         if isinstance(obj, BaseModel):
-            return obj.model_dump()
+            # mode="json" coerces datetime/UUID/Decimal/Enum fields to JSON-native
+            # types. The default mode="python" leaves them as native objects, which
+            # json.dumps then passes back into this hook and we reject as
+            # unserializable -- turning an ordinary tool result into a failure.
+            return obj.model_dump(mode="json")
         raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
     try:

--- a/python/test_tools.py
+++ b/python/test_tools.py
@@ -1,6 +1,10 @@
 """Unit tests for define_tool"""
 
+import datetime
+import decimal
+import enum
 import json
+import uuid
 
 import pytest
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -387,6 +391,33 @@ class TestNormalizeResult:
         result = _normalize_result(items)
         parsed = json.loads(result.text_result_for_llm)
         assert parsed == [{"name": "a", "value": 1}, {"name": "b", "value": 2}]
+        assert result.result_type == "success"
+
+    def test_pydantic_model_with_non_primitive_fields_is_serialized(self):
+        class IssueState(enum.StrEnum):
+            OPEN = "open"
+            CLOSED = "closed"
+
+        class Issue(BaseModel):
+            id: uuid.UUID
+            created_at: datetime.datetime
+            price: decimal.Decimal
+            state: IssueState
+
+        issue = Issue(
+            id=uuid.UUID("6b686a99-0000-4000-8000-000000000000"),
+            created_at=datetime.datetime(2026, 8, 1, 1, 49, 10),
+            price=decimal.Decimal("1.5"),
+            state=IssueState.OPEN,
+        )
+        result = _normalize_result(issue)
+        parsed = json.loads(result.text_result_for_llm)
+        assert parsed == {
+            "id": "6b686a99-0000-4000-8000-000000000000",
+            "created_at": "2026-08-01T01:49:10",
+            "price": "1.5",
+            "state": "open",
+        }
         assert result.result_type == "success"
 
     def test_raises_for_unserializable_value(self):


### PR DESCRIPTION
Fixes #2203

### What's wrong

`_normalize_result`'s `default` hook calls `model_dump()`, which uses the default `mode="python"`. That leaves `datetime`, `date`, `UUID`, `Decimal`, `Enum` and `set` fields as native Python objects, so `json.dumps` passes them straight back into the same hook, which doesn't recognise them and raises `TypeError`.

That raise happens inside `wrapped_handler`'s `try` block, which converts any exception into the deliberately redacted failure result. So a tool returning a perfectly ordinary model:

```python
class Issue(BaseModel):
    id: uuid.UUID
    created_at: datetime.datetime
```

reports `"Invoking this tool produced an error. Detailed information is not available."` to the model on **every** call, and the tool author sees no indication of why.

### The fix

`model_dump(mode="json")` makes Pydantic coerce each field to a JSON-native type before `json.dumps` sees it. Models whose fields are all JSON primitives serialize exactly as before, so this is backwards compatible.

This matches what the TypeScript SDK already does via `JSON.stringify` (JS `Date` implements `toJSON()`).

### Verification

Added `test_pydantic_model_with_non_primitive_fields_is_serialized` to the existing `TestNormalizeResult` class, covering `UUID`, `datetime`, `Decimal` and `StrEnum` in one model.

It **fails on the unfixed code** with the reported error:

```
TypeError: Failed to serialize tool result: Object of type UUID is not JSON serializable
copilot/tools.py:360: TypeError
```

and passes with the change. Full local run:

- `uv run pytest test_tools.py` → **41 passed** (40 before, plus the new test)
- `uv run pytest --ignore=e2e --ignore=test_client.py --ignore=test_commands_and_elicitation.py --ignore=test_e2e_harness_cli_path.py` → **184 passed**
- `uv run ruff check .` → All checks passed
- `uv run ruff format --check` → already formatted

The four ignored modules fail at collection with `RuntimeError: CLI not found for tests` in my environment; I confirmed they fail identically on unmodified `main`, so that is environmental and unrelated to this change.

### Scope

Deliberately minimal — one line of behaviour change plus a test. For fuller parity with the TypeScript SDK you may also want fallbacks in `default` for `dataclasses.asdict`, `datetime/date/time.isoformat()`, `UUID`/`Decimal` → `str`, `Enum` → `.value` and `set` → `list`, so a plain `dict` carrying those types works too. I left that out to keep the diff focused — happy to add it if you'd prefer it here.
