### PR TITLE
docs: remove the nonexistent toolName field from tool.execution_complete

### DIFF
--- a/nodejs/docs/agent-author.md
+++ b/nodejs/docs/agent-author.md
@@ -258,7 +258,7 @@ Subscribe to session events. Returns an unsubscribe function.
 
 ```js
 const unsub = session.on("tool.execution_complete", (event) => {
-    // event.data.toolName, event.data.success, event.data.result
+    // event.data.success, event.data.result
 });
 ```
 
@@ -268,7 +268,7 @@ const unsub = session.on("tool.execution_complete", (event) => {
 | ------------------------- | ------------------------------------------------------ |
 | `assistant.message`       | `content`, `messageId`                                 |
 | `tool.execution_start`    | `toolCallId`, `toolName`, `arguments`                  |
-| `tool.execution_complete` | `toolCallId`, `toolName`, `success`, `result`, `error` |
+| `tool.execution_complete` | `toolCallId`, `success`, `result`, `error`             |
 | `user.message`            | `content`, `attachments`, `source`                     |
 | `session.idle`            | `backgroundTasks`                                      |
 | `session.error`           | `errorType`, `message`, `stack`                        |

--- a/nodejs/docs/examples.md
+++ b/nodejs/docs/examples.md
@@ -368,7 +368,7 @@ session.on((event) => {
 
 ```js
 const unsubscribe = session.on("tool.execution_complete", (event) => {
-    // event.data.toolName, event.data.success, event.data.result, event.data.error
+    // event.data.success, event.data.result, event.data.error
 });
 
 // Later, stop listening
@@ -417,7 +417,7 @@ session.on("assistant.message", (event) => {
 | `assistant.message`         | Agent's final response                           | `content`, `messageId`, `toolRequests`                 |
 | `assistant.message_delta`   | Message content chunks (ephemeral)               | `deltaContent`                                         |
 | `tool.execution_start`      | A tool is about to run                           | `toolCallId`, `toolName`, `arguments`                  |
-| `tool.execution_complete`   | A tool finished running                          | `toolCallId`, `toolName`, `success`, `result`, `error` |
+| `tool.execution_complete`   | A tool finished running                          | `toolCallId`, `success`, `result`, `error`             |
 | `user.message`              | User sent a message                              | `content`, `attachments`, `source`                     |
 | `session.idle`              | Session finished processing a turn               | `backgroundTasks`                                      |
 | `session.error`             | An error occurred                                | `errorType`, `message`, `stack`                        |
@@ -677,6 +677,6 @@ session.on("assistant.message", (event) => {
 });
 
 session.on("tool.execution_complete", (event) => {
-    // event.data.success, event.data.toolName, event.data.result
+    // event.data.success, event.data.result
 });
 ```


### PR DESCRIPTION
### What

The Node.js extension-authoring docs list a `toolName` field on the `tool.execution_complete` session event, in two event-field reference tables and three handler code-comments. That event has no `toolName`, so a reader who copies the reference row or the comment writes `event.data.toolName` and gets `undefined`. Because the snippets are JavaScript, there is no error to notice. `toolName` is emitted on `tool.execution_start`, and a completion is correlated to its start by `toolCallId`.

Fixes #2211

### Why it is a bug

The shipped types and the bundled schema both disagree with the docs:

- `ToolExecutionCompleteData` has `toolCallId`, `success`, `result?`, `error?`, `model?`, `interactionId?`, ... and no `toolName`; `ToolExecutionStartData` has `toolName: string`.
- The bundled `session-events.schema.json` declares `ToolExecutionCompleteData` with `"required": ["toolCallId", "success"]` and `"additionalProperties": false`, without a `toolName` property, so the field is not part of the event's contract.

The repository's own shared reference already documents the event correctly: `docs/features/streaming-events.md` lists `tool.execution_complete` without `toolName` and describes `toolCallId` as "Matches the corresponding `tool.execution_start`". These two Node.js pages were the only place making the claim - no other language binding's documentation does, so this brings them back in line with the shared reference rather than introducing a Node.js-specific rule.

The correct pattern is already shown in `nodejs/docs/examples.md`, which reads `toolName` in `tool.execution_start` handlers, records the `toolCallId`, and matches the completion event by that id. It also states the rule directly: "Correlate `tool.execution_start` / `tool.execution_complete` events by `toolCallId`". No new guidance is added here.

### Change

Remove `toolName` from the two `tool.execution_complete` reference rows and the three completion-handler comments. It stays on the `tool.execution_start` rows. Documentation only - no code, type, schema or public API change.

- `nodejs/docs/agent-author.md`: 1 table row + 1 comment
- `nodejs/docs/examples.md`: 1 table row + 2 comments

Before / after (reference table):

```diff
-| `tool.execution_complete` | `toolCallId`, `toolName`, `success`, `result`, `error` |
+| `tool.execution_complete` | `toolCallId`, `success`, `result`, `error`             |
```

The table cells are re-padded so the column widths stay byte-identical, keeping the diff to the five changed lines.

### Verification

- Every field still listed on the corrected rows (`toolCallId`, `success`, `result`, `error`) was checked against both the generated types and the bundled schema; all four exist.
- Type-level: accessing `.toolName` on `ToolExecutionCompleteData` fails with `TS2339: Property 'toolName' does not exist on type 'ToolExecutionCompleteData'`, while the same access on `ToolExecutionStartData` compiles; a control file using only the fields the corrected docs list compiles cleanly.
- Runtime: in a real session, the `tool.execution_complete` payload's own keys were `toolCallId`, `success`, `result`, `model`, `interactionId`, `turnId`, `toolTelemetry` - `hasOwnProperty("toolName")` was `false`, and the `toolCallId` matched the preceding `tool.execution_start`.
- Repository-wide check: no remaining Markdown file associates `toolName` with `tool.execution_complete`. The 22 other `toolName` mentions in these two files are `tool.execution_start` fields, hook inputs, or tool-invocation metadata, and are unchanged.
- `npm run lint`, `npm run format:check`, `npm run typecheck` and `npm run build` pass, and the unit suite is green (363 tests). Note that CI does not otherwise exercise this change: `scripts/docs-validation` only scans the top-level `docs/` directory, so `nodejs/docs/**` snippets are never extracted or compiled - which is why this survived since the pages were added.

### Out of scope

The `session.idle` row in these same two tables lists `backgroundTasks`, which also does not match the current `IdleData` (it carries `aborted`). That claim additionally appears in `docs/features/streaming-events.md`, so correcting it touches the shared reference and is a wider change than this one; it is deliberately left alone here.

Likewise, these tables are curated "key data fields" summaries rather than exhaustive field lists, so this PR only removes a field that does not exist - it does not add the ones that are merely omitted.
