### PR TITLE
docs: fix the Node.js inbound trace-context example to use a real tool-registration API

### DIFF
--- a/docs/observability/opentelemetry.md
+++ b/docs/observability/opentelemetry.md
@@ -152,29 +152,36 @@ When the CLI invokes a tool handler, the `traceparent` and `tracestate` from the
 
 <!-- docs-validate: skip -->
 ```typescript
+import { defineTool } from "@github/copilot-sdk";
 import { propagation, context, trace } from "@opentelemetry/api";
 
-session.registerTool(myTool, async (args, invocation) => {
-  // Restore the CLI's trace context as the active context
-  const carrier = {
-    traceparent: invocation.traceparent,
-    tracestate: invocation.tracestate,
-  };
-  const parentCtx = propagation.extract(context.active(), carrier);
+const myTool = defineTool("my-tool", {
+  description: "Do work",
+  handler: async (args, invocation) => {
+    // Restore the CLI's trace context as the active context
+    const carrier = {
+      traceparent: invocation.traceparent,
+      tracestate: invocation.tracestate,
+    };
+    const parentCtx = propagation.extract(context.active(), carrier);
 
-  // Create a child span under the CLI's span
-  const tracer = trace.getTracer("my-app");
-  return context.with(parentCtx, () =>
-    tracer.startActiveSpan("my-tool", async (span) => {
-      try {
-        const result = await doWork(args);
-        return result;
-      } finally {
-        span.end();
-      }
-    })
-  );
+    // Create a child span under the CLI's span
+    const tracer = trace.getTracer("my-app");
+    return context.with(parentCtx, () =>
+      tracer.startActiveSpan("my-tool", async (span) => {
+        try {
+          const result = await doWork(args);
+          return result;
+        } finally {
+          span.end();
+        }
+      })
+    );
+  },
 });
+
+// Tool handlers are registered when the session is created.
+const session = await client.createSession({ tools: [myTool] });
 ```
 
 ### Per-language dependencies


### PR DESCRIPTION
Fixes #2222

## Problem

The Node.js example in the **CLI -> SDK (inbound)** part of `docs/observability/opentelemetry.md`
registered a tool by calling `session.registerTool(myTool, handler)`. That method is not part of the
public `CopilotSession` API, so the documented snippet does not compile:

```
error TS2339: Property 'registerTool' does not exist on type 'CopilotSession'.
```

and throws `TypeError: session.registerTool is not a function` if the types are bypassed. The plural
`registerTools()` is `@internal` and removed from the shipped declarations by `stripInternal: true`,
so there is no public session method to swap in - the registration step has to be restructured.

The example's trace-restoration logic was always correct: `ToolInvocation.traceparent` and
`.tracestate` are public and are delivered to the handler. Only the registration mechanism was wrong.

## Fix

Move the trace-restoring handler into `defineTool()` and register the tool through
`client.createSession({ tools: [myTool] })`, the public registration path already used by the rest of
the documentation. Every part of the trace-context logic is carried over unchanged:
`propagation.extract(context.active(), carrier)`, `trace.getTracer("my-app")`,
`context.with(parentCtx, ...)`, `tracer.startActiveSpan("my-tool", ...)` and `span.end()` in a
`finally`.

One file changes, and only the one fenced block inside it. No API, no behaviour, and no other
documentation is touched.

The `<!-- docs-validate: skip -->` marker on the block is deliberately kept: `scripts/docs-validation`
has no `@opentelemetry/api` dependency, so unskipping the block would make it fail on the missing
third-party import rather than validate anything about the SDK.

## Verification

Reproducer, against the published package so it does not depend on this branch:

```bash
printf '{"name":"repro","version":"0.0.0","private":true,"type":"module"}\n' > package.json
npm install @github/copilot-sdk@1.0.8 typescript@5.9.3 @opentelemetry/api@1.9.1
```

**Before** - the old snippet, with only the scaffolding the surrounding docs supply out-of-band
(`session`, `myTool`, `doWork`):

```console
$ npx tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --strict --skipLibCheck before.ts
before.ts(7,9): error TS2339: Property 'registerTool' does not exist on type 'CopilotSession'.
before.ts(7,37): error TS7006: Parameter 'args' implicitly has an 'any' type.
before.ts(7,43): error TS7006: Parameter 'invocation' implicitly has an 'any' type.
$ echo $?
2
```

**After** - the new snippet extracted from the updated doc, with `client` and `doWork` declared:

```console
$ npx tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --strict --skipLibCheck after.ts
$ echo $?
0
```

Both results hold against the published `@github/copilot-sdk@1.0.8` and against a local build of this
branch, and under both TypeScript 5.9.3 and 7.0.2. The two `TS7006` errors disappear with the fix
because `args` and `invocation` become contextually typed, so the example's
`invocation.traceparent` / `.tracestate` access is now genuinely type-checked.

Runtime confirmation that the old call could never have worked:

```console
$ node --input-type=module -e 'import { CopilotSession } from "@github/copilot-sdk";
  const p = CopilotSession.prototype;
  console.log("registerTool: ", typeof p.registerTool);
  console.log("registerTools:", typeof p.registerTools);'
registerTool:  undefined
registerTools: function
```

I also confirmed the corrected path really does deliver the trace context, so the section still does
what it promises: `createSession()` passes `config.tools` to the session, the session stores each
tool's handler by name, and the handler is invoked with a `ToolInvocation` carrying `traceparent` and
`tracestate` from the incoming request.

`scripts/docs-validation` was run before and after; its extracted-block manifest is identical, which
confirms no collateral damage (it skips this block by design, so it is a regression check, not proof
of the fix - the compile above is the proof).

## Out of scope

The feature table in `docs/troubleshooting/compatibility.md` lists two methods that are absent from
the shipped declarations: `registerTools()` at line 35 and `destroy()` at line 19, both under the
"Available in SDK" heading. Line 35 is not the only stale cell there, so correcting just it in an
OpenTelemetry docs fix would be arbitrary. That table looks like its own small pass, so I left it
alone.
