### PR TITLE
Support reasoningEffort: max

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -123,7 +123,7 @@ Create a new conversation session.
 
 - `SessionId` - Custom session ID
 - `Model` - Model to use ("gpt-5", "claude-sonnet-4.5", etc.)
-- `ReasoningEffort` - Reasoning effort level for models that support it ("low", "medium", "high", "xhigh"). Use `ListModelsAsync()` to check which models support this option.
+- `ReasoningEffort` - Reasoning effort level for models that support it ("low", "medium", "high", "xhigh", "max"). Use `ListModelsAsync()` to check which models support this option.
 - `Tools` - Custom tool declarations exposed to the CLI. Declarations without an invocable `AIFunction` are left pending for manual resolution.
 - `SystemMessage` - System message customization
 - `AvailableTools` - List of tool names to allow

--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -1,4 +1,4 @@
-﻿/*---------------------------------------------------------------------------------------------
+/*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
@@ -1790,7 +1790,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
     /// The new model takes effect for the next message. Conversation history is preserved.
     /// </summary>
     /// <param name="model">Model ID to switch to (e.g., "gpt-5.4").</param>
-    /// <param name="reasoningEffort">Reasoning effort level (e.g., "low", "medium", "high", "xhigh").</param>
+    /// <param name="reasoningEffort">Reasoning effort level (e.g., "low", "medium", "high", "xhigh", "max").</param>
     /// <param name="modelCapabilities">Per-property overrides for model capabilities, deep-merged over runtime defaults.</param>
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <example>

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -3108,7 +3108,7 @@ public abstract class SessionConfigBase
 
     /// <summary>
     /// Reasoning effort level for models that support it.
-    /// Valid values: "low", "medium", "high", "xhigh".
+    /// Valid values: "low", "medium", "high", "xhigh", "max".
     /// Only applies to models where capabilities.supports.reasoningEffort is true.
     /// </summary>
     public string? ReasoningEffort { get; set; }

--- a/go/README.md
+++ b/go/README.md
@@ -210,7 +210,7 @@ Event types: `SessionLifecycleCreated`, `SessionLifecycleDeleted`, `SessionLifec
 **SessionConfig:**
 
 - `Model` (string): Model to use ("gpt-5", "claude-sonnet-4.5", etc.). **Required when using custom provider.**
-- `ReasoningEffort` (string): Reasoning effort level for models that support it ("low", "medium", "high", "xhigh"). Use `ListModels()` to check which models support this option.
+- `ReasoningEffort` (string): Reasoning effort level for models that support it ("low", "medium", "high", "xhigh", "max"). Use `ListModels()` to check which models support this option.
 - `SessionID` (string): Custom session ID
 - `Tools` ([]Tool): Custom tools exposed to the CLI
 - `SystemMessage` (\*SystemMessageConfig): System message configuration. Supports three modes:

--- a/go/session.go
+++ b/go/session.go
@@ -1769,7 +1769,7 @@ func (s *Session) Abort(ctx context.Context) error {
 
 // SetModelOptions configures optional parameters for SetModel.
 type SetModelOptions struct {
-	// ReasoningEffort sets the reasoning effort level for the new model (e.g., "low", "medium", "high", "xhigh").
+	// ReasoningEffort sets the reasoning effort level for the new model (e.g., "low", "medium", "high", "xhigh", "max").
 	ReasoningEffort *string
 	// ReasoningSummary sets the reasoning summary mode for the new model.
 	// Use ReasoningSummaryNone to suppress summary output regardless of whether reasoning is enabled.

--- a/go/types.go
+++ b/go/types.go
@@ -1163,7 +1163,7 @@ type SessionConfig struct {
 	// Model to use for this session
 	Model string
 	// ReasoningEffort level for models that support it.
-	// Valid values: "low", "medium", "high", "xhigh"
+	// Valid values: "low", "medium", "high", "xhigh", "max"
 	// Only applies to models where capabilities.supports.reasoningEffort is true.
 	ReasoningEffort string
 	// ReasoningSummary mode for models that support configurable reasoning summaries.
@@ -1710,7 +1710,7 @@ type ResumeSessionConfig struct {
 	// Only non-nil fields are applied over the runtime-resolved capabilities.
 	ModelCapabilities *rpc.ModelCapabilitiesOverride
 	// ReasoningEffort level for models that support it.
-	// Valid values: "low", "medium", "high", "xhigh"
+	// Valid values: "low", "medium", "high", "xhigh", "max"
 	ReasoningEffort string
 	// ReasoningSummary mode for models that support configurable reasoning summaries.
 	// Use ReasoningSummaryNone to suppress summary output regardless of whether reasoning is enabled.

--- a/java/src/main/java/com/github/copilot/CopilotSession.java
+++ b/java/src/main/java/com/github/copilot/CopilotSession.java
@@ -1972,7 +1972,7 @@ public final class CopilotSession implements AutoCloseable {
      *            the model ID to switch to (e.g., {@code "gpt-5.4"})
      * @param reasoningEffort
      *            reasoning effort level (e.g., {@code "low"}, {@code "medium"},
-     *            {@code "high"}, {@code "xhigh"}); {@code null} to use default
+     *            {@code "high"}, {@code "xhigh"}, {@code "max"}); {@code null} to use default
      * @return a future that completes when the model switch is acknowledged
      * @throws IllegalStateException
      *             if this session has been terminated
@@ -2003,7 +2003,7 @@ public final class CopilotSession implements AutoCloseable {
      *            the model ID to switch to (e.g., {@code "gpt-5.4"})
      * @param reasoningEffort
      *            reasoning effort level (e.g., {@code "low"}, {@code "medium"},
-     *            {@code "high"}, {@code "xhigh"}); {@code null} to use default
+     *            {@code "high"}, {@code "xhigh"}, {@code "max"}); {@code null} to use default
      * @param modelCapabilities
      *            per-property overrides for model capabilities; {@code null} to use
      *            runtime defaults

--- a/java/src/main/java/com/github/copilot/CopilotSession.java
+++ b/java/src/main/java/com/github/copilot/CopilotSession.java
@@ -1972,7 +1972,8 @@ public final class CopilotSession implements AutoCloseable {
      *            the model ID to switch to (e.g., {@code "gpt-5.4"})
      * @param reasoningEffort
      *            reasoning effort level (e.g., {@code "low"}, {@code "medium"},
-     *            {@code "high"}, {@code "xhigh"}, {@code "max"}); {@code null} to use default
+     *            {@code "high"}, {@code "xhigh"}, {@code "max"}); {@code null} to
+     *            use default
      * @return a future that completes when the model switch is acknowledged
      * @throws IllegalStateException
      *             if this session has been terminated
@@ -2003,7 +2004,8 @@ public final class CopilotSession implements AutoCloseable {
      *            the model ID to switch to (e.g., {@code "gpt-5.4"})
      * @param reasoningEffort
      *            reasoning effort level (e.g., {@code "low"}, {@code "medium"},
-     *            {@code "high"}, {@code "xhigh"}, {@code "max"}); {@code null} to use default
+     *            {@code "high"}, {@code "xhigh"}, {@code "max"}); {@code null} to
+     *            use default
      * @param modelCapabilities
      *            per-property overrides for model capabilities; {@code null} to use
      *            runtime defaults

--- a/java/src/main/java/com/github/copilot/rpc/ResumeSessionConfig.java
+++ b/java/src/main/java/com/github/copilot/rpc/ResumeSessionConfig.java
@@ -637,7 +637,7 @@ public class ResumeSessionConfig {
     /**
      * Gets the reasoning effort level.
      *
-     * @return the reasoning effort level ("low", "medium", "high", or "xhigh")
+     * @return the reasoning effort level ("low", "medium", "high", "xhigh", or "max")
      */
     public String getReasoningEffort() {
         return reasoningEffort;
@@ -646,7 +646,7 @@ public class ResumeSessionConfig {
     /**
      * Sets the reasoning effort level for models that support it.
      * <p>
-     * Valid values: "low", "medium", "high", "xhigh".
+     * Valid values: "low", "medium", "high", "xhigh", "max".
      *
      * @param reasoningEffort
      *            the reasoning effort level

--- a/java/src/main/java/com/github/copilot/rpc/ResumeSessionConfig.java
+++ b/java/src/main/java/com/github/copilot/rpc/ResumeSessionConfig.java
@@ -637,7 +637,8 @@ public class ResumeSessionConfig {
     /**
      * Gets the reasoning effort level.
      *
-     * @return the reasoning effort level ("low", "medium", "high", "xhigh", or "max")
+     * @return the reasoning effort level ("low", "medium", "high", "xhigh", or
+     *         "max")
      */
     public String getReasoningEffort() {
         return reasoningEffort;

--- a/java/src/main/java/com/github/copilot/rpc/SessionConfig.java
+++ b/java/src/main/java/com/github/copilot/rpc/SessionConfig.java
@@ -178,7 +178,8 @@ public class SessionConfig {
     /**
      * Gets the reasoning effort level.
      *
-     * @return the reasoning effort level ("low", "medium", "high", "xhigh", or "max")
+     * @return the reasoning effort level ("low", "medium", "high", "xhigh", or
+     *         "max")
      */
     public String getReasoningEffort() {
         return reasoningEffort;
@@ -187,8 +188,8 @@ public class SessionConfig {
     /**
      * Sets the reasoning effort level for models that support it.
      * <p>
-     * Valid values: "low", "medium", "high", "xhigh", "max". Only applies to models where
-     * {@code capabilities.supports.reasoningEffort} is true.
+     * Valid values: "low", "medium", "high", "xhigh", "max". Only applies to models
+     * where {@code capabilities.supports.reasoningEffort} is true.
      *
      * @param reasoningEffort
      *            the reasoning effort level

--- a/java/src/main/java/com/github/copilot/rpc/SessionConfig.java
+++ b/java/src/main/java/com/github/copilot/rpc/SessionConfig.java
@@ -178,7 +178,7 @@ public class SessionConfig {
     /**
      * Gets the reasoning effort level.
      *
-     * @return the reasoning effort level ("low", "medium", "high", or "xhigh")
+     * @return the reasoning effort level ("low", "medium", "high", "xhigh", or "max")
      */
     public String getReasoningEffort() {
         return reasoningEffort;
@@ -187,7 +187,7 @@ public class SessionConfig {
     /**
      * Sets the reasoning effort level for models that support it.
      * <p>
-     * Valid values: "low", "medium", "high", "xhigh". Only applies to models where
+     * Valid values: "low", "medium", "high", "xhigh", "max". Only applies to models where
      * {@code capabilities.supports.reasoningEffort} is true.
      *
      * @param reasoningEffort

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -131,7 +131,7 @@ Create a new conversation session.
 
 - `sessionId?: string` - Custom session ID.
 - `model?: string` - Model to use ("gpt-5", "claude-sonnet-4.5", etc.). **Required when using custom provider.**
-- `reasoningEffort?: "low" | "medium" | "high" | "xhigh"` - Reasoning effort level for models that support it. Use `listModels()` to check which models support this option.
+- `reasoningEffort?: "low" | "medium" | "high" | "xhigh" | "max"` - Reasoning effort level for models that support it. Use `listModels()` to check which models support this option.
 - `tools?: Tool[]` - Custom tools exposed to the CLI. Tools without `handler` are declaration-only and must be resolved via pending tool-call RPCs.
 - `systemMessage?: SystemMessageConfig` - System message customization (see below)
 - `infiniteSessions?: InfiniteSessionConfig` - Configure automatic context compaction (see below)

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -1823,7 +1823,7 @@ export interface LargeToolOutputConfig {
 /**
  * Valid reasoning effort levels for models that support it.
  */
-export type ReasoningEffort = "low" | "medium" | "high" | "xhigh";
+export type ReasoningEffort = "low" | "medium" | "high" | "xhigh" | "max";
 
 /**
  * Context window tier for the session. "long_context" pins the session to the

--- a/python/README.md
+++ b/python/README.md
@@ -272,7 +272,7 @@ finally:
 These are passed as keyword arguments to `create_session()`:
 
 - `model` (str): Model to use ("gpt-5", "claude-sonnet-4.5", etc.). **Required when using custom provider.**
-- `reasoning_effort` (str): Reasoning effort level for models that support it ("low", "medium", "high", "xhigh"). Use `list_models()` to check which models support this option.
+- `reasoning_effort` (str): Reasoning effort level for models that support it ("low", "medium", "high", "xhigh", "max"). Use `list_models()` to check which models support this option.
 - `session_id` (str): Custom session ID
 - `tools` (list): Custom tools exposed to the CLI. Tools with `handler=None` are declaration-only and must be resolved via pending tool-call RPCs.
 - `system_message` (SystemMessageConfig): System message configuration

--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -169,7 +169,7 @@ def _capabilities_to_dict(caps: ModelCapabilitiesOverride) -> dict:
     return result
 
 
-ReasoningEffort = Literal["low", "medium", "high", "xhigh"]
+ReasoningEffort = Literal["low", "medium", "high", "xhigh", "max"]
 ReasoningSummary = Literal["none", "concise", "detailed"]
 ContextTier = Literal["default", "long_context"]
 SessionFsConventions = Literal["posix", "windows"]
@@ -2976,7 +2976,7 @@ class CopilotSession:
         Args:
             model: Model ID to switch to (e.g., "gpt-5.4", "claude-sonnet-4").
             reasoning_effort: Optional reasoning effort level for the new model
-                (e.g., "low", "medium", "high", "xhigh").
+                (e.g., "low", "medium", "high", "xhigh", "max").
             reasoning_summary: Optional reasoning summary mode for supported
                 models. Use "none" to suppress summary output regardless of
                 whether reasoning is enabled.

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -4330,7 +4330,7 @@ impl LogOptions {
 #[derive(Debug, Clone, Default)]
 pub struct SetModelOptions {
     /// Reasoning effort for the new model (e.g. `"low"`, `"medium"`,
-    /// `"high"`, `"xhigh"`).
+    /// `"high"`, `"xhigh"`, `"max"`).
     pub reasoning_effort: Option<String>,
     /// Reasoning summary mode for the new model. Use
     /// [`ReasoningSummary::None`] to suppress summary output regardless of


### PR DESCRIPTION
## Summary

This PR adds support for the `max` reasoning effort level so the SDK matches the capabilities already supported by the model and CLI.

## Changes

- Added `max` to the supported `ReasoningEffort` values.
- Updated related documentation/tests where applicable.

Closes #2207