### PR TITLE
docs: replace removed `session.idle.backgroundTasks` field with the current `aborted` field

### DIFF
--- a/docs/features/streaming-events.md
+++ b/docs/features/streaming-events.md
@@ -548,7 +548,7 @@ Ephemeral. The agent has finished all processing and is ready for the next messa
 
 | Data Field | Type | Required | Description |
 |------------|------|----------|-------------|
-| `backgroundTasks` | `BackgroundTasks` | | Background agents/shells still running when the agent became idle |
+| `aborted` | `boolean` | | True when the preceding turn was cancelled via abort signal |
 
 ### `session.error`
 
@@ -958,7 +958,7 @@ This table lists key `data` payload fields. Common envelope fields are documente
 | `tool.execution_partial_result` | ✅ | Tool | `toolCallId`, `partialOutput` |
 | `tool.execution_progress` | ✅ | Tool | `toolCallId`, `progressMessage` |
 | `tool.execution_complete` | | Tool | `toolCallId`, `success`, `result?`, `error?` |
-| `session.idle` | ✅ | Session | `backgroundTasks?` |
+| `session.idle` | ✅ | Session | `aborted?` |
 | `session.error` | | Session | `errorType`, `message`, `statusCode?` |
 | `session.compaction_start` | | Session | *(empty)* |
 | `session.compaction_complete` | | Session | `success`, `preCompactionTokens?`, `summaryContent?` |

--- a/nodejs/docs/agent-author.md
+++ b/nodejs/docs/agent-author.md
@@ -270,7 +270,7 @@ const unsub = session.on("tool.execution_complete", (event) => {
 | `tool.execution_start`    | `toolCallId`, `toolName`, `arguments`                  |
 | `tool.execution_complete` | `toolCallId`, `toolName`, `success`, `result`, `error` |
 | `user.message`            | `content`, `attachments`, `source`                     |
-| `session.idle`            | `backgroundTasks`                                      |
+| `session.idle`            | `aborted`                                              |
 | `session.error`           | `errorType`, `message`, `stack`                        |
 | `permission.requested`    | `requestId`, `permissionRequest.kind`                  |
 | `session.shutdown`        | `shutdownType`, `totalPremiumRequests`                 |

--- a/nodejs/docs/examples.md
+++ b/nodejs/docs/examples.md
@@ -419,7 +419,7 @@ session.on("assistant.message", (event) => {
 | `tool.execution_start`      | A tool is about to run                           | `toolCallId`, `toolName`, `arguments`                  |
 | `tool.execution_complete`   | A tool finished running                          | `toolCallId`, `toolName`, `success`, `result`, `error` |
 | `user.message`              | User sent a message                              | `content`, `attachments`, `source`                     |
-| `session.idle`              | Session finished processing a turn               | `backgroundTasks`                                      |
+| `session.idle`              | Session finished processing a turn               | `aborted`                                              |
 | `session.error`             | An error occurred                                | `errorType`, `message`, `stack`                        |
 | `permission.requested`      | Agent needs permission (shell, file write, etc.) | `requestId`, `permissionRequest.kind`                  |
 | `session.shutdown`          | Session is ending                                | `shutdownType`, `totalPremiumRequests`, `codeChanges`  |


### PR DESCRIPTION
Fixes #2231

### What

The `session.idle` documentation still lists a `backgroundTasks` field of type `BackgroundTasks`. That field was removed from the payload a while ago and the docs were never updated; the type name no longer exists in the schema either. Meanwhile the optional field the event may carry, `aborted`, was undocumented.

This replaces the stale rows with the real field in all four places that named it.

### Why it is wrong today

`session-events.schema.json` defines the payload as (field descriptions elided):

```json
{
  "type": "object",
  "properties": {
    "aborted": { "type": "boolean" }
  },
  "additionalProperties": false,
  "title": "IdleData"
}
```

`additionalProperties` is `false`, and `backgroundTasks` appears nowhere in `session-events.schema.json` or `api.schema.json`. All six generated bindings expose only an optional/nullable boolean named `aborted`.

Verified on the wire against CLI `1.0.78-2` by capturing raw JSON-RPC frames:

```jsonc
// normal completion
{"type":"session.idle","data":{},"ephemeral":true, ...}

// after session.abort()
{"type":"session.idle","data":{"aborted":true},"ephemeral":true, ...}
```

`session.idle` is now emitted only after tracked active background work has quiesced, so a `backgroundTasks` snapshot on that payload would always be empty. Changes to background-task state are signalled separately, by the empty-payload `session.background_tasks_changed` event.

### Before / after

`docs/features/streaming-events.md` (the `session.idle` data-field table):

```diff
-| `backgroundTasks` | `BackgroundTasks` | | Background agents/shells still running when the agent became idle |
+| `aborted` | `boolean` | | True when the preceding turn was cancelled via abort signal |
```

and the "at a glance" summary table:

```diff
-| `session.idle` | ✅ | Session | `backgroundTasks?` |
+| `session.idle` | ✅ | Session | `aborted?` |
```

The same stale cell is corrected in the two Node.js quick-reference tables (`nodejs/docs/examples.md`, `nodejs/docs/agent-author.md`).

The description is worded to match this guide's existing vocabulary for the same concept (see the `abort` event's "Why the turn was aborted" row). The Required column is left empty because `aborted` is optional (matching the convention used by other optional rows in the same file, e.g. `interactionId` and `reasoningOpaque`), and the at-a-glance table uses the `?` suffix for the same reason.

### Verification

- `rg -n 'backgroundTasks|BackgroundTasks' docs/ nodejs/docs/` returns no hits after the change. The only remaining matches in the repo are the generated `BackgroundTasksChanged*` types belonging to the separate `session.background_tasks_changed` event.
- Every changed row keeps its table's column count; the two Node.js tables keep their existing pipe alignment.
- Docs only: no code, schema, generated file, or public API is touched, so codegen output is unchanged.

### Scope

Deliberately limited to the incorrect `session.idle` rows. No new event sections are added, and no other event's field table is changed.
