### PR TITLE
fix(python): serialize datetime/UUID/Decimal/Enum/set/dataclass in plain-dict tool results

### DIFF
--- a/python/copilot/tools.py
+++ b/python/copilot/tools.py
@@ -7,8 +7,13 @@ generation from Pydantic models.
 
 from __future__ import annotations
 
+import dataclasses
+import datetime
+import decimal
+import enum
 import inspect
 import json
+import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, get_type_hints, overload
@@ -352,6 +357,16 @@ def _normalize_result(result: Any) -> ToolResult:
     def default(obj: Any) -> Any:
         if isinstance(obj, BaseModel):
             return obj.model_dump(mode="json")
+        if isinstance(obj, (datetime.datetime, datetime.date, datetime.time)):
+            return obj.isoformat()
+        if isinstance(obj, (uuid.UUID, decimal.Decimal)):
+            return str(obj)
+        if isinstance(obj, enum.Enum):
+            return obj.value
+        if isinstance(obj, (set, frozenset)):
+            return list(obj)
+        if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+            return dataclasses.asdict(obj)
         raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
     try:

--- a/python/test_tools.py
+++ b/python/test_tools.py
@@ -432,6 +432,45 @@ class TestNormalizeResult:
         with pytest.raises(TypeError, match="Failed to serialize"):
             _normalize_result(lambda x: x)
 
+    def test_dict_with_non_primitive_values_is_serialized(self):
+        """Plain dicts containing datetime/UUID/Decimal/Enum/set serialize correctly."""
+        from dataclasses import dataclass
+        from datetime import date, datetime, time
+        from decimal import Decimal
+        from enum import Enum
+        from uuid import UUID
+
+        class Color(Enum):
+            RED = "red"
+
+        @dataclass
+        class Point:
+            x: int
+            y: int
+
+        result = _normalize_result({
+            "id": UUID("12345678-1234-5678-1234-567812345678"),
+            "created": datetime(2026, 1, 15, 10, 30, 0),
+            "day": date(2026, 1, 15),
+            "meeting_time": time(14, 30),
+            "score": Decimal("99.5"),
+            "color": Color.RED,
+            "tags": {"a", "b"},
+            "frozen": frozenset([1, 2]),
+            "point": Point(x=1, y=2),
+        })
+        parsed = json.loads(result.text_result_for_llm)
+        assert parsed["id"] == "12345678-1234-5678-1234-567812345678"
+        assert parsed["created"] == "2026-01-15T10:30:00"
+        assert parsed["day"] == "2026-01-15"
+        assert parsed["meeting_time"] == "14:30:00"
+        assert parsed["score"] == "99.5"
+        assert parsed["color"] == "red"
+        assert set(parsed["tags"]) == {"a", "b"}
+        assert set(parsed["frozen"]) == {1, 2}
+        assert parsed["point"] == {"x": 1, "y": 2}
+        assert result.result_type == "success"
+
 
 class TestConvertMcpCallToolResult:
     def test_text_only_call_tool_result(self):


### PR DESCRIPTION
## Summary

Fix silent tool failures when a `@define_tool` handler returns a plain dict (non-Pydantic) containing `datetime`, `UUID`, `Decimal`, `Enum`, `set`, or `dataclass` values.

### Problem

`_normalize_result` uses `json.dumps` with a `default` hook that only handles `BaseModel`. Any other non-JSON-native type raises `TypeError`, which `wrapped_handler` catches and reports to the model as:

> Invoking this tool produced an error. Detailed information is not available.

This is easy to hit (returning a dict with a timestamp or UUID) and hard to diagnose (the error is intentionally redacted).

### Fix

Add type-specific fallbacks in `default()`:

| Type | Serialization |
|------|--------------|
| `datetime` / `date` / `time` | `.isoformat()` |
| `UUID` / `Decimal` | `str()` |
| `Enum` | `.value` |
| `set` / `frozenset` | `list()` |
| `dataclass` | `dataclasses.asdict()` |

### Tests

New test `test_dict_with_non_primitive_values_is_serialized` covers all 9 types in a single plain-dict return. Existing `test_pydantic_model_with_non_primitive_fields_is_serialized` continues to pass (Pydantic path uses `model_dump(mode=json)`).

Partially addresses #2203.