### PR TITLE
chore(ci): bump Go 1.22 to 1.24 in codegen-check and update-copilot-dependency workflows

### DIFF
--- a/.github/workflows/codegen-check.yml
+++ b/.github/workflows/codegen-check.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
 
       # Rust generator runs `cargo fmt` on the output, so we need a toolchain with rustfmt.
       - name: Install Rust toolchain

--- a/.github/workflows/update-copilot-dependency.yml
+++ b/.github/workflows/update-copilot-dependency.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
 
       - uses: actions/setup-dotnet@v5
         with:


### PR DESCRIPTION
Two workflows still use Go 1.22 while go.mod requires Go 1.24 and other workflows already use 1.24. Changes: codegen-check.yml and update-copilot-dependency.yml go-version 1.22 to 1.24.