### PR TITLE
Parallelize Python and Windows .NET CI tests

### DIFF
--- a/.github/workflows/dotnet-sdk-tests.yml
+++ b/.github/workflows/dotnet-sdk-tests.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   test:
-    name: ".NET SDK Tests (${{ matrix.os }}, ${{ matrix.transport }}, ${{ matrix.backend }})"
+    name: ".NET SDK Tests (${{ matrix.os }}, ${{ matrix.transport }}, ${{ matrix.backend }}, ${{ matrix.shard }})"
     if: github.event.repository.fork == false
     env:
       POWERSHELL_UPDATECHECK: Off
@@ -24,22 +24,39 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         transport: ["default", "inprocess"]
         backend: [capi]
+        shard: [full]
         # TODO: Re-enable after fixing in-process sqlite file locking on shutdown on Windows.
         exclude:
           - os: windows-latest
             transport: "inprocess"
+          - os: windows-latest
+            transport: default
+            shard: full
         include:
+          # Keep xUnit serial within each process, but split the slow Windows
+          # default-transport suite across two isolated test hosts.
+          - os: windows-latest
+            transport: default
+            backend: capi
+            shard: "1"
+          - os: windows-latest
+            transport: default
+            backend: capi
+            shard: "2"
           - os: ubuntu-latest
             transport: inprocess
             backend: anthropic-messages
+            shard: full
             test-filter: "FullyQualifiedName~GitHub.Copilot.Test.E2E&E2EBackend!=SelfConfiguredBackend&E2EBackend!=CapiOnly"
           - os: ubuntu-latest
             transport: inprocess
             backend: openai-responses
+            shard: full
             test-filter: "FullyQualifiedName~GitHub.Copilot.Test.E2E&E2EBackend!=SelfConfiguredBackend&E2EBackend!=CapiOnly"
           - os: ubuntu-latest
             transport: inprocess
             backend: openai-completions
+            shard: full
             test-filter: "FullyQualifiedName~GitHub.Copilot.Test.E2E&E2EBackend!=SelfConfiguredBackend&E2EBackend!=CapiOnly"
     runs-on: ${{ matrix.os }}
     defaults:
@@ -92,9 +109,30 @@ jobs:
       - name: Run .NET SDK tests
         env:
           COPILOT_HMAC_KEY: ${{ secrets.COPILOT_DEVELOPER_CLI_INTEGRATION_HMAC_KEY }}
+          DOTNET_TEST_SHARD: ${{ matrix.shard }}
         run: |
           args=(--no-build -v n)
-          if [[ -n "$DOTNET_TEST_FILTER" ]]; then
-            args+=(--filter "$DOTNET_TEST_FILTER")
+
+          filter="$DOTNET_TEST_FILTER"
+          if [[ "$DOTNET_TEST_SHARD" != "full" ]]; then
+            if [[ "$DOTNET_TEST_SHARD" == "1" ]]; then
+              initials=(A C D H I J K L N Q S U W Y)
+              shard_filter="FullyQualifiedName~GitHub.Copilot.Test.ConnectionToken"
+            else
+              initials=(B E F G M O P R T V X Z)
+              shard_filter=""
+            fi
+
+            for namespace in E2E Unit; do
+              for initial in "${initials[@]}"; do
+                clause="FullyQualifiedName~GitHub.Copilot.Test.${namespace}.${initial}"
+                shard_filter="${shard_filter:+${shard_filter}|}${clause}"
+              done
+            done
+            filter="${filter:+(${filter})&}(${shard_filter})"
+          fi
+
+          if [[ -n "$filter" ]]; then
+            args+=(--filter "$filter")
           fi
           dotnet test "${args[@]}"

--- a/.github/workflows/python-sdk-tests.yml
+++ b/.github/workflows/python-sdk-tests.yml
@@ -79,4 +79,6 @@ jobs:
       - name: Run Python SDK tests
         env:
           COPILOT_HMAC_KEY: ${{ secrets.COPILOT_DEVELOPER_CLI_INTEGRATION_HMAC_KEY }}
-        run: uv run pytest -v -s
+        # Keep each module's shared E2E client and proxy on one process while
+        # running independent modules concurrently in isolated workers.
+        run: uv run pytest -v -s -n 2 --dist=loadfile

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "pytest-timeout>=2.0.0",
+    "pytest-xdist>=3.6.0",
     "websockets>=12.0",
     "opentelemetry-sdk>=1.0.0",
 ]


### PR DESCRIPTION
## Summary
- run Python tests in two `pytest-xdist` worker processes
- use file-level scheduling so each module-scoped E2E client and replay proxy remains on one worker
- split the slow Windows/default .NET suite across two isolated CI jobs
- keep xUnit execution serial within each process, avoiding the process-global environment and working-directory races that in-process class parallelism would introduce

## Results

Timings from the PR check run:

| Leg | Recent baseline | PR check |
| --- | ---: | ---: |
| Python, Ubuntu, default | 10.7 min | 5.8 min |
| Python, Windows, default | 21.6 min | 12.5 min |
| Python, Windows, in-process | 27.4 min | 15.8 min |
| .NET, Windows test step | 18.1 min | 10.7 min critical shard |
| .NET, Windows whole job | 21.9 min | 17.8 min critical shard |

The Windows .NET critical job was 17.8 minutes in the PR run because one shard had an anomalous 8.9-minute build; its test step was 7.5 minutes. In the separate all-SDK dispatch, builds were normal and the critical Windows shard completed in 15.4 minutes.

The overall PR workflow took 26.8 minutes because two unchanged Ubuntu .NET backend cells had anomalous 12.4- and 19.9-minute build steps. The same final commit completed the all-SDK dispatch in 16.3 minutes. This change does not parallelize or otherwise modify those Ubuntu cells.

The .NET shard filters cover all 710 discovered tests exactly once, split 355/355. All six SDK workflows passed on the final commit in [workflow run 30923106592](https://github.com/github/copilot-sdk/actions/runs/30923106592).

## Relationship to #2186

#2186 splits Windows .NET execution by target framework for isolation. This PR splits it by test class for latency. The approaches are complementary; if #2186 merges first, the matrix should compose both dimensions (two frameworks by two test shards).