### PR TITLE
docs: move SDK development guidance to local READMEs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,62 +33,25 @@ We are generally **not** looking for:
 - Additional documentation
 - **SDKs for other languages** — if you want to create a Copilot SDK for another language, we'd love to hear from you and may offer to link to your SDK from our repo. However we do not plan to add further language-specific SDKs to this repo in the short term, since we need to retain our maintenance capacity for moving forwards quickly with the existing language set. For other languages, please consider running your own external project.
 
-## Prerequisites for Running and Testing Code
+## Developing an SDK
 
-This is a multi-language SDK repository. Install the tools for the SDK(s) you plan to work on:
+Setup, build, and test instructions are maintained with each SDK:
 
-### All SDKs
-
-1. The end-to-end tests across all languages use a shared test harness written in Node.js. Before running tests in any language, `cd test/harness && npm ci`.
-
-### Node.js/TypeScript SDK
-
-1. Install [Node.js](https://nodejs.org/) (v18+)
-1. Install dependencies: `cd nodejs && npm ci`
-
-### Python SDK
-
-1. Install [Python 3.8+](https://www.python.org/downloads/)
-1. Install [uv](https://github.com/astral-sh/uv)
-1. Install dependencies: `cd python && uv pip install -e . --group dev`
-
-### Go SDK
-
-1. Install [Go 1.24+](https://go.dev/doc/install)
-1. Install [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation)
-1. Install dependencies: `cd go && go mod download`
-
-### .NET SDK
-
-1. Install [.NET SDK 10+](https://dotnet.microsoft.com/download)
-1. Install .NET dependencies: `cd dotnet && dotnet restore`
+- [Node.js/TypeScript](nodejs/README.md#development)
+- [Python](python/README.md#development)
+- [Go](go/README.md#development)
+- [.NET](dotnet/README.md#development)
+- [Rust](rust/README.md#development)
+- [Java](java/README.md#development)
 
 ## Submitting a Pull Request
 
 1. Fork and clone the repository
-1. Install dependencies for the SDK(s) you're modifying (see above)
-1. Make sure the tests pass on your machine (see commands below)
-1. Make sure linter passes on your machine (see commands below)
+1. Follow the development instructions for the SDK(s) you're modifying
 1. Create a new branch: `git checkout -b my-branch-name`
-1. Make your change, add tests, and make sure the tests and linter still pass
+1. Make your change, add tests, and run the documented checks
 1. Push to your fork and [submit a pull request][pr]
 1. Pat yourself on the back and wait for your pull request to be reviewed and merged.
-
-### Running Tests and Linters
-
-```bash
-# Node.js
-cd nodejs && npm test && npm run lint
-
-# Python
-cd python && uv run pytest && uv run ruff check .
-
-# Go
-cd go && go test ./... && golangci-lint run ./...
-
-# .NET
-cd dotnet && dotnet test test/GitHub.Copilot.SDK.Test.csproj
-```
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Setup, build, and test instructions are maintained with each SDK:
 - [Go](go/README.md#development)
 - [.NET](dotnet/README.md#development)
 - [Rust](rust/README.md#development)
-- [Java](java/README.md#development)
+- [Java](java/README.md#development-setup)
 
 ## Submitting a Pull Request
 

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1054,7 +1054,7 @@ npm ci
 
 ```bash
 cd dotnet
-GITHUB_ACTIONS=true dotnet test
+dotnet test
 ```
 
 ## License

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1038,6 +1038,22 @@ catch (Exception ex)
 }
 ```
 
+## Development
+
+Development requires [.NET SDK 10+](https://dotnet.microsoft.com/download) and a supported [Node.js version](../nodejs/README.md#prerequisites) for the runtime and shared test harness. From the repository root:
+
+```bash
+cd nodejs
+npm ci --ignore-scripts
+cd ../test/harness
+npm ci --ignore-scripts
+cd ../../dotnet
+dotnet restore
+dotnet format --verify-no-changes
+dotnet build --no-restore
+dotnet test --no-build -v n
+```
+
 ## License
 
 MIT

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1043,9 +1043,18 @@ catch (Exception ex)
 Development requires [.NET SDK 10+](https://dotnet.microsoft.com/download). From the repository root:
 
 ```bash
-(cd nodejs && npm ci)
-(cd test/harness && npm ci)
-cd dotnet && dotnet test
+cd nodejs
+npm ci
+```
+
+```bash
+cd test/harness
+npm ci
+```
+
+```bash
+cd dotnet
+GITHUB_ACTIONS=true dotnet test
 ```
 
 ## License

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1040,18 +1040,12 @@ catch (Exception ex)
 
 ## Development
 
-Development requires [.NET SDK 10+](https://dotnet.microsoft.com/download) and a supported [Node.js version](../nodejs/README.md#prerequisites) for the runtime and shared test harness. From the repository root:
+Development requires [.NET SDK 10+](https://dotnet.microsoft.com/download). From the repository root:
 
 ```bash
-cd nodejs
-npm ci --ignore-scripts
-cd ../test/harness
-npm ci --ignore-scripts
-cd ../../dotnet
-dotnet restore
-dotnet format --verify-no-changes
-dotnet build --no-restore
-dotnet test --no-build -v n
+(cd nodejs && npm ci)
+(cd test/harness && npm ci)
+cd dotnet && dotnet test
 ```
 
 ## License

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1040,7 +1040,7 @@ catch (Exception ex)
 
 ## Development
 
-Development requires [.NET SDK 10+](https://dotnet.microsoft.com/download). From the repository root:
+Development requires [.NET SDK 10+](https://dotnet.microsoft.com/download) and a supported [Node.js version](../nodejs/README.md#prerequisites). From the repository root:
 
 ```bash
 cd nodejs

--- a/go/README.md
+++ b/go/README.md
@@ -980,19 +980,12 @@ Communicates with CLI via TCP socket. Useful for distributed scenarios.
 
 ## Development
 
-Development requires Go 1.24+, [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation), and a supported [Node.js version](../nodejs/README.md#prerequisites) for the runtime and shared test harness. From the repository root:
+From the repository root:
 
 ```bash
-cd go
-go mod download
-go fmt ./...
-golangci-lint run --timeout=5m
-cd ../nodejs
-npm ci --ignore-scripts
-cd ../test/harness
-npm ci --ignore-scripts
-cd ../../go
-./test.sh
+(cd nodejs && npm ci)
+(cd test/harness && npm ci)
+cd go && ./test.sh
 ```
 
 ## License

--- a/go/README.md
+++ b/go/README.md
@@ -983,9 +983,18 @@ Communicates with CLI via TCP socket. Useful for distributed scenarios.
 From the repository root:
 
 ```bash
-(cd nodejs && npm ci)
-(cd test/harness && npm ci)
-cd go && ./test.sh
+cd nodejs
+npm ci
+```
+
+```bash
+cd test/harness
+npm ci
+```
+
+```bash
+cd go
+GITHUB_ACTIONS=true ./test.sh
 ```
 
 ## License

--- a/go/README.md
+++ b/go/README.md
@@ -980,7 +980,7 @@ Communicates with CLI via TCP socket. Useful for distributed scenarios.
 
 ## Development
 
-From the repository root:
+Tests require a supported [Node.js version](../nodejs/README.md#prerequisites). From the repository root:
 
 ```bash
 cd nodejs

--- a/go/README.md
+++ b/go/README.md
@@ -994,7 +994,7 @@ npm ci
 
 ```bash
 cd go
-GITHUB_ACTIONS=true ./test.sh
+./test.sh
 ```
 
 ## License

--- a/go/README.md
+++ b/go/README.md
@@ -978,6 +978,23 @@ Communicates with CLI via TCP socket. Useful for distributed scenarios.
 
 - `COPILOT_CLI_PATH` - Path to the Copilot CLI executable
 
+## Development
+
+Development requires Go 1.24+, [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation), and a supported [Node.js version](../nodejs/README.md#prerequisites) for the runtime and shared test harness. From the repository root:
+
+```bash
+cd go
+go mod download
+go fmt ./...
+golangci-lint run --timeout=5m
+cd ../nodejs
+npm ci --ignore-scripts
+cd ../test/harness
+npm ci --ignore-scripts
+cd ../../go
+./test.sh
+```
+
 ## License
 
 MIT

--- a/java/README.md
+++ b/java/README.md
@@ -420,12 +420,25 @@ The gate also applies to individual methods annotated with `@CopilotExperimental
 
 > Want to add your project? Open a PR!
 
-## Development
+### Development Setup
 
-Development requires JDK 25+ and [Maven](https://maven.apache.org/download.cgi). From the repository root:
+Requires JDK 25 or later for development. The following steps validate the artifact built with JDK 25 runs on both 25 and 17, preserving the MR-JAR behavior.
 
 ```bash
-cd java && mvn verify
+# Clone the repository
+git clone https://github.com/github/copilot-sdk.git
+cd copilot-sdk/java
+
+# Enable git hooks for code formatting
+git config core.hooksPath .githooks
+
+# Build and test with JDK 25
+mvn test-compile jar:jar
+mvn verify -Dskip.test.harness=true
+
+# Set your paths for JDK 17
+# Run the JDK 25 built jar with JDK 17 JVM for tests. Do not re-compile the jar.
+mvn jacoco:prepare-agent@wire-up-coverage-instrumentation antrun:run@print-test-jdk-banner surefire:test failsafe:integration-test failsafe:verify jacoco:report@build-coverage-report-from-tests -Denforcer.skip=true
 ```
 
 ## License

--- a/java/README.md
+++ b/java/README.md
@@ -422,7 +422,7 @@ The gate also applies to individual methods annotated with `@CopilotExperimental
 
 ### Development Setup
 
-Requires JDK 25 or later for development. The following steps validate the artifact built with JDK 25 runs on both 25 and 17, preserving the MR-JAR behavior.
+Requires JDK 25 or later and a supported [Node.js version](../nodejs/README.md#prerequisites) for development. The following steps validate the artifact built with JDK 25 runs on both 25 and 17, preserving the MR-JAR behavior.
 
 ```bash
 # Clone the repository

--- a/java/README.md
+++ b/java/README.md
@@ -422,20 +422,10 @@ The gate also applies to individual methods annotated with `@CopilotExperimental
 
 ## Development
 
-Development requires JDK 25+, [Maven](https://maven.apache.org/download.cgi), and a supported [Node.js version](../nodejs/README.md#prerequisites). Testing the multi-release JAR also requires JDK 17.
+Development requires JDK 25+ and [Maven](https://maven.apache.org/download.cgi). From the repository root:
 
 ```bash
-# From the repository root
-cd java
-git config core.hooksPath .githooks
-
-# Build and test with JDK 25
-mvn test-compile jar:jar
-mvn spotless:check
-mvn verify -Dskip.test.harness=true
-
-# Switch JAVA_HOME and PATH to JDK 17, then test without recompiling
-mvn jacoco:prepare-agent@wire-up-coverage-instrumentation antrun:run@print-test-jdk-banner surefire:test failsafe:integration-test failsafe:verify jacoco:report@build-coverage-report-from-tests -Denforcer.skip=true
+cd java && mvn verify
 ```
 
 ## License

--- a/java/README.md
+++ b/java/README.md
@@ -420,24 +420,21 @@ The gate also applies to individual methods annotated with `@CopilotExperimental
 
 > Want to add your project? Open a PR!
 
-### Development Setup
+## Development
 
-Requires JDK 25 or later for development. The following steps validate the artifact built with JDK 25 runs on both 25 and 17, preserving the MR-JAR behavior.
+Development requires JDK 25+, [Maven](https://maven.apache.org/download.cgi), and a supported [Node.js version](../nodejs/README.md#prerequisites). Testing the multi-release JAR also requires JDK 17.
 
 ```bash
-# Clone the repository
-git clone https://github.com/github/copilot-sdk.git
-cd copilot-sdk/java
-
-# Enable git hooks for code formatting
+# From the repository root
+cd java
 git config core.hooksPath .githooks
 
 # Build and test with JDK 25
 mvn test-compile jar:jar
+mvn spotless:check
 mvn verify -Dskip.test.harness=true
 
-# Set your paths for JDK 17
-# Run the JDK 25 built jar with JDK 17 JVM for tests. Do not re-compile the jar.
+# Switch JAVA_HOME and PATH to JDK 17, then test without recompiling
 mvn jacoco:prepare-agent@wire-up-coverage-instrumentation antrun:run@print-test-jdk-banner surefire:test failsafe:integration-test failsafe:verify jacoco:report@build-coverage-report-from-tests -Denforcer.skip=true
 ```
 

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -1121,7 +1121,7 @@ npm ci
 ```bash
 cd nodejs
 npm ci
-GITHUB_ACTIONS=true npm test
+npm test
 ```
 
 ## License

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -1111,19 +1111,11 @@ try {
 
 ## Development
 
-Development requires a supported Node.js version listed in [Prerequisites](#prerequisites). From the repository root:
+From the repository root:
 
 ```bash
-cd nodejs
-npm ci --ignore-scripts
-npm run format:check
-npm run lint
-npm run typecheck
-npm run build
-cd ../test/harness
-npm ci --ignore-scripts
-cd ../../nodejs
-npm test
+(cd test/harness && npm ci)
+cd nodejs && npm ci && npm test
 ```
 
 ## License

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -1114,8 +1114,14 @@ try {
 From the repository root:
 
 ```bash
-(cd test/harness && npm ci)
-cd nodejs && npm ci && npm test
+cd test/harness
+npm ci
+```
+
+```bash
+cd nodejs
+npm ci
+GITHUB_ACTIONS=true npm test
 ```
 
 ## License

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -1109,6 +1109,23 @@ try {
 }
 ```
 
+## Development
+
+Development requires a supported Node.js version listed in [Prerequisites](#prerequisites). From the repository root:
+
+```bash
+cd nodejs
+npm ci --ignore-scripts
+npm run format:check
+npm run lint
+npm run typecheck
+npm run build
+cd ../test/harness
+npm ci --ignore-scripts
+cd ../../nodejs
+npm test
+```
+
 ## License
 
 MIT

--- a/python/README.md
+++ b/python/README.md
@@ -1145,18 +1145,10 @@ When `on_elicitation_request` is provided, the SDK automatically:
 
 ## Development
 
-Development requires Python 3.11+, [uv](https://docs.astral.sh/uv/), and a supported [Node.js version](../nodejs/README.md#prerequisites) for the runtime and shared test harness. From the repository root:
+Install [uv](https://docs.astral.sh/uv/), then from the repository root:
 
 ```bash
-cd python
-uv sync --all-extras --dev
-uv run ruff format --check .
-uv run ruff check
-uv run ty check copilot
-cd ../nodejs
-npm ci --ignore-scripts
-cd ../test/harness
-npm ci --ignore-scripts
-cd ../../python
-uv run pytest -v -s
+(cd nodejs && npm ci)
+(cd test/harness && npm ci)
+cd python && uv sync && uv run pytest
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -1142,3 +1142,21 @@ When `on_elicitation_request` is provided, the SDK automatically:
 - Reports the `elicitation` capability on the session
 - Dispatches `elicitation.requested` events to your handler
 - Auto-cancels if your handler throws an error (so the server doesn't hang)
+
+## Development
+
+Development requires Python 3.11+, [uv](https://docs.astral.sh/uv/), and a supported [Node.js version](../nodejs/README.md#prerequisites) for the runtime and shared test harness. From the repository root:
+
+```bash
+cd python
+uv sync --all-extras --dev
+uv run ruff format --check .
+uv run ruff check
+uv run ty check copilot
+cd ../nodejs
+npm ci --ignore-scripts
+cd ../test/harness
+npm ci --ignore-scripts
+cd ../../python
+uv run pytest -v -s
+```

--- a/python/README.md
+++ b/python/README.md
@@ -1148,7 +1148,17 @@ When `on_elicitation_request` is provided, the SDK automatically:
 Install [uv](https://docs.astral.sh/uv/), then from the repository root:
 
 ```bash
-(cd nodejs && npm ci)
-(cd test/harness && npm ci)
-cd python && uv sync && uv run pytest
+cd nodejs
+npm ci
+```
+
+```bash
+cd test/harness
+npm ci
+```
+
+```bash
+cd python
+uv sync
+GITHUB_ACTIONS=true uv run pytest
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -1145,7 +1145,7 @@ When `on_elicitation_request` is provided, the SDK automatically:
 
 ## Development
 
-Install [uv](https://docs.astral.sh/uv/), then from the repository root:
+Install [uv](https://docs.astral.sh/uv/) and a supported [Node.js version](../nodejs/README.md#prerequisites), then from the repository root:
 
 ```bash
 cd nodejs

--- a/python/README.md
+++ b/python/README.md
@@ -1160,5 +1160,5 @@ npm ci
 ```bash
 cd python
 uv sync
-GITHUB_ACTIONS=true uv run pytest
+uv run pytest
 ```

--- a/rust/README.md
+++ b/rust/README.md
@@ -968,7 +968,7 @@ github-copilot-sdk = { version = "0.1", features = ["derive"] }
 
 ## Development
 
-From the repository root:
+Tests require a supported [Node.js version](../nodejs/README.md#prerequisites). From the repository root:
 
 ```bash
 cd nodejs

--- a/rust/README.md
+++ b/rust/README.md
@@ -971,6 +971,16 @@ github-copilot-sdk = { version = "0.1", features = ["derive"] }
 From the repository root:
 
 ```bash
-(cd test/harness && npm ci)
-cd rust && cargo test
+cd nodejs
+npm ci
+```
+
+```bash
+cd test/harness
+npm ci
+```
+
+```bash
+cd rust
+cargo test --features test-support
 ```

--- a/rust/README.md
+++ b/rust/README.md
@@ -968,19 +968,9 @@ github-copilot-sdk = { version = "0.1", features = ["derive"] }
 
 ## Development
 
-The repository pins Rust 1.94.0 in `rust-toolchain.toml`. The tests also require a supported [Node.js version](../nodejs/README.md#prerequisites) for the shared test harness. Formatting requires the pinned nightly toolchain:
-
-```bash
-rustup toolchain install nightly-2026-04-14 --component rustfmt
-```
-
 From the repository root:
 
 ```bash
-cd test/harness
-npm ci --ignore-scripts
-cd ../../rust
-cargo +nightly-2026-04-14 fmt --all -- --config-path .rustfmt.nightly.toml --check
-cargo clippy --all-targets --features test-support,bundled-in-process -- --no-deps -D warnings -D clippy::unwrap_used -D clippy::disallowed_macros -D clippy::await_holding_invalid_type
-cargo test
+(cd test/harness && npm ci)
+cd rust && cargo test
 ```

--- a/rust/README.md
+++ b/rust/README.md
@@ -965,3 +965,22 @@ github-copilot-sdk = { version = "0.1", default-features = false }
 # Derive JSON Schema for tool parameters (adds to default bundled-cli).
 github-copilot-sdk = { version = "0.1", features = ["derive"] }
 ```
+
+## Development
+
+The repository pins Rust 1.94.0 in `rust-toolchain.toml`. The tests also require a supported [Node.js version](../nodejs/README.md#prerequisites) for the shared test harness. Formatting requires the pinned nightly toolchain:
+
+```bash
+rustup toolchain install nightly-2026-04-14 --component rustfmt
+```
+
+From the repository root:
+
+```bash
+cd test/harness
+npm ci --ignore-scripts
+cd ../../rust
+cargo +nightly-2026-04-14 fmt --all -- --config-path .rustfmt.nightly.toml --check
+cargo clippy --all-targets --features test-support,bundled-in-process -- --no-deps -D warnings -D clippy::unwrap_used -D clippy::disallowed_macros -D clippy::await_holding_invalid_type
+cargo test
+```


### PR DESCRIPTION
## Summary

- keep the top-level contribution guide focused on shared policy and links to each SDK README
- add only the prerequisites and commands needed to install dependencies and run each SDK's tests
- use the existing per-language manifests and READMEs as the source of version requirements

This is a smaller alternative to #2247 that avoids duplicating mutable language-specific instructions in `CONTRIBUTING.md`.

## Validation

- ran the documented Node.js workflow, including E2E tests
- verified Python setup with `uv sync` and ran its formatting, linting, and type checks
- checked every development command block for valid shell syntax and every top-level README link/anchor