### PR TITLE
docs: correct the Python Customize Mode section IDs and action list

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -710,9 +710,9 @@ async with await client.create_session(
     ...
 ```
 
-Available section IDs: `"identity"`, `"tone"`, `"tool_efficiency"`, `"environment_context"`, `"code_change_rules"`, `"guidelines"`, `"safety"`, `"tool_instructions"`, `"custom_instructions"`, `"last_instructions"`.
+Available section IDs: `"preamble"`, `"identity"`, `"tone"`, `"tool_efficiency"`, `"environment_context"`, `"code_change_rules"`, `"guidelines"`, `"safety"`, `"tool_instructions"`, `"custom_instructions"`, `"runtime_instructions"`, `"last_instructions"`. `"identity"` and `"tool_instructions"` are section groups that target a collection of related sub-sections as a unit; use `"preamble"` to target just the identity preamble.
 
-Each section override supports four string actions: `"replace"`, `"remove"`, `"append"`, and `"prepend"`. Unknown section IDs are handled gracefully: content is appended to additional instructions, and `"remove"` overrides are silently ignored.
+Each section override supports five string actions: `"replace"`, `"remove"`, `"append"`, `"prepend"`, and `"preserve"` (a no-op that opts an individually-addressable section out of a group-level `"remove"`). Unknown section IDs are handled gracefully: content from `"replace"`/`"append"`/`"prepend"` overrides is appended to additional instructions, and `"remove"` overrides are silently ignored.
 
 You can also pass a transform callback as the `action` instead of a string. The callback receives the current section content and returns the new content (sync or async):
 


### PR DESCRIPTION
Fixes #2263

The Python README's "Customize Mode" section listed 10 section IDs and described "four string actions". The shipped Python API exposes 12 sections and 5 string actions, so `preamble`, `runtime_instructions` and `preserve` were undiscoverable for anyone following the Python README.

## The change

Two lines in `python/README.md`:

- the "Available section IDs" list now enumerates all 12 members of `SystemMessageSection`, in declaration order, and notes that `identity` and `tool_instructions` are section groups and that `preamble` targets just the identity preamble;
- the actions sentence now says "five string actions" and includes `preserve`, with a short gloss of what it is for, and the unknown-section sentence is scoped to the content-bearing actions.

Both additions reuse the wording already in `dotnet/README.md`, `nodejs/README.md`, `go/README.md` and `docs/getting-started.md`, so the Python README now matches the rest of the documentation rather than introducing a new phrasing.

No code changes.

## What the package actually exposes

```bash
pip install github-copilot-sdk
python surface.py
```

`surface.py`:

```python
import typing

from copilot.session import SectionOverrideAction, SystemMessageSection

section_ids = typing.get_args(SystemMessageSection)
literal_arm = next(
    arg for arg in typing.get_args(SectionOverrideAction)
    if typing.get_origin(arg) is typing.Literal
)
string_actions = typing.get_args(literal_arm)

print(len(section_ids), "section IDs:", list(section_ids))
print(len(string_actions), "string actions:", list(string_actions))
```

Output:

```
12 section IDs: ['preamble', 'identity', 'tone', 'tool_efficiency', 'environment_context', 'code_change_rules', 'guidelines', 'safety', 'tool_instructions', 'custom_instructions', 'runtime_instructions', 'last_instructions']
5 string actions: ['replace', 'remove', 'append', 'prepend', 'preserve']
```

The README previously listed 10 of those 12 section IDs (omitting `preamble` and `runtime_instructions`) and 4 of those 5 actions (omitting `preserve`). After this change it lists all 12 and all 5, in the order shown above.

## Checks

`python/README.md` is the only file changed, so no Python code path is affected.

Run in `python/`:

- `uv run ruff format --check .` — passes
- `uv run ruff check` — `All checks passed!`
- `uv run ty check copilot` — exits 0
