### PR TITLE
fix(java): preserve MCP permission extension data

### DIFF
--- a/java/src/main/java/com/github/copilot/rpc/PermissionRequest.java
+++ b/java/src/main/java/com/github/copilot/rpc/PermissionRequest.java
@@ -5,8 +5,10 @@
 package com.github.copilot.rpc;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -44,6 +46,14 @@ public class PermissionRequest {
     private Boolean managedApprovalRequired;
 
     private Map<String, Object> extensionData;
+
+    @JsonAnySetter
+    private void setExtensionDataEntry(String key, Object value) {
+        if (extensionData == null) {
+            extensionData = new LinkedHashMap<>();
+        }
+        extensionData.put(key, value);
+    }
 
     private static final class ManagedApprovalRequiredDeserializer extends JsonDeserializer<Boolean> {
 

--- a/java/src/test/java/com/github/copilot/DataObjectCoverageTest.java
+++ b/java/src/test/java/com/github/copilot/DataObjectCoverageTest.java
@@ -139,6 +139,22 @@ class DataObjectCoverageTest {
         assertEquals("value", req.getExtensionData().get("key"));
     }
 
+    @Test
+    void permissionRequestPreservesMcpExtensionData() {
+        var request = PermissionRequest.fromJsonValue(java.util.Map.of(
+                "kind", "mcp",
+                "serverName", "playwright",
+                "toolName", "playwright-browser_navigate",
+                "args", java.util.Map.of("url", "http://127.0.0.1:8106/docs/target-app/")));
+
+        assertEquals("mcp", request.getKind());
+        assertEquals("playwright", request.getExtensionData().get("serverName"));
+        assertEquals("playwright-browser_navigate", request.getExtensionData().get("toolName"));
+        @SuppressWarnings("unchecked")
+        var args = (java.util.Map<String, Object>) request.getExtensionData().get("args");
+        assertEquals("http://127.0.0.1:8106/docs/target-app/", args.get("url"));
+    }
+
     // ===== SectionOverride setContent =====
 
     @Test

--- a/java/src/test/java/com/github/copilot/DataObjectCoverageTest.java
+++ b/java/src/test/java/com/github/copilot/DataObjectCoverageTest.java
@@ -155,6 +155,13 @@ class DataObjectCoverageTest {
         assertEquals("http://127.0.0.1:8106/docs/target-app/", args.get("url"));
     }
 
+    @Test
+    void permissionRequestWithoutExtensionDataPreservesNull() {
+        var request = PermissionRequest.fromJsonValue(java.util.Map.of("kind", "read", "toolCallId", "tool-123"));
+
+        assertNull(request.getExtensionData());
+    }
+
     // ===== SectionOverride setContent =====
 
     @Test

--- a/java/src/test/java/com/github/copilot/DataObjectCoverageTest.java
+++ b/java/src/test/java/com/github/copilot/DataObjectCoverageTest.java
@@ -141,11 +141,9 @@ class DataObjectCoverageTest {
 
     @Test
     void permissionRequestPreservesMcpExtensionData() {
-        var request = PermissionRequest.fromJsonValue(java.util.Map.of(
-                "kind", "mcp",
-                "serverName", "playwright",
-                "toolName", "playwright-browser_navigate",
-                "args", java.util.Map.of("url", "http://127.0.0.1:8106/docs/target-app/")));
+        var request = PermissionRequest.fromJsonValue(
+                java.util.Map.of("kind", "mcp", "serverName", "playwright", "toolName", "playwright-browser_navigate",
+                        "args", java.util.Map.of("url", "http://127.0.0.1:8106/docs/target-app/")));
 
         assertEquals("mcp", request.getKind());
         assertEquals("playwright", request.getExtensionData().get("serverName"));


### PR DESCRIPTION
## Summary

Preserve MCP-specific permission request fields in Java `PermissionRequest.extensionData`.

Jackson previously ignored unknown fields such as `serverName`, `toolName`, and nested `args`, preventing permission handlers from making scoped approval decisions. A private `@JsonAnySetter` now captures those fields lazily without changing the existing `null` behavior when no extension fields are present.

## Tests

- Added an MCP-shaped deserialization regression test covering `serverName`, `toolName`, and `args.url`.
- `mvnw.cmd test -Dtest=DataObjectCoverageTest -Denforcer.skip=true -Pskip-test-harness` (28 tests passed)
- Changed-file Spotless check passed
- Checkstyle passed with 0 violations

Fixes #2273.