### PR TITLE
SDK, Runtime: Recover JSON-RPC frames containing unpaired UTF-16 surrogates

### DIFF
--- a/rust/src/jsonrpc.rs
+++ b/rust/src/jsonrpc.rs
@@ -169,6 +169,68 @@ impl JsonRpcResponse {
 
 const CONTENT_LENGTH_HEADER: &str = "Content-Length: ";
 
+/// Rewrites unpaired UTF-16 surrogate escapes to `\uFFFD`.
+///
+/// Returns `None` when the body contains no unpaired surrogate, so valid
+/// frames do not incur a repair allocation.
+fn repair_lone_surrogates(body: &[u8]) -> Option<Vec<u8>> {
+    fn hex_escape_at(body: &[u8], index: usize) -> Option<u16> {
+        let digits = body.get(index + 2..index + 6)?;
+        let text = std::str::from_utf8(digits).ok()?;
+        u16::from_str_radix(text, 16).ok()
+    }
+
+    let mut repaired = None;
+    let mut in_string = false;
+    let mut index = 0;
+
+    while index < body.len() {
+        let byte = body[index];
+
+        if !in_string {
+            in_string = byte == b'"';
+            index += 1;
+            continue;
+        }
+
+        match byte {
+            b'"' => {
+                in_string = false;
+                index += 1;
+            }
+            // Consume non-Unicode escapes whole so an escaped backslash cannot
+            // be mistaken for the start of a surrogate escape.
+            b'\\' if body.get(index + 1) != Some(&b'u') => index += 2,
+            b'\\' => {
+                let Some(unit) = hex_escape_at(body, index) else {
+                    index += 2;
+                    continue;
+                };
+
+                let is_pair = (0xD800..0xDC00).contains(&unit)
+                    && body.get(index + 6) == Some(&b'\\')
+                    && body.get(index + 7) == Some(&b'u')
+                    && hex_escape_at(body, index + 6)
+                        .is_some_and(|low| (0xDC00..0xE000).contains(&low));
+
+                if is_pair {
+                    index += 12;
+                    continue;
+                }
+
+                if (0xD800..0xE000).contains(&unit) {
+                    let output = repaired.get_or_insert_with(|| body.to_vec());
+                    output[index..index + 6].copy_from_slice(br"\ufffd");
+                }
+                index += 6;
+            }
+            _ => index += 1,
+        }
+    }
+
+    repaired
+}
+
 /// One framed JSON-RPC message handed to the writer actor.
 ///
 /// `frame` is the fully serialized bytes (header + body); the caller pays
@@ -428,8 +490,26 @@ impl JsonRpcClient {
         let mut body = vec![0u8; length];
         reader.read_exact(&mut body).await?;
 
-        let message: JsonRpcMessage = serde_json::from_slice(&body)?;
-        Ok(Some(message))
+        match serde_json::from_slice::<JsonRpcMessage>(&body) {
+            Ok(message) => Ok(Some(message)),
+            Err(error) => {
+                // Dropping an undecodable frame could leave its pending
+                // request waiting forever because this layer has no timeout.
+                match repair_lone_surrogates(&body)
+                    .and_then(|repaired| serde_json::from_slice::<JsonRpcMessage>(&repaired).ok())
+                {
+                    Some(message) => {
+                        warn!(
+                            error = %error,
+                            length,
+                            "recovered JSON-RPC frame containing unpaired UTF-16 surrogates"
+                        );
+                        Ok(Some(message))
+                    }
+                    None => Err(error.into()),
+                }
+            }
+        }
     }
 
     /// Send a JSON-RPC request and wait for the matching response.

--- a/rust/tests/jsonrpc_test.rs
+++ b/rust/tests/jsonrpc_test.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::unwrap_used)]
 
 use github_copilot_sdk::test_support::{JsonRpcClient, JsonRpcNotification, JsonRpcRequest};
-use tokio::io::{AsyncWrite, AsyncWriteExt, duplex};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, duplex};
 use tokio::sync::{broadcast, mpsc};
 
 /// Write a Content-Length framed JSON-RPC message to a writer.
@@ -11,6 +11,28 @@ async fn write_framed(writer: &mut (impl AsyncWrite + Unpin), body: &[u8]) {
     writer.write_all(header.as_bytes()).await.unwrap();
     writer.write_all(body).await.unwrap();
     writer.flush().await.unwrap();
+}
+
+async fn read_framed(reader: &mut (impl AsyncRead + Unpin)) -> Vec<u8> {
+    let mut header = String::new();
+    loop {
+        let mut byte = [0u8; 1];
+        reader.read_exact(&mut byte).await.unwrap();
+        header.push(byte[0] as char);
+        if header.ends_with("\r\n\r\n") {
+            break;
+        }
+    }
+
+    let length = header
+        .trim()
+        .strip_prefix("Content-Length: ")
+        .unwrap()
+        .parse()
+        .unwrap();
+    let mut body = vec![0u8; length];
+    reader.read_exact(&mut body).await.unwrap();
+    body
 }
 
 #[tokio::test]
@@ -408,5 +430,118 @@ async fn send_request_cancellation_does_not_leak_pending() {
 
     let response = client.send_request("second", None).await.unwrap();
     assert_eq!(response.result.unwrap()["ok"], true);
+    server_task.await.unwrap();
+}
+
+#[test]
+fn lone_surrogate_yields_unexpected_end_of_hex_escape() {
+    let error = serde_json::from_slice::<serde_json::Value>(br#""\ud83d""#).unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "unexpected end of hex escape at line 1 column 8"
+    );
+}
+
+#[tokio::test]
+async fn lone_surrogate_frame_is_recovered_without_closing_connection() {
+    let (client_write, mut server_read) = duplex(4096);
+    let (mut server_write, client_read) = duplex(4096);
+    let (notification_tx, _) = broadcast::channel(16);
+    let (request_tx, _) = mpsc::unbounded_channel();
+    let client = JsonRpcClient::new(client_write, client_read, notification_tx, request_tx);
+
+    let server_task = tokio::spawn(async move {
+        let request: JsonRpcRequest =
+            serde_json::from_slice(&read_framed(&mut server_read).await).unwrap();
+        let response = format!(
+            r#"{{"jsonrpc":"2.0","id":{},"result":{{"name":"invalid \ud83d value"}}}}"#,
+            request.id
+        );
+        write_framed(&mut server_write, response.as_bytes()).await;
+
+        let request: JsonRpcRequest =
+            serde_json::from_slice(&read_framed(&mut server_read).await).unwrap();
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": request.id,
+            "result": {"name": "still connected"}
+        });
+        write_framed(&mut server_write, &serde_json::to_vec(&response).unwrap()).await;
+    });
+
+    let response = client.send_request("models.list", None).await.unwrap();
+    assert_eq!(
+        response.result.unwrap()["name"],
+        serde_json::json!("invalid \u{FFFD} value")
+    );
+
+    let response = client.send_request("account.getQuota", None).await.unwrap();
+    assert_eq!(
+        response.result.unwrap()["name"],
+        serde_json::json!("still connected")
+    );
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn unrepairable_frame_remains_fatal() {
+    let (client_write, mut server_read) = duplex(4096);
+    let (mut server_write, client_read) = duplex(4096);
+    let (notification_tx, _) = broadcast::channel(16);
+    let (request_tx, _) = mpsc::unbounded_channel();
+    let client = JsonRpcClient::new(client_write, client_read, notification_tx, request_tx);
+
+    let server_task = tokio::spawn(async move {
+        let request: JsonRpcRequest =
+            serde_json::from_slice(&read_framed(&mut server_read).await).unwrap();
+        let response = format!(
+            r#"{{"jsonrpc":"2.0","id":{},"result":{{"surrogate":"\ud83d","escape":"\q"}}}}"#,
+            request.id
+        );
+        write_framed(&mut server_write, response.as_bytes()).await;
+    });
+
+    let error = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        client.send_request("models.list", None),
+    )
+    .await
+    .expect("unrepairable frame did not terminate the pending request")
+    .unwrap_err();
+
+    assert_eq!(error.to_string(), "request cancelled");
+    assert!(error.is_transport_failure());
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn valid_pairs_and_escaped_backslashes_are_untouched() {
+    let (client_write, mut server_read) = duplex(4096);
+    let (mut server_write, client_read) = duplex(4096);
+    let (notification_tx, _) = broadcast::channel(16);
+    let (request_tx, _) = mpsc::unbounded_channel();
+    let client = JsonRpcClient::new(client_write, client_read, notification_tx, request_tx);
+
+    let server_task = tokio::spawn(async move {
+        let request: JsonRpcRequest =
+            serde_json::from_slice(&read_framed(&mut server_read).await).unwrap();
+        let response = format!(
+            r#"{{"jsonrpc":"2.0","id":{},"result":{{"emoji":"\ud83d\ude00","path":"C:\\ud83d","invalid":"\ud83d"}}}}"#,
+            request.id
+        );
+        write_framed(&mut server_write, response.as_bytes()).await;
+    });
+
+    let result = client
+        .send_request("models.list", None)
+        .await
+        .unwrap()
+        .result
+        .unwrap();
+
+    assert_eq!(result["emoji"], serde_json::json!("😀"));
+    assert_eq!(result["path"], serde_json::json!(r"C:\ud83d"));
+    assert_eq!(result["invalid"], serde_json::json!("\u{FFFD}"));
     server_task.await.unwrap();
 }


### PR DESCRIPTION
## Why

This PR fixes a problem that appeared in the github-app but appears to be a broader fix in the SDK. 

Fixes github/app#678
Fixes github/app#1055

...and likely others.

The symptom is that the model picker in the App is permanently empty for some users, along with the quota counter and the agents/skills lists. All four report `request cancelled`, the failure is 100% reproducible across restarts, and re-authorization does not clear it.

Root cause appears to be  a single unpaired UTF-16 surrogate in a CLI response (github/app#1055 has good data):

- `serde_json` correctly rejects lone surrogates per RFC 8259, failing with `unexpected end of hex escape`.
- The JSON-RPC read loop treats *any* decode failure as fatal: it breaks, then drains `pending_requests`, so every in-flight call resolves as `RequestCancelled`.
- Consumers that multiplex several RPCs over one client lose all of them at once. In the desktop app a single shared client carries `models.list`, `account.getQuota`, `agents.discover` and `skills.discover`, so one bad frame takes out all four.
- `is_transport_failure()` is true, so the consumer spawns a fresh CLI, which refetches the same payload and dies at the same byte offset. Deterministic, and it survives restarts — matching the reporter's "same column 256886 across every restart".

The CLI subprocess is the victim here, not the cause: its `write EPIPE` flood is just the SDK having closed the pipe after the parse error.

## What changed

Repair unpaired surrogates to `U+FFFD` (matching JavaScript's `String.prototype.toWellFormed`) and retry the decode once.

Two properties keep this contained:

- **The repair only runs after a strict parse has already failed.** Well-formed frames never enter the repair path, so they are byte-identical to before and the happy path allocates nothing.
- **Frames the repair cannot fix stay fatal, exactly as before.** Without a trustworthy decode we cannot tell which pending request a frame belonged to, and silently dropping it would hang that caller forever — `send_request_with_inline_callback` awaits its oneshot with no transport-layer deadline. Those still return the original `serde_json` error, preserving the existing fast-fail-and-replace recovery.

Net effect: exactly one input class changes behavior — a frame whose only defect is an unpaired surrogate.

The scanner tracks string context and consumes non-`\u` escapes whole, so a literal `C:\\ud83d` is never mistaken for an escape prefix, and valid surrogate pairs pass through untouched.

## Demo

`rust/tests/jsonrpc_test.rs` covers this end of it:

- the root-cause payload produces the exact error string from the issue logs
- a `#1055`-shaped frame is recovered and delivered with `U+FFFD` substituted, and the connection stays up for a subsequent request
- an unrepairable frame **remains fatal** — this guards the narrow scope above and fails if a caller is ever left hanging
- valid surrogate pairs and escaped backslashes are untouched, verified in a frame that also contains a lone surrogate so the repair path genuinely runs

Reverting the fix while keeping the tests fails `lone_surrogate_frame_is_recovered_without_closing_connection` and `valid_pairs_and_escaped_backslashes_are_untouched`, both unwrapping `Protocol(RequestCancelled)`.

The fix was also validated against the real desktop app and real CLI subprocesses before being brought upstream, by splicing a lone surrogate into live `models.list` frames via a temporary debug-only injector (never committed).

Same injected payload, two builds:

| | repair disabled | repair enabled |
| --- | --- | --- |
| `ERROR ... error reading from CLI` | 4 | 0 |
| `failed to list models` / `fetch account quota` | yes | 0 |
| `request cancelled` | yes | 0 |
| connection lost / client replaced | yes | 0 |
| frames recovered | — | 3 |
| CLI respawns | repeated | 0 (one pid throughout) |

With the fix, a single CLI pid survived all three corrupted frames, across two different RPCs on the shared channel:

```
WARN jsonrpc_read_loop: recovered JSON-RPC frame containing unpaired UTF-16 surrogates
     error=unexpected end of hex escape at line 1 column 72  length=25422
```

The original `serde_json` message is preserved in the `error=` field, so the diagnostic is kept rather than swallowed.

## Notes

- Review focus: `repair_lone_surrogates`. It is a hand-rolled byte scanner on the JSON-RPC read path, so the string-context and backslash-parity handling is where a bug would hide. It only ever runs on already-failed frames.
- This is client-side hardening. The real fix belongs with whatever produces the lone surrogate — it should not reach the wire — but the SDK should not lose an entire CLI connection over one bad character. The producer path is not in this repo, so its origin could not be established here.
- Adjacent issue found while investigating, deliberately **not** addressed here: `send_request_with_inline_callback` has no timeout, so any lost response hangs its caller indefinitely. That is the reason unrepairable frames must stay fatal, and it is worth revisiting on its own.
- Other language SDKs are out of scope. JavaScript's `JSON.parse` accepts lone surrogates natively so the TS SDK likely never had this bug; the strict-parser SDKs should be assessed separately rather than receiving unverified cross-language changes.
- github-app vendors this crate, so the fix reaches the desktop app via `scripts/sync-copilot-sdk.sh` once this merges.