### PR TITLE
Rust: add race-safe canvas availability waiter

### DIFF
--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -131,6 +131,24 @@ pub enum SessionErrorKind {
     /// The session event loop exited before a pending `send_and_wait` completed.
     EventLoopClosed,
 
+    /// A requested canvas did not become available before the wait timeout.
+    CanvasWaitTimeout {
+        /// Provider-local canvas identifier.
+        canvas_id: String,
+        /// Owning provider identifier, when the wait was provider-specific.
+        extension_id: Option<String>,
+        /// Configured wait timeout.
+        timeout: Duration,
+    },
+
+    /// The session shut down while waiting for a canvas.
+    CanvasWaitSessionClosed {
+        /// Provider-local canvas identifier.
+        canvas_id: String,
+        /// Owning provider identifier, when the wait was provider-specific.
+        extension_id: Option<String>,
+    },
+
     /// Elicitation is not supported by the host.
     /// Check `session.capabilities().ui.elicitation` before calling UI methods.
     ElicitationNotSupported,
@@ -165,6 +183,36 @@ impl fmt::Display for SessionErrorKind {
             }
             SessionErrorKind::EventLoopClosed => {
                 write!(f, "event loop closed before session reached idle")
+            }
+            SessionErrorKind::CanvasWaitTimeout {
+                canvas_id,
+                extension_id,
+                timeout,
+            } => {
+                if let Some(extension_id) = extension_id {
+                    write!(
+                        f,
+                        "timed out after {timeout:?} waiting for canvas {extension_id}:{canvas_id}"
+                    )
+                } else {
+                    write!(
+                        f,
+                        "timed out after {timeout:?} waiting for canvas {canvas_id}"
+                    )
+                }
+            }
+            SessionErrorKind::CanvasWaitSessionClosed {
+                canvas_id,
+                extension_id,
+            } => {
+                if let Some(extension_id) = extension_id {
+                    write!(
+                        f,
+                        "session closed while waiting for canvas {extension_id}:{canvas_id}"
+                    )
+                } else {
+                    write!(f, "session closed while waiting for canvas {canvas_id}")
+                }
             }
             SessionErrorKind::ElicitationNotSupported => write!(
                 f,

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -12,8 +12,8 @@ use tracing::{Instrument, warn};
 
 use crate::canvas::CanvasHandler;
 use crate::generated::api_types::{
-    LogRequest, ModelSwitchToRequest, OpenCanvasInstance, RegisterEventInterestParams,
-    ToolsGetCurrentMetadataResult, rpc_methods,
+    DiscoveredCanvas, LogRequest, ModelSwitchToRequest, OpenCanvasInstance,
+    RegisterEventInterestParams, ToolsGetCurrentMetadataResult, rpc_methods,
 };
 use crate::generated::session_events::{
     CommandExecuteData, ElicitationRequestedData, ExternalToolRequestedData, McpOauthRequiredData,
@@ -27,6 +27,7 @@ use crate::handler::{
 use crate::hooks::SessionHooks;
 use crate::provider_token::BearerTokenProvider;
 use crate::session_fs::SessionFsProvider;
+use crate::subscription::RecvErrorKind;
 use crate::trace_context::inject_trace_context;
 use crate::transforms::SystemMessageTransform;
 use crate::types::{
@@ -35,7 +36,7 @@ use crate::types::{
     PermissionRequestData, RequestId, ResumeSessionConfig, ResumeSessionResult, SectionOverride,
     SessionCapabilities, SessionConfig, SessionEvent, SessionId, SetModelOptions,
     SystemMessageConfig, ToolInvocation, ToolResult, ToolResultExpanded, TraceContext,
-    UiInputOptions, ensure_attachment_display_names,
+    UiInputOptions, WaitForCanvasOptions, ensure_attachment_display_names,
 };
 use crate::{
     Client, Error, ErrorKind, JsonRpcResponse, SessionErrorKind, SessionEventNotification,
@@ -290,6 +291,108 @@ impl Session {
     /// ```
     pub fn subscribe(&self) -> crate::subscription::EventSubscription {
         crate::subscription::EventSubscription::new(self.event_tx.subscribe())
+    }
+
+    /// Wait for a canvas declaration to become available in this session.
+    ///
+    /// The waiter subscribes before reading the current registry, so a
+    /// declaration registered concurrently with the initial `canvas.list`
+    /// request cannot be missed. Subscription lag triggers another registry
+    /// read rather than failing the wait.
+    ///
+    /// This waits only for the requested canvas. It does not indicate that
+    /// extension initialization or the complete canvas registry has settled.
+    ///
+    /// # Cancel safety
+    ///
+    /// **Cancel-safe.** Dropping this future cancels the wait without changing
+    /// session or canvas state.
+    pub async fn wait_for_canvas(
+        &self,
+        options: WaitForCanvasOptions,
+    ) -> Result<DiscoveredCanvas, Error> {
+        let WaitForCanvasOptions {
+            canvas_id,
+            extension_id,
+            timeout,
+        } = options;
+
+        let wait = async {
+            let mut events = self.subscribe();
+
+            loop {
+                let canvas_rpc = self.rpc().canvas();
+                let canvases = tokio::select! {
+                    biased;
+                    _ = self.shutdown.cancelled() => {
+                        return Err(ErrorKind::Session(
+                            SessionErrorKind::CanvasWaitSessionClosed {
+                                canvas_id: canvas_id.clone(),
+                                extension_id: extension_id.clone(),
+                            },
+                        )
+                        .into());
+                    }
+                    result = canvas_rpc.list() => result?.canvases,
+                };
+                if let Some(canvas) = canvases.into_iter().find(|canvas| {
+                    canvas.canvas_id == canvas_id
+                        && extension_id
+                            .as_ref()
+                            .is_none_or(|id| canvas.extension_id == *id)
+                }) {
+                    return Ok(canvas);
+                }
+
+                loop {
+                    tokio::select! {
+                        biased;
+                        _ = self.shutdown.cancelled() => {
+                            return Err(ErrorKind::Session(
+                                SessionErrorKind::CanvasWaitSessionClosed {
+                                    canvas_id: canvas_id.clone(),
+                                    extension_id: extension_id.clone(),
+                                },
+                            )
+                            .into());
+                        }
+                        result = events.recv() => {
+                            match result {
+                                Ok(event)
+                                    if event.parsed_type()
+                                        == SessionEventType::SessionCanvasRegistryChanged =>
+                                {
+                                    break;
+                                }
+                                Ok(_) => {}
+                                Err(error) => match error.kind() {
+                                    RecvErrorKind::Lagged(_) => break,
+                                    RecvErrorKind::Closed => {
+                                        return Err(ErrorKind::Session(
+                                            SessionErrorKind::CanvasWaitSessionClosed {
+                                                canvas_id: canvas_id.clone(),
+                                                extension_id: extension_id.clone(),
+                                            },
+                                        )
+                                        .into());
+                                    }
+                                },
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        match tokio::time::timeout(timeout, wait).await {
+            Ok(result) => result,
+            Err(_) => Err(ErrorKind::Session(SessionErrorKind::CanvasWaitTimeout {
+                canvas_id,
+                extension_id,
+                timeout,
+            })
+            .into()),
+        }
     }
 
     /// The underlying Client (for advanced use cases).

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -4487,6 +4487,35 @@ impl SetModelOptions {
     }
 }
 
+/// Options for [`Session::wait_for_canvas`](crate::session::Session::wait_for_canvas).
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct WaitForCanvasOptions {
+    /// Provider-local canvas identifier to wait for.
+    pub canvas_id: String,
+    /// Owning provider identifier used to disambiguate canvases with the same ID.
+    pub extension_id: Option<String>,
+    /// Maximum time to wait for the canvas to become available.
+    pub timeout: Duration,
+}
+
+impl WaitForCanvasOptions {
+    /// Wait for a canvas with the given provider-local ID.
+    pub fn new(canvas_id: impl Into<String>, timeout: Duration) -> Self {
+        Self {
+            canvas_id: canvas_id.into(),
+            extension_id: None,
+            timeout,
+        }
+    }
+
+    /// Require the canvas to belong to the given provider.
+    pub fn with_extension_id(mut self, extension_id: impl Into<String>) -> Self {
+        self.extension_id = Some(extension_id.into());
+        self
+    }
+}
+
 /// Response from the top-level `ping` RPC.
 ///
 /// The `protocol_version` field is the most commonly-inspected piece —

--- a/rust/tests/session_test.rs
+++ b/rust/tests/session_test.rs
@@ -23,9 +23,11 @@ use github_copilot_sdk::types::{
     CanvasProviderIdentity, CloudSessionOptions, CloudSessionRepository, CommandContext,
     CommandDefinition, CommandHandler, DeliveryMode, ElicitationRequest, ElicitationResult,
     ExitPlanModeData, ExtensionInfo, MessageOptions, RequestId, SessionConfig, SessionId,
-    SetModelOptions, Tool, ToolInvocation, ToolResult,
+    SetModelOptions, Tool, ToolInvocation, ToolResult, WaitForCanvasOptions,
 };
-use github_copilot_sdk::{Client, ContextTier, ErrorKind, ProtocolErrorKind, tool};
+use github_copilot_sdk::{
+    Client, ContextTier, ErrorKind, ProtocolErrorKind, SessionErrorKind, tool,
+};
 use serde_json::Value;
 use tokio::io::{AsyncWrite, AsyncWriteExt, duplex};
 use tokio::time::timeout;
@@ -75,6 +77,15 @@ fn test_canvas(id: &str) -> CanvasDeclaration {
 
 fn test_canvas_handler() -> Arc<dyn CanvasHandler> {
     Arc::new(TestCanvasHandler)
+}
+
+fn discovered_canvas(canvas_id: &str, extension_id: &str) -> Value {
+    serde_json::json!({
+        "canvasId": canvas_id,
+        "extensionId": extension_id,
+        "displayName": "Test Canvas",
+        "description": "Test canvas description"
+    })
 }
 
 async fn write_framed(writer: &mut (impl AsyncWrite + Unpin), body: &[u8]) {
@@ -3390,6 +3401,217 @@ async fn resume_session_sends_canvas_fields_and_captures_open_canvases() {
     assert_eq!(open[0].instance_id, "counter-1");
     let caps = session.capabilities();
     assert_eq!(caps.ui.unwrap().canvases, Some(true));
+}
+
+#[tokio::test]
+async fn wait_for_canvas_returns_matching_existing_canvas() {
+    let (session, mut server) = create_session_pair().await;
+    let session = Arc::new(session);
+    let waiter = tokio::spawn({
+        let session = session.clone();
+        async move {
+            session
+                .wait_for_canvas(
+                    WaitForCanvasOptions::new("counter", TIMEOUT)
+                        .with_extension_id("project:counter"),
+                )
+                .await
+        }
+    });
+
+    let request = server.read_request().await;
+    assert_eq!(request["method"], "session.canvas.list");
+    server
+        .respond(
+            &request,
+            serde_json::json!({
+                "canvases": [
+                    discovered_canvas("counter", "user:counter"),
+                    discovered_canvas("counter", "project:counter")
+                ]
+            }),
+        )
+        .await;
+
+    let canvas = timeout(TIMEOUT, waiter).await.unwrap().unwrap().unwrap();
+    assert_eq!(canvas.canvas_id, "counter");
+    assert_eq!(canvas.extension_id, "project:counter");
+}
+
+#[tokio::test]
+async fn wait_for_canvas_handles_registration_during_initial_list() {
+    let (session, mut server) = create_session_pair().await;
+    let session = Arc::new(session);
+    let waiter = tokio::spawn({
+        let session = session.clone();
+        async move {
+            session
+                .wait_for_canvas(WaitForCanvasOptions::new("counter", TIMEOUT))
+                .await
+        }
+    });
+
+    let initial_list = server.read_request().await;
+    assert_eq!(initial_list["method"], "session.canvas.list");
+    server
+        .send_event(
+            "session.canvas.registry_changed",
+            serde_json::json!({
+                "canvases": [discovered_canvas("counter", "project:counter")]
+            }),
+        )
+        .await;
+    server
+        .respond(&initial_list, serde_json::json!({ "canvases": [] }))
+        .await;
+
+    let refreshed_list = server.read_request().await;
+    assert_eq!(refreshed_list["method"], "session.canvas.list");
+    server
+        .respond(
+            &refreshed_list,
+            serde_json::json!({
+                "canvases": [discovered_canvas("counter", "project:counter")]
+            }),
+        )
+        .await;
+
+    let canvas = timeout(TIMEOUT, waiter).await.unwrap().unwrap().unwrap();
+    assert_eq!(canvas.extension_id, "project:counter");
+}
+
+#[tokio::test]
+async fn wait_for_canvas_resyncs_after_subscription_lag() {
+    let (session, mut server) = create_session_pair().await;
+    let session = Arc::new(session);
+    let waiter = tokio::spawn({
+        let session = session.clone();
+        async move {
+            session
+                .wait_for_canvas(WaitForCanvasOptions::new("counter", TIMEOUT))
+                .await
+        }
+    });
+
+    let initial_list = server.read_request().await;
+    for sequence in 0..600 {
+        server
+            .send_event("test.event", serde_json::json!({ "sequence": sequence }))
+            .await;
+    }
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    server
+        .respond(&initial_list, serde_json::json!({ "canvases": [] }))
+        .await;
+
+    let refreshed_list = timeout(TIMEOUT, server.read_request()).await.unwrap();
+    assert_eq!(refreshed_list["method"], "session.canvas.list");
+    server
+        .respond(
+            &refreshed_list,
+            serde_json::json!({
+                "canvases": [discovered_canvas("counter", "project:counter")]
+            }),
+        )
+        .await;
+
+    let canvas = timeout(TIMEOUT, waiter).await.unwrap().unwrap().unwrap();
+    assert_eq!(canvas.canvas_id, "counter");
+}
+
+#[tokio::test]
+async fn wait_for_canvas_times_out_without_sending_a_turn() {
+    let (session, mut server) = create_session_pair().await;
+    let session = Arc::new(session);
+    let waiter = tokio::spawn({
+        let session = session.clone();
+        async move {
+            session
+                .wait_for_canvas(WaitForCanvasOptions::new(
+                    "missing",
+                    Duration::from_millis(50),
+                ))
+                .await
+        }
+    });
+
+    let request = server.read_request().await;
+    assert_eq!(request["method"], "session.canvas.list");
+    server
+        .respond(&request, serde_json::json!({ "canvases": [] }))
+        .await;
+
+    let error = timeout(TIMEOUT, waiter)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap_err();
+    assert!(matches!(
+        error.kind(),
+        ErrorKind::Session(SessionErrorKind::CanvasWaitTimeout { canvas_id, .. })
+            if canvas_id == "missing"
+    ));
+}
+
+#[tokio::test]
+async fn wait_for_canvas_stops_when_session_closes() {
+    let (session, mut server) = create_session_pair().await;
+    let session = Arc::new(session);
+    let waiter = tokio::spawn({
+        let session = session.clone();
+        async move {
+            session
+                .wait_for_canvas(WaitForCanvasOptions::new("missing", TIMEOUT))
+                .await
+        }
+    });
+
+    let request = server.read_request().await;
+    assert_eq!(request["method"], "session.canvas.list");
+    server
+        .respond(&request, serde_json::json!({ "canvases": [] }))
+        .await;
+    session.stop_event_loop().await;
+
+    let error = timeout(TIMEOUT, waiter)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap_err();
+    assert!(matches!(
+        error.kind(),
+        ErrorKind::Session(SessionErrorKind::CanvasWaitSessionClosed { canvas_id, .. })
+            if canvas_id == "missing"
+    ));
+}
+
+#[tokio::test]
+async fn wait_for_canvas_stops_when_session_closes_during_list() {
+    let (session, mut server) = create_session_pair().await;
+    let session = Arc::new(session);
+    let waiter = tokio::spawn({
+        let session = session.clone();
+        async move {
+            session
+                .wait_for_canvas(WaitForCanvasOptions::new("missing", TIMEOUT))
+                .await
+        }
+    });
+
+    let request = server.read_request().await;
+    assert_eq!(request["method"], "session.canvas.list");
+    session.stop_event_loop().await;
+
+    let error = timeout(TIMEOUT, waiter)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap_err();
+    assert!(matches!(
+        error.kind(),
+        ErrorKind::Session(SessionErrorKind::CanvasWaitSessionClosed { canvas_id, .. })
+            if canvas_id == "missing"
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- add `Session::wait_for_canvas(WaitForCanvasOptions)` for waiting on a known canvas declaration without sending a model turn
- subscribe before the initial `session.canvas.list` snapshot, then re-list on registry changes or subscription lag
- support provider-specific matching, total timeouts, and deterministic session-shutdown errors
- cover existing declarations, registration races, lag recovery, timeout/no-turn behavior, and shutdown during both event waiting and an in-flight list request

## Motivation

github/github-app#11029 currently has to coordinate `session.canvas.list` and `session.canvas.registry_changed` itself while asynchronously loaded extensions register their canvases. This helper provides the smallest SDK-level primitive that removes the list/subscription race when the caller already knows the target canvas.

The API deliberately guarantees only target availability. It does **not** claim that extension initialization or the complete canvas registry has settled. A handshake-backed bounded initialization snapshot remains a separate copilot-agent-runtime protocol follow-up for github/github-app#7544 and github/github-app#10224.

## Compatibility

This is an additive Rust API implemented entirely over existing protocol-v3 methods and events. It does not change `session.create`, add wire fields, block session creation on extension startup, or require a model turn. Older runtimes therefore need no protocol changes.

`CHANGELOG.md` is release-generated and has no unreleased section, so this PR relies on public rustdoc rather than editing it manually.

## Validation

- `cargo +nightly-2026-04-14 fmt --all -- --config-path .rustfmt.nightly.toml --check`
- `cargo clippy --all-targets --features test-support -- --no-deps -D warnings -D clippy::unwrap_used -D clippy::disallowed_macros -D clippy::await_holding_invalid_type`
- `cargo test --features test-support`