### PR TITLE
Skip untyped internal properties in C# codegen

### DIFF
--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -355,6 +355,41 @@ function failUnmappable(context: string, schema: JSONSchema7): never {
     );
 }
 
+function omitUntypedInternalProperties(value: unknown): void {
+    if (!value || typeof value !== "object") return;
+    if (Array.isArray(value)) {
+        value.forEach(omitUntypedInternalProperties);
+        return;
+    }
+
+    const node = value as Record<string, unknown>;
+    const properties = node.properties;
+    if (properties && typeof properties === "object" && !Array.isArray(properties)) {
+        for (const [name, property] of Object.entries(properties)) {
+            if (!property || typeof property !== "object" || Array.isArray(property)) continue;
+            const schema = property as JSONSchema7;
+            const hasType =
+                schema.type !== undefined ||
+                schema.$ref !== undefined ||
+                schema.anyOf !== undefined ||
+                schema.oneOf !== undefined ||
+                schema.allOf !== undefined ||
+                schema.enum !== undefined ||
+                schema.const !== undefined ||
+                isOpaqueJson(schema);
+            if (isSchemaInternal(schema) && !hasType) {
+                delete (properties as Record<string, unknown>)[name];
+            } else {
+                omitUntypedInternalProperties(property);
+            }
+        }
+    }
+
+    for (const [name, child] of Object.entries(node)) {
+        if (name !== "properties") omitUntypedInternalProperties(child);
+    }
+}
+
 function requiresArgumentNullCheck(typeName: string, isRequired: boolean): boolean {
     return isRequired && !typeName.endsWith("?") && !isNonNullableCSharpValueType(typeName);
 }
@@ -2568,6 +2603,8 @@ function generateRpcCode(
     externalJsonSerializableRefs: Map<string, Set<string>> = new Map(),
     externalValueTypes: Set<string> = new Set()
 ): string {
+    schema = cloneSchemaForCodegen(schema);
+    omitUntypedInternalProperties(schema);
     emittedRpcClassSchemas.clear();
     emittedRpcEnumResultTypes.clear();
     experimentalRpcTypes.clear();


### PR DESCRIPTION
`@github/copilot` 1.0.79-9 adds internal, in-process-only properties without JSON Schema types. The C# generator currently attempts to map every property to a C# type, causing dependency-update codegen to fail.

Clone and preprocess the RPC schema before generation, recursively omitting only internal properties that have no representable schema shape. Typed internal properties continue to be generated, and untyped public properties still fail validation.

Validated generation against the exact 1.0.79-9 API and session-event schemas. Other language generators remain unchanged because they already tolerate these shapes.

Generated by Copilot