### PR TITLE
docs: note the minimum language runtimes in the bundled CLI quick start

### DIFF
--- a/docs/setup/bundled-cli.md
+++ b/docs/setup/bundled-cli.md
@@ -39,6 +39,9 @@ flowchart TB
 
 ## Quick start
 
+> [!NOTE]
+> Each SDK requires a minimum language runtime: **Node.js** 20+, **Python** 3.11+, **Go** 1.24+, **Rust** 1.94+, **Java** 17+, or **.NET** 8.0+. On an older Python, `pip` installs an outdated SDK release rather than reporting the version conflict, and the example below then fails with an error that does not mention the Python version. See [Prerequisites](../getting-started.md#prerequisites).
+
 <details open>
 <summary><strong>Node.js / TypeScript</strong></summary>
 

--- a/docs/setup/bundled-cli.md
+++ b/docs/setup/bundled-cli.md
@@ -40,7 +40,7 @@ flowchart TB
 ## Quick start
 
 > [!NOTE]
-> Each SDK requires a minimum language runtime: **Node.js** 20+, **Python** 3.11+, **Go** 1.24+, **Rust** 1.94+, **Java** 17+, or **.NET** 8.0+. On an older Python, `pip` installs an outdated SDK release rather than reporting the version conflict, and the example below then fails with an error that does not mention the Python version. See [Prerequisites](../getting-started.md#prerequisites).
+> Each SDK has a minimum language runtime requirement—see the Prerequisites section of the [Node.js](../../nodejs/README.md#prerequisites), [Python](../../python/README.md#prerequisites), [Go](../../go/README.md#prerequisites), [Rust](../../rust/README.md#prerequisites), [Java](../../java/README.md#prerequisites), or [.NET](../../dotnet/README.md#prerequisites) README—since an unsupported runtime (e.g. Python below the stated floor) can cause `pip`/package managers to silently resolve an outdated SDK release instead of reporting a version conflict.
 
 <details open>
 <summary><strong>Node.js / TypeScript</strong></summary>


### PR DESCRIPTION
## Summary

The bundled CLI quick start goes straight from install to code with no statement of the supported language runtimes, so nothing warns a reader who is on an unsupported one.

For Python this fails in a way that gives no hint about the cause. The package declares `requires-python = ">=3.11"`, so on 3.10 `pip` does not report a conflict - it silently resolves to an old pre-3.11 SDK release. The quick start snippet then blows up inside that old release with an error that never mentions the Python version (`AttributeError: type object 'Callable' has no attribute 'approve_all'` in the linked issue).

This adds a note above the language tabs listing the same minimum runtimes already stated in the getting-started tutorial, and links there.

## Notes

* Versions copied verbatim from the `Prerequisites` section of `docs/getting-started.md`; the Python floor matches `requires-python` in `python/pyproject.toml`.
* Prose sits above the `<details>` group, per the multi-language rule in the docs style guide.
* No code blocks were touched, so `docs-validate` behaviour is unchanged.

Fixes #2293.