### PR TITLE
Fix codegen for internal runtime schemas

### DIFF
--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -40,6 +40,7 @@ import {
     isSchemaExperimental,
     isSchemaInternal,
     isOpaqueJson,
+    isOpaqueInProcess,
     isObjectSchema,
     isVoidSchema,
     getNullableInner,
@@ -355,10 +356,10 @@ function failUnmappable(context: string, schema: JSONSchema7): never {
     );
 }
 
-function omitUntypedInternalProperties(value: unknown): void {
+function omitUnrepresentableInternalProperties(value: unknown): void {
     if (!value || typeof value !== "object") return;
     if (Array.isArray(value)) {
-        value.forEach(omitUntypedInternalProperties);
+        value.forEach(omitUnrepresentableInternalProperties);
         return;
     }
 
@@ -377,16 +378,16 @@ function omitUntypedInternalProperties(value: unknown): void {
                 schema.enum !== undefined ||
                 schema.const !== undefined ||
                 isOpaqueJson(schema);
-            if (isSchemaInternal(schema) && !hasType) {
+            if (isSchemaInternal(schema) && (!hasType || isOpaqueInProcess(schema))) {
                 delete (properties as Record<string, unknown>)[name];
             } else {
-                omitUntypedInternalProperties(property);
+                omitUnrepresentableInternalProperties(property);
             }
         }
     }
 
     for (const [name, child] of Object.entries(node)) {
-        if (name !== "properties") omitUntypedInternalProperties(child);
+        if (name !== "properties") omitUnrepresentableInternalProperties(child);
     }
 }
 
@@ -2604,7 +2605,7 @@ function generateRpcCode(
     externalValueTypes: Set<string> = new Set()
 ): string {
     schema = cloneSchemaForCodegen(schema);
-    omitUntypedInternalProperties(schema);
+    omitUnrepresentableInternalProperties(schema);
     emittedRpcClassSchemas.clear();
     emittedRpcEnumResultTypes.clear();
     experimentalRpcTypes.clear();

--- a/scripts/codegen/typescript.ts
+++ b/scripts/codegen/typescript.ts
@@ -383,16 +383,39 @@ export function normalizeSchemaForTypeScript(
     root.definitions = definitions;
     delete root.$defs;
 
-    const rewrite = (value: unknown): unknown => {
+    const internalDefinitionNames = new Set(
+        Object.entries(definitions)
+            .filter(([, definition]) => typeof definition === "object" && definition !== null && isSchemaInternal(definition as JSONSchema7))
+            .map(([name]) => name)
+    );
+    const isInternalUnionVariant = (value: unknown): boolean => {
+        if (!value || typeof value !== "object") return false;
+        const variant = value as JSONSchema7;
+        if (isSchemaInternal(variant)) return true;
+        const match = variant.$ref?.match(/^#\/(?:definitions|\$defs)\/([^/]+)$/);
+        return match ? internalDefinitionNames.has(match[1]) : false;
+    };
+
+    const rewrite = (value: unknown, withinInternalDefinition = false): unknown => {
         if (Array.isArray(value)) {
-            return value.map(rewrite);
+            return value.map((item) => rewrite(item, withinInternalDefinition));
         }
         if (!value || typeof value !== "object") {
             return value;
         }
 
+        const source = value as Record<string, unknown>;
+        const isInternal = withinInternalDefinition || isSchemaInternal(source as JSONSchema7);
         const rewritten = Object.fromEntries(
-            Object.entries(value as Record<string, unknown>).map(([key, child]) => [key, rewrite(child)])
+            Object.entries(source).map(([key, child]) => {
+                const publicChild =
+                    !isInternal &&
+                    (key === "anyOf" || key === "oneOf") &&
+                    Array.isArray(child)
+                        ? child.filter((variant) => !isInternalUnionVariant(variant))
+                        : child;
+                return [key, rewrite(publicChild, isInternal)];
+            })
         ) as Record<string, unknown>;
 
         if (isBareSchemaNode(rewritten as JSONSchema7)) {


### PR DESCRIPTION
`@github/copilot` 1.0.80-0 adds internal-only MCP schema shapes that caused the dependency update workflow to fail. TypeScript exposed an internal union variant through a public type, and C# attempted to map an in-process-only value that cannot cross the JSON-RPC boundary.

## Changes

- Filter internal `anyOf` and `oneOf` variants from public TypeScript unions while retaining internal definitions for internal APIs.
- Omit internal `x-opaque-in-process` properties from C# output as unrepresentable SDK transport fields.

## Validation

- Generated all language SDK outputs against the 1.0.80-0 runtime schemas.
- Regenerated against the pinned 1.0.79 schemas with no generated-file changes.

Generated by Copilot