### PR TITLE
fix(node): reject sendAndWait on session shutdown

### DIFF
--- a/nodejs/src/session.ts
+++ b/nodejs/src/session.ts
@@ -754,6 +754,17 @@ export class CopilotSession {
         const shutdownPromise = new Promise<Error>((resolve) => {
             resolveShutdown = resolve;
         });
+        let outcomeSettled = false;
+        const settleOutcome = (outcome: SessionOutcome, shutdown = false): void => {
+            if (outcomeSettled) {
+                return;
+            }
+            outcomeSettled = true;
+            resolveOutcome(outcome);
+            if (shutdown && outcome.kind === "error") {
+                resolveShutdown(outcome.error);
+            }
+        };
 
         let lastAssistantMessage: AssistantMessageEvent | undefined;
 
@@ -763,29 +774,29 @@ export class CopilotSession {
             if (event.type === "assistant.message") {
                 lastAssistantMessage = event;
             } else if (event.type === "session.idle") {
-                resolveOutcome({ kind: "idle" });
+                settleOutcome({ kind: "idle" });
             } else if (event.type === "session.error") {
                 const error = new Error(event.data.message);
                 error.stack = event.data.stack;
-                resolveOutcome({ kind: "error", error });
+                settleOutcome({ kind: "error", error });
             } else if (event.type === "session.shutdown") {
                 const reason = event.data.errorReason ? `: ${event.data.errorReason}` : "";
                 const error = new Error(
                     `Session ${this.sessionId} shut down before becoming idle${reason}`
                 );
-                resolveOutcome({ kind: "error", error });
-                resolveShutdown(error);
+                settleOutcome({ kind: "error", error }, true);
             }
         });
 
         let timeoutId: ReturnType<typeof setTimeout> | undefined;
         try {
-            await Promise.race([
-                this.send(options),
-                shutdownPromise.then((error) => {
-                    throw error;
-                }),
+            const sendResult = await Promise.race([
+                this.send(options).then(() => ({ kind: "sent" }) as const),
+                shutdownPromise.then((error) => ({ kind: "shutdown", error }) as const),
             ]);
+            if (sendResult.kind === "shutdown") {
+                throw sendResult.error;
+            }
 
             const timeoutPromise = new Promise<never>((_, reject) => {
                 timeoutId = setTimeout(

--- a/nodejs/src/session.ts
+++ b/nodejs/src/session.ts
@@ -750,6 +750,10 @@ export class CopilotSession {
         const outcomePromise = new Promise<SessionOutcome>((resolve) => {
             resolveOutcome = resolve;
         });
+        let resolveShutdown: (error: Error) => void;
+        const shutdownPromise = new Promise<Error>((resolve) => {
+            resolveShutdown = resolve;
+        });
 
         let lastAssistantMessage: AssistantMessageEvent | undefined;
 
@@ -764,12 +768,24 @@ export class CopilotSession {
                 const error = new Error(event.data.message);
                 error.stack = event.data.stack;
                 resolveOutcome({ kind: "error", error });
+            } else if (event.type === "session.shutdown") {
+                const reason = event.data.errorReason ? `: ${event.data.errorReason}` : "";
+                const error = new Error(
+                    `Session ${this.sessionId} shut down before becoming idle${reason}`
+                );
+                resolveOutcome({ kind: "error", error });
+                resolveShutdown(error);
             }
         });
 
         let timeoutId: ReturnType<typeof setTimeout> | undefined;
         try {
-            await this.send(options);
+            await Promise.race([
+                this.send(options),
+                shutdownPromise.then((error) => {
+                    throw error;
+                }),
+            ]);
 
             const timeoutPromise = new Promise<never>((_, reject) => {
                 timeoutId = setTimeout(

--- a/nodejs/test/session-send-and-wait.test.ts
+++ b/nodejs/test/session-send-and-wait.test.ts
@@ -29,6 +29,23 @@ function errorEvent(message: string): SessionEvent {
     } as SessionEvent;
 }
 
+function shutdownEvent(errorReason?: string): SessionEvent {
+    return {
+        type: "session.shutdown",
+        id: "00000000-0000-4000-8000-000000000002",
+        parentId: null,
+        timestamp: new Date().toISOString(),
+        data: {
+            codeChanges: { filesModified: [], linesAdded: 0, linesRemoved: 0 },
+            errorReason,
+            modelMetrics: {},
+            sessionStartTime: Date.now(),
+            shutdownType: errorReason ? "error" : "routine",
+            totalApiDurationMs: 0,
+        },
+    } as SessionEvent;
+}
+
 function controlledSession(): {
     session: CopilotSession;
     sendStarted: Promise<void>;
@@ -133,5 +150,17 @@ describe("sendAndWait", () => {
         errorFirst.session._dispatchEvent(sessionEvent("session.idle"));
         errorFirst.resolveSend();
         await expect(errorFirstPending).rejects.toThrow("first error");
+    });
+
+    it("rejects when the session shuts down before becoming idle", async () => {
+        const { session, sendStarted } = controlledSession();
+        const pending = session.sendAndWait({ prompt: "hi" });
+        await sendStarted;
+
+        session._dispatchEvent(shutdownEvent("runtime session was lost"));
+
+        await expect(pending).rejects.toThrow(
+            "Session session-1 shut down before becoming idle: runtime session was lost"
+        );
     });
 });

--- a/nodejs/test/session-send-and-wait.test.ts
+++ b/nodejs/test/session-send-and-wait.test.ts
@@ -112,6 +112,7 @@ describe("sendAndWait", () => {
         await sendStarted;
 
         session._dispatchEvent(sessionEvent("session.idle"));
+        session._dispatchEvent(shutdownEvent("later shutdown"));
 
         const stateBeforeSend = await Promise.race([
             pending.then(() => "settled"),


### PR DESCRIPTION
## Summary

- treat `session.shutdown` as a terminal outcome in the Node SDK `sendAndWait()` helper
- reject even when shutdown arrives while the underlying `session.send` RPC is still pending
- add regression coverage for the lost-turn behavior reported in microsoft/vscode#330888

The runtime now emits `session.shutdown` when a session is torn down during an accepted turn, but `sendAndWait()` previously only observed `session.idle` and `session.error`, leaving callers waiting until timeout.

POC: [index.js](https://github.com/user-attachments/files/31084043/index.js)

## Validation

- `npm test -- session-send-and-wait.test.ts`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run format:check`
- deterministic resumed-session POC against the local SDK and current runtime main