### PR TITLE
Fix Anthropic replay normalization for adjacent text blocks

### DIFF
--- a/test/harness/anthropicMessagesAdapter.ts
+++ b/test/harness/anthropicMessagesAdapter.ts
@@ -4,6 +4,7 @@
 
 import type { ChatCompletion } from "openai/resources/chat/completions";
 import {
+  canonicalUserMessageSeparator,
   CanonicalMessage,
   CanonicalToolCall,
   formatSseEvent,
@@ -178,7 +179,7 @@ function convertAnthropicUserMessage(
       content: onlyText
         ? contentParts
             .map((part) => (part.type === "text" ? part.text : ""))
-            .join("\n")
+            .join(canonicalUserMessageSeparator)
         : [...contentParts],
     });
     contentParts.length = 0;

--- a/test/harness/modelProtocolAdapterShared.ts
+++ b/test/harness/modelProtocolAdapterShared.ts
@@ -4,6 +4,8 @@
 
 export type JsonObject = Record<string, unknown>;
 
+export const canonicalUserMessageSeparator = "\n\n\n";
+
 export type CanonicalToolCall = {
   id: string;
   type: "function";

--- a/test/harness/modelProtocolAdapters.test.ts
+++ b/test/harness/modelProtocolAdapters.test.ts
@@ -128,6 +128,52 @@ async function postJson(
 }
 
 describe("Anthropic Messages adapter", () => {
+  test("canonicalizes adjacent plain-text content blocks", () => {
+    const result = JSON.parse(
+      anthropicMessagesRequestToChatCompletion(
+        JSON.stringify({
+          model: "test-model",
+          messages: [
+            {
+              role: "user",
+              content: [
+                { type: "text", text: "First prompt" },
+                { type: "text", text: "Recovery prompt" },
+              ],
+            },
+          ],
+        }),
+      ),
+    ) as {
+      messages: Array<{ role: string; content: unknown }>;
+    };
+
+    expect(result.messages).toEqual([
+      {
+        role: "user",
+        content: "First prompt\n\n\nRecovery prompt",
+      },
+    ]);
+  });
+
+  test.each([
+    ["string content", "Hello"],
+    ["one text block", [{ type: "text", text: "Hello" }]],
+  ])("preserves a single plain-text user block from %s", (_, content) => {
+    const result = JSON.parse(
+      anthropicMessagesRequestToChatCompletion(
+        JSON.stringify({
+          model: "test-model",
+          messages: [{ role: "user", content }],
+        }),
+      ),
+    ) as {
+      messages: Array<{ role: string; content: unknown }>;
+    };
+
+    expect(result.messages).toEqual([{ role: "user", content: "Hello" }]);
+  });
+
   test("normalizes messages, binary content, and tools", () => {
     const result = JSON.parse(
       anthropicMessagesRequestToChatCompletion(
@@ -584,6 +630,36 @@ describe("protocol-aware replay", () => {
           "anthropic-messages",
           "First prompt\n\n\n\n\nRecovery prompt",
         ),
+      );
+      expect(response.status).toBe(200);
+    });
+  });
+
+  test("canonicalizes Anthropic content blocks before coalescing user messages", async () => {
+    await writeSnapshot([
+      { role: "system", content: "${system}" },
+      { role: "user", content: "First prompt" },
+      { role: "user", content: "Recovery prompt" },
+      { role: "user", content: "Final prompt" },
+      { role: "assistant", content: "Recovered" },
+    ]);
+    const request = requestFor("anthropic-messages", "Final prompt");
+    request.messages = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "First prompt" },
+          { type: "text", text: "Recovery prompt" },
+        ],
+      },
+      ...(request.messages as unknown[]),
+    ];
+
+    await withProxy("anthropic-messages", async (proxyUrl) => {
+      const response = await postJson(
+        proxyUrl,
+        endpoints["anthropic-messages"],
+        request,
       );
       expect(response.status).toBe(200);
     });

--- a/test/harness/replayingCapiProxy.ts
+++ b/test/harness/replayingCapiProxy.ts
@@ -26,6 +26,7 @@ import {
   chatCompletionResponseToAnthropicMessage,
   chatCompletionResponseToAnthropicSseChunks,
 } from "./anthropicMessagesAdapter";
+import { canonicalUserMessageSeparator } from "./modelProtocolAdapterShared";
 import {
   chatCompletionResponseToResponsesApiMessage,
   chatCompletionResponseToResponsesApiSseChunks,
@@ -983,7 +984,7 @@ function coalesceAdjacentUserMessages(requestBody: string): string {
       typeof previous.content === "string" &&
       typeof message.content === "string"
     ) {
-      previous.content = `${previous.content.trimEnd()}\n\n\n${message.content.trimStart()}`;
+      previous.content = `${previous.content.trimEnd()}${canonicalUserMessageSeparator}${message.content.trimStart()}`;
     } else {
       messages.push(message);
     }
@@ -993,7 +994,7 @@ function coalesceAdjacentUserMessages(requestBody: string): string {
     if (message.role === "user" && typeof message.content === "string") {
       message.content = normalizeUserMessage(message.content).replace(
         /\n{5,}/g,
-        "\n\n\n",
+        canonicalUserMessageSeparator,
       );
     }
   }
@@ -1348,7 +1349,8 @@ function coalesceMessages(
       continue;
     }
 
-    const separator = message.role === "user" ? "\n\n\n" : "";
+    const separator =
+      message.role === "user" ? canonicalUserMessageSeparator : "";
     const previousContent = previous.content ?? "";
     const currentContent = message.content ?? "";
     const content = `${previousContent}${previousContent && currentContent ? separator : ""}${currentContent}`;


### PR DESCRIPTION
## Summary

- canonicalize adjacent plain-text Anthropic user content blocks with the replay harness's existing `\n\n\n` user-message separator
- share the canonical separator with request and snapshot coalescing so those normalization paths cannot drift
- add adapter and protocol-aware replay regressions while retaining single-block, multimodal, and tool-result coverage

## Root cause

[github/copilot-agent-runtime#15832](https://github.com/github/copilot-agent-runtime/pull/15832) intentionally preserves adjacent user messages as separate Anthropic content blocks for prompt-cache stability. The replay adapter flattened those block boundaries with `\n`, while captured canonical snapshots and adjacent-user-message coalescing use `\n\n\n`. Requests therefore failed to match snapshots during compaction and session-limit flows.

This change fixes normalization only at the replay adapter boundary; it does not alter the runtime's Anthropic serialization or broadly relax matching.

## Tests

- `cd test/harness && npm test` (61 passed)
- `COPILOT_SDK_E2E_BACKEND=anthropic-messages COPILOT_SDK_DEFAULT_CONNECTION=inprocess dotnet test test/GitHub.Copilot.SDK.Test.csproj -f net8.0 --no-restore -v normal --filter FullyQualifiedName=GitHub.Copilot.Test.E2E.CompactionE2ETests.Should_Trigger_Compaction_With_Low_Threshold_And_Emit_Events`