### PR TITLE
[SDK/Factories] Stop the factory guide inviting an invented limit

### DIFF
--- a/nodejs/docs/factories.md
+++ b/nodejs/docs/factories.md
@@ -23,12 +23,6 @@ const reviewChanged = defineFactory({
                 files: { type: "array", items: { type: "string" } },
             },
         },
-        limits: {
-            maxConcurrentSubagents: 3,
-            maxTotalSubagents: 10,
-            timeoutSeconds: 90.5,
-            maxAiCredits: 5,
-        },
     },
     run: async (ctx) => {
         ctx.phase("Review");
@@ -121,7 +115,14 @@ See [factory-patterns.md](./factory-patterns.md) for composable orchestration pa
 
 ## Resource limits
 
-Limits may be declared in `meta.limits` and overridden per invocation. All limits must be positive when present.
+Limits may be declared in `meta.limits` and overridden per invocation. Every limit is optional and must be positive when present; an omitted limit leaves that dimension unbounded.
+
+Set a ceiling only from real knowledge of what the factory costs, or because the user named one. A guessed ceiling does not make a run safer: it stops a healthy run partway with `factory_limit_reached`, after that run has already taken the user's approval and spent credits. An agent authoring or invoking a factory on the user's behalf has no basis for estimating a number, so it should leave `limits` unset and bound the work with the factory's own counters instead. Omitting limits does not remove oversight, because the run still needs an approval and that prompt shows the effective limits first.
+
+```js
+// Only when the cost profile is known, or the user asked for this ceiling.
+limits: { maxTotalSubagents: 10 },
+```
 
 - `maxConcurrentSubagents`: Positive integer concurrent-subagent cap. Additional subagents wait in a queue. Queueing applies backpressure and does not fail the run.
 - `maxTotalSubagents`: Positive integer cumulative admission cap. An attempted subagent beyond the cap ends the attempt with failure kind `maxTotalSubagents`.

--- a/nodejs/docs/factories.md
+++ b/nodejs/docs/factories.md
@@ -115,9 +115,9 @@ See [factory-patterns.md](./factory-patterns.md) for composable orchestration pa
 
 ## Resource limits
 
-Limits may be declared in `meta.limits` and overridden per invocation. Every limit is optional and must be positive when present; an omitted limit leaves that dimension unbounded.
+Limits may be declared in `meta.limits` and overridden per invocation. Every limit is optional and must be positive when present; an omitted limit leaves that dimension unbounded, except that an omitted `maxConcurrentSubagents` falls back to `maxTotalSubagents`, so a declared total cap also bounds concurrency.
 
-Set a ceiling only from real knowledge of what the factory costs, or because the user named one. A guessed ceiling does not make a run safer: it stops a healthy run partway with `factory_limit_reached`, after that run has already taken the user's approval and spent credits. An agent authoring or invoking a factory on the user's behalf has no basis for estimating a number, so it should leave `limits` unset and bound the work with the factory's own counters instead. Omitting limits does not remove oversight, because the run still needs an approval and that prompt shows the effective limits first.
+Set a ceiling only from real knowledge of what the factory costs, or because the user named one. A guessed ceiling does not make a run safer: it stops a healthy run partway with `factory_limit_reached`, after that run has already spent credits. An agent authoring or invoking a factory on the user's behalf has no basis for estimating a number, so it should leave `limits` unset and bound the work with the factory's own counters instead. Omitting limits does not remove oversight of a model-initiated run: `run_factory` requests permission first, and that prompt shows the effective limits. SDK-initiated `run` and `resume` do not request permission, so an SDK caller that wants a ceiling sets it deliberately, from the cost it already knows.
 
 ```js
 // Only when the cost profile is known, or the user asked for this ceiling.

--- a/nodejs/docs/factory-patterns.md
+++ b/nodejs/docs/factory-patterns.md
@@ -189,6 +189,6 @@ Compose these freely.
 
 Match the orchestration to what was asked. A quick check wants a couple of subagents and single-vote verification; a request to be thorough or comprehensive wants a larger finder pool, a three-to-five vote adversarial pass, and a synthesis stage.
 
-There is no in-script budget object. Scale with your own counters, as in the loop patterns above, and treat the declared limits as the safety ceiling rather than the control mechanism. Only `agent()` spawns are throttled, by `maxConcurrentSubagents` falling back to `maxTotalSubagents`; with neither declared there is no built-in concurrency cap, so declare one before fanning out widely. `parallel` itself is `Promise.all`, so non-agent work in a thunk runs fully concurrently regardless.
+There is no in-script budget object. Scale with your own counters, as in the loop patterns above, and treat any declared limits as the safety ceiling rather than the control mechanism. Only `agent()` spawns are throttled, by `maxConcurrentSubagents` falling back to `maxTotalSubagents`; with neither declared there is no built-in concurrency cap, so bound a wide fan-out with the factory's own counters. Do not invent a ceiling to compensate, and see [Resource limits](./factories.md#resource-limits) for when declaring one is appropriate. `parallel` itself is `Promise.all`, so non-agent work in a thunk runs fully concurrently regardless.
 
 These patterns are not exhaustive. Compose novel harnesses — tournament brackets, self-repair loops, staged escalation — when the task calls for it.

--- a/nodejs/test/factory.test.ts
+++ b/nodejs/test/factory.test.ts
@@ -403,6 +403,34 @@ describe("factories", () => {
         expect(generatedRpc).toContain("timeoutSeconds?: number;");
     });
 
+    // A guessed ceiling does not make a run safer: it stops a healthy run partway
+    // with `factory_limit_reached`, after that run has already taken the user's
+    // approval and spent credits. Both documents are handed to the model verbatim
+    // by the `factories_manage` guide, so neither may read as an invitation to
+    // invent one.
+    it("documents limits as opt-in rather than inviting an invented ceiling", () => {
+        const guide = readFileSync(new URL("../docs/factories.md", import.meta.url), "utf8");
+        const patterns = readFileSync(
+            new URL("../docs/factory-patterns.md", import.meta.url),
+            "utf8"
+        );
+
+        expect(guide).toContain(
+            "Set a ceiling only from real knowledge of what the factory costs, or because the user named one"
+        );
+        expect(guide).toContain("no basis for estimating a number");
+
+        // The opening `defineFactory` sample is the shape an author copies. Filling
+        // all four ceilings in there taught the numbers as much as the syntax.
+        const openingSample = guide.slice(0, guide.indexOf("## Declaring an argument shape"));
+        expect(openingSample).not.toContain("limits: {");
+
+        // The Scaling section used to answer "there is no built-in concurrency cap"
+        // with "so declare one before fanning out widely".
+        expect(patterns).not.toContain("declare one before fanning out widely");
+        expect(patterns).toContain("bound a wide fan-out with the factory's own counters");
+    });
+
     it("documents factory invocation and list paging behavior accurately", () => {
         const guide = readFileSync(new URL("../docs/factories.md", import.meta.url), "utf8");
         const publicApi = readFileSync(new URL("../src/factory.ts", import.meta.url), "utf8");


### PR DESCRIPTION
## What

The two factory guide documents are handed to the model verbatim by the `factories_manage` `"guide"` operation. Read literally, both told it to pick a resource ceiling for a factory whose cost it has no way to estimate:

- `factories.md` opened on a `defineFactory` sample with all four ceilings filled in (`maxConcurrentSubagents: 3`, `maxTotalSubagents: 10`, `timeoutSeconds: 90.5`, `maxAiCredits: 5`). That sample is the shape an author copies, so it taught the numbers as much as the syntax.
- The Scaling section of `factory-patterns.md` answered "there is no built-in concurrency cap" with "so declare one before fanning out widely".

Changes:

- Drop `limits` from the opening sample, and document the declaration syntax in `## Resource limits` instead, where the rule now sits next to it.
- State in `## Resource limits` that a ceiling comes from real knowledge of what the factory costs or from the user, that an agent acting on the user's behalf has no basis for estimating one, and that omitting limits does not remove oversight, since a run still needs an approval whose prompt shows the effective limits.
- Redirect the Scaling remedy from declaring a cap to bounding a wide fan-out with the factory's own counters, with a cross-link for when declaring one is appropriate.
- Add a regression test asserting the new guidance and the absence of both old passages.

The API documentation is unchanged. Every limit keeps its own description, the reject-and-retry semantics are untouched, and limits stay declarable for an author who does know the cost profile.

## Why

A guessed ceiling does not make a run safer. It stops a healthy run partway with `factory_limit_reached`, after that run has already taken the user's approval and spent credits, and the caller then raises the ceiling a step at a time.

github/copilot-agent-runtime#16189 fixes the same problem on the tool-description side, telling the model to leave `limits` unset unless the user named a ceiling. That change cannot reach these documents, because they ship from the pinned `@github/copilot-sdk` package, so the runtime currently has to append an override to the guide output naming these two passages. Fixing the source here is what lets that override be retired on the next SDK bump.

## Testing

`npx vitest run test/factory.test.ts` passes, 110 tests, including the new `documents limits as opt-in rather than inviting an invented ceiling`. I confirmed the test is a real guard by restoring the old "declare one before fanning out widely" wording and watching it fail, then reverting.

`npm run typecheck`, `npm run format:check`, and `npm run lint` are clean. Lint reports 3 pre-existing `no-explicit-any` warnings in `test/extension.test.ts` and `test/shared-codegen.test.ts`, which this PR does not touch.
