### PR TITLE
docs: expand authentication examples

### DIFF
--- a/docs/auth/authenticate.md
+++ b/docs/auth/authenticate.md
@@ -7,7 +7,7 @@ The GitHub Copilot SDK supports multiple authentication methods to fit different
 | Method | Use Case | Copilot Subscription Required |
 |--------|----------|-------------------------------|
 | [GitHub Signed-in User](#github-signed-in-user) | Interactive apps where users sign in with GitHub | Yes |
-| [OAuth GitHub App](#oauth-github-app) | Apps acting on behalf of users via OAuth | Yes |
+| [GitHub OAuth App](#github-oauth-app) | Apps acting on behalf of users via OAuth | Yes |
 | [Environment Variables](#environment-variables) | CI/CD, automation, server-to-server | Yes |
 | [Server-to-server authentication](./server-to-server-tokens.md) | Organization-attributed automation and direct organization billing | No user subscription; organization policy required |
 | [BYOK (Bring Your Own Key)](./byok.md) | Using your own API keys (Microsoft Foundry, OpenAI, and more) | No |
@@ -24,26 +24,13 @@ This is the default authentication method when running the Copilot CLI interacti
 **SDK Configuration:**
 
 <details open>
-<summary><strong>Node.js / TypeScript</strong></summary>
+<summary><strong>.NET</strong></summary>
 
-```typescript
-import { CopilotClient } from "@github/copilot-sdk";
+```csharp
+using GitHub.Copilot;
 
 // Default: uses logged-in user credentials
-const client = new CopilotClient();
-```
-
-</details>
-
-<details>
-<summary><strong>Python</strong></summary>
-
-```python
-from copilot import CopilotClient
-
-# Default: uses logged-in user credentials
-client = CopilotClient()
-await client.start()
+await using CopilotClient client = new();
 ```
 
 </details>
@@ -75,18 +62,6 @@ client := copilot.NewClient(nil)
 </details>
 
 <details>
-<summary><strong>.NET</strong></summary>
-
-```csharp
-using GitHub.Copilot;
-
-// Default: uses logged-in user credentials
-await using var client = new CopilotClient();
-```
-
-</details>
-
-<details>
 <summary><strong>Java</strong></summary>
 
 ```java
@@ -99,47 +74,83 @@ client.start().get();
 
 </details>
 
-**When to use:**
-* Desktop applications where users interact directly
-* Development and testing environments
-* Any scenario where a user can sign in interactively
-
-## OAuth GitHub App
-
-Use an OAuth GitHub App to authenticate users through your application and pass their credentials to the SDK. This enables your application to make Copilot API requests on behalf of users who authorize your app.
-
-**How it works:**
-1. User authorizes your OAuth GitHub App
-1. Your app receives a user access token (`gho_` or `ghu_` prefix)
-1. Pass the token to the SDK via `gitHubToken` option
-
-**SDK Configuration:**
-
-<details open>
-<summary><strong>Node.js / TypeScript</strong></summary>
-
-```typescript
-import { CopilotClient } from "@github/copilot-sdk";
-
-const client = new CopilotClient({
-    gitHubToken: userAccessToken,  // Token from OAuth flow
-    useLoggedInUser: false,        // Don't use stored CLI credentials
-});
-```
-
-</details>
-
 <details>
 <summary><strong>Python</strong></summary>
 
 ```python
 from copilot import CopilotClient
 
-client = CopilotClient({
-    "github_token": user_access_token,  # Token from OAuth flow
-    "use_logged_in_user": False,        # Don't use stored CLI credentials
-})
+# Default: uses logged-in user credentials
+client = CopilotClient()
 await client.start()
+```
+
+</details>
+
+<details>
+<summary><strong>Rust</strong></summary>
+
+```rust
+use github_copilot_sdk::{Client, ClientOptions};
+
+// Default: uses logged-in user credentials
+let client = Client::start(ClientOptions::default()).await?;
+```
+
+</details>
+
+<details>
+<summary><strong>TypeScript</strong></summary>
+
+```typescript
+import { CopilotClient } from "@github/copilot-sdk";
+
+// Default: uses logged-in user credentials
+const client = new CopilotClient();
+```
+
+</details>
+
+**When to use:**
+* Desktop applications where users interact directly
+* Development and testing environments
+* Any scenario where a user can sign in interactively
+
+## GitHub OAuth App
+
+Use an OAuth GitHub App to authenticate users through your application and pass their credentials to the SDK. This enables your application to make Copilot API requests on behalf of users who authorize your app.
+
+**How it works:**
+1. User authorizes your OAuth GitHub App
+1. Your app receives a user access token (`gho_` or `ghu_` prefix)
+1. Pass the token to the SDK through its client configuration
+
+**SDK Configuration:**
+
+<details open>
+<summary><strong>.NET</strong></summary>
+
+<!-- docs-validate: hidden -->
+```csharp
+using GitHub.Copilot;
+
+var userAccessToken = "token";
+await using CopilotClient client = new(new CopilotClientOptions
+{
+    GitHubToken = userAccessToken,
+    UseLoggedInUser = false,
+});
+```
+<!-- /docs-validate: hidden -->
+
+```csharp
+using GitHub.Copilot;
+
+await using var client = new CopilotClient(new CopilotClientOptions
+{
+    GitHubToken = userAccessToken,     // Token from OAuth flow
+    UseLoggedInUser = false,           // Don't use stored CLI credentials
+});
 ```
 
 </details>
@@ -168,37 +179,9 @@ func main() {
 import copilot "github.com/github/copilot-sdk/go"
 
 client := copilot.NewClient(&copilot.ClientOptions{
-    GitHubToken:     userAccessToken,   // Token from OAuth flow
-    UseLoggedInUser: copilot.Bool(false), // Don't use stored CLI credentials
+    GitHubToken:       userAccessToken,      // Token from OAuth flow
+    UseLoggedInUser:   copilot.Bool(false),  // Don't use stored CLI credentials
 })
-```
-
-</details>
-
-<details>
-<summary><strong>.NET</strong></summary>
-
-<!-- docs-validate: hidden -->
-```csharp
-using GitHub.Copilot;
-
-var userAccessToken = "token";
-await using var client = new CopilotClient(new CopilotClientOptions
-{
-    GitHubToken = userAccessToken,
-    UseLoggedInUser = false,
-});
-```
-<!-- /docs-validate: hidden -->
-
-```csharp
-using GitHub.Copilot;
-
-await using var client = new CopilotClient(new CopilotClientOptions
-{
-    GitHubToken = userAccessToken,     // Token from OAuth flow
-    UseLoggedInUser = false,           // Don't use stored CLI credentials
-});
 ```
 
 </details>
@@ -220,6 +203,50 @@ client.start().get();
 
 </details>
 
+<details>
+<summary><strong>Python</strong></summary>
+
+```python
+from copilot import CopilotClient
+
+client = CopilotClient({
+    "github_token": user_access_token,  # Token from OAuth flow
+    "use_logged_in_user": False,        # Don't use stored CLI credentials
+})
+await client.start()
+```
+
+</details>
+
+<details>
+<summary><strong>Rust</strong></summary>
+
+```rust
+use github_copilot_sdk::{Client, ClientOptions};
+
+let client = Client::start(
+    ClientOptions::default()
+        .with_github_token(user_access_token)
+        .with_use_logged_in_user(false),
+).await?;
+```
+
+</details>
+
+<details>
+<summary><strong>TypeScript</strong></summary>
+
+```typescript
+import { CopilotClient } from "@github/copilot-sdk";
+
+const client = new CopilotClient({
+    gitHubToken: userAccessToken,  // Token from OAuth flow
+    useLoggedInUser: false,        // Don't use stored CLI credentials
+});
+```
+
+</details>
+
 **Supported token types:**
 * `gho_` - OAuth user access tokens
 * `ghu_` - GitHub App user access tokens
@@ -232,6 +259,8 @@ client.start().get();
 * Web applications where users sign in via GitHub
 * SaaS applications building on top of Copilot
 * Any multi-user application where you need to make requests on behalf of different users
+
+For more information, see [GitHub OAuth](../setup/github-oauth.md).
 
 ## Environment variables
 
@@ -253,13 +282,52 @@ For organization-attributed automation that should not use a user's personal acc
 No code changes needed—the SDK automatically detects environment variables:
 
 <details open>
-<summary><strong>Node.js / TypeScript</strong></summary>
+<summary><strong>.NET</strong></summary>
 
-```typescript
-import { CopilotClient } from "@github/copilot-sdk";
+```csharp
+using GitHub.Copilot;
 
 // Token is read from environment variable automatically
-const client = new CopilotClient();
+await using CopilotClient client = new();
+```
+
+</details>
+
+<details>
+<summary><strong>Go</strong></summary>
+
+<!-- docs-validate: hidden -->
+```go
+package main
+
+import copilot "github.com/github/copilot-sdk/go"
+
+func main() {
+	// Token is read from environment variable automatically
+	client := copilot.NewClient(nil)
+	_ = client
+}
+```
+<!-- /docs-validate: hidden -->
+
+```go
+import copilot "github.com/github/copilot-sdk/go"
+
+// Token is read from environment variable automatically
+client := copilot.NewClient(nil)
+```
+
+</details>
+
+<details>
+<summary><strong>Java</strong></summary>
+
+```java
+import com.github.copilot.CopilotClient;
+
+// Token is read from environment variable automatically
+var client = new CopilotClient();
+client.start().get();
 ```
 
 </details>
@@ -273,6 +341,30 @@ from copilot import CopilotClient
 # Token is read from environment variable automatically
 client = CopilotClient()
 await client.start()
+```
+
+</details>
+
+<details>
+<summary><strong>Rust</strong></summary>
+
+```rust
+use github_copilot_sdk::{Client, ClientOptions};
+
+// Token is read from environment variable automatically
+let client = Client::start(ClientOptions::default()).await?;
+```
+
+</details>
+
+<details>
+<summary><strong>TypeScript</strong></summary>
+
+```typescript
+import { CopilotClient } from "@github/copilot-sdk";
+
+// Token is read from environment variable automatically
+const client = new CopilotClient();
 ```
 
 </details>
@@ -313,36 +405,16 @@ For multi-user server mode, pass a per-session `gitHubToken` so each session run
 
 ## Disabling auto-login
 
-To prevent the SDK from automatically using stored credentials or `gh` CLI auth, use the `useLoggedInUser: false` option:
+To prevent the SDK from automatically using stored credentials or `gh` CLI auth, configure it to disable logged-in-user fallback:
 
 <details open>
-<summary><strong>Node.js / TypeScript</strong></summary>
+<summary><strong>.NET</strong></summary>
 
-```typescript
-const client = new CopilotClient({
-    useLoggedInUser: false,  // Only use explicit tokens
+```csharp
+await using var client = new CopilotClient(new CopilotClientOptions
+{
+    UseLoggedInUser = false,  // Only use explicit tokens
 });
-```
-
-</details>
-
-<details>
-<summary><strong>Python</strong></summary>
-
-<!-- docs-validate: hidden -->
-```python
-from copilot import CopilotClient
-
-client = CopilotClient({
-    "use_logged_in_user": False,
-})
-```
-<!-- /docs-validate: hidden -->
-
-```python
-client = CopilotClient({
-    "use_logged_in_user": False,  # Only use explicit tokens
-})
 ```
 
 </details>
@@ -374,18 +446,6 @@ client := copilot.NewClient(&copilot.ClientOptions{
 </details>
 
 <details>
-<summary><strong>.NET</strong></summary>
-
-```csharp
-await using var client = new CopilotClient(new CopilotClientOptions
-{
-    UseLoggedInUser = false,  // Only use explicit tokens
-});
-```
-
-</details>
-
-<details>
 <summary><strong>Java</strong></summary>
 
 ```java
@@ -396,6 +456,51 @@ var client = new CopilotClient(new CopilotClientOptions()
     .setUseLoggedInUser(false)  // Only use explicit tokens
 );
 client.start().get();
+```
+
+</details>
+
+<details>
+<summary><strong>Python</strong></summary>
+
+<!-- docs-validate: hidden -->
+```python
+from copilot import CopilotClient
+
+client = CopilotClient({
+    "use_logged_in_user": False,
+})
+```
+<!-- /docs-validate: hidden -->
+
+```python
+client = CopilotClient({
+    "use_logged_in_user": False,  # Only use explicit tokens
+})
+```
+
+</details>
+
+<details>
+<summary><strong>Rust</strong></summary>
+
+```rust
+use github_copilot_sdk::{Client, ClientOptions};
+
+let client = Client::start(
+    ClientOptions::default().with_use_logged_in_user(false),
+).await?;
+```
+
+</details>
+
+<details>
+<summary><strong>TypeScript</strong></summary>
+
+```typescript
+const client = new CopilotClient({
+    useLoggedInUser: false,  // Only use explicit tokens
+});
 ```
 
 </details>


### PR DESCRIPTION
## Why
Improve the authentication guide's cross-language coverage and make the examples easier to compare.

## What changed
- Add Rust examples for signed-in users, GitHub OAuth Apps, and disabling auto-login.
- Add Go, Rust, .NET, and Java examples to the environment-variable section.
- Order each language tab group alphabetically and use `TypeScript` as the tab label.
- Use language-neutral guidance for client token configuration and logged-in-user fallback.
- Link the GitHub OAuth App section to the detailed OAuth setup guide.

## Validation
- TypeScript documentation validation passed.
- Go documentation validation passed.
- C# documentation validation passed.
- Full validation is environment-limited because Python and Maven are unavailable.