### PR TITLE
[Test] Update Permission Denial Snapshots for the New Runtime Message

### DIFF
--- a/test/snapshots/permissions/should_deny_tool_operations_when_handler_explicitly_denies.yaml
+++ b/test/snapshots/permissions/should_deny_tool_operations_when_handler_explicitly_denies.yaml
@@ -44,7 +44,9 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: Permission denied and could not request permission from user
+        content: |-
+          Permission denied and could not request permission from user.
+          No approval rule matched and this session has no way to ask, so retrying this request unchanged will be denied again. Use an approach that does not need this permission, or stop and report that it requires an approval rule this session does not have.
       - role: assistant
         content: I don't have permission to execute commands in this environment. It seems access is restricted. You may need to
           grant permission or run the command directly in your terminal.

--- a/test/snapshots/permissions/should_deny_tool_operations_when_handler_explicitly_denies.yaml
+++ b/test/snapshots/permissions/should_deny_tool_operations_when_handler_explicitly_denies.yaml
@@ -44,9 +44,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: |-
-          Permission denied and could not request permission from user.
-          No approval rule matched and this session has no way to ask, so retrying this request unchanged will be denied again. Use an approach that does not need this permission, or stop and report that it requires an approval rule this session does not have.
+        content: Permission denied and could not request permission from user.
       - role: assistant
         content: I don't have permission to execute commands in this environment. It seems access is restricted. You may need to
           grant permission or run the command directly in your terminal.

--- a/test/snapshots/permissions/should_deny_tool_operations_when_handler_explicitly_denies_after_resume.yaml
+++ b/test/snapshots/permissions/should_deny_tool_operations_when_handler_explicitly_denies_after_resume.yaml
@@ -52,9 +52,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: |-
-          Permission denied and could not request permission from user.
-          No approval rule matched and this session has no way to ask, so retrying this request unchanged will be denied again. Use an approach that does not need this permission, or stop and report that it requires an approval rule this session does not have.
+        content: Permission denied and could not request permission from user.
       - role: assistant
         content: I don't have permission to run commands in this environment. Please try running `node --version` directly in
           your terminal.

--- a/test/snapshots/permissions/should_deny_tool_operations_when_handler_explicitly_denies_after_resume.yaml
+++ b/test/snapshots/permissions/should_deny_tool_operations_when_handler_explicitly_denies_after_resume.yaml
@@ -52,7 +52,9 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: Permission denied and could not request permission from user
+        content: |-
+          Permission denied and could not request permission from user.
+          No approval rule matched and this session has no way to ask, so retrying this request unchanged will be denied again. Use an approach that does not need this permission, or stop and report that it requires an approval rule this session does not have.
       - role: assistant
         content: I don't have permission to run commands in this environment. Please try running `node --version` directly in
           your terminal.

--- a/test/snapshots/permissions/should_handle_permission_handler_errors_gracefully.yaml
+++ b/test/snapshots/permissions/should_handle_permission_handler_errors_gracefully.yaml
@@ -44,6 +44,8 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: Permission denied and could not request permission from user
+        content: |-
+          Permission denied and could not request permission from user.
+          No approval rule matched and this session has no way to ask, so retrying this request unchanged will be denied again. Use an approach that does not need this permission, or stop and report that it requires an approval rule this session does not have.
       - role: assistant
         content: failed

--- a/test/snapshots/permissions/should_handle_permission_handler_errors_gracefully.yaml
+++ b/test/snapshots/permissions/should_handle_permission_handler_errors_gracefully.yaml
@@ -44,8 +44,6 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: |-
-          Permission denied and could not request permission from user.
-          No approval rule matched and this session has no way to ask, so retrying this request unchanged will be denied again. Use an approach that does not need this permission, or stop and report that it requires an approval rule this session does not have.
+        content: Permission denied and could not request permission from user.
       - role: assistant
         content: failed


### PR DESCRIPTION
## What

This change updates three permission snapshots so they carry the denial text the runtime sends after github/copilot-agent-runtime#16319. The tool result for a `UserNotAvailable` decision gains a trailing full stop.

## Why

That pull request makes permission denials name what was refused. The E2E suites here replay against these snapshots, and the proxy matches a request only when every message is identical, so the old text no longer matches and the permission tests fail with `No cached response found`.

## Merge this after the runtime ships, not before

This repository tests against the published `@github/copilot` (`^1.0.81-4` in `nodejs/package.json`), not against a runtime branch. That creates a two-sided ordering constraint:

- **This pull request cannot be green now.** Its CI runs the new snapshots against the *published* runtime, which still emits the old text. Every language suite fails on `No cached response found`, which is expected and is not a defect in this change.
- **Merging it early would turn `main` red here** for the same reason, until a runtime containing #16319 is published.

The runtime pull request merges first. Its "Copilot SDK C# tests" legs are non-blocking precisely so a cross-repo text change can land in this order. Once a runtime carrying #16319 is published, this becomes mergeable and both repositories are green.

Kept as a draft so it is not merged ahead of that.