### PR TITLE
fix(go): close failed session event loops

### DIFF
--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -1356,7 +1356,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         }
         catch (Exception ex)
         {
-            session?.RemoveFromClient();
+            session?.Unregister();
 
             if (ex is not OperationCanceledException)
             {
@@ -1561,7 +1561,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         }
         catch (Exception ex)
         {
-            session?.RemoveFromClient();
+            session?.Unregister();
             if (ex is not OperationCanceledException)
             {
                 LoggingHelpers.LogTiming(_logger, LogLevel.Warning, ex,

--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -204,6 +204,31 @@ public sealed partial class CopilotSession : IAsyncDisposable
         ((ICollection<KeyValuePair<string, CopilotSession>>)_parentClient._sessions).Remove(new(SessionId, this));
     }
 
+    /// <summary>
+    /// Stops the session's event consumer (<see cref="ProcessEventsAsync"/>) without
+    /// making an RPC. <see cref="CopilotClient.CreateSessionAsync"/> and
+    /// <see cref="CopilotClient.ResumeSessionAsync"/> use this on error paths where a
+    /// locally registered session fails before it can be returned to the caller:
+    /// <see cref="StartProcessingEvents"/> starts the consumer eagerly, and no caller
+    /// ever receives the failed session to dispose it. Safe to call more than once —
+    /// <see cref="ChannelWriter{T}.TryComplete"/> is idempotent.
+    /// </summary>
+    internal void CloseEventChannel()
+    {
+        _eventChannel.Writer.TryComplete();
+    }
+
+    /// <summary>
+    /// Removes the session from its parent client and stops its event consumer.
+    /// Used on session-creation/resume error paths where the session was registered
+    /// (and its event loop started) but never returned to the caller.
+    /// </summary>
+    internal void Unregister()
+    {
+        CloseEventChannel();
+        RemoveFromClient();
+    }
+
     internal void SetGitHubTokenProviderRegistration(string registrationId)
     {
         _gitHubTokenProviderRegistrationId = registrationId;
@@ -1933,7 +1958,7 @@ public sealed partial class CopilotSession : IAsyncDisposable
             return;
         }
 
-        _eventChannel.Writer.TryComplete();
+        CloseEventChannel();
 
         try
         {

--- a/dotnet/test/E2E/SessionEventLoopLeakE2ETests.cs
+++ b/dotnet/test/E2E/SessionEventLoopLeakE2ETests.cs
@@ -1,0 +1,198 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+using GitHub.Copilot.Test.Harness;
+using System.Collections;
+using System.Reflection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace GitHub.Copilot.Test.E2E;
+
+/// <summary>
+/// Regression coverage for the goroutine/task leak fixed alongside
+/// github/copilot-sdk#2360: <see cref="CopilotClient.CreateSessionAsync"/> and
+/// <see cref="CopilotClient.ResumeSessionAsync"/> construct a <see cref="CopilotSession"/>
+/// and start its event-dispatch consumer (<c>ProcessEventsAsync</c>) eagerly, before the
+/// CLI confirms the session, so the CLI can route session-scoped requests to it while
+/// session.create (or session.resume) is still being processed. Every failure path must
+/// stop that consumer — otherwise each failed call leaks a background task forever, since
+/// no caller ever receives the failed session to dispose it. Mirrors
+/// <c>go/internal/e2e/session_event_loop_leak_e2e_test.go</c>.
+/// </summary>
+[Trait(E2ETestTraits.Backend, E2ETestTraits.CapiOnly)]
+public class SessionEventLoopLeakE2ETests(E2ETestFixture fixture, ITestOutputHelper output)
+    : E2ETestBase(fixture, "session-event-loop-leak", output)
+{
+    private static readonly FieldInfo SessionsField =
+        typeof(CopilotClient).GetField("_sessions", BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("CopilotClient._sessions was not found.");
+
+    private static readonly FieldInfo EventChannelField =
+        typeof(CopilotSession).GetField("_eventChannel", BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("CopilotSession._eventChannel was not found.");
+
+    private static IDictionary GetSessionsMap(CopilotClient client) =>
+        (IDictionary)SessionsField.GetValue(client)!;
+
+    private static bool IsEventChannelClosed(CopilotSession session)
+    {
+        var channel = EventChannelField.GetValue(session)!;
+        var readerProperty = channel.GetType().GetProperty("Reader")
+            ?? throw new InvalidOperationException("Channel<T>.Reader was not found.");
+        var reader = readerProperty.GetValue(channel)!;
+        var completionProperty = reader.GetType().GetProperty("Completion")
+            ?? throw new InvalidOperationException("ChannelReader<T>.Completion was not found.");
+        var completion = (Task)completionProperty.GetValue(reader)!;
+        return completion.IsCompleted;
+    }
+
+    /// <summary>
+    /// Continuously scans <see cref="CopilotClient"/>'s session dictionary on a dedicated,
+    /// tightly-spinning thread (not the thread pool, and no <c>await</c>-based yielding) so
+    /// that even a sub-millisecond in-flight registration window — as seen with a fast local
+    /// RPC failure like a nonexistent-session resume — is reliably observed.
+    /// </summary>
+    private sealed class SessionSniffer : IDisposable
+    {
+        private readonly List<CopilotSession> _seen = [];
+        private readonly Thread _thread;
+        private volatile bool _stop;
+
+        public SessionSniffer(IDictionary sessions)
+        {
+            _thread = new Thread(() =>
+            {
+                var iterations = 0L;
+                while (!_stop)
+                {
+                    iterations++;
+                    foreach (CopilotSession s in sessions.Values)
+                    {
+                        lock (_seen)
+                        {
+                            if (!_seen.Contains(s)) _seen.Add(s);
+                        }
+                    }
+                }
+                Iterations = iterations;
+            })
+            { IsBackground = true };
+            _thread.Start();
+        }
+
+        public long Iterations { get; private set; }
+
+        public IReadOnlyList<CopilotSession> Stop()
+        {
+            _stop = true;
+            _thread.Join();
+            lock (_seen) return [.. _seen];
+        }
+
+        public void Dispose() => _stop = true;
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_Failure_Does_Not_Leak_The_Session_Or_Its_Event_Loop()
+    {
+        // An invalid per-session GitHub token, redirected at the replaying proxy, makes
+        // the real CLI reject session.create with a genuine RPC error (401 Unauthorized)
+        // — the same failure path a real user would hit, not a mocked transport.
+        var env = new Dictionary<string, string>(Ctx.GetEnvironment())
+        {
+            ["COPILOT_DEBUG_GITHUB_API_URL"] = Ctx.ProxyUrl,
+        };
+        var client = Ctx.CreateClient(environment: env, autoInjectGitHubToken: false);
+
+        async Task CreateFailingAsync()
+        {
+            var ex = await Assert.ThrowsAnyAsync<Exception>(() => Ctx.CreateSessionAsync(client, new SessionConfig
+            {
+                GitHubToken = "invalid-token",
+                OnPermissionRequest = PermissionHandler.ApproveAll,
+            }));
+            Assert.Contains("401", ex.ToString(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        // Warm up: the first call establishes the CLI connection.
+        await CreateFailingAsync();
+
+        var sessions = GetSessionsMap(client);
+
+        // The session is registered (and its event-loop consumer started) before the RPC
+        // completes, and is only ever removed inside CreateSessionAsync's own catch block —
+        // by the time a failed call *returns* to us, RemoveFromClient() has already run, so
+        // polling the dictionary after each await observes nothing. We must instead observe
+        // it concurrently, while each call is still in flight, to capture the real session
+        // object and verify its event channel actually got closed.
+        using var sniffer = new SessionSniffer(sessions);
+
+        for (var i = 0; i < 20; i++)
+        {
+            await CreateFailingAsync();
+        }
+
+        var seen = sniffer.Stop();
+
+        Assert.True(seen.Count > 0, "Test did not observe any in-flight session registrations; cannot validate the fix.");
+        Assert.Empty(sessions);
+
+        foreach (var s in seen)
+        {
+            Assert.True(IsEventChannelClosed(s), "A failed CreateSessionAsync's session had its event channel left open, leaking its background event-processing task.");
+        }
+    }
+
+    [Fact]
+    public async Task ResumeSessionAsync_Failure_Does_Not_Leak_The_Session_Or_Its_Event_Loop()
+    {
+        // Use our own dedicated client rather than the shared fixture's ResumeSessionAsync
+        // helper: that helper spins up a brand-new CopilotClient for every call it makes
+        // (to support the multi-client resume scenarios it's designed for), so each call's
+        // pre-registered session would land in a different, short-lived client's dictionary
+        // that we'd never get to observe. A single, reused client lets us watch one
+        // dictionary across all 20 failed calls.
+        var client = Ctx.CreateClient();
+        var sessions = GetSessionsMap(client);
+
+        async Task ResumeNonExistentAsync()
+        {
+            await Assert.ThrowsAnyAsync<Exception>(() =>
+                Ctx.ResumeSessionAsync(client, "non-existent-leak-check-session", new ResumeSessionConfig
+                {
+                    OnPermissionRequest = PermissionHandler.ApproveAll,
+                }));
+        }
+
+        // Warm up: the first call establishes the CLI connection.
+        await ResumeNonExistentAsync();
+
+        // Same rationale as the CreateSessionAsync test above: the pre-registered session is
+        // already removed from the dictionary by the time a failed call returns, so we must
+        // observe it concurrently, while the call is still in flight, to actually validate
+        // that its event channel got closed rather than just that it got unregistered.
+        using var sniffer = new SessionSniffer(sessions);
+
+        var baseline = sessions.Count;
+        for (var i = 0; i < 20; i++)
+        {
+            await ResumeNonExistentAsync();
+        }
+
+        var seen = sniffer.Stop();
+
+        Assert.True(seen.Count > 0, $"Test did not observe any in-flight session registrations (sniffer ran {sniffer.Iterations} iterations); cannot validate the fix.");
+
+        Assert.True(
+            sessions.Count == baseline,
+            $"Expected no sessions left registered after 20 failed ResumeSessionAsync calls (baseline={baseline}), " +
+            $"but found {sessions.Count}. Failed ResumeSessionAsync calls must not leak the local session registration.");
+
+        foreach (var s in seen)
+        {
+            Assert.True(IsEventChannelClosed(s), "A failed ResumeSessionAsync's session had its event channel left open, leaking its background event-processing task.");
+        }
+    }
+}

--- a/go/client.go
+++ b/go/client.go
@@ -985,6 +985,19 @@ func (c *Client) CreateSession(ctx context.Context, config *SessionConfig) (*Ses
 	}
 	req.SessionID = localSessionID
 
+	// unregisterSession removes only the session created by this call and stops
+	// its event consumer. The latter is essential on CreateSession error paths:
+	// newSession starts processEvents eagerly, and no caller receives the failed
+	// session to disconnect it.
+	unregisterSession := func(sessionID string, s *Session) {
+		c.sessionsMux.Lock()
+		if c.sessions[sessionID] == s {
+			delete(c.sessions, sessionID)
+		}
+		c.sessionsMux.Unlock()
+		s.stopEventProcessing()
+	}
+
 	// initializeSession creates the session, wires up handlers, and registers
 	// it in the sessions map. Invoked from the read loop the instant the
 	// session.create response arrives (synchronously, before the next
@@ -1038,17 +1051,13 @@ func (c *Client) CreateSession(ctx context.Context, config *SessionConfig) (*Ses
 
 		if c.options.SessionFS != nil {
 			if config.CreateSessionFSProvider == nil {
-				c.sessionsMux.Lock()
-				delete(c.sessions, sessionID)
-				c.sessionsMux.Unlock()
+				unregisterSession(sessionID, s)
 				return nil, fmt.Errorf("CreateSessionFSProvider is required in session config when SessionFS is enabled in client options")
 			}
 			provider := config.CreateSessionFSProvider(s)
 			if c.options.SessionFS.Capabilities != nil && c.options.SessionFS.Capabilities.Sqlite {
 				if _, ok := provider.(SessionFSSqliteProvider); !ok {
-					c.sessionsMux.Lock()
-					delete(c.sessions, sessionID)
-					c.sessionsMux.Unlock()
+					unregisterSession(sessionID, s)
 					return nil, fmt.Errorf("SessionFS capabilities declare SQLite support but the provider does not implement SessionFSSqliteProvider")
 				}
 			}
@@ -1105,9 +1114,7 @@ func (c *Client) CreateSession(ctx context.Context, config *SessionConfig) (*Ses
 	result, err := c.client.RequestWithInlineResponse(ctx, "session.create", req, inlineCb)
 	if err != nil {
 		if registeredSessionID != "" {
-			c.sessionsMux.Lock()
-			delete(c.sessions, registeredSessionID)
-			c.sessionsMux.Unlock()
+			unregisterSession(registeredSessionID, session)
 		}
 		return nil, fmt.Errorf("failed to create session: %w", err)
 	}
@@ -1115,9 +1122,7 @@ func (c *Client) CreateSession(ctx context.Context, config *SessionConfig) (*Ses
 	var response createSessionResponse
 	if err := json.Unmarshal(result, &response); err != nil {
 		if registeredSessionID != "" {
-			c.sessionsMux.Lock()
-			delete(c.sessions, registeredSessionID)
-			c.sessionsMux.Unlock()
+			unregisterSession(registeredSessionID, session)
 		}
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
@@ -1127,9 +1132,7 @@ func (c *Client) CreateSession(ctx context.Context, config *SessionConfig) (*Ses
 	}
 
 	if localSessionID != "" && response.SessionID != "" && response.SessionID != localSessionID {
-		c.sessionsMux.Lock()
-		delete(c.sessions, registeredSessionID)
-		c.sessionsMux.Unlock()
+		unregisterSession(registeredSessionID, session)
 		return nil, fmt.Errorf("session.create returned sessionId %s but the caller requested %s", response.SessionID, localSessionID)
 	}
 	if config.OnMCPAuthRequest != nil {

--- a/go/client.go
+++ b/go/client.go
@@ -1414,6 +1414,11 @@ func (c *Client) ResumeSessionWithOptions(ctx context.Context, sessionID string,
 			}
 		}
 		c.sessionsMux.Unlock()
+		// newSession starts processEvents eagerly, before the RPC confirms the
+		// resume; every failure path here restores the previously-registered
+		// session (if any) but never returns this failed one to the caller, so
+		// its event consumer must be stopped here or it leaks forever.
+		session.stopEventProcessing()
 	}
 
 	if c.options.SessionFS != nil {

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -924,6 +924,139 @@ func sessionIDFromParams(t *testing.T, params json.RawMessage) string {
 	return decoded.SessionID
 }
 
+func TestClient_CreateSessionFailureClosesRegisteredSession(t *testing.T) {
+	tests := []struct {
+		name       string
+		response   func(string) (json.RawMessage, *jsonrpc2.Error)
+		wantErrSub string
+	}{
+		{
+			name: "RPC failure",
+			response: func(string) (json.RawMessage, *jsonrpc2.Error) {
+				return nil, &jsonrpc2.Error{Code: -32000, Message: "session creation failed"}
+			},
+			wantErrSub: "failed to create session",
+		},
+		{
+			name: "invalid response",
+			response: func(string) (json.RawMessage, *jsonrpc2.Error) {
+				return json.RawMessage(`"invalid"`), nil
+			},
+			wantErrSub: "failed to unmarshal response",
+		},
+		{
+			name: "session ID mismatch",
+			response: func(string) (json.RawMessage, *jsonrpc2.Error) {
+				return json.RawMessage(`{"sessionId":"different-session"}`), nil
+			},
+			wantErrSub: "but the caller requested failed-session",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rpcClient, server, _ := newRuntimeShutdownRpcPair(t)
+			t.Cleanup(server.Stop)
+			client := &Client{
+				client:   rpcClient,
+				RPC:      rpc.NewServerRPC(rpcClient),
+				sessions: make(map[string]*Session),
+			}
+
+			captured := make(chan *Session, 1)
+			server.SetRequestHandler("session.create", func(params json.RawMessage) (json.RawMessage, *jsonrpc2.Error) {
+				sessionID := sessionIDFromParams(t, params)
+				client.sessionsMux.Lock()
+				session := client.sessions[sessionID]
+				client.sessionsMux.Unlock()
+				captured <- session
+				return tt.response(sessionID)
+			})
+
+			_, err := client.CreateSession(t.Context(), &SessionConfig{SessionID: "failed-session"})
+			if err == nil || !strings.Contains(err.Error(), tt.wantErrSub) {
+				t.Fatalf("CreateSession error = %v, want substring %q", err, tt.wantErrSub)
+			}
+
+			session := <-captured
+			if session == nil {
+				t.Fatal("session was not registered before session.create")
+			}
+			assertSessionEventChannelClosed(t, session)
+			assertSessionNotRegistered(t, client, "failed-session")
+		})
+	}
+}
+
+func TestClient_CreateSessionInitializationFailureClosesRegisteredSession(t *testing.T) {
+	rpcClient, server, _ := newRuntimeShutdownRpcPair(t)
+	t.Cleanup(server.Stop)
+	client := &Client{
+		client:   rpcClient,
+		RPC:      rpc.NewServerRPC(rpcClient),
+		sessions: make(map[string]*Session),
+		options: ClientOptions{SessionFS: &SessionFSConfig{
+			InitialWorkingDirectory: "/",
+			SessionStatePath:        "/session-state",
+			Conventions:             rpc.SessionFSSetProviderConventionsPosix,
+			Capabilities:            &SessionFSCapabilities{Sqlite: true},
+		}},
+	}
+
+	var captured *Session
+	_, err := client.CreateSession(t.Context(), &SessionConfig{
+		SessionID: "failed-session-fs",
+		CreateSessionFSProvider: func(session *Session) SessionFSProvider {
+			captured = session
+			return noSQLiteSessionFSProvider{}
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not implement SessionFSSqliteProvider") {
+		t.Fatalf("CreateSession error = %v, want SQLite provider validation error", err)
+	}
+	if captured == nil {
+		t.Fatal("CreateSessionFSProvider did not receive the registered session")
+	}
+	assertSessionEventChannelClosed(t, captured)
+	assertSessionNotRegistered(t, client, "failed-session-fs")
+}
+
+func assertSessionEventChannelClosed(t *testing.T, session *Session) {
+	t.Helper()
+	select {
+	case _, ok := <-session.eventCh:
+		if ok {
+			t.Fatal("session event channel is still open")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for session event channel to close")
+	}
+}
+
+func assertSessionNotRegistered(t *testing.T, client *Client, sessionID string) {
+	t.Helper()
+	client.sessionsMux.Lock()
+	defer client.sessionsMux.Unlock()
+	if _, ok := client.sessions[sessionID]; ok {
+		t.Fatalf("session %q is still registered", sessionID)
+	}
+}
+
+type noSQLiteSessionFSProvider struct{}
+
+func (noSQLiteSessionFSProvider) ReadFile(string) (string, error)         { return "", nil }
+func (noSQLiteSessionFSProvider) WriteFile(string, string, *int) error    { return nil }
+func (noSQLiteSessionFSProvider) AppendFile(string, string, *int) error   { return nil }
+func (noSQLiteSessionFSProvider) Exists(string) (bool, error)             { return false, nil }
+func (noSQLiteSessionFSProvider) Stat(string) (*SessionFSFileInfo, error) { return nil, nil }
+func (noSQLiteSessionFSProvider) MakeDirectory(string, bool, *int) error  { return nil }
+func (noSQLiteSessionFSProvider) ReadDirectory(string) ([]string, error)  { return nil, nil }
+func (noSQLiteSessionFSProvider) ReadDirectoryWithTypes(string) ([]rpc.SessionFSReaddirWithTypesEntry, error) {
+	return nil, nil
+}
+func (noSQLiteSessionFSProvider) Remove(string, bool, bool) error { return nil }
+func (noSQLiteSessionFSProvider) Rename(string, string) error     { return nil }
+
 func assertRuntimeShutdownNotCalled(t *testing.T, shutdownCalled <-chan struct{}) {
 	t.Helper()
 	select {

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -1021,15 +1021,101 @@ func TestClient_CreateSessionInitializationFailureClosesRegisteredSession(t *tes
 	assertSessionNotRegistered(t, client, "failed-session-fs")
 }
 
+func TestClient_ResumeSessionFailureClosesRegisteredSession(t *testing.T) {
+	tests := []struct {
+		name       string
+		response   func(string) (json.RawMessage, *jsonrpc2.Error)
+		wantErrSub string
+	}{
+		{
+			name: "RPC failure",
+			response: func(string) (json.RawMessage, *jsonrpc2.Error) {
+				return nil, &jsonrpc2.Error{Code: -32000, Message: "session resume failed"}
+			},
+			wantErrSub: "failed to resume session",
+		},
+		{
+			name: "invalid response",
+			response: func(string) (json.RawMessage, *jsonrpc2.Error) {
+				return json.RawMessage(`"invalid"`), nil
+			},
+			wantErrSub: "failed to unmarshal response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rpcClient, server, _ := newRuntimeShutdownRpcPair(t)
+			t.Cleanup(server.Stop)
+			client := &Client{
+				client:   rpcClient,
+				RPC:      rpc.NewServerRPC(rpcClient),
+				sessions: make(map[string]*Session),
+			}
+
+			captured := make(chan *Session, 1)
+			server.SetRequestHandler("session.resume", func(params json.RawMessage) (json.RawMessage, *jsonrpc2.Error) {
+				sessionID := sessionIDFromParams(t, params)
+				client.sessionsMux.Lock()
+				session := client.sessions[sessionID]
+				client.sessionsMux.Unlock()
+				captured <- session
+				return tt.response(sessionID)
+			})
+
+			_, err := client.ResumeSession(t.Context(), "resumed-session", &ResumeSessionConfig{})
+			if err == nil || !strings.Contains(err.Error(), tt.wantErrSub) {
+				t.Fatalf("ResumeSession error = %v, want substring %q", err, tt.wantErrSub)
+			}
+
+			session := <-captured
+			if session == nil {
+				t.Fatal("session was not registered before session.resume")
+			}
+			assertSessionEventChannelClosed(t, session)
+			assertSessionNotRegistered(t, client, "resumed-session")
+		})
+	}
+}
+
+func TestClient_ResumeSessionInitializationFailureClosesRegisteredSession(t *testing.T) {
+	rpcClient, server, _ := newRuntimeShutdownRpcPair(t)
+	t.Cleanup(server.Stop)
+	client := &Client{
+		client:   rpcClient,
+		RPC:      rpc.NewServerRPC(rpcClient),
+		sessions: make(map[string]*Session),
+		options: ClientOptions{SessionFS: &SessionFSConfig{
+			InitialWorkingDirectory: "/",
+			SessionStatePath:        "/session-state",
+			Conventions:             rpc.SessionFSSetProviderConventionsPosix,
+			Capabilities:            &SessionFSCapabilities{Sqlite: true},
+		}},
+	}
+
+	var captured *Session
+	_, err := client.ResumeSession(t.Context(), "resumed-session-fs", &ResumeSessionConfig{
+		CreateSessionFSProvider: func(session *Session) SessionFSProvider {
+			captured = session
+			return noSQLiteSessionFSProvider{}
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not implement SessionFSSqliteProvider") {
+		t.Fatalf("ResumeSession error = %v, want SQLite provider validation error", err)
+	}
+	if captured == nil {
+		t.Fatal("CreateSessionFSProvider did not receive the registered session")
+	}
+	assertSessionEventChannelClosed(t, captured)
+	assertSessionNotRegistered(t, client, "resumed-session-fs")
+}
+
 func assertSessionEventChannelClosed(t *testing.T, session *Session) {
 	t.Helper()
 	select {
-	case _, ok := <-session.eventCh:
-		if ok {
-			t.Fatal("session event channel is still open")
-		}
+	case <-session.eventDone:
 	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for session event channel to close")
+		t.Fatal("timed out waiting for session event processing to stop")
 	}
 }
 

--- a/go/internal/e2e/session_event_loop_leak_e2e_test.go
+++ b/go/internal/e2e/session_event_loop_leak_e2e_test.go
@@ -1,0 +1,102 @@
+package e2e
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	copilot "github.com/github/copilot-sdk/go"
+	"github.com/github/copilot-sdk/go/internal/e2e/testharness"
+)
+
+// TestSessionEventLoopLeakE2E is a regression test for the goroutine leak fixed
+// alongside PR #2360: CreateSession/ResumeSession construct a *Session and start
+// its event-dispatch goroutine eagerly, before the server confirms the session,
+// so the CLI can route session-scoped requests to it while session.create (or
+// session.resume) is still being processed. Every failure path must stop that
+// goroutine — otherwise each failed call leaks one goroutine forever, since no
+// caller ever receives the failed session to Disconnect() it. This test fails
+// without the fix and passes with it.
+func TestSessionEventLoopLeakE2E(t *testing.T) {
+	ctx := testharness.NewTestContext(t)
+
+	t.Run("CreateSession failure does not leak the event loop goroutine", func(t *testing.T) {
+		ctx.ConfigureForTest(t)
+
+		// Redirect the CLI's GitHub API calls at the replaying proxy so an
+		// invalid per-session token makes the real CLI reject session.create
+		// with a genuine RPC error (401 Unauthorized), exercising the same
+		// failure path a real user would hit — not a mocked transport.
+		client := ctx.NewClient(func(opts *copilot.ClientOptions) {
+			opts.Env = append(opts.Env, "COPILOT_DEBUG_GITHUB_API_URL="+ctx.ProxyURL)
+		})
+		t.Cleanup(func() { client.ForceStop() })
+
+		createFailing := func() {
+			if _, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
+				OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+				GitHubToken:         "invalid-token",
+			}); err == nil {
+				t.Fatal("expected CreateSession to fail with an invalid token")
+			}
+		}
+
+		// Warm up: the first call spawns the CLI subprocess and its steady-state
+		// goroutines (read loop, etc.), which must not be counted as leaks.
+		createFailing()
+
+		assertNoGoroutineLeak(t, 20, createFailing)
+	})
+
+	t.Run("ResumeSession failure does not leak the event loop goroutine", func(t *testing.T) {
+		ctx.ConfigureForTest(t)
+
+		client := ctx.NewClient()
+		t.Cleanup(func() { client.ForceStop() })
+
+		resumeNonExistent := func() {
+			if _, err := client.ResumeSession(t.Context(), "non-existent-leak-check-session", &copilot.ResumeSessionConfig{
+				OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+			}); err == nil {
+				t.Fatal("expected ResumeSession for a non-existent session to fail")
+			}
+		}
+
+		// Warm up: the first call spawns the CLI subprocess and its steady-state
+		// goroutines (read loop, etc.), which must not be counted as leaks.
+		resumeNonExistent()
+
+		assertNoGoroutineLeak(t, 20, resumeNonExistent)
+	})
+}
+
+// assertNoGoroutineLeak runs fn n times and fails if the goroutine count grows
+// roughly in proportion to n afterward, which would indicate one goroutine
+// leaked per call rather than transient goroutines that already exited.
+func assertNoGoroutineLeak(t *testing.T, n int, fn func()) {
+	t.Helper()
+	runtime.GC()
+	before := runtime.NumGoroutine()
+
+	for i := 0; i < n; i++ {
+		fn()
+	}
+
+	// Give any goroutines that exit promptly (but not synchronously with the
+	// call returning) a brief window to actually terminate before measuring.
+	deadline := time.Now().Add(2 * time.Second)
+	var after int
+	for {
+		runtime.GC()
+		after = runtime.NumGoroutine()
+		if after <= before+3 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	t.Logf("goroutines before=%d after=%d (n=%d)", before, after, n)
+	if after > before+3 {
+		t.Fatalf("goroutine count grew from %d to %d after %d failed calls; suspected event-loop leak", before, after, n)
+	}
+}

--- a/go/session.go
+++ b/go/session.go
@@ -1433,6 +1433,9 @@ func (s *Session) processEvents() {
 	}
 }
 
+// stopEventProcessing stops the session event consumer without making an RPC.
+// CreateSession/ResumeSession use this when a locally registered session fails
+// before it can be returned to the caller.
 func (s *Session) stopEventProcessing() {
 	s.closeOnce.Do(func() { close(s.eventDone) })
 }


### PR DESCRIPTION
## Summary

- stop the eagerly started session event consumer when `CreateSession` fails
- centralize local event-channel shutdown so failure cleanup does not issue a `session.destroy` RPC
- cover RPC errors, malformed responses, session ID mismatches, and SessionFS initialization failures

## Root cause

`newSession` starts `processEvents` immediately. The affected error paths removed the pre-registered session from `Client.sessions` but left its event channel open. Because the failed session was neither returned to the caller nor retained for `Client.Stop`, its goroutine remained blocked on the channel for the lifetime of the process.

The cleanup now removes only the session instance created by the failing call and closes its event channel without making another RPC.

## Impact

Failed non-cloud session creation no longer leaks one goroutine, session object, and buffered event channel per attempt.

## Validation

- `go test .`
- `go test -race . -run 'TestClient_CreateSession(Failure|InitializationFailure)ClosesRegisteredSession' -count=1`
- `git diff --check`

Fixes #2320
