### PR TITLE
Add reportedClientSessionId to Rust session create/resume wire

### DIFF
--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1909,6 +1909,14 @@ impl ManagedSettings {
 pub struct SessionConfig {
     /// Custom session ID. When unset, the CLI generates one.
     pub session_id: Option<SessionId>,
+    /// Client session ID reported for AI-credit attribution and telemetry.
+    ///
+    /// When set to a non-empty value, this seeds the runtime's client-session
+    /// scalar (which drives `X-Client-Session-Id` and telemetry) without
+    /// affecting the logical [`session_id`](Self::session_id) used for
+    /// resume-reattach, permission hooks, and the workspace filesystem. When
+    /// unset or empty, the runtime falls back to `session_id`.
+    pub reported_client_session_id: Option<String>,
     /// Model to use (e.g. `"gpt-4"`, `"claude-sonnet-4"`).
     pub model: Option<String>,
     /// Application name sent as `User-Agent` context.
@@ -2222,6 +2230,10 @@ impl std::fmt::Debug for SessionConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SessionConfig")
             .field("session_id", &self.session_id)
+            .field(
+                "reported_client_session_id",
+                &self.reported_client_session_id,
+            )
             .field("model", &self.model)
             .field("client_name", &self.client_name)
             .field("reasoning_effort", &self.reasoning_effort)
@@ -2357,6 +2369,7 @@ impl Default for SessionConfig {
     fn default() -> Self {
         Self {
             session_id: None,
+            reported_client_session_id: None,
             model: None,
             client_name: None,
             reasoning_effort: None,
@@ -2515,6 +2528,7 @@ impl SessionConfig {
 
         let wire = crate::wire::SessionCreateWire {
             session_id,
+            reported_client_session_id: self.reported_client_session_id,
             model: self.model,
             client_name: self.client_name,
             reasoning_effort: self.reasoning_effort,
@@ -2720,6 +2734,15 @@ impl SessionConfig {
     /// Set a custom session ID (when unset, the CLI generates one).
     pub fn with_session_id(mut self, id: impl Into<SessionId>) -> Self {
         self.session_id = Some(id.into());
+        self
+    }
+
+    /// Set the client session ID reported for AI-credit attribution and
+    /// telemetry. Seeds the runtime's client-session scalar
+    /// (`X-Client-Session-Id`) without changing the logical session ID used for
+    /// resume-reattach, permission hooks, and the workspace filesystem.
+    pub fn with_reported_client_session_id(mut self, id: impl Into<String>) -> Self {
+        self.reported_client_session_id = Some(id.into());
         self
     }
 
@@ -3239,6 +3262,16 @@ impl SessionConfig {
 pub struct ResumeSessionConfig {
     /// ID of the session to resume.
     pub session_id: SessionId,
+    /// Client session ID reported for AI-credit attribution and telemetry.
+    ///
+    /// When set to a non-empty value, this seeds the runtime's client-session
+    /// scalar (which drives `X-Client-Session-Id` and telemetry) without
+    /// affecting the logical [`session_id`](Self::session_id) used for
+    /// resume-reattach, permission hooks, and the workspace filesystem. When
+    /// unset or empty, the runtime falls back to `session_id`. This matters for
+    /// steering/resume runs where the reported client session differs from the
+    /// session being resumed.
+    pub reported_client_session_id: Option<String>,
     /// Model to use for this session (e.g. `"gpt-4"`, `"claude-sonnet-4"`).
     /// Can change the model when resuming.
     pub model: Option<String>,
@@ -3487,6 +3520,10 @@ impl std::fmt::Debug for ResumeSessionConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ResumeSessionConfig")
             .field("session_id", &self.session_id)
+            .field(
+                "reported_client_session_id",
+                &self.reported_client_session_id,
+            )
             .field("model", &self.model)
             .field("client_name", &self.client_name)
             .field("reasoning_effort", &self.reasoning_effort)
@@ -3659,6 +3696,7 @@ impl ResumeSessionConfig {
 
         let wire = crate::wire::SessionResumeWire {
             session_id: self.session_id,
+            reported_client_session_id: self.reported_client_session_id,
             model: self.model,
             client_name: self.client_name,
             reasoning_effort: self.reasoning_effort,
@@ -3763,6 +3801,7 @@ impl ResumeSessionConfig {
     pub fn new(session_id: SessionId) -> Self {
         Self {
             session_id,
+            reported_client_session_id: None,
             model: None,
             client_name: None,
             reasoning_effort: None,
@@ -3944,6 +3983,16 @@ impl ResumeSessionConfig {
     /// Set the model identifier to switch to on resume (e.g. `"claude-sonnet-4"`).
     pub fn with_model(mut self, model: impl Into<String>) -> Self {
         self.model = Some(model.into());
+        self
+    }
+
+    /// Set the client session ID reported for AI-credit attribution and
+    /// telemetry. Seeds the runtime's client-session scalar
+    /// (`X-Client-Session-Id`) without changing the logical session ID being
+    /// resumed. On steering/resume runs this lets credit spend bill to the
+    /// steering session rather than the resumed task session.
+    pub fn with_reported_client_session_id(mut self, id: impl Into<String>) -> Self {
+        self.reported_client_session_id = Some(id.into());
         self
     }
 
@@ -7152,6 +7201,40 @@ mod tests {
             .expect("no duplicate handlers");
         let empty_json = serde_json::to_value(&empty_wire).unwrap();
         assert!(empty_json.get("capi").is_none());
+    }
+
+    #[test]
+    fn reported_client_session_id_serializes_top_level_on_create() {
+        let (wire, _) = SessionConfig::default()
+            .with_reported_client_session_id("steering-session")
+            .into_wire(Some(SessionId::from("task-session")))
+            .expect("no duplicate handlers");
+        let json = serde_json::to_value(&wire).unwrap();
+        assert_eq!(json["reportedClientSessionId"], "steering-session");
+        assert_eq!(json["sessionId"], "task-session");
+
+        let (empty_wire, _) = SessionConfig::default()
+            .into_wire(Some(SessionId::from("task-session")))
+            .expect("no duplicate handlers");
+        let empty_json = serde_json::to_value(&empty_wire).unwrap();
+        assert!(empty_json.get("reportedClientSessionId").is_none());
+    }
+
+    #[test]
+    fn reported_client_session_id_serializes_top_level_on_resume() {
+        let (wire, _) = ResumeSessionConfig::new(SessionId::from("task-session"))
+            .with_reported_client_session_id("steering-session")
+            .into_wire()
+            .expect("no duplicate handlers");
+        let json = serde_json::to_value(&wire).unwrap();
+        assert_eq!(json["reportedClientSessionId"], "steering-session");
+        assert_eq!(json["sessionId"], "task-session");
+
+        let (empty_wire, _) = ResumeSessionConfig::new(SessionId::from("task-session"))
+            .into_wire()
+            .expect("no duplicate handlers");
+        let empty_json = serde_json::to_value(&empty_wire).unwrap();
+        assert!(empty_json.get("reportedClientSessionId").is_none());
     }
 
     #[test]

--- a/rust/src/wire.rs
+++ b/rust/src/wire.rs
@@ -50,6 +50,8 @@ pub(crate) struct SessionCreateWire {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_id: Option<SessionId>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub reported_client_session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_name: Option<String>,
@@ -198,6 +200,8 @@ pub(crate) struct SessionCreateWire {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SessionResumeWire {
     pub session_id: SessionId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reported_client_session_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## What

Threads a new optional `reported_client_session_id` through the **Rust** SDK's `SessionConfig` and `ResumeSessionConfig`, serialized as a flat top-level `reportedClientSessionId` on both the `session.create` and `session.resume` JSON-RPC wire.

Part of a 4-repo fix for CCA (Cloud Copilot Coding Agent) per-session AI-credit attribution. On steering/resume runs the wrong session id lands on `X-Client-Session-Id`, so AI-credit spend bills to the task session instead of the steering session. This field lets callers seed the runtime's client-session scalar (→ `X-Client-Session-Id` + telemetry) **without** touching the logical/registry `session_id`, which keys resume-reattach, permission hooks, and the workspace filesystem.

## Semantics

- Wire key (camelCase JSON): `reportedClientSessionId` — **flat top-level, sibling of `sessionId`** (not nested), on both create and resume.
- Rust field: `reported_client_session_id: Option<String>`; builder: `with_reported_client_session_id(impl Into<String>)`.
- `#[serde(skip_serializing_if = "Option::is_none")]` ⇒ **absent/`None` emits nothing and the wire is byte-for-byte identical to today**; the engine then falls back to `session_id`. Non-empty wins.

Flat top-level is required because the runtime consumer (`copilot-agent-runtime#16469`) forwards this via its standalone-jsonrpc `UPDATE_OPTIONS_FORWARDED_KEYS` allowlist, which reads a flat top-level param on both `create_session` and `resume_session`. Nesting it under a sub-object would break pickup.

## Changes (Rust only)

- `SessionConfig` + `ResumeSessionConfig`: new `reported_client_session_id` field (docs; `Default`/`new` initialize to `None`; included in the custom `Debug` impls).
- `with_reported_client_session_id(..)` builder on each (mirrors `with_client_name`).
- `SessionCreateWire` + `SessionResumeWire`: new field, `skip_serializing_if = Option::is_none`, camelCase, flat top-level sibling of `sessionId`.
- Mapped through both `into_wire()`.
- Tests: absent ⇒ `reportedClientSessionId` omitted; present ⇒ appears top-level on **create and resume** (with `sessionId` unchanged).

## Scope: Rust-only (TS intentionally out of scope)

CCA drives copilotd via **copilotd bootstrap env vars** → copilot-host (Rust) → this Rust SDK builder → closed wire. It does **not** convey this identity through the TS `CopilotClient.createSession`/`resumeSession` JSON-RPC param path, so a TS `reportedClientSessionId` option would be permanent dead surface for this use case. Any non-CCA TS parity is a separate future PR.

## Consumer / release ordering

- Runtime consumer: `copilot-agent-runtime#16469`.
- **This SDK must release before copilot-host can bump its pin** and call `.with_reported_client_session_id(..)`.

## Validation

- `cargo test --all-features` — new tests pass.
- `cargo +nightly-2026-04-14 fmt --check` — clean.
- `cargo clippy --all-features --all-targets -- -D warnings` — clean.