### PR TITLE
fix(python): serialize native values in tool results

### DIFF
--- a/python/copilot/tools.py
+++ b/python/copilot/tools.py
@@ -11,7 +11,11 @@ import inspect
 import json
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from datetime import date, datetime, time
+from decimal import Decimal
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, get_type_hints, overload
+from uuid import UUID
 
 from pydantic import BaseModel, ValidationError
 
@@ -363,10 +367,18 @@ def _normalize_result(result: Any) -> ToolResult:
             result_type="success",
         )
 
-    # Everything else gets JSON-serialized (with Pydantic model support)
+    # Everything else gets JSON-serialized (with common Python and Pydantic values)
     def default(obj: Any) -> Any:
         if isinstance(obj, BaseModel):
             return obj.model_dump(mode="json")
+        if isinstance(obj, (date, datetime, time)):
+            return obj.isoformat()
+        if isinstance(obj, (Decimal, UUID)):
+            return str(obj)
+        if isinstance(obj, Enum):
+            return obj.value
+        if isinstance(obj, set):
+            return list(obj)
         raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
     try:

--- a/python/test_tools.py
+++ b/python/test_tools.py
@@ -427,6 +427,39 @@ class TestNormalizeResult:
         assert set(parsed["tags"]) == {"python", "sdk"}
         assert result.result_type == "success"
 
+    def test_plain_dict_with_non_primitive_fields_is_serialized(self):
+        from datetime import date, datetime, time
+        from decimal import Decimal
+        from enum import Enum
+        from uuid import UUID
+
+        class Status(Enum):
+            ACTIVE = "active"
+
+        result = _normalize_result(
+            {
+                "id": UUID("12345678-1234-5678-1234-567812345678"),
+                "created": datetime(2026, 1, 15, 10, 30, 0),
+                "day": date(2026, 1, 15),
+                "at": time(10, 30, 0),
+                "score": Decimal("99.5"),
+                "status": Status.ACTIVE,
+                "tags": {"python", "sdk"},
+            }
+        )
+        parsed = json.loads(result.text_result_for_llm)
+        assert parsed == {
+            "id": "12345678-1234-5678-1234-567812345678",
+            "created": "2026-01-15T10:30:00",
+            "day": "2026-01-15",
+            "at": "10:30:00",
+            "score": "99.5",
+            "status": "active",
+            "tags": parsed["tags"],
+        }
+        assert set(parsed["tags"]) == {"python", "sdk"}
+        assert result.result_type == "success"
+
     def test_raises_for_unserializable_value(self):
         # Functions cannot be JSON serialized
         with pytest.raises(TypeError, match="Failed to serialize"):


### PR DESCRIPTION
Fixes #2203

## Summary

Complete the plain-container serialization case intentionally left out of #2225. Python tool handlers can now return dictionaries containing common native values without those successful results being converted into opaque tool failures.

## Fix

Extend the existing json.dumps fallback with the same JSON-safe representations used for Pydantic tool results:

- datetime, date, and time values use ISO 8601 strings
- UUID and Decimal values use strings
- Enum values use their underlying value
- sets use JSON arrays

Unsupported objects continue to raise the existing clear serialization error.

## Tests

The regression test failed on current main with:

    TypeError: Failed to serialize tool result: Object of type UUID is not JSON serializable

Passing validation:

- Python 3.13: 42 tool tests passed
- Python 3.11 (the oldest CI version): 42 tool tests passed
- complete offline root suite: 209 tests passed
- Ruff formatting check passed
- Ruff lint passed
- ty check copilot passed
- git diff --check passed

No Copilot session, model, paid API, or external service is required for the regression test. Authenticated runtime E2E tests were not run locally.