### PR TITLE
feat(nodejs): add Session.searchMessages() to query session history (#2376)

### DIFF
--- a/nodejs/src/index.ts
+++ b/nodejs/src/index.ts
@@ -135,6 +135,7 @@ export type {
     ProviderTokenArgs,
     RemoteSessionMode,
     ResumeSessionConfig,
+    SearchMessagesOptions,
     SectionOverride,
     SectionOverrideAction,
     SectionTransformFn,

--- a/nodejs/src/session.ts
+++ b/nodejs/src/session.ts
@@ -47,6 +47,7 @@ import type {
     ReasoningEffort,
     ReasoningSummary,
     ModelCapabilitiesOverride,
+    SearchMessagesOptions,
     SectionTransformFn,
     SessionCapabilities,
     SessionEvent,
@@ -1962,6 +1963,61 @@ export class CopilotSession {
     }
 
     /**
+     * Searches this session's history for events whose textual content matches a query.
+     *
+     * This is a convenience wrapper over {@link getEvents}: it fetches the full
+     * conversation history and filters it in memory. The `query` is matched
+     * against the textual content of each event — every string value nested
+     * within the event's `data` payload (message text, tool output, error
+     * messages, and so on). Structural fields such as `type`, `id`, and
+     * `timestamp`, as well as object keys, are not searched; use
+     * {@link SearchMessagesOptions.eventType} to filter by event type instead.
+     *
+     * Matching events are returned in history order (the order {@link getEvents}
+     * returns them).
+     *
+     * @param query - A substring to look for, or a {@link RegExp} to test
+     *   against. A string matches case-insensitively by default; pass
+     *   `{ caseSensitive: true }` for exact-case matching. A RegExp is applied
+     *   as-is, so control its case sensitivity with the `i` flag. An empty
+     *   string matches every event (subject to the `eventType` filter).
+     * @param options - Optional filters. See {@link SearchMessagesOptions}.
+     * @returns A promise that resolves with the matching events.
+     * @throws Error if the session has been disconnected or the connection fails
+     *
+     * @example
+     * ```typescript
+     * // Case-insensitive substring search across all events
+     * const results = await session.searchMessages("authentication");
+     *
+     * // Only assistant messages mentioning "deploy"
+     * const deploys = await session.searchMessages("deploy", {
+     *   eventType: "assistant.message",
+     * });
+     *
+     * // Regular-expression search (case-insensitive via the i flag)
+     * const failures = await session.searchMessages(/timed out|refused/i, {
+     *   eventType: "session.error",
+     * });
+     * ```
+     */
+    async searchMessages(
+        query: string | RegExp,
+        options?: SearchMessagesOptions
+    ): Promise<SessionEvent[]> {
+        const events = await this.getEvents();
+        const eventType = options?.eventType;
+        const matches = createSearchMatcher(query, options?.caseSensitive === true);
+
+        return events.filter((event) => {
+            if (eventType !== undefined && event.type !== eventType) {
+                return false;
+            }
+            return matches(collectSearchableText(event));
+        });
+    }
+
+    /**
      * Disconnects this session and releases all in-memory resources (event handlers,
      * tool handlers, permission handlers).
      *
@@ -2101,6 +2157,56 @@ function isToolResultObject(value: unknown): value is ToolResultObject {
     ];
 
     return allowedResultTypes.includes((value as ToolResultObject).resultType);
+}
+
+/**
+ * Builds a predicate that tests whether a piece of text matches a search query,
+ * for {@link CopilotSession.searchMessages}.
+ *
+ * A RegExp query is cloned with its stateful global/sticky (`g`/`y`) flags
+ * removed, so repeated `.test()` calls never depend on a shared `lastIndex` and
+ * the caller's RegExp is never mutated; case sensitivity (the `i` flag) and all
+ * other flags are preserved. A string query is a substring match,
+ * case-insensitive unless `caseSensitive` is set.
+ */
+function createSearchMatcher(
+    query: string | RegExp,
+    caseSensitive: boolean
+): (text: string) => boolean {
+    if (query instanceof RegExp) {
+        const stablePattern = new RegExp(query.source, query.flags.replace(/[gy]/g, ""));
+        return (text: string): boolean => stablePattern.test(text);
+    }
+    if (caseSensitive) {
+        return (text: string): boolean => text.includes(query);
+    }
+    const needle = query.toLowerCase();
+    return (text: string): boolean => text.toLowerCase().includes(needle);
+}
+
+/**
+ * Collects every string value nested within a session event's `data` payload
+ * into a single newline-joined string for text searching. Object keys and
+ * non-string leaves (numbers, booleans, null) are ignored, so a search matches
+ * message content rather than structural field names or identifiers.
+ */
+function collectSearchableText(event: SessionEvent): string {
+    const parts: string[] = [];
+    const visit = (value: unknown): void => {
+        if (typeof value === "string") {
+            parts.push(value);
+        } else if (Array.isArray(value)) {
+            for (const item of value) {
+                visit(item);
+            }
+        } else if (value !== null && typeof value === "object") {
+            for (const nested of Object.values(value)) {
+                visit(nested);
+            }
+        }
+    };
+    visit((event as { data?: unknown }).data);
+    return parts.join("\n");
 }
 
 /** Convert a canvas handler error into a ResponseError with a structured data envelope. */

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -3263,6 +3263,28 @@ export type TypedSessionEventHandler<T extends SessionEventType> = (
 export type SessionEventHandler = (event: SessionEvent) => void;
 
 /**
+ * Options for {@link CopilotSession.searchMessages}.
+ */
+export interface SearchMessagesOptions {
+    /**
+     * Restrict the search to events of this exact type (for example
+     * `"assistant.message"` or `"user.message"`). When omitted, events of every
+     * type are searched. Known event-type literals are offered as autocomplete
+     * suggestions, but any string is accepted.
+     */
+    eventType?: SessionEventType | (string & {});
+
+    /**
+     * Whether string matching is case-sensitive. Defaults to `false`
+     * (case-insensitive).
+     *
+     * Ignored when `query` is a {@link RegExp}: a regular expression controls its
+     * own case sensitivity through the `i` flag.
+     */
+    caseSensitive?: boolean;
+}
+
+/**
  * Working directory context for a session
  */
 export interface SessionContext {

--- a/nodejs/test/session-search-messages.test.ts
+++ b/nodejs/test/session-search-messages.test.ts
@@ -1,0 +1,231 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it, vi } from "vitest";
+import type { MessageConnection } from "vscode-jsonrpc/node.js";
+import { CopilotSession } from "../src/session.js";
+import type { SessionEvent } from "../src/types.js";
+
+/**
+ * Builds a session event with an arbitrary `type` and `data` payload. The shape
+ * is cast to {@link SessionEvent} so tests can exercise `searchMessages` against
+ * realistic fixtures without reconstructing every field of each event variant.
+ */
+function event(type: string, data: unknown, id: string): SessionEvent {
+    return {
+        type,
+        id,
+        parentId: null,
+        timestamp: "2026-08-23T00:00:00.000Z",
+        data,
+    } as unknown as SessionEvent;
+}
+
+/** History fixture covering assistant/user/error events, nested data, and a string-free event. */
+function historyFixture(): SessionEvent[] {
+    return [
+        event(
+            "user.message",
+            { content: "Please add user Authentication to the login flow" },
+            "u1"
+        ),
+        event(
+            "assistant.message",
+            { content: "I'll implement authentication using JWT tokens." },
+            "a1"
+        ),
+        event("user.message", { content: "Now DEPLOY it to staging" }, "u2"),
+        event("assistant.message", { content: "Deploying to staging now." }, "a2"),
+        event(
+            "session.error",
+            { errorType: "notification", message: "Connection refused: timed out after 30s" },
+            "e1"
+        ),
+        // Nested string values (an attachment's displayName) must be searchable.
+        event(
+            "user.message",
+            {
+                content: "See attached",
+                attachments: [{ type: "file", path: "/tmp/x", displayName: "deploy-config.yaml" }],
+            },
+            "t1"
+        ),
+        // No string values anywhere in `data`.
+        event("assistant.usage", { inputTokens: 10, outputTokens: 20, ok: true }, "n1"),
+    ];
+}
+
+/**
+ * Creates a session backed by a mock connection that answers `session.getMessages`
+ * with the given events. Returns the session and a spy on the connection's
+ * `sendRequest` so tests can assert how history is fetched.
+ */
+function sessionWithHistory(events: SessionEvent[]): {
+    session: CopilotSession;
+    sendRequest: ReturnType<typeof vi.fn>;
+} {
+    const sendRequest = vi.fn((method: string) => {
+        if (method === "session.getMessages") {
+            return Promise.resolve({ events });
+        }
+        throw new Error(`unexpected request: ${method}`);
+    });
+    const connection = { sendRequest } as unknown as MessageConnection;
+    return { session: new CopilotSession("session-search", connection), sendRequest };
+}
+
+/** Convenience: run a search and return only the matching event ids, in order. */
+async function searchIds(
+    session: CopilotSession,
+    query: string | RegExp,
+    options?: Parameters<CopilotSession["searchMessages"]>[1]
+): Promise<string[]> {
+    const results = await session.searchMessages(query, options);
+    return results.map((e) => e.id);
+}
+
+describe("searchMessages", () => {
+    it("matches string queries case-insensitively by default", async () => {
+        const { session } = sessionWithHistory(historyFixture());
+        expect(await searchIds(session, "authentication")).toEqual(["u1", "a1"]);
+    });
+
+    it("honors caseSensitive: true for string queries", async () => {
+        const { session } = sessionWithHistory(historyFixture());
+        // Capitalized in u1 ("Authentication"), lowercase in a1 ("authentication").
+        expect(await searchIds(session, "Authentication", { caseSensitive: true })).toEqual(["u1"]);
+        expect(await searchIds(session, "authentication", { caseSensitive: true })).toEqual(["a1"]);
+    });
+
+    it("treats caseSensitive: false the same as the default", async () => {
+        const { session } = sessionWithHistory(historyFixture());
+        expect(await searchIds(session, "AUTHENTICATION", { caseSensitive: false })).toEqual([
+            "u1",
+            "a1",
+        ]);
+    });
+
+    it("filters by eventType", async () => {
+        const { session } = sessionWithHistory(historyFixture());
+        // "deploy" appears in u2, a2, and t1 (nested), but only the assistant one is kept.
+        expect(await searchIds(session, "deploy", { eventType: "assistant.message" })).toEqual([
+            "a2",
+        ]);
+    });
+
+    it("combines eventType with the text query", async () => {
+        const { session } = sessionWithHistory(historyFixture());
+        // Both user.message events mention deploy: u2 directly, t1 via a nested attachment name.
+        expect(await searchIds(session, "deploy", { eventType: "user.message" })).toEqual([
+            "u2",
+            "t1",
+        ]);
+    });
+
+    it("returns an empty array when the eventType matches nothing", async () => {
+        const { session } = sessionWithHistory(historyFixture());
+        expect(
+            await searchIds(session, "deploy", { eventType: "tool.execution_complete" })
+        ).toEqual([]);
+    });
+
+    it("matches RegExp queries", async () => {
+        const { session } = sessionWithHistory(historyFixture());
+        expect(await searchIds(session, /jwt|refused/i)).toEqual(["a1", "e1"]);
+    });
+
+    it("uses a RegExp's own flags for case sensitivity", async () => {
+        const { session } = sessionWithHistory(historyFixture());
+        // "JWT" appears verbatim in a1; a case-sensitive pattern for "jwt" matches nothing.
+        expect(await searchIds(session, /JWT/)).toEqual(["a1"]);
+        expect(await searchIds(session, /jwt/)).toEqual([]);
+    });
+
+    it("ignores caseSensitive when the query is a RegExp", async () => {
+        const { session } = sessionWithHistory(historyFixture());
+        // The i flag wins; the option is inert for RegExp queries.
+        expect(await searchIds(session, /AUTHENTICATION/i, { caseSensitive: true })).toEqual([
+            "u1",
+            "a1",
+        ]);
+    });
+
+    it("matches every applicable event for a global-flagged RegExp (no lastIndex leakage)", async () => {
+        const { session } = sessionWithHistory(historyFixture());
+        // A stateful `g` regex reused across events would skip alternating matches;
+        // all three "deploy" events must be returned regardless of the flag.
+        expect(await searchIds(session, /deploy/gi)).toEqual(["u2", "a2", "t1"]);
+    });
+
+    it("searches string values nested inside data", async () => {
+        const { session } = sessionWithHistory(historyFixture());
+        expect(await searchIds(session, "deploy-config")).toEqual(["t1"]);
+    });
+
+    it("does not match object keys or structural fields", async () => {
+        const { session } = sessionWithHistory(historyFixture());
+        // "content" is a data key; the event type strings and top-level fields are not searched.
+        expect(await searchIds(session, "content")).toEqual([]);
+        expect(await searchIds(session, "assistant.message")).toEqual([]);
+        expect(await searchIds(session, "timestamp")).toEqual([]);
+    });
+
+    it("does not stringify non-string leaves such as numbers or booleans", async () => {
+        const { session } = sessionWithHistory(historyFixture());
+        // n1's data is { inputTokens: 10, outputTokens: 20, ok: true } — no string values.
+        expect(await searchIds(session, "true")).toEqual([]);
+        expect(await searchIds(session, "10")).toEqual([]);
+    });
+
+    it("returns an empty array when nothing matches", async () => {
+        const { session } = sessionWithHistory(historyFixture());
+        expect(await searchIds(session, "no-such-token-xyz")).toEqual([]);
+    });
+
+    it("treats an empty string query as matching every event", async () => {
+        const { session } = sessionWithHistory(historyFixture());
+        expect(await searchIds(session, "")).toEqual(["u1", "a1", "u2", "a2", "e1", "t1", "n1"]);
+        // Still subject to the eventType filter.
+        expect(await searchIds(session, "", { eventType: "assistant.message" })).toEqual([
+            "a1",
+            "a2",
+        ]);
+    });
+
+    it("preserves history order in the results", async () => {
+        const { session } = sessionWithHistory(historyFixture());
+        expect(await searchIds(session, "staging")).toEqual(["u2", "a2"]);
+    });
+
+    it("returns the original SessionEvent objects unchanged", async () => {
+        const events = historyFixture();
+        const { session } = sessionWithHistory(events);
+        const results = await session.searchMessages("JWT tokens");
+        expect(results).toHaveLength(1);
+        // The returned event is the very object from history, not a copy.
+        expect(results[0]).toBe(events[1]);
+    });
+
+    it("does not mutate a RegExp passed by the caller", async () => {
+        const { session } = sessionWithHistory(historyFixture());
+        const query = /deploy/g;
+        await session.searchMessages(query);
+        // A shared global regex would have advanced lastIndex; ours must not touch it.
+        expect(query.lastIndex).toBe(0);
+    });
+
+    it("fetches history via a single session.getMessages request per call", async () => {
+        const { session, sendRequest } = sessionWithHistory(historyFixture());
+        await session.searchMessages("authentication");
+        expect(sendRequest).toHaveBeenCalledTimes(1);
+        expect(sendRequest).toHaveBeenCalledWith("session.getMessages", {
+            sessionId: "session-search",
+        });
+    });
+
+    it("returns an empty array when the session has no history", async () => {
+        const { session } = sessionWithHistory([]);
+        expect(await session.searchMessages("anything")).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary

Implements the feature requested in #2376 — an async `searchMessages()` method on `CopilotSession` for querying inside a session's history, for the **Node.js/TypeScript** SDK.

```ts
async searchMessages(
    query: string | RegExp,
    options?: SearchMessagesOptions,
): Promise<SessionEvent[]>
```

- **`query`** — a `string` (case-insensitive substring by default; exact case via `{ caseSensitive: true }`) or a `RegExp` (case sensitivity governed by its own `i` flag).
- **`options.eventType`** — restrict results to a single event type (e.g. `"assistant.message"`). Typed as `SessionEventType | (string & {})` for autocomplete while still accepting any string.
- Returns the matching `SessionEvent[]` in history order.

## Design notes

- Fetches history via `getEvents()` and filters in memory.
- Matching runs only over the **string leaf values nested within `event.data`** (message text, tool output, error messages, nested attachment fields). Structural fields (`type`, `id`, `timestamp`) and object keys are intentionally not searched, so a query matches content rather than field names or UUIDs.
- For a `RegExp` query, the pattern is cloned with the stateful `g`/`y` flags stripped, so repeated `.test()` calls never depend on a shared `lastIndex` and the caller's `RegExp` is never mutated.
- An empty-string query matches every event (still subject to the `eventType` filter).

## Testing

- `npm test -- test/session-search-messages.test.ts` → 20/20 pass (string/RegExp matching, case sensitivity, `eventType` filtering, nested-`data` matching, `lastIndex` safety, caller's `RegExp` not mutated, order preservation, edge cases).
- `npm run typecheck` → clean. `npm run lint` → 0 errors.

## Scope / alignment

I read [CONTRIBUTING.md](CONTRIBUTING.md) and understand that (a) feature work should be discussed with the team first, and (b) features need to be maintained in sync across all supported languages. This PR is a **Node.js-first implementation** opened against the existing open enhancement issue #2376 as a concrete starting point for that discussion.

If the team is open to this feature, I'm happy to:
- extend it to the other SDKs (Python, Go, .NET, Java, Rust) for parity, and
- adjust the API shape or search semantics to match your preferences.

If it's not aligned with the roadmap, feel free to close — no worries at all, and thanks for the great SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
