### PR TITLE
docs(python): convert bold title to heading

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -349,7 +349,7 @@ async with await client.create_session(
 
 > **Note:** When using `from __future__ import annotations`, define Pydantic models at module level (not inside functions).
 
-**Low-level API (without Pydantic):**
+#### Low-level API (without Pydantic)
 
 For users who prefer manual schema definition:
 


### PR DESCRIPTION
While reporting #2381, I noticed I couldn't link to the **Low-level API** section because it's just bold text, but I think a heading would fit better.