### PR TITLE
fix(python): make pydantic imports lazy

### DIFF
--- a/python/copilot/tools.py
+++ b/python/copilot/tools.py
@@ -13,10 +13,14 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, get_type_hints, overload
 
-from pydantic import BaseModel, ValidationError
-
 if TYPE_CHECKING:
+    from pydantic import BaseModel
+
     from .generated.rpc import CurrentToolMetadata
+
+    T = TypeVar("T", bound=BaseModel)
+else:
+    T = TypeVar("T")
 
 from .generated.rpc import (
     ExternalToolTextResultForLlm,
@@ -89,7 +93,6 @@ class Tool:
     is_terminal: bool = False
 
 
-T = TypeVar("T", bound=BaseModel)
 R = TypeVar("R")
 
 
@@ -144,7 +147,7 @@ def define_tool(
     *,
     description: str | None = None,
     handler: Callable[[Any, ToolInvocation], Any] | None = None,
-    params_type: type[BaseModel] | None = None,
+    params_type: type[Any] | None = None,
     overrides_built_in_tool: bool = False,
     skip_permission: bool = False,
     defer: Literal["auto", "never"] | None = None,
@@ -251,6 +254,8 @@ def define_tool(
                 if takes_params:
                     args = invocation.arguments or {}
                     if ptype is not None and _is_pydantic_model(ptype):
+                        from pydantic import ValidationError
+
                         try:
                             call_args.append(ptype.model_validate(args))
                         except ValidationError as exc:
@@ -332,7 +337,12 @@ def define_tool(
 def _is_pydantic_model(t: Any) -> bool:
     """Check if a type is a Pydantic BaseModel subclass."""
     try:
-        return isinstance(t, type) and issubclass(t, BaseModel)
+        from pydantic import BaseModel as PydanticBaseModel
+    except ImportError:
+        return False
+
+    try:
+        return isinstance(t, type) and issubclass(t, PydanticBaseModel)
     except TypeError:
         return False
 
@@ -365,8 +375,13 @@ def _normalize_result(result: Any) -> ToolResult:
 
     # Everything else gets JSON-serialized (with Pydantic model support)
     def default(obj: Any) -> Any:
-        if isinstance(obj, BaseModel):
-            return obj.model_dump(mode="json")
+        try:
+            from pydantic import BaseModel as PydanticBaseModel
+        except ImportError:
+            pass
+        else:
+            if isinstance(obj, PydanticBaseModel):
+                return obj.model_dump(mode="json")
         raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
     try:

--- a/python/test_tools.py
+++ b/python/test_tools.py
@@ -1,6 +1,9 @@
 """Unit tests for define_tool"""
 
 import json
+import subprocess
+import sys
+import textwrap
 
 import pytest
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -15,6 +18,37 @@ from copilot.tools import (
     convert_mcp_call_tool_result,
     tool_result_to_external_tool_text_result_for_llm,
 )
+
+
+def test_low_level_tool_api_imports_without_pydantic():
+    script = textwrap.dedent(
+        """
+        import builtins
+
+        real_import = builtins.__import__
+
+        def import_without_pydantic(name, *args, **kwargs):
+            if name == "pydantic" or name.startswith("pydantic."):
+                raise ModuleNotFoundError("pydantic is intentionally unavailable")
+            return real_import(name, *args, **kwargs)
+
+        builtins.__import__ = import_without_pydantic
+
+        from copilot.tools import Tool
+
+        tool = Tool(name="low_level", description="No Pydantic required")
+        assert tool.name == "low_level"
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 class TestDefineTool:


### PR DESCRIPTION
Fixes #2381

## Summary

- move the Pydantic model bound behind `TYPE_CHECKING`
- import `ValidationError` and `BaseModel` only when tool type detection, typed validation, or Pydantic result serialization actually needs them
- add a subprocess regression test that blocks all `pydantic` imports and constructs the low-level `Tool` dataclass

This leaves `pydantic` in the package's declared dependencies, so existing `define_tool` installations keep their current behavior. The change only removes the module-level runtime dependency and lets controlled environments use the low-level API when Pydantic is unavailable.

## Validation

- `python -m pytest -q test_tools.py --tb=short` — 42 passed
- `ruff==0.16.0 check .` — passed
- `ruff==0.16.0 format --check .` — 115 files already formatted
- `ty check --python <existing-venv> copilot` — passed
- `git diff --check` — passed

The wider unit suite requires the repository's Copilot CLI binary at collection/runtime. I did not install the Node dependencies locally; the changed tool test module and full static checks are green.
