### PR TITLE
Java: add Windows x64 in-process runtime and native classifier publishing

### DIFF
--- a/.github/actions/java-test-report/action.yml
+++ b/.github/actions/java-test-report/action.yml
@@ -126,7 +126,8 @@ runs:
             if [ -n "$covered" ] && [ -n "$missed" ]; then
               local total=$((covered + missed))
               if [ "$total" -gt 0 ]; then
-                echo "scale=1; $covered * 100 / $total" | bc
+                awk -v covered="$covered" -v total="$total" \
+                  'BEGIN { printf "%.1f\n", covered * 100 / total }'
               else
                 echo "0"
               fi

--- a/.github/workflows/java-publish-maven.yml
+++ b/.github/workflows/java-publish-maven.yml
@@ -1,9 +1,6 @@
 name: "Java Publish to Maven Central"
 
 env:
-  # Disable Husky Git hooks in CI to prevent local development hooks
-  # (e.g., pre-commit formatting checks) from running during automated
-  # workflows that perform git commits and pushes.
   HUSKY: 0
 
 on:
@@ -40,7 +37,7 @@ on:
     outputs:
       mavenPublished:
         description: "Whether the Java package was published to Maven Central"
-        value: ${{ jobs.publish-maven.outputs.published }}
+        value: ${{ jobs.deploy-maven.outputs.published }}
     secrets:
       JAVA_RELEASE_TOKEN:
         required: true
@@ -56,8 +53,7 @@ on:
         required: true
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 concurrency:
   group: publish-maven
@@ -70,11 +66,6 @@ jobs:
     steps:
       - name: Verify JAVA_RELEASE_TOKEN can push to repository
         run: |
-          # JAVA_RELEASE_TOKEN is used by actions/checkout and for:
-          #   - git push origin main (doc updates)
-          #   - mvn release:prepare -DpushChanges=true (release commits + tags)
-          #   - git revert + push (rollback on failure)
-          # It must have push (contents:write) permission on this repo.
           PUSH=$(gh api repos/${{ github.repository }} --jq '.permissions.push // false')
           if [ "$PUSH" != "true" ]; then
             echo "::error::JAVA_RELEASE_TOKEN lacks push permission on ${{ github.repository }}. It is required for pushing release commits and tags to main."
@@ -84,17 +75,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.JAVA_RELEASE_TOKEN }}
 
-  publish-maven:
-    name: Publish Java SDK to Maven Central
+  prepare-release:
+    name: Prepare Java release
     needs: preflight
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         shell: bash
         working-directory: ./java
     outputs:
-      version: ${{ steps.versions.outputs.release_version }}
-      published: ${{ steps.publish-maven.outcome == 'success' }}
+      release_version: ${{ steps.versions.outputs.release_version }}
+      development_version: ${{ steps.versions.outputs.development_version }}
+      release_tag: ${{ steps.release-identity.outputs.release_tag }}
+      tag_commit: ${{ steps.release-identity.outputs.tag_commit }}
+      pre_prepare_commit: ${{ steps.pre-prepare.outputs.pre_prepare_commit }}
+      post_prepare_commit: ${{ steps.release-identity.outputs.post_prepare_commit }}
+      docs_commit: ${{ steps.update-docs.outputs.docs_commit_sha }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -108,8 +106,164 @@ jobs:
 
       - uses: ./.github/actions/setup-copilot
 
-      - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: "25"
+          distribution: "microsoft"
+          cache: "maven"
+
+      - name: Determine versions
+        id: versions
+        run: |
+          CURRENT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "Current pom.xml version: $CURRENT_VERSION"
+
+          if [ -n "${{ inputs.releaseVersion }}" ]; then
+            RELEASE_VERSION="${{ inputs.releaseVersion }}"
+          else
+            RELEASE_VERSION="${CURRENT_VERSION%-SNAPSHOT}"
+          fi
+          echo "Release version: $RELEASE_VERSION"
+
+          if [ -n "${{ inputs.developmentVersion }}" ]; then
+            DEV_VERSION="${{ inputs.developmentVersion }}"
+            if [[ "$DEV_VERSION" != *-SNAPSHOT ]]; then
+              echo "::error::developmentVersion '${DEV_VERSION}' must end with '-SNAPSHOT'."
+              exit 1
+            fi
+          else
+            if ! echo "$RELEASE_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-(preview|(beta-)?java(-preview)?)\.[0-9]+)?$'; then
+              echo "Error: RELEASE_VERSION '$RELEASE_VERSION' is invalid." >&2
+              exit 1
+            fi
+            BASE_VERSION=$(echo "$RELEASE_VERSION" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
+            QUALIFIER=$(echo "$RELEASE_VERSION" | sed "s|^${BASE_VERSION}||")
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
+            DEV_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))${QUALIFIER}-SNAPSHOT"
+          fi
+
+          echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "development_version=$DEV_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Update documentation with release version
+        id: update-docs
+        run: |
+          VERSION="${{ steps.versions.outputs.release_version }}"
+          DEV_VERSION="${{ steps.versions.outputs.development_version }}"
+          ./scripts/test-update-documentation-versions.sh
+          ./scripts/update-documentation-versions.sh "$VERSION" "$DEV_VERSION" README.md sdk/jbang-example.java
+          git add README.md sdk/jbang-example.java
+          git commit -m "docs: update version references to ${VERSION}"
+          echo "docs_commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          git push origin main
+
+      - name: Record rollback base
+        id: pre-prepare
+        run: echo "pre_prepare_commit=$(git rev-parse HEAD^)" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare Release
+        run: |
+          mvn -B release:prepare \
+            -DreleaseVersion=${{ steps.versions.outputs.release_version }} \
+            -DdevelopmentVersion=${{ steps.versions.outputs.development_version }} \
+            -DtagNameFormat=java/v@{project.version} \
+            -DpushChanges=true \
+            -Darguments="-DskipTests"
+        env:
+          MAVEN_USERNAME: ${{ secrets.JAVA_MAVEN_CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.JAVA_MAVEN_CENTRAL_PASSWORD }}
+          JAVA_GPG_PASSPHRASE: ${{ secrets.JAVA_GPG_PASSPHRASE }}
+
+      - name: Record immutable release identity
+        id: release-identity
+        run: |
+          TAG="java/v${{ steps.versions.outputs.release_version }}"
+          TAG_COMMIT=$(git rev-parse "${TAG}^{commit}")
+          POST_PREPARE_COMMIT=$(git rev-parse HEAD)
+          echo "release_tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "tag_commit=$TAG_COMMIT" >> "$GITHUB_OUTPUT"
+          echo "post_prepare_commit=$POST_PREPARE_COMMIT" >> "$GITHUB_OUTPUT"
+
+  build-windows-classifier:
+    name: Build Windows native classifier
+    needs: prepare-release
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: pwsh
+        working-directory: ./java
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: "25"
+          distribution: "microsoft"
+          cache: "maven"
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+
+      - name: Build and validate win32-x64 classifier
+        run: |
+          $sourceCommit = git rev-parse HEAD
+          if ($sourceCommit -ne '${{ needs.prepare-release.outputs.tag_commit }}') {
+            throw "Checked out $sourceCommit instead of the prepared tag commit."
+          }
+          node copilot-native/scripts/validate-native-host.mjs win32-x64
+          mvn -B -pl copilot-native package -DskipTests
+          $version = '${{ needs.prepare-release.outputs.release_version }}'
+          $jar = "copilot-native/target/copilot-sdk-java-runtime-$version-win32-x64.jar"
+          $primaryJar = "copilot-native/target/copilot-sdk-java-runtime-$version.jar"
+          if (-not (Test-Path -LiteralPath $jar -PathType Leaf)) {
+            throw "Expected Windows classifier was not produced: $jar"
+          }
+          node copilot-native/scripts/validate-native-artifact.mjs classifier win32-x64 $jar ([IO.Path]::GetFileName($jar)) ..
+          node copilot-native/scripts/validate-native-artifact.mjs placeholder $primaryJar
+          $manifest = "copilot-native/target/win32-x64-$version.sha256"
+          $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $jar).Hash.ToLowerInvariant()
+          "$hash  $([IO.Path]::GetFileName($jar))" | Set-Content -NoNewline -Encoding ascii $manifest
+          node copilot-native/scripts/validate-native-artifact.mjs checksum $jar $manifest ([IO.Path]::GetFileName($jar))
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: java-native-win32-x64-release-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            java/copilot-native/target/copilot-sdk-java-runtime-${{ needs.prepare-release.outputs.release_version }}-win32-x64.jar
+            java/copilot-native/target/win32-x64-${{ needs.prepare-release.outputs.release_version }}.sha256
+          if-no-files-found: error
+          retention-days: 1
+
+  deploy-maven:
+    name: Deploy Java release to Maven Central
+    needs: [prepare-release, build-windows-classifier]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./java
+    outputs:
+      version: ${{ needs.prepare-release.outputs.release_version }}
+      published: ${{ steps.publish-maven.outcome == 'success' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-copilot
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: "25"
           distribution: "microsoft"
@@ -120,116 +274,203 @@ jobs:
           gpg-private-key: ${{ secrets.JAVA_GPG_SECRET_KEY }}
           gpg-passphrase: JAVA_GPG_PASSPHRASE
 
-      - name: Determine versions
-        id: versions
-        working-directory: ./java
-        run: |
-          CURRENT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo "Current pom.xml version: $CURRENT_VERSION"
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
 
-          # Determine release version
-          if [ -n "${{ inputs.releaseVersion }}" ]; then
-            RELEASE_VERSION="${{ inputs.releaseVersion }}"
-          else
-            # Remove -SNAPSHOT suffix if present
-            RELEASE_VERSION="${CURRENT_VERSION%-SNAPSHOT}"
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: java-native-win32-x64-release-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/java-native-win32-x64
+
+      - name: Verify immutable source and Windows classifier
+        id: windows-artifact
+        run: |
+          SOURCE_COMMIT=$(git rev-parse HEAD)
+          if [ "$SOURCE_COMMIT" != "${{ needs.prepare-release.outputs.tag_commit }}" ]; then
+            echo "::error::Checked out $SOURCE_COMMIT instead of the prepared tag commit."
+            exit 1
           fi
-          echo "Release version: $RELEASE_VERSION"
+          VERSION="${{ needs.prepare-release.outputs.release_version }}"
+          ARTIFACT_DIRECTORY="${{ runner.temp }}/java-native-win32-x64"
+          JAR="$ARTIFACT_DIRECTORY/copilot-sdk-java-runtime-$VERSION-win32-x64.jar"
+          MANIFEST="$ARTIFACT_DIRECTORY/win32-x64-$VERSION.sha256"
+          test -f "$JAR"
+          test -f "$MANIFEST"
+          node "$GITHUB_WORKSPACE/java/copilot-native/scripts/validate-native-artifact.mjs" \
+            checksum "$JAR" "$MANIFEST" "$(basename "$JAR")"
+          node "$GITHUB_WORKSPACE/java/copilot-native/scripts/validate-native-artifact.mjs" \
+            classifier win32-x64 "$JAR" "$(basename "$JAR")" "$GITHUB_WORKSPACE"
+          echo "windows_jar=$JAR" >> "$GITHUB_OUTPUT"
+          echo "windows_sha=$(cut -d ' ' -f 1 "$MANIFEST")" >> "$GITHUB_OUTPUT"
 
-          # Determine next development version
-          if [ -n "${{ inputs.developmentVersion }}" ]; then
-            DEV_VERSION="${{ inputs.developmentVersion }}"
-            if [[ "$DEV_VERSION" != *-SNAPSHOT ]]; then
-              echo "::error::developmentVersion '${DEV_VERSION}' must end with '-SNAPSHOT' (e.g., '${DEV_VERSION}-SNAPSHOT'). The maven-release-plugin requires the next development version to be a snapshot."
-              exit 1
-            fi
-          else
-            # Split version: supports "0.1.32", "0.1.32-preview.0", "0.1.32-java.0", and "0.1.32-java-preview.0" formats
-            # Validate RELEASE_VERSION format explicitly to provide clear errors
-            if ! echo "$RELEASE_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-(preview|(beta-)?java(-preview)?)\.[0-9]+)?$'; then
-              echo "Error: RELEASE_VERSION '$RELEASE_VERSION' is invalid. Expected format: M.M.P, M.M.P-preview.N, M.M.P-java.N, M.M.P-java-preview.N, M.M.P-beta-java.N, or M.M.P-beta-java-preview.N (e.g., 1.2.3, 1.2.3-preview.0, 1.2.3-java.0, 1.2.3-java-preview.0, 1.2.3-beta-java.0, or 1.2.3-beta-java-preview.0)." >&2
-              exit 1
-            fi
-            # Extract the base M.M.P portion (before any qualifier)
-            BASE_VERSION=$(echo "$RELEASE_VERSION" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
-            QUALIFIER=$(echo "$RELEASE_VERSION" | sed "s|^${BASE_VERSION}||")
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
-            NEXT_PATCH=$((PATCH + 1))
-            DEV_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}${QUALIFIER}-SNAPSHOT"
-          fi
-          echo "Next development version: $DEV_VERSION"
-
-          echo "release_version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
-          echo "dev_version=$DEV_VERSION" >> $GITHUB_OUTPUT
-
-          echo "### Version Summary" >> $GITHUB_STEP_SUMMARY
-          echo "- **Release version:** $RELEASE_VERSION" >> $GITHUB_STEP_SUMMARY
-          echo "- **Next development version:** $DEV_VERSION" >> $GITHUB_STEP_SUMMARY
-
-      - name: Update documentation with release version
-        id: update-docs
-        working-directory: ./java
-        run: |
-          VERSION="${{ steps.versions.outputs.release_version }}"
-          DEV_VERSION="${{ steps.versions.outputs.dev_version }}"
-          ./scripts/test-update-documentation-versions.sh
-          ./scripts/update-documentation-versions.sh "$VERSION" "$DEV_VERSION" README.md sdk/jbang-example.java
-
-          # Commit the documentation changes before release:prepare (requires clean working directory)
-          git add README.md sdk/jbang-example.java
-          git commit -m "docs: update version references to ${VERSION}"
-
-          # Save the commit SHA for potential rollback
-          echo "docs_commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-
-          git push origin main
-
-      - name: Prepare Release
-        working-directory: ./java
-        run: |
-          mvn -B release:prepare \
-            -DreleaseVersion=${{ steps.versions.outputs.release_version }} \
-            -DdevelopmentVersion=${{ steps.versions.outputs.dev_version }} \
-            -DtagNameFormat=java/v@{project.version} \
-            -DpushChanges=true \
-            -Darguments="-DskipTests"
-        env:
-          MAVEN_USERNAME: ${{ secrets.JAVA_MAVEN_CENTRAL_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.JAVA_MAVEN_CENTRAL_PASSWORD }}
-          JAVA_GPG_PASSPHRASE: ${{ secrets.JAVA_GPG_PASSPHRASE }}
-
-      - name: Perform Release and Deploy to Maven Central
+      - name: Build Linux classifier and deploy complete release
         id: publish-maven
-        working-directory: ./java
         run: |
-          mvn -B release:perform \
-            -Dgoals="deploy" \
-            -Darguments="-DskipTests -Prelease"
+          VERSION="${{ needs.prepare-release.outputs.release_version }}"
+          mvn -B deploy -DskipTests -Prelease -Dcopilot.native.libc=glibc \
+            "-Dcopilot.native.external.win32.classifier.path=${{ steps.windows-artifact.outputs.windows_jar }}"
+          LINUX_JAR="copilot-native/target/copilot-sdk-java-runtime-$VERSION-linux-x64.jar"
+          test -f "$LINUX_JAR"
+          node copilot-native/scripts/validate-native-artifact.mjs \
+            classifier linux-x64 "$LINUX_JAR" "$(basename "$LINUX_JAR")" ..
+          LINUX_SHA=$(sha256sum "$LINUX_JAR" | cut -d ' ' -f 1)
+          {
+            echo "### Maven Central Release"
+            echo "- **Version:** $VERSION"
+            echo "- **Source tag:** \`${{ needs.prepare-release.outputs.release_tag }}\`"
+            echo "- **Source commit:** \`${{ needs.prepare-release.outputs.tag_commit }}\`"
+            echo "- **Next development version:** ${{ needs.prepare-release.outputs.development_version }}"
+            echo "- **Repository:** Maven Central"
+            echo ""
+            echo "#### Published Native Classifiers"
+            echo ""
+            echo "| Classifier | Build runner | Artifact | SHA-256 | Status |"
+            echo "| --- | --- | --- | --- | --- |"
+            echo "| \`linux-x64\` | \`ubuntu-latest\` | \`$(basename "$LINUX_JAR")\` | \`$LINUX_SHA\` | Published |"
+            echo "| \`win32-x64\` | \`windows-latest\` | \`$(basename "${{ steps.windows-artifact.outputs.windows_jar }}")\` | \`${{ steps.windows-artifact.outputs.windows_sha }}\` | Published |"
+          } >> "$GITHUB_STEP_SUMMARY"
         env:
           MAVEN_USERNAME: ${{ secrets.JAVA_MAVEN_CENTRAL_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.JAVA_MAVEN_CENTRAL_PASSWORD }}
           JAVA_GPG_PASSPHRASE: ${{ secrets.JAVA_GPG_PASSPHRASE }}
 
-      - name: Rollback documentation commit on failure
-        if: failure() && steps.update-docs.outputs.docs_commit_sha != ''
+  rollback-release:
+    name: Roll back failed Java release preparation
+    needs: [prepare-release, build-windows-classifier, deploy-maven]
+    if: ${{ failure() && needs.prepare-release.outputs.docs_commit != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    defaults:
+      run:
+        shell: bash
         working-directory: ./java
-        run: |
-          echo "Release failed, rolling back documentation commit..."
-          git revert --no-edit ${{ steps.update-docs.outputs.docs_commit_sha }}
-          git push origin main
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.JAVA_RELEASE_TOKEN }}
 
-          # Also run Maven release:rollback to clean up any partial release state
-          mvn -B release:rollback || true
+      - name: Safely revert release commits and tag
+        env:
+          DOCS_COMMIT: ${{ needs.prepare-release.outputs.docs_commit }}
+          PREPARE_RESULT: ${{ needs.prepare-release.result }}
+          PRE_PREPARE_COMMIT: ${{ needs.prepare-release.outputs.pre_prepare_commit }}
+          POST_PREPARE_COMMIT: ${{ needs.prepare-release.outputs.post_prepare_commit }}
+          RELEASE_TAG: java/v${{ needs.prepare-release.outputs.release_version }}
+          TAG_COMMIT: ${{ needs.prepare-release.outputs.tag_commit }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main --tags
+          MAIN_COMMIT=$(git rev-parse origin/main)
+          echo "Rollback inspection: main=$MAIN_COMMIT docs=$DOCS_COMMIT pre=$PRE_PREPARE_COMMIT post=$POST_PREPARE_COMMIT tag=$RELEASE_TAG"
+
+          unsafe_rollback() {
+            echo "::error::Unsafe rollback state: $*" >&2
+            exit 1
+          }
+
+          if ! git cat-file -e "${PRE_PREPARE_COMMIT}^{commit}"; then
+            unsafe_rollback "Recorded pre-prepare commit does not exist: $PRE_PREPARE_COMMIT"
+          fi
+          if ! git cat-file -e "${DOCS_COMMIT}^{commit}"; then
+            unsafe_rollback "Recorded documentation commit does not exist: $DOCS_COMMIT"
+          fi
+          if ! git merge-base --is-ancestor "$PRE_PREPARE_COMMIT" "$MAIN_COMMIT"; then
+            unsafe_rollback "Recorded pre-prepare commit is not an ancestor of main."
+          fi
+          if [ "$(git rev-parse "${DOCS_COMMIT}^")" != "$PRE_PREPARE_COMMIT" ]; then
+            unsafe_rollback "Documentation commit is not immediately based on the recorded pre-prepare commit."
+          fi
+
+          mapfile -t ROLLBACK_COMMITS < <(git rev-list --reverse "$PRE_PREPARE_COMMIT..$MAIN_COMMIT")
+          FIRST_PARENT_COUNT=$(git rev-list --count --first-parent "$PRE_PREPARE_COMMIT..$MAIN_COMMIT")
+          if [ "${#ROLLBACK_COMMITS[@]}" -ne "$FIRST_PARENT_COUNT" ]; then
+            unsafe_rollback "Release range contains merged history."
+          fi
+          if [ "${#ROLLBACK_COMMITS[@]}" -lt 1 ] || [ "${#ROLLBACK_COMMITS[@]}" -gt 3 ]; then
+            unsafe_rollback "Expected one to three release-preparation commits after the recorded base; found ${#ROLLBACK_COMMITS[@]}."
+          fi
+          if [ "${ROLLBACK_COMMITS[0]}" != "$DOCS_COMMIT" ]; then
+            unsafe_rollback "The first commit after the recorded base is not the recorded documentation commit."
+          fi
+
+          EXPECTED_PARENT="$PRE_PREPARE_COMMIT"
+          for COMMIT in "${ROLLBACK_COMMITS[@]}"; do
+            if git rev-parse -q --verify "${COMMIT}^2" >/dev/null; then
+              unsafe_rollback "Release range contains merge commit $COMMIT."
+            fi
+            if [ "$(git rev-parse "${COMMIT}^")" != "$EXPECTED_PARENT" ]; then
+              unsafe_rollback "Release range is not a linear continuation of the recorded base."
+            fi
+            EXPECTED_PARENT="$COMMIT"
+          done
+
+          RELEASE_VERSION="${RELEASE_TAG#java/v}"
+          if [ "$(git log -1 --format=%s "$DOCS_COMMIT")" != "docs: update version references to $RELEASE_VERSION" ]; then
+            unsafe_rollback "Recorded documentation commit has an unexpected subject."
+          fi
+
+          RELEASE_PREPARE_COMMIT=""
+          if [ "${#ROLLBACK_COMMITS[@]}" -ge 2 ]; then
+            RELEASE_PREPARE_COMMIT="${ROLLBACK_COMMITS[1]}"
+            if [ "$(git log -1 --format=%s "$RELEASE_PREPARE_COMMIT")" != "[maven-release-plugin] prepare release $RELEASE_TAG" ]; then
+              unsafe_rollback "Release-version commit has an unexpected subject."
+            fi
+          fi
+          if [ "${#ROLLBACK_COMMITS[@]}" -eq 3 ] && [ "$(git log -1 --format=%s "${ROLLBACK_COMMITS[2]}")" != "[maven-release-plugin] prepare for next development iteration" ]; then
+            unsafe_rollback "Development-version commit has an unexpected subject."
+          fi
+
+          TAG_OBJECT=$(git ls-remote --refs origin "refs/tags/$RELEASE_TAG" | awk '{print $1}')
+          if [ -n "$TAG_OBJECT" ]; then
+            git fetch --no-tags origin "+refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+            REMOTE_TAG_COMMIT=$(git rev-parse "${RELEASE_TAG}^{commit}")
+            if [ -z "$RELEASE_PREPARE_COMMIT" ] || [ "$REMOTE_TAG_COMMIT" != "$RELEASE_PREPARE_COMMIT" ]; then
+              unsafe_rollback "Release tag does not point to the guarded release-version commit."
+            fi
+          elif [ -n "$TAG_COMMIT" ]; then
+            unsafe_rollback "Recorded release tag is absent from the remote."
+          fi
+
+          if [ "$PREPARE_RESULT" = "success" ]; then
+            if [ -z "$POST_PREPARE_COMMIT" ] || [ -z "$TAG_COMMIT" ]; then
+              unsafe_rollback "Successful preparation did not record its immutable release identity."
+            fi
+            if [ "$MAIN_COMMIT" != "$POST_PREPARE_COMMIT" ]; then
+              unsafe_rollback "main has advanced beyond the recorded post-prepare commit."
+            fi
+            if [ -z "$TAG_OBJECT" ] || [ "$REMOTE_TAG_COMMIT" != "$TAG_COMMIT" ]; then
+              unsafe_rollback "Remote release tag does not match the recorded tag commit."
+            fi
+          fi
+
+          git checkout -B release-rollback "$MAIN_COMMIT"
+          git revert --no-edit "$PRE_PREPARE_COMMIT..$MAIN_COMMIT"
+          if [ -n "$TAG_OBJECT" ]; then
+            git push --atomic \
+              "--force-with-lease=refs/heads/main:$MAIN_COMMIT" \
+              "--force-with-lease=refs/tags/$RELEASE_TAG:$TAG_OBJECT" \
+              origin HEAD:refs/heads/main ":refs/tags/$RELEASE_TAG"
+          else
+            git push \
+              "--force-with-lease=refs/heads/main:$MAIN_COMMIT" \
+              origin HEAD:refs/heads/main
+          fi
+          echo "Release preparation rollback completed after guarded history inspection."
 
   deploy-site:
     name: Deploy Documentation Site
-    needs: [preflight, publish-maven]
-    if: github.ref == 'refs/heads/main'
+    needs: [preflight, deploy-maven]
+    if: github.ref == 'refs/heads/main' && needs.deploy-maven.outputs.published == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger site deployment on standalone repo
         run: |
-          VERSION="${{ needs.publish-maven.outputs.version }}"
+          VERSION="${{ needs.deploy-maven.outputs.version }}"
           TAG="java/v${VERSION}"
           PUBLISH_AS_LATEST=true
           if [ "${{ inputs.prerelease }}" = "true" ]; then
@@ -241,7 +482,9 @@ jobs:
             -f version="${VERSION}" \
             -f publish_as_latest="${PUBLISH_AS_LATEST}" \
             -f monorepo_tag="${TAG}"
-          echo "### Site Deployment" >> $GITHUB_STEP_SUMMARY
-          echo "Triggered deploy-site.yml on github/copilot-sdk-java for version ${VERSION}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### Site Deployment"
+            echo "Triggered deploy-site.yml on github/copilot-sdk-java for version ${VERSION}"
+          } >> "$GITHUB_STEP_SUMMARY"
         env:
           GITHUB_TOKEN: ${{ secrets.JAVA_RELEASE_GITHUB_TOKEN }}

--- a/.github/workflows/java-publish-snapshot.yml
+++ b/.github/workflows/java-publish-snapshot.yml
@@ -16,8 +16,86 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish-snapshot:
+  resolve-source:
+    name: Resolve immutable snapshot source
+    runs-on: ubuntu-latest
+    outputs:
+      source_sha: ${{ steps.source.outputs.sha }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - id: source
+        shell: bash
+        run: |
+          SHA=$(git rev-parse HEAD)
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+  build-windows-classifier:
+    name: Build Windows snapshot classifier
+    needs: resolve-source
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: pwsh
+        working-directory: ./java
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: "25"
+          distribution: "microsoft"
+          cache: "maven"
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+
+      - name: Build and validate win32-x64 classifier
+        id: build
+        run: |
+          $sourceCommit = git rev-parse HEAD
+          if ($sourceCommit -ne '${{ needs.resolve-source.outputs.source_sha }}') {
+            throw "Checked out $sourceCommit instead of the resolved snapshot source."
+          }
+          node copilot-native/scripts/validate-native-host.mjs win32-x64
+          mvn -B -pl copilot-native package -DskipTests
+          $version = mvn help:evaluate "-Dexpression=project.version" -q "-DforceStdout"
+          $jar = "copilot-native/target/copilot-sdk-java-runtime-$version-win32-x64.jar"
+          $primaryJar = "copilot-native/target/copilot-sdk-java-runtime-$version.jar"
+          if (-not (Test-Path -LiteralPath $jar -PathType Leaf)) {
+            throw "Expected Windows classifier was not produced: $jar"
+          }
+          node copilot-native/scripts/validate-native-artifact.mjs classifier win32-x64 $jar ([IO.Path]::GetFileName($jar)) ..
+          node copilot-native/scripts/validate-native-artifact.mjs placeholder $primaryJar
+          $manifest = "copilot-native/target/win32-x64-$version.sha256"
+          $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $jar).Hash.ToLowerInvariant()
+          "$hash  $([IO.Path]::GetFileName($jar))" | Set-Content -NoNewline -Encoding ascii $manifest
+          node copilot-native/scripts/validate-native-artifact.mjs checksum $jar $manifest ([IO.Path]::GetFileName($jar))
+          "version=$version" | Add-Content $env:GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: java-native-win32-x64-snapshot-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            java/copilot-native/target/copilot-sdk-java-runtime-${{ steps.build.outputs.version }}-win32-x64.jar
+            java/copilot-native/target/win32-x64-${{ steps.build.outputs.version }}.sha256
+          if-no-files-found: error
+          retention-days: 1
+
+  deploy-snapshot:
     name: Publish SNAPSHOT to Maven Central
+    needs: [resolve-source, build-windows-classifier]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -26,12 +104,13 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-copilot
 
-      - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: "25"
           distribution: "microsoft"
@@ -40,22 +119,64 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
 
-      - name: Verify version is a SNAPSHOT
-        working-directory: ./java
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: java-native-win32-x64-snapshot-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/java-native-win32-x64
+
+      - name: Verify version, source, and Windows classifier
+        id: windows-artifact
         run: |
-          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo "Publishing version: $VERSION"
-          if [[ "$VERSION" != *"-SNAPSHOT" ]]; then
-            echo "ERROR: This workflow only publishes SNAPSHOT versions. Current version: $VERSION"
+          SOURCE_COMMIT=$(git rev-parse HEAD)
+          if [ "$SOURCE_COMMIT" != "${{ needs.resolve-source.outputs.source_sha }}" ]; then
+            echo "::error::Checked out $SOURCE_COMMIT instead of the resolved snapshot source."
             exit 1
           fi
-          echo "### Snapshot Publish" >> $GITHUB_STEP_SUMMARY
-          echo "- **Version:** $VERSION" >> $GITHUB_STEP_SUMMARY
-          echo "- **Repository:** Maven Central Snapshots" >> $GITHUB_STEP_SUMMARY
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          if [[ "$VERSION" != *"-SNAPSHOT" ]]; then
+            echo "::error::This workflow only publishes SNAPSHOT versions. Current version: $VERSION"
+            exit 1
+          fi
+          ARTIFACT_DIRECTORY="${{ runner.temp }}/java-native-win32-x64"
+          JAR="$ARTIFACT_DIRECTORY/copilot-sdk-java-runtime-$VERSION-win32-x64.jar"
+          MANIFEST="$ARTIFACT_DIRECTORY/win32-x64-$VERSION.sha256"
+          test -f "$JAR"
+          test -f "$MANIFEST"
+          node "$GITHUB_WORKSPACE/java/copilot-native/scripts/validate-native-artifact.mjs" \
+            checksum "$JAR" "$MANIFEST" "$(basename "$JAR")"
+          node "$GITHUB_WORKSPACE/java/copilot-native/scripts/validate-native-artifact.mjs" \
+            classifier win32-x64 "$JAR" "$(basename "$JAR")" "$GITHUB_WORKSPACE"
+          echo "windows_jar=$JAR" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "windows_sha=$(cut -d ' ' -f 1 "$MANIFEST")" >> "$GITHUB_OUTPUT"
 
-      - name: Deploy Snapshot
-        working-directory: ./java
-        run: mvn -B deploy -DskipTests
+      - name: Build Linux classifier and deploy complete snapshot
+        run: |
+          VERSION="${{ steps.windows-artifact.outputs.version }}"
+          mvn -B deploy -DskipTests -Dcopilot.native.libc=glibc \
+            "-Dcopilot.native.external.win32.classifier.path=${{ steps.windows-artifact.outputs.windows_jar }}"
+          LINUX_JAR="copilot-native/target/copilot-sdk-java-runtime-$VERSION-linux-x64.jar"
+          test -f "$LINUX_JAR"
+          node copilot-native/scripts/validate-native-artifact.mjs \
+            classifier linux-x64 "$LINUX_JAR" "$(basename "$LINUX_JAR")" ..
+          LINUX_SHA=$(sha256sum "$LINUX_JAR" | cut -d ' ' -f 1)
+          {
+            echo "### Snapshot Publish"
+            echo "- **Version:** $VERSION"
+            echo "- **Source commit:** \`${{ needs.resolve-source.outputs.source_sha }}\`"
+            echo "- **Repository:** Maven Central Snapshots"
+            echo ""
+            echo "#### Published Native Classifiers"
+            echo ""
+            echo "| Classifier | Build runner | Artifact | SHA-256 | Status |"
+            echo "| --- | --- | --- | --- | --- |"
+            echo "| \`linux-x64\` | \`ubuntu-latest\` | \`$(basename "$LINUX_JAR")\` | \`$LINUX_SHA\` | Published |"
+            echo "| \`win32-x64\` | \`windows-latest\` | \`$(basename "${{ steps.windows-artifact.outputs.windows_jar }}")\` | \`${{ steps.windows-artifact.outputs.windows_sha }}\` | Published |"
+          } >> "$GITHUB_STEP_SUMMARY"
         env:
           MAVEN_USERNAME: ${{ secrets.JAVA_MAVEN_CENTRAL_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.JAVA_MAVEN_CENTRAL_PASSWORD }}

--- a/.github/workflows/java-sdk-tests.yml
+++ b/.github/workflows/java-sdk-tests.yml
@@ -18,12 +18,19 @@ permissions:
 
 jobs:
   java-sdk-inprocess:
-    name: "Java SDK InProcess Tests"
+    name: "Java SDK InProcess Tests (${{ matrix.classifier }})"
     if: github.event.repository.fork == false
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            classifier: linux-x64
+          - os: windows-latest
+            classifier: win32-x64
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
-        shell: bash
         working-directory: ./java
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -40,13 +47,13 @@ jobs:
         with:
           node-version: 22
 
-      - name: Validate Linux glibc native host
-        run: node copilot-native/scripts/validate-native-host.mjs linux-x64
+      - name: Validate native host
+        run: node copilot-native/scripts/validate-native-host.mjs ${{ matrix.classifier }}
 
       - name: Run Java SDK tests (InProcess)
         env:
           CI: "true"
-        run: mvn clean verify -Pinprocess -Dcopilot.native.skip.download=false
+        run: mvn clean verify -Pinprocess
 
       - name: Generate Test Report Summary
         if: always()
@@ -58,12 +65,127 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: java-test-results-inprocess
+          name: java-test-results-inprocess-${{ matrix.classifier }}
           path: |
             java/sdk/target/surefire-reports/
             java/sdk/target/surefire-reports-isolated/
             java/sdk/target/failsafe-reports/
           retention-days: 7
+
+  java-native-publication-windows:
+    name: "Java Native Publication Input (win32-x64)"
+    if: github.event.repository.fork == false
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    outputs:
+      source_sha: ${{ steps.build.outputs.source_sha }}
+      version: ${{ steps.build.outputs.version }}
+    defaults:
+      run:
+        shell: pwsh
+        working-directory: ./java
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: "25"
+          distribution: "microsoft"
+          cache: "maven"
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+
+      - name: Build and validate win32-x64 classifier
+        id: build
+        run: |
+          node copilot-native/scripts/validate-native-host.mjs win32-x64
+          mvn -B -pl copilot-native package -DskipTests
+          $version = mvn help:evaluate "-Dexpression=project.version" -q "-DforceStdout"
+          $jar = "copilot-native/target/copilot-sdk-java-runtime-$version-win32-x64.jar"
+          $primaryJar = "copilot-native/target/copilot-sdk-java-runtime-$version.jar"
+          if (-not (Test-Path -LiteralPath $jar -PathType Leaf)) {
+            throw "Expected Windows classifier was not produced: $jar"
+          }
+          node copilot-native/scripts/validate-native-artifact.mjs classifier win32-x64 $jar ([IO.Path]::GetFileName($jar)) ..
+          node copilot-native/scripts/validate-native-artifact.mjs placeholder $primaryJar
+          $manifest = "copilot-native/target/win32-x64-$version.sha256"
+          $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $jar).Hash.ToLowerInvariant()
+          "$hash  $([IO.Path]::GetFileName($jar))" | Set-Content -NoNewline -Encoding ascii $manifest
+          node copilot-native/scripts/validate-native-artifact.mjs checksum $jar $manifest ([IO.Path]::GetFileName($jar))
+          echo "source_sha=$(git rev-parse HEAD)" >> $env:GITHUB_OUTPUT
+          echo "version=$version" >> $env:GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: java-native-publication-win32-x64-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            java/copilot-native/target/copilot-sdk-java-runtime-${{ steps.build.outputs.version }}-win32-x64.jar
+            java/copilot-native/target/win32-x64-${{ steps.build.outputs.version }}.sha256
+          if-no-files-found: error
+          retention-days: 1
+
+  java-native-publication-assembly:
+    name: "Java Native Publication Assembly"
+    if: github.event.repository.fork == false
+    needs: java-native-publication-windows
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./java
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: "25"
+          distribution: "microsoft"
+          cache: "maven"
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: java-native-publication-win32-x64-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ github.workspace }}/java/native-publication-input
+
+      - name: Verify Windows input and deploy the complete local release
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${{ needs.java-native-publication-windows.outputs.source_sha }}"
+          VERSION="${{ needs.java-native-publication-windows.outputs.version }}"
+          INPUT_DIRECTORY="$GITHUB_WORKSPACE/java/native-publication-input"
+          WINDOWS_JAR="$INPUT_DIRECTORY/copilot-sdk-java-runtime-$VERSION-win32-x64.jar"
+          WINDOWS_MANIFEST="$INPUT_DIRECTORY/win32-x64-$VERSION.sha256"
+          node copilot-native/scripts/validate-native-artifact.mjs \
+            checksum "$WINDOWS_JAR" "$WINDOWS_MANIFEST" "$(basename "$WINDOWS_JAR")"
+          node copilot-native/scripts/validate-native-artifact.mjs \
+            classifier win32-x64 "$WINDOWS_JAR" "$(basename "$WINDOWS_JAR")" ..
+          export GNUPGHOME="$GITHUB_WORKSPACE/java/copilot-native/target/local-publication-gpg"
+          rm -rf "$GNUPGHOME"
+          mkdir -p "$GNUPGHOME"
+          chmod 700 "$GNUPGHOME"
+          gpg --batch --pinentry-mode loopback --passphrase '' \
+            --quick-generate-key 'Copilot SDK local validation <local-validation@example.invalid>' rsa2048 sign 1d
+          LOCAL_REPOSITORY="$GITHUB_WORKSPACE/java/copilot-native/target/local-publication-repository"
+          rm -rf "$LOCAL_REPOSITORY"
+          mvn -B -pl copilot-native deploy -Prelease -DskipTests \
+            -Dcopilot.native.libc=glibc \
+            -Dcopilot.native.test.local.publication=true \
+            "-Dcopilot.native.external.win32.classifier.path=$WINDOWS_JAR" \
+            "-Dmaven.repo.local=$LOCAL_REPOSITORY"
+          node copilot-native/scripts/validate-local-publication.mjs \
+            "$LOCAL_REPOSITORY" copilot-sdk-java-runtime "$VERSION" .. --signatures
 
   java-sdk:
     name: "Java SDK Tests (JDK ${{ matrix.test-jdk }})"

--- a/java/README.md
+++ b/java/README.md
@@ -72,7 +72,7 @@ implementation 'com.github:copilot-sdk-java:1.0.13-preview.0-SNAPSHOT'
 
 ## In-process mode (experimental)
 
-The SDK supports running the Copilot runtime **in-process** as a native library instead of spawning a separate CLI process. This eliminates process management overhead and simplifies deployment. In-process mode is currently experimental and only supported on **linux-x64**.
+The SDK supports running the Copilot runtime **in-process** as a native library instead of spawning a separate CLI process. This eliminates process management overhead and simplifies deployment. In-process mode is currently experimental and supported on **linux-x64** (glibc) and **win32-x64**.
 
 Because in-process mode is experimental, see the [Using experimental APIs](#using-experimental-apis) section for how to opt in.
 
@@ -88,13 +88,14 @@ Add both the SDK and the platform-specific native runtime to your project:
         <artifactId>copilot-sdk-java</artifactId>
         <version>${copilot.version}</version>
     </dependency>
-    <!-- Native runtime for linux-x64 (~20-26 MB) -->
+    <!-- Add the native runtime for the target platform -->
     <dependency>
         <groupId>com.github</groupId>
         <artifactId>copilot-sdk-java-runtime</artifactId>
         <version>${copilot.version}</version>
         <classifier>linux-x64</classifier>
     </dependency>
+    <!-- Use win32-x64 instead when the application runs on Windows x64 -->
     <!-- JNA (required for in-process mode) -->
     <dependency>
         <groupId>net.java.dev.jna</groupId>
@@ -491,7 +492,7 @@ mvn jacoco:prepare-agent@wire-up-coverage-instrumentation antrun:run@print-test-
 
 Run native-runtime Maven commands from the `java` directory. Native packaging requires Node.js and npm in addition to JDK 25 and Maven because `copilot-native/scripts/fetch-native.mjs` retrieves the pinned npm runtime package.
 
-Validated on a native Linux x64 glibc host: Maven activates the `native-linux-x64` profile on Linux `amd64` when `copilot.native.libc=glibc` is set. The build validates the host before downloading or packaging native files. The profile runs the native script tests, fetches the pinned `@github/copilot-linux-x64` package during `generate-resources`, packages the `linux-x64` classifier JAR during `package`, and verifies its native contents. An absent or explicitly false `copilot.native.skip.download` value preserves normal native packaging. Ensure npm can authenticate to the package registry before running the build.
+On a native Linux x64 glibc host, Maven activates the `native-linux-x64` profile when `copilot.native.libc=glibc` is set. On Windows x64, Maven activates `native-win32-x64` automatically. The matching profile validates the host, runs the native script tests, fetches the pinned `@github/copilot-<classifier>` package during `generate-resources`, packages the classifier JAR during `package`, and verifies its native contents. Ensure npm can authenticate to the package registry before running the build.
 
 Before opting in, validate that Node.js reports glibc for the build host:
 
@@ -506,7 +507,13 @@ The `inprocess` test profile performs the same validation and native packaging a
 mvn -Pinprocess clean verify
 ```
 
-On macOS, Windows, Linux ARM64, Linux x64 musl, and other unsupported hosts, do not set `copilot.native.libc=glibc`. A normal build produces only the OS-neutral primary, sources, and Javadoc JARs; it does not run the Linux x64 native script tests, download or stage Linux native files, or produce a `linux-x64` classifier JAR.
+On Windows PowerShell, initialize Java and run the same profile:
+
+```powershell
+mvn -Pinprocess clean verify
+```
+
+On macOS, Linux ARM64, Linux x64 musl, and other unsupported hosts, do not set `copilot.native.libc=glibc`. A normal build produces only the OS-neutral primary, sources, and Javadoc JARs; it does not run native script tests, download or stage native files, or produce a platform classifier JAR.
 
 To build only the OS-neutral artifacts on any host, or override the glibc opt-in, disable native download and packaging:
 
@@ -524,7 +531,7 @@ mvn clean verify -Dcopilot.native.libc=glibc
 mvn clean package -pl copilot-native -DskipTests -Dcopilot.native.libc=glibc -Dcopilot.native.skip.download=true
 ```
 
-On a supported Linux x64 host, the classifier JAR contains `native/linux-x64/runtime.node`, `native/linux-x64/platform.properties`, and `native/linux-x64/copilot`. The placeholder JAR remains OS-neutral and contains no native binaries. Unsupported hosts retain the placeholder-only behavior without producing a `-linux-x64.jar`.
+On Linux x64, the classifier JAR contains `native/linux-x64/runtime.node`, `native/linux-x64/platform.properties`, and `native/linux-x64/copilot`. On Windows x64, it contains `native/win32-x64/runtime.node`, `native/win32-x64/platform.properties`, and `native/win32-x64/copilot.exe`. The placeholder JAR remains OS-neutral and contains no native binaries. Unsupported hosts retain the placeholder-only behavior.
 
 ## License
 

--- a/java/copilot-native/pom.xml
+++ b/java/copilot-native/pom.xml
@@ -113,6 +113,7 @@
                                 <argument>--test</argument>
                                 <argument>${project.basedir}/scripts/fetch-native.test.mjs</argument>
                                 <argument>${project.basedir}/scripts/validate-native-host.test.mjs</argument>
+                                <argument>${project.basedir}/scripts/validate-native-artifact.test.mjs</argument>
                             </arguments>
                         </configuration>
                     </execution>
@@ -125,7 +126,7 @@
                     <!--
                         Additional classifier JAR containing
                         native/<classifier>/runtime.node,
-                        native/<classifier>/copilot, and
+                        native/<classifier>/copilot or copilot.exe, and
                         native/<classifier>/platform.properties.
                     -->
                     <execution>
@@ -233,6 +234,60 @@
 
     <profiles>
         <!--
+            The explicit in-process test profile defaults to Linux x64. A later
+            host profile overrides these properties on Windows x64. Unsupported
+            hosts fail validation before downloading or packaging native files.
+        -->
+        <profile>
+            <id>inprocess</id>
+            <properties>
+                <copilot.native.classifier>linux-x64</copilot.native.classifier>
+                <copilot.native.cli.filename>copilot</copilot.native.cli.filename>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>validate-native-host</id>
+                                <phase>validate</phase>
+                            </execution>
+                            <execution>
+                                <id>fetch-native</id>
+                                <phase>generate-resources</phase>
+                            </execution>
+                            <execution>
+                                <id>test-fetch-native</id>
+                                <phase>test</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>jar-native</id>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>verify-native-jars</id>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--
             Bind native packaging only when the build host matches an implemented
             classifier. Add sibling profiles as additional platforms are supported.
         -->
@@ -295,17 +350,17 @@
                 </plugins>
             </build>
         </profile>
-        <!--
-            The SDK's inprocess test profile requires this module's classifier
-            artifact. Bind the same guarded native lifecycle so `-Pinprocess`
-            works without a separate libc property. Host validation fails
-            before download or packaging on non-glibc and unsupported hosts.
-        -->
         <profile>
-            <id>inprocess</id>
+            <id>native-win32-x64</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                    <arch>amd64</arch>
+                </os>
+            </activation>
             <properties>
-                <copilot.native.classifier>linux-x64</copilot.native.classifier>
-                <copilot.native.cli.filename>copilot</copilot.native.cli.filename>
+                <copilot.native.classifier>win32-x64</copilot.native.classifier>
+                <copilot.native.cli.filename>copilot.exe</copilot.native.cli.filename>
             </properties>
             <build>
                 <plugins>
@@ -351,6 +406,156 @@
             </build>
         </profile>
         <!--
+            The Windows classifier is assembled on windows-latest and passed to
+            the sole Ubuntu publisher. Validate it before attaching so deploy
+            and release signing see one complete, host-matched artifact set.
+        -->
+        <profile>
+            <id>attach-external-win32-classifier</id>
+            <activation>
+                <property>
+                    <name>copilot.native.external.win32.classifier.path</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>validate-external-win32-classifier</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>node</executable>
+                                    <arguments>
+                                        <argument>${project.basedir}/scripts/validate-native-artifact.mjs</argument>
+                                        <argument>classifier</argument>
+                                        <argument>win32-x64</argument>
+                                        <argument>${copilot.native.external.win32.classifier.path}</argument>
+                                        <argument>${project.build.finalName}-win32-x64.jar</argument>
+                                        <argument>${copilot.sdk.root}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-external-win32-classifier</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>attach-artifact</goal>
+                                </goals>
+                                <configuration>
+                                    <artifacts>
+                                        <artifact>
+                                            <file>${copilot.native.external.win32.classifier.path}</file>
+                                            <type>jar</type>
+                                            <classifier>win32-x64</classifier>
+                                        </artifact>
+                                    </artifacts>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--
+            This test-only hook makes Windows-host local deployment validation
+            deterministic. Publication workflows never set this property: they
+            build the Linux classifier on Ubuntu instead.
+        -->
+        <profile>
+            <id>attach-test-linux-classifier</id>
+            <activation>
+                <property>
+                    <name>copilot.native.test.linux.classifier.path</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>validate-test-linux-classifier</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>node</executable>
+                                    <arguments>
+                                        <argument>${project.basedir}/scripts/validate-native-artifact.mjs</argument>
+                                        <argument>classifier</argument>
+                                        <argument>linux-x64</argument>
+                                        <argument>${copilot.native.test.linux.classifier.path}</argument>
+                                        <argument>${project.build.finalName}-linux-x64.jar</argument>
+                                        <argument>${copilot.sdk.root}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-test-linux-classifier</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>attach-artifact</goal>
+                                </goals>
+                                <configuration>
+                                    <artifacts>
+                                        <artifact>
+                                            <file>${copilot.native.test.linux.classifier.path}</file>
+                                            <type>jar</type>
+                                            <classifier>linux-x64</classifier>
+                                        </artifact>
+                                    </artifacts>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--
+            Keep the end-to-end local deployment check entirely local while
+            exercising the same deploy lifecycle used by releases.
+        -->
+        <profile>
+            <id>local-publication-validation</id>
+            <activation>
+                <property>
+                    <name>copilot.native.test.local.publication</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <configuration>
+                            <skipPublishing>true</skipPublishing>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--
             Skip the npm download when building offline or when only the
             placeholder JAR is needed: mvn -Dcopilot.native.skip.download=true
         -->
@@ -367,9 +572,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>validate-native-host</id>

--- a/java/copilot-native/scripts/create-native-classifier-test-fixture.mjs
+++ b/java/copilot-native/scripts/create-native-classifier-test-fixture.mjs
@@ -1,0 +1,119 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { readPinnedNativeVersion } from "./validate-native-artifact.mjs";
+
+export function createNativeClassifierTestFixture({
+  classifier,
+  outputPath,
+  repoRoot,
+}) {
+  const cliFilename = classifier.startsWith("win32")
+    ? "copilot.exe"
+    : "copilot";
+  const nativeVersion = readPinnedNativeVersion(repoRoot, classifier);
+  const prefix = `native/${classifier}`;
+  writeStoredZip(outputPath, [
+    [`${prefix}/runtime.node`, "test runtime"],
+    [`${prefix}/${cliFilename}`, "test cli"],
+    [
+      `${prefix}/platform.properties`,
+      `classifier=${classifier}\nversion=${nativeVersion}\n`,
+    ],
+  ]);
+}
+
+export function writeStoredZip(outputPath, entries) {
+  const localRecords = [];
+  const centralRecords = [];
+  let offset = 0;
+
+  for (const [filename, contents] of entries) {
+    const filenameBuffer = Buffer.from(filename);
+    const contentsBuffer = Buffer.isBuffer(contents)
+      ? contents
+      : Buffer.from(contents);
+    const crc = crc32(contentsBuffer);
+    const localHeader = Buffer.alloc(30);
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(20, 4);
+    localHeader.writeUInt32LE(crc, 14);
+    localHeader.writeUInt32LE(contentsBuffer.length, 18);
+    localHeader.writeUInt32LE(contentsBuffer.length, 22);
+    localHeader.writeUInt16LE(filenameBuffer.length, 26);
+    const localRecord = Buffer.concat([
+      localHeader,
+      filenameBuffer,
+      contentsBuffer,
+    ]);
+    localRecords.push(localRecord);
+
+    const centralHeader = Buffer.alloc(46);
+    centralHeader.writeUInt32LE(0x02014b50, 0);
+    centralHeader.writeUInt16LE(20, 4);
+    centralHeader.writeUInt16LE(20, 6);
+    centralHeader.writeUInt32LE(crc, 16);
+    centralHeader.writeUInt32LE(contentsBuffer.length, 20);
+    centralHeader.writeUInt32LE(contentsBuffer.length, 24);
+    centralHeader.writeUInt16LE(filenameBuffer.length, 28);
+    centralHeader.writeUInt32LE(offset, 42);
+    centralRecords.push(Buffer.concat([centralHeader, filenameBuffer]));
+    offset += localRecord.length;
+  }
+
+  const centralDirectory = Buffer.concat(centralRecords);
+  const endOfCentralDirectory = Buffer.alloc(22);
+  endOfCentralDirectory.writeUInt32LE(0x06054b50, 0);
+  endOfCentralDirectory.writeUInt16LE(entries.length, 8);
+  endOfCentralDirectory.writeUInt16LE(entries.length, 10);
+  endOfCentralDirectory.writeUInt32LE(centralDirectory.length, 12);
+  endOfCentralDirectory.writeUInt32LE(offset, 16);
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(
+    outputPath,
+    Buffer.concat([...localRecords, centralDirectory, endOfCentralDirectory]),
+  );
+}
+
+function crc32(buffer) {
+  let crc = 0xffffffff;
+  for (const byte of buffer) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function main() {
+  const [classifier, outputPath, repoRoot] = process.argv.slice(2);
+  if (!classifier || !outputPath || !repoRoot) {
+    console.error(
+      "Usage: node create-native-classifier-test-fixture.mjs <classifier> <outputJar> <repoRoot>",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    createNativeClassifierTestFixture({ classifier, outputPath, repoRoot });
+    console.log(`Created ${classifier} test fixture: ${outputPath}`);
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/java/copilot-native/scripts/fetch-native.test.mjs
+++ b/java/copilot-native/scripts/fetch-native.test.mjs
@@ -11,51 +11,52 @@ import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 
-const classifier = 'linux-x64';
 const version = '1.0.79';
 const integrity = 'sha512-test-integrity';
 const runtimeContent = 'runtime content';
 const cliContent = 'cli content';
 const scriptPath = fileURLToPath(new URL('./fetch-native.mjs', import.meta.url));
 
-test('missing CLI does not use incremental fast path', (t) => {
-  const fixture = createFixture(t);
-  fs.rmSync(fixture.cliPath);
+for (const classifier of ['linux-x64', 'win32-x64']) {
+  test(`${classifier}: missing CLI does not use incremental fast path`, (t) => {
+    const fixture = createFixture(t, classifier);
+    fs.rmSync(fixture.cliPath);
 
-  const result = runScript(fixture);
+    const result = runScript(fixture);
 
-  assertRestagingAttempted(fixture, result);
-});
+    assertRestagingAttempted(fixture, result);
+  });
 
-test('stale CLI does not use incremental fast path', (t) => {
-  const fixture = createFixture(t);
-  fs.writeFileSync(fixture.cliPath, 'stale CLI content');
+  test(`${classifier}: stale CLI does not use incremental fast path`, (t) => {
+    const fixture = createFixture(t, classifier);
+    fs.writeFileSync(fixture.cliPath, 'stale CLI content');
 
-  const result = runScript(fixture);
+    const result = runScript(fixture);
 
-  assertRestagingAttempted(fixture, result);
-});
+    assertRestagingAttempted(fixture, result);
+  });
 
-test('missing platform metadata does not use incremental fast path', (t) => {
-  const fixture = createFixture(t);
-  fs.rmSync(fixture.platformPropertiesPath);
+  test(`${classifier}: missing platform metadata does not use incremental fast path`, (t) => {
+    const fixture = createFixture(t, classifier);
+    fs.rmSync(fixture.platformPropertiesPath);
 
-  const result = runScript(fixture);
+    const result = runScript(fixture);
 
-  assertRestagingAttempted(fixture, result);
-});
+    assertRestagingAttempted(fixture, result);
+  });
 
-test('complete matching artifacts use incremental fast path', (t) => {
-  const fixture = createFixture(t);
+  test(`${classifier}: complete matching artifacts use incremental fast path`, (t) => {
+    const fixture = createFixture(t, classifier);
 
-  const result = runScript(fixture);
+    const result = runScript(fixture);
 
-  assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, /already staged/);
-  assert.equal(fs.existsSync(fixture.npmMarkerPath), false);
-});
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /already staged/);
+    assert.equal(fs.existsSync(fixture.npmMarkerPath), false);
+  });
+}
 
-function createFixture(t) {
+function createFixture(t, classifier) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fetch-native-test-'));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
 
@@ -78,7 +79,7 @@ function createFixture(t) {
   );
 
   const runtimePath = path.join(resourceDir, 'runtime.node');
-  const cliPath = path.join(resourceDir, 'copilot');
+  const cliPath = path.join(resourceDir, classifier.startsWith('win32') ? 'copilot.exe' : 'copilot');
   const platformPropertiesPath = path.join(resourceDir, 'platform.properties');
   fs.writeFileSync(runtimePath, runtimeContent);
   fs.writeFileSync(cliPath, cliContent);
@@ -88,11 +89,16 @@ function createFixture(t) {
     `${version}\n${integrity}\n${digest(runtimeContent)}\n${digest(cliContent)}\n`,
   );
 
-  const fakeNpmPath = path.join(fakeBinDir, 'npm');
-  fs.writeFileSync(fakeNpmPath, '#!/bin/sh\nprintf invoked > \"$FETCH_NATIVE_NPM_MARKER\"\nexit 42\n');
-  fs.chmodSync(fakeNpmPath, 0o755);
+  const fakeNpmPath = path.join(fakeBinDir, process.platform === 'win32' ? 'npm.cmd' : 'npm');
+  if (process.platform === 'win32') {
+    fs.writeFileSync(fakeNpmPath, '@echo off\r\n> "%FETCH_NATIVE_NPM_MARKER%" echo invoked\r\nexit /b 42\r\n');
+  } else {
+    fs.writeFileSync(fakeNpmPath, '#!/bin/sh\nprintf invoked > "$FETCH_NATIVE_NPM_MARKER"\nexit 42\n');
+    fs.chmodSync(fakeNpmPath, 0o755);
+  }
 
   return {
+    classifier,
     repoRoot,
     stagingDir,
     fakeBinDir,
@@ -104,7 +110,7 @@ function createFixture(t) {
 }
 
 function runScript(fixture) {
-  return spawnSync(process.execPath, [scriptPath, fixture.repoRoot, fixture.stagingDir, classifier], {
+  return spawnSync(process.execPath, [scriptPath, fixture.repoRoot, fixture.stagingDir, fixture.classifier], {
     encoding: 'utf8',
     env: {
       ...process.env,
@@ -116,7 +122,7 @@ function runScript(fixture) {
 
 function assertRestagingAttempted(fixture, result) {
   assert.notEqual(result.status, 0, 'The fake npm command should make restaging fail');
-  assert.equal(fs.readFileSync(fixture.npmMarkerPath, 'utf8'), 'invoked');
+  assert.equal(fs.readFileSync(fixture.npmMarkerPath, 'utf8').trim(), 'invoked');
 }
 
 function digest(content) {

--- a/java/copilot-native/scripts/validate-local-publication.mjs
+++ b/java/copilot-native/scripts/validate-local-publication.mjs
@@ -1,0 +1,108 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  validateNativeClassifierJar,
+  validatePlaceholderJar,
+} from "./validate-native-artifact.mjs";
+
+export function validateLocalPublication({
+  artifactId,
+  repositoryPath,
+  repoRoot,
+  requireSignatures,
+  version,
+}) {
+  const artifactDirectory = path.join(
+    repositoryPath,
+    "com",
+    "github",
+    artifactId,
+    version,
+  );
+  const requiredArtifacts = [
+    `${artifactId}-${version}.jar`,
+    `${artifactId}-${version}.pom`,
+    `${artifactId}-${version}-sources.jar`,
+    `${artifactId}-${version}-javadoc.jar`,
+    `${artifactId}-${version}-linux-x64.jar`,
+    `${artifactId}-${version}-win32-x64.jar`,
+  ];
+  const files = new Set(fs.readdirSync(artifactDirectory));
+
+  for (const artifact of requiredArtifacts) {
+    if (!files.has(artifact)) {
+      throw new Error(`Local publication is missing ${artifact}`);
+    }
+    if (requireSignatures && !files.has(`${artifact}.asc`)) {
+      throw new Error(
+        `Local release publication is missing signature ${artifact}.asc`,
+      );
+    }
+  }
+
+  const publishedJars = [...files]
+    .filter((file) => file.endsWith(".jar"))
+    .sort();
+  const expectedJars = requiredArtifacts
+    .filter((file) => file.endsWith(".jar"))
+    .sort();
+  if (publishedJars.join("\n") !== expectedJars.join("\n")) {
+    throw new Error(
+      `Local publication contains unexpected JARs:\n${publishedJars.join("\n")}`,
+    );
+  }
+
+  validatePlaceholderJar(
+    path.join(artifactDirectory, `${artifactId}-${version}.jar`),
+  );
+  for (const classifier of ["linux-x64", "win32-x64"]) {
+    const filename = `${artifactId}-${version}-${classifier}.jar`;
+    validateNativeClassifierJar({
+      classifier,
+      jarPath: path.join(artifactDirectory, filename),
+      expectedFilename: filename,
+      repoRoot,
+    });
+  }
+
+  return artifactDirectory;
+}
+
+function main() {
+  const [repositoryPath, artifactId, version, repoRoot, signatures] =
+    process.argv.slice(2);
+  if (!repositoryPath || !artifactId || !version || !repoRoot) {
+    console.error(
+      "Usage: node validate-local-publication.mjs <repositoryPath> <artifactId> <version> <repoRoot> [--signatures]",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    const artifactDirectory = validateLocalPublication({
+      artifactId,
+      repositoryPath,
+      repoRoot,
+      requireSignatures: signatures === "--signatures",
+      version,
+    });
+    console.log(`Validated local Maven publication: ${artifactDirectory}`);
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/java/copilot-native/scripts/validate-native-artifact.mjs
+++ b/java/copilot-native/scripts/validate-native-artifact.mjs
@@ -1,0 +1,338 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import zlib from "node:zlib";
+
+const END_OF_CENTRAL_DIRECTORY = 0x06054b50;
+const CENTRAL_DIRECTORY_FILE_HEADER = 0x02014b50;
+const LOCAL_FILE_HEADER = 0x04034b50;
+
+export function validateNativeClassifierJar({
+  classifier,
+  jarPath,
+  expectedFilename,
+  repoRoot,
+}) {
+  if (path.basename(jarPath) !== expectedFilename) {
+    throw new Error(
+      `External ${classifier} classifier must be named ${expectedFilename}; received ${path.basename(jarPath)}`,
+    );
+  }
+
+  const archive = readJar(jarPath);
+  const cliFilename = classifier.startsWith("win32")
+    ? "copilot.exe"
+    : "copilot";
+  const resourcePrefix = `native/${classifier}/`;
+  const requiredEntries = [
+    `${resourcePrefix}runtime.node`,
+    `${resourcePrefix}${cliFilename}`,
+    `${resourcePrefix}platform.properties`,
+  ];
+
+  for (const entryName of requiredEntries) {
+    const entry = archive.entries.get(entryName);
+    if (!entry || entry.uncompressedSize === 0) {
+      throw new Error(
+        `External ${classifier} classifier is missing nonempty ${entryName}`,
+      );
+    }
+  }
+
+  for (const entryName of archive.entries.keys()) {
+    const nativeClassifier = /^native\/([^/]+)\//.exec(entryName)?.[1];
+    if (nativeClassifier && nativeClassifier !== classifier) {
+      throw new Error(
+        `External ${classifier} classifier must not contain ${entryName}`,
+      );
+    }
+  }
+
+  const properties = parseProperties(
+    readEntry(archive, `${resourcePrefix}platform.properties`),
+  );
+  const expectedVersion = readPinnedNativeVersion(repoRoot, classifier);
+  if (properties.classifier !== classifier) {
+    throw new Error(
+      `External classifier metadata must contain classifier=${classifier}; received ${properties.classifier ?? "none"}`,
+    );
+  }
+  if (properties.version !== expectedVersion) {
+    throw new Error(
+      `External ${classifier} classifier metadata must contain version=${expectedVersion}; received ${properties.version ?? "none"}`,
+    );
+  }
+
+  return {
+    classifier,
+    nativeVersion: expectedVersion,
+    sha256: undefined,
+  };
+}
+
+export function validatePlaceholderJar(jarPath) {
+  const archive = readJar(jarPath);
+  for (const entryName of archive.entries.keys()) {
+    if (/^native\/(?:linux|win32)-x64\//.test(entryName)) {
+      throw new Error(
+        `Placeholder primary JAR must not contain platform-native resources; found ${entryName}`,
+      );
+    }
+  }
+}
+
+export function validateSha256Manifest({
+  expectedFilename,
+  jarPath,
+  manifestPath,
+}) {
+  let manifest;
+  try {
+    manifest = fs.readFileSync(manifestPath, "utf8").trim();
+  } catch (error) {
+    throw new Error(
+      `Could not read SHA-256 manifest ${manifestPath}: ${error.message}`,
+    );
+  }
+  const match = /^([a-fA-F0-9]{64}) {2}(.+)$/.exec(manifest);
+  if (!match || match[2] !== expectedFilename) {
+    throw new Error(
+      `SHA-256 manifest must contain one checksum for ${expectedFilename}: ${manifestPath}`,
+    );
+  }
+  const actual = createHash("sha256")
+    .update(fs.readFileSync(jarPath))
+    .digest("hex");
+  if (actual !== match[1].toLowerCase()) {
+    throw new Error(
+      `SHA-256 mismatch for ${expectedFilename}; expected ${match[1].toLowerCase()}, received ${actual}`,
+    );
+  }
+}
+
+export function readPinnedNativeVersion(repoRoot, classifier) {
+  const packageName = `@github/copilot-${classifier}`;
+  const lockPath = path.join(repoRoot, "nodejs", "package-lock.json");
+  let lock;
+  try {
+    lock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `Could not read pinned ${packageName} version from ${lockPath}: ${error.message}`,
+    );
+  }
+
+  const version = lock.packages?.[`node_modules/${packageName}`]?.version;
+  if (!version) {
+    throw new Error(
+      `Could not find pinned ${packageName} version in ${lockPath}`,
+    );
+  }
+  return version;
+}
+
+function readJar(jarPath) {
+  let stat;
+  try {
+    stat = fs.statSync(jarPath);
+  } catch (error) {
+    throw new Error(`External classifier JAR does not exist: ${jarPath}`);
+  }
+  if (!stat.isFile() || path.extname(jarPath).toLowerCase() !== ".jar") {
+    throw new Error(
+      `External classifier must be a regular .jar file: ${jarPath}`,
+    );
+  }
+
+  const data = fs.readFileSync(jarPath);
+  const eocdOffset = findEndOfCentralDirectory(data);
+  const entryCount = data.readUInt16LE(eocdOffset + 10);
+  const centralDirectorySize = data.readUInt32LE(eocdOffset + 12);
+  const centralDirectoryOffset = data.readUInt32LE(eocdOffset + 16);
+  if (entryCount === 0xffff || centralDirectoryOffset === 0xffffffff) {
+    throw new Error(`ZIP64 classifier JARs are not supported: ${jarPath}`);
+  }
+  if (centralDirectoryOffset + centralDirectorySize > data.length) {
+    throw new Error(
+      `Classifier JAR has an invalid central directory: ${jarPath}`,
+    );
+  }
+
+  const entries = new Map();
+  let offset = centralDirectoryOffset;
+  for (let index = 0; index < entryCount; index += 1) {
+    if (readUInt32(data, offset, jarPath) !== CENTRAL_DIRECTORY_FILE_HEADER) {
+      throw new Error(
+        `Classifier JAR has an invalid central directory entry: ${jarPath}`,
+      );
+    }
+    const compressionMethod = data.readUInt16LE(offset + 10);
+    const compressedSize = data.readUInt32LE(offset + 20);
+    const uncompressedSize = data.readUInt32LE(offset + 24);
+    const filenameLength = data.readUInt16LE(offset + 28);
+    const extraLength = data.readUInt16LE(offset + 30);
+    const commentLength = data.readUInt16LE(offset + 32);
+    const localHeaderOffset = data.readUInt32LE(offset + 42);
+    const filenameOffset = offset + 46;
+    const nextOffset =
+      filenameOffset + filenameLength + extraLength + commentLength;
+    if (nextOffset > data.length) {
+      throw new Error(
+        `Classifier JAR has a truncated central directory entry: ${jarPath}`,
+      );
+    }
+
+    const filename = data.toString(
+      "utf8",
+      filenameOffset,
+      filenameOffset + filenameLength,
+    );
+    if (entries.has(filename)) {
+      throw new Error(
+        `Classifier JAR contains duplicate entry ${filename}: ${jarPath}`,
+      );
+    }
+    entries.set(filename, {
+      compressionMethod,
+      compressedSize,
+      uncompressedSize,
+      localHeaderOffset,
+    });
+    offset = nextOffset;
+  }
+
+  return { data, entries, jarPath };
+}
+
+function findEndOfCentralDirectory(data) {
+  const minimumSize = 22;
+  const minimumOffset = Math.max(0, data.length - minimumSize - 0xffff);
+  for (
+    let offset = data.length - minimumSize;
+    offset >= minimumOffset;
+    offset -= 1
+  ) {
+    if (
+      data.readUInt32LE(offset) === END_OF_CENTRAL_DIRECTORY &&
+      offset + minimumSize + data.readUInt16LE(offset + 20) === data.length
+    ) {
+      return offset;
+    }
+  }
+  throw new Error("Classifier JAR is not a valid ZIP archive");
+}
+
+function readEntry(archive, entryName) {
+  const entry = archive.entries.get(entryName);
+  if (!entry) {
+    throw new Error(`Classifier JAR is missing ${entryName}`);
+  }
+  if (entry.uncompressedSize > 1024 * 1024) {
+    throw new Error(
+      `Classifier JAR metadata entry is unexpectedly large: ${entryName}`,
+    );
+  }
+
+  const { data, jarPath } = archive;
+  const localOffset = entry.localHeaderOffset;
+  if (readUInt32(data, localOffset, jarPath) !== LOCAL_FILE_HEADER) {
+    throw new Error(
+      `Classifier JAR has an invalid local entry for ${entryName}`,
+    );
+  }
+  const filenameLength = data.readUInt16LE(localOffset + 26);
+  const extraLength = data.readUInt16LE(localOffset + 28);
+  const contentsOffset = localOffset + 30 + filenameLength + extraLength;
+  const contentsEnd = contentsOffset + entry.compressedSize;
+  if (contentsEnd > data.length) {
+    throw new Error(
+      `Classifier JAR has a truncated local entry for ${entryName}`,
+    );
+  }
+
+  const compressed = data.subarray(contentsOffset, contentsEnd);
+  let contents;
+  if (entry.compressionMethod === 0) {
+    contents = compressed;
+  } else if (entry.compressionMethod === 8) {
+    contents = zlib.inflateRawSync(compressed);
+  } else {
+    throw new Error(
+      `Classifier JAR uses unsupported compression for ${entryName}: ${entry.compressionMethod}`,
+    );
+  }
+  if (contents.length !== entry.uncompressedSize) {
+    throw new Error(`Classifier JAR has an invalid size for ${entryName}`);
+  }
+  return contents.toString("utf8");
+}
+
+function parseProperties(contents) {
+  const properties = {};
+  for (const line of contents.split(/\r?\n/)) {
+    const separator = line.indexOf("=");
+    if (separator > 0) {
+      properties[line.slice(0, separator).trim()] = line
+        .slice(separator + 1)
+        .trim();
+    }
+  }
+  return properties;
+}
+
+function readUInt32(data, offset, jarPath) {
+  if (offset + 4 > data.length) {
+    throw new Error(`Classifier JAR is truncated: ${jarPath}`);
+  }
+  return data.readUInt32LE(offset);
+}
+
+function main() {
+  const [mode, ...arguments_] = process.argv.slice(2);
+  try {
+    if (mode === "classifier" && arguments_.length === 4) {
+      const [classifier, jarPath, expectedFilename, repoRoot] = arguments_;
+      const result = validateNativeClassifierJar({
+        classifier,
+        jarPath,
+        expectedFilename,
+        repoRoot,
+      });
+      console.log(
+        `Validated ${result.classifier} classifier JAR (${result.nativeVersion}): ${jarPath}`,
+      );
+      return;
+    }
+    if (mode === "placeholder" && arguments_.length === 1) {
+      validatePlaceholderJar(arguments_[0]);
+      console.log(`Validated native-free placeholder JAR: ${arguments_[0]}`);
+      return;
+    }
+    if (mode === "checksum" && arguments_.length === 3) {
+      const [jarPath, manifestPath, expectedFilename] = arguments_;
+      validateSha256Manifest({ expectedFilename, jarPath, manifestPath });
+      console.log(
+        `Validated SHA-256 manifest for ${expectedFilename}: ${manifestPath}`,
+      );
+      return;
+    }
+    throw new Error(
+      "Usage: node validate-native-artifact.mjs classifier <classifier> <jar> <expectedFilename> <repoRoot> | placeholder <jar> | checksum <jar> <manifest> <expectedFilename>",
+    );
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/java/copilot-native/scripts/validate-native-artifact.test.mjs
+++ b/java/copilot-native/scripts/validate-native-artifact.test.mjs
@@ -1,0 +1,413 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  createNativeClassifierTestFixture,
+  writeStoredZip,
+} from "./create-native-classifier-test-fixture.mjs";
+import {
+  validateNativeClassifierJar,
+  validatePlaceholderJar,
+  validateSha256Manifest,
+} from "./validate-native-artifact.mjs";
+import { validateLocalPublication } from "./validate-local-publication.mjs";
+
+const classifier = "win32-x64";
+const artifactName = "copilot-sdk-java-runtime-1.2.3-win32-x64.jar";
+const moduleRoot = fileURLToPath(new URL("../", import.meta.url));
+
+test("accepts a matching, complete Windows classifier", (t) => {
+  const fixture = createFixture(t);
+  createNativeClassifierTestFixture({
+    classifier,
+    outputPath: fixture.jarPath,
+    repoRoot: fixture.repoRoot,
+  });
+
+  assert.deepEqual(
+    validateNativeClassifierJar({
+      classifier,
+      jarPath: fixture.jarPath,
+      expectedFilename: artifactName,
+      repoRoot: fixture.repoRoot,
+    }),
+    { classifier, nativeVersion: "9.8.7", sha256: undefined },
+  );
+});
+
+test("rejects a wrong external filename before attachment", (t) => {
+  const fixture = createFixture(t);
+  const wrongName = path.join(fixture.root, "arbitrary.jar");
+  createNativeClassifierTestFixture({
+    classifier,
+    outputPath: wrongName,
+    repoRoot: fixture.repoRoot,
+  });
+
+  assert.throws(
+    () =>
+      validateNativeClassifierJar({
+        classifier,
+        jarPath: wrongName,
+        expectedFilename: artifactName,
+        repoRoot: fixture.repoRoot,
+      }),
+    /must be named/,
+  );
+});
+
+test("rejects a missing classifier JAR with the expected filename", (t) => {
+  const fixture = createFixture(t);
+
+  assert.throws(
+    () =>
+      validateNativeClassifierJar({
+        classifier,
+        jarPath: fixture.jarPath,
+        expectedFilename: artifactName,
+        repoRoot: fixture.repoRoot,
+      }),
+    /does not exist/,
+  );
+});
+
+test("rejects missing native resources", (t) => {
+  const fixture = createFixture(t);
+  writeStoredZip(fixture.jarPath, [
+    ["native/win32-x64/runtime.node", "runtime"],
+    [
+      "native/win32-x64/platform.properties",
+      "classifier=win32-x64\nversion=9.8.7\n",
+    ],
+  ]);
+
+  assert.throws(
+    () =>
+      validateNativeClassifierJar({
+        classifier,
+        jarPath: fixture.jarPath,
+        expectedFilename: artifactName,
+        repoRoot: fixture.repoRoot,
+      }),
+    /copilot\.exe/,
+  );
+});
+
+test("rejects incorrect pinned package metadata", (t) => {
+  const fixture = createFixture(t);
+  writeStoredZip(fixture.jarPath, [
+    ["native/win32-x64/runtime.node", "runtime"],
+    ["native/win32-x64/copilot.exe", "cli"],
+    [
+      "native/win32-x64/platform.properties",
+      "classifier=win32-x64\nversion=0.0.1\n",
+    ],
+  ]);
+
+  assert.throws(
+    () =>
+      validateNativeClassifierJar({
+        classifier,
+        jarPath: fixture.jarPath,
+        expectedFilename: artifactName,
+        repoRoot: fixture.repoRoot,
+      }),
+    /version=9\.8\.7/,
+  );
+});
+
+test("rejects Linux resources in a Windows classifier", (t) => {
+  const fixture = createFixture(t);
+  createNativeClassifierTestFixture({
+    classifier,
+    outputPath: fixture.jarPath,
+    repoRoot: fixture.repoRoot,
+  });
+  writeStoredZip(fixture.jarPath, [
+    ["native/win32-x64/runtime.node", "runtime"],
+    ["native/win32-x64/copilot.exe", "cli"],
+    [
+      "native/win32-x64/platform.properties",
+      "classifier=win32-x64\nversion=9.8.7\n",
+    ],
+    ["native/linux-x64/runtime.node", "wrong platform"],
+  ]);
+
+  assert.throws(
+    () =>
+      validateNativeClassifierJar({
+        classifier,
+        jarPath: fixture.jarPath,
+        expectedFilename: artifactName,
+        repoRoot: fixture.repoRoot,
+      }),
+    /must not contain/,
+  );
+});
+
+test("rejects Windows resources in a Linux classifier", (t) => {
+  const fixture = createFixture(t);
+  const linuxClassifier = "linux-x64";
+  const linuxArtifactName =
+    "copilot-sdk-java-runtime-1.2.3-linux-x64.jar";
+  const linuxJarPath = path.join(fixture.root, linuxArtifactName);
+  writeStoredZip(linuxJarPath, [
+    ["native/linux-x64/runtime.node", "runtime"],
+    ["native/linux-x64/copilot", "cli"],
+    [
+      "native/linux-x64/platform.properties",
+      "classifier=linux-x64\nversion=9.8.6\n",
+    ],
+    ["native/win32-x64/runtime.node", "wrong platform"],
+  ]);
+
+  assert.throws(
+    () =>
+      validateNativeClassifierJar({
+        classifier: linuxClassifier,
+        jarPath: linuxJarPath,
+        expectedFilename: linuxArtifactName,
+        repoRoot: fixture.repoRoot,
+      }),
+    /must not contain/,
+  );
+});
+
+test("rejects native resources in the placeholder JAR", (t) => {
+  const fixture = createFixture(t);
+  writeStoredZip(fixture.jarPath, [
+    ["native/win32-x64/runtime.node", "runtime"],
+  ]);
+
+  assert.throws(
+    () => validatePlaceholderJar(fixture.jarPath),
+    /must not contain/,
+  );
+});
+
+test("accepts a native-free placeholder JAR", (t) => {
+  const fixture = createFixture(t);
+  writeStoredZip(fixture.jarPath, [
+    ["META-INF/MANIFEST.MF", "Manifest-Version: 1.0\n"],
+  ]);
+
+  assert.doesNotThrow(() => validatePlaceholderJar(fixture.jarPath));
+});
+
+test("rejects an invalid SHA-256 manifest", (t) => {
+  const fixture = createFixture(t);
+  createNativeClassifierTestFixture({
+    classifier,
+    outputPath: fixture.jarPath,
+    repoRoot: fixture.repoRoot,
+  });
+  const manifestPath = path.join(fixture.root, "classifier.sha256");
+  fs.writeFileSync(manifestPath, `${"0".repeat(64)}  ${artifactName}\n`);
+
+  assert.throws(
+    () =>
+      validateSha256Manifest({
+        expectedFilename: artifactName,
+        jarPath: fixture.jarPath,
+        manifestPath,
+      }),
+    /SHA-256 mismatch/,
+  );
+});
+
+test("accepts a matching SHA-256 manifest", (t) => {
+  const fixture = createFixture(t);
+  createNativeClassifierTestFixture({
+    classifier,
+    outputPath: fixture.jarPath,
+    repoRoot: fixture.repoRoot,
+  });
+  const manifestPath = path.join(fixture.root, "classifier.sha256");
+  const digest = createHash("sha256")
+    .update(fs.readFileSync(fixture.jarPath))
+    .digest("hex");
+  fs.writeFileSync(manifestPath, `${digest}  ${artifactName}\n`);
+
+  assert.doesNotThrow(() =>
+    validateSha256Manifest({
+      expectedFilename: artifactName,
+      jarPath: fixture.jarPath,
+      manifestPath,
+    }),
+  );
+});
+
+test("validates one complete signed local publication", (t) => {
+  const fixture = createFixture(t);
+  const artifactId = "copilot-sdk-java-runtime";
+  const version = "1.2.3";
+  const publicationDirectory = path.join(
+    fixture.root,
+    "repository",
+    "com",
+    "github",
+    artifactId,
+    version,
+  );
+  fs.mkdirSync(publicationDirectory, { recursive: true });
+  const primaryJar = `${artifactId}-${version}.jar`;
+  const linuxJar = `${artifactId}-${version}-linux-x64.jar`;
+  const windowsJar = `${artifactId}-${version}-win32-x64.jar`;
+  writeStoredZip(path.join(publicationDirectory, primaryJar), [
+    ["META-INF/MANIFEST.MF", "Manifest-Version: 1.0\n"],
+  ]);
+  writeStoredZip(
+    path.join(publicationDirectory, `${artifactId}-${version}-sources.jar`),
+    [],
+  );
+  writeStoredZip(
+    path.join(publicationDirectory, `${artifactId}-${version}-javadoc.jar`),
+    [],
+  );
+  createNativeClassifierTestFixture({
+    classifier: "linux-x64",
+    outputPath: path.join(publicationDirectory, linuxJar),
+    repoRoot: fixture.repoRoot,
+  });
+  createNativeClassifierTestFixture({
+    classifier,
+    outputPath: path.join(publicationDirectory, windowsJar),
+    repoRoot: fixture.repoRoot,
+  });
+  fs.writeFileSync(
+    path.join(publicationDirectory, `${artifactId}-${version}.pom`),
+    "<project />",
+  );
+  for (const artifact of [
+    primaryJar,
+    `${artifactId}-${version}.pom`,
+    `${artifactId}-${version}-sources.jar`,
+    `${artifactId}-${version}-javadoc.jar`,
+    linuxJar,
+    windowsJar,
+  ]) {
+    fs.writeFileSync(
+      path.join(publicationDirectory, `${artifact}.asc`),
+      "signature",
+    );
+  }
+
+  assert.equal(
+    validateLocalPublication({
+      artifactId,
+      repositoryPath: path.join(fixture.root, "repository"),
+      repoRoot: fixture.repoRoot,
+      requireSignatures: true,
+      version,
+    }),
+    publicationDirectory,
+  );
+});
+
+test("local publication validation rejects cross-classifier contamination", (t) => {
+  const fixture = createFixture(t);
+  const artifactId = "copilot-sdk-java-runtime";
+  const version = "1.2.3";
+  const publicationDirectory = path.join(
+    fixture.root,
+    "repository",
+    "com",
+    "github",
+    artifactId,
+    version,
+  );
+  fs.mkdirSync(publicationDirectory, { recursive: true });
+
+  writeStoredZip(
+    path.join(publicationDirectory, `${artifactId}-${version}.jar`),
+    [["META-INF/MANIFEST.MF", "Manifest-Version: 1.0\n"]],
+  );
+  writeStoredZip(
+    path.join(publicationDirectory, `${artifactId}-${version}-sources.jar`),
+    [],
+  );
+  writeStoredZip(
+    path.join(publicationDirectory, `${artifactId}-${version}-javadoc.jar`),
+    [],
+  );
+  writeStoredZip(
+    path.join(publicationDirectory, `${artifactId}-${version}-linux-x64.jar`),
+    [
+      ["native/linux-x64/runtime.node", "runtime"],
+      ["native/linux-x64/copilot", "cli"],
+      [
+        "native/linux-x64/platform.properties",
+        "classifier=linux-x64\nversion=9.8.6\n",
+      ],
+      ["native/win32-x64/runtime.node", "wrong platform"],
+    ],
+  );
+  createNativeClassifierTestFixture({
+    classifier: "win32-x64",
+    outputPath: path.join(
+      publicationDirectory,
+      `${artifactId}-${version}-win32-x64.jar`,
+    ),
+    repoRoot: fixture.repoRoot,
+  });
+  fs.writeFileSync(
+    path.join(publicationDirectory, `${artifactId}-${version}.pom`),
+    "<project />",
+  );
+
+  assert.throws(
+    () =>
+      validateLocalPublication({
+        artifactId,
+        repositoryPath: path.join(fixture.root, "repository"),
+        repoRoot: fixture.repoRoot,
+        requireSignatures: false,
+        version,
+      }),
+    /must not contain/,
+  );
+});
+
+function createFixture(t) {
+  const fixtureParent = path.join(
+    moduleRoot,
+    "target",
+    "validate-native-artifact-test-",
+  );
+  fs.mkdirSync(fixtureParent, { recursive: true });
+  const root = fs.mkdtempSync(path.join(fixtureParent, `${process.pid}-`));
+  t.after(() =>
+    fs.rmSync(root, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 100,
+    }),
+  );
+
+  const repoRoot = path.join(root, "repo");
+  fs.mkdirSync(path.join(repoRoot, "nodejs"), { recursive: true });
+  fs.writeFileSync(
+    path.join(repoRoot, "nodejs", "package-lock.json"),
+    JSON.stringify({
+      packages: {
+        "node_modules/@github/copilot-win32-x64": { version: "9.8.7" },
+        "node_modules/@github/copilot-linux-x64": { version: "9.8.6" },
+      },
+    }),
+  );
+
+  return {
+    root,
+    repoRoot,
+    jarPath: path.join(root, artifactName),
+  };
+}

--- a/java/copilot-native/scripts/validate-native-host.mjs
+++ b/java/copilot-native/scripts/validate-native-host.mjs
@@ -5,21 +5,30 @@
 import { pathToFileURL } from "node:url";
 
 export function validateNativeHost(classifier, host) {
-  if (classifier !== "linux-x64") {
-    throw new Error(`Unsupported native build classifier: ${classifier}`);
-  }
-  if (host.platform !== "linux" || host.arch !== "x64") {
-    throw new Error(
-      `Native ${classifier} packaging requires Linux x64; detected ${host.platform}-${host.arch}`,
-    );
-  }
-  if (!host.glibcVersionRuntime) {
-    throw new Error(
-      `Native ${classifier} packaging requires glibc; musl and unknown libc hosts are unsupported`,
-    );
+  if (classifier === "linux-x64") {
+    if (host.platform !== "linux" || host.arch !== "x64") {
+      throw new Error(
+        `Native ${classifier} packaging requires Linux x64; detected ${host.platform}-${host.arch}`,
+      );
+    }
+    if (!host.glibcVersionRuntime) {
+      throw new Error(
+        `Native ${classifier} packaging requires glibc; musl and unknown libc hosts are unsupported`,
+      );
+    }
+    return `Validated native build host: ${classifier} (glibc ${host.glibcVersionRuntime})`;
   }
 
-  return `Validated native build host: ${classifier} (glibc ${host.glibcVersionRuntime})`;
+  if (classifier === "win32-x64") {
+    if (host.platform !== "win32" || host.arch !== "x64") {
+      throw new Error(
+        `Native ${classifier} packaging requires Windows x64; detected ${host.platform}-${host.arch}`,
+      );
+    }
+    return `Validated native build host: ${classifier}`;
+  }
+
+  throw new Error(`Unsupported native build classifier: ${classifier}`);
 }
 
 export function detectNativeHost() {

--- a/java/copilot-native/scripts/validate-native-host.test.mjs
+++ b/java/copilot-native/scripts/validate-native-host.test.mjs
@@ -18,6 +18,17 @@ test("accepts Linux x64 with glibc", () => {
   );
 });
 
+test("accepts Windows x64 without a libc requirement", () => {
+  assert.equal(
+    validateNativeHost("win32-x64", {
+      platform: "win32",
+      arch: "x64",
+      glibcVersionRuntime: undefined,
+    }),
+    "Validated native build host: win32-x64",
+  );
+});
+
 test("rejects Linux x64 with musl or unknown libc", () => {
   assert.throws(
     () =>
@@ -51,6 +62,30 @@ test("rejects a non-x64 host", () => {
         glibcVersionRuntime: "2.39",
       }),
     /requires Linux x64/,
+  );
+});
+
+test("rejects a non-Windows host for the Windows classifier", () => {
+  assert.throws(
+    () =>
+      validateNativeHost("win32-x64", {
+        platform: "linux",
+        arch: "x64",
+        glibcVersionRuntime: "2.39",
+      }),
+    /requires Windows x64/,
+  );
+});
+
+test("rejects Windows ARM64 for the Windows x64 classifier", () => {
+  assert.throws(
+    () =>
+      validateNativeHost("win32-x64", {
+        platform: "win32",
+        arch: "arm64",
+        glibcVersionRuntime: undefined,
+      }),
+    /requires Windows x64/,
   );
 });
 

--- a/java/docs/adr/adr-007-native-bundling-strategy.md
+++ b/java/docs/adr/adr-007-native-bundling-strategy.md
@@ -208,7 +208,9 @@ If none succeeds, startup fails. The PATH fallback does not claim to support eve
 
 ### Current platform scope
 
-The platform detector recognizes the 8 classifiers listed in this ADR. The Maven build binds native packaging only for an explicitly selected implemented classifier. Currently, Linux x64 glibc hosts can opt in with `copilot.native.libc=glibc`, while the `inprocess` test profile selects the required `linux-x64` classifier automatically. Both paths validate the host before downloading or packaging native files. Linux x64 musl and other unsupported hosts build only the OS-neutral placeholder, sources, and Javadoc artifacts unless they explicitly request in-process tests, which fail during host validation. Additional classifier artifacts remain follow-up work.
+The platform detector recognizes the 8 classifiers listed in this ADR. The Maven build binds native packaging only for a host matching an implemented classifier. Windows x64 hosts package `win32-x64` automatically. Linux x64 glibc hosts can opt in with `copilot.native.libc=glibc`. The `inprocess` test profile selects the matching implemented classifier automatically on both hosts. Every path validates the host before downloading or packaging native files. Linux x64 musl and other unsupported hosts build only the OS-neutral placeholder, sources, and Javadoc artifacts unless they explicitly request in-process tests, which fail during host validation. Additional classifier artifacts remain follow-up work.
+
+Maven Central release and snapshot workflows build the Windows classifier on Windows and the Linux classifier on Ubuntu from the same immutable source. The Windows job uploads only a verified `win32-x64` classifier and checksum manifest. The Ubuntu job verifies and attaches that classifier, builds `linux-x64` with the glibc opt-in, and performs the only Maven deployment. Release signing therefore covers the neutral artifacts and both classifiers in one deployment.
 
 ## Binding technology: JNA over Panama FFM
 
@@ -360,7 +362,7 @@ The pattern follows DJL's `LibUtils.loadLibrary()` approach: detect the platform
   3. Extracts `runtime.node` and the transitional CLI entrypoint into `~/.copilot/runtime-cache/` if valid cached files are not already present.
   4. Loads it via [JNA](#references) using the C ABI entry points, per the [binding technology decision](#binding-technology-jna-over-panama-ffm) above. The JNA-specific code is confined behind an internal binding interface to preserve a future FFM migration path.
 * A validated supported-host profile fetches the pinned matching `@github/copilot-<classifier>` npm package, verifies its SHA-512 integrity from `nodejs/package-lock.json`, and packages the version-matched runtime and CLI files.
-* The current release work publishes the `linux-x64` classifier. The planned classifier set expands to the other detected platforms.
+* The current release work publishes the `linux-x64` and `win32-x64` classifiers. The planned classifier set expands to the other detected platforms.
 * Adding an implemented platform requires validated host activation, a profile that supplies the classifier and platform CLI filename, and lifecycle bindings for the shared host validation, fetch, script test, package, and verification executions.
 * `cli-native.node` is not bundled. It provides terminal UI features that are irrelevant to the Java SDK's programmatic API surface.
 

--- a/java/sdk/pom.xml
+++ b/java/sdk/pom.xml
@@ -51,16 +51,6 @@
               mvn verify -Dcopilot.cli.path=/some/other/copilot/npm-loader.js
         -->
         <copilot.cli.path>${copilot.sdk.root}/nodejs/node_modules/@github/copilot/npm-loader.js</copilot.cli.path>
-        <!--
-            Path to the platform-specific Copilot CLI binary (not the
-            npm-loader.js dispatcher) used by the -Pinprocess profile: the
-            in-process FFI host loads runtime.node directly, so it needs the
-            real per-platform binary/prebuilds layout, not the thin loader
-            script. Override with -Dcopilot.inprocess.cli.path=... for other
-            platforms/architectures; Linux-x64 is the only supported platform
-            for InProcess E2E tests in this phase.
-        -->
-        <copilot.inprocess.cli.path>${copilot.sdk.root}/nodejs/node_modules/@github/copilot-linux-x64/copilot</copilot.inprocess.cli.path>
         <!-- Set to true (via -Pskip-test-harness) to skip npm install of test harness -->
         <skip.test.harness>false</skip.test.harness>
         <!--
@@ -604,10 +594,13 @@ did not produce the multi-release output. Re-build on JDK 25+ and verify the
             <id>inprocess</id>
             <properties>
                 <COPILOT_SDK_DEFAULT_CONNECTION>inprocess</COPILOT_SDK_DEFAULT_CONNECTION>
+                <copilot.native.classifier>linux-x64</copilot.native.classifier>
+                <!-- Force classpath resolution of runtime.node and the embedded CLI. -->
+                <copilot.inprocess.cli.path></copilot.inprocess.cli.path>
             </properties>
             <dependencies>
                 <!--
-                    Classpath resource native/linux-x64/runtime.node, resolved by
+                    Classpath resource native/<classifier>/runtime.node, resolved by
                     NativeRuntimeLoader when no runtime.node is found next to
                     COPILOT_CLI_PATH. Test-scoped: production consumers add the
                     classifier they need themselves.
@@ -616,7 +609,7 @@ did not produce the multi-release output. Re-build on JDK 25+ and verify the
                     <groupId>com.github</groupId>
                     <artifactId>copilot-sdk-java-runtime</artifactId>
                     <version>${project.version}</version>
-                    <classifier>linux-x64</classifier>
+                    <classifier>${copilot.native.classifier}</classifier>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -660,6 +653,7 @@ did not produce the multi-release output. Re-build on JDK 25+ and verify the
                                 <exclude>**/ToolsTest.java</exclude>
                             </excludes>
                             <environmentVariables>
+                                <COPILOT_CLI_PATH>${copilot.inprocess.cli.path}</COPILOT_CLI_PATH>
                                 <COPILOT_SDK_DEFAULT_CONNECTION>inprocess</COPILOT_SDK_DEFAULT_CONNECTION>
                             </environmentVariables>
                         </configuration>
@@ -689,6 +683,18 @@ did not produce the multi-release output. Re-build on JDK 25+ and verify the
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>native-win32-x64</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                    <arch>amd64</arch>
+                </os>
+            </activation>
+            <properties>
+                <copilot.native.classifier>win32-x64</copilot.native.classifier>
+            </properties>
         </profile>
         <!--
             Skip the install-nodejs-cli-dependencies (npm ci) execution when

--- a/java/sdk/src/main/java/com/github/copilot/ffi/NativeRuntimeLoader.java
+++ b/java/sdk/src/main/java/com/github/copilot/ffi/NativeRuntimeLoader.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.channels.FileChannel;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -77,8 +78,9 @@ public final class NativeRuntimeLoader {
         } catch (AtomicMoveNotSupportedException ex) {
             throw new IllegalStateException("Filesystem does not support atomic moves; cannot safely publish "
                     + RUNTIME_FILENAME + " to " + cached, ex);
-        } catch (FileAlreadyExistsException ex) {
-            // Another process won the race — accept the winner if it is a valid file.
+        } catch (FileAlreadyExistsException | AccessDeniedException ex) {
+            // Windows can report AccessDeniedException instead of
+            // FileAlreadyExistsException when another publisher wins the race.
             try {
                 if (isValidCachedFile(cached)) {
                     return;

--- a/java/sdk/src/test/java/com/github/copilot/e2e/RewindIT.java
+++ b/java/sdk/src/test/java/com/github/copilot/e2e/RewindIT.java
@@ -106,13 +106,17 @@ class RewindIT {
         SessionHistoryListRewindPointsResult result;
         do {
             result = session.getRpc().history.listRewindPoints().get(10, TimeUnit.SECONDS);
-            if (result.unavailableReason() == null) {
+            if (result.unavailableReason() == null && !result.points().isEmpty()
+                    && Boolean.TRUE.equals(result.points().get(0).canRestoreFiles())) {
                 return result;
             }
             TimeUnit.MILLISECONDS.sleep(100);
         } while (System.nanoTime() < deadline);
 
         assertNull(result.unavailableReason(), "Timed out waiting for rewind points to become available");
+        assertFalse(result.points().isEmpty(), "Timed out waiting for a rewind point");
+        assertTrue(Boolean.TRUE.equals(result.points().get(0).canRestoreFiles()),
+                "Timed out waiting for rewind file restoration to become available");
         return result;
     }
 

--- a/java/sdk/src/test/java/com/github/copilot/ffi/JnaNativeBindingTest.java
+++ b/java/sdk/src/test/java/com/github/copilot/ffi/JnaNativeBindingTest.java
@@ -303,11 +303,13 @@ class JnaNativeBindingTest {
     }
 
     @Test
-    void resetForTestingAllowsReloadFromDifferentPath(@TempDir Path tempDir) throws Exception {
+    void resetForTestingAllowsReloadFromDifferentPath() throws Exception {
         Path nativeLib = resolveNativeLib();
         assumeTrue(nativeLib != null, "Native runtime not available (run with -Pinprocess)");
-        Path altPath = tempDir.resolve("runtime-copy-reset.node");
-        Files.copy(nativeLib, altPath);
+        Path altDir = Path.of("target", "jna-test-runtime");
+        Files.createDirectories(altDir);
+        Path altPath = altDir.resolve("runtime-copy-reset.node");
+        Files.copy(nativeLib, altPath, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
 
         new JnaNativeBinding(nativeLib);
 

--- a/java/sdk/src/test/java/com/github/copilot/ffi/NativeRuntimeLoaderTest.java
+++ b/java/sdk/src/test/java/com/github/copilot/ffi/NativeRuntimeLoaderTest.java
@@ -34,8 +34,13 @@ import org.junit.jupiter.api.io.TempDir;
 
 class NativeRuntimeLoaderTest {
 
-    private static final String TEST_CLASSIFIER = "linux-x64";
-    private static final String OTHER_CLASSIFIER = "darwin-arm64";
+    private static final String TEST_CLASSIFIER = PlatformDetector.detectClassifier();
+    private static final String OTHER_CLASSIFIER = TEST_CLASSIFIER.equals("darwin-arm64")
+            ? "linux-x64"
+            : "darwin-arm64";
+    private static final String TEST_CLI_FILENAME = TEST_CLASSIFIER.startsWith("win32")
+            ? NativeRuntimeLoader.CLI_FILENAME_WINDOWS
+            : NativeRuntimeLoader.CLI_FILENAME;
     private static final String TEST_VERSION = "1.2.3-test";
     private static final String TEST_NATIVE_VERSION = "0.0.1-test";
     private static final byte[] FAKE_BINARY_CONTENT = "fake runtime.node binary content".getBytes();
@@ -153,10 +158,9 @@ class NativeRuntimeLoaderTest {
     }
 
     @Test
-    void resolveFromCliPathReturnsAbsolutePathForRelativeCliPath(@TempDir Path tempDir) throws Exception {
+    void resolveFromCliPathReturnsAbsolutePathForRelativeCliPath() throws Exception {
         Path workingDirectory = Path.of("").toAbsolutePath();
-        Path fakeCliDir = tempDir.resolve("cli-dir");
-        Files.createDirectories(fakeCliDir);
+        Path fakeCliDir = Files.createTempDirectory(Path.of("target").toAbsolutePath(), "relative-cli-test-");
         Path fakeCliPath = fakeCliDir.resolve("copilot");
         Files.createFile(fakeCliPath);
         Path runtimeNode = fakeCliDir.resolve(NativeRuntimeLoader.RUNTIME_FILENAME);
@@ -169,7 +173,6 @@ class NativeRuntimeLoaderTest {
 
     @Test
     void cliPathOverrideTakesPriorityOverClasspathExtraction(@TempDir Path tempDir) throws Exception {
-        assumeLinuxX64();
         // Create a valid runtime.node alongside the fake CLI path
         Path fakeCliDir = tempDir.resolve("cli-dir");
         Files.createDirectories(fakeCliDir);
@@ -194,7 +197,6 @@ class NativeRuntimeLoaderTest {
 
     @Test
     void extractToCacheCopiesResourceToVersionedCacheDirectory(@TempDir Path tempDir) throws Exception {
-        assumeLinuxX64();
         Path cacheBase = tempDir.resolve("cache");
         ClassLoader loader = classLoaderWithRuntimeResource(tempDir, TEST_CLASSIFIER);
 
@@ -209,7 +211,6 @@ class NativeRuntimeLoaderTest {
 
     @Test
     void extractToCacheReturnsCachedFileOnSecondCall(@TempDir Path tempDir) throws Exception {
-        assumeLinuxX64();
         Path cacheBase = tempDir.resolve("cache");
         ClassLoader loader = classLoaderWithRuntimeResource(tempDir, TEST_CLASSIFIER);
 
@@ -229,7 +230,6 @@ class NativeRuntimeLoaderTest {
 
     @Test
     void changedNativeVersionDoesNotReuseCachedArtifactsForSameSdkVersion(@TempDir Path tempDir) throws Exception {
-        assumeLinuxX64();
         Path cacheBase = tempDir.resolve("cache");
         ClassLoader firstLoader = classLoaderWithNativeArtifacts(tempDir.resolve("native-v1"), TEST_CLASSIFIER, "1.0.0",
                 FAKE_BINARY_CONTENT, FAKE_CLI_CONTENT);
@@ -241,16 +241,13 @@ class NativeRuntimeLoaderTest {
 
         assertNotEquals(firstRuntime, secondRuntime, "Different native versions must use different cache entries");
         assertBytesEqual(FAKE_BINARY_CONTENT, Files.readAllBytes(firstRuntime));
-        assertBytesEqual(FAKE_CLI_CONTENT,
-                Files.readAllBytes(firstRuntime.getParent().resolve(NativeRuntimeLoader.CLI_FILENAME)));
+        assertBytesEqual(FAKE_CLI_CONTENT, Files.readAllBytes(firstRuntime.getParent().resolve(TEST_CLI_FILENAME)));
         assertBytesEqual(OTHER_BINARY_CONTENT, Files.readAllBytes(secondRuntime));
-        assertBytesEqual(OTHER_CLI_CONTENT,
-                Files.readAllBytes(secondRuntime.getParent().resolve(NativeRuntimeLoader.CLI_FILENAME)));
+        assertBytesEqual(OTHER_CLI_CONTENT, Files.readAllBytes(secondRuntime.getParent().resolve(TEST_CLI_FILENAME)));
     }
 
     @Test
     void extractToCacheThrowsWhenClasspathResourceMissing(@TempDir Path tempDir) {
-        assumeLinuxX64();
         Path cacheBase = tempDir.resolve("cache");
         ClassLoader emptyLoader = new URLClassLoader(new URL[0], null);
 
@@ -260,7 +257,6 @@ class NativeRuntimeLoaderTest {
 
     @Test
     void extractToCacheThrowsWhenNativeMetadataMissing(@TempDir Path tempDir) throws Exception {
-        assumeLinuxX64();
         Path resourceDir = tempDir.resolve("native").resolve(TEST_CLASSIFIER);
         Files.createDirectories(resourceDir);
         Files.write(resourceDir.resolve(NativeRuntimeLoader.RUNTIME_FILENAME), FAKE_BINARY_CONTENT);
@@ -274,7 +270,6 @@ class NativeRuntimeLoaderTest {
 
     @Test
     void extractedBinaryContentsMatchClasspathResource(@TempDir Path tempDir) throws Exception {
-        assumeLinuxX64();
         Path cacheBase = tempDir.resolve("cache");
         ClassLoader loader = classLoaderWithRuntimeResource(tempDir, TEST_CLASSIFIER);
 
@@ -286,7 +281,6 @@ class NativeRuntimeLoaderTest {
 
     @Test
     void extractToCacheFiltersClasspathByClassifier(@TempDir Path tempDir) throws Exception {
-        assumeLinuxX64();
         Path cacheBase = tempDir.resolve("cache");
         writeRuntimeResource(tempDir, TEST_CLASSIFIER, FAKE_BINARY_CONTENT);
         writeRuntimeResource(tempDir, OTHER_CLASSIFIER, OTHER_BINARY_CONTENT);
@@ -300,7 +294,6 @@ class NativeRuntimeLoaderTest {
 
     @Test
     void extractToCacheRepairsInvalidCacheEntry(@TempDir Path tempDir) throws Exception {
-        assumeLinuxX64();
         Path cacheBase = tempDir.resolve("cache");
         Path cached = cacheBase.resolve(TEST_VERSION).resolve(TEST_NATIVE_VERSION).resolve(TEST_CLASSIFIER)
                 .resolve(NativeRuntimeLoader.RUNTIME_FILENAME);
@@ -316,13 +309,13 @@ class NativeRuntimeLoaderTest {
 
     @Test
     void nonExecutableCachedCliIsNotAcceptedAsValid(@TempDir Path tempDir) throws Exception {
-        assumeLinuxX64();
+        assumeTrue(!TEST_CLASSIFIER.startsWith("win32"));
         assumeTrue(Files.getFileStore(tempDir).supportsFileAttributeView("posix"));
         Path cacheBase = tempDir.resolve("cache");
         Path cacheDir = cacheBase.resolve(TEST_VERSION).resolve(TEST_NATIVE_VERSION).resolve(TEST_CLASSIFIER);
         Files.createDirectories(cacheDir);
         Files.write(cacheDir.resolve(NativeRuntimeLoader.RUNTIME_FILENAME), FAKE_BINARY_CONTENT);
-        Path cachedCli = Files.write(cacheDir.resolve(NativeRuntimeLoader.CLI_FILENAME), FAKE_CLI_CONTENT);
+        Path cachedCli = Files.write(cacheDir.resolve(TEST_CLI_FILENAME), FAKE_CLI_CONTENT);
         Files.setPosixFilePermissions(cachedCli, PosixFilePermissions.fromString("rw-------"));
         ClassLoader loader = classLoaderWithRuntimeAndCliResources(tempDir, TEST_CLASSIFIER);
 
@@ -337,7 +330,6 @@ class NativeRuntimeLoaderTest {
 
     @Test
     void bundledCliSiblingIsUsedWhenClasspathResourceAbsent(@TempDir Path tempDir) throws Exception {
-        assumeLinuxX64();
         Path bundledCliDir = tempDir.resolve("bundled-cli");
         Files.createDirectories(bundledCliDir);
         Path runtimeNode = bundledCliDir.resolve(NativeRuntimeLoader.RUNTIME_FILENAME);
@@ -355,7 +347,6 @@ class NativeRuntimeLoaderTest {
 
     @Test
     void classpathResourceWinsOverBundledCliSibling(@TempDir Path tempDir) throws Exception {
-        assumeLinuxX64();
         // Source 3: bundled CLI dir with runtime.node (should NOT win)
         Path bundledCliDir = tempDir.resolve("bundled-cli");
         Files.createDirectories(bundledCliDir);
@@ -377,7 +368,6 @@ class NativeRuntimeLoaderTest {
 
     @Test
     void bundledCliSiblingIsIgnoredWhenRuntimeNodeMissing(@TempDir Path tempDir) {
-        assumeLinuxX64();
         Path bundledCliDir = tempDir.resolve("bundled-cli-no-runtime");
         // bundledCliDir doesn't even exist — no runtime.node present
 
@@ -409,12 +399,12 @@ class NativeRuntimeLoaderTest {
 
     @Test
     void cliIsExecutableBeforeAtomicPublication(@TempDir Path tempDir) throws Exception {
-        assumeLinuxX64();
+        assumeTrue(!TEST_CLASSIFIER.startsWith("win32"));
         assumeTrue(Files.getFileStore(tempDir).supportsFileAttributeView("posix"));
         Path cacheBase = tempDir.resolve("cache");
         ClassLoader loader = classLoaderWithRuntimeAndCliResources(tempDir, TEST_CLASSIFIER);
         NativeRuntimeLoader.AtomicPublisher publisher = (temp, cached) -> {
-            if (cached.getFileName().toString().equals(NativeRuntimeLoader.CLI_FILENAME)) {
+            if (cached.getFileName().toString().equals(TEST_CLI_FILENAME)) {
                 assertTrue(Files.isExecutable(temp), "CLI temp file must be executable before atomic publication");
             }
             Files.move(temp, cached, StandardCopyOption.REPLACE_EXISTING);
@@ -425,7 +415,6 @@ class NativeRuntimeLoaderTest {
 
     @Test
     void extractionCleansUpTempFileWhenPublicationFails(@TempDir Path tempDir) throws Exception {
-        assumeLinuxX64();
         Path cacheBase = tempDir.resolve("cache");
         ClassLoader loader = classLoaderWithRuntimeResource(tempDir, TEST_CLASSIFIER);
 
@@ -446,7 +435,6 @@ class NativeRuntimeLoaderTest {
 
     @Test
     void extractionCleansUpTempFileWhenPublisherThrowsIllegalStateException(@TempDir Path tempDir) throws Exception {
-        assumeLinuxX64();
         Path cacheBase = tempDir.resolve("cache");
         ClassLoader loader = classLoaderWithRuntimeResource(tempDir, TEST_CLASSIFIER);
 
@@ -474,7 +462,6 @@ class NativeRuntimeLoaderTest {
 
     @Test
     void concurrentExtractionByMultipleThreadsBothSucceed(@TempDir Path tempDir) throws Exception {
-        assumeLinuxX64();
         Path cacheBase = tempDir.resolve("cache");
         ClassLoader loader = classLoaderWithRuntimeResource(tempDir, TEST_CLASSIFIER);
         int threadCount = 8;
@@ -512,7 +499,6 @@ class NativeRuntimeLoaderTest {
 
     @Test
     void resolveWithNullCliEnvExtractsFromClasspath(@TempDir Path tempDir) throws Exception {
-        assumeLinuxX64();
         Path cacheBase = tempDir.resolve("cache");
         ClassLoader loader = classLoaderWithRuntimeResource(tempDir, TEST_CLASSIFIER);
 
@@ -525,7 +511,6 @@ class NativeRuntimeLoaderTest {
 
     @Test
     void resolveThrowsWhenNoSourceIsAvailable(@TempDir Path tempDir) {
-        assumeLinuxX64();
         Path cacheBase = tempDir.resolve("cache");
         ClassLoader emptyLoader = new URLClassLoader(new URL[0], null);
 
@@ -536,7 +521,6 @@ class NativeRuntimeLoaderTest {
 
     @Test
     void resolveFallsBackToRuntimeAlongsideBundledCli(@TempDir Path tempDir) throws Exception {
-        assumeLinuxX64();
         Path cacheBase = tempDir.resolve("cache");
         ClassLoader emptyLoader = new URLClassLoader(new URL[0], null);
         Path bundledCli = tempDir.resolve("copilot");
@@ -554,17 +538,6 @@ class NativeRuntimeLoaderTest {
     // Helpers
     // -------------------------------------------------------------------------
 
-    private static void assumeLinuxX64() {
-        String actualClassifier;
-        try {
-            actualClassifier = PlatformDetector.detectClassifier();
-        } catch (IllegalStateException ex) {
-            actualClassifier = "unsupported";
-        }
-        assumeTrue(TEST_CLASSIFIER.equals(actualClassifier),
-                "Requires linux-x64; detected " + actualClassifier + "; see #2323");
-    }
-
     private static ClassLoader classLoaderWithVersionResource(Path tempDir, String version) throws IOException {
         Path propsFile = tempDir.resolve(NativeRuntimeLoader.VERSION_RESOURCE);
         Files.writeString(propsFile, "version=" + version + "\n");
@@ -580,7 +553,7 @@ class NativeRuntimeLoaderTest {
             throws IOException {
         writeRuntimeResource(tempDir, classifier, FAKE_BINARY_CONTENT);
         Path resourceDir = tempDir.resolve("native").resolve(classifier);
-        Files.write(resourceDir.resolve(NativeRuntimeLoader.CLI_FILENAME), FAKE_CLI_CONTENT);
+        Files.write(resourceDir.resolve(TEST_CLI_FILENAME), FAKE_CLI_CONTENT);
         return new URLClassLoader(new URL[]{tempDir.toUri().toURL()}, null);
     }
 
@@ -588,7 +561,7 @@ class NativeRuntimeLoaderTest {
             byte[] runtimeContent, byte[] cliContent) throws IOException {
         writeRuntimeResource(tempDir, classifier, runtimeContent);
         Path resourceDir = tempDir.resolve("native").resolve(classifier);
-        Files.write(resourceDir.resolve(NativeRuntimeLoader.CLI_FILENAME), cliContent);
+        Files.write(resourceDir.resolve(TEST_CLI_FILENAME), cliContent);
         Files.writeString(resourceDir.resolve("platform.properties"),
                 "classifier=" + classifier + "\nversion=" + nativeVersion + "\n");
         return new URLClassLoader(new URL[]{tempDir.toUri().toURL()}, null);

--- a/test/harness/package-lock.json
+++ b/test/harness/package-lock.json
@@ -1750,8 +1750,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Fixes #2392 .

## Summary

Adds `win32-x64` as a supported target for the Java SDK's experimental in-process runtime, alongside the existing GNU/Linux `linux-x64` target.

- Packages a Windows native classifier containing `runtime.node`, `copilot.exe`, and `platform.properties`.
- Selects and validates the host-appropriate classifier when Maven runs with `-Pinprocess`: `linux-x64` on x64 glibc Linux and `win32-x64` on x64 Windows.
- Updates native extraction/loading and tests for Windows filesystem, executable-name, loaded-DLL, and atomic-move behavior.
- Runs the Java in-process test suite on both Ubuntu and Windows and adds blocking publication-assembly coverage.
- Builds each classifier on its native runner, verifies source/version identity, checksums, expected contents, and cross-classifier contamination, then publishes both classifiers in one Maven deployment.
- Applies that coordinated publication model to Maven Central snapshots and releases, including signed local-publication validation and one post-deployment summary covering every published classifier.
- Documents Windows x64 dependencies and updates ADR-007's supported-platform status.

## User experience

In-process mode remains opt-in and the SDK's default connection behavior is unchanged. Applications enable it by:

1. Depending on `com.github:copilot-sdk-java-runtime` with the target classifier (`linux-x64` or `win32-x64`) plus JNA.
2. Configuring `CopilotClientOptions` with `RuntimeConnection.forInProcess()`.

For SDK development, `mvn -Pinprocess clean verify` automatically exercises the native runtime appropriate to the supported host. Unsupported OS/architecture/libc combinations fail validation instead of silently packaging the wrong native binary.

## Publication model

Windows builds and uploads only the `win32-x64` classifier and its checksum. Ubuntu independently builds `linux-x64`, verifies the Windows handoff came from the same immutable source and version, attaches it to the reactor, and performs a single deployment. This ensures snapshot coordinates share one Maven timestamp/build number and release signing covers both classifiers.

Scheduled snapshot publication remains restricted naturally to the default branch, while imperative `workflow_dispatch` runs can still publish from a selected non-default branch. Publication summaries are emitted only after Maven succeeds and list both classifier filenames and SHA-256 hashes without duplicate per-job callouts.

During the active Rust migration, each classifier intentionally includes the version-matched `copilot`/`copilot.exe` embedded-host executable in addition to `runtime.node`. The executable can be removed once the native runtime no longer delegates unported method bodies to the CLI.

## Validation

- Native packaging script suite: 29 tests passing.
- Full Windows x64 `mvn -Pinprocess clean verify` reactor run.
- Host-matched Linux/Windows in-process Actions matrix.
- Local signed Maven publication containing the primary artifact, POM, sources, Javadoc, and both native classifiers with signatures.
- Topic-branch snapshot publication produced `linux-x64` and `win32-x64` under one snapshot build: https://github.com/github/copilot-sdk/actions/runs/32891483956