### PR TITLE
Expose contextual model discovery in Node.js and Rust

### DIFF
--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -1523,7 +1523,9 @@ export type ModelPickerCategory =
   /** Versatile model category suitable for a broad range of tasks. */
   | "versatile"
   /** Powerful model category optimized for complex tasks. */
-  | "powerful";
+  | "powerful"
+  /** Experimental model category for models that require an explicit experimental opt-in. */
+  | "experimental";
 /**
  * Relative cost tier for token-based billing users
  *
@@ -1541,6 +1543,14 @@ export type ModelPickerPriceCategory =
   /** Highest relative token cost tier. */
   | "very_high";
 /**
+ * How a server-level model list was resolved.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ModelsListResolutionMode".
+ */
+/** @experimental */
+export type ModelsListResolutionMode = /** The runtime applied the supplied pre-session context. */ "pre-session";
+/**
  * Optional listing options.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -1557,6 +1567,15 @@ export type ModelListRequest =
        */
       skipCache?: boolean;
     };
+
+/** @experimental */
+export type ModelsListSessionKind = "top-level";
+
+/** @experimental */
+export type ModelsListExecutionEnvironment = "local";
+
+/** @experimental */
+export type ModelsListModelBackend = "copilot";
 /**
  * Provider type. Defaults to "openai" for generic OpenAI-compatible APIs.
  *
@@ -9707,6 +9726,21 @@ export interface ModelList {
    * List of available models with full metadata
    */
   models: Model[];
+  resolution?: ModelsListResolution;
+}
+/**
+ * Acknowledges how the runtime resolved a server-level model list.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ModelsListResolution".
+ */
+/** @experimental */
+export interface ModelsListResolution {
+  mode: ModelsListResolutionMode;
+  /**
+   * Version of the applied pre-session context contract.
+   */
+  contextVersion: number;
 }
 /**
  * Reasoning effort level to apply to the currently selected model.
@@ -9741,6 +9775,35 @@ export interface ModelsListRequest {
    * GitHub token for per-user model listing. When provided, resolves this token to determine the user's Copilot plan and available models instead of using the global auth.
    */
   gitHubToken?: string;
+  sessionContext?: ModelsListPreSessionContext;
+}
+/**
+ * Ordinary session inputs used to resolve a selectable model snapshot before session creation. Version 1 is limited to local, top-level, Copilot-backed sessions.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ModelsListPreSessionContext".
+ */
+/** @experimental */
+export interface ModelsListPreSessionContext {
+  /**
+   * Pre-session context contract version. Version 1 is the only supported value.
+   */
+  version: number;
+  sessionKind: ModelsListSessionKind;
+  executionEnvironment: ModelsListExecutionEnvironment;
+  modelBackend: ModelsListModelBackend;
+  /**
+   * Working directory used to evaluate repository model policy.
+   */
+  workingDirectory: string;
+  /**
+   * Whether the subsequent top-level session will enable experimental mode.
+   */
+  enableExperimentalMode: boolean;
+  /**
+   * Existing ExP assignment response supplied using the same ordinary session input as `session.create`. The runtime interprets assignments; callers must not submit resolved feature or kill-switch claims.
+   */
+  expAssignments?: JsonValue;
 }
 /**
  * Target model identifier and optional reasoning effort, summary, capability overrides, and context tier.
@@ -18769,7 +18832,7 @@ export function createServerRpc(connection: MessageConnection) {
             /**
              * Lists Copilot models available to the authenticated user.
              *
-             * @param params Optional GitHub token used to list models for a specific user instead of the global auth context.
+             * @param params Optional account selection and pre-session context used to list models.
              *
              * @returns List of Copilot models available to the resolved user, including capabilities and billing metadata.
              */

--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -2265,7 +2265,9 @@ export type ModelPickerCategory =
   /** Versatile model category suitable for a broad range of tasks. */
   | "versatile"
   /** Powerful model category optimized for complex tasks. */
-  | "powerful";
+  | "powerful"
+  /** Experimental model category for models that require an explicit experimental opt-in. */
+  | "experimental";
 /**
  * Relative cost tier for token-based billing users
  *
@@ -2283,6 +2285,14 @@ export type ModelPickerPriceCategory =
   /** Highest relative token cost tier. */
   | "very_high";
 /**
+ * How a server-level model list was resolved.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ModelsListResolutionMode".
+ */
+/** @experimental */
+export type ModelsListResolutionMode = /** The runtime applied the supplied pre-session context. */ "pre-session";
+/**
  * Optional listing options.
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
@@ -2299,6 +2309,15 @@ export type ModelListRequest =
        */
       skipCache?: boolean;
     };
+
+/** @experimental */
+export type ModelsListSessionKind = "top-level";
+
+/** @experimental */
+export type ModelsListExecutionEnvironment = "local";
+
+/** @experimental */
+export type ModelsListModelBackend = "copilot";
 /**
  * Provider type. Defaults to "openai" for generic OpenAI-compatible APIs.
  *
@@ -12194,6 +12213,21 @@ export interface ModelList {
    * List of available models with full metadata
    */
   models: Model[];
+  resolution?: ModelsListResolution;
+}
+/**
+ * Acknowledges how the runtime resolved a server-level model list.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ModelsListResolution".
+ */
+/** @experimental */
+export interface ModelsListResolution {
+  mode: ModelsListResolutionMode;
+  /**
+   * Version of the applied pre-session context contract.
+   */
+  contextVersion: number;
 }
 
 /** @experimental */
@@ -12266,6 +12300,35 @@ export interface ModelsListRequest {
    * GitHub token accepted for compatibility with existing SDK clients. When provided, resolves this token instead of using the current account.
    */
   gitHubToken?: string;
+  sessionContext?: ModelsListPreSessionContext;
+}
+/**
+ * Ordinary session inputs used to resolve a selectable model snapshot before session creation. Version 1 is limited to local, top-level, Copilot-backed sessions.
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ModelsListPreSessionContext".
+ */
+/** @experimental */
+export interface ModelsListPreSessionContext {
+  /**
+   * Pre-session context contract version. Version 1 is the only supported value.
+   */
+  version: number;
+  sessionKind: ModelsListSessionKind;
+  executionEnvironment: ModelsListExecutionEnvironment;
+  modelBackend: ModelsListModelBackend;
+  /**
+   * Working directory used to evaluate repository model policy.
+   */
+  workingDirectory: string;
+  /**
+   * Whether the subsequent top-level session will enable experimental mode.
+   */
+  enableExperimentalMode: boolean;
+  /**
+   * Existing ExP assignment response supplied using the same ordinary session input as `session.create`. The runtime interprets assignments; callers must not submit resolved feature or kill-switch claims.
+   */
+  expAssignments?: JsonValue;
 }
 
 /** @experimental */
@@ -22442,7 +22505,7 @@ export function createServerRpc(connection: MessageConnection) {
             /**
              * Lists Copilot models available to the authenticated user.
              *
-             * @param params Optional opaque account selection or compatibility GitHub token used to list models.
+             * @param params Optional account selection and pre-session context used to list models.
              *
              * @returns List of Copilot models available to the resolved user, including capabilities and billing metadata.
              */

--- a/rust/src/generated/api_types.rs
+++ b/rust/src/generated/api_types.rs
@@ -8454,6 +8454,23 @@ pub struct ModelCapabilitiesOverride {
     pub supports: Option<ModelCapabilitiesOverrideSupports>,
 }
 
+/// Acknowledges how the runtime resolved a server-level model list.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelsListResolution {
+    /// Version of the applied pre-session context contract.
+    pub context_version: i32,
+    /// Resolution mode applied by the runtime.
+    pub mode: ModelsListResolutionMode,
+}
+
 /// List of Copilot models available to the resolved user, including capabilities and billing metadata.
 ///
 /// <div class="warning">
@@ -8467,6 +8484,9 @@ pub struct ModelCapabilitiesOverride {
 pub struct ModelList {
     /// List of available models with full metadata
     pub models: Vec<Model>,
+    /// Present only when the runtime applied a pre-session resolution context.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolution: Option<ModelsListResolution>,
 }
 
 /// Optional listing options.
@@ -8515,7 +8535,35 @@ pub struct ModelSetReasoningEffortResult {
     pub reasoning_effort: String,
 }
 
-/// Optional GitHub token used to list models for a specific user instead of the global auth context.
+/// Ordinary session inputs used to resolve a selectable model snapshot before session creation. Version 1 is limited to local, top-level, Copilot-backed sessions.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelsListPreSessionContext {
+    /// Whether the subsequent top-level session will enable experimental mode.
+    pub enable_experimental_mode: bool,
+    /// Execution environment being planned. Version 1 accepts only `local`.
+    pub execution_environment: ModelsListExecutionEnvironment,
+    /// Existing ExP assignment response supplied using the same ordinary session input as `session.create`. The runtime interprets assignments; callers must not submit resolved feature or kill-switch claims.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exp_assignments: Option<serde_json::Value>,
+    /// Model backend being planned. Version 1 accepts only `copilot`.
+    pub model_backend: ModelsListModelBackend,
+    /// Session kind being planned. Version 1 accepts only `top-level`.
+    pub session_kind: ModelsListSessionKind,
+    /// Pre-session context contract version. Version 1 is the only supported value.
+    pub version: i32,
+    /// Working directory used to evaluate repository model policy.
+    pub working_directory: String,
+}
+
+/// Optional account selection and pre-session context used to list models.
 ///
 /// <div class="warning">
 ///
@@ -8529,6 +8577,12 @@ pub struct ModelsListRequest {
     /// GitHub token for per-user model listing. When provided, resolves this token to determine the user's Copilot plan and available models instead of using the global auth.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub git_hub_token: Option<String>,
+    /// Opaque account identifier returned by `account.getAllUsers`. When omitted, the current account is used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selection_id: Option<String>,
+    /// Optional versioned context for resolving the model picker before creating a session.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_context: Option<ModelsListPreSessionContext>,
 }
 
 /// Target model identifier and optional reasoning effort, summary, capability overrides, and context tier.
@@ -18448,6 +18502,9 @@ pub struct WorkspacesWriteAutopilotObjectiveResult {
 pub struct ModelsListResult {
     /// List of available models with full metadata
     pub models: Vec<Model>,
+    /// Present only when the runtime applied a pre-session resolution context.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolution: Option<ModelsListResolution>,
 }
 
 /// The running runtime's complete catalog of well-known built-in model IDs, including supported models and additional IDs with built-in metadata.
@@ -25956,6 +26013,9 @@ pub enum ModelPickerCategory {
     /// Powerful model category optimized for complex tasks.
     #[serde(rename = "powerful")]
     Powerful,
+    /// Experimental model category for models that require an explicit experimental opt-in.
+    #[serde(rename = "experimental")]
+    Experimental,
     /// Unknown variant for forward compatibility.
     #[default]
     #[serde(other)]
@@ -26009,6 +26069,76 @@ pub enum ModelPolicyState {
     /// No explicit policy is configured for the model.
     #[serde(rename = "unconfigured")]
     Unconfigured,
+    /// Unknown variant for forward compatibility.
+    #[default]
+    #[serde(other)]
+    Unknown,
+}
+
+/// How a server-level model list was resolved.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ModelsListResolutionMode {
+    /// The runtime applied the supplied pre-session context.
+    #[serde(rename = "pre-session")]
+    PreSession,
+    /// Unknown variant for forward compatibility.
+    #[default]
+    #[serde(other)]
+    Unknown,
+}
+
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ModelsListExecutionEnvironment {
+    #[serde(rename = "local")]
+    Local,
+    /// Unknown variant for forward compatibility.
+    #[default]
+    #[serde(other)]
+    Unknown,
+}
+
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ModelsListModelBackend {
+    #[serde(rename = "copilot")]
+    Copilot,
+    /// Unknown variant for forward compatibility.
+    #[default]
+    #[serde(other)]
+    Unknown,
+}
+
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ModelsListSessionKind {
+    #[serde(rename = "top-level")]
+    TopLevel,
     /// Unknown variant for forward compatibility.
     #[default]
     #[serde(other)]

--- a/rust/src/generated/api_types.rs
+++ b/rust/src/generated/api_types.rs
@@ -10077,6 +10077,23 @@ pub struct ModelCapabilitiesOverride {
     pub supports: Option<ModelCapabilitiesOverrideSupports>,
 }
 
+/// Acknowledges how the runtime resolved a server-level model list.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelsListResolution {
+    /// Version of the applied pre-session context contract.
+    pub context_version: i32,
+    /// Resolution mode applied by the runtime.
+    pub mode: ModelsListResolutionMode,
+}
+
 /// List of Copilot models available to the resolved user, including capabilities and billing metadata.
 ///
 /// <div class="warning">
@@ -10090,6 +10107,9 @@ pub struct ModelCapabilitiesOverride {
 pub struct ModelList {
     /// List of available models with full metadata
     pub models: Vec<Model>,
+    /// Present only when the runtime applied a pre-session resolution context.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolution: Option<ModelsListResolution>,
 }
 
 /// Optional listing options.
@@ -10178,7 +10198,35 @@ pub struct ModelSetReasoningEffortResult {
     pub reasoning_effort: String,
 }
 
-/// Optional opaque account selection or compatibility GitHub token used to list models.
+/// Ordinary session inputs used to resolve a selectable model snapshot before session creation. Version 1 is limited to local, top-level, Copilot-backed sessions.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelsListPreSessionContext {
+    /// Whether the subsequent top-level session will enable experimental mode.
+    pub enable_experimental_mode: bool,
+    /// Execution environment being planned. Version 1 accepts only `local`.
+    pub execution_environment: ModelsListExecutionEnvironment,
+    /// Existing ExP assignment response supplied using the same ordinary session input as `session.create`. The runtime interprets assignments; callers must not submit resolved feature or kill-switch claims.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exp_assignments: Option<serde_json::Value>,
+    /// Model backend being planned. Version 1 accepts only `copilot`.
+    pub model_backend: ModelsListModelBackend,
+    /// Session kind being planned. Version 1 accepts only `top-level`.
+    pub session_kind: ModelsListSessionKind,
+    /// Pre-session context contract version. Version 1 is the only supported value.
+    pub version: i32,
+    /// Working directory used to evaluate repository model policy.
+    pub working_directory: String,
+}
+
+/// Optional account selection and pre-session context used to list models.
 ///
 /// <div class="warning">
 ///
@@ -10195,6 +10243,9 @@ pub struct ModelsListRequest {
     /// Opaque account identifier returned by `account.getAllUsers`. When omitted, the current account is used.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub selection_id: Option<String>,
+    /// Optional versioned context for resolving the model picker before creating a session.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_context: Option<ModelsListPreSessionContext>,
 }
 
 ///
@@ -21082,6 +21133,9 @@ pub struct WorkspacesWriteAutopilotObjectiveResult {
 pub struct ModelsListResult {
     /// List of available models with full metadata
     pub models: Vec<Model>,
+    /// Present only when the runtime applied a pre-session resolution context.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolution: Option<ModelsListResolution>,
 }
 
 /// The running runtime's complete catalog of well-known built-in model IDs, including supported models and additional IDs with built-in metadata.
@@ -30406,6 +30460,9 @@ pub enum ModelPickerCategory {
     /// Powerful model category optimized for complex tasks.
     #[serde(rename = "powerful")]
     Powerful,
+    /// Experimental model category for models that require an explicit experimental opt-in.
+    #[serde(rename = "experimental")]
+    Experimental,
     /// Unknown variant for forward compatibility.
     #[default]
     #[serde(other)]
@@ -30459,6 +30516,76 @@ pub enum ModelPolicyState {
     /// No explicit policy is configured for the model.
     #[serde(rename = "unconfigured")]
     Unconfigured,
+    /// Unknown variant for forward compatibility.
+    #[default]
+    #[serde(other)]
+    Unknown,
+}
+
+/// How a server-level model list was resolved.
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ModelsListResolutionMode {
+    /// The runtime applied the supplied pre-session context.
+    #[serde(rename = "pre-session")]
+    PreSession,
+    /// Unknown variant for forward compatibility.
+    #[default]
+    #[serde(other)]
+    Unknown,
+}
+
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ModelsListExecutionEnvironment {
+    #[serde(rename = "local")]
+    Local,
+    /// Unknown variant for forward compatibility.
+    #[default]
+    #[serde(other)]
+    Unknown,
+}
+
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ModelsListModelBackend {
+    #[serde(rename = "copilot")]
+    Copilot,
+    /// Unknown variant for forward compatibility.
+    #[default]
+    #[serde(other)]
+    Unknown,
+}
+
+///
+/// <div class="warning">
+///
+/// **Experimental.** This type is part of an experimental wire-protocol surface
+/// and may change or be removed in future SDK or CLI releases.
+///
+/// </div>
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ModelsListSessionKind {
+    #[serde(rename = "top-level")]
+    TopLevel,
     /// Unknown variant for forward compatibility.
     #[default]
     #[serde(other)]

--- a/rust/src/generated/rpc.rs
+++ b/rust/src/generated/rpc.rs
@@ -1070,7 +1070,7 @@ impl<'a> ClientRpcModels<'a> {
     ///
     /// # Parameters
     ///
-    /// * `params` - Optional GitHub token used to list models for a specific user instead of the global auth context.
+    /// * `params` - Optional account selection and pre-session context used to list models.
     ///
     /// # Returns
     ///

--- a/rust/src/generated/rpc.rs
+++ b/rust/src/generated/rpc.rs
@@ -1144,7 +1144,7 @@ impl<'a> ClientRpcModels<'a> {
     ///
     /// # Parameters
     ///
-    /// * `params` - Optional opaque account selection or compatibility GitHub token used to list models.
+    /// * `params` - Optional account selection and pre-session context used to list models.
     ///
     /// # Returns
     ///


### PR DESCRIPTION
## Summary
- regenerate the Node.js and Rust RPC contracts for the versioned pre-session `models.list` context from github/copilot-agent-runtime#16938
- expose the contextual resolution acknowledgment and `experimental` model picker category in both generated clients
- leave the cached high-level `listModels()` APIs unchanged for backward compatibility

## Compatibility
- old SDK clients continue sending legacy `models.list` requests to new runtimes
- new clients can use the generated low-level RPC API with `sessionContext` and require the `resolution` acknowledgment
- new clients remain safe with old runtimes because an absent acknowledgment means contextual discovery was not applied
- contextual results bypass the high-level account-scoped model cache

## GitHub App integration
The coordinated app change is github/github-app#13556. It vendors compatibility commit `3b2019f05e3a8455541e3fd2778748216ed2ea24`, which applies only this generated contract to the SDK revision the app already consumed. That commit is included in this PR's ancestry.

This avoids coupling HydraFusion discovery to the roughly 20 newer SDK commits currently on this branch, which would otherwise force the app through an unrelated permissions/API migration. The PR's final tree still contains the current generated Node.js and Rust contract updates.

## Validation
- `npm --prefix nodejs run typecheck`
- `npm --prefix nodejs test -- test/typescript-codegen.test.ts`
- `npx prettier --check src/generated/rpc.ts`
- `cargo check --manifest-path rust/Cargo.toml`
- `cargo fmt --manifest-path rust/Cargo.toml -- --check`
- `cargo test --manifest-path rust/Cargo.toml --lib`

## Dependency
Draft until github/copilot-agent-runtime#16938 lands and the generated contract can be refreshed from a published runtime package.