### PR TITLE
Java: add Apple Silicon macOS in-process runtime and native classifier publishing

### DIFF
--- a/.github/workflows/java-publish-maven.yml
+++ b/.github/workflows/java-publish-maven.yml
@@ -241,9 +241,68 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  build-darwin-classifier:
+    name: Build Darwin native classifier
+    needs: prepare-release
+    runs-on: macos-26
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./java
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: "25"
+          distribution: "microsoft"
+          cache: "maven"
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+
+      - name: Build and validate darwin-arm64 classifier
+        run: |
+          set -euo pipefail
+          SOURCE_COMMIT=$(git rev-parse HEAD)
+          if [ "$SOURCE_COMMIT" != "${{ needs.prepare-release.outputs.tag_commit }}" ]; then
+            echo "::error::Checked out $SOURCE_COMMIT instead of the prepared tag commit."
+            exit 1
+          fi
+          node copilot-native/scripts/validate-native-host.mjs darwin-arm64
+          mvn -B -pl copilot-native package -DskipTests
+          VERSION="${{ needs.prepare-release.outputs.release_version }}"
+          JAR="copilot-native/target/copilot-sdk-java-runtime-$VERSION-darwin-arm64.jar"
+          PRIMARY_JAR="copilot-native/target/copilot-sdk-java-runtime-$VERSION.jar"
+          test -f "$JAR"
+          node copilot-native/scripts/validate-native-artifact.mjs \
+            classifier darwin-arm64 "$JAR" "$(basename "$JAR")" ..
+          node copilot-native/scripts/validate-native-artifact.mjs placeholder "$PRIMARY_JAR"
+          MANIFEST="copilot-native/target/darwin-arm64-$VERSION.sha256"
+          HASH=$(shasum -a 256 "$JAR" | cut -d ' ' -f 1)
+          printf '%s  %s' "$HASH" "$(basename "$JAR")" > "$MANIFEST"
+          node copilot-native/scripts/validate-native-artifact.mjs \
+            checksum "$JAR" "$MANIFEST" "$(basename "$JAR")"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: java-native-darwin-arm64-release-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            java/copilot-native/target/copilot-sdk-java-runtime-${{ needs.prepare-release.outputs.release_version }}-darwin-arm64.jar
+            java/copilot-native/target/darwin-arm64-${{ needs.prepare-release.outputs.release_version }}.sha256
+          if-no-files-found: error
+          retention-days: 1
+
   deploy-maven:
     name: Deploy Java release to Maven Central
-    needs: [prepare-release, build-windows-classifier]
+    needs: [prepare-release, build-windows-classifier, build-darwin-classifier]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -283,6 +342,11 @@ jobs:
           name: java-native-win32-x64-release-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/java-native-win32-x64
 
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: java-native-darwin-arm64-release-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/java-native-darwin-arm64
+
       - name: Verify immutable source and Windows classifier
         id: windows-artifact
         run: |
@@ -304,12 +368,34 @@ jobs:
           echo "windows_jar=$JAR" >> "$GITHUB_OUTPUT"
           echo "windows_sha=$(cut -d ' ' -f 1 "$MANIFEST")" >> "$GITHUB_OUTPUT"
 
+      - name: Verify immutable source and Darwin classifier
+        id: darwin-artifact
+        run: |
+          SOURCE_COMMIT=$(git rev-parse HEAD)
+          if [ "$SOURCE_COMMIT" != "${{ needs.prepare-release.outputs.tag_commit }}" ]; then
+            echo "::error::Checked out $SOURCE_COMMIT instead of the prepared tag commit."
+            exit 1
+          fi
+          VERSION="${{ needs.prepare-release.outputs.release_version }}"
+          ARTIFACT_DIRECTORY="${{ runner.temp }}/java-native-darwin-arm64"
+          JAR="$ARTIFACT_DIRECTORY/copilot-sdk-java-runtime-$VERSION-darwin-arm64.jar"
+          MANIFEST="$ARTIFACT_DIRECTORY/darwin-arm64-$VERSION.sha256"
+          test -f "$JAR"
+          test -f "$MANIFEST"
+          node "$GITHUB_WORKSPACE/java/copilot-native/scripts/validate-native-artifact.mjs" \
+            checksum "$JAR" "$MANIFEST" "$(basename "$JAR")"
+          node "$GITHUB_WORKSPACE/java/copilot-native/scripts/validate-native-artifact.mjs" \
+            classifier darwin-arm64 "$JAR" "$(basename "$JAR")" "$GITHUB_WORKSPACE"
+          echo "darwin_jar=$JAR" >> "$GITHUB_OUTPUT"
+          echo "darwin_sha=$(cut -d ' ' -f 1 "$MANIFEST")" >> "$GITHUB_OUTPUT"
+
       - name: Build Linux classifier and deploy complete release
         id: publish-maven
         run: |
           VERSION="${{ needs.prepare-release.outputs.release_version }}"
           mvn -B deploy -DskipTests -Prelease -Dcopilot.native.libc=glibc \
-            "-Dcopilot.native.external.win32.classifier.path=${{ steps.windows-artifact.outputs.windows_jar }}"
+            "-Dcopilot.native.external.win32.classifier.path=${{ steps.windows-artifact.outputs.windows_jar }}" \
+            "-Dcopilot.native.external.darwin.classifier.path=${{ steps.darwin-artifact.outputs.darwin_jar }}"
           LINUX_JAR="copilot-native/target/copilot-sdk-java-runtime-$VERSION-linux-x64.jar"
           test -f "$LINUX_JAR"
           node copilot-native/scripts/validate-native-artifact.mjs \
@@ -329,6 +415,7 @@ jobs:
             echo "| --- | --- | --- | --- | --- |"
             echo "| \`linux-x64\` | \`ubuntu-latest\` | \`$(basename "$LINUX_JAR")\` | \`$LINUX_SHA\` | Published |"
             echo "| \`win32-x64\` | \`windows-latest\` | \`$(basename "${{ steps.windows-artifact.outputs.windows_jar }}")\` | \`${{ steps.windows-artifact.outputs.windows_sha }}\` | Published |"
+            echo "| \`darwin-arm64\` | \`macos-26\` | \`$(basename "${{ steps.darwin-artifact.outputs.darwin_jar }}")\` | \`${{ steps.darwin-artifact.outputs.darwin_sha }}\` | Published |"
           } >> "$GITHUB_STEP_SUMMARY"
         env:
           MAVEN_USERNAME: ${{ secrets.JAVA_MAVEN_CENTRAL_USERNAME }}
@@ -337,7 +424,7 @@ jobs:
 
   rollback-release:
     name: Roll back failed Java release preparation
-    needs: [prepare-release, build-windows-classifier, deploy-maven]
+    needs: [prepare-release, build-windows-classifier, build-darwin-classifier, deploy-maven]
     if: ${{ failure() && needs.prepare-release.outputs.docs_commit != '' }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/java-publish-snapshot.yml
+++ b/.github/workflows/java-publish-snapshot.yml
@@ -40,6 +40,8 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: read
+    outputs:
+      version: ${{ steps.build.outputs.version }}
     defaults:
       run:
         shell: pwsh
@@ -93,9 +95,72 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  build-darwin-classifier:
+    name: Build Darwin snapshot classifier
+    needs: resolve-source
+    runs-on: macos-26
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.build.outputs.version }}
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./java
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: "25"
+          distribution: "microsoft"
+          cache: "maven"
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+
+      - name: Build and validate darwin-arm64 classifier
+        id: build
+        run: |
+          set -euo pipefail
+          SOURCE_COMMIT=$(git rev-parse HEAD)
+          if [ "$SOURCE_COMMIT" != "${{ needs.resolve-source.outputs.source_sha }}" ]; then
+            echo "::error::Checked out $SOURCE_COMMIT instead of the resolved snapshot source."
+            exit 1
+          fi
+          node copilot-native/scripts/validate-native-host.mjs darwin-arm64
+          mvn -B -pl copilot-native package -DskipTests
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          JAR="copilot-native/target/copilot-sdk-java-runtime-$VERSION-darwin-arm64.jar"
+          PRIMARY_JAR="copilot-native/target/copilot-sdk-java-runtime-$VERSION.jar"
+          test -f "$JAR"
+          node copilot-native/scripts/validate-native-artifact.mjs \
+            classifier darwin-arm64 "$JAR" "$(basename "$JAR")" ..
+          node copilot-native/scripts/validate-native-artifact.mjs placeholder "$PRIMARY_JAR"
+          MANIFEST="copilot-native/target/darwin-arm64-$VERSION.sha256"
+          HASH=$(shasum -a 256 "$JAR" | cut -d ' ' -f 1)
+          printf '%s  %s' "$HASH" "$(basename "$JAR")" > "$MANIFEST"
+          node copilot-native/scripts/validate-native-artifact.mjs \
+            checksum "$JAR" "$MANIFEST" "$(basename "$JAR")"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: java-native-darwin-arm64-snapshot-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            java/copilot-native/target/copilot-sdk-java-runtime-${{ steps.build.outputs.version }}-darwin-arm64.jar
+            java/copilot-native/target/darwin-arm64-${{ steps.build.outputs.version }}.sha256
+          if-no-files-found: error
+          retention-days: 1
+
   deploy-snapshot:
     name: Publish SNAPSHOT to Maven Central
-    needs: [resolve-source, build-windows-classifier]
+    needs: [resolve-source, build-windows-classifier, build-darwin-classifier]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -128,6 +193,11 @@ jobs:
           name: java-native-win32-x64-snapshot-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/java-native-win32-x64
 
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: java-native-darwin-arm64-snapshot-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/java-native-darwin-arm64
+
       - name: Verify version, source, and Windows classifier
         id: windows-artifact
         run: |
@@ -139,6 +209,10 @@ jobs:
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           if [[ "$VERSION" != *"-SNAPSHOT" ]]; then
             echo "::error::This workflow only publishes SNAPSHOT versions. Current version: $VERSION"
+            exit 1
+          fi
+          if [ "$VERSION" != "${{ needs.build-windows-classifier.outputs.version }}" ]; then
+            echo "::error::Windows classifier version does not match deploy version."
             exit 1
           fi
           ARTIFACT_DIRECTORY="${{ runner.temp }}/java-native-win32-x64"
@@ -154,11 +228,37 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "windows_sha=$(cut -d ' ' -f 1 "$MANIFEST")" >> "$GITHUB_OUTPUT"
 
+      - name: Verify version, source, and Darwin classifier
+        id: darwin-artifact
+        run: |
+          SOURCE_COMMIT=$(git rev-parse HEAD)
+          if [ "$SOURCE_COMMIT" != "${{ needs.resolve-source.outputs.source_sha }}" ]; then
+            echo "::error::Checked out $SOURCE_COMMIT instead of the resolved snapshot source."
+            exit 1
+          fi
+          VERSION="${{ steps.windows-artifact.outputs.version }}"
+          if [ "$VERSION" != "${{ needs.build-darwin-classifier.outputs.version }}" ]; then
+            echo "::error::Darwin classifier version does not match deploy version."
+            exit 1
+          fi
+          ARTIFACT_DIRECTORY="${{ runner.temp }}/java-native-darwin-arm64"
+          JAR="$ARTIFACT_DIRECTORY/copilot-sdk-java-runtime-$VERSION-darwin-arm64.jar"
+          MANIFEST="$ARTIFACT_DIRECTORY/darwin-arm64-$VERSION.sha256"
+          test -f "$JAR"
+          test -f "$MANIFEST"
+          node "$GITHUB_WORKSPACE/java/copilot-native/scripts/validate-native-artifact.mjs" \
+            checksum "$JAR" "$MANIFEST" "$(basename "$JAR")"
+          node "$GITHUB_WORKSPACE/java/copilot-native/scripts/validate-native-artifact.mjs" \
+            classifier darwin-arm64 "$JAR" "$(basename "$JAR")" "$GITHUB_WORKSPACE"
+          echo "darwin_jar=$JAR" >> "$GITHUB_OUTPUT"
+          echo "darwin_sha=$(cut -d ' ' -f 1 "$MANIFEST")" >> "$GITHUB_OUTPUT"
+
       - name: Build Linux classifier and deploy complete snapshot
         run: |
           VERSION="${{ steps.windows-artifact.outputs.version }}"
           mvn -B deploy -DskipTests -Dcopilot.native.libc=glibc \
-            "-Dcopilot.native.external.win32.classifier.path=${{ steps.windows-artifact.outputs.windows_jar }}"
+            "-Dcopilot.native.external.win32.classifier.path=${{ steps.windows-artifact.outputs.windows_jar }}" \
+            "-Dcopilot.native.external.darwin.classifier.path=${{ steps.darwin-artifact.outputs.darwin_jar }}"
           LINUX_JAR="copilot-native/target/copilot-sdk-java-runtime-$VERSION-linux-x64.jar"
           test -f "$LINUX_JAR"
           node copilot-native/scripts/validate-native-artifact.mjs \
@@ -176,6 +276,7 @@ jobs:
             echo "| --- | --- | --- | --- | --- |"
             echo "| \`linux-x64\` | \`ubuntu-latest\` | \`$(basename "$LINUX_JAR")\` | \`$LINUX_SHA\` | Published |"
             echo "| \`win32-x64\` | \`windows-latest\` | \`$(basename "${{ steps.windows-artifact.outputs.windows_jar }}")\` | \`${{ steps.windows-artifact.outputs.windows_sha }}\` | Published |"
+            echo "| \`darwin-arm64\` | \`macos-26\` | \`$(basename "${{ steps.darwin-artifact.outputs.darwin_jar }}")\` | \`${{ steps.darwin-artifact.outputs.darwin_sha }}\` | Published |"
           } >> "$GITHUB_STEP_SUMMARY"
         env:
           MAVEN_USERNAME: ${{ secrets.JAVA_MAVEN_CENTRAL_USERNAME }}

--- a/.github/workflows/java-sdk-tests.yml
+++ b/.github/workflows/java-sdk-tests.yml
@@ -28,6 +28,8 @@ jobs:
             classifier: linux-x64
           - os: windows-latest
             classifier: win32-x64
+          - os: macos-26
+            classifier: darwin-arm64
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -129,10 +131,68 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  java-native-publication-darwin:
+    name: "Java Native Publication Input (darwin-arm64)"
+    if: github.event.repository.fork == false
+    runs-on: macos-26
+    permissions:
+      contents: read
+    outputs:
+      source_sha: ${{ steps.build.outputs.source_sha }}
+      version: ${{ steps.build.outputs.version }}
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./java
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: "25"
+          distribution: "microsoft"
+          cache: "maven"
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+
+      - name: Build and validate darwin-arm64 classifier
+        id: build
+        run: |
+          set -euo pipefail
+          node copilot-native/scripts/validate-native-host.mjs darwin-arm64
+          mvn -B -pl copilot-native package -DskipTests
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          JAR="copilot-native/target/copilot-sdk-java-runtime-$VERSION-darwin-arm64.jar"
+          PRIMARY_JAR="copilot-native/target/copilot-sdk-java-runtime-$VERSION.jar"
+          test -f "$JAR"
+          node copilot-native/scripts/validate-native-artifact.mjs \
+            classifier darwin-arm64 "$JAR" "$(basename "$JAR")" ..
+          node copilot-native/scripts/validate-native-artifact.mjs placeholder "$PRIMARY_JAR"
+          MANIFEST="copilot-native/target/darwin-arm64-$VERSION.sha256"
+          HASH=$(shasum -a 256 "$JAR" | cut -d ' ' -f 1)
+          printf '%s  %s' "$HASH" "$(basename "$JAR")" > "$MANIFEST"
+          node copilot-native/scripts/validate-native-artifact.mjs \
+            checksum "$JAR" "$MANIFEST" "$(basename "$JAR")"
+          echo "source_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: java-native-publication-darwin-arm64-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            java/copilot-native/target/copilot-sdk-java-runtime-${{ steps.build.outputs.version }}-darwin-arm64.jar
+            java/copilot-native/target/darwin-arm64-${{ steps.build.outputs.version }}.sha256
+          if-no-files-found: error
+          retention-days: 1
+
   java-native-publication-assembly:
     name: "Java Native Publication Assembly"
     if: github.event.repository.fork == false
-    needs: java-native-publication-windows
+    needs: [java-native-publication-windows, java-native-publication-darwin]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -157,20 +217,34 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: java-native-publication-win32-x64-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ github.workspace }}/java/native-publication-input
+          path: ${{ github.workspace }}/java/native-publication-input/windows
 
-      - name: Verify Windows input and deploy the complete local release
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: java-native-publication-darwin-arm64-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ github.workspace }}/java/native-publication-input/darwin
+
+      - name: Verify native inputs and deploy the complete local release
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "${{ needs.java-native-publication-windows.outputs.source_sha }}"
+          test "$(git rev-parse HEAD)" = "${{ needs.java-native-publication-darwin.outputs.source_sha }}"
           VERSION="${{ needs.java-native-publication-windows.outputs.version }}"
-          INPUT_DIRECTORY="$GITHUB_WORKSPACE/java/native-publication-input"
-          WINDOWS_JAR="$INPUT_DIRECTORY/copilot-sdk-java-runtime-$VERSION-win32-x64.jar"
-          WINDOWS_MANIFEST="$INPUT_DIRECTORY/win32-x64-$VERSION.sha256"
+          test "$VERSION" = "${{ needs.java-native-publication-darwin.outputs.version }}"
+          WINDOWS_DIRECTORY="$GITHUB_WORKSPACE/java/native-publication-input/windows"
+          DARWIN_DIRECTORY="$GITHUB_WORKSPACE/java/native-publication-input/darwin"
+          WINDOWS_JAR="$WINDOWS_DIRECTORY/copilot-sdk-java-runtime-$VERSION-win32-x64.jar"
+          WINDOWS_MANIFEST="$WINDOWS_DIRECTORY/win32-x64-$VERSION.sha256"
+          DARWIN_JAR="$DARWIN_DIRECTORY/copilot-sdk-java-runtime-$VERSION-darwin-arm64.jar"
+          DARWIN_MANIFEST="$DARWIN_DIRECTORY/darwin-arm64-$VERSION.sha256"
           node copilot-native/scripts/validate-native-artifact.mjs \
             checksum "$WINDOWS_JAR" "$WINDOWS_MANIFEST" "$(basename "$WINDOWS_JAR")"
           node copilot-native/scripts/validate-native-artifact.mjs \
             classifier win32-x64 "$WINDOWS_JAR" "$(basename "$WINDOWS_JAR")" ..
+          node copilot-native/scripts/validate-native-artifact.mjs \
+            checksum "$DARWIN_JAR" "$DARWIN_MANIFEST" "$(basename "$DARWIN_JAR")"
+          node copilot-native/scripts/validate-native-artifact.mjs \
+            classifier darwin-arm64 "$DARWIN_JAR" "$(basename "$DARWIN_JAR")" ..
           export GNUPGHOME="$GITHUB_WORKSPACE/java/copilot-native/target/local-publication-gpg"
           rm -rf "$GNUPGHOME"
           mkdir -p "$GNUPGHOME"
@@ -183,6 +257,7 @@ jobs:
             -Dcopilot.native.libc=glibc \
             -Dcopilot.native.test.local.publication=true \
             "-Dcopilot.native.external.win32.classifier.path=$WINDOWS_JAR" \
+            "-Dcopilot.native.external.darwin.classifier.path=$DARWIN_JAR" \
             "-Dmaven.repo.local=$LOCAL_REPOSITORY"
           node copilot-native/scripts/validate-local-publication.mjs \
             "$LOCAL_REPOSITORY" copilot-sdk-java-runtime "$VERSION" .. --signatures

--- a/java/README.md
+++ b/java/README.md
@@ -72,7 +72,7 @@ implementation 'com.github:copilot-sdk-java:1.0.13-preview.0-SNAPSHOT'
 
 ## In-process mode (experimental)
 
-The SDK supports running the Copilot runtime **in-process** as a native library instead of spawning a separate CLI process. This eliminates process management overhead and simplifies deployment. In-process mode is currently experimental and supported on **linux-x64** (glibc) and **win32-x64**.
+The SDK supports running the Copilot runtime **in-process** as a native library instead of spawning a separate CLI process. This eliminates process management overhead and simplifies deployment. In-process mode is currently experimental and supported on **linux-x64** (glibc), **win32-x64**, and **darwin-arm64**.
 
 Because in-process mode is experimental, see the [Using experimental APIs](#using-experimental-apis) section for how to opt in.
 
@@ -95,7 +95,7 @@ Add both the SDK and the platform-specific native runtime to your project:
         <version>${copilot.version}</version>
         <classifier>linux-x64</classifier>
     </dependency>
-    <!-- Use win32-x64 instead when the application runs on Windows x64 -->
+    <!-- Use win32-x64 on Windows x64 or darwin-arm64 on Apple Silicon macOS -->
     <!-- JNA (required for in-process mode) -->
     <dependency>
         <groupId>net.java.dev.jna</groupId>
@@ -492,7 +492,7 @@ mvn jacoco:prepare-agent@wire-up-coverage-instrumentation antrun:run@print-test-
 
 Run native-runtime Maven commands from the `java` directory. Native packaging requires Node.js and npm in addition to JDK 25 and Maven because `copilot-native/scripts/fetch-native.mjs` retrieves the pinned npm runtime package.
 
-On a native Linux x64 glibc host, Maven activates the `native-linux-x64` profile when `copilot.native.libc=glibc` is set. On Windows x64, Maven activates `native-win32-x64` automatically. The matching profile validates the host, runs the native script tests, fetches the pinned `@github/copilot-<classifier>` package during `generate-resources`, packages the classifier JAR during `package`, and verifies its native contents. Ensure npm can authenticate to the package registry before running the build.
+On a native Linux x64 glibc host, Maven activates the `native-linux-x64` profile when `copilot.native.libc=glibc` is set. On Windows x64, Maven activates `native-win32-x64` automatically. On Apple Silicon macOS, Maven activates `native-darwin-arm64` automatically. The matching profile validates the host, runs the native script tests, fetches the pinned `@github/copilot-<classifier>` package during `generate-resources`, packages the classifier JAR during `package`, and verifies its native contents. Ensure npm can authenticate to the package registry before running the build.
 
 Before opting in, validate that Node.js reports glibc for the build host:
 
@@ -513,7 +513,14 @@ On Windows PowerShell, initialize Java and run the same profile:
 mvn -Pinprocess clean verify
 ```
 
-On macOS, Linux ARM64, Linux x64 musl, and other unsupported hosts, do not set `copilot.native.libc=glibc`. A normal build produces only the OS-neutral primary, sources, and Javadoc JARs; it does not run native script tests, download or stage native files, or produce a platform classifier JAR.
+The same command validates in-process mode on Apple Silicon macOS:
+
+```bash
+node copilot-native/scripts/validate-native-host.mjs darwin-arm64
+mvn -Pinprocess clean verify
+```
+
+On Intel macOS, Linux ARM64, Linux x64 musl, and other unsupported hosts, do not set `copilot.native.libc=glibc`. A normal build produces only the OS-neutral primary, sources, and Javadoc JARs; it does not run native script tests, download or stage native files, or produce a platform classifier JAR.
 
 To build only the OS-neutral artifacts on any host, or override the glibc opt-in, disable native download and packaging:
 
@@ -531,7 +538,7 @@ mvn clean verify -Dcopilot.native.libc=glibc
 mvn clean package -pl copilot-native -DskipTests -Dcopilot.native.libc=glibc -Dcopilot.native.skip.download=true
 ```
 
-On Linux x64, the classifier JAR contains `native/linux-x64/runtime.node`, `native/linux-x64/platform.properties`, and `native/linux-x64/copilot`. On Windows x64, it contains `native/win32-x64/runtime.node`, `native/win32-x64/platform.properties`, and `native/win32-x64/copilot.exe`. The placeholder JAR remains OS-neutral and contains no native binaries. Unsupported hosts retain the placeholder-only behavior.
+On Linux x64, the classifier JAR contains `native/linux-x64/runtime.node`, `native/linux-x64/platform.properties`, and `native/linux-x64/copilot`. On Windows x64, it contains `native/win32-x64/runtime.node`, `native/win32-x64/platform.properties`, and `native/win32-x64/copilot.exe`. On Apple Silicon macOS, it contains `native/darwin-arm64/runtime.node`, `native/darwin-arm64/platform.properties`, and `native/darwin-arm64/copilot`. The placeholder JAR remains OS-neutral and contains no native binaries. Unsupported hosts retain the placeholder-only behavior.
 
 ## License
 

--- a/java/copilot-native/pom.xml
+++ b/java/copilot-native/pom.xml
@@ -235,8 +235,9 @@
     <profiles>
         <!--
             The explicit in-process test profile defaults to Linux x64. A later
-            host profile overrides these properties on Windows x64. Unsupported
-            hosts fail validation before downloading or packaging native files.
+            host profile overrides these properties on Windows x64 or Apple
+            Silicon macOS. Unsupported hosts fail validation before downloading
+            or packaging native files.
         -->
         <profile>
             <id>inprocess</id>
@@ -405,6 +406,61 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>native-darwin-arm64</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <copilot.native.classifier>darwin-arm64</copilot.native.classifier>
+                <copilot.native.cli.filename>copilot</copilot.native.cli.filename>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>validate-native-host</id>
+                                <phase>validate</phase>
+                            </execution>
+                            <execution>
+                                <id>fetch-native</id>
+                                <phase>generate-resources</phase>
+                            </execution>
+                            <execution>
+                                <id>test-fetch-native</id>
+                                <phase>test</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>jar-native</id>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>verify-native-jars</id>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <!--
             The Windows classifier is assembled on windows-latest and passed to
             the sole Ubuntu publisher. Validate it before attaching so deploy
@@ -459,6 +515,68 @@
                                             <file>${copilot.native.external.win32.classifier.path}</file>
                                             <type>jar</type>
                                             <classifier>win32-x64</classifier>
+                                        </artifact>
+                                    </artifacts>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--
+            The Darwin classifier is assembled on an Apple Silicon macOS runner
+            and passed to the sole Ubuntu publisher with the Windows classifier.
+        -->
+        <profile>
+            <id>attach-external-darwin-classifier</id>
+            <activation>
+                <property>
+                    <name>copilot.native.external.darwin.classifier.path</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>validate-external-darwin-classifier</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>node</executable>
+                                    <arguments>
+                                        <argument>${project.basedir}/scripts/validate-native-artifact.mjs</argument>
+                                        <argument>classifier</argument>
+                                        <argument>darwin-arm64</argument>
+                                        <argument>${copilot.native.external.darwin.classifier.path}</argument>
+                                        <argument>${project.build.finalName}-darwin-arm64.jar</argument>
+                                        <argument>${copilot.sdk.root}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-external-darwin-classifier</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>attach-artifact</goal>
+                                </goals>
+                                <configuration>
+                                    <artifacts>
+                                        <artifact>
+                                            <file>${copilot.native.external.darwin.classifier.path}</file>
+                                            <type>jar</type>
+                                            <classifier>darwin-arm64</classifier>
                                         </artifact>
                                     </artifacts>
                                 </configuration>

--- a/java/copilot-native/scripts/fetch-native.test.mjs
+++ b/java/copilot-native/scripts/fetch-native.test.mjs
@@ -17,7 +17,7 @@ const runtimeContent = 'runtime content';
 const cliContent = 'cli content';
 const scriptPath = fileURLToPath(new URL('./fetch-native.mjs', import.meta.url));
 
-for (const classifier of ['linux-x64', 'win32-x64']) {
+for (const classifier of ['linux-x64', 'win32-x64', 'darwin-arm64']) {
   test(`${classifier}: missing CLI does not use incremental fast path`, (t) => {
     const fixture = createFixture(t, classifier);
     fs.rmSync(fixture.cliPath);

--- a/java/copilot-native/scripts/validate-local-publication.mjs
+++ b/java/copilot-native/scripts/validate-local-publication.mjs
@@ -32,6 +32,7 @@ export function validateLocalPublication({
     `${artifactId}-${version}-javadoc.jar`,
     `${artifactId}-${version}-linux-x64.jar`,
     `${artifactId}-${version}-win32-x64.jar`,
+    `${artifactId}-${version}-darwin-arm64.jar`,
   ];
   const files = new Set(fs.readdirSync(artifactDirectory));
 
@@ -61,7 +62,7 @@ export function validateLocalPublication({
   validatePlaceholderJar(
     path.join(artifactDirectory, `${artifactId}-${version}.jar`),
   );
-  for (const classifier of ["linux-x64", "win32-x64"]) {
+  for (const classifier of ["linux-x64", "win32-x64", "darwin-arm64"]) {
     const filename = `${artifactId}-${version}-${classifier}.jar`;
     validateNativeClassifierJar({
       classifier,

--- a/java/copilot-native/scripts/validate-native-artifact.mjs
+++ b/java/copilot-native/scripts/validate-native-artifact.mjs
@@ -11,6 +11,8 @@ import zlib from "node:zlib";
 const END_OF_CENTRAL_DIRECTORY = 0x06054b50;
 const CENTRAL_DIRECTORY_FILE_HEADER = 0x02014b50;
 const LOCAL_FILE_HEADER = 0x04034b50;
+const PLATFORM_CLASSIFIER =
+  /^(?:linux(?:musl)?-(?:x64|arm64)|darwin-(?:x64|arm64)|win32-(?:x64|arm64))$/;
 
 export function validateNativeClassifierJar({
   classifier,
@@ -78,7 +80,8 @@ export function validateNativeClassifierJar({
 export function validatePlaceholderJar(jarPath) {
   const archive = readJar(jarPath);
   for (const entryName of archive.entries.keys()) {
-    if (/^native\/(?:linux|win32)-x64\//.test(entryName)) {
+    const nativeClassifier = /^native\/([^/]+)\//.exec(entryName)?.[1];
+    if (nativeClassifier && PLATFORM_CLASSIFIER.test(nativeClassifier)) {
       throw new Error(
         `Placeholder primary JAR must not contain platform-native resources; found ${entryName}`,
       );

--- a/java/copilot-native/scripts/validate-native-artifact.test.mjs
+++ b/java/copilot-native/scripts/validate-native-artifact.test.mjs
@@ -43,6 +43,33 @@ test("accepts a matching, complete Windows classifier", (t) => {
   );
 });
 
+test("accepts a matching, complete Darwin classifier", (t) => {
+  const fixture = createFixture(t);
+  const darwinClassifier = "darwin-arm64";
+  const darwinArtifactName =
+    "copilot-sdk-java-runtime-1.2.3-darwin-arm64.jar";
+  const darwinJarPath = path.join(fixture.root, darwinArtifactName);
+  createNativeClassifierTestFixture({
+    classifier: darwinClassifier,
+    outputPath: darwinJarPath,
+    repoRoot: fixture.repoRoot,
+  });
+
+  assert.deepEqual(
+    validateNativeClassifierJar({
+      classifier: darwinClassifier,
+      jarPath: darwinJarPath,
+      expectedFilename: darwinArtifactName,
+      repoRoot: fixture.repoRoot,
+    }),
+    {
+      classifier: darwinClassifier,
+      nativeVersion: "9.8.8",
+      sha256: undefined,
+    },
+  );
+});
+
 test("rejects a wrong external filename before attachment", (t) => {
   const fixture = createFixture(t);
   const wrongName = path.join(fixture.root, "arbitrary.jar");
@@ -193,6 +220,18 @@ test("rejects native resources in the placeholder JAR", (t) => {
   );
 });
 
+test("rejects Darwin native resources in the placeholder JAR", (t) => {
+  const fixture = createFixture(t);
+  writeStoredZip(fixture.jarPath, [
+    ["native/darwin-arm64/runtime.node", "runtime"],
+  ]);
+
+  assert.throws(
+    () => validatePlaceholderJar(fixture.jarPath),
+    /must not contain/,
+  );
+});
+
 test("accepts a native-free placeholder JAR", (t) => {
   const fixture = createFixture(t);
   writeStoredZip(fixture.jarPath, [
@@ -261,6 +300,7 @@ test("validates one complete signed local publication", (t) => {
   const primaryJar = `${artifactId}-${version}.jar`;
   const linuxJar = `${artifactId}-${version}-linux-x64.jar`;
   const windowsJar = `${artifactId}-${version}-win32-x64.jar`;
+  const darwinJar = `${artifactId}-${version}-darwin-arm64.jar`;
   writeStoredZip(path.join(publicationDirectory, primaryJar), [
     ["META-INF/MANIFEST.MF", "Manifest-Version: 1.0\n"],
   ]);
@@ -282,6 +322,11 @@ test("validates one complete signed local publication", (t) => {
     outputPath: path.join(publicationDirectory, windowsJar),
     repoRoot: fixture.repoRoot,
   });
+  createNativeClassifierTestFixture({
+    classifier: "darwin-arm64",
+    outputPath: path.join(publicationDirectory, darwinJar),
+    repoRoot: fixture.repoRoot,
+  });
   fs.writeFileSync(
     path.join(publicationDirectory, `${artifactId}-${version}.pom`),
     "<project />",
@@ -293,6 +338,7 @@ test("validates one complete signed local publication", (t) => {
     `${artifactId}-${version}-javadoc.jar`,
     linuxJar,
     windowsJar,
+    darwinJar,
   ]) {
     fs.writeFileSync(
       path.join(publicationDirectory, `${artifact}.asc`),
@@ -358,6 +404,14 @@ test("local publication validation rejects cross-classifier contamination", (t) 
     ),
     repoRoot: fixture.repoRoot,
   });
+  createNativeClassifierTestFixture({
+    classifier: "darwin-arm64",
+    outputPath: path.join(
+      publicationDirectory,
+      `${artifactId}-${version}-darwin-arm64.jar`,
+    ),
+    repoRoot: fixture.repoRoot,
+  });
   fs.writeFileSync(
     path.join(publicationDirectory, `${artifactId}-${version}.pom`),
     "<project />",
@@ -401,6 +455,7 @@ function createFixture(t) {
       packages: {
         "node_modules/@github/copilot-win32-x64": { version: "9.8.7" },
         "node_modules/@github/copilot-linux-x64": { version: "9.8.6" },
+        "node_modules/@github/copilot-darwin-arm64": { version: "9.8.8" },
       },
     }),
   );

--- a/java/copilot-native/scripts/validate-native-host.mjs
+++ b/java/copilot-native/scripts/validate-native-host.mjs
@@ -28,6 +28,15 @@ export function validateNativeHost(classifier, host) {
     return `Validated native build host: ${classifier}`;
   }
 
+  if (classifier === "darwin-arm64") {
+    if (host.platform !== "darwin" || host.arch !== "arm64") {
+      throw new Error(
+        `Native ${classifier} packaging requires macOS ARM64; detected ${host.platform}-${host.arch}`,
+      );
+    }
+    return `Validated native build host: ${classifier}`;
+  }
+
   throw new Error(`Unsupported native build classifier: ${classifier}`);
 }
 

--- a/java/copilot-native/scripts/validate-native-host.test.mjs
+++ b/java/copilot-native/scripts/validate-native-host.test.mjs
@@ -29,6 +29,17 @@ test("accepts Windows x64 without a libc requirement", () => {
   );
 });
 
+test("accepts macOS ARM64 without a libc requirement", () => {
+  assert.equal(
+    validateNativeHost("darwin-arm64", {
+      platform: "darwin",
+      arch: "arm64",
+      glibcVersionRuntime: undefined,
+    }),
+    "Validated native build host: darwin-arm64",
+  );
+});
+
 test("rejects Linux x64 with musl or unknown libc", () => {
   assert.throws(
     () =>
@@ -86,6 +97,30 @@ test("rejects Windows ARM64 for the Windows x64 classifier", () => {
         glibcVersionRuntime: undefined,
       }),
     /requires Windows x64/,
+  );
+});
+
+test("rejects a non-macOS host for the macOS classifier", () => {
+  assert.throws(
+    () =>
+      validateNativeHost("darwin-arm64", {
+        platform: "linux",
+        arch: "arm64",
+        glibcVersionRuntime: "2.39",
+      }),
+    /requires macOS ARM64/,
+  );
+});
+
+test("rejects macOS x64 for the macOS ARM64 classifier", () => {
+  assert.throws(
+    () =>
+      validateNativeHost("darwin-arm64", {
+        platform: "darwin",
+        arch: "x64",
+        glibcVersionRuntime: undefined,
+      }),
+    /requires macOS ARM64/,
   );
 });
 

--- a/java/docs/adr/adr-007-native-bundling-strategy.md
+++ b/java/docs/adr/adr-007-native-bundling-strategy.md
@@ -208,9 +208,9 @@ If none succeeds, startup fails. The PATH fallback does not claim to support eve
 
 ### Current platform scope
 
-The platform detector recognizes the 8 classifiers listed in this ADR. The Maven build binds native packaging only for a host matching an implemented classifier. Windows x64 hosts package `win32-x64` automatically. Linux x64 glibc hosts can opt in with `copilot.native.libc=glibc`. The `inprocess` test profile selects the matching implemented classifier automatically on both hosts. Every path validates the host before downloading or packaging native files. Linux x64 musl and other unsupported hosts build only the OS-neutral placeholder, sources, and Javadoc artifacts unless they explicitly request in-process tests, which fail during host validation. Additional classifier artifacts remain follow-up work.
+The platform detector recognizes the 8 classifiers listed in this ADR. The Maven build binds native packaging only for a host matching an implemented classifier. Windows x64 hosts package `win32-x64` automatically, Apple Silicon macOS hosts package `darwin-arm64` automatically, and Linux x64 glibc hosts can opt in with `copilot.native.libc=glibc`. The `inprocess` test profile selects the matching implemented classifier automatically on all three hosts. Every path validates the host before downloading or packaging native files. Linux x64 musl and other unsupported hosts build only the OS-neutral placeholder, sources, and Javadoc artifacts unless they explicitly request in-process tests, which fail during host validation. Additional classifier artifacts remain follow-up work.
 
-Maven Central release and snapshot workflows build the Windows classifier on Windows and the Linux classifier on Ubuntu from the same immutable source. The Windows job uploads only a verified `win32-x64` classifier and checksum manifest. The Ubuntu job verifies and attaches that classifier, builds `linux-x64` with the glibc opt-in, and performs the only Maven deployment. Release signing therefore covers the neutral artifacts and both classifiers in one deployment.
+Maven Central release and snapshot workflows build the Windows classifier on Windows, the Darwin classifier on Apple Silicon macOS, and the Linux classifier on Ubuntu from the same immutable source. The Windows and macOS jobs each upload only their verified classifier and checksum manifest. The Ubuntu job verifies and attaches both classifiers, builds `linux-x64` with the glibc opt-in, and performs the only Maven deployment. Release signing therefore covers the neutral artifacts and all three classifiers in one deployment.
 
 ## Binding technology: JNA over Panama FFM
 
@@ -362,7 +362,7 @@ The pattern follows DJL's `LibUtils.loadLibrary()` approach: detect the platform
   3. Extracts `runtime.node` and the transitional CLI entrypoint into `~/.copilot/runtime-cache/` if valid cached files are not already present.
   4. Loads it via [JNA](#references) using the C ABI entry points, per the [binding technology decision](#binding-technology-jna-over-panama-ffm) above. The JNA-specific code is confined behind an internal binding interface to preserve a future FFM migration path.
 * A validated supported-host profile fetches the pinned matching `@github/copilot-<classifier>` npm package, verifies its SHA-512 integrity from `nodejs/package-lock.json`, and packages the version-matched runtime and CLI files.
-* The current release work publishes the `linux-x64` and `win32-x64` classifiers. The planned classifier set expands to the other detected platforms.
+* The current release work publishes the `linux-x64`, `win32-x64`, and `darwin-arm64` classifiers. The planned classifier set expands to the other detected platforms.
 * Adding an implemented platform requires validated host activation, a profile that supplies the classifier and platform CLI filename, and lifecycle bindings for the shared host validation, fetch, script test, package, and verification executions.
 * `cli-native.node` is not bundled. It provides terminal UI features that are irrelevant to the Java SDK's programmatic API surface.
 

--- a/java/sdk/pom.xml
+++ b/java/sdk/pom.xml
@@ -696,6 +696,18 @@ did not produce the multi-release output. Re-build on JDK 25+ and verify the
                 <copilot.native.classifier>win32-x64</copilot.native.classifier>
             </properties>
         </profile>
+        <profile>
+            <id>native-darwin-arm64</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <copilot.native.classifier>darwin-arm64</copilot.native.classifier>
+            </properties>
+        </profile>
         <!--
             Skip the install-nodejs-cli-dependencies (npm ci) execution when
             tests are skipped via -DskipTests, so non-test builds do not


### PR DESCRIPTION
Implements the `darwin-arm64` portion of #2399.

Fixes #2400.

## Summary

Adds Apple Silicon macOS (`darwin-arm64`) as a supported target for the Java SDK's experimental in-process runtime, alongside the existing GNU/Linux `linux-x64` and Windows `win32-x64` targets delivered by #2301 and #2393.

- Packages a macOS native classifier containing `runtime.node`, `copilot`, and `platform.properties`.
- Activates and validates the `darwin-arm64` classifier automatically on Apple Silicon macOS, including when Maven runs with `-Pinprocess`.
- Extends native fetch, host-validation, artifact-validation, and local-publication tests to cover Darwin artifacts and reject unsupported Intel macOS hosts.
- Runs the Java in-process test suite on `macos-26` in addition to the existing Ubuntu and Windows matrix.
- Builds the Darwin classifier on an Apple Silicon macOS runner and adds it to the blocking publication-assembly test.
- Extends both snapshot and Maven Central release workflows so Linux, Windows, and Darwin classifiers are built on their matching native hosts and published together in one Maven deployment.
- Documents Apple Silicon setup, classifier contents, supported-host behavior, and the updated ADR-007 platform status.

## User experience

In-process mode remains opt-in, experimental, and unchanged for existing Linux and Windows consumers. The SDK's default connection behavior is also unchanged.

An Apple Silicon macOS application enables in-process mode by:

1. Depending on `com.github:copilot-sdk-java-runtime` with classifier `darwin-arm64`, plus JNA.
2. Configuring `CopilotClientOptions` with `RuntimeConnection.forInProcess()`.

The classifier JAR contains:

```text
native/darwin-arm64/runtime.node
native/darwin-arm64/platform.properties
native/darwin-arm64/copilot
```

For SDK development on Apple Silicon, `mvn -Pinprocess clean verify` detects `darwin-arm64`, validates that the host is macOS ARM64, fetches the pinned `@github/copilot-darwin-arm64` package, packages its version-matched runtime and transitional CLI, and exercises the in-process integration suite. Intel macOS and other unsupported OS/architecture combinations fail explicit in-process host validation rather than packaging the wrong binary.

During the active Rust migration, the classifier intentionally includes the version-matched `copilot` embedded-host executable in addition to `runtime.node`. It can be removed once the native runtime no longer delegates unported method bodies to the CLI.

## Packaging and publication model

This extends the coordinated publication model introduced by #2393 from two native classifiers to three:

| Classifier | Build host | Native contents |
|---|---|---|
| `linux-x64` | Ubuntu x64 glibc | `runtime.node`, `copilot`, metadata |
| `win32-x64` | Windows x64 | `runtime.node`, `copilot.exe`, metadata |
| `darwin-arm64` | Apple Silicon macOS | `runtime.node`, `copilot`, metadata |

The macOS job builds only the `darwin-arm64` classifier and a SHA-256 manifest. The sole Ubuntu publisher then:

1. Verifies that the macOS and Windows handoffs came from the same immutable source and Maven version as the Linux build.
2. Verifies each checksum, expected filename, pinned native-runtime version, required contents, and absence of cross-classifier contamination.
3. Attaches the external Windows and Darwin classifier JARs to the Maven reactor.
4. Builds `linux-x64` locally and performs one deployment containing the neutral SDK artifacts and all three native classifiers.

Using one deployment preserves a shared Maven snapshot timestamp/build number and ensures release signing covers every classifier. Snapshot and release summaries now report the build host, filename, and SHA-256 hash for all three classifiers.

## CI and safety checks

- The in-process Actions matrix covers `linux-x64`, `win32-x64`, and `darwin-arm64`.
- A dedicated `macos-26` job builds and validates the Darwin publication input before upload.
- Blocking publication assembly downloads both external native artifacts and validates the complete signed local repository before publication workflows can drift unnoticed.
- Host validation accepts only `darwin` + `arm64` for `darwin-arm64`; Intel macOS and non-macOS hosts are rejected.
- Artifact validation requires a nonempty Darwin `runtime.node`, `copilot`, and matching `platform.properties`.
- Local-publication validation requires all three classifiers and rejects native resources from the wrong platform.
- Fetch tests cover complete, missing, and stale Darwin staging states.

## Validation coverage

- Darwin native-host acceptance and rejection tests.
- Darwin classifier artifact-validation tests.
- Three-classifier local-publication validation and contamination tests.
- Native fetch tests across Linux, Windows, and Darwin classifiers.
- Apple Silicon `mvn -Pinprocess clean verify` in the Java CI matrix.
- Native publication-input build on `macos-26`.
- Complete Linux/Windows/Darwin local publication assembly on Ubuntu.
