### PR TITLE
docs: remove false 30-minute idle timeout claim from deployment guides

### DIFF
--- a/docs/setup/backend-services.md
+++ b/docs/setup/backend-services.md
@@ -540,7 +540,7 @@ setInterval(() => cleanupSessions(24 * 60 * 60 * 1000), 60 * 60 * 1000);
 | **Single CLI server = single point of failure** | See [Scaling guide](./scaling.md) for HA patterns |
 | **No built-in auth between SDK and CLI** | Secure the network path (same host, VPC, etc.) |
 | **Session state on local disk** | Mount persistent storage for container restarts |
-| **30-minute idle timeout** | Sessions without activity are auto-cleaned |
+| **No idle timeout by default** | Pass `--session-idle-timeout <seconds>` to the CLI server to automatically clean up inactive sessions |
 
 ## When to move on
 

--- a/docs/setup/scaling.md
+++ b/docs/setup/scaling.md
@@ -626,7 +626,7 @@ flowchart TB
 | **No built-in session locking** | Implement application-level locking for concurrent access |
 | **No built-in load balancing** | Use external LB or service mesh |
 | **Session state is file-based** | Requires shared filesystem for multi-server setups |
-| **30-minute idle timeout** | Sessions without activity are auto-cleaned by the CLI |
+| **No idle timeout by default** | Pass `--session-idle-timeout <seconds>` to the CLI server to automatically clean up inactive sessions |
 | **CLI is single-process** | Scale by adding more CLI server instances, not threads |
 
 ## Next steps


### PR DESCRIPTION
Fixes #2416

## What was wrong

The **Limitations** tables in `docs/setup/scaling.md` and `docs/setup/backend-services.md` both claimed the CLI automatically cleans up idle sessions after 30 minutes:

```
| **30-minute idle timeout** | Sessions without activity are auto-cleaned by the CLI |
| **30-minute idle timeout** | Sessions without activity are auto-cleaned |
```

There is no such timeout. Idle-session cleanup is opt-in and off by default — sessions are cleaned up for inactivity only when a positive idle timeout is configured on the server, and nothing is configured by default.

The rest of the documentation already says this correctly: `docs/features/session-persistence.md` states "By default, sessions have **no idle timeout**", and `docs/setup/multi-tenancy.md` lists "Not setting `sessionIdleTimeoutSeconds`" as a common pitfall — a pitfall that only exists because there is no default. Both offending files also contradict themselves within a few lines, recommending hand-rolled periodic cleanup immediately above the row that says the CLI already does it.

## Before / after

Both rows, previously:

```
| **30-minute idle timeout** | Sessions without activity are auto-cleaned by the CLI |
```

Now, in both files:

```
| **No idle timeout by default** | Pass `--session-idle-timeout <seconds>` to the CLI server to automatically clean up inactive sessions |
```

"No idle timeout by default" is a genuine limitation, so the row keeps its place in the table rather than being dropped, and it now points at the setting that actually applies.

## Why the server flag rather than `sessionIdleTimeoutSeconds`

Both of these guides describe connecting to a **separately launched** CLI server — `scaling.md` uses `cliUrl`, `backend-services.md` uses `RuntimeConnection.forUri(...)`, and both deploy `copilot --headless` directly. `nodejs/src/types.ts` documents `sessionIdleTimeoutSeconds` as "Ignored when connecting to an existing runtime via `RuntimeConnection.forUri`", and `docs/setup/multi-tenancy.md` already states the same rule: with `forUri(...)`, configure the idle timeout on the runtime process itself.

Naming the SDK option in these two guides would therefore have sent readers to a setting that is silently dropped in the topology the guides teach. The server flag is also language-neutral, which matters because `backend-services.md` carries Python, Go, C# and Java examples alongside TypeScript.

## Verification

A positive/negative pair, because the CLI logs a line at `--log-level debug` when it starts its idle-session checker. Tested with CLI `1.0.81-10`, the version pinned in `nodejs/package-lock.json`. Note that `--session-idle-timeout` does not appear in `copilot --help`, the same as `--port` and `--headless`, which these guides already instruct readers to pass.

```bash
mkdir -p logs-a logs-b

# Arm A (control): idle timeout configured
timeout 12 copilot --headless --no-auto-update --port 47321 \
  --log-level debug --log-dir "$PWD/logs-a" --session-idle-timeout 300

# Arm B: the default, option not passed
timeout 12 copilot --headless --no-auto-update --port 47322 \
  --log-level debug --log-dir "$PWD/logs-b"

grep -rh "Started session timeout checker" logs-a/ | wc -l   # -> 1
grep -rh "Started session timeout checker" logs-b/ | wc -l   # -> 0
```

Arm A logs `Started session timeout checker (timeout: 300000ms, check interval: 300000ms)`; arm B logs no checker line and no idle- or stale-session activity at all. Debug logging is live in both arms — this run produced 22 and 20 `[DEBUG]` lines, differing by exactly arm A's two checker lines — so arm B's zero is a real absence, not a logging gap. Exact counts vary by version and environment.

Scope was checked repo-wide: these were the only two places claiming a default or automatic idle timeout. The remaining `30`-minute references are explicit opt-in examples and recommendations, and are correct as they stand.

## Checks

- Documentation only. No source, public API, schema, generated file, or lockfile is touched.
- The docs-validation pipeline extracts fenced code blocks; running it against the tree before and after this change produced byte-identical extraction output (the only difference being the timestamp field), so all five language validation jobs behave exactly as they do on `main`.
- `git diff --check` is clean; both rows keep the sibling style of their table (bold first cell, two columns, trailing pipe, no terminal punctuation).
