### PR TITLE
Update view replay captures after line numbers were removed

### DIFF
--- a/test/harness/replayingCapiProxy.test.ts
+++ b/test/harness/replayingCapiProxy.test.ts
@@ -546,6 +546,107 @@ Always include PINEAPPLE_COCONUT_42.
     expect(toolMessage?.content).toBe("Tool 'report_intent' does not exist.");
   });
 
+  test("strips view line-number prefixes from view tool results", async () => {
+    const requestBody = JSON.stringify({
+      messages: [
+        { role: "user", content: "Read the file" },
+        {
+          role: "assistant",
+          tool_calls: [
+            {
+              id: "tc1",
+              type: "function",
+              function: {
+                name: "view",
+                arguments: '{"path":"lines.txt","view_range":[2,4]}',
+              },
+            },
+            {
+              id: "tc2",
+              type: "function",
+              function: { name: "sql", arguments: '{"query":"SELECT 1"}' },
+            },
+            {
+              id: "tc3",
+              type: "function",
+              function: { name: "view", arguments: '{"path":"crlf.txt"}' },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "tc1",
+          content: "2. line2\n3. line3\n4. line4",
+        },
+        {
+          role: "tool",
+          tool_call_id: "tc2",
+          content: "1. INSERT\n2. INSERT",
+        },
+        {
+          role: "tool",
+          tool_call_id: "tc3",
+          content: "1. first\r\n2. second",
+        },
+      ],
+    });
+    const responseBody = JSON.stringify({
+      choices: [{ message: { role: "assistant", content: "Done" } }],
+    });
+
+    const outputPath = await createProxy([
+      { url: "/chat/completions", requestBody, responseBody },
+    ]);
+
+    const result = await readYamlOutput(outputPath);
+    const toolMessages = result.conversations[0].messages.filter(
+      (m) => m.role === "tool",
+    );
+    expect(toolMessages.map((message) => message.content)).toEqual([
+      "line2\nline3\nline4",
+      // Only `view` results carried line-number prefixes, so other tools that
+      // legitimately return numbered lines must be left alone.
+      "1. INSERT\n2. INSERT",
+      "first\r\nsecond",
+    ]);
+  });
+
+  test("stops stripping view line numbers at the first non-consecutive line", async () => {
+    const requestBody = JSON.stringify({
+      messages: [
+        { role: "user", content: "Read the file" },
+        {
+          role: "assistant",
+          tool_calls: [
+            {
+              id: "tc1",
+              type: "function",
+              function: { name: "view", arguments: '{"path":"steps.md"}' },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "tc1",
+          content: "1. first step\n1. second step",
+        },
+      ],
+    });
+    const responseBody = JSON.stringify({
+      choices: [{ message: { role: "assistant", content: "Done" } }],
+    });
+
+    const outputPath = await createProxy([
+      { url: "/chat/completions", requestBody, responseBody },
+    ]);
+
+    const result = await readYamlOutput(outputPath);
+    const toolMessage = result.conversations[0].messages.find(
+      (m) => m.role === "tool",
+    );
+    expect(toolMessage?.content).toBe("first step\n1. second step");
+  });
+
   test("normalizes interrupted tool execution results", async () => {
     const requestBody = JSON.stringify({
       messages: [
@@ -1146,6 +1247,94 @@ Always include PINEAPPLE_COCONUT_42.
           (JSON.parse(response.body) as ChatCompletion).choices[0].message
             .content,
         ).toBe("Done");
+      } finally {
+        await proxy.stop();
+      }
+    });
+
+    test("matches view results recorded before line numbers were removed", async () => {
+      const cachePath = path.join(tempDir, "cache.yaml");
+      // Snapshots now store the raw file content that current runtimes send.
+      const cacheContent = yaml.stringify({
+        models: ["test-model"],
+        conversations: [
+          {
+            messages: [
+              { role: "system", content: "${system}" },
+              { role: "user", content: "Read the file" },
+              {
+                role: "assistant",
+                tool_calls: [
+                  {
+                    id: "toolcall_0",
+                    type: "function",
+                    function: {
+                      name: "view",
+                      arguments: '{"path":"greeting.txt"}',
+                    },
+                  },
+                ],
+              },
+              {
+                role: "tool",
+                tool_call_id: "toolcall_0",
+                content: "Hello\nWorld",
+              },
+              { role: "assistant", content: "Done" },
+            ],
+          },
+        ],
+      } satisfies NormalizedData);
+      await writeFile(cachePath, cacheContent);
+
+      const proxy = new ReplayingCapiProxy(
+        "http://localhost:9999",
+        cachePath,
+        workDir,
+      );
+      const proxyUrl = await proxy.start();
+
+      try {
+        for (const viewResult of [
+          // Older runtimes prefixed each line with its line number.
+          "1. Hello\n2. World",
+          // Current runtimes return the raw content.
+          "Hello\nWorld",
+        ]) {
+          const response = await makeRequest(proxyUrl, "/chat/completions", {
+            body: {
+              model: "test-model",
+              messages: [
+                { role: "system", content: "System prompt" },
+                { role: "user", content: "Read the file" },
+                {
+                  role: "assistant",
+                  tool_calls: [
+                    {
+                      id: "runtime-call-id",
+                      type: "function",
+                      function: {
+                        name: "view",
+                        arguments: '{"path":"greeting.txt"}',
+                      },
+                    },
+                  ],
+                },
+                {
+                  role: "tool",
+                  tool_call_id: "runtime-call-id",
+                  content: viewResult,
+                },
+              ],
+            },
+          });
+
+          expect(response.status).toBe(200);
+          expect(
+            (JSON.parse(response.body) as ChatCompletion).choices[0].message
+              .content,
+          ).toBe("Done");
+        }
       } finally {
         await proxy.stop();
       }

--- a/test/harness/replayingCapiProxy.ts
+++ b/test/harness/replayingCapiProxy.ts
@@ -132,6 +132,7 @@ export class ReplayingCapiProxy extends CapturingHttpProxy {
     { toolName: "*", normalizer: normalizeAvailableToolNames },
     { toolName: "*", normalizer: normalizeBackgroundAgentStartMessage },
     { toolName: "read_agent", normalizer: normalizeReadAgentResult },
+    { toolName: "view", normalizer: normalizeViewLineNumbers },
   ];
 
   /**
@@ -1552,6 +1553,36 @@ function normalizeAvailableToolNames(result: string): string {
     /(Tool '[^']+' does not exist\.) Available tools that can be called are [^.]*\./g,
     "$1",
   );
+}
+
+// The runtime used to prefix every line of `view` output with `N. ` (the line
+// number). copilot-agent-runtime#13802 shipped the winning experiment branch and
+// made raw file content the unconditional behavior, so captures recorded against
+// older runtimes carry the prefixes while current runtimes do not. Strip a leading
+// run of consecutively numbered lines so both forms replay against the same
+// snapshot. Trailing content such as the truncation notice is left untouched
+// because it was never numbered.
+function normalizeViewLineNumbers(result: string): string {
+  const lines = result.split("\n");
+  let expected: number | undefined;
+  let index = 0;
+  for (; index < lines.length; index++) {
+    // Lines of a CRLF file keep their carriage return after splitting on "\n".
+    const carriageReturn = lines[index].endsWith("\r");
+    const line = carriageReturn ? lines[index].slice(0, -1) : lines[index];
+    const match = /^(\d+)\.(?: (.*))?$/.exec(line);
+    if (!match) break;
+    const lineNumber = Number(match[1]);
+    if (expected === undefined) {
+      if (lineNumber < 1) break;
+    } else if (lineNumber !== expected) {
+      break;
+    }
+    expected = lineNumber + 1;
+    lines[index] = `${match[2] ?? ""}${carriageReturn ? "\r" : ""}`;
+  }
+
+  return index === 0 ? result : lines.join("\n").trimEnd();
 }
 
 function normalizeInterruptedToolResult(result: string): string {

--- a/test/snapshots/builtin_tools/should_create_a_new_file.yaml
+++ b/test/snapshots/builtin_tools/should_create_a_new_file.yaml
@@ -54,6 +54,6 @@ conversations:
               arguments: '{"path":"${workdir}/new_file.txt"}'
       - role: tool
         tool_call_id: toolcall_2
-        content: 1. Created by test
+        content: Created by test
       - role: assistant
         content: ✓ Done! Created `new_file.txt` with content "Created by test" and confirmed the content matches.

--- a/test/snapshots/builtin_tools/should_edit_a_file_successfully.yaml
+++ b/test/snapshots/builtin_tools/should_edit_a_file_successfully.yaml
@@ -57,9 +57,8 @@ conversations:
       - role: tool
         tool_call_id: toolcall_2
         content: |-
-          1. Hi Universe
-          2. Goodbye World
-          3.
+          Hi Universe
+          Goodbye World
       - role: assistant
         content: |-
           Done! The file now contains:

--- a/test/snapshots/builtin_tools/should_read_file_with_line_range.yaml
+++ b/test/snapshots/builtin_tools/should_read_file_with_line_range.yaml
@@ -45,9 +45,9 @@ conversations:
       - role: tool
         tool_call_id: toolcall_1
         content: |-
-          2. line2
-          3. line3
-          4. line4
+          line2
+          line3
+          line4
       - role: assistant
         content: |-
           Lines 2 through 4 of 'lines.txt' contain:

--- a/test/snapshots/client_options/should_use_client_cwd_for_default_workingdirectory.yaml
+++ b/test/snapshots/client_options/should_use_client_cwd_for_default_workingdirectory.yaml
@@ -25,6 +25,6 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. I am in the client cwd
+        content: I am in the client cwd
       - role: assistant
         content: 'The file `marker.txt` says: "I am in the client cwd"'

--- a/test/snapshots/event_fidelity/should_emit_events_in_correct_order_for_tool_using_conversation.yaml
+++ b/test/snapshots/event_fidelity/should_emit_events_in_correct_order_for_tool_using_conversation.yaml
@@ -44,7 +44,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. Hello World
+        content: Hello World
       - role: assistant
         content: |-
           The file 'hello.txt' contains:

--- a/test/snapshots/event_fidelity/should_emit_tool_execution_events_with_correct_fields.yaml
+++ b/test/snapshots/event_fidelity/should_emit_tool_execution_events_with_correct_fields.yaml
@@ -44,7 +44,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. test data
+        content: test data
       - role: assistant
         content: |-
           The file `data.txt` contains:

--- a/test/snapshots/event_fidelity/should_preserve_message_order_in_getmessages_after_tool_use.yaml
+++ b/test/snapshots/event_fidelity/should_preserve_message_order_in_getmessages_after_tool_use.yaml
@@ -15,6 +15,6 @@ conversations:
               arguments: '{"path":"order.txt"}'
       - role: tool
         tool_call_id: toolcall_0
-        content: 1. ORDER_CONTENT_42
+        content: ORDER_CONTENT_42
       - role: assistant
         content: The number in 'order.txt' is **42**.

--- a/test/snapshots/hooks/invoke_both_hooks_for_single_tool_call.yaml
+++ b/test/snapshots/hooks/invoke_both_hooks_for_single_tool_call.yaml
@@ -44,7 +44,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. Testing both hooks!
+        content: Testing both hooks!
       - role: assistant
         content: |-
           The file **both.txt** contains:

--- a/test/snapshots/hooks/invoke_post_tool_use_hook_after_model_runs_a_tool.yaml
+++ b/test/snapshots/hooks/invoke_post_tool_use_hook_after_model_runs_a_tool.yaml
@@ -44,7 +44,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. World from the test!
+        content: World from the test!
       - role: assistant
         content: |-
           The file `world.txt` contains:

--- a/test/snapshots/hooks/invoke_pre_tool_use_hook_when_model_runs_a_tool.yaml
+++ b/test/snapshots/hooks/invoke_pre_tool_use_hook_when_model_runs_a_tool.yaml
@@ -44,7 +44,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. Hello from the test!
+        content: Hello from the test!
       - role: assistant
         content: |-
           The file **hello.txt** contains:

--- a/test/snapshots/hooks/should_invoke_both_pretooluse_and_posttooluse_hooks_for_a_single_tool_call.yaml
+++ b/test/snapshots/hooks/should_invoke_both_pretooluse_and_posttooluse_hooks_for_a_single_tool_call.yaml
@@ -44,7 +44,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. Testing both hooks!
+        content: Testing both hooks!
       - role: assistant
         content: |-
           The file **both.txt** contains:

--- a/test/snapshots/hooks/should_invoke_both_pretooluse_and_posttooluse_hooks_for_single_tool_call.yaml
+++ b/test/snapshots/hooks/should_invoke_both_pretooluse_and_posttooluse_hooks_for_single_tool_call.yaml
@@ -44,7 +44,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. Testing both hooks!
+        content: Testing both hooks!
       - role: assistant
         content: |-
           The file **both.txt** contains:

--- a/test/snapshots/hooks/should_invoke_posttooluse_hook_after_model_runs_a_tool.yaml
+++ b/test/snapshots/hooks/should_invoke_posttooluse_hook_after_model_runs_a_tool.yaml
@@ -44,7 +44,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. World from the test!
+        content: World from the test!
       - role: assistant
         content: |-
           The file `world.txt` contains:

--- a/test/snapshots/hooks/should_invoke_pretooluse_hook_when_model_runs_a_tool.yaml
+++ b/test/snapshots/hooks/should_invoke_pretooluse_hook_when_model_runs_a_tool.yaml
@@ -44,7 +44,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. Hello from the test!
+        content: Hello from the test!
       - role: assistant
         content: |-
           The file **hello.txt** contains:

--- a/test/snapshots/multi_turn/should_handle_file_creation_then_reading_across_turns.yaml
+++ b/test/snapshots/multi_turn/should_handle_file_creation_then_reading_across_turns.yaml
@@ -39,33 +39,6 @@ conversations:
               arguments: '{"path":"${workdir}/greeting.txt","file_text":"Hello from multi-turn test"}'
       - role: tool
         tool_call_id: toolcall_0
-        content: Tool 'report_intent' does not exist. Available tools that can be called are ${shell}, ${read_shell},
-          ${stop_shell}, ${list_shell}, view, create, edit, web_fetch, skill, sql, read_agent, list_agents, grep, glob,
-          task.
-      - role: tool
-        tool_call_id: toolcall_1
-        content: Created file ${workdir}/greeting.txt with 26 characters
-      - role: assistant
-        content: Created `greeting.txt` with the content "Hello from multi-turn test".
-  - messages:
-      - role: system
-        content: ${system}
-      - role: user
-        content: Create a file called 'greeting.txt' with the content 'Hello from multi-turn test'.
-      - role: assistant
-        tool_calls:
-          - id: toolcall_0
-            type: function
-            function:
-              name: report_intent
-              arguments: '{"intent":"Creating greeting file"}'
-          - id: toolcall_1
-            type: function
-            function:
-              name: create
-              arguments: '{"path":"${workdir}/greeting.txt","file_text":"Hello from multi-turn test"}'
-      - role: tool
-        tool_call_id: toolcall_0
         content: Tool 'report_intent' does not exist.
       - role: tool
         tool_call_id: toolcall_1
@@ -83,7 +56,7 @@ conversations:
               arguments: '{"path":"${workdir}/greeting.txt"}'
       - role: tool
         tool_call_id: toolcall_2
-        content: 1. Hello from multi-turn test
+        content: Hello from multi-turn test
       - role: assistant
         content: |-
           The exact contents of `greeting.txt` are:

--- a/test/snapshots/multi_turn/should_use_tool_results_from_previous_turns.yaml
+++ b/test/snapshots/multi_turn/should_use_tool_results_from_previous_turns.yaml
@@ -39,37 +39,10 @@ conversations:
               arguments: '{"path":"${workdir}/secret.txt"}'
       - role: tool
         tool_call_id: toolcall_0
-        content: Tool 'report_intent' does not exist. Available tools that can be called are ${shell}, ${read_shell},
-          ${stop_shell}, ${list_shell}, view, create, edit, web_fetch, skill, sql, read_agent, list_agents, grep, glob,
-          task.
-      - role: tool
-        tool_call_id: toolcall_1
-        content: 1. The magic number is 42.
-      - role: assistant
-        content: The magic number is **42**.
-  - messages:
-      - role: system
-        content: ${system}
-      - role: user
-        content: Read the file 'secret.txt' and tell me what the magic number is.
-      - role: assistant
-        tool_calls:
-          - id: toolcall_0
-            type: function
-            function:
-              name: report_intent
-              arguments: '{"intent":"Reading secret file"}'
-          - id: toolcall_1
-            type: function
-            function:
-              name: view
-              arguments: '{"path":"${workdir}/secret.txt"}'
-      - role: tool
-        tool_call_id: toolcall_0
         content: Tool 'report_intent' does not exist.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. The magic number is 42.
+        content: The magic number is 42.
       - role: assistant
         content: The magic number is **42**.
       - role: user

--- a/test/snapshots/permissions/permission_handler_for_write_operations.yaml
+++ b/test/snapshots/permissions/permission_handler_for_write_operations.yaml
@@ -47,7 +47,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. original content
+        content: original content
       - role: assistant
         content: "Now I'll replace 'original' with 'modified':"
       - role: assistant
@@ -82,7 +82,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. original content
+        content: original content
       - role: assistant
         content: "Now I'll replace 'original' with 'modified':"
         tool_calls:

--- a/test/snapshots/permissions/should_invoke_permission_handler_for_write_operations.yaml
+++ b/test/snapshots/permissions/should_invoke_permission_handler_for_write_operations.yaml
@@ -47,7 +47,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. original content
+        content: original content
       - role: assistant
         content: "Now I'll replace 'original' with 'modified':"
       - role: assistant
@@ -82,7 +82,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. original content
+        content: original content
       - role: assistant
         content: "Now I'll replace 'original' with 'modified':"
         tool_calls:

--- a/test/snapshots/session/should_send_with_file_attachment.yaml
+++ b/test/snapshots/session/should_send_with_file_attachment.yaml
@@ -58,7 +58,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. FILE_ATTACHMENT_SENTINEL
+        content: FILE_ATTACHMENT_SENTINEL
       - role: assistant
         content: |-
           The file contains:

--- a/test/snapshots/session_config/should_accept_message_attachments.yaml
+++ b/test/snapshots/session_config/should_accept_message_attachments.yaml
@@ -61,7 +61,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. This file is attached
+        content: This file is attached
       - role: assistant
         content: |-
           The attached file contains a single line of text that says: "This file is attached"

--- a/test/snapshots/session_config/should_apply_workingdirectory_on_session_resume.yaml
+++ b/test/snapshots/session_config/should_apply_workingdirectory_on_session_resume.yaml
@@ -25,7 +25,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. I am in the resume working directory
+        content: I am in the resume working directory
       - role: assistant
         content: |-
           The file `resume-marker.txt` says:

--- a/test/snapshots/session_config/should_use_workingdirectory_for_tool_execution.yaml
+++ b/test/snapshots/session_config/should_use_workingdirectory_for_tool_execution.yaml
@@ -44,6 +44,6 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. I am in the subdirectory
+        content: I am in the subdirectory
       - role: assistant
         content: 'The file marker.txt says: "I am in the subdirectory"'

--- a/test/snapshots/subagent_hooks/should_invoke_pretooluse_and_posttooluse_hooks_for_sub_agent_tool_calls.yaml
+++ b/test/snapshots/subagent_hooks/should_invoke_pretooluse_and_posttooluse_hooks_for_sub_agent_tool_calls.yaml
@@ -56,7 +56,7 @@ conversations:
               arguments: '{"path":"${workdir}/subagent-test.txt"}'
       - role: tool
         tool_call_id: toolcall_0
-        content: 1. Hello from subagent test!
+        content: Hello from subagent test!
       - role: assistant
         content: |-
           The complete contents of the file "subagent-test.txt" are:

--- a/test/snapshots/system_message_transform/should_apply_transform_modifications_to_section_content.yaml
+++ b/test/snapshots/system_message_transform/should_apply_transform_modifications_to_section_content.yaml
@@ -26,7 +26,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. Hello!
+        content: Hello!
       - role: assistant
         content: |-
           The file **hello.txt** contains:

--- a/test/snapshots/system_message_transform/should_invoke_transform_callbacks_with_section_content.yaml
+++ b/test/snapshots/system_message_transform/should_invoke_transform_callbacks_with_section_content.yaml
@@ -47,6 +47,6 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. Hello transform!
+        content: Hello transform!
       - role: assistant
         content: 'The file `test.txt` contains: **"Hello transform!"**'

--- a/test/snapshots/system_message_transform/should_work_with_static_overrides_and_transforms_together.yaml
+++ b/test/snapshots/system_message_transform/should_work_with_static_overrides_and_transforms_together.yaml
@@ -47,7 +47,7 @@ conversations:
           task.
       - role: tool
         tool_call_id: toolcall_1
-        content: 1. Combo test!
+        content: Combo test!
       - role: assistant
         content: |-
           The file `combo.txt` contains:

--- a/test/snapshots/tools/invokes_built_in_tools.yaml
+++ b/test/snapshots/tools/invokes_built_in_tools.yaml
@@ -15,6 +15,6 @@ conversations:
               arguments: '{"path":"${workdir}/README.md"}'
       - role: tool
         tool_call_id: toolcall_0
-        content: "1. # ELIZA, the only chatbot you'll ever need"
+        content: "# ELIZA, the only chatbot you'll ever need"
       - role: assistant
         content: "The first line of README.md is: `# ELIZA, the only chatbot you'll ever need`"


### PR DESCRIPTION
## Overview

### What

Update the `view` replay captures to the raw-content form that current runtimes emit, and add a `view`-scoped tool-result normalizer so captures replay against runtimes on either side of the behavior change.

- 30 `view` tool results across 27 snapshots in `test/snapshots/` lose their `N. ` line-number prefixes.
- `normalizeViewLineNumbers` strips a leading run of *consecutively* numbered lines from `view` results only.

### Why

[github/copilot-agent-runtime#13802](https://github.com/github/copilot-agent-runtime/pull/13802) (`CLI: Remove line numbers from view output`, merged 2026-08-26, merge commit `36db7e12b91d2264060eb3f8892c25485fcefcef`) graduated the winning experiment and made raw file content the unconditional `view` behavior. That PR updated the runtime's own prompt snapshots and replay captures, but the external captures living in this repo were not updated, so they still hold the numbered form:

```yaml
- role: tool
  tool_call_id: toolcall_2
  content: 1. Hello from multi-turn test
```

Under the current runtime the CLI sends `Hello from multi-turn test`. Strict replay matching rejects it, the replaying CAPI proxy answers `500 Internal Server Error` with `Request-ID proxy-error`, and the CLI retries five times before the session fails:

```
System.InvalidOperationException : Session error: Execution failed: Failed to get response
from the AI model; retried 5 times (Request-ID proxy-error) Last error: 500 Internal Server Error
```

Because the drift is in a tool result rather than in any provider protocol, it cascades to every backend leg of agent-runtime's `Copilot SDK C# tests` workflow — `capi`, `anthropic-messages`, `openai-responses`, and `openai-completions` — for every test whose conversation contains a `view` call. See agent-runtime workflow runs [33072804346](https://github.com/github/copilot-agent-runtime/actions/runs/33072804346) (main) and [33046860889](https://github.com/github/copilot-agent-runtime/actions/runs/33046860889). This is upstream fixture drift in this repo; it is not caused by agent-runtime #17389.

### Why a normalizer as well as updated fixtures

`nodejs/package-lock.json` pins `@github/copilot` to `1.0.81-11`, published before #13802 merged, so this repo's own CI still runs a CLI that emits the prefixes. Updating the fixtures alone would fix the agent-runtime canary and break every SDK's E2E suite here. The normalizer bridges both runtimes, and it also keeps locally re-recorded captures in the shipped raw-content form.

This follows the precedent set by #2013 (`Collapse built-in tool list in replay-proxy snapshot matching`), which resolved the same class of runtime-version drift for the same C# canary.

Matching is not loosened beyond the affected shape:

- The normalizer is registered for `toolName: "view"`, so tools that legitimately return numbered lines keep matching strictly. `test/snapshots/session_todos_changed/fires_session_todos_changed_and_exposes_rows_and_dependencies.yaml` has a `sql` result of `1. INSERT ...` and is deliberately untouched.
- Only a leading run of *consecutive* numbers is stripped; it stops at the first gap, so trailing content such as the truncation notice is preserved.
- Nothing in the test assertions changed.

### Validation

Local, Windows, `net8.0`, snapshots forced read-only (`GITHUB_ACTIONS=true`).

Reproduced first: with the fix stashed and `COPILOT_CLI_PATH` pointed at a post-#13802 CLI (`1.0.81-14`), `MultiTurnE2ETests` fails with exactly the CI signature — `proxy-error`, `500`, retried 5 times.

With the fix applied:

| Suite | Runtime | Result |
| --- | --- | --- |
| `test/harness` vitest (incl. 3 new tests) | n/a | 67 passed |
| .NET `MultiTurn`, `BuiltinTools`, `Tools`, `Hooks`, `SubagentHooks`, `EventFidelity`, `SystemMessageTransform` | 1.0.81-14 (post-change) | 37 passed, 1 skipped |
| .NET `Permission`, `SessionConfig`, `Session`, `ClientOptions`, `SessionTodosChanged` | 1.0.81-14 (post-change) | 106 passed, 2 failed |
| .NET `MultiTurn` | 1.0.81-11 (pinned, pre-change) | 2 passed |
| Node.js `multi_turn`, `builtin_tools` E2E | 1.0.81-14 (post-change) | 9 passed, 1 skipped |

The 2 failures are `SessionConfigE2ETests.Vision_Enabled_Then_Disabled_Via_SetModel` and `Vision_Disabled_Then_Enabled_Via_SetModel`, which time out identically on a clean tree at `main` with the pinned CLI. They are pre-existing and unrelated: their `view` results are `Viewed image file successfully.` and were never numbered.

New harness tests cover capture-time stripping, the non-consecutive stop condition, `sql` results being left alone, CRLF content, and replaying both the numbered and unnumbered request forms against the same snapshot.

### Checklist

- [x] The Overview section above is filled with a description of the PR
- [x] Fixtures reflect shipped runtime behavior, with no unrelated or machine-specific capture churn
- [x] Strict replay matching preserved outside the `view` line-number shape