### PR TITLE
Fix Windows unused-variable warning in rust/build/in_process.rs

### DIFF
--- a/rust/build/in_process.rs
+++ b/rust/build/in_process.rs
@@ -574,6 +574,12 @@ fn install_cached_file_path(
     bytes: &[u8],
     executable: bool,
 ) {
+    // `executable` only affects file permissions on Unix (see the `#[cfg(unix)]`
+    // block below); explicitly mark it used elsewhere so non-Unix targets don't
+    // warn about an unused parameter under `-D warnings`.
+    #[cfg(not(unix))]
+    let _ = executable;
+
     assert!(
         !relative_path.is_absolute()
             && !relative_path.components().any(|component| {


### PR DESCRIPTION
## Problem

`install_cached_file_path` in `rust/build/in_process.rs` takes an `executable: bool` parameter that is only read inside a `#[cfg(unix)]` block (used to `chmod` extracted binaries). On non-Unix targets the parameter is therefore reported as unused, which fails downstream consumers compiling this crate directly from `main` with `RUSTFLAGS=-D warnings`.

## Fix

Add an explicit `#[cfg(not(unix))] let _ = executable;` inside the function so the parameter is marked used on non-Unix targets, without changing any Unix behavior (the `chmod` logic under `#[cfg(unix)]` is untouched).

## Validation

- `cargo fmt -- --check` — clean
- `RUSTFLAGS=-D warnings cargo check --all-targets` and `cargo clippy --all-targets -- -D warnings` — clean on the host
- Reproduced and verified the fix directly: compiled the affected function signature with `rustc --target x86_64-pc-windows-msvc --crate-type lib -D warnings` — this fails with `error: unused variable: 'executable'` before the fix and compiles cleanly after it (also re-verified clean on a Unix target to confirm no regression to the `chmod` path).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>