### PR TITLE
test: update replay harness default to Claude Sonnet 5

### DIFF
--- a/.github/skills/new-java-e2e-test-yaml-and-test/SKILL.md
+++ b/.github/skills/new-java-e2e-test-yaml-and-test/SKILL.md
@@ -33,7 +33,7 @@ The format is:
 
 ```yaml
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/.github/skills/new-java-e2e-test-yaml-and-test/examples.md
+++ b/.github/skills/new-java-e2e-test-yaml-and-test/examples.md
@@ -8,7 +8,7 @@ File: `test/snapshots/system_message_sections/should_use_replaced_identity_secti
 
 ```yaml
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system
@@ -73,7 +73,7 @@ File: `test/snapshots/system_message_transform/should_invoke_transform_callbacks
 
 ```yaml
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   # First exchange: model decides to call tools
   - messages:

--- a/dotnet/test/E2E/ClientOptionsE2ETests.cs
+++ b/dotnet/test/E2E/ClientOptionsE2ETests.cs
@@ -296,7 +296,7 @@ public class ClientOptionsE2ETests(E2ETestFixture fixture, ITestOutputHelper out
         var session = await Ctx.CreateSessionAsync(client, new SessionConfig
         {
             ClientName = "advanced-create-client",
-            Model = "claude-sonnet-4.5",
+            Model = "claude-sonnet-5",
             ReasoningEffort = "medium",
             ReasoningSummary = ReasoningSummary.Detailed,
             ContextTier = ContextTier.LongContext,
@@ -379,7 +379,7 @@ public class ClientOptionsE2ETests(E2ETestFixture fixture, ITestOutputHelper out
                     Provider = "create-provider",
                     Id = "create-model",
                     Name = "Create Model",
-                    ModelId = "claude-sonnet-4.5",
+                    ModelId = "claude-sonnet-5",
                     WireModel = "create-wire-model",
                     MaxContextWindowTokens = 12_000,
                     MaxPromptTokens = 10_000,
@@ -392,7 +392,7 @@ public class ClientOptionsE2ETests(E2ETestFixture fixture, ITestOutputHelper out
         using var capture = JsonDocument.Parse(await File.ReadAllTextAsync(capturePath));
         var createRequest = GetCapturedRequestParams(capture.RootElement, "session.create");
         Assert.Equal("advanced-create-client", createRequest.GetProperty("clientName").GetString());
-        Assert.Equal("claude-sonnet-4.5", createRequest.GetProperty("model").GetString());
+        Assert.Equal("claude-sonnet-5", createRequest.GetProperty("model").GetString());
         Assert.Equal("medium", createRequest.GetProperty("reasoningEffort").GetString());
         Assert.Equal("detailed", createRequest.GetProperty("reasoningSummary").GetString());
         Assert.Equal("long_context", createRequest.GetProperty("contextTier").GetString());
@@ -442,7 +442,7 @@ public class ClientOptionsE2ETests(E2ETestFixture fixture, ITestOutputHelper out
 
         var session = await Ctx.CreateSessionAsync(client, new SessionConfig
         {
-            Model = "claude-sonnet-4.5",
+            Model = "claude-sonnet-5",
             Provider = new ProviderConfig
             {
                 Type = "azure",
@@ -453,7 +453,7 @@ public class ClientOptionsE2ETests(E2ETestFixture fixture, ITestOutputHelper out
                 BearerToken = "provider-bearer-token",
                 Azure = new AzureOptions { ApiVersion = "2024-02-15-preview" },
                 Headers = new Dictionary<string, string> { ["X-Provider-Wire"] = "yes" },
-                ModelId = "claude-sonnet-4.5",
+                ModelId = "claude-sonnet-5",
                 WireModel = "azure-deployment",
                 MaxPromptTokens = 8192,
                 MaxOutputTokens = 1024,
@@ -471,7 +471,7 @@ public class ClientOptionsE2ETests(E2ETestFixture fixture, ITestOutputHelper out
         Assert.Equal("provider-bearer-token", provider.GetProperty("bearerToken").GetString());
         Assert.Equal("2024-02-15-preview", provider.GetProperty("azure").GetProperty("apiVersion").GetString());
         Assert.Equal("yes", provider.GetProperty("headers").GetProperty("X-Provider-Wire").GetString());
-        Assert.Equal("claude-sonnet-4.5", provider.GetProperty("modelId").GetString());
+        Assert.Equal("claude-sonnet-5", provider.GetProperty("modelId").GetString());
         Assert.Equal("azure-deployment", provider.GetProperty("wireModel").GetString());
         Assert.Equal(8192, provider.GetProperty("maxPromptTokens").GetInt32());
         Assert.Equal(1024, provider.GetProperty("maxOutputTokens").GetInt32());

--- a/dotnet/test/E2E/CopilotRequestE2EProvider.cs
+++ b/dotnet/test/E2E/CopilotRequestE2EProvider.cs
@@ -160,9 +160,9 @@ internal sealed class RecordingRequestHandler : CopilotRequestHandler
 
     private static readonly string[] ChatCompletionStreamEvents =
     [
-        "data: {\"id\":\"chatcmpl-stub-1\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"claude-sonnet-4.5\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"},\"finish_reason\":null}]}\n\n",
-        "data: {\"id\":\"chatcmpl-stub-1\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"claude-sonnet-4.5\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"" + SyntheticText + "\"},\"finish_reason\":null}]}\n\n",
-        "data: {\"id\":\"chatcmpl-stub-1\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"claude-sonnet-4.5\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":7,\"total_tokens\":12}}\n\n",
+        "data: {\"id\":\"chatcmpl-stub-1\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"claude-sonnet-5\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"},\"finish_reason\":null}]}\n\n",
+        "data: {\"id\":\"chatcmpl-stub-1\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"claude-sonnet-5\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"" + SyntheticText + "\"},\"finish_reason\":null}]}\n\n",
+        "data: {\"id\":\"chatcmpl-stub-1\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"claude-sonnet-5\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":7,\"total_tokens\":12}}\n\n",
         "data: [DONE]\n\n",
     ];
 
@@ -172,7 +172,7 @@ internal sealed class RecordingRequestHandler : CopilotRequestHandler
     // runtime's Anthropic client fail with "stream ended without producing a Message".
     private static readonly string[] AnthropicStreamEvents =
     [
-        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_stub_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-4.5\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}}\n\n",
+        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_stub_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-5\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}}\n\n",
         "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
         "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"" + SyntheticText + "\"}}\n\n",
         "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
@@ -184,13 +184,13 @@ internal sealed class RecordingRequestHandler : CopilotRequestHandler
         "{\"id\":\"resp_stub_1\",\"object\":\"response\",\"status\":\"completed\",\"output\":[{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"" + SyntheticText + "\"}]}],\"usage\":{\"input_tokens\":5,\"output_tokens\":7,\"total_tokens\":12}}";
 
     private static readonly string BufferedChatCompletionJson =
-        "{\"id\":\"chatcmpl-stub-1\",\"object\":\"chat.completion\",\"created\":1,\"model\":\"claude-sonnet-4.5\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"" + SyntheticText + "\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":7,\"total_tokens\":12}}";
+        "{\"id\":\"chatcmpl-stub-1\",\"object\":\"chat.completion\",\"created\":1,\"model\":\"claude-sonnet-5\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"" + SyntheticText + "\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":7,\"total_tokens\":12}}";
 
     private static readonly string BufferedAnthropicMessageJson =
-        "{\"id\":\"msg_stub_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-4.5\",\"content\":[{\"type\":\"text\",\"text\":\"" + SyntheticText + "\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":5,\"output_tokens\":7}}";
+        "{\"id\":\"msg_stub_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-5\",\"content\":[{\"type\":\"text\",\"text\":\"" + SyntheticText + "\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":5,\"output_tokens\":7}}";
 
     private const string ModelCatalogJson =
-        "{\"data\":[{\"id\":\"claude-sonnet-4.5\",\"name\":\"Claude Sonnet 4.5\",\"object\":\"model\",\"vendor\":\"Anthropic\",\"version\":\"1\",\"preview\":false,\"model_picker_enabled\":true,\"capabilities\":{\"type\":\"chat\",\"family\":\"claude-sonnet-4.5\",\"tokenizer\":\"o200k_base\",\"limits\":{\"max_context_window_tokens\":200000,\"max_output_tokens\":8192},\"supports\":{\"streaming\":true,\"tool_calls\":true,\"parallel_tool_calls\":true,\"vision\":true}}}]}";
+        "{\"data\":[{\"id\":\"claude-sonnet-5\",\"name\":\"Claude Sonnet 5\",\"object\":\"model\",\"vendor\":\"Anthropic\",\"version\":\"1\",\"preview\":false,\"model_picker_enabled\":true,\"capabilities\":{\"type\":\"chat\",\"family\":\"claude-sonnet-5\",\"tokenizer\":\"o200k_base\",\"limits\":{\"max_context_window_tokens\":200000,\"max_output_tokens\":8192},\"supports\":{\"streaming\":true,\"tool_calls\":true,\"parallel_tool_calls\":true,\"vision\":true}}}]}";
 }
 
 /// <summary>A single request the callback intercepted.</summary>

--- a/dotnet/test/E2E/CopilotRequestSessionIdE2ETests.cs
+++ b/dotnet/test/E2E/CopilotRequestSessionIdE2ETests.cs
@@ -76,15 +76,15 @@ public class CopilotRequestSessionIdE2ETests(E2ETestFixture fixture, ITestOutput
         {
             OnPermissionRequest = PermissionHandler.ApproveAll,
             // BYOK providers require an explicit model id.
-            Model = "claude-sonnet-4.5",
+            Model = "claude-sonnet-5",
             Provider = new ProviderConfig
             {
                 Type = "openai",
                 WireApi = "responses",
                 BaseUrl = "https://byok.invalid/v1",
                 ApiKey = "byok-secret",
-                ModelId = "claude-sonnet-4.5",
-                WireModel = "claude-sonnet-4.5",
+                ModelId = "claude-sonnet-5",
+                WireModel = "claude-sonnet-5",
             },
         });
         var byokSessionId = session.SessionId;

--- a/dotnet/test/E2E/CopilotRequestWebSocketE2ETests.cs
+++ b/dotnet/test/E2E/CopilotRequestWebSocketE2ETests.cs
@@ -349,7 +349,7 @@ internal sealed class FakeCopilotUpstream : IAsyncDisposable
     ];
 
     private const string ModelCatalogJson =
-        "{\"data\":[{\"id\":\"claude-sonnet-4.5\",\"name\":\"Claude Sonnet 4.5\",\"object\":\"model\",\"vendor\":\"Anthropic\",\"version\":\"1\",\"preview\":false,\"model_picker_enabled\":true,\"supported_endpoints\":[\"/responses\",\"ws:/responses\"],\"capabilities\":{\"type\":\"chat\",\"family\":\"claude-sonnet-4.5\",\"tokenizer\":\"o200k_base\",\"limits\":{\"max_context_window_tokens\":200000,\"max_output_tokens\":8192},\"supports\":{\"streaming\":true,\"tool_calls\":true,\"parallel_tool_calls\":true,\"vision\":true}}}]}";
+        "{\"data\":[{\"id\":\"claude-sonnet-5\",\"name\":\"Claude Sonnet 5\",\"object\":\"model\",\"vendor\":\"Anthropic\",\"version\":\"1\",\"preview\":false,\"model_picker_enabled\":true,\"supported_endpoints\":[\"/responses\",\"ws:/responses\"],\"capabilities\":{\"type\":\"chat\",\"family\":\"claude-sonnet-5\",\"tokenizer\":\"o200k_base\",\"limits\":{\"max_context_window_tokens\":200000,\"max_output_tokens\":8192},\"supports\":{\"streaming\":true,\"tool_calls\":true,\"parallel_tool_calls\":true,\"vision\":true}}}]}";
 
     private static int GetFreePort()
     {

--- a/dotnet/test/E2E/RewindE2ETests.cs
+++ b/dotnet/test/E2E/RewindE2ETests.cs
@@ -24,7 +24,7 @@ public class RewindE2ETests(E2ETestFixture fixture, ITestOutputHelper output)
         await File.WriteAllTextAsync(filePath, OriginalFileContent);
         await using var session = await CreateSessionAsync(new SessionConfig
         {
-            Model = "claude-sonnet-4.5",
+            Model = "claude-sonnet-5",
             EnableFileChangeTracking = true,
         });
 

--- a/dotnet/test/E2E/RpcServerE2ETests.cs
+++ b/dotnet/test/E2E/RpcServerE2ETests.cs
@@ -171,7 +171,7 @@ public class RpcServerE2ETests(E2ETestFixture fixture, ITestOutputHelper output)
         var result = await client.Rpc.Models.ListAsync();
 
         Assert.NotNull(result.Models);
-        Assert.Contains(result.Models, model => model.Id == "claude-sonnet-4.5");
+        Assert.Contains(result.Models, model => model.Id == "claude-sonnet-5");
         Assert.All(result.Models, model => Assert.False(string.IsNullOrWhiteSpace(model.Name)));
     }
 

--- a/dotnet/test/E2E/RpcSessionStateE2ETests.cs
+++ b/dotnet/test/E2E/RpcSessionStateE2ETests.cs
@@ -22,14 +22,14 @@ public class RpcSessionStateE2ETests(E2ETestFixture fixture, ITestOutputHelper o
     [Fact]
     public async Task Should_Call_Session_Rpc_Model_GetCurrent()
     {
-        await using var session = await CreateSessionAsync(new SessionConfig { Model = "claude-sonnet-4.5" });
+        await using var session = await CreateSessionAsync(new SessionConfig { Model = "claude-sonnet-5" });
 
         var result = await session.Rpc.Model.GetCurrentAsync();
 
         Assert.NotNull(result.ModelId);
         Assert.NotEmpty(result.ModelId);
         // Strengthen: verify the configured model is actually in effect, not just any model
-        Assert.Equal("claude-sonnet-4.5", result.ModelId);
+        Assert.Equal("claude-sonnet-5", result.ModelId);
     }
 
     [Fact]
@@ -48,12 +48,12 @@ public class RpcSessionStateE2ETests(E2ETestFixture fixture, ITestOutputHelper o
 
         await using var session = await isolatedCtx.CreateSessionAsync(isolatedClient, new SessionConfig
         {
-            Model = "claude-sonnet-4.5",
+            Model = "claude-sonnet-5",
             OnPermissionRequest = PermissionHandler.ApproveAll,
         });
 
         var before = await session.Rpc.Model.GetCurrentAsync();
-        Assert.Equal("claude-sonnet-4.5", before.ModelId);
+        Assert.Equal("claude-sonnet-5", before.ModelId);
 
         var result = await session.Rpc.Model.SwitchToAsync(modelId: "gpt-5.4", reasoningEffort: "high");
         Assert.Equal("gpt-5.4", result.ModelId);
@@ -281,14 +281,14 @@ public class RpcSessionStateE2ETests(E2ETestFixture fixture, ITestOutputHelper o
         var branch = $"rpc-context-{Guid.NewGuid():N}";
         await using var session = await CreateSessionAsync(new SessionConfig
         {
-            Model = "claude-sonnet-4.5",
+            Model = "claude-sonnet-5",
             WorkingDirectory = firstDirectory,
         });
 
         var initialSnapshot = await session.Rpc.Metadata.SnapshotAsync();
         Assert.Equal(session.SessionId, initialSnapshot.SessionId);
         Assert.Equal(MetadataSnapshotCurrentMode.Interactive, initialSnapshot.CurrentMode);
-        Assert.Equal("claude-sonnet-4.5", initialSnapshot.SelectedModel);
+        Assert.Equal("claude-sonnet-5", initialSnapshot.SelectedModel);
         Assert.False(initialSnapshot.IsRemote);
         Assert.False(initialSnapshot.AlreadyInUse);
         Assert.NotEqual(default, initialSnapshot.StartTime);
@@ -405,14 +405,14 @@ public class RpcSessionStateE2ETests(E2ETestFixture fixture, ITestOutputHelper o
     {
         await using var session = await CreateSessionAsync(new SessionConfig
         {
-            Model = "claude-sonnet-4.5",
+            Model = "claude-sonnet-5",
         });
 
         var reasoning = await session.Rpc.Model.SetReasoningEffortAsync("high");
         Assert.Equal("high", reasoning.ReasoningEffort);
 
         var currentModel = await session.Rpc.Model.GetCurrentAsync();
-        Assert.Equal("claude-sonnet-4.5", currentModel.ModelId);
+        Assert.Equal("claude-sonnet-5", currentModel.ModelId);
         Assert.Equal("high", currentModel.ReasoningEffort);
 
         var autoName = $"Auto Session {Guid.NewGuid():N}";
@@ -653,9 +653,9 @@ public class RpcSessionStateE2ETests(E2ETestFixture fixture, ITestOutputHelper o
         var contextInfo = await session.Rpc.Metadata.ContextInfoAsync(
             promptTokenLimit: 128_000,
             outputTokenLimit: 4_096,
-            selectedModel: "claude-sonnet-4.5");
+            selectedModel: "claude-sonnet-5");
         var context = Assert.IsType<MetadataContextInfoResultContextInfo>(contextInfo.ContextInfo);
-        Assert.Equal("claude-sonnet-4.5", context.ModelName);
+        Assert.Equal("claude-sonnet-5", context.ModelName);
         Assert.Equal(128_000, context.PromptTokenLimit);
         Assert.True(context.Limit >= context.PromptTokenLimit);
         Assert.True(context.TotalTokens > 0);
@@ -666,7 +666,7 @@ public class RpcSessionStateE2ETests(E2ETestFixture fixture, ITestOutputHelper o
             context.SystemTokens + context.ConversationTokens + context.ToolDefinitionsTokens,
             context.TotalTokens);
 
-        var recomputed = await session.Rpc.Metadata.RecomputeContextTokensAsync("claude-sonnet-4.5");
+        var recomputed = await session.Rpc.Metadata.RecomputeContextTokensAsync("claude-sonnet-5");
         Assert.True(recomputed.SystemTokenCount > 0);
         Assert.True(recomputed.MessagesTokenCount > 0);
         Assert.Equal(recomputed.SystemTokenCount + recomputed.MessagesTokenCount, recomputed.TotalTokens);

--- a/dotnet/test/E2E/RpcSessionStateExtrasE2ETests.cs
+++ b/dotnet/test/E2E/RpcSessionStateExtrasE2ETests.cs
@@ -32,7 +32,7 @@ public class RpcSessionStateExtrasE2ETests(E2ETestFixture fixture, ITestOutputHe
         await using var client = CreateAuthenticatedClient(token);
         await using var session = await Ctx.CreateSessionAsync(client, new SessionConfig
         {
-            Model = "claude-sonnet-4.5",
+            Model = "claude-sonnet-5",
             OnPermissionRequest = PermissionHandler.ApproveAll,
         });
 
@@ -41,7 +41,7 @@ public class RpcSessionStateExtrasE2ETests(E2ETestFixture fixture, ITestOutputHe
         Assert.NotNull(result.List);
         Assert.NotEmpty(result.List);
         // The configured model must be present in the returned catalog.
-        Assert.Contains(result.List, model => model.GetRawText().Contains("claude-sonnet-4.5", StringComparison.Ordinal));
+        Assert.Contains(result.List, model => model.GetRawText().Contains("claude-sonnet-5", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -73,7 +73,7 @@ public class RpcSessionStateExtrasE2ETests(E2ETestFixture fixture, ITestOutputHe
                     Provider = providerName,
                     Id = modelId,
                     Name = "SDK Runtime Model",
-                    ModelId = "claude-sonnet-4.5",
+                    ModelId = "claude-sonnet-5",
                     WireModel = "wire-sdk-runtime-model",
                     MaxContextWindowTokens = 4_096,
                     MaxPromptTokens = 3_072,
@@ -277,7 +277,7 @@ public class RpcSessionStateExtrasE2ETests(E2ETestFixture fixture, ITestOutputHe
             {
                 ["general-purpose"] = new()
                 {
-                    Model = "claude-sonnet-4.5",
+                    Model = "claude-sonnet-5",
                     EffortLevel = "high",
                     ContextTier = SubagentSettingsEntryContextTier.Default,
                 },

--- a/dotnet/test/E2E/SessionConfigE2ETests.cs
+++ b/dotnet/test/E2E/SessionConfigE2ETests.cs
@@ -31,7 +31,7 @@ public class SessionConfigE2ETests(E2ETestFixture fixture, ITestOutputHelper out
 
         var session = await CreateSessionAsync(new SessionConfig
         {
-            Model = "claude-sonnet-4.5",
+            Model = "claude-sonnet-5",
             ModelCapabilities = new ModelCapabilitiesOverride
             {
                 Supports = new ModelCapabilitiesOverrideSupports { Vision = false },
@@ -46,7 +46,7 @@ public class SessionConfigE2ETests(E2ETestFixture fixture, ITestOutputHelper out
 
         // Switch vision on
         await session.SetModelAsync(
-            "claude-sonnet-4.5",
+            "claude-sonnet-5",
             reasoningEffort: null,
             modelCapabilities: new ModelCapabilitiesOverride
             {
@@ -74,7 +74,7 @@ public class SessionConfigE2ETests(E2ETestFixture fixture, ITestOutputHelper out
 
         var session = await CreateSessionAsync(new SessionConfig
         {
-            Model = "claude-sonnet-4.5",
+            Model = "claude-sonnet-5",
             ModelCapabilities = new ModelCapabilitiesOverride
             {
                 Supports = new ModelCapabilitiesOverrideSupports { Vision = true },
@@ -89,7 +89,7 @@ public class SessionConfigE2ETests(E2ETestFixture fixture, ITestOutputHelper out
 
         // Switch vision off
         await session.SetModelAsync(
-            "claude-sonnet-4.5",
+            "claude-sonnet-5",
             reasoningEffort: null,
             modelCapabilities: new ModelCapabilitiesOverride
             {

--- a/dotnet/test/E2E/SessionConfigE2ETests.cs
+++ b/dotnet/test/E2E/SessionConfigE2ETests.cs
@@ -216,7 +216,7 @@ public class SessionConfigE2ETests(E2ETestFixture fixture, ITestOutputHelper out
     {
         var session = await CreateSessionAsync(new SessionConfig
         {
-            Model = "claude-sonnet-4.5",
+            Model = "claude-sonnet-5",
             Provider = CreateProxyProvider("create-provider-header"),
         });
 
@@ -240,7 +240,7 @@ public class SessionConfigE2ETests(E2ETestFixture fixture, ITestOutputHelper out
 
         var session2 = await ResumeSessionAsync(sessionId, new ResumeSessionConfig
         {
-            Model = "claude-sonnet-4.5",
+            Model = "claude-sonnet-5",
             Provider = CreateProxyProvider("resume-provider-header"),
         });
 
@@ -267,7 +267,7 @@ public class SessionConfigE2ETests(E2ETestFixture fixture, ITestOutputHelper out
         // tests for serialization coverage).
         var session = await CreateSessionAsync(new SessionConfig
         {
-            Model = "claude-sonnet-4.5",
+            Model = "claude-sonnet-5",
             Provider = new ProviderConfig
             {
                 Type = "openai",
@@ -300,14 +300,14 @@ public class SessionConfigE2ETests(E2ETestFixture fixture, ITestOutputHelper out
                 Type = "openai",
                 BaseUrl = Ctx.ProxyUrl,
                 ApiKey = "test-provider-key",
-                ModelId = "claude-sonnet-4.5",
+                ModelId = "claude-sonnet-5",
             },
         });
 
         await session.SendAndWaitAsync(new MessageOptions { Prompt = "What is 1+1?" });
 
         var exchange = Assert.Single(await Ctx.GetExchangesAsync());
-        Assert.Equal("claude-sonnet-4.5", exchange.Request.Model);
+        Assert.Equal("claude-sonnet-5", exchange.Request.Model);
 
         await session.DisposeAsync();
     }
@@ -598,7 +598,7 @@ public class SessionConfigE2ETests(E2ETestFixture fixture, ITestOutputHelper out
         var session = await Ctx.CreateSessionAsync(client, new SessionConfig
         {
             OnPermissionRequest = PermissionHandler.ApproveAll,
-            Model = "claude-sonnet-4.5",
+            Model = "claude-sonnet-5",
             EnableCitations = true,
             Provider = CreateAnthropicProvider(),
         });
@@ -645,7 +645,7 @@ public class SessionConfigE2ETests(E2ETestFixture fixture, ITestOutputHelper out
         var session2 = await Ctx.ResumeSessionAsync(resumeClient, sessionId, new ResumeSessionConfig
         {
             OnPermissionRequest = PermissionHandler.ApproveAll,
-            Model = "claude-sonnet-4.5",
+            Model = "claude-sonnet-5",
             EnableCitations = true,
             Provider = CreateAnthropicProvider(),
         });
@@ -834,8 +834,8 @@ public class SessionConfigE2ETests(E2ETestFixture fixture, ITestOutputHelper out
             Type = "anthropic",
             BaseUrl = "https://anthropic-citations.invalid/v1",
             ApiKey = "test-provider-key",
-            ModelId = "claude-sonnet-4.5",
-            WireModel = "claude-sonnet-4.5",
+            ModelId = "claude-sonnet-5",
+            WireModel = "claude-sonnet-5",
         };
     }
 

--- a/dotnet/test/E2E/SessionE2ETests.cs
+++ b/dotnet/test/E2E/SessionE2ETests.cs
@@ -17,7 +17,7 @@ public class SessionE2ETests(E2ETestFixture fixture, ITestOutputHelper output) :
     [Fact]
     public async Task ShouldCreateAndDisconnectSessions()
     {
-        var session = await CreateSessionAsync(new SessionConfig { Model = "claude-sonnet-4.5" });
+        var session = await CreateSessionAsync(new SessionConfig { Model = "claude-sonnet-5" });
 
         Assert.Matches(@"^[a-f0-9-]+$", session.SessionId);
 

--- a/dotnet/test/Harness/E2ETestBackend.cs
+++ b/dotnet/test/Harness/E2ETestBackend.cs
@@ -15,7 +15,7 @@ internal enum E2ETestBackend
 internal static class E2ETestBackendConfiguration
 {
     internal const string EnvironmentVariable = "COPILOT_SDK_E2E_BACKEND";
-    private const string AnthropicDefaultModel = "claude-sonnet-4.5";
+    private const string AnthropicDefaultModel = "claude-sonnet-5";
     private const string OpenAIDefaultModel = "gpt-4.1";
     private const string FakeCredential = "fake-byok-credential-for-e2e-tests";
 

--- a/dotnet/test/Unit/E2ETestBackendTests.cs
+++ b/dotnet/test/Unit/E2ETestBackendTests.cs
@@ -25,7 +25,7 @@ public class E2ETestBackendTests
             () => E2ETestBackendConfiguration.Parse("unknown"));
 
     [Theory]
-    [InlineData("anthropic-messages", "anthropic", null, "claude-sonnet-4.5")]
+    [InlineData("anthropic-messages", "anthropic", null, "claude-sonnet-5")]
     [InlineData("openai-responses", "openai", "responses", "gpt-4.1")]
     [InlineData("openai-completions", "openai", "completions", "gpt-4.1")]
     public void AppliesProvider(

--- a/go/internal/e2e/client_options_e2e_test.go
+++ b/go/internal/e2e/client_options_e2e_test.go
@@ -329,7 +329,7 @@ func TestClientOptionsE2E(t *testing.T) {
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
 			SessionID:                          sessionID,
 			ClientName:                         "go-sdk-e2e-client",
-			Model:                              "claude-sonnet-4.5",
+			Model:                              "claude-sonnet-5",
 			ReasoningEffort:                    "low",
 			ReasoningSummary:                   copilot.ReasoningSummaryNone,
 			ContextTier:                        copilot.ContextTierLongContext,
@@ -388,7 +388,7 @@ func TestClientOptionsE2E(t *testing.T) {
 		expectedValues := map[string]any{
 			"sessionId":                          sessionID,
 			"clientName":                         "go-sdk-e2e-client",
-			"model":                              "claude-sonnet-4.5",
+			"model":                              "claude-sonnet-5",
 			"reasoningEffort":                    "low",
 			"reasoningSummary":                   "none",
 			"contextTier":                        "long_context",

--- a/go/internal/e2e/copilot_request_helpers_test.go
+++ b/go/internal/e2e/copilot_request_helpers_test.go
@@ -47,8 +47,8 @@ func sseFrame(eventType string, data map[string]any) string {
 
 func modelCatalogJSON(supportedEndpoints []string) string {
 	model := map[string]any{
-		"id":                   "claude-sonnet-4.5",
-		"name":                 "Claude Sonnet 4.5",
+		"id":                   "claude-sonnet-5",
+		"name":                 "Claude Sonnet 5",
 		"object":               "model",
 		"vendor":               "Anthropic",
 		"version":              "1",
@@ -56,7 +56,7 @@ func modelCatalogJSON(supportedEndpoints []string) string {
 		"model_picker_enabled": true,
 		"capabilities": map[string]any{
 			"type":      "chat",
-			"family":    "claude-sonnet-4.5",
+			"family":    "claude-sonnet-5",
 			"tokenizer": "o200k_base",
 			"limits": map[string]any{
 				"max_context_window_tokens": 200000,
@@ -141,7 +141,7 @@ func buildAnthropicMessageSSEBody(text string) string {
 			"type": "message_start",
 			"message": map[string]any{
 				"id": "msg_stub_1", "type": "message", "role": "assistant",
-				"model": "claude-sonnet-4.5", "content": []any{},
+				"model": "claude-sonnet-5", "content": []any{},
 				"stop_reason": nil, "stop_sequence": nil,
 				"usage": map[string]any{"input_tokens": 5, "output_tokens": 1},
 			},
@@ -188,7 +188,7 @@ func buildInferenceResponse(url string, bodyText string) *http.Response {
 		base := func() map[string]any {
 			return map[string]any{
 				"id": "chatcmpl-stub-1", "object": "chat.completion.chunk",
-				"created": 1, "model": "claude-sonnet-4.5",
+				"created": 1, "model": "claude-sonnet-5",
 			}
 		}
 		c1 := base()
@@ -215,7 +215,7 @@ func buildInferenceResponse(url string, bodyText string) *http.Response {
 			"id":            "msg_stub_1",
 			"type":          "message",
 			"role":          "assistant",
-			"model":         "claude-sonnet-4.5",
+			"model":         "claude-sonnet-5",
 			"content":       []any{map[string]any{"type": "text", "text": syntheticResponseText}},
 			"stop_reason":   "end_turn",
 			"stop_sequence": nil,
@@ -225,7 +225,7 @@ func buildInferenceResponse(url string, bodyText string) *http.Response {
 	}
 
 	raw, _ := json.Marshal(map[string]any{
-		"id": "chatcmpl-stub-1", "object": "chat.completion", "created": 1, "model": "claude-sonnet-4.5",
+		"id": "chatcmpl-stub-1", "object": "chat.completion", "created": 1, "model": "claude-sonnet-5",
 		"choices": []any{map[string]any{"index": 0, "message": map[string]any{"role": "assistant", "content": syntheticResponseText}, "finish_reason": "stop"}},
 		"usage":   map[string]any{"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
 	})

--- a/go/internal/e2e/copilot_request_session_id_e2e_test.go
+++ b/go/internal/e2e/copilot_request_session_id_e2e_test.go
@@ -139,14 +139,14 @@ func TestCopilotRequestSessionID(t *testing.T) {
 		before := len(transport.inferenceRecords())
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
-			Model:               "claude-sonnet-4.5",
+			Model:               "claude-sonnet-5",
 			Provider: &copilot.ProviderConfig{
 				Type:      "openai",
 				WireAPI:   "responses",
 				BaseURL:   "https://byok.invalid/v1",
 				APIKey:    "byok-secret",
-				ModelID:   "claude-sonnet-4.5",
-				WireModel: "claude-sonnet-4.5",
+				ModelID:   "claude-sonnet-5",
+				WireModel: "claude-sonnet-5",
 			},
 		})
 		if err != nil {

--- a/go/internal/e2e/rewind_e2e_test.go
+++ b/go/internal/e2e/rewind_e2e_test.go
@@ -32,7 +32,7 @@ func TestRewindE2E(t *testing.T) {
 			t.Fatalf("Failed to create original file: %v", err)
 		}
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
-			Model:                    "claude-sonnet-4.5",
+			Model:                    "claude-sonnet-5",
 			EnableFileChangeTracking: copilot.Bool(true),
 			OnPermissionRequest:      copilot.PermissionHandler.ApproveAll,
 		})

--- a/go/internal/e2e/rpc_e2e_test.go
+++ b/go/internal/e2e/rpc_e2e_test.go
@@ -128,7 +128,7 @@ func TestSessionRPCE2E(t *testing.T) {
 
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
-			Model:               "claude-sonnet-4.5",
+			Model:               "claude-sonnet-5",
 		})
 		if err != nil {
 			t.Fatalf("Failed to create session: %v", err)
@@ -150,7 +150,7 @@ func TestSessionRPCE2E(t *testing.T) {
 
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
-			Model:               "claude-sonnet-4.5",
+			Model:               "claude-sonnet-5",
 		})
 		if err != nil {
 			t.Fatalf("Failed to create session: %v", err)
@@ -194,7 +194,7 @@ func TestSessionRPCE2E(t *testing.T) {
 
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
-			Model:               "claude-sonnet-4.5",
+			Model:               "claude-sonnet-5",
 		})
 		if err != nil {
 			t.Fatalf("Failed to create session: %v", err)

--- a/go/internal/e2e/rpc_server_e2e_test.go
+++ b/go/internal/e2e/rpc_server_e2e_test.go
@@ -64,12 +64,12 @@ func TestRPCServerE2E(t *testing.T) {
 			if strings.TrimSpace(model.Name) == "" {
 				t.Errorf("Model %q has empty Name", model.ID)
 			}
-			if model.ID == "claude-sonnet-4.5" {
+			if model.ID == "claude-sonnet-5" {
 				hasClaude = true
 			}
 		}
 		if !hasClaude {
-			t.Errorf("Expected models list to contain 'claude-sonnet-4.5'")
+			t.Errorf("Expected models list to contain 'claude-sonnet-5'")
 		}
 	})
 

--- a/go/internal/e2e/rpc_session_state_e2e_test.go
+++ b/go/internal/e2e/rpc_session_state_e2e_test.go
@@ -26,7 +26,7 @@ func TestRPCSessionStateE2E(t *testing.T) {
 
 	t.Run("should call session rpc model getCurrent", func(t *testing.T) {
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
-			Model:               "claude-sonnet-4.5",
+			Model:               "claude-sonnet-5",
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
 		})
 		if err != nil {
@@ -37,8 +37,8 @@ func TestRPCSessionStateE2E(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Model.GetCurrent failed: %v", err)
 		}
-		if result.ModelID == nil || *result.ModelID != "claude-sonnet-4.5" {
-			t.Fatalf("Expected current model claude-sonnet-4.5, got %+v", result)
+		if result.ModelID == nil || *result.ModelID != "claude-sonnet-5" {
+			t.Fatalf("Expected current model claude-sonnet-5, got %+v", result)
 		}
 	})
 
@@ -58,7 +58,7 @@ func TestRPCSessionStateE2E(t *testing.T) {
 		switchCtx.ConfigureForTest(t)
 
 		session, err := switchClient.CreateSession(t.Context(), &copilot.SessionConfig{
-			Model:               "claude-sonnet-4.5",
+			Model:               "claude-sonnet-5",
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
 		})
 		if err != nil {
@@ -485,7 +485,7 @@ func TestRPCSessionStateE2E(t *testing.T) {
 		branch := "rpc-context-" + randomHex(t)
 
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
-			Model:               "claude-sonnet-4.5",
+			Model:               "claude-sonnet-5",
 			WorkingDirectory:    firstDirectory,
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
 		})
@@ -498,7 +498,7 @@ func TestRPCSessionStateE2E(t *testing.T) {
 			t.Fatalf("Metadata.Snapshot failed: %v", err)
 		}
 		if initial.SessionID != session.SessionID || initial.CurrentMode != rpc.MetadataSnapshotCurrentModeInteractive ||
-			initial.SelectedModel == nil || *initial.SelectedModel != "claude-sonnet-4.5" ||
+			initial.SelectedModel == nil || *initial.SelectedModel != "claude-sonnet-5" ||
 			initial.IsRemote || initial.AlreadyInUse || initial.StartTime.IsZero() || initial.ModifiedTime.IsZero() ||
 			initial.Workspace == nil || initial.WorkspacePath == nil || *initial.WorkspacePath == "" {
 			t.Fatalf("Unexpected initial metadata snapshot: %+v", initial)
@@ -630,7 +630,7 @@ func TestRPCSessionStateE2E(t *testing.T) {
 
 	t.Run("should set reasoning effort and auto name", func(t *testing.T) {
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
-			Model:               "claude-sonnet-4.5",
+			Model:               "claude-sonnet-5",
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
 		})
 		if err != nil {
@@ -648,9 +648,9 @@ func TestRPCSessionStateE2E(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Model.GetCurrent failed: %v", err)
 		}
-		if current.ModelID == nil || *current.ModelID != "claude-sonnet-4.5" ||
+		if current.ModelID == nil || *current.ModelID != "claude-sonnet-5" ||
 			current.ReasoningEffort == nil || *current.ReasoningEffort != "high" {
-			t.Fatalf("Expected current model claude-sonnet-4.5/high, got %+v", current)
+			t.Fatalf("Expected current model claude-sonnet-5/high, got %+v", current)
 		}
 
 		autoName := "Auto Session " + randomHex(t)
@@ -760,7 +760,7 @@ func TestRPCSessionStateE2E(t *testing.T) {
 			t.Fatal("Expected fresh session to be idle")
 		}
 
-		model := "claude-sonnet-4.5"
+		model := "claude-sonnet-5"
 		contextInfo, err := session.RPC.Metadata.ContextInfo(t.Context(), &rpc.MetadataContextInfoRequest{
 			PromptTokenLimit: 128000,
 			OutputTokenLimit: 4096,

--- a/go/internal/e2e/rpc_session_state_extras_e2e_test.go
+++ b/go/internal/e2e/rpc_session_state_extras_e2e_test.go
@@ -22,7 +22,7 @@ func TestRpcSessionStateExtras(t *testing.T) {
 		authClient := newAuthenticatedClient(ctx, token)
 		defer authClient.ForceStop()
 
-		session := createPortedSession(t, authClient, &copilot.SessionConfig{Model: "claude-sonnet-4.5"})
+		session := createPortedSession(t, authClient, &copilot.SessionConfig{Model: "claude-sonnet-5"})
 		defer session.Disconnect()
 
 		result, err := session.RPC.Model.List(t.Context())
@@ -38,13 +38,13 @@ func TestRpcSessionStateExtras(t *testing.T) {
 		found := false
 		for _, model := range result.List {
 			data, err := json.Marshal(model)
-			if err == nil && strings.Contains(string(data), "claude-sonnet-4.5") {
+			if err == nil && strings.Contains(string(data), "claude-sonnet-5") {
 				found = true
 				break
 			}
 		}
 		if !found {
-			t.Fatalf("Expected model list to include claude-sonnet-4.5, got %+v", result.List)
+			t.Fatalf("Expected model list to include claude-sonnet-5, got %+v", result.List)
 		}
 	})
 

--- a/go/internal/e2e/session_config_e2e_test.go
+++ b/go/internal/e2e/session_config_e2e_test.go
@@ -119,8 +119,8 @@ func createAnthropicProvider() *copilot.ProviderConfig {
 		Type:      "anthropic",
 		BaseURL:   "https://anthropic-citations.invalid/v1",
 		APIKey:    "test-provider-key",
-		ModelID:   "claude-sonnet-4.5",
-		WireModel: "claude-sonnet-4.5",
+		ModelID:   "claude-sonnet-5",
+		WireModel: "claude-sonnet-5",
 	}
 }
 
@@ -422,7 +422,7 @@ func TestSessionConfigNewOptionsCopilotRequestE2E(t *testing.T) {
 
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
-			Model:               "claude-sonnet-4.5",
+			Model:               "claude-sonnet-5",
 			EnableCitations:     copilot.Bool(true),
 			Provider:            createAnthropicProvider(),
 		})
@@ -483,7 +483,7 @@ func TestSessionConfigNewOptionsCopilotRequestE2E(t *testing.T) {
 
 		session2, err := resumeClient.ResumeSessionWithOptions(t.Context(), session1.SessionID, &copilot.ResumeSessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
-			Model:               "claude-sonnet-4.5",
+			Model:               "claude-sonnet-5",
 			EnableCitations:     copilot.Bool(true),
 			Provider:            createAnthropicProvider(),
 		})
@@ -591,7 +591,7 @@ func TestSessionConfigExtrasE2E(t *testing.T) {
 
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
-			Model:               "claude-sonnet-4.5",
+			Model:               "claude-sonnet-5",
 			Provider:            createProxyProvider(ctx, providerHeaderName, "create-provider-header"),
 		})
 		if err != nil {
@@ -635,7 +635,7 @@ func TestSessionConfigExtrasE2E(t *testing.T) {
 
 		session2, err := client.ResumeSession(t.Context(), sessionID, &copilot.ResumeSessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
-			Model:               "claude-sonnet-4.5",
+			Model:               "claude-sonnet-5",
 			Provider:            createProxyProvider(ctx, providerHeaderName, "resume-provider-header"),
 		})
 		if err != nil {
@@ -679,7 +679,7 @@ func TestSessionConfigExtrasE2E(t *testing.T) {
 		maxOutputTokens := 1024
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
-			Model:               "claude-sonnet-4.5",
+			Model:               "claude-sonnet-5",
 			Provider: &copilot.ProviderConfig{
 				Type:            "openai",
 				BaseURL:         ctx.ProxyURL,
@@ -721,7 +721,7 @@ func TestSessionConfigExtrasE2E(t *testing.T) {
 				Type:    "openai",
 				BaseURL: ctx.ProxyURL,
 				APIKey:  "test-provider-key",
-				ModelID: "claude-sonnet-4.5",
+				ModelID: "claude-sonnet-5",
 			},
 		})
 		if err != nil {
@@ -740,8 +740,8 @@ func TestSessionConfigExtrasE2E(t *testing.T) {
 		if len(exchanges) != 1 {
 			t.Fatalf("Expected exactly 1 exchange, got %d", len(exchanges))
 		}
-		if exchanges[0].Request.Model != "claude-sonnet-4.5" {
-			t.Errorf("Expected request model to be 'claude-sonnet-4.5', got %q", exchanges[0].Request.Model)
+		if exchanges[0].Request.Model != "claude-sonnet-5" {
+			t.Errorf("Expected request model to be 'claude-sonnet-5', got %q", exchanges[0].Request.Model)
 		}
 	})
 

--- a/go/internal/e2e/session_config_e2e_test.go
+++ b/go/internal/e2e/session_config_e2e_test.go
@@ -184,7 +184,7 @@ func TestSessionConfigE2E(t *testing.T) {
 
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
-			Model:               "claude-sonnet-4.5",
+			Model:               "claude-sonnet-5",
 			ModelCapabilities: &copilot.ModelCapabilitiesOverride{
 				Supports: &copilot.ModelCapabilitiesOverrideSupports{
 					Vision: copilot.Bool(false),
@@ -209,7 +209,7 @@ func TestSessionConfigE2E(t *testing.T) {
 		}
 
 		// Switch vision on
-		if err := session.SetModel(t.Context(), "claude-sonnet-4.5", &copilot.SetModelOptions{
+		if err := session.SetModel(t.Context(), "claude-sonnet-5", &copilot.SetModelOptions{
 			ModelCapabilities: &copilot.ModelCapabilitiesOverride{
 				Supports: &copilot.ModelCapabilitiesOverrideSupports{
 					Vision: copilot.Bool(true),
@@ -239,7 +239,7 @@ func TestSessionConfigE2E(t *testing.T) {
 
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
-			Model:               "claude-sonnet-4.5",
+			Model:               "claude-sonnet-5",
 			ModelCapabilities: &copilot.ModelCapabilitiesOverride{
 				Supports: &copilot.ModelCapabilitiesOverrideSupports{
 					Vision: copilot.Bool(true),
@@ -264,7 +264,7 @@ func TestSessionConfigE2E(t *testing.T) {
 		}
 
 		// Switch vision off
-		if err := session.SetModel(t.Context(), "claude-sonnet-4.5", &copilot.SetModelOptions{
+		if err := session.SetModel(t.Context(), "claude-sonnet-5", &copilot.SetModelOptions{
 			ModelCapabilities: &copilot.ModelCapabilitiesOverride{
 				Supports: &copilot.ModelCapabilitiesOverrideSupports{
 					Vision: copilot.Bool(false),

--- a/go/internal/e2e/session_config_e2e_test.go
+++ b/go/internal/e2e/session_config_e2e_test.go
@@ -184,6 +184,7 @@ func TestSessionConfigE2E(t *testing.T) {
 
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+			Model:               "claude-sonnet-4.5",
 			ModelCapabilities: &copilot.ModelCapabilitiesOverride{
 				Supports: &copilot.ModelCapabilitiesOverrideSupports{
 					Vision: copilot.Bool(false),
@@ -238,6 +239,7 @@ func TestSessionConfigE2E(t *testing.T) {
 
 		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{
 			OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+			Model:               "claude-sonnet-4.5",
 			ModelCapabilities: &copilot.ModelCapabilitiesOverride{
 				Supports: &copilot.ModelCapabilitiesOverrideSupports{
 					Vision: copilot.Bool(true),

--- a/go/internal/e2e/session_e2e_test.go
+++ b/go/internal/e2e/session_e2e_test.go
@@ -23,7 +23,7 @@ func TestSessionE2E(t *testing.T) {
 	t.Run("should create and disconnect sessions", func(t *testing.T) {
 		ctx.ConfigureForTest(t)
 
-		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{OnPermissionRequest: copilot.PermissionHandler.ApproveAll, Model: "claude-sonnet-4.5"})
+		session, err := client.CreateSession(t.Context(), &copilot.SessionConfig{OnPermissionRequest: copilot.PermissionHandler.ApproveAll, Model: "claude-sonnet-5"})
 		if err != nil {
 			t.Fatalf("Failed to create session: %v", err)
 		}
@@ -47,8 +47,8 @@ func TestSessionE2E(t *testing.T) {
 			t.Errorf("Expected session.start sessionId to match")
 		}
 
-		if !startOk || startData.SelectedModel == nil || *startData.SelectedModel != "claude-sonnet-4.5" {
-			t.Errorf("Expected selectedModel to be 'claude-sonnet-4.5', got %v", startData)
+		if !startOk || startData.SelectedModel == nil || *startData.SelectedModel != "claude-sonnet-5" {
+			t.Errorf("Expected selectedModel to be 'claude-sonnet-5', got %v", startData)
 		}
 
 		if err := session.Disconnect(); err != nil {

--- a/java/sdk/src/test/java/com/github/copilot/CopilotRequestSessionIdE2ETest.java
+++ b/java/sdk/src/test/java/com/github/copilot/CopilotRequestSessionIdE2ETest.java
@@ -77,11 +77,11 @@ public class CopilotRequestSessionIdE2ETest {
             // BYOK session.
             int before = handler.inferenceRequests().size();
             ProviderConfig provider = new ProviderConfig().setType("openai").setWireApi("responses")
-                    .setBaseUrl("https://byok.invalid/v1").setApiKey("byok-secret").setModelId("claude-sonnet-4.5")
-                    .setWireModel("claude-sonnet-4.5");
+                    .setBaseUrl("https://byok.invalid/v1").setApiKey("byok-secret").setModelId("claude-sonnet-5")
+                    .setWireModel("claude-sonnet-5");
             CopilotSession byokSession = client
                     .createSession(new SessionConfig().setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
-                            .setModel("claude-sonnet-4.5").setProvider(provider))
+                            .setModel("claude-sonnet-5").setProvider(provider))
                     .get();
             String byokSessionId = byokSession.getSessionId();
 

--- a/java/sdk/src/test/java/com/github/copilot/CopilotRequestTestSupport.java
+++ b/java/sdk/src/test/java/com/github/copilot/CopilotRequestTestSupport.java
@@ -134,7 +134,7 @@ final class CopilotRequestTestSupport {
         startMessage.put("id", "msg_stub_1");
         startMessage.put("type", "message");
         startMessage.put("role", "assistant");
-        startMessage.put("model", "claude-sonnet-4.5");
+        startMessage.put("model", "claude-sonnet-5");
         startMessage.put("content", List.of());
         startMessage.put("stop_reason", null);
         startMessage.put("stop_sequence", null);
@@ -251,7 +251,7 @@ final class CopilotRequestTestSupport {
             body.put("id", "msg_stub_1");
             body.put("type", "message");
             body.put("role", "assistant");
-            body.put("model", "claude-sonnet-4.5");
+            body.put("model", "claude-sonnet-5");
             body.put("content", List.of(Map.of("type", "text", "text", text)));
             body.put("stop_reason", "end_turn");
             body.put("stop_sequence", null);
@@ -301,14 +301,14 @@ final class CopilotRequestTestSupport {
 
         Map<String, Object> capabilities = new LinkedHashMap<>();
         capabilities.put("type", "chat");
-        capabilities.put("family", "claude-sonnet-4.5");
+        capabilities.put("family", "claude-sonnet-5");
         capabilities.put("tokenizer", "o200k_base");
         capabilities.put("limits", limits);
         capabilities.put("supports", supports);
 
         Map<String, Object> model = new LinkedHashMap<>();
-        model.put("id", "claude-sonnet-4.5");
-        model.put("name", "Claude Sonnet 4.5");
+        model.put("id", "claude-sonnet-5");
+        model.put("name", "Claude Sonnet 5");
         model.put("object", "model");
         model.put("vendor", "Anthropic");
         model.put("version", "1");
@@ -416,7 +416,7 @@ final class CopilotRequestTestSupport {
         base.put("id", "chatcmpl-stub-1");
         base.put("object", "chat.completion.chunk");
         base.put("created", 1);
-        base.put("model", "claude-sonnet-4.5");
+        base.put("model", "claude-sonnet-5");
         return base;
     }
 
@@ -459,7 +459,7 @@ final class CopilotRequestTestSupport {
         root.put("id", "chatcmpl-stub-1");
         root.put("object", "chat.completion");
         root.put("created", 1);
-        root.put("model", "claude-sonnet-4.5");
+        root.put("model", "claude-sonnet-5");
         root.put("choices", List.of(choice));
         root.put("usage", chatUsage());
         return root;

--- a/java/sdk/src/test/java/com/github/copilot/RpcServerE2ETest.java
+++ b/java/sdk/src/test/java/com/github/copilot/RpcServerE2ETest.java
@@ -135,7 +135,7 @@ class RpcServerE2ETest {
             var result = client.getRpc().models.list().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
             assertNotNull(result.models());
-            assertTrue(result.models().stream().anyMatch(model -> "claude-sonnet-4.5".equals(model.id())));
+            assertTrue(result.models().stream().anyMatch(model -> "claude-sonnet-5".equals(model.id())));
             result.models().forEach(model -> {
                 assertFalse(model.id().isBlank());
                 assertFalse(model.name().isBlank());

--- a/java/sdk/src/test/java/com/github/copilot/SessionConfigE2ETest.java
+++ b/java/sdk/src/test/java/com/github/copilot/SessionConfigE2ETest.java
@@ -125,7 +125,7 @@ public class SessionConfigE2ETest {
 
         try (CopilotClient client = ctx.createClient()) {
             CopilotSession session = client
-                    .createSession(new SessionConfig().setModel("claude-sonnet-4.5")
+                    .createSession(new SessionConfig().setModel("claude-sonnet-5")
                             .setProvider(new ProviderConfig().setType("openai").setBaseUrl(ctx.getProxyUrl())
                                     .setApiKey("test-provider-key").setWireModel("test-wire-model")
                                     .setMaxOutputTokens(1024))
@@ -149,7 +149,7 @@ public class SessionConfigE2ETest {
         try (CopilotClient client = ctx.createClient()) {
             CopilotSession session = client.createSession(new SessionConfig()
                     .setProvider(new ProviderConfig().setType("openai").setBaseUrl(ctx.getProxyUrl())
-                            .setApiKey("test-provider-key").setModelId("claude-sonnet-4.5"))
+                            .setApiKey("test-provider-key").setModelId("claude-sonnet-5"))
                     .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)).get();
 
             session.sendAndWait(new MessageOptions().setPrompt("What is 1+1?")).get(30, TimeUnit.SECONDS);
@@ -158,7 +158,7 @@ public class SessionConfigE2ETest {
             assertFalse(exchanges.isEmpty(), "Should have at least one exchange");
             @SuppressWarnings("unchecked")
             Map<String, Object> request = (Map<String, Object>) exchanges.get(0).get("request");
-            assertEquals("claude-sonnet-4.5", request.get("model"));
+            assertEquals("claude-sonnet-5", request.get("model"));
         }
     }
 
@@ -272,7 +272,7 @@ public class SessionConfigE2ETest {
         var handler = new CopilotRequestTestSupport.RecordingRequestHandler(SYNTHETIC_TEXT);
 
         try (CopilotClient client = newLlmClient(ctx, handler)) {
-            CopilotSession session = client.createSession(new SessionConfig().setModel("claude-sonnet-4.5")
+            CopilotSession session = client.createSession(new SessionConfig().setModel("claude-sonnet-5")
                     .setEnableCitations(true).setProvider(createAnthropicProvider())
                     .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)).get();
 
@@ -296,7 +296,7 @@ public class SessionConfigE2ETest {
             CopilotSession session1 = client
                     .createSession(new SessionConfig().setOnPermissionRequest(PermissionHandler.APPROVE_ALL)).get();
             CopilotSession session2 = client.resumeSession(session1.getSessionId(),
-                    new ResumeSessionConfig().setModel("claude-sonnet-4.5").setEnableCitations(true)
+                    new ResumeSessionConfig().setModel("claude-sonnet-5").setEnableCitations(true)
                             .setProvider(createAnthropicProvider())
                             .setOnPermissionRequest(PermissionHandler.APPROVE_ALL))
                     .get();
@@ -388,7 +388,7 @@ public class SessionConfigE2ETest {
 
     private static ProviderConfig createAnthropicProvider() {
         return new ProviderConfig().setType("anthropic").setBaseUrl("https://anthropic-citations.invalid/v1")
-                .setApiKey("test-provider-key").setModelId("claude-sonnet-4.5").setWireModel("claude-sonnet-4.5");
+                .setApiKey("test-provider-key").setModelId("claude-sonnet-5").setWireModel("claude-sonnet-5");
     }
 
     private static String singleInferenceRequestBody(CopilotRequestTestSupport.RecordingRequestHandler handler) {

--- a/java/sdk/src/test/java/com/github/copilot/e2e/RewindIT.java
+++ b/java/sdk/src/test/java/com/github/copilot/e2e/RewindIT.java
@@ -62,7 +62,7 @@ class RewindIT {
         try (CopilotClient client = ctx.createClient();
                 CopilotSession session = client
                         .createSession(
-                                new SessionConfig().setModel("claude-sonnet-4.5").setEnableFileChangeTracking(true)
+                                new SessionConfig().setModel("claude-sonnet-5").setEnableFileChangeTracking(true)
                                         .setOnPermissionRequest(PermissionHandler.APPROVE_ALL))
                         .get(30, TimeUnit.SECONDS)) {
             AssistantMessageEvent ready = session

--- a/java/sdk/src/test/java/com/github/copilot/e2e/RewindIT.java
+++ b/java/sdk/src/test/java/com/github/copilot/e2e/RewindIT.java
@@ -60,10 +60,8 @@ class RewindIT {
         Files.writeString(filePath, ORIGINAL_FILE_CONTENT);
 
         try (CopilotClient client = ctx.createClient();
-                CopilotSession session = client
-                        .createSession(
-                                new SessionConfig().setModel("claude-sonnet-5").setEnableFileChangeTracking(true)
-                                        .setOnPermissionRequest(PermissionHandler.APPROVE_ALL))
+                CopilotSession session = client.createSession(new SessionConfig().setModel("claude-sonnet-5")
+                        .setEnableFileChangeTracking(true).setOnPermissionRequest(PermissionHandler.APPROVE_ALL))
                         .get(30, TimeUnit.SECONDS)) {
             AssistantMessageEvent ready = session
                     .sendAndWait(new MessageOptions().setPrompt("Use the edit tool to replace the exact contents of "

--- a/java/sdk/src/test/java/com/github/copilot/generated/rpc/GeneratedRpcRecordsCoverageTest.java
+++ b/java/sdk/src/test/java/com/github/copilot/generated/rpc/GeneratedRpcRecordsCoverageTest.java
@@ -326,10 +326,10 @@ class GeneratedRpcRecordsCoverageTest {
 
     @Test
     void sessionModelSwitchToParams_record() {
-        var params = new SessionModelSwitchToParams("sess-32", "claude-sonnet-4.5", "high", null, null, null, null,
+        var params = new SessionModelSwitchToParams("sess-32", "claude-sonnet-5", "high", null, null, null, null,
                 null, null, null, null, null, null, null, null);
         assertEquals("sess-32", params.sessionId());
-        assertEquals("claude-sonnet-4.5", params.modelId());
+        assertEquals("claude-sonnet-5", params.modelId());
         assertEquals("high", params.reasoningEffort());
         assertNull(params.reasoningSummary());
         assertNull(params.verbosity());
@@ -656,8 +656,8 @@ class GeneratedRpcRecordsCoverageTest {
 
     @Test
     void sessionModelGetCurrentResult_record() {
-        var result = new SessionModelGetCurrentResult("claude-sonnet-4.5", null, null);
-        assertEquals("claude-sonnet-4.5", result.modelId());
+        var result = new SessionModelGetCurrentResult("claude-sonnet-5", null, null);
+        assertEquals("claude-sonnet-5", result.modelId());
     }
 
     @Test

--- a/java/sdk/src/test/java/com/github/copilot/generated/rpc/GeneratedRpcRecordsCoverageTest.java
+++ b/java/sdk/src/test/java/com/github/copilot/generated/rpc/GeneratedRpcRecordsCoverageTest.java
@@ -326,8 +326,8 @@ class GeneratedRpcRecordsCoverageTest {
 
     @Test
     void sessionModelSwitchToParams_record() {
-        var params = new SessionModelSwitchToParams("sess-32", "claude-sonnet-5", "high", null, null, null, null,
-                null, null, null, null, null, null, null, null);
+        var params = new SessionModelSwitchToParams("sess-32", "claude-sonnet-5", "high", null, null, null, null, null,
+                null, null, null, null, null, null, null);
         assertEquals("sess-32", params.sessionId());
         assertEquals("claude-sonnet-5", params.modelId());
         assertEquals("high", params.reasoningEffort());

--- a/nodejs/test/e2e/client_options.e2e.test.ts
+++ b/nodejs/test/e2e/client_options.e2e.test.ts
@@ -467,7 +467,7 @@ describe("Client options", async () => {
         });
         const session = await client.createSession({
             clientName: "advanced-create-client",
-            model: "claude-sonnet-4.5",
+            model: "claude-sonnet-5",
             reasoningEffort: "medium",
             reasoningSummary: "detailed",
             contextTier: "long_context",
@@ -532,7 +532,7 @@ describe("Client options", async () => {
                     provider: "create-provider",
                     id: "create-model",
                     name: "Create Model",
-                    modelId: "claude-sonnet-4.5",
+                    modelId: "claude-sonnet-5",
                     wireModel: "create-wire-model",
                     maxContextWindowTokens: 12_000,
                     maxPromptTokens: 10_000,
@@ -544,7 +544,7 @@ describe("Client options", async () => {
 
         const createRequest = getCapturedRequest(capturePath, "session.create");
         expect(createRequest.clientName).toBe("advanced-create-client");
-        expect(createRequest.model).toBe("claude-sonnet-4.5");
+        expect(createRequest.model).toBe("claude-sonnet-5");
         expect(createRequest.reasoningEffort).toBe("medium");
         expect(createRequest.reasoningSummary).toBe("detailed");
         expect(createRequest.contextTier).toBe("long_context");
@@ -609,7 +609,7 @@ describe("Client options", async () => {
         await client.start();
 
         const session = await client.createSession({
-            model: "claude-sonnet-4.5",
+            model: "claude-sonnet-5",
             provider: {
                 type: "azure",
                 wireApi: "responses",
@@ -619,7 +619,7 @@ describe("Client options", async () => {
                 bearerToken: "provider-bearer-token",
                 azure: { apiVersion: "2024-02-15-preview" },
                 headers: { "X-Provider-Wire": "yes" },
-                modelId: "claude-sonnet-4.5",
+                modelId: "claude-sonnet-5",
                 wireModel: "azure-deployment",
                 maxPromptTokens: 8192,
                 maxOutputTokens: 1024,
@@ -636,7 +636,7 @@ describe("Client options", async () => {
         expect(provider.bearerToken).toBe("provider-bearer-token");
         expect(getObject(provider.azure).apiVersion).toBe("2024-02-15-preview");
         expect(getObject(provider.headers)["X-Provider-Wire"]).toBe("yes");
-        expect(provider.modelId).toBe("claude-sonnet-4.5");
+        expect(provider.modelId).toBe("claude-sonnet-5");
         expect(provider.wireModel).toBe("azure-deployment");
         expect(provider.maxPromptTokens).toBe(8192);
         expect(provider.maxOutputTokens).toBe(1024);

--- a/nodejs/test/e2e/copilot_request_cancel_error.e2e.test.ts
+++ b/nodejs/test/e2e/copilot_request_cancel_error.e2e.test.ts
@@ -56,8 +56,8 @@ function serveNonInference(url: string): Response {
 const MODEL_CATALOG_JSON = JSON.stringify({
     data: [
         {
-            id: "claude-sonnet-4.5",
-            name: "Claude Sonnet 4.5",
+            id: "claude-sonnet-5",
+            name: "Claude Sonnet 5",
             object: "model",
             vendor: "Anthropic",
             version: "1",
@@ -65,7 +65,7 @@ const MODEL_CATALOG_JSON = JSON.stringify({
             model_picker_enabled: true,
             capabilities: {
                 type: "chat",
-                family: "claude-sonnet-4.5",
+                family: "claude-sonnet-5",
                 tokenizer: "o200k_base",
                 limits: { max_context_window_tokens: 200000, max_output_tokens: 8192 },
                 supports: {

--- a/nodejs/test/e2e/copilot_request_handler.e2e.test.ts
+++ b/nodejs/test/e2e/copilot_request_handler.e2e.test.ts
@@ -42,8 +42,8 @@ async function startFakeUpstream(): Promise<{
             sendJson(res, 200, {
                 data: [
                     {
-                        id: "claude-sonnet-4.5",
-                        name: "Claude Sonnet 4.5",
+                        id: "claude-sonnet-5",
+                        name: "Claude Sonnet 5",
                         object: "model",
                         vendor: "Anthropic",
                         version: "1",
@@ -52,7 +52,7 @@ async function startFakeUpstream(): Promise<{
                         supported_endpoints: ["/responses", "ws:/responses"],
                         capabilities: {
                             type: "chat",
-                            family: "claude-sonnet-4.5",
+                            family: "claude-sonnet-5",
                             tokenizer: "o200k_base",
                             limits: {
                                 max_context_window_tokens: 200000,

--- a/nodejs/test/e2e/copilot_request_session_id.e2e.test.ts
+++ b/nodejs/test/e2e/copilot_request_session_id.e2e.test.ts
@@ -171,7 +171,7 @@ const CHAT_COMPLETION_STREAM_EVENTS: string[] = (() => {
         id: "chatcmpl-stub-1",
         object: "chat.completion.chunk",
         created: 1,
-        model: "claude-sonnet-4.5",
+        model: "claude-sonnet-5",
     };
     return [
         `data: ${JSON.stringify({
@@ -210,7 +210,7 @@ const BUFFERED_CHAT_COMPLETION_JSON = JSON.stringify({
     id: "chatcmpl-stub-1",
     object: "chat.completion",
     created: 1,
-    model: "claude-sonnet-4.5",
+    model: "claude-sonnet-5",
     choices: [
         {
             index: 0,
@@ -224,8 +224,8 @@ const BUFFERED_CHAT_COMPLETION_JSON = JSON.stringify({
 const MODEL_CATALOG_JSON = JSON.stringify({
     data: [
         {
-            id: "claude-sonnet-4.5",
-            name: "Claude Sonnet 4.5",
+            id: "claude-sonnet-5",
+            name: "Claude Sonnet 5",
             object: "model",
             vendor: "Anthropic",
             version: "1",
@@ -233,7 +233,7 @@ const MODEL_CATALOG_JSON = JSON.stringify({
             model_picker_enabled: true,
             capabilities: {
                 type: "chat",
-                family: "claude-sonnet-4.5",
+                family: "claude-sonnet-5",
                 tokenizer: "o200k_base",
                 limits: { max_context_window_tokens: 200000, max_output_tokens: 8192 },
                 supports: {
@@ -300,14 +300,14 @@ describe("CopilotRequestHandler threads the runtime session id (CAPI + BYOK)", a
         const session = await client.createSession({
             onPermissionRequest: approveAll,
             // BYOK providers require an explicit model id.
-            model: "claude-sonnet-4.5",
+            model: "claude-sonnet-5",
             provider: {
                 type: "openai",
                 wireApi: "responses",
                 baseUrl: "https://byok.invalid/v1",
                 apiKey: "byok-secret",
-                modelId: "claude-sonnet-4.5",
-                wireModel: "claude-sonnet-4.5",
+                modelId: "claude-sonnet-5",
+                wireModel: "claude-sonnet-5",
             },
         });
         const byokSessionId = session.sessionId;

--- a/nodejs/test/e2e/disabled_mcp_servers.e2e.test.ts
+++ b/nodejs/test/e2e/disabled_mcp_servers.e2e.test.ts
@@ -154,7 +154,7 @@ const CHAT_COMPLETION_STREAM = [
         id: "persisted-session",
         object: "chat.completion.chunk",
         created: 1,
-        model: "claude-sonnet-4.5",
+        model: "claude-sonnet-5",
         choices: [
             {
                 index: 0,
@@ -167,7 +167,7 @@ const CHAT_COMPLETION_STREAM = [
         id: "persisted-session",
         object: "chat.completion.chunk",
         created: 1,
-        model: "claude-sonnet-4.5",
+        model: "claude-sonnet-5",
         choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
     },
 ]
@@ -179,7 +179,7 @@ const CHAT_COMPLETION_RESPONSE_JSON = JSON.stringify({
     id: "persisted-session",
     object: "chat.completion",
     created: 1,
-    model: "claude-sonnet-4.5",
+    model: "claude-sonnet-5",
     choices: [
         {
             index: 0,
@@ -193,8 +193,8 @@ const CHAT_COMPLETION_RESPONSE_JSON = JSON.stringify({
 const MODEL_CATALOG_JSON = JSON.stringify({
     data: [
         {
-            id: "claude-sonnet-4.5",
-            name: "Claude Sonnet 4.5",
+            id: "claude-sonnet-5",
+            name: "Claude Sonnet 5",
             object: "model",
             vendor: "Anthropic",
             version: "1",
@@ -202,7 +202,7 @@ const MODEL_CATALOG_JSON = JSON.stringify({
             model_picker_enabled: true,
             capabilities: {
                 type: "chat",
-                family: "claude-sonnet-4.5",
+                family: "claude-sonnet-5",
                 tokenizer: "o200k_base",
                 limits: { max_context_window_tokens: 200000, max_output_tokens: 8192 },
                 supports: { streaming: true, tool_calls: true, parallel_tool_calls: true },

--- a/nodejs/test/e2e/rewind.e2e.test.ts
+++ b/nodejs/test/e2e/rewind.e2e.test.ts
@@ -30,7 +30,7 @@ describe("Rewind", async () => {
         const filePath = join(workDir, FILE_NAME);
         writeFileSync(filePath, ORIGINAL_FILE_CONTENT);
         const session = await client.createSession({
-            model: "claude-sonnet-4.5",
+            model: "claude-sonnet-5",
             enableFileChangeTracking: true,
             onPermissionRequest: approveAll,
         });

--- a/nodejs/test/e2e/rpc.e2e.test.ts
+++ b/nodejs/test/e2e/rpc.e2e.test.ts
@@ -73,7 +73,7 @@ describe("Session RPC", async () => {
     it.skip("should call session.rpc.model.getCurrent", async () => {
         const session = await client.createSession({
             onPermissionRequest: approveAll,
-            model: "claude-sonnet-4.5",
+            model: "claude-sonnet-5",
         });
 
         const result = await session.rpc.model.getCurrent();
@@ -85,7 +85,7 @@ describe("Session RPC", async () => {
     it.skip("should call session.rpc.model.switchTo", async () => {
         const session = await client.createSession({
             onPermissionRequest: approveAll,
-            model: "claude-sonnet-4.5",
+            model: "claude-sonnet-5",
         });
 
         // Get initial model

--- a/nodejs/test/e2e/rpc_server.e2e.test.ts
+++ b/nodejs/test/e2e/rpc_server.e2e.test.ts
@@ -144,7 +144,7 @@ describe("Server-scoped RPC", async () => {
 
         const result = await authClient.listModels();
         expect(Array.isArray(result)).toBe(true);
-        expect(result.some((m) => m.id === "claude-sonnet-4.5")).toBe(true);
+        expect(result.some((m) => m.id === "claude-sonnet-5")).toBe(true);
         for (const model of result) {
             expect(model.name).toBeTruthy();
         }

--- a/nodejs/test/e2e/rpc_session_state.e2e.test.ts
+++ b/nodejs/test/e2e/rpc_session_state.e2e.test.ts
@@ -40,7 +40,7 @@ describe("Session-scoped RPC", async () => {
     it("should call session rpc model getcurrent", async () => {
         const session = await client.createSession({
             onPermissionRequest: approveAll,
-            model: "claude-sonnet-4.5",
+            model: "claude-sonnet-5",
         });
 
         const result = await session.rpc.model.getCurrent();
@@ -65,7 +65,7 @@ describe("Session-scoped RPC", async () => {
         it("should call session rpc model switchto", async () => {
             const session = await switchClient.createSession({
                 onPermissionRequest: approveAll,
-                model: "claude-sonnet-4.5",
+                model: "claude-sonnet-5",
             });
 
             const before = await session.rpc.model.getCurrent();
@@ -315,14 +315,14 @@ describe("Session-scoped RPC", async () => {
         const branch = `rpc-context-${randomUUID()}`;
         const session = await client.createSession({
             onPermissionRequest: approveAll,
-            model: "claude-sonnet-4.5",
+            model: "claude-sonnet-5",
             workingDirectory: firstDirectory,
         });
         try {
             const initialSnapshot = await session.rpc.metadata.snapshot();
             expect(initialSnapshot.sessionId).toBe(session.sessionId);
             expect(initialSnapshot.currentMode).toBe("interactive");
-            expect(initialSnapshot.selectedModel).toBe("claude-sonnet-4.5");
+            expect(initialSnapshot.selectedModel).toBe("claude-sonnet-5");
             expect(initialSnapshot.isRemote).toBe(false);
             expect(initialSnapshot.alreadyInUse).toBe(false);
             expect(Date.parse(initialSnapshot.startTime)).not.toBeNaN();
@@ -446,7 +446,7 @@ describe("Session-scoped RPC", async () => {
     it("should set reasoning effort and auto name", async () => {
         const session = await client.createSession({
             onPermissionRequest: approveAll,
-            model: "claude-sonnet-4.5",
+            model: "claude-sonnet-5",
         });
         try {
             const reasoning = await session.rpc.model.setReasoningEffort({
@@ -455,7 +455,7 @@ describe("Session-scoped RPC", async () => {
             expect(reasoning.reasoningEffort).toBe("high");
 
             const currentModel = await session.rpc.model.getCurrent();
-            expect(currentModel.modelId).toBe("claude-sonnet-4.5");
+            expect(currentModel.modelId).toBe("claude-sonnet-5");
             expect(currentModel.reasoningEffort).toBe("high");
 
             const autoName = `Auto Session ${randomUUID()}`;
@@ -734,11 +734,11 @@ describe("Session-scoped RPC", async () => {
         const contextInfo = await session.rpc.metadata.contextInfo({
             promptTokenLimit: 128_000,
             outputTokenLimit: 4_096,
-            selectedModel: "claude-sonnet-4.5",
+            selectedModel: "claude-sonnet-5",
         });
         expect(contextInfo.contextInfo).not.toBeNull();
         if (contextInfo.contextInfo) {
-            expect(contextInfo.contextInfo.modelName).toBe("claude-sonnet-4.5");
+            expect(contextInfo.contextInfo.modelName).toBe("claude-sonnet-5");
             expect(contextInfo.contextInfo.promptTokenLimit).toBe(128_000);
             expect(contextInfo.contextInfo.limit).toBeGreaterThanOrEqual(
                 contextInfo.contextInfo.promptTokenLimit
@@ -755,7 +755,7 @@ describe("Session-scoped RPC", async () => {
         }
 
         const recomputed = await session.rpc.metadata.recomputeContextTokens({
-            modelId: "claude-sonnet-4.5",
+            modelId: "claude-sonnet-5",
         });
         expect(recomputed.systemTokenCount).toBeGreaterThan(0);
         expect(recomputed.messagesTokenCount).toBeGreaterThan(0);

--- a/nodejs/test/e2e/rpc_session_state_extras.e2e.test.ts
+++ b/nodejs/test/e2e/rpc_session_state_extras.e2e.test.ts
@@ -70,7 +70,7 @@ describe("Session-scoped state extras RPC", async () => {
         try {
             await authClient.start();
             session = await authClient.createSession({
-                model: "claude-sonnet-4.5",
+                model: "claude-sonnet-5",
                 onPermissionRequest: approveAll,
             });
 
@@ -79,7 +79,7 @@ describe("Session-scoped state extras RPC", async () => {
             expect(Array.isArray(result.list)).toBe(true);
             expect(result.list.length).toBeGreaterThan(0);
             expect(
-                result.list.some((model) => JSON.stringify(model).includes("claude-sonnet-4.5"))
+                result.list.some((model) => JSON.stringify(model).includes("claude-sonnet-5"))
             ).toBe(true);
         } finally {
             await disconnect(session);
@@ -126,7 +126,7 @@ describe("Session-scoped state extras RPC", async () => {
                         provider: providerName,
                         id: modelId,
                         name: "SDK Runtime Model",
-                        modelId: "claude-sonnet-4.5",
+                        modelId: "claude-sonnet-5",
                         wireModel: "wire-sdk-runtime-model",
                         maxContextWindowTokens: 4096,
                         maxPromptTokens: 3072,

--- a/nodejs/test/e2e/session.e2e.test.ts
+++ b/nodejs/test/e2e/session.e2e.test.ts
@@ -98,7 +98,7 @@ describe("Sessions", () => {
     it("should create and disconnect sessions", async () => {
         await using session = await client.createSession({
             onPermissionRequest: approveAll,
-            model: "claude-sonnet-4.5",
+            model: "claude-sonnet-5",
         });
         expect(session.sessionId).toMatch(/^[a-f0-9-]+$/);
 
@@ -107,7 +107,7 @@ describe("Sessions", () => {
         expect(sessionStartEvents).toMatchObject([
             {
                 type: "session.start",
-                data: { sessionId: session.sessionId, selectedModel: "claude-sonnet-4.5" },
+                data: { sessionId: session.sessionId, selectedModel: "claude-sonnet-5" },
             },
         ]);
 

--- a/nodejs/test/e2e/session_config.e2e.test.ts
+++ b/nodejs/test/e2e/session_config.e2e.test.ts
@@ -119,6 +119,7 @@ describe("Session Configuration", async () => {
 
         const session = await client.createSession({
             onPermissionRequest: approveAll,
+            model: "claude-sonnet-4.5",
             modelCapabilities: { supports: { vision: false } },
         });
 
@@ -149,6 +150,7 @@ describe("Session Configuration", async () => {
 
         const session = await client.createSession({
             onPermissionRequest: approveAll,
+            model: "claude-sonnet-4.5",
             modelCapabilities: { supports: { vision: true } },
         });
 

--- a/nodejs/test/e2e/session_config.e2e.test.ts
+++ b/nodejs/test/e2e/session_config.e2e.test.ts
@@ -344,7 +344,7 @@ describe("Session Configuration", async () => {
                         id: "msg_stub_1",
                         type: "message",
                         role: "assistant",
-                        model: "claude-sonnet-4.5",
+                        model: "claude-sonnet-5",
                         content: [],
                         stop_reason: null,
                         stop_sequence: null,
@@ -386,8 +386,8 @@ describe("Session Configuration", async () => {
             return json({
                 data: [
                     {
-                        id: "claude-sonnet-4.5",
-                        name: "Claude Sonnet 4.5",
+                        id: "claude-sonnet-5",
+                        name: "Claude Sonnet 5",
                         object: "model",
                         vendor: "Anthropic",
                         version: "1",
@@ -395,7 +395,7 @@ describe("Session Configuration", async () => {
                         model_picker_enabled: true,
                         capabilities: {
                             type: "chat",
-                            family: "claude-sonnet-4.5",
+                            family: "claude-sonnet-5",
                             tokenizer: "o200k_base",
                             limits: { max_context_window_tokens: 200000, max_output_tokens: 8192 },
                             supports: {
@@ -425,7 +425,7 @@ describe("Session Configuration", async () => {
                 id: "msg_stub_1",
                 type: "message",
                 role: "assistant",
-                model: "claude-sonnet-4.5",
+                model: "claude-sonnet-5",
                 content: [{ type: "text", text: "OK from the synthetic stream." }],
                 stop_reason: "end_turn",
                 stop_sequence: null,
@@ -436,7 +436,7 @@ describe("Session Configuration", async () => {
             id: "chatcmpl-stub-1",
             object: "chat.completion",
             created: 1,
-            model: "claude-sonnet-4.5",
+            model: "claude-sonnet-5",
             choices: [
                 {
                     index: 0,
@@ -464,8 +464,8 @@ describe("Session Configuration", async () => {
             type: "anthropic" as const,
             baseUrl: "https://anthropic-citations.invalid/v1",
             apiKey: "test-provider-key",
-            modelId: "claude-sonnet-4.5",
-            wireModel: "claude-sonnet-4.5",
+            modelId: "claude-sonnet-5",
+            wireModel: "claude-sonnet-5",
         };
     }
 
@@ -565,7 +565,7 @@ describe("Session Configuration", async () => {
         try {
             const session = await citationClient.createSession({
                 onPermissionRequest: approveAll,
-                model: "claude-sonnet-4.5",
+                model: "claude-sonnet-5",
                 enableCitations: true,
                 provider: createAnthropicProvider(),
             });
@@ -609,7 +609,7 @@ describe("Session Configuration", async () => {
             try {
                 const session2 = await resumeClient.resumeSession(session1.sessionId, {
                     onPermissionRequest: approveAll,
-                    model: "claude-sonnet-4.5",
+                    model: "claude-sonnet-5",
                     enableCitations: true,
                     provider: createAnthropicProvider(),
                 });
@@ -713,7 +713,7 @@ describe("Session Configuration", async () => {
     it("should forward custom provider headers on create", async () => {
         const session = await client.createSession({
             onPermissionRequest: approveAll,
-            model: "claude-sonnet-4.5",
+            model: "claude-sonnet-5",
             provider: createProxyProvider("create-provider-header"),
         });
 
@@ -736,7 +736,7 @@ describe("Session Configuration", async () => {
 
         const session2 = await client.resumeSession(sessionId, {
             onPermissionRequest: approveAll,
-            model: "claude-sonnet-4.5",
+            model: "claude-sonnet-5",
             provider: createProxyProvider("resume-provider-header"),
         });
 
@@ -764,7 +764,7 @@ describe("Session Configuration", async () => {
         // tests for serialization coverage).
         const session = await client.createSession({
             onPermissionRequest: approveAll,
-            model: "claude-sonnet-4.5",
+            model: "claude-sonnet-5",
             provider: {
                 type: "openai",
                 baseUrl: openAiEndpoint.url,
@@ -793,7 +793,7 @@ describe("Session Configuration", async () => {
                 type: "openai",
                 baseUrl: openAiEndpoint.url,
                 apiKey: "test-provider-key",
-                modelId: "claude-sonnet-4.5",
+                modelId: "claude-sonnet-5",
             },
         });
 
@@ -801,7 +801,7 @@ describe("Session Configuration", async () => {
 
         const exchanges = await openAiEndpoint.getExchanges();
         expect(exchanges.length).toBe(1);
-        expect(exchanges[0].request.model).toBe("claude-sonnet-4.5");
+        expect(exchanges[0].request.model).toBe("claude-sonnet-5");
 
         await session.disconnect();
     });

--- a/nodejs/test/e2e/session_config.e2e.test.ts
+++ b/nodejs/test/e2e/session_config.e2e.test.ts
@@ -119,7 +119,7 @@ describe("Session Configuration", async () => {
 
         const session = await client.createSession({
             onPermissionRequest: approveAll,
-            model: "claude-sonnet-4.5",
+            model: "claude-sonnet-5",
             modelCapabilities: { supports: { vision: false } },
         });
 
@@ -130,7 +130,7 @@ describe("Session Configuration", async () => {
         expect(hasImageUrlContent(t1Messages)).toBe(false);
 
         // Switch vision on (re-specify same model with updated capabilities)
-        await session.setModel("claude-sonnet-4.5", {
+        await session.setModel("claude-sonnet-5", {
             modelCapabilities: { supports: { vision: true } },
         });
 
@@ -150,7 +150,7 @@ describe("Session Configuration", async () => {
 
         const session = await client.createSession({
             onPermissionRequest: approveAll,
-            model: "claude-sonnet-4.5",
+            model: "claude-sonnet-5",
             modelCapabilities: { supports: { vision: true } },
         });
 
@@ -161,7 +161,7 @@ describe("Session Configuration", async () => {
         expect(hasImageUrlContent(t1Messages)).toBe(true);
 
         // Switch vision off
-        await session.setModel("claude-sonnet-4.5", {
+        await session.setModel("claude-sonnet-5", {
             modelCapabilities: { supports: { vision: false } },
         });
 

--- a/python/e2e/_copilot_request_helpers.py
+++ b/python/e2e/_copilot_request_helpers.py
@@ -58,8 +58,8 @@ def _wants_stream(body: bytes) -> bool:
 def model_catalog(supported_endpoints: list[str] | None = None) -> dict:
     """The synthetic ``/models`` catalog payload."""
     model: dict = {
-        "id": "claude-sonnet-4.5",
-        "name": "Claude Sonnet 4.5",
+        "id": "claude-sonnet-5",
+        "name": "Claude Sonnet 5",
         "object": "model",
         "vendor": "Anthropic",
         "version": "1",
@@ -67,7 +67,7 @@ def model_catalog(supported_endpoints: list[str] | None = None) -> dict:
         "model_picker_enabled": True,
         "capabilities": {
             "type": "chat",
-            "family": "claude-sonnet-4.5",
+            "family": "claude-sonnet-5",
             "tokenizer": "o200k_base",
             "limits": {"max_context_window_tokens": 200000, "max_output_tokens": 8192},
             "supports": {
@@ -191,7 +191,7 @@ def build_inference_response(request: httpx.Request, text: str = SYNTHETIC_TEXT)
             "id": "chatcmpl-stub-1",
             "object": "chat.completion.chunk",
             "created": 1,
-            "model": "claude-sonnet-4.5",
+            "model": "claude-sonnet-5",
         }
         chunks = [
             {
@@ -234,7 +234,7 @@ def build_inference_response(request: httpx.Request, text: str = SYNTHETIC_TEXT)
                             "id": "msg_stub_1",
                             "type": "message",
                             "role": "assistant",
-                            "model": "claude-sonnet-4.5",
+                            "model": "claude-sonnet-5",
                             "content": [],
                             "stop_reason": None,
                             "stop_sequence": None,
@@ -283,7 +283,7 @@ def build_inference_response(request: httpx.Request, text: str = SYNTHETIC_TEXT)
                     "id": "msg_stub_1",
                     "type": "message",
                     "role": "assistant",
-                    "model": "claude-sonnet-4.5",
+                    "model": "claude-sonnet-5",
                     "content": [{"type": "text", "text": text}],
                     "stop_reason": "end_turn",
                     "stop_sequence": None,
@@ -300,7 +300,7 @@ def build_inference_response(request: httpx.Request, text: str = SYNTHETIC_TEXT)
                 "id": "chatcmpl-stub-1",
                 "object": "chat.completion",
                 "created": 1,
-                "model": "claude-sonnet-4.5",
+                "model": "claude-sonnet-5",
                 "choices": [
                     {
                         "index": 0,

--- a/python/e2e/test_client_options_e2e.py
+++ b/python/e2e/test_client_options_e2e.py
@@ -396,7 +396,7 @@ class TestClientOptions:
             await client.start()
             session = await client.create_session(
                 client_name="advanced-create-client",
-                model="claude-sonnet-4.5",
+                model="claude-sonnet-5",
                 reasoning_effort="medium",
                 reasoning_summary="detailed",
                 context_tier="long_context",
@@ -470,7 +470,7 @@ class TestClientOptions:
                         "provider": "create-provider",
                         "id": "create-model",
                         "name": "Create Model",
-                        "model_id": "claude-sonnet-4.5",
+                        "model_id": "claude-sonnet-5",
                         "wire_model": "create-wire-model",
                         "max_context_window_tokens": 12_000,
                         "max_prompt_tokens": 10_000,
@@ -482,7 +482,7 @@ class TestClientOptions:
             try:
                 params = _get_captured_request(capture_path, "session.create")
                 assert params["clientName"] == "advanced-create-client"
-                assert params["model"] == "claude-sonnet-4.5"
+                assert params["model"] == "claude-sonnet-5"
                 assert params["reasoningEffort"] == "medium"
                 assert params["reasoningSummary"] == "detailed"
                 assert params["contextTier"] == "long_context"
@@ -538,7 +538,7 @@ class TestClientOptions:
         try:
             await client.start()
             session = await client.create_session(
-                model="claude-sonnet-4.5",
+                model="claude-sonnet-5",
                 provider={
                     "type": "azure",
                     "wire_api": "responses",
@@ -548,7 +548,7 @@ class TestClientOptions:
                     "bearer_token": "provider-bearer-token",
                     "azure": {"api_version": "2024-02-15-preview"},
                     "headers": {"X-Provider-Wire": "yes"},
-                    "model_id": "claude-sonnet-4.5",
+                    "model_id": "claude-sonnet-5",
                     "wire_model": "azure-deployment",
                     "max_prompt_tokens": 8192,
                     "max_output_tokens": 1024,
@@ -565,7 +565,7 @@ class TestClientOptions:
                 assert provider["bearerToken"] == "provider-bearer-token"
                 assert provider["azure"]["apiVersion"] == "2024-02-15-preview"
                 assert provider["headers"]["X-Provider-Wire"] == "yes"
-                assert provider["modelId"] == "claude-sonnet-4.5"
+                assert provider["modelId"] == "claude-sonnet-5"
                 assert provider["wireModel"] == "azure-deployment"
                 assert provider["maxPromptTokens"] == 8192
                 assert provider["maxOutputTokens"] == 1024

--- a/python/e2e/test_copilot_request_session_id_e2e.py
+++ b/python/e2e/test_copilot_request_session_id_e2e.py
@@ -105,14 +105,14 @@ class TestCopilotRequestSessionId:
         baseline = len(handler.records)
         session = await client.create_session(
             on_permission_request=PermissionHandler.approve_all,
-            model="claude-sonnet-4.5",
+            model="claude-sonnet-5",
             provider={
                 "type": "openai",
                 "wire_api": "responses",
                 "base_url": "https://byok.invalid/v1",
                 "api_key": "byok-secret",
-                "model_id": "claude-sonnet-4.5",
-                "wire_model": "claude-sonnet-4.5",
+                "model_id": "claude-sonnet-5",
+                "wire_model": "claude-sonnet-5",
             },
         )
         byok_session_id = session.session_id

--- a/python/e2e/test_rewind_e2e.py
+++ b/python/e2e/test_rewind_e2e.py
@@ -35,7 +35,7 @@ class TestRewind:
         file_path = Path(ctx.work_dir) / FILE_NAME
         file_path.write_text(ORIGINAL_FILE_CONTENT, encoding="utf-8")
         session = await ctx.client.create_session(
-            model="claude-sonnet-4.5",
+            model="claude-sonnet-5",
             enable_file_change_tracking=True,
             on_permission_request=PermissionHandler.approve_all,
         )

--- a/python/e2e/test_rpc_e2e.py
+++ b/python/e2e/test_rpc_e2e.py
@@ -82,7 +82,7 @@ class TestSessionRpc:
     async def test_should_call_session_rpc_model_get_current(self, ctx: E2ETestContext):
         """Test calling session.rpc.model.getCurrent"""
         session = await ctx.client.create_session(
-            on_permission_request=PermissionHandler.approve_all, model="claude-sonnet-4.5"
+            on_permission_request=PermissionHandler.approve_all, model="claude-sonnet-5"
         )
 
         result = await session.rpc.model.get_current()
@@ -96,7 +96,7 @@ class TestSessionRpc:
         from copilot.rpc import ModelSwitchToRequest
 
         session = await ctx.client.create_session(
-            on_permission_request=PermissionHandler.approve_all, model="claude-sonnet-4.5"
+            on_permission_request=PermissionHandler.approve_all, model="claude-sonnet-5"
         )
 
         # Get initial model

--- a/python/e2e/test_rpc_server_e2e.py
+++ b/python/e2e/test_rpc_server_e2e.py
@@ -183,7 +183,7 @@ class TestRpcServer:
             await client.start()
             result = await client.rpc.models.list(ModelsListRequest())
             assert result.models is not None
-            assert any(model.id == "claude-sonnet-4.5" for model in result.models)
+            assert any(model.id == "claude-sonnet-5" for model in result.models)
             assert all((model.name or "").strip() for model in result.models)
         finally:
             try:

--- a/python/e2e/test_rpc_session_state_e2e.py
+++ b/python/e2e/test_rpc_session_state_e2e.py
@@ -104,7 +104,7 @@ class TestRpcSessionState:
     async def test_should_call_session_rpc_model_get_current(self, ctx: E2ETestContext):
         session = await ctx.client.create_session(
             on_permission_request=PermissionHandler.approve_all,
-            model="claude-sonnet-4.5",
+            model="claude-sonnet-5",
         )
         try:
             result = await session.rpc.model.get_current()
@@ -128,7 +128,7 @@ class TestRpcSessionState:
             )
             session = await isolated_ctx.client.create_session(
                 on_permission_request=PermissionHandler.approve_all,
-                model="claude-sonnet-4.5",
+                model="claude-sonnet-5",
             )
             try:
                 before = await session.rpc.model.get_current()
@@ -264,13 +264,13 @@ class TestRpcSessionState:
 
         session = await ctx.client.create_session(
             on_permission_request=PermissionHandler.approve_all,
-            model="claude-sonnet-4.5",
+            model="claude-sonnet-5",
             working_directory=first_dir,
         )
         try:
             snapshot = await session.rpc.metadata.snapshot()
             assert snapshot.session_id == session.session_id
-            assert snapshot.selected_model == "claude-sonnet-4.5"
+            assert snapshot.selected_model == "claude-sonnet-5"
             assert snapshot.is_remote is False
             assert snapshot.already_in_use is False
             assert _path_equals(first_dir, snapshot.working_directory)
@@ -395,7 +395,7 @@ class TestRpcSessionState:
     async def test_should_set_reasoning_effort_and_auto_name(self, ctx: E2ETestContext):
         session = await ctx.client.create_session(
             on_permission_request=PermissionHandler.approve_all,
-            model="claude-sonnet-4.5",
+            model="claude-sonnet-5",
         )
         try:
             reasoning = await session.rpc.model.set_reasoning_effort(
@@ -403,7 +403,7 @@ class TestRpcSessionState:
             )
             assert reasoning.reasoning_effort == "high"
             current = await session.rpc.model.get_current()
-            assert current.model_id == "claude-sonnet-4.5"
+            assert current.model_id == "claude-sonnet-5"
             assert current.reasoning_effort == "high"
 
             auto_name = f"Auto Session {uuid.uuid4().hex}"
@@ -637,12 +637,12 @@ class TestRpcSessionState:
                 MetadataContextInfoRequest(
                     prompt_token_limit=128_000,
                     output_token_limit=4_096,
-                    selected_model="claude-sonnet-4.5",
+                    selected_model="claude-sonnet-5",
                 )
             )
             if context_info.context_info is not None:
                 context = context_info.context_info
-                assert context.model_name == "claude-sonnet-4.5"
+                assert context.model_name == "claude-sonnet-5"
                 assert context.prompt_token_limit == 128_000
                 assert context.limit >= context.prompt_token_limit
                 assert context.total_tokens > 0
@@ -657,7 +657,7 @@ class TestRpcSessionState:
                 )
 
             recomputed = await session.rpc.metadata.recompute_context_tokens(
-                MetadataRecomputeContextTokensRequest(model_id="claude-sonnet-4.5")
+                MetadataRecomputeContextTokensRequest(model_id="claude-sonnet-5")
             )
             assert recomputed.system_token_count > 0
             assert recomputed.messages_token_count > 0

--- a/python/e2e/test_rpc_session_state_extras_e2e.py
+++ b/python/e2e/test_rpc_session_state_extras_e2e.py
@@ -86,8 +86,7 @@ class TestRpcSessionStateExtras:
                 assert result.list is not None
                 assert len(result.list) > 0
                 assert any(
-                    "claude-sonnet-5" in json.dumps(model, sort_keys=True)
-                    for model in result.list
+                    "claude-sonnet-5" in json.dumps(model, sort_keys=True) for model in result.list
                 )
         finally:
             await _stop_client(client)

--- a/python/e2e/test_rpc_session_state_extras_e2e.py
+++ b/python/e2e/test_rpc_session_state_extras_e2e.py
@@ -77,7 +77,7 @@ class TestRpcSessionStateExtras:
         client = _make_authed_client(ctx, token)
         try:
             async with await client.create_session(
-                model="claude-sonnet-4.5",
+                model="claude-sonnet-5",
                 on_permission_request=PermissionHandler.approve_all,
                 github_token=token,
             ) as session:
@@ -86,7 +86,7 @@ class TestRpcSessionStateExtras:
                 assert result.list is not None
                 assert len(result.list) > 0
                 assert any(
-                    "claude-sonnet-4.5" in json.dumps(model, sort_keys=True)
+                    "claude-sonnet-5" in json.dumps(model, sort_keys=True)
                     for model in result.list
                 )
         finally:
@@ -126,7 +126,7 @@ class TestRpcSessionStateExtras:
                             provider=provider_name,
                             id=model_id,
                             name="SDK Runtime Model",
-                            model_id="claude-sonnet-4.5",
+                            model_id="claude-sonnet-5",
                             wire_model="wire-sdk-runtime-model",
                             max_context_window_tokens=4096,
                             max_prompt_tokens=3072,

--- a/python/e2e/test_session_config_e2e.py
+++ b/python/e2e/test_session_config_e2e.py
@@ -201,6 +201,7 @@ class TestSessionConfig:
 
         session = await ctx.client.create_session(
             on_permission_request=PermissionHandler.approve_all,
+            model="claude-sonnet-4.5",
             model_capabilities=ModelCapabilitiesOverride(
                 supports=ModelSupportsOverride(vision=False)
             ),
@@ -234,6 +235,7 @@ class TestSessionConfig:
 
         session = await ctx.client.create_session(
             on_permission_request=PermissionHandler.approve_all,
+            model="claude-sonnet-4.5",
             model_capabilities=ModelCapabilitiesOverride(
                 supports=ModelSupportsOverride(vision=True)
             ),

--- a/python/e2e/test_session_config_e2e.py
+++ b/python/e2e/test_session_config_e2e.py
@@ -201,7 +201,7 @@ class TestSessionConfig:
 
         session = await ctx.client.create_session(
             on_permission_request=PermissionHandler.approve_all,
-            model="claude-sonnet-4.5",
+            model="claude-sonnet-5",
             model_capabilities=ModelCapabilitiesOverride(
                 supports=ModelSupportsOverride(vision=False)
             ),
@@ -214,7 +214,7 @@ class TestSessionConfig:
 
         # Switch vision on
         await session.set_model(
-            "claude-sonnet-4.5",
+            "claude-sonnet-5",
             model_capabilities=ModelCapabilitiesOverride(
                 supports=ModelSupportsOverride(vision=True)
             ),
@@ -235,7 +235,7 @@ class TestSessionConfig:
 
         session = await ctx.client.create_session(
             on_permission_request=PermissionHandler.approve_all,
-            model="claude-sonnet-4.5",
+            model="claude-sonnet-5",
             model_capabilities=ModelCapabilitiesOverride(
                 supports=ModelSupportsOverride(vision=True)
             ),
@@ -248,7 +248,7 @@ class TestSessionConfig:
 
         # Switch vision off
         await session.set_model(
-            "claude-sonnet-4.5",
+            "claude-sonnet-5",
             model_capabilities=ModelCapabilitiesOverride(
                 supports=ModelSupportsOverride(vision=False)
             ),

--- a/python/e2e/test_session_config_e2e.py
+++ b/python/e2e/test_session_config_e2e.py
@@ -167,8 +167,8 @@ def _create_anthropic_provider() -> dict:
         "type": "anthropic",
         "base_url": "https://anthropic-citations.invalid/v1",
         "api_key": "test-provider-key",
-        "model_id": "claude-sonnet-4.5",
-        "wire_model": "claude-sonnet-4.5",
+        "model_id": "claude-sonnet-5",
+        "wire_model": "claude-sonnet-5",
     }
 
 
@@ -297,7 +297,7 @@ class TestSessionConfig:
     async def test_should_forward_custom_provider_headers_on_create(self, ctx: E2ETestContext):
         session = await ctx.client.create_session(
             on_permission_request=PermissionHandler.approve_all,
-            model="claude-sonnet-4.5",
+            model="claude-sonnet-5",
             provider=_make_proxy_provider(ctx.proxy_url, "create-provider-header"),
         )
 
@@ -321,7 +321,7 @@ class TestSessionConfig:
         session2 = await ctx.client.resume_session(
             session_id,
             on_permission_request=PermissionHandler.approve_all,
-            model="claude-sonnet-4.5",
+            model="claude-sonnet-5",
             provider=_make_proxy_provider(ctx.proxy_url, "resume-provider-header"),
         )
 
@@ -347,7 +347,7 @@ class TestSessionConfig:
         # it directly (see unit tests for serialization coverage).
         session = await ctx.client.create_session(
             on_permission_request=PermissionHandler.approve_all,
-            model="claude-sonnet-4.5",
+            model="claude-sonnet-5",
             provider={
                 "type": "openai",
                 "base_url": ctx.proxy_url,
@@ -376,7 +376,7 @@ class TestSessionConfig:
                 "type": "openai",
                 "base_url": ctx.proxy_url,
                 "api_key": "test-provider-key",
-                "model_id": "claude-sonnet-4.5",
+                "model_id": "claude-sonnet-5",
             },
         )
 
@@ -384,7 +384,7 @@ class TestSessionConfig:
 
         exchanges = await ctx.get_exchanges()
         assert len(exchanges) == 1
-        assert exchanges[0]["request"]["model"] == "claude-sonnet-4.5"
+        assert exchanges[0]["request"]["model"] == "claude-sonnet-5"
 
         await session.disconnect()
 
@@ -475,7 +475,7 @@ class TestSessionConfig:
         try:
             session = await client.create_session(
                 on_permission_request=PermissionHandler.approve_all,
-                model="claude-sonnet-4.5",
+                model="claude-sonnet-5",
                 enable_citations=True,
                 provider=_create_anthropic_provider(),
             )
@@ -523,7 +523,7 @@ class TestSessionConfig:
                 session2 = await resume_client.resume_session(
                     session1.session_id,
                     on_permission_request=PermissionHandler.approve_all,
-                    model="claude-sonnet-4.5",
+                    model="claude-sonnet-5",
                     enable_citations=True,
                     provider=_create_anthropic_provider(),
                 )

--- a/python/e2e/test_session_e2e.py
+++ b/python/e2e/test_session_e2e.py
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.asyncio(loop_scope="module")
 class TestSessions:
     async def test_should_create_and_disconnect_sessions(self, ctx: E2ETestContext):
         session = await ctx.client.create_session(
-            on_permission_request=PermissionHandler.approve_all, model="claude-sonnet-4.5"
+            on_permission_request=PermissionHandler.approve_all, model="claude-sonnet-5"
         )
         assert session.session_id
 
@@ -33,7 +33,7 @@ class TestSessions:
         assert len(messages) > 0
         assert messages[0].type.value == "session.start"
         assert messages[0].data.session_id == session.session_id
-        assert messages[0].data.selected_model == "claude-sonnet-4.5"
+        assert messages[0].data.selected_model == "claude-sonnet-5"
 
         await session.disconnect()
 

--- a/rust/tests/e2e/client.rs
+++ b/rust/tests/e2e/client.rs
@@ -120,7 +120,7 @@ async fn should_list_models_when_authenticated() {
             let models = client.list_models().await.expect("list models");
 
             assert!(
-                models.iter().any(|model| model.id == "claude-sonnet-4.5"),
+                models.iter().any(|model| model.id == "claude-sonnet-5"),
                 "expected default replay model in {models:?}"
             );
 

--- a/rust/tests/e2e/client_options.rs
+++ b/rust/tests/e2e/client_options.rs
@@ -27,7 +27,7 @@ async fn should_forward_advanced_session_creation_options_to_the_cli() {
             SessionConfig::default()
                 .with_session_id("advanced-session-id")
                 .with_client_name("rust-sdk-e2e-client")
-                .with_model("claude-sonnet-4.5")
+                .with_model("claude-sonnet-5")
                 .with_reasoning_effort("low")
                 .with_reasoning_summary(ReasoningSummary::None)
                 .with_context_tier("long_context")
@@ -90,7 +90,7 @@ async fn should_forward_advanced_session_creation_options_to_the_cli() {
         [
             ("sessionId", json!("advanced-session-id")),
             ("clientName", json!("rust-sdk-e2e-client")),
-            ("model", json!("claude-sonnet-4.5")),
+            ("model", json!("claude-sonnet-5")),
             ("reasoningEffort", json!("low")),
             ("reasoningSummary", json!("none")),
             ("contextTier", json!("long_context")),

--- a/rust/tests/e2e/copilot_request_handler.rs
+++ b/rust/tests/e2e/copilot_request_handler.rs
@@ -101,8 +101,8 @@ fn sse(event_type: &str, data: &Value) -> String {
 
 fn model_catalog(supported_endpoints: Option<&[&str]>) -> String {
     let mut model = json!({
-        "id": "claude-sonnet-4.5",
-        "name": "Claude Sonnet 4.5",
+        "id": "claude-sonnet-5",
+        "name": "Claude Sonnet 5",
         "object": "model",
         "vendor": "Anthropic",
         "version": "1",
@@ -110,7 +110,7 @@ fn model_catalog(supported_endpoints: Option<&[&str]>) -> String {
         "model_picker_enabled": true,
         "capabilities": {
             "type": "chat",
-            "family": "claude-sonnet-4.5",
+            "family": "claude-sonnet-5",
             "tokenizer": "o200k_base",
             "limits": {
                 "max_context_window_tokens": 200000,
@@ -232,7 +232,7 @@ fn synth_inference_response(url: &str, body: &[u8], text: &str) -> CopilotHttpRe
                 "id": "chatcmpl-stub-1",
                 "object": "chat.completion.chunk",
                 "created": 1,
-                "model": "claude-sonnet-4.5",
+                "model": "claude-sonnet-5",
             })
         };
         let mut c1 = base();
@@ -257,7 +257,7 @@ fn synth_inference_response(url: &str, body: &[u8], text: &str) -> CopilotHttpRe
         "id": "chatcmpl-stub-1",
         "object": "chat.completion",
         "created": 1,
-        "model": "claude-sonnet-4.5",
+        "model": "claude-sonnet-5",
         "choices": [{
             "index": 0,
             "message": { "role": "assistant", "content": text },
@@ -668,14 +668,14 @@ async fn threads_session_id_into_inference() {
             let before = handler.inference_records().len();
             let byok_config = SessionConfig::default()
                 .with_permission_handler(Arc::new(ApproveAllHandler))
-                .with_model("claude-sonnet-4.5")
+                .with_model("claude-sonnet-5")
                 .with_provider(
                     ProviderConfig::new("https://byok.invalid/v1")
                         .with_provider_type("openai")
                         .with_wire_api("responses")
                         .with_api_key("byok-secret")
-                        .with_model_id("claude-sonnet-4.5")
-                        .with_wire_model("claude-sonnet-4.5"),
+                        .with_model_id("claude-sonnet-5")
+                        .with_wire_model("claude-sonnet-5"),
                 );
             let byok_session = client
                 .create_session(byok_config)

--- a/rust/tests/e2e/rewind.rs
+++ b/rust/tests/e2e/rewind.rs
@@ -28,7 +28,7 @@ async fn should_restore_tracked_file_and_conversation() {
                 let session = client
                     .create_session(
                         ctx.approve_all_session_config()
-                            .with_model("claude-sonnet-4.5")
+                            .with_model("claude-sonnet-5")
                             .with_enable_file_change_tracking(true),
                     )
                     .await

--- a/rust/tests/e2e/rpc_server.rs
+++ b/rust/tests/e2e/rpc_server.rs
@@ -70,7 +70,7 @@ async fn should_call_rpc_models_list_with_typed_result() {
                     result
                         .models
                         .iter()
-                        .any(|model| model.id == "claude-sonnet-4.5")
+                        .any(|model| model.id == "claude-sonnet-5")
                 );
                 assert!(result.models.iter().all(|model| !model.name.is_empty()));
                 client.stop().await.expect("stop client");

--- a/rust/tests/e2e/rpc_session_state.rs
+++ b/rust/tests/e2e/rpc_session_state.rs
@@ -27,7 +27,7 @@ use super::support::{
     assistant_message_content, recv_with_timeout, wait_for_condition, wait_for_event,
 };
 
-const MODEL_ID: &str = "claude-sonnet-4.5";
+const MODEL_ID: &str = "claude-sonnet-5";
 
 #[tokio::test]
 async fn should_call_session_rpc_model_getcurrent() {

--- a/rust/tests/e2e/rpc_session_state_extras.rs
+++ b/rust/tests/e2e/rpc_session_state_extras.rs
@@ -12,7 +12,7 @@ use github_copilot_sdk::session_events::PermissionMode;
 
 use super::support::{assistant_message_content, with_e2e_context};
 
-const MODEL_ID: &str = "claude-sonnet-4.5";
+const MODEL_ID: &str = "claude-sonnet-5";
 
 #[tokio::test]
 async fn should_list_models_for_session() {

--- a/rust/tests/e2e/session.rs
+++ b/rust/tests/e2e/session.rs
@@ -37,7 +37,7 @@ async fn shouldcreateanddisconnectsessions() {
                 let session = client
                     .create_session(
                         ctx.approve_all_session_config()
-                            .with_model("claude-sonnet-4.5"),
+                            .with_model("claude-sonnet-5"),
                     )
                     .await
                     .expect("create session");

--- a/rust/tests/e2e/session_config.rs
+++ b/rust/tests/e2e/session_config.rs
@@ -362,7 +362,7 @@ fn anthropic_message_stream_body(text: &str) -> String {
                     "id": "msg_stub_1",
                     "type": "message",
                     "role": "assistant",
-                    "model": "claude-sonnet-4.5",
+                    "model": "claude-sonnet-5",
                     "content": [],
                     "stop_reason": null,
                     "stop_sequence": null,
@@ -414,8 +414,8 @@ fn synth_non_inference_response(url: &str) -> CopilotHttpResponse {
             json_headers(),
             json!({
                 "data": [{
-                    "id": "claude-sonnet-4.5",
-                    "name": "Claude Sonnet 4.5",
+                    "id": "claude-sonnet-5",
+                    "name": "Claude Sonnet 5",
                     "object": "model",
                     "vendor": "Anthropic",
                     "version": "1",
@@ -423,7 +423,7 @@ fn synth_non_inference_response(url: &str) -> CopilotHttpResponse {
                     "model_picker_enabled": true,
                     "capabilities": {
                         "type": "chat",
-                        "family": "claude-sonnet-4.5",
+                        "family": "claude-sonnet-5",
                         "tokenizer": "o200k_base",
                         "limits": {
                             "max_context_window_tokens": 200000,
@@ -459,7 +459,7 @@ fn synth_inference_response(url: &str, body: &[u8]) -> CopilotHttpResponse {
                 "id": "msg_stub_1",
                 "type": "message",
                 "role": "assistant",
-                "model": "claude-sonnet-4.5",
+                "model": "claude-sonnet-5",
                 "content": [{ "type": "text", "text": SYNTHETIC_TEXT }],
                 "stop_reason": "end_turn",
                 "stop_sequence": null,
@@ -474,7 +474,7 @@ fn synth_inference_response(url: &str, body: &[u8]) -> CopilotHttpResponse {
             "id": "chatcmpl-stub-1",
             "object": "chat.completion",
             "created": 1,
-            "model": "claude-sonnet-4.5",
+            "model": "claude-sonnet-5",
             "choices": [{
                 "index": 0,
                 "message": { "role": "assistant", "content": SYNTHETIC_TEXT },
@@ -489,8 +489,8 @@ fn anthropic_provider() -> ProviderConfig {
     ProviderConfig::new("https://anthropic-citations.invalid/v1")
         .with_provider_type("anthropic")
         .with_api_key("test-provider-key")
-        .with_model_id("claude-sonnet-4.5")
-        .with_wire_model("claude-sonnet-4.5")
+        .with_model_id("claude-sonnet-5")
+        .with_wire_model("claude-sonnet-5")
 }
 
 fn pdf_attachment() -> Attachment {
@@ -532,7 +532,7 @@ async fn should_enable_citations_for_anthropic_file_attachments_on_create() {
                 .create_session(
                     SessionConfig::default()
                         .with_permission_handler(Arc::new(ApproveAllHandler))
-                        .with_model("claude-sonnet-4.5")
+                        .with_model("claude-sonnet-5")
                         .with_enable_citations(true)
                         .with_provider(anthropic_provider()),
                 )
@@ -592,7 +592,7 @@ async fn should_enable_citations_for_anthropic_file_attachments_on_resume() {
                 .resume_session(
                     ResumeSessionConfig::new(session1.id().clone())
                         .with_permission_handler(Arc::new(ApproveAllHandler))
-                        .with_model("claude-sonnet-4.5")
+                        .with_model("claude-sonnet-5")
                         .with_enable_citations(true)
                         .with_provider(anthropic_provider()),
                 )

--- a/test/harness/modelProtocolAdapters.test.ts
+++ b/test/harness/modelProtocolAdapters.test.ts
@@ -42,7 +42,7 @@ const endpoints: Record<ReplayBackend, string> = {
 
 const models: Record<ReplayBackend, string> = {
   capi: "gpt-4.1",
-  "anthropic-messages": "claude-sonnet-4.5",
+  "anthropic-messages": "claude-sonnet-5",
   "openai-responses": "gpt-4.1",
   "openai-completions": "gpt-4.1",
 };

--- a/test/harness/replayingCapiProxy.test.ts
+++ b/test/harness/replayingCapiProxy.test.ts
@@ -1594,22 +1594,22 @@ Always include PINEAPPLE_COCONUT_42.
     test.each([
       {
         storedModels: undefined,
-        expected: ["claude-sonnet-5", "claude-sonnet-4.5"],
+        expected: ["claude-sonnet-5"],
       },
       {
         storedModels: [],
-        expected: ["claude-sonnet-5", "claude-sonnet-4.5"],
+        expected: ["claude-sonnet-5"],
       },
       {
-        storedModels: ["claude-sonnet-4.5"],
-        expected: ["claude-sonnet-5", "claude-sonnet-4.5"],
+        storedModels: ["claude-sonnet-5"],
+        expected: ["claude-sonnet-5"],
       },
       {
-        storedModels: ["claude-sonnet-5", "claude-sonnet-4.5"],
-        expected: ["claude-sonnet-5", "claude-sonnet-4.5"],
+        storedModels: ["custom-provider-model"],
+        expected: ["custom-provider-model"],
       },
     ])(
-      "advertises the current default for $storedModels",
+      "uses the stored catalog or the default for $storedModels",
       async ({ storedModels, expected }) => {
         const cachePath = path.join(tempDir, "cache.yaml");
         if (storedModels !== undefined) {
@@ -1644,14 +1644,14 @@ Always include PINEAPPLE_COCONUT_42.
       },
     );
 
-    test.each(["claude-sonnet-5", "claude-sonnet-4.5"])(
-      "replays historical conversations with requested model %s",
+    test.each(["claude-sonnet-5", "custom-provider-model"])(
+      "replays model-independent conversations with requested model %s",
       async (model) => {
         const cachePath = path.join(tempDir, "cache.yaml");
         await writeFile(
           cachePath,
           yaml.stringify({
-            models: ["claude-sonnet-4.5"],
+            models: ["claude-sonnet-5"],
             conversations: [
               {
                 messages: [
@@ -1683,7 +1683,7 @@ Always include PINEAPPLE_COCONUT_42.
       },
     );
 
-    test("preserves explicit catalogs without the historical default", async () => {
+    test("preserves explicit catalogs without adding the default", async () => {
       const cachePath = path.join(tempDir, "cache.yaml");
       const cacheContent = yaml.stringify({
         models: ["gpt-4o", "claude-sonnet-4"],

--- a/test/harness/replayingCapiProxy.test.ts
+++ b/test/harness/replayingCapiProxy.test.ts
@@ -1591,32 +1591,15 @@ Always include PINEAPPLE_COCONUT_42.
       }
     });
 
-    test.each([
-      {
-        storedModels: undefined,
-        expected: ["claude-sonnet-5"],
-      },
-      {
-        storedModels: [],
-        expected: ["claude-sonnet-5"],
-      },
-      {
-        storedModels: ["claude-sonnet-5"],
-        expected: ["claude-sonnet-5"],
-      },
-      {
-        storedModels: ["custom-provider-model"],
-        expected: ["custom-provider-model"],
-      },
-    ])(
-      "uses the stored catalog or the default for $storedModels",
-      async ({ storedModels, expected }) => {
+    test.each([false, true])(
+      "defaults to Sonnet 5 without stored models (capture exists: %s)",
+      async (captureExists) => {
         const cachePath = path.join(tempDir, "cache.yaml");
-        if (storedModels !== undefined) {
+        if (captureExists) {
           await writeFile(
             cachePath,
             yaml.stringify({
-              models: storedModels,
+              models: [],
               conversations: [],
             } satisfies NormalizedData),
           );
@@ -1637,53 +1620,14 @@ Always include PINEAPPLE_COCONUT_42.
           const parsed = JSON.parse(response.body) as {
             data: Array<{ id: string }>;
           };
-          expect(parsed.data.map((model) => model.id)).toEqual(expected);
+          expect(parsed.data.map((model) => model.id)).toEqual(["claude-sonnet-5"]);
         } finally {
           await proxy.stop();
         }
       },
     );
 
-    test.each(["claude-sonnet-5", "custom-provider-model"])(
-      "replays model-independent conversations with requested model %s",
-      async (model) => {
-        const cachePath = path.join(tempDir, "cache.yaml");
-        await writeFile(
-          cachePath,
-          yaml.stringify({
-            models: ["claude-sonnet-5"],
-            conversations: [
-              {
-                messages: [
-                  { role: "user", content: "Hello" },
-                  { role: "assistant", content: "Hi there!" },
-                ],
-              },
-            ],
-          } satisfies NormalizedData),
-        );
-        const proxy = new ReplayingCapiProxy(
-          "http://localhost:9999",
-          cachePath,
-          workDir,
-        );
-        const proxyUrl = await proxy.start();
-
-        try {
-          const response = await makeRequest(proxyUrl, "/chat/completions", {
-            body: { model, messages: [{ role: "user", content: "Hello" }] },
-          });
-          expect(response.status).toBe(200);
-          const parsed = JSON.parse(response.body) as ChatCompletion;
-          expect(parsed.model).toBe(model);
-          expect(parsed.choices[0].message.content).toBe("Hi there!");
-        } finally {
-          await proxy.stop(true);
-        }
-      },
-    );
-
-    test("preserves explicit catalogs without adding the default", async () => {
+    test("returns cached models for /models endpoint", async () => {
       const cachePath = path.join(tempDir, "cache.yaml");
       const cacheContent = yaml.stringify({
         models: ["gpt-4o", "claude-sonnet-4"],

--- a/test/harness/replayingCapiProxy.test.ts
+++ b/test/harness/replayingCapiProxy.test.ts
@@ -1592,8 +1592,14 @@ Always include PINEAPPLE_COCONUT_42.
     });
 
     test.each([
-      { storedModels: undefined, expected: ["claude-sonnet-5"] },
-      { storedModels: [], expected: ["claude-sonnet-5"] },
+      {
+        storedModels: undefined,
+        expected: ["claude-sonnet-5", "claude-sonnet-4.5"],
+      },
+      {
+        storedModels: [],
+        expected: ["claude-sonnet-5", "claude-sonnet-4.5"],
+      },
       {
         storedModels: ["claude-sonnet-4.5"],
         expected: ["claude-sonnet-5", "claude-sonnet-4.5"],

--- a/test/harness/replayingCapiProxy.test.ts
+++ b/test/harness/replayingCapiProxy.test.ts
@@ -1591,7 +1591,93 @@ Always include PINEAPPLE_COCONUT_42.
       }
     });
 
-    test("returns cached models for /models endpoint", async () => {
+    test.each([
+      { storedModels: undefined, expected: ["claude-sonnet-5"] },
+      { storedModels: [], expected: ["claude-sonnet-5"] },
+      {
+        storedModels: ["claude-sonnet-4.5"],
+        expected: ["claude-sonnet-5", "claude-sonnet-4.5"],
+      },
+      {
+        storedModels: ["claude-sonnet-5", "claude-sonnet-4.5"],
+        expected: ["claude-sonnet-5", "claude-sonnet-4.5"],
+      },
+    ])(
+      "advertises the current default for $storedModels",
+      async ({ storedModels, expected }) => {
+        const cachePath = path.join(tempDir, "cache.yaml");
+        if (storedModels !== undefined) {
+          await writeFile(
+            cachePath,
+            yaml.stringify({
+              models: storedModels,
+              conversations: [],
+            } satisfies NormalizedData),
+          );
+        }
+
+        const proxy = new ReplayingCapiProxy(
+          "http://localhost:9999",
+          cachePath,
+          workDir,
+        );
+        const proxyUrl = await proxy.start();
+
+        try {
+          const response = await makeRequest(proxyUrl, "/models", {
+            method: "GET",
+          });
+          expect(response.status).toBe(200);
+          const parsed = JSON.parse(response.body) as {
+            data: Array<{ id: string }>;
+          };
+          expect(parsed.data.map((model) => model.id)).toEqual(expected);
+        } finally {
+          await proxy.stop();
+        }
+      },
+    );
+
+    test.each(["claude-sonnet-5", "claude-sonnet-4.5"])(
+      "replays historical conversations with requested model %s",
+      async (model) => {
+        const cachePath = path.join(tempDir, "cache.yaml");
+        await writeFile(
+          cachePath,
+          yaml.stringify({
+            models: ["claude-sonnet-4.5"],
+            conversations: [
+              {
+                messages: [
+                  { role: "user", content: "Hello" },
+                  { role: "assistant", content: "Hi there!" },
+                ],
+              },
+            ],
+          } satisfies NormalizedData),
+        );
+        const proxy = new ReplayingCapiProxy(
+          "http://localhost:9999",
+          cachePath,
+          workDir,
+        );
+        const proxyUrl = await proxy.start();
+
+        try {
+          const response = await makeRequest(proxyUrl, "/chat/completions", {
+            body: { model, messages: [{ role: "user", content: "Hello" }] },
+          });
+          expect(response.status).toBe(200);
+          const parsed = JSON.parse(response.body) as ChatCompletion;
+          expect(parsed.model).toBe(model);
+          expect(parsed.choices[0].message.content).toBe("Hi there!");
+        } finally {
+          await proxy.stop(true);
+        }
+      },
+    );
+
+    test("preserves explicit catalogs without the historical default", async () => {
       const cachePath = path.join(tempDir, "cache.yaml");
       const cacheContent = yaml.stringify({
         models: ["gpt-4o", "claude-sonnet-4"],

--- a/test/harness/replayingCapiProxy.ts
+++ b/test/harness/replayingCapiProxy.ts
@@ -415,21 +415,10 @@ export class ReplayingCapiProxy extends CapturingHttpProxy {
         // Handle /models endpoint
         // Use stored models if available, otherwise use default model
         if (options.requestOptions.path === "/models") {
-          // Tests that explicitly select the legacy model may not send inference
-          // requests, so they have no capture file to advertise that model.
-          let models =
+          const models =
             state.storedData?.models && state.storedData.models.length > 0
               ? state.storedData.models
-              : [defaultModel, "claude-sonnet-4.5"];
-          // Historical captures used Sonnet 4.5 as the default. Keep it available
-          // for explicit selection, but offer a supported default for unpinned
-          // sessions without rewriting model-independent conversation captures.
-          if (
-            models.includes("claude-sonnet-4.5") &&
-            !models.includes(defaultModel)
-          ) {
-            models = [defaultModel, ...models];
-          }
+              : [defaultModel];
           const modelsResponse = createGetModelsResponse(models);
           const body = JSON.stringify(modelsResponse);
           const headers = {

--- a/test/harness/replayingCapiProxy.ts
+++ b/test/harness/replayingCapiProxy.ts
@@ -415,10 +415,12 @@ export class ReplayingCapiProxy extends CapturingHttpProxy {
         // Handle /models endpoint
         // Use stored models if available, otherwise use default model
         if (options.requestOptions.path === "/models") {
+          // Tests that explicitly select the legacy model may not send inference
+          // requests, so they have no capture file to advertise that model.
           let models =
             state.storedData?.models && state.storedData.models.length > 0
               ? state.storedData.models
-              : [defaultModel];
+              : [defaultModel, "claude-sonnet-4.5"];
           // Historical captures used Sonnet 4.5 as the default. Keep it available
           // for explicit selection, but offer a supported default for unpinned
           // sessions without rewriting model-independent conversation captures.

--- a/test/harness/replayingCapiProxy.ts
+++ b/test/harness/replayingCapiProxy.ts
@@ -107,7 +107,7 @@ const normalizedToolNames: Record<string, string> = {
  * Default model to use when no stored data is available for a given test.
  * This enables responding to /models without needing to have a capture file.
  */
-const defaultModel = "claude-sonnet-4.5";
+const defaultModel = "claude-sonnet-5";
 
 /**
  * An HTTP proxy that not only captures HTTP exchanges, but also stores them in a file on disk and
@@ -415,10 +415,19 @@ export class ReplayingCapiProxy extends CapturingHttpProxy {
         // Handle /models endpoint
         // Use stored models if available, otherwise use default model
         if (options.requestOptions.path === "/models") {
-          const models =
+          let models =
             state.storedData?.models && state.storedData.models.length > 0
               ? state.storedData.models
               : [defaultModel];
+          // Historical captures used Sonnet 4.5 as the default. Keep it available
+          // for explicit selection, but offer a supported default for unpinned
+          // sessions without rewriting model-independent conversation captures.
+          if (
+            models.includes("claude-sonnet-4.5") &&
+            !models.includes(defaultModel)
+          ) {
+            models = [defaultModel, ...models];
+          }
           const modelsResponse = createGetModelsResponse(models);
           const body = JSON.stringify(modelsResponse);
           const headers = {

--- a/test/snapshots/abort/should_abort_during_active_streaming.yaml
+++ b/test/snapshots/abort/should_abort_during_active_streaming.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/abort/should_abort_during_active_tool_execution.yaml
+++ b/test/snapshots/abort/should_abort_during_active_tool_execution.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/agent_and_compact_rpc/should_compact_session_history_after_messages.yaml
+++ b/test/snapshots/agent_and_compact_rpc/should_compact_session_history_after_messages.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/ask_user/ask_user_does_not_block_sibling_tool_call_in_same_turn.yaml
+++ b/test/snapshots/ask_user/ask_user_does_not_block_sibling_tool_call_in_same_turn.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/ask_user/should_handle_freeform_user_input_response.yaml
+++ b/test/snapshots/ask_user/should_handle_freeform_user_input_response.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/ask_user/should_invoke_user_input_handler_when_model_uses_ask_user_tool.yaml
+++ b/test/snapshots/ask_user/should_invoke_user_input_handler_when_model_uses_ask_user_tool.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/ask_user/should_receive_choices_in_user_input_request.yaml
+++ b/test/snapshots/ask_user/should_receive_choices_in_user_input_request.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/builtin_tools/should_capture_exit_code_in_output.yaml
+++ b/test/snapshots/builtin_tools/should_capture_exit_code_in_output.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/builtin_tools/should_capture_stderr_output.yaml
+++ b/test/snapshots/builtin_tools/should_capture_stderr_output.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/builtin_tools/should_create_a_new_file.yaml
+++ b/test/snapshots/builtin_tools/should_create_a_new_file.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/builtin_tools/should_edit_a_file_successfully.yaml
+++ b/test/snapshots/builtin_tools/should_edit_a_file_successfully.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/builtin_tools/should_find_files_by_pattern.yaml
+++ b/test/snapshots/builtin_tools/should_find_files_by_pattern.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/builtin_tools/should_handle_nonexistent_file_gracefully.yaml
+++ b/test/snapshots/builtin_tools/should_handle_nonexistent_file_gracefully.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/builtin_tools/should_read_file_with_line_range.yaml
+++ b/test/snapshots/builtin_tools/should_read_file_with_line_range.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/builtin_tools/should_search_for_patterns_in_files.yaml
+++ b/test/snapshots/builtin_tools/should_search_for_patterns_in_files.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/canvas/canvas_list_discovers_declared_canvases.yaml
+++ b/test/snapshots/canvas/canvas_list_discovers_declared_canvases.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/client/listmodels_withcustomhandler_callshandler.yaml
+++ b/test/snapshots/client/listmodels_withcustomhandler_callshandler.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/client/should_force_stop_client.yaml
+++ b/test/snapshots/client/should_force_stop_client.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/client/should_get_authenticated_status.yaml
+++ b/test/snapshots/client/should_get_authenticated_status.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/client/should_get_status.yaml
+++ b/test/snapshots/client/should_get_status.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/client/should_list_models_when_authenticated.yaml
+++ b/test/snapshots/client/should_list_models_when_authenticated.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/client/should_start_ping_and_stop_stdio_client.yaml
+++ b/test/snapshots/client/should_start_ping_and_stop_stdio_client.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/client/should_start_ping_and_stop_tcp_client.yaml
+++ b/test/snapshots/client/should_start_ping_and_stop_tcp_client.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/client/should_stop_client_with_active_session.yaml
+++ b/test/snapshots/client/should_stop_client_with_active_session.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/client_api/should_delete_session_by_id.yaml
+++ b/test/snapshots/client_api/should_delete_session_by_id.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/client_api/should_track_last_session_id_after_session_created.yaml
+++ b/test/snapshots/client_api/should_track_last_session_id_after_session_created.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/client_lifecycle/should_emit_session_lifecycle_events.yaml
+++ b/test/snapshots/client_lifecycle/should_emit_session_lifecycle_events.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/client_lifecycle/should_receive_session_deleted_lifecycle_event_when_deleted.yaml
+++ b/test/snapshots/client_lifecycle/should_receive_session_deleted_lifecycle_event_when_deleted.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/client_lifecycle/should_return_last_session_id_after_sending_a_message.yaml
+++ b/test/snapshots/client_lifecycle/should_return_last_session_id_after_sending_a_message.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/client_options/should_listen_on_configured_tcp_port.yaml
+++ b/test/snapshots/client_options/should_listen_on_configured_tcp_port.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/client_options/should_use_client_cwd_for_default_workingdirectory.yaml
+++ b/test/snapshots/client_options/should_use_client_cwd_for_default_workingdirectory.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/combinedconfiguration/accept_mcp_servers_and_custom_agents.yaml
+++ b/test/snapshots/combinedconfiguration/accept_mcp_servers_and_custom_agents.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/commands/session_with_commands_creates_successfully.yaml
+++ b/test/snapshots/commands/session_with_commands_creates_successfully.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/commands/session_with_commands_resumes_successfully.yaml
+++ b/test/snapshots/commands/session_with_commands_resumes_successfully.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/commands/session_with_no_commands_creates_successfully.yaml
+++ b/test/snapshots/commands/session_with_no_commands_creates_successfully.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/compaction/should_not_emit_compaction_events_when_infinite_sessions_disabled.yaml
+++ b/test/snapshots/compaction/should_not_emit_compaction_events_when_infinite_sessions_disabled.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/compaction/should_trigger_compaction_with_low_threshold_and_emit_events.yaml
+++ b/test/snapshots/compaction/should_trigger_compaction_with_low_threshold_and_emit_events.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/customagents/accept_custom_agent_config_on_create.yaml
+++ b/test/snapshots/customagents/accept_custom_agent_config_on_create.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/customagents/accept_custom_agent_config_on_resume.yaml
+++ b/test/snapshots/customagents/accept_custom_agent_config_on_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/elicitation/confirm_returns_false_when_handler_declines.yaml
+++ b/test/snapshots/elicitation/confirm_returns_false_when_handler_declines.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/elicitation/confirm_returns_true_when_handler_accepts.yaml
+++ b/test/snapshots/elicitation/confirm_returns_true_when_handler_accepts.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/elicitation/defaults_capabilities_when_not_provided.yaml
+++ b/test/snapshots/elicitation/defaults_capabilities_when_not_provided.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/elicitation/elicitation_returns_all_action_shapes.yaml
+++ b/test/snapshots/elicitation/elicitation_returns_all_action_shapes.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/elicitation/elicitation_throws_when_capability_is_missing.yaml
+++ b/test/snapshots/elicitation/elicitation_throws_when_capability_is_missing.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/elicitation/input_returns_freeform_value.yaml
+++ b/test/snapshots/elicitation/input_returns_freeform_value.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/elicitation/select_returns_selected_option.yaml
+++ b/test/snapshots/elicitation/select_returns_selected_option.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/elicitation/sends_requestelicitation_when_handler_provided.yaml
+++ b/test/snapshots/elicitation/sends_requestelicitation_when_handler_provided.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/elicitation/session_without_elicitationhandler_creates_successfully.yaml
+++ b/test/snapshots/elicitation/session_without_elicitationhandler_creates_successfully.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/elicitation/should_report_elicitation_capability_based_on_handler_presence.yaml
+++ b/test/snapshots/elicitation/should_report_elicitation_capability_based_on_handler_presence.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/event_fidelity/should_emit_assistant_message_with_messageid.yaml
+++ b/test/snapshots/event_fidelity/should_emit_assistant_message_with_messageid.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/event_fidelity/should_emit_assistant_usage_event_after_model_call.yaml
+++ b/test/snapshots/event_fidelity/should_emit_assistant_usage_event_after_model_call.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/event_fidelity/should_emit_events_in_correct_order_for_tool_using_conversation.yaml
+++ b/test/snapshots/event_fidelity/should_emit_events_in_correct_order_for_tool_using_conversation.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/event_fidelity/should_emit_pending_messages_modified_event_when_message_queue_changes.yaml
+++ b/test/snapshots/event_fidelity/should_emit_pending_messages_modified_event_when_message_queue_changes.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/event_fidelity/should_emit_session_usage_info_event_after_model_call.yaml
+++ b/test/snapshots/event_fidelity/should_emit_session_usage_info_event_after_model_call.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/event_fidelity/should_emit_tool_execution_events_with_correct_fields.yaml
+++ b/test/snapshots/event_fidelity/should_emit_tool_execution_events_with_correct_fields.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/event_fidelity/should_include_valid_fields_on_all_events.yaml
+++ b/test/snapshots/event_fidelity/should_include_valid_fields_on_all_events.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/event_fidelity/should_preserve_message_order_in_getmessages_after_tool_use.yaml
+++ b/test/snapshots/event_fidelity/should_preserve_message_order_in_getmessages_after_tool_use.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks/deny_tool_execution_when_pre_tool_use_returns_deny.yaml
+++ b/test/snapshots/hooks/deny_tool_execution_when_pre_tool_use_returns_deny.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks/invoke_both_hooks_for_single_tool_call.yaml
+++ b/test/snapshots/hooks/invoke_both_hooks_for_single_tool_call.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks/invoke_post_tool_use_hook_after_model_runs_a_tool.yaml
+++ b/test/snapshots/hooks/invoke_post_tool_use_hook_after_model_runs_a_tool.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks/invoke_pre_tool_use_hook_when_model_runs_a_tool.yaml
+++ b/test/snapshots/hooks/invoke_pre_tool_use_hook_when_model_runs_a_tool.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks/should_deny_tool_execution_when_pretooluse_returns_deny.yaml
+++ b/test/snapshots/hooks/should_deny_tool_execution_when_pretooluse_returns_deny.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks/should_invoke_both_pretooluse_and_posttooluse_hooks_for_a_single_tool_call.yaml
+++ b/test/snapshots/hooks/should_invoke_both_pretooluse_and_posttooluse_hooks_for_a_single_tool_call.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks/should_invoke_both_pretooluse_and_posttooluse_hooks_for_single_tool_call.yaml
+++ b/test/snapshots/hooks/should_invoke_both_pretooluse_and_posttooluse_hooks_for_single_tool_call.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks/should_invoke_posttooluse_hook_after_model_runs_a_tool.yaml
+++ b/test/snapshots/hooks/should_invoke_posttooluse_hook_after_model_runs_a_tool.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks/should_invoke_pretooluse_hook_when_model_runs_a_tool.yaml
+++ b/test/snapshots/hooks/should_invoke_pretooluse_hook_when_model_runs_a_tool.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks_extended/should_allow_posttooluse_to_return_modifiedresult.yaml
+++ b/test/snapshots/hooks_extended/should_allow_posttooluse_to_return_modifiedresult.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks_extended/should_allow_pretooluse_to_return_modifiedargs_and_suppressoutput.yaml
+++ b/test/snapshots/hooks_extended/should_allow_pretooluse_to_return_modifiedargs_and_suppressoutput.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks_extended/should_invoke_agentstop_hook_and_apply_block_response.yaml
+++ b/test/snapshots/hooks_extended/should_invoke_agentstop_hook_and_apply_block_response.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks_extended/should_invoke_onerroroccurred_hook_when_error_occurs.yaml
+++ b/test/snapshots/hooks_extended/should_invoke_onerroroccurred_hook_when_error_occurs.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks_extended/should_invoke_onsessionend_hook_when_session_is_disconnected.yaml
+++ b/test/snapshots/hooks_extended/should_invoke_onsessionend_hook_when_session_is_disconnected.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks_extended/should_invoke_onsessionstart_hook_on_new_session.yaml
+++ b/test/snapshots/hooks_extended/should_invoke_onsessionstart_hook_on_new_session.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks_extended/should_invoke_onuserpromptsubmitted_hook_when_sending_a_message.yaml
+++ b/test/snapshots/hooks_extended/should_invoke_onuserpromptsubmitted_hook_when_sending_a_message.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks_extended/should_invoke_posttoolusefailure_hook_for_failed_tool_result.yaml
+++ b/test/snapshots/hooks_extended/should_invoke_posttoolusefailure_hook_for_failed_tool_result.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks_extended/should_invoke_sessionend_hook.yaml
+++ b/test/snapshots/hooks_extended/should_invoke_sessionend_hook.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks_extended/should_invoke_sessionstart_hook.yaml
+++ b/test/snapshots/hooks_extended/should_invoke_sessionstart_hook.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system
@@ -13,7 +13,7 @@ conversations:
           Hi! 👋 
 
 
-          I'm GitHub Copilot CLI, powered by claude-sonnet-4.5. I'm here to help you with software engineering tasks
+          I'm GitHub Copilot CLI, powered by claude-sonnet-5. I'm here to help you with software engineering tasks
           like exploring codebases, running commands, making code changes, and more. 
 
 

--- a/test/snapshots/hooks_extended/should_invoke_userpromptsubmitted_hook_and_modify_prompt.yaml
+++ b/test/snapshots/hooks_extended/should_invoke_userpromptsubmitted_hook_and_modify_prompt.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks_extended/should_invoke_userprompttransformed_hook_and_modify_transformed_prompt.yaml
+++ b/test/snapshots/hooks_extended/should_invoke_userprompttransformed_hook_and_modify_transformed_prompt.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/hooks_extended/should_register_erroroccurred_hook.yaml
+++ b/test/snapshots/hooks_extended/should_register_erroroccurred_hook.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp-and-agents/should_accept_both_mcp_servers_and_custom_agents.yaml
+++ b/test/snapshots/mcp-and-agents/should_accept_both_mcp_servers_and_custom_agents.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/mcp-and-agents/should_accept_custom_agent_configuration_on_session_create.yaml
+++ b/test/snapshots/mcp-and-agents/should_accept_custom_agent_configuration_on_session_create.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp-and-agents/should_accept_custom_agent_configuration_on_session_resume.yaml
+++ b/test/snapshots/mcp-and-agents/should_accept_custom_agent_configuration_on_session_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp-and-agents/should_accept_mcp_server_configuration_on_session_create.yaml
+++ b/test/snapshots/mcp-and-agents/should_accept_mcp_server_configuration_on_session_create.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp-and-agents/should_accept_mcp_server_configuration_on_session_resume.yaml
+++ b/test/snapshots/mcp-and-agents/should_accept_mcp_server_configuration_on_session_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp_and_agents/accept_custom_agent_config_on_create.yaml
+++ b/test/snapshots/mcp_and_agents/accept_custom_agent_config_on_create.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp_and_agents/accept_custom_agent_config_on_resume.yaml
+++ b/test/snapshots/mcp_and_agents/accept_custom_agent_config_on_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp_and_agents/accept_mcp_server_config_on_create.yaml
+++ b/test/snapshots/mcp_and_agents/accept_mcp_server_config_on_create.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp_and_agents/accept_mcp_server_config_on_resume.yaml
+++ b/test/snapshots/mcp_and_agents/accept_mcp_server_config_on_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp_and_agents/accept_mcp_server_config_without_args.yaml
+++ b/test/snapshots/mcp_and_agents/accept_mcp_server_config_without_args.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp_and_agents/accept_mcp_servers_and_custom_agents.yaml
+++ b/test/snapshots/mcp_and_agents/accept_mcp_servers_and_custom_agents.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp_and_agents/should_accept_both_mcp_servers_and_custom_agents.yaml
+++ b/test/snapshots/mcp_and_agents/should_accept_both_mcp_servers_and_custom_agents.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp_and_agents/should_accept_custom_agent_configuration_on_session_create.yaml
+++ b/test/snapshots/mcp_and_agents/should_accept_custom_agent_configuration_on_session_create.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp_and_agents/should_accept_custom_agent_configuration_on_session_resume.yaml
+++ b/test/snapshots/mcp_and_agents/should_accept_custom_agent_configuration_on_session_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp_and_agents/should_accept_defaultagent_configuration_on_session_resume.yaml
+++ b/test/snapshots/mcp_and_agents/should_accept_defaultagent_configuration_on_session_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp_and_agents/should_accept_mcp_server_configuration_on_session_create.yaml
+++ b/test/snapshots/mcp_and_agents/should_accept_mcp_server_configuration_on_session_create.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp_and_agents/should_accept_mcp_server_configuration_on_session_resume.yaml
+++ b/test/snapshots/mcp_and_agents/should_accept_mcp_server_configuration_on_session_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp_and_agents/should_accept_mcp_server_configuration_without_args.yaml
+++ b/test/snapshots/mcp_and_agents/should_accept_mcp_server_configuration_without_args.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp_and_agents/should_handle_custom_agent_with_mcp_servers.yaml
+++ b/test/snapshots/mcp_and_agents/should_handle_custom_agent_with_mcp_servers.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/mcp_and_agents/should_handle_custom_agent_with_tools_configuration.yaml
+++ b/test/snapshots/mcp_and_agents/should_handle_custom_agent_with_tools_configuration.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/mcp_and_agents/should_handle_multiple_custom_agents.yaml
+++ b/test/snapshots/mcp_and_agents/should_handle_multiple_custom_agents.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/mcp_and_agents/should_handle_multiple_mcp_servers.yaml
+++ b/test/snapshots/mcp_and_agents/should_handle_multiple_mcp_servers.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/mcp_and_agents/should_hide_excluded_tools_from_default_agent.yaml
+++ b/test/snapshots/mcp_and_agents/should_hide_excluded_tools_from_default_agent.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp_and_agents/should_pass_literal_env_values_to_mcp_server_subprocess.yaml
+++ b/test/snapshots/mcp_and_agents/should_pass_literal_env_values_to_mcp_server_subprocess.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcp_and_agents/should_round_trip_mcp_server_elicitation_request.yaml
+++ b/test/snapshots/mcp_and_agents/should_round_trip_mcp_server_elicitation_request.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcpservers/accept_mcp_server_config_on_create.yaml
+++ b/test/snapshots/mcpservers/accept_mcp_server_config_on_create.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mcpservers/accept_mcp_server_config_on_resume.yaml
+++ b/test/snapshots/mcpservers/accept_mcp_server_config_on_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mode_empty/empty_mode_append_caller_instruction_takes_effect_and_env_context_stripped.yaml
+++ b/test/snapshots/mode_empty/empty_mode_append_caller_instruction_takes_effect_and_env_context_stripped.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mode_empty/empty_mode_builtin_star_exposes_all_built_in_tools.yaml
+++ b/test/snapshots/mode_empty/empty_mode_builtin_star_exposes_all_built_in_tools.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mode_empty/empty_mode_excluded_tools_subtracts_from_available_tools.yaml
+++ b/test/snapshots/mode_empty/empty_mode_excluded_tools_subtracts_from_available_tools.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mode_empty/empty_mode_isolated_set_shell_tool_is_not_exposed.yaml
+++ b/test/snapshots/mode_empty/empty_mode_isolated_set_shell_tool_is_not_exposed.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mode_empty/empty_mode_strips_environment_context_from_the_system_message_by_default.yaml
+++ b/test/snapshots/mode_empty/empty_mode_strips_environment_context_from_the_system_message_by_default.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mode_empty/empty_mode_system_message_replace_llm_follows_caller_content_verbatim.yaml
+++ b/test/snapshots/mode_empty/empty_mode_system_message_replace_llm_follows_caller_content_verbatim.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/mode_handlers/should_invoke_auto_mode_switch_handler_when_rate_limited.yaml
+++ b/test/snapshots/mode_handlers/should_invoke_auto_mode_switch_handler_when_rate_limited.yaml
@@ -1,8 +1,8 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
   - auto
 errors:
-  - model: claude-sonnet-4.5
+  - model: claude-sonnet-5
     status: 429
     code: user_weekly_rate_limited
     message: You've reached your weekly rate limit.

--- a/test/snapshots/mode_handlers/should_invoke_exit_plan_mode_handler_when_model_uses_tool.yaml
+++ b/test/snapshots/mode_handlers/should_invoke_exit_plan_mode_handler_when_model_uses_tool.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/multi_client/both_clients_see_tool_request_and_completion_events.yaml
+++ b/test/snapshots/multi_client/both_clients_see_tool_request_and_completion_events.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/multi_client/disconnecting_client_removes_its_tools.yaml
+++ b/test/snapshots/multi_client/disconnecting_client_removes_its_tools.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/multi_client/one_client_approves_permission_and_both_see_the_result.yaml
+++ b/test/snapshots/multi_client/one_client_approves_permission_and_both_see_the_result.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/multi_client/one_client_rejects_permission_and_both_see_the_result.yaml
+++ b/test/snapshots/multi_client/one_client_rejects_permission_and_both_see_the_result.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/multi_client/two_clients_register_different_tools_and_agent_uses_both.yaml
+++ b/test/snapshots/multi_client/two_clients_register_different_tools_and_agent_uses_both.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/multi_provider_registry/should_register_multiple_providers_with_custom_agents_bound_to_their_models.yaml
+++ b/test/snapshots/multi_provider_registry/should_register_multiple_providers_with_custom_agents_bound_to_their_models.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/multi_turn/should_handle_file_creation_then_reading_across_turns.yaml
+++ b/test/snapshots/multi_turn/should_handle_file_creation_then_reading_across_turns.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/multi_turn/should_use_tool_results_from_previous_turns.yaml
+++ b/test/snapshots/multi_turn/should_use_tool_results_from_previous_turns.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/pending_work_resume/should_continue_parallel_pending_external_tool_requests_after_resume.yaml
+++ b/test/snapshots/pending_work_resume/should_continue_parallel_pending_external_tool_requests_after_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/pending_work_resume/should_continue_pending_external_tool_request_after_resume.yaml
+++ b/test/snapshots/pending_work_resume/should_continue_pending_external_tool_request_after_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/pending_work_resume/should_continue_pending_permission_request_after_resume.yaml
+++ b/test/snapshots/pending_work_resume/should_continue_pending_permission_request_after_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/pending_work_resume/should_keep_pending_external_tool_handleable_on_cold_resume_when_continuependingwork_is_false.yaml
+++ b/test/snapshots/pending_work_resume/should_keep_pending_external_tool_handleable_on_cold_resume_when_continuependingwork_is_false.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/pending_work_resume/should_keep_pending_external_tool_handleable_on_warm_resume_when_continuependingwork_is_false.yaml
+++ b/test/snapshots/pending_work_resume/should_keep_pending_external_tool_handleable_on_warm_resume_when_continuependingwork_is_false.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/pending_work_resume/should_report_continuependingwork_true_in_resume_event.yaml
+++ b/test/snapshots/pending_work_resume/should_report_continuependingwork_true_in_resume_event.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/pending_work_resume/should_resume_successfully_when_no_pending_work_exists.yaml
+++ b/test/snapshots/pending_work_resume/should_resume_successfully_when_no_pending_work_exists.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/per-session-auth/session_auth_status_is_unauthenticated_without_token.yaml
+++ b/test/snapshots/per-session-auth/session_auth_status_is_unauthenticated_without_token.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/per-session-auth/session_fails_with_invalid_token.yaml
+++ b/test/snapshots/per-session-auth/session_fails_with_invalid_token.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/per-session-auth/session_token_overrides_client_token.yaml
+++ b/test/snapshots/per-session-auth/session_token_overrides_client_token.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/per-session-auth/session_uses_client_token_when_no_session_token_is_supplied.yaml
+++ b/test/snapshots/per-session-auth/session_uses_client_token_when_no_session_token_is_supplied.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/permissions/async_permission_handler.yaml
+++ b/test/snapshots/permissions/async_permission_handler.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/deny_permission.yaml
+++ b/test/snapshots/permissions/deny_permission.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/permission_handler_errors.yaml
+++ b/test/snapshots/permissions/permission_handler_errors.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/permission_handler_for_shell_commands.yaml
+++ b/test/snapshots/permissions/permission_handler_for_shell_commands.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/permission_handler_for_write_operations.yaml
+++ b/test/snapshots/permissions/permission_handler_for_write_operations.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/resume_session_with_permission_handler.yaml
+++ b/test/snapshots/permissions/resume_session_with_permission_handler.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/should_deny_permission_when_handler_returns_denied.yaml
+++ b/test/snapshots/permissions/should_deny_permission_when_handler_returns_denied.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/should_deny_permission_with_noresult_kind.yaml
+++ b/test/snapshots/permissions/should_deny_permission_with_noresult_kind.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/should_deny_tool_operations_when_handler_explicitly_denies.yaml
+++ b/test/snapshots/permissions/should_deny_tool_operations_when_handler_explicitly_denies.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/should_deny_tool_operations_when_handler_explicitly_denies_after_resume.yaml
+++ b/test/snapshots/permissions/should_deny_tool_operations_when_handler_explicitly_denies_after_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/should_handle_async_permission_handler.yaml
+++ b/test/snapshots/permissions/should_handle_async_permission_handler.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/should_handle_concurrent_permission_requests_from_parallel_tools.yaml
+++ b/test/snapshots/permissions/should_handle_concurrent_permission_requests_from_parallel_tools.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/should_handle_permission_handler_errors_gracefully.yaml
+++ b/test/snapshots/permissions/should_handle_permission_handler_errors_gracefully.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/should_honor_a_decision_annotated_with_decisioncontext.yaml
+++ b/test/snapshots/permissions/should_honor_a_decision_annotated_with_decisioncontext.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/should_invoke_permission_handler_for_write_operations.yaml
+++ b/test/snapshots/permissions/should_invoke_permission_handler_for_write_operations.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/should_receive_toolcallid_in_permission_requests.yaml
+++ b/test/snapshots/permissions/should_receive_toolcallid_in_permission_requests.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/should_resume_session_with_permission_handler.yaml
+++ b/test/snapshots/permissions/should_resume_session_with_permission_handler.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/should_short_circuit_permission_handler_when_set_approve_all_enabled.yaml
+++ b/test/snapshots/permissions/should_short_circuit_permission_handler_when_set_approve_all_enabled.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/should_wait_for_slow_permission_handler.yaml
+++ b/test/snapshots/permissions/should_wait_for_slow_permission_handler.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/should_work_with_approve_all_permission_handler.yaml
+++ b/test/snapshots/permissions/should_work_with_approve_all_permission_handler.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/permissions/tool_call_id_in_permission_requests.yaml
+++ b/test/snapshots/permissions/tool_call_id_in_permission_requests.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/pre_mcp_tool_call_hook/should_remove_meta_via_premcptoolcall_hook.yaml
+++ b/test/snapshots/pre_mcp_tool_call_hook/should_remove_meta_via_premcptoolcall_hook.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/pre_mcp_tool_call_hook/should_replace_meta_via_premcptoolcall_hook.yaml
+++ b/test/snapshots/pre_mcp_tool_call_hook/should_replace_meta_via_premcptoolcall_hook.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/pre_mcp_tool_call_hook/should_set_meta_via_premcptoolcall_hook.yaml
+++ b/test/snapshots/pre_mcp_tool_call_hook/should_set_meta_via_premcptoolcall_hook.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/resume_mcp_oauth/should_resume_a_persisted_session_with_mcp_auth_handler.yaml
+++ b/test/snapshots/resume_mcp_oauth/should_resume_a_persisted_session_with_mcp_auth_handler.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/rewind/should_restore_tracked_file_and_conversation.yaml
+++ b/test/snapshots/rewind/should_restore_tracked_file_and_conversation.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/rpc_additional_edge_cases/mode_set_to_same_value_multiple_times_stays_stable.yaml
+++ b/test/snapshots/rpc_additional_edge_cases/mode_set_to_same_value_multiple_times_stays_stable.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_additional_edge_cases/name_set_with_unicode_round_trips.yaml
+++ b/test/snapshots/rpc_additional_edge_cases/name_set_with_unicode_round_trips.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_additional_edge_cases/permissions_reset_session_approvals_on_fresh_session_is_noop.yaml
+++ b/test/snapshots/rpc_additional_edge_cases/permissions_reset_session_approvals_on_fresh_session_is_noop.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_additional_edge_cases/permissions_set_approve_all_toggle_round_trips.yaml
+++ b/test/snapshots/rpc_additional_edge_cases/permissions_set_approve_all_toggle_round_trips.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_additional_edge_cases/plan_delete_when_none_exists_is_idempotent.yaml
+++ b/test/snapshots/rpc_additional_edge_cases/plan_delete_when_none_exists_is_idempotent.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_additional_edge_cases/plan_update_with_empty_content_then_read_returns_empty.yaml
+++ b/test/snapshots/rpc_additional_edge_cases/plan_update_with_empty_content_then_read_returns_empty.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_additional_edge_cases/shell_exec_with_zero_timeout_does_not_kill_long_running_command.yaml
+++ b/test/snapshots/rpc_additional_edge_cases/shell_exec_with_zero_timeout_does_not_kill_long_running_command.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_additional_edge_cases/usage_get_metrics_on_fresh_session_returns_zero_tokens.yaml
+++ b/test/snapshots/rpc_additional_edge_cases/usage_get_metrics_on_fresh_session_returns_zero_tokens.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_additional_edge_cases/workspaces_create_file_with_empty_content_round_trips.yaml
+++ b/test/snapshots/rpc_additional_edge_cases/workspaces_create_file_with_empty_content_round_trips.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_additional_edge_cases/workspaces_create_file_with_large_content_round_trips.yaml
+++ b/test/snapshots/rpc_additional_edge_cases/workspaces_create_file_with_large_content_round_trips.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_additional_edge_cases/workspaces_create_file_with_unicode_content_round_trips.yaml
+++ b/test/snapshots/rpc_additional_edge_cases/workspaces_create_file_with_unicode_content_round_trips.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_additional_edge_cases/workspaces_createfile_then_listfiles_returns_sorted_or_stable_order.yaml
+++ b/test/snapshots/rpc_additional_edge_cases/workspaces_createfile_then_listfiles_returns_sorted_or_stable_order.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_additional_edge_cases/workspaces_getworkspace_returns_stable_result_across_calls.yaml
+++ b/test/snapshots/rpc_additional_edge_cases/workspaces_getworkspace_returns_stable_result_across_calls.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_agents/should_call_agent_reload.yaml
+++ b/test/snapshots/rpc_agents/should_call_agent_reload.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_agents/should_deselect_current_agent.yaml
+++ b/test/snapshots/rpc_agents/should_deselect_current_agent.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_agents/should_emit_subagent_selected_and_deselected_events.yaml
+++ b/test/snapshots/rpc_agents/should_emit_subagent_selected_and_deselected_events.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_agents/should_list_available_custom_agents.yaml
+++ b/test/snapshots/rpc_agents/should_list_available_custom_agents.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_agents/should_return_empty_list_when_no_custom_agents_configured.yaml
+++ b/test/snapshots/rpc_agents/should_return_empty_list_when_no_custom_agents_configured.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_agents/should_return_null_when_no_agent_is_selected.yaml
+++ b/test/snapshots/rpc_agents/should_return_null_when_no_agent_is_selected.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_agents/should_select_and_get_current_agent.yaml
+++ b/test/snapshots/rpc_agents/should_select_and_get_current_agent.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_event_side_effects/should_allow_session_use_after_truncate.yaml
+++ b/test/snapshots/rpc_event_side_effects/should_allow_session_use_after_truncate.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/rpc_event_side_effects/should_emit_mode_changed_event_when_mode_set.yaml
+++ b/test/snapshots/rpc_event_side_effects/should_emit_mode_changed_event_when_mode_set.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_event_side_effects/should_emit_plan_changed_event_for_update_and_delete.yaml
+++ b/test/snapshots/rpc_event_side_effects/should_emit_plan_changed_event_for_update_and_delete.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_event_side_effects/should_emit_plan_changed_update_operation_on_second_update.yaml
+++ b/test/snapshots/rpc_event_side_effects/should_emit_plan_changed_update_operation_on_second_update.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_event_side_effects/should_emit_snapshot_rewind_event_and_remove_events_on_truncate.yaml
+++ b/test/snapshots/rpc_event_side_effects/should_emit_snapshot_rewind_event_and_remove_events_on_truncate.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/rpc_event_side_effects/should_emit_title_changed_event_when_name_set.yaml
+++ b/test/snapshots/rpc_event_side_effects/should_emit_title_changed_event_when_name_set.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_event_side_effects/should_emit_workspace_file_changed_event_when_file_created.yaml
+++ b/test/snapshots/rpc_event_side_effects/should_emit_workspace_file_changed_event_when_file_created.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_mcp_and_skills/should_list_and_toggle_session_skills.yaml
+++ b/test/snapshots/rpc_mcp_and_skills/should_list_and_toggle_session_skills.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_mcp_and_skills/should_list_extensions.yaml
+++ b/test/snapshots/rpc_mcp_and_skills/should_list_extensions.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_mcp_and_skills/should_list_mcp_servers_with_configured_server.yaml
+++ b/test/snapshots/rpc_mcp_and_skills/should_list_mcp_servers_with_configured_server.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_mcp_and_skills/should_list_plugins.yaml
+++ b/test/snapshots/rpc_mcp_and_skills/should_list_plugins.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_mcp_and_skills/should_reload_session_skills.yaml
+++ b/test/snapshots/rpc_mcp_and_skills/should_reload_session_skills.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_mcp_and_skills/should_report_error_when_extensions_are_not_available.yaml
+++ b/test/snapshots/rpc_mcp_and_skills/should_report_error_when_extensions_are_not_available.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_mcp_and_skills/should_report_error_when_mcp_host_is_not_initialized.yaml
+++ b/test/snapshots/rpc_mcp_and_skills/should_report_error_when_mcp_host_is_not_initialized.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_mcp_and_skills/should_report_error_when_mcp_oauth_server_is_not_configured.yaml
+++ b/test/snapshots/rpc_mcp_and_skills/should_report_error_when_mcp_oauth_server_is_not_configured.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_mcp_and_skills/should_report_error_when_mcp_oauth_server_is_not_remote.yaml
+++ b/test/snapshots/rpc_mcp_and_skills/should_report_error_when_mcp_oauth_server_is_not_remote.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_mcp_config/should_call_server_mcp_config_rpcs.yaml
+++ b/test/snapshots/rpc_mcp_config/should_call_server_mcp_config_rpcs.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_mcp_config/should_round_trip_http_mcp_oauth_config_rpc.yaml
+++ b/test/snapshots/rpc_mcp_config/should_round_trip_http_mcp_oauth_config_rpc.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_mcp_lifecycle/should_configure_github_mcp_server.yaml
+++ b/test/snapshots/rpc_mcp_lifecycle/should_configure_github_mcp_server.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_mcp_lifecycle/should_list_tools_and_report_running_status_for_connected_server.yaml
+++ b/test/snapshots/rpc_mcp_lifecycle/should_list_tools_and_report_running_status_for_connected_server.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_mcp_lifecycle/should_reload_mcp_servers_with_config.yaml
+++ b/test/snapshots/rpc_mcp_lifecycle/should_reload_mcp_servers_with_config.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_mcp_lifecycle/should_start_and_restart_mcp_server.yaml
+++ b/test/snapshots/rpc_mcp_lifecycle/should_start_and_restart_mcp_server.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_mcp_lifecycle/should_stop_running_mcp_server.yaml
+++ b/test/snapshots/rpc_mcp_lifecycle/should_stop_running_mcp_server.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_mcp_lifecycle/should_throw_when_listing_tools_for_unconnected_server.yaml
+++ b/test/snapshots/rpc_mcp_lifecycle/should_throw_when_listing_tools_for_unconnected_server.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server/should_call_rpc_account_get_quota_when_authenticated.yaml
+++ b/test/snapshots/rpc_server/should_call_rpc_account_get_quota_when_authenticated.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server/should_call_rpc_models_list_with_typed_result.yaml
+++ b/test/snapshots/rpc_server/should_call_rpc_models_list_with_typed_result.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server/should_call_rpc_ping_with_typed_params_and_result.yaml
+++ b/test/snapshots/rpc_server/should_call_rpc_ping_with_typed_params_and_result.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server/should_call_rpc_tools_list_with_typed_result.yaml
+++ b/test/snapshots/rpc_server/should_call_rpc_tools_list_with_typed_result.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server/should_discover_server_mcp_and_skills.yaml
+++ b/test/snapshots/rpc_server/should_discover_server_mcp_and_skills.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server_misc/should_get_set_and_clear_user_settings.yaml
+++ b/test/snapshots/rpc_server_misc/should_get_set_and_clear_user_settings.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server_misc/should_login_list_getcurrentauth_and_logout_account.yaml
+++ b/test/snapshots/rpc_server_misc/should_login_list_getcurrentauth_and_logout_account.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server_misc/should_reject_send_attachments_from_non_extension_connection.yaml
+++ b/test/snapshots/rpc_server_misc/should_reject_send_attachments_from_non_extension_connection.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server_misc/should_reload_user_settings.yaml
+++ b/test/snapshots/rpc_server_misc/should_reload_user_settings.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server_misc/should_report_agent_registry_spawn_gate_closed.yaml
+++ b/test/snapshots/rpc_server_misc/should_report_agent_registry_spawn_gate_closed.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server_misc/should_report_not_found_when_opening_session_without_context.yaml
+++ b/test/snapshots/rpc_server_misc/should_report_not_found_when_opening_session_without_context.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server_misc/should_shut_down_owned_runtime.yaml
+++ b/test/snapshots/rpc_server_misc/should_shut_down_owned_runtime.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server_plugins/should_enable_and_disable_marketplace_plugin.yaml
+++ b/test/snapshots/rpc_server_plugins/should_enable_and_disable_marketplace_plugin.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server_plugins/should_install_direct_local_plugin_with_deprecation_warning.yaml
+++ b/test/snapshots/rpc_server_plugins/should_install_direct_local_plugin_with_deprecation_warning.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server_plugins/should_install_list_and_uninstall_plugin_from_local_marketplace.yaml
+++ b/test/snapshots/rpc_server_plugins/should_install_list_and_uninstall_plugin_from_local_marketplace.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server_plugins/should_list_browse_refresh_and_remove_local_marketplace.yaml
+++ b/test/snapshots/rpc_server_plugins/should_list_browse_refresh_and_remove_local_marketplace.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server_plugins/should_reload_mcp_config_cache.yaml
+++ b/test/snapshots/rpc_server_plugins/should_reload_mcp_config_cache.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server_plugins/should_update_all_installed_plugins.yaml
+++ b/test/snapshots/rpc_server_plugins/should_update_all_installed_plugins.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server_plugins/should_update_single_marketplace_plugin.yaml
+++ b/test/snapshots/rpc_server_plugins/should_update_single_marketplace_plugin.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server_remote_control/should_reach_runtime_when_starting_remote_control_for_unknown_session.yaml
+++ b/test/snapshots/rpc_server_remote_control/should_reach_runtime_when_starting_remote_control_for_unknown_session.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server_remote_control/should_reject_transfer_when_off_with_compare_and_swap.yaml
+++ b/test/snapshots/rpc_server_remote_control/should_reject_transfer_when_off_with_compare_and_swap.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server_remote_control/should_report_not_stopped_when_remote_control_is_off.yaml
+++ b/test/snapshots/rpc_server_remote_control/should_report_not_stopped_when_remote_control_is_off.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server_remote_control/should_report_remote_control_status_as_off.yaml
+++ b/test/snapshots/rpc_server_remote_control/should_report_remote_control_status_as_off.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_server_remote_control/should_treat_set_steering_as_no_op_when_off.yaml
+++ b/test/snapshots/rpc_server_remote_control/should_treat_set_steering_as_no_op_when_off.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state/should_call_session_rpc_model_getcurrent.yaml
+++ b/test/snapshots/rpc_session_state/should_call_session_rpc_model_getcurrent.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state/should_call_session_rpc_model_switchto.yaml
+++ b/test/snapshots/rpc_session_state/should_call_session_rpc_model_switchto.yaml
@@ -1,4 +1,4 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
   - gpt-5.4
 conversations: []

--- a/test/snapshots/rpc_session_state/should_call_session_usage_and_permission_rpcs.yaml
+++ b/test/snapshots/rpc_session_state/should_call_session_usage_and_permission_rpcs.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state/should_call_workspace_file_rpc_methods.yaml
+++ b/test/snapshots/rpc_session_state/should_call_workspace_file_rpc_methods.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state/should_compact_session_history_after_messages.yaml
+++ b/test/snapshots/rpc_session_state/should_compact_session_history_after_messages.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/rpc_session_state/should_create_workspace_file_with_nested_path_auto_creating_dirs.yaml
+++ b/test/snapshots/rpc_session_state/should_create_workspace_file_with_nested_path_auto_creating_dirs.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state/should_emit_title_changed_event_each_time_name_set_is_called.yaml
+++ b/test/snapshots/rpc_session_state/should_emit_title_changed_event_each_time_name_set_is_called.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state/should_fork_session_to_event_id_excluding_boundary_event.yaml
+++ b/test/snapshots/rpc_session_state/should_fork_session_to_event_id_excluding_boundary_event.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/rpc_session_state/should_fork_session_with_persisted_messages.yaml
+++ b/test/snapshots/rpc_session_state/should_fork_session_with_persisted_messages.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/rpc_session_state/should_get_and_set_session_metadata.yaml
+++ b/test/snapshots/rpc_session_state/should_get_and_set_session_metadata.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state/should_get_and_set_session_mode.yaml
+++ b/test/snapshots/rpc_session_state/should_get_and_set_session_mode.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state/should_handle_forking_session_without_persisted_events.yaml
+++ b/test/snapshots/rpc_session_state/should_handle_forking_session_without_persisted_events.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state/should_read_update_and_delete_plan.yaml
+++ b/test/snapshots/rpc_session_state/should_read_update_and_delete_plan.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state/should_reject_empty_or_whitespace_session_name.yaml
+++ b/test/snapshots/rpc_session_state/should_reject_empty_or_whitespace_session_name.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state/should_reject_workspace_file_path_traversal.yaml
+++ b/test/snapshots/rpc_session_state/should_reject_workspace_file_path_traversal.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state/should_report_error_reading_nonexistent_workspace_file.yaml
+++ b/test/snapshots/rpc_session_state/should_report_error_reading_nonexistent_workspace_file.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state/should_report_error_when_forking_session_to_unknown_event_id.yaml
+++ b/test/snapshots/rpc_session_state/should_report_error_when_forking_session_to_unknown_event_id.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/rpc_session_state/should_report_implemented_errors_for_unsupported_session_rpc_paths.yaml
+++ b/test/snapshots/rpc_session_state/should_report_implemented_errors_for_unsupported_session_rpc_paths.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state/should_report_processing_and_context_metadata.yaml
+++ b/test/snapshots/rpc_session_state/should_report_processing_and_context_metadata.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/rpc_session_state/should_set_and_get_each_session_mode_value.yaml
+++ b/test/snapshots/rpc_session_state/should_set_and_get_each_session_mode_value.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state/should_update_existing_workspace_file_with_update_operation.yaml
+++ b/test/snapshots/rpc_session_state/should_update_existing_workspace_file_with_update_operation.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state_extras/should_add_byok_provider_and_model_at_runtime.yaml
+++ b/test/snapshots/rpc_session_state_extras/should_add_byok_provider_and_model_at_runtime.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state_extras/should_get_and_set_allowall_permissions.yaml
+++ b/test/snapshots/rpc_session_state_extras/should_get_and_set_allowall_permissions.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state_extras/should_get_context_attribution_and_heaviest_messages_after_turn.yaml
+++ b/test/snapshots/rpc_session_state_extras/should_get_context_attribution_and_heaviest_messages_after_turn.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/rpc_session_state_extras/should_get_current_tool_metadata_after_initialization.yaml
+++ b/test/snapshots/rpc_session_state_extras/should_get_current_tool_metadata_after_initialization.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/rpc_session_state_extras/should_get_telemetry_engagement_id.yaml
+++ b/test/snapshots/rpc_session_state_extras/should_get_telemetry_engagement_id.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state_extras/should_list_models_for_session.yaml
+++ b/test/snapshots/rpc_session_state_extras/should_list_models_for_session.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state_extras/should_read_empty_sql_todos_for_fresh_session.yaml
+++ b/test/snapshots/rpc_session_state_extras/should_read_empty_sql_todos_for_fresh_session.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state_extras/should_reload_session_plugins.yaml
+++ b/test/snapshots/rpc_session_state_extras/should_reload_session_plugins.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state_extras/should_report_session_activity_when_idle.yaml
+++ b/test/snapshots/rpc_session_state_extras/should_report_session_activity_when_idle.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state_extras/should_report_visibility_as_unsynced_for_local_session.yaml
+++ b/test/snapshots/rpc_session_state_extras/should_report_visibility_as_unsynced_for_local_session.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state_extras/should_return_empty_completions_when_host_does_not_provide_them.yaml
+++ b/test/snapshots/rpc_session_state_extras/should_return_empty_completions_when_host_does_not_provide_them.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_session_state_extras/should_update_and_clear_live_subagent_settings.yaml
+++ b/test/snapshots/rpc_session_state_extras/should_update_and_clear_live_subagent_settings.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_shell_and_fleet/should_execute_shell_command.yaml
+++ b/test/snapshots/rpc_shell_and_fleet/should_execute_shell_command.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_shell_and_fleet/should_kill_shell_process.yaml
+++ b/test/snapshots/rpc_shell_and_fleet/should_kill_shell_process.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_shell_and_fleet/should_start_fleet_and_complete_custom_tool_task.yaml
+++ b/test/snapshots/rpc_shell_and_fleet/should_start_fleet_and_complete_custom_tool_task.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/rpc_shell_edge_cases/shell_exec_with_custom_cwd_honors_override.yaml
+++ b/test/snapshots/rpc_shell_edge_cases/shell_exec_with_custom_cwd_honors_override.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_shell_edge_cases/shell_exec_with_large_stdout_cleans_up.yaml
+++ b/test/snapshots/rpc_shell_edge_cases/shell_exec_with_large_stdout_cleans_up.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_shell_edge_cases/shell_exec_with_nonexistent_command_returns_processid_and_cleans_up.yaml
+++ b/test/snapshots/rpc_shell_edge_cases/shell_exec_with_nonexistent_command_returns_processid_and_cleans_up.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_shell_edge_cases/shell_exec_with_stderr_output_cleans_up.yaml
+++ b/test/snapshots/rpc_shell_edge_cases/shell_exec_with_stderr_output_cleans_up.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_shell_edge_cases/shell_exec_with_timeout_kills_long_running_command.yaml
+++ b/test/snapshots/rpc_shell_edge_cases/shell_exec_with_timeout_kills_long_running_command.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_shell_edge_cases/shell_kill_cleans_up_after_terminating_signal.yaml
+++ b/test/snapshots/rpc_shell_edge_cases/shell_kill_cleans_up_after_terminating_signal.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_shell_edge_cases/shell_kill_unknown_processid_returns_false.yaml
+++ b/test/snapshots/rpc_shell_edge_cases/shell_kill_unknown_processid_returns_false.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_shell_user_requested/should_cancel_user_requested_shell_command.yaml
+++ b/test/snapshots/rpc_shell_user_requested/should_cancel_user_requested_shell_command.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_shell_user_requested/should_execute_user_requested_shell_command.yaml
+++ b/test/snapshots/rpc_shell_user_requested/should_execute_user_requested_shell_command.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_tasks_and_handlers/should_list_task_state_and_return_false_for_missing_task_operations.yaml
+++ b/test/snapshots/rpc_tasks_and_handlers/should_list_task_state_and_return_false_for_missing_task_operations.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_tasks_and_handlers/should_report_implemented_error_for_invalid_task_agent_model.yaml
+++ b/test/snapshots/rpc_tasks_and_handlers/should_report_implemented_error_for_invalid_task_agent_model.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_tasks_and_handlers/should_report_implemented_error_for_missing_task_agent_type.yaml
+++ b/test/snapshots/rpc_tasks_and_handlers/should_report_implemented_error_for_missing_task_agent_type.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_tasks_and_handlers/should_return_expected_results_for_missing_pending_handler_requestids.yaml
+++ b/test/snapshots/rpc_tasks_and_handlers/should_return_expected_results_for_missing_pending_handler_requestids.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/rpc_tasks_and_handlers/should_start_background_agent_and_report_task_details.yaml
+++ b/test/snapshots/rpc_tasks_and_handlers/should_start_background_agent_and_report_task_details.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/rpc_ui_ephemeral_query/should_answer_ephemeral_query.yaml
+++ b/test/snapshots/rpc_ui_ephemeral_query/should_answer_ephemeral_query.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/rust_multi_client/both_clients_see_tool_request_and_completion_events.yaml
+++ b/test/snapshots/rust_multi_client/both_clients_see_tool_request_and_completion_events.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/rust_multi_client/disconnecting_client_removes_its_tools.yaml
+++ b/test/snapshots/rust_multi_client/disconnecting_client_removes_its_tools.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/rust_multi_client/two_clients_register_different_tools_and_agent_uses_both.yaml
+++ b/test/snapshots/rust_multi_client/two_clients_register_different_tools_and_agent_uses_both.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/disposeasync_from_handler_does_not_deadlock.yaml
+++ b/test/snapshots/session/disposeasync_from_handler_does_not_deadlock.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/handler_exception_does_not_halt_event_delivery.yaml
+++ b/test/snapshots/session/handler_exception_does_not_halt_event_delivery.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/resumes_a_persisted_session_from_a_new_client_when_an_mcp_oauth_handler_is_configured.yaml
+++ b/test/snapshots/session/resumes_a_persisted_session_from_a_new_client_when_an_mcp_oauth_handler_is_configured.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/send_returns_immediately_while_events_stream_in_background.yaml
+++ b/test/snapshots/session/send_returns_immediately_while_events_stream_in_background.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/sendandwait_blocks_until_session_idle_and_returns_final_assistant_message.yaml
+++ b/test/snapshots/session/sendandwait_blocks_until_session_idle_and_returns_final_assistant_message.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/sendandwait_throws_on_timeout.yaml
+++ b/test/snapshots/session/sendandwait_throws_on_timeout.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/sendandwait_throws_operationcanceledexception_when_token_cancelled.yaml
+++ b/test/snapshots/session/sendandwait_throws_operationcanceledexception_when_token_cancelled.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_abort_a_session.yaml
+++ b/test/snapshots/session/should_abort_a_session.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_accept_blob_attachments.yaml
+++ b/test/snapshots/session/should_accept_blob_attachments.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_create_a_session_with_appended_systemmessage_config.yaml
+++ b/test/snapshots/session/should_create_a_session_with_appended_systemmessage_config.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_create_a_session_with_availabletools.yaml
+++ b/test/snapshots/session/should_create_a_session_with_availabletools.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_create_a_session_with_customized_systemmessage_config.yaml
+++ b/test/snapshots/session/should_create_a_session_with_customized_systemmessage_config.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system
@@ -8,8 +8,8 @@ conversations:
         content: Who are you?
       - role: assistant
         content: >-
-          I'm **GitHub Copilot CLI**, a terminal assistant built by GitHub. I'm powered by claude-sonnet-4.5 (model ID:
-          claude-sonnet-4.5).
+          I'm **GitHub Copilot CLI**, a terminal assistant built by GitHub. I'm powered by claude-sonnet-5 (model ID:
+          claude-sonnet-5).
 
 
           I'm here to help you with software engineering tasks, including:

--- a/test/snapshots/session/should_create_a_session_with_defaultagent_excludedtools.yaml
+++ b/test/snapshots/session/should_create_a_session_with_defaultagent_excludedtools.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_create_a_session_with_excludedtools.yaml
+++ b/test/snapshots/session/should_create_a_session_with_excludedtools.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_create_a_session_with_replaced_systemmessage_config.yaml
+++ b/test/snapshots/session/should_create_a_session_with_replaced_systemmessage_config.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_create_session_with_custom_config_dir.yaml
+++ b/test/snapshots/session/should_create_session_with_custom_config_dir.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_create_session_with_custom_tool.yaml
+++ b/test/snapshots/session/should_create_session_with_custom_tool.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_delete_session.yaml
+++ b/test/snapshots/session/should_delete_session.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_get_last_session_id.yaml
+++ b/test/snapshots/session/should_get_last_session_id.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_get_session_metadata.yaml
+++ b/test/snapshots/session/should_get_session_metadata.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_get_session_metadata_by_id.yaml
+++ b/test/snapshots/session/should_get_session_metadata_by_id.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_have_stateful_conversation.yaml
+++ b/test/snapshots/session/should_have_stateful_conversation.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_list_sessions.yaml
+++ b/test/snapshots/session/should_list_sessions.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_list_sessions_with_context.yaml
+++ b/test/snapshots/session/should_list_sessions_with_context.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_log_messages_at_various_levels.yaml
+++ b/test/snapshots/session/should_log_messages_at_various_levels.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_receive_session_events.yaml
+++ b/test/snapshots/session/should_receive_session_events.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_resume_a_session_using_a_new_client.yaml
+++ b/test/snapshots/session/should_resume_a_session_using_a_new_client.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_resume_a_session_using_the_same_client.yaml
+++ b/test/snapshots/session/should_resume_a_session_using_the_same_client.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_send_with_custom_requestheaders.yaml
+++ b/test/snapshots/session/should_send_with_custom_requestheaders.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_send_with_directory_attachment.yaml
+++ b/test/snapshots/session/should_send_with_directory_attachment.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_send_with_file_attachment.yaml
+++ b/test/snapshots/session/should_send_with_file_attachment.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_send_with_github_reference_attachment.yaml
+++ b/test/snapshots/session/should_send_with_github_reference_attachment.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_send_with_mode_property.yaml
+++ b/test/snapshots/session/should_send_with_mode_property.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_send_with_selection_attachment.yaml
+++ b/test/snapshots/session/should_send_with_selection_attachment.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_set_model_on_existing_session.yaml
+++ b/test/snapshots/session/should_set_model_on_existing_session.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session/should_set_model_with_reasoningeffort.yaml
+++ b/test/snapshots/session/should_set_model_with_reasoningeffort.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
   - gpt-5.4
 conversations:
   - messages:

--- a/test/snapshots/session_config/should_accept_blob_attachments.yaml
+++ b/test/snapshots/session_config/should_accept_blob_attachments.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_accept_message_attachments.yaml
+++ b/test/snapshots/session_config/should_accept_message_attachments.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_apply_all_reasoning_effort_values_on_session_create.yaml
+++ b/test/snapshots/session_config/should_apply_all_reasoning_effort_values_on_session_create.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/session_config/should_apply_availabletools_on_session_resume.yaml
+++ b/test/snapshots/session_config/should_apply_availabletools_on_session_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_apply_excluded_built_in_agents_on_create.yaml
+++ b/test/snapshots/session_config/should_apply_excluded_built_in_agents_on_create.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_apply_excluded_built_in_agents_on_resume.yaml
+++ b/test/snapshots/session_config/should_apply_excluded_built_in_agents_on_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_apply_github_mcp_tool_config_on_create.yaml
+++ b/test/snapshots/session_config/should_apply_github_mcp_tool_config_on_create.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/session_config/should_apply_instruction_directories_on_create.yaml
+++ b/test/snapshots/session_config/should_apply_instruction_directories_on_create.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_apply_instruction_directories_on_resume.yaml
+++ b/test/snapshots/session_config/should_apply_instruction_directories_on_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_apply_instructiondirectories_on_create.yaml
+++ b/test/snapshots/session_config/should_apply_instructiondirectories_on_create.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_apply_instructiondirectories_on_resume.yaml
+++ b/test/snapshots/session_config/should_apply_instructiondirectories_on_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_apply_instructiondirectories_on_session_create.yaml
+++ b/test/snapshots/session_config/should_apply_instructiondirectories_on_session_create.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_apply_instructiondirectories_on_session_resume.yaml
+++ b/test/snapshots/session_config/should_apply_instructiondirectories_on_session_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_apply_reasoning_effort_on_session_create.yaml
+++ b/test/snapshots/session_config/should_apply_reasoning_effort_on_session_create.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/session_config/should_apply_session_limits_on_create.yaml
+++ b/test/snapshots/session_config/should_apply_session_limits_on_create.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_apply_session_limits_on_resume.yaml
+++ b/test/snapshots/session_config/should_apply_session_limits_on_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_apply_systemmessage_on_session_resume.yaml
+++ b/test/snapshots/session_config/should_apply_systemmessage_on_session_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_apply_workingdirectory_on_session_resume.yaml
+++ b/test/snapshots/session_config/should_apply_workingdirectory_on_session_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_create_session_with_custom_provider_config.yaml
+++ b/test/snapshots/session_config/should_create_session_with_custom_provider_config.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/session_config/should_forward_clientname_in_user_agent.yaml
+++ b/test/snapshots/session_config/should_forward_clientname_in_user_agent.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_forward_clientname_in_useragent.yaml
+++ b/test/snapshots/session_config/should_forward_clientname_in_useragent.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_forward_custom_provider_headers_on_create.yaml
+++ b/test/snapshots/session_config/should_forward_custom_provider_headers_on_create.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_forward_custom_provider_headers_on_resume.yaml
+++ b/test/snapshots/session_config/should_forward_custom_provider_headers_on_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_use_custom_session_id.yaml
+++ b/test/snapshots/session_config/should_use_custom_session_id.yaml
@@ -1,3 +1,3 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations: []

--- a/test/snapshots/session_config/should_use_provider_model_id_as_wire_model.yaml
+++ b/test/snapshots/session_config/should_use_provider_model_id_as_wire_model.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/should_use_workingdirectory_for_tool_execution.yaml
+++ b/test/snapshots/session_config/should_use_workingdirectory_for_tool_execution.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/vision_disabled_then_enabled_via_setmodel.yaml
+++ b/test/snapshots/session_config/vision_disabled_then_enabled_via_setmodel.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_config/vision_enabled_then_disabled_via_setmodel.yaml
+++ b/test/snapshots/session_config/vision_enabled_then_disabled_via_setmodel.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_fs/should_load_session_data_from_fs_provider_on_resume.yaml
+++ b/test/snapshots/session_fs/should_load_session_data_from_fs_provider_on_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_fs/should_map_large_output_handling_into_sessionfs.yaml
+++ b/test/snapshots/session_fs/should_map_large_output_handling_into_sessionfs.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_fs/should_persist_plan_md_via_sessionfs.yaml
+++ b/test/snapshots/session_fs/should_persist_plan_md_via_sessionfs.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_fs/should_reject_setprovider_when_sessions_already_exist.yaml
+++ b/test/snapshots/session_fs/should_reject_setprovider_when_sessions_already_exist.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_fs/should_route_file_operations_through_the_session_fs_provider.yaml
+++ b/test/snapshots/session_fs/should_route_file_operations_through_the_session_fs_provider.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_fs/should_succeed_with_compaction_while_using_sessionfs.yaml
+++ b/test/snapshots/session_fs/should_succeed_with_compaction_while_using_sessionfs.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_fs/should_write_workspace_metadata_via_sessionfs.yaml
+++ b/test/snapshots/session_fs/should_write_workspace_metadata_via_sessionfs.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_fs_sqlite/should_allow_subagents_to_use_sql_tool_via_inherited_sessionfs.yaml
+++ b/test/snapshots/session_fs_sqlite/should_allow_subagents_to_use_sql_tool_via_inherited_sessionfs.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_fs_sqlite/should_route_sql_queries_through_the_sessionfs_sqlite_handler.yaml
+++ b/test/snapshots/session_fs_sqlite/should_route_sql_queries_through_the_sessionfs_sqlite_handler.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_lifecycle/should_delete_session_permanently.yaml
+++ b/test/snapshots/session_lifecycle/should_delete_session_permanently.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_lifecycle/should_isolate_events_between_concurrent_sessions.yaml
+++ b/test/snapshots/session_lifecycle/should_isolate_events_between_concurrent_sessions.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_lifecycle/should_list_created_sessions_after_sending_a_message.yaml
+++ b/test/snapshots/session_lifecycle/should_list_created_sessions_after_sending_a_message.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_lifecycle/should_return_events_via_getmessages_after_conversation.yaml
+++ b/test/snapshots/session_lifecycle/should_return_events_via_getmessages_after_conversation.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_lifecycle/should_support_multiple_concurrent_sessions.yaml
+++ b/test/snapshots/session_lifecycle/should_support_multiple_concurrent_sessions.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/session_todos_changed/fires_session_todos_changed_and_exposes_rows_and_dependencies.yaml
+++ b/test/snapshots/session_todos_changed/fires_session_todos_changed_and_exposes_rows_and_dependencies.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/skills/should_allow_agent_with_skills_to_invoke_skill.yaml
+++ b/test/snapshots/skills/should_allow_agent_with_skills_to_invoke_skill.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/skills/should_load_and_apply_skill_from_skilldirectories.yaml
+++ b/test/snapshots/skills/should_load_and_apply_skill_from_skilldirectories.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/skills/should_not_apply_skill_when_disabled_via_disabledskills.yaml
+++ b/test/snapshots/skills/should_not_apply_skill_when_disabled_via_disabledskills.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/skills/should_not_provide_skills_to_agent_without_skills_field.yaml
+++ b/test/snapshots/skills/should_not_provide_skills_to_agent_without_skills_field.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/streaming_fidelity/should_emit_assistantmessagestart_before_deltas_with_matching_messageid.yaml
+++ b/test/snapshots/streaming_fidelity/should_emit_assistantmessagestart_before_deltas_with_matching_messageid.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/streaming_fidelity/should_not_produce_deltas_after_session_resume_with_streaming_disabled.yaml
+++ b/test/snapshots/streaming_fidelity/should_not_produce_deltas_after_session_resume_with_streaming_disabled.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/streaming_fidelity/should_not_produce_deltas_when_streaming_is_disabled.yaml
+++ b/test/snapshots/streaming_fidelity/should_not_produce_deltas_when_streaming_is_disabled.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/streaming_fidelity/should_produce_delta_events_when_streaming_is_enabled.yaml
+++ b/test/snapshots/streaming_fidelity/should_produce_delta_events_when_streaming_is_enabled.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/streaming_fidelity/should_produce_deltas_after_session_resume.yaml
+++ b/test/snapshots/streaming_fidelity/should_produce_deltas_after_session_resume.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/subagent_hooks/should_invoke_pretooluse_and_posttooluse_hooks_for_sub_agent_tool_calls.yaml
+++ b/test/snapshots/subagent_hooks/should_invoke_pretooluse_and_posttooluse_hooks_for_sub_agent_tool_calls.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/suspend/should_allow_resume_and_continue_conversation_after_suspend.yaml
+++ b/test/snapshots/suspend/should_allow_resume_and_continue_conversation_after_suspend.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/suspend/should_cancel_pending_permission_request_when_suspending.yaml
+++ b/test/snapshots/suspend/should_cancel_pending_permission_request_when_suspending.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/suspend/should_reject_pending_external_tool_when_suspending.yaml
+++ b/test/snapshots/suspend/should_reject_pending_external_tool_when_suspending.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/suspend/should_suspend_idle_session_without_throwing.yaml
+++ b/test/snapshots/suspend/should_suspend_idle_session_without_throwing.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/system_message_sections/should_use_replaced_identity_section_in_response.yaml
+++ b/test/snapshots/system_message_sections/should_use_replaced_identity_section_in_response.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/system_message_sections/should_use_replaced_preamble_section_in_response.yaml
+++ b/test/snapshots/system_message_sections/should_use_replaced_preamble_section_in_response.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system
@@ -13,5 +13,5 @@ conversations:
           watering, pests, plant identification, or growing tips, I'm here to help!
 
 
-          I'm powered by claude-sonnet-4.5, but I focus specifically on gardening topics. What plant or gardening
+          I'm powered by claude-sonnet-5, but I focus specifically on gardening topics. What plant or gardening
           question can I help you with today?

--- a/test/snapshots/system_message_transform/should_apply_transform_modifications_to_section_content.yaml
+++ b/test/snapshots/system_message_transform/should_apply_transform_modifications_to_section_content.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/system_message_transform/should_invoke_transform_callbacks_with_section_content.yaml
+++ b/test/snapshots/system_message_transform/should_invoke_transform_callbacks_with_section_content.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/system_message_transform/should_work_with_static_overrides_and_transforms_together.yaml
+++ b/test/snapshots/system_message_transform/should_work_with_static_overrides_and_transforms_together.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/telemetry/should_export_file_telemetry_for_sdk_interactions.yaml
+++ b/test/snapshots/telemetry/should_export_file_telemetry_for_sdk_interactions.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tool_results/should_handle_structured_toolresultobject_from_custom_tool.yaml
+++ b/test/snapshots/tool_results/should_handle_structured_toolresultobject_from_custom_tool.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tool_results/should_handle_tool_result_with_denied_resulttype.yaml
+++ b/test/snapshots/tool_results/should_handle_tool_result_with_denied_resulttype.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tool_results/should_handle_tool_result_with_failure_resulttype.yaml
+++ b/test/snapshots/tool_results/should_handle_tool_result_with_failure_resulttype.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tool_results/should_handle_tool_result_with_rejected_resulttype.yaml
+++ b/test/snapshots/tool_results/should_handle_tool_result_with_rejected_resulttype.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tool_results/should_pass_validated_zod_parameters_to_tool_handler.yaml
+++ b/test/snapshots/tool_results/should_pass_validated_zod_parameters_to_tool_handler.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tool_results/should_preserve_tooltelemetry_and_not_stringify_structured_results_for_llm.yaml
+++ b/test/snapshots/tool_results/should_preserve_tooltelemetry_and_not_stringify_structured_results_for_llm.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tools/can_receive_and_return_complex_types.yaml
+++ b/test/snapshots/tools/can_receive_and_return_complex_types.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tools/clears_context_from_a_terminal_tool_and_starts_the_seeded_turn.yaml
+++ b/test/snapshots/tools/clears_context_from_a_terminal_tool_and_starts_the_seeded_turn.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tools/denies_custom_tool_when_permission_denied.yaml
+++ b/test/snapshots/tools/denies_custom_tool_when_permission_denied.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tools/ergonomic_tool_arity0.yaml
+++ b/test/snapshots/tools/ergonomic_tool_arity0.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tools/ergonomic_tool_arity2.yaml
+++ b/test/snapshots/tools/ergonomic_tool_arity2.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tools/ergonomic_tool_definition.yaml
+++ b/test/snapshots/tools/ergonomic_tool_definition.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tools/handles_tool_calling_errors.yaml
+++ b/test/snapshots/tools/handles_tool_calling_errors.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tools/invokes_built_in_tools.yaml
+++ b/test/snapshots/tools/invokes_built_in_tools.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tools/invokes_custom_tool.yaml
+++ b/test/snapshots/tools/invokes_custom_tool.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tools/invokes_custom_tool_with_permission_handler.yaml
+++ b/test/snapshots/tools/invokes_custom_tool_with_permission_handler.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tools/low_level_tool_definition.yaml
+++ b/test/snapshots/tools/low_level_tool_definition.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tools/overrides_built_in_tool_with_custom_tool.yaml
+++ b/test/snapshots/tools/overrides_built_in_tool_with_custom_tool.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tools/should_execute_multiple_custom_tools_in_parallel_single_turn.yaml
+++ b/test/snapshots/tools/should_execute_multiple_custom_tools_in_parallel_single_turn.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tools/should_respect_availabletools_and_excludedtools_combined.yaml
+++ b/test/snapshots/tools/should_respect_availabletools_and_excludedtools_combined.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system

--- a/test/snapshots/tools/skippermission_sent_in_tool_definition.yaml
+++ b/test/snapshots/tools/skippermission_sent_in_tool_definition.yaml
@@ -1,5 +1,5 @@
 models:
-  - claude-sonnet-4.5
+  - claude-sonnet-5
 conversations:
   - messages:
       - role: system


### PR DESCRIPTION
## Summary

Migrate SDK **tests, replay fixtures, and fixture-authoring templates** from `claude-sonnet-4.5` to `claude-sonnet-5`, in coordination with https://github.com/github/copilot-agent-runtime/pull/18419. No SDK production behavior, runtime default-selection policy, or agentic-workflow configuration changes. Consumer documentation and generated production API examples remain out of scope.

- Use Sonnet 5 consistently in test sessions, fake provider catalogs/responses, assertions, the Anthropic test backend, and shared replay fixture model identifiers.
- Use Sonnet 5 for both session creation and `setModel` in vision capability tests across Node, Python, Go, and C#.
- Keep the proxy simple: return stored catalogs unchanged, or Sonnet 5 when no catalog is stored. The interim Sonnet 4.5 compatibility shim is removed.
- Add only focused missing/empty-catalog default coverage; preserve the existing cached-catalog test. Extra tests introduced for the interim compatibility approach are removed.
- Update exact model matches in rate-limit fixtures along with their catalogs. No conversation captures were regenerated.
- Update Java snapshot-authoring skill templates so new fixtures do not reintroduce Sonnet 4.5.

The broad file count is primarily mechanical fixture updates. The main migration changed 449 files solely through model identifier/display-label replacement; subsequent formatter reflow affects three test files. No Sonnet 4.5 references remain in the SDK test/harness/fixture directories or Java snapshot-authoring templates.

## Validation

Migration runs use `GITHUB_ACTIONS=true` and `TEST_CI=true` for strict, read-only replay:

| Scope | Result |
| --- | --- |
| Shared harness suite after trimming tests, and TypeScript check | 66 passed; typecheck passed |
| Full Node E2E suite, companion runtime | 455 passed, 11 skipped |
| Full Python E2E suite, pinned CLI | 419 passed, 8 skipped |
| Full Go E2E suite, pinned CLI | Passed |
| Affected C# classes, companion runtime | 166 passed |
| Affected Rust E2E modules, pinned CLI | 86 passed |
| Affected Java tests plus rewind integration, companion runtime | 118 tests + 1 integration test passed |

An independent Opus 5 review confirmed the migration's functional completeness and catalog consistency. It found stale fixture-authoring examples and formatter reflow missed by the earlier local validation. Those findings are addressed in the follow-up: repository-wide Python `ruff format --check .` / `ruff check .` and Java `mvn spotless:check -pl sdk -am` now pass. Fresh CI is pending; earlier Python/Java formatter failures should not be mistaken for functional test failures.

Before the original harness fix, all seven reported C# regressions reproduced against the companion runtime; all seven passed after the fix and are covered by subsequent affected-class runs.

The separate consistency-review agent's HTTP 400 model-availability failure is outside this test-harness change.

## Companion rollout

The runtime C# workflow clones the SDK default branch in its prepare job. Merge this SDK PR before rerunning that workflow, including its prepare job so downstream jobs do not reuse the old prepared SDK artifact.