### PR TITLE
docs(readme): list community Zig SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,11 @@ Please use the [GitHub Issues](https://github.com/github/copilot-sdk/issues) pag
 | ----------- | -------------------------------------------------------- |
 | **Clojure** | [copilot-community-sdk/copilot-sdk-clojure][sdk-clojure] |
 | **C++**     | [0xeb/copilot-sdk-cpp][sdk-cpp]                          |
+| **Zig**     | [scaryrawr/copilot-sdk-zig][sdk-zig]                     |
 
 [sdk-cpp]: https://github.com/0xeb/copilot-sdk-cpp
 [sdk-clojure]: https://github.com/copilot-community-sdk/copilot-sdk-clojure
+[sdk-zig]: https://github.com/scaryrawr/copilot-sdk-zig
 
 ## Contributing
 


### PR DESCRIPTION
## Why

The Zig SDK now lives in a standalone community repository. Listing it with the other unofficial SDKs makes the ownership and support boundary clear.

## Scope

Add `scaryrawr/copilot-sdk-zig` to the unofficial community-maintained SDK table in `README.md`.

## Blast Radius

Documentation only. The change does not affect an official SDK package or runtime behavior.

## Verification

`git diff --check` passed. The standalone repository CI and its upstream synchronization workflow both passed.