### PR TITLE
Reduce merge queue flakiness

### DIFF
--- a/.github/workflows/dotnet-sdk-tests.yml
+++ b/.github/workflows/dotnet-sdk-tests.yml
@@ -12,7 +12,7 @@ jobs:
     name: ".NET SDK Build and Format"
     if: github.event.repository.fork == false
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 20
     defaults:
       run:
         shell: bash
@@ -128,7 +128,7 @@ jobs:
     # A hung test used to run until the runner died (~50 min) and the dying
     # runner never uploaded its logs, so the failures were undiagnosable.
     # Every healthy cell finishes well under 15 min.
-    timeout-minutes: 20
+    timeout-minutes: 25
     defaults:
       run:
         shell: bash

--- a/.github/workflows/dotnet-sdk-tests.yml
+++ b/.github/workflows/dotnet-sdk-tests.yml
@@ -128,7 +128,7 @@ jobs:
     # A hung test used to run until the runner died (~50 min) and the dying
     # runner never uploaded its logs, so the failures were undiagnosable.
     # Every healthy cell finishes well under 15 min.
-    timeout-minutes: 25
+    timeout-minutes: 20
     defaults:
       run:
         shell: bash
@@ -166,13 +166,12 @@ jobs:
         run: echo "COPILOT_SDK_DEFAULT_CONNECTION=inprocess" >> "$GITHUB_ENV"
 
       - name: Run .NET SDK tests
-        timeout-minutes: 18
         env:
           COPILOT_HMAC_KEY: ${{ secrets.COPILOT_DEVELOPER_CLI_INTEGRATION_HMAC_KEY }}
           DOTNET_TEST_SHARD: ${{ matrix.shard }}
         run: |
           # --blame-hang names the offending test instead of letting it wedge
-          # the runner. No single test legitimately runs for five minutes; the
+          # the runner. No single test legitimately runs for 10 minutes; the
           # whole suite normally finishes in about five.
           # The validation job performs the full analyzer-enabled SDK build.
           # Build only test-consumed frameworks here and do not repeat analyzers.
@@ -180,7 +179,7 @@ jobs:
             --no-restore
             -v n
             --blame-hang
-            --blame-hang-timeout 5m
+            --blame-hang-timeout 10m
             --blame-hang-dump-type none
             --logger "trx;LogFilePrefix=test-results"
             --results-directory "$GITHUB_WORKSPACE/dotnet/TestResults"

--- a/.github/workflows/dotnet-sdk-tests.yml
+++ b/.github/workflows/dotnet-sdk-tests.yml
@@ -12,7 +12,7 @@ jobs:
     name: ".NET SDK Build and Format"
     if: github.event.repository.fork == false
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     defaults:
       run:
         shell: bash
@@ -166,16 +166,26 @@ jobs:
         run: echo "COPILOT_SDK_DEFAULT_CONNECTION=inprocess" >> "$GITHUB_ENV"
 
       - name: Run .NET SDK tests
+        timeout-minutes: 18
         env:
           COPILOT_HMAC_KEY: ${{ secrets.COPILOT_DEVELOPER_CLI_INTEGRATION_HMAC_KEY }}
           DOTNET_TEST_SHARD: ${{ matrix.shard }}
         run: |
           # --blame-hang names the offending test instead of letting it wedge
-          # the runner. No single test legitimately runs for 10 minutes; the
+          # the runner. No single test legitimately runs for five minutes; the
           # whole suite normally finishes in about five.
           # The validation job performs the full analyzer-enabled SDK build.
           # Build only test-consumed frameworks here and do not repeat analyzers.
-          args=(--no-restore -v n --blame-hang --blame-hang-timeout 10m --blame-hang-dump-type none -p:RunAnalyzers=false)
+          args=(
+            --no-restore
+            -v n
+            --blame-hang
+            --blame-hang-timeout 5m
+            --blame-hang-dump-type none
+            --logger "trx;LogFilePrefix=test-results"
+            --results-directory "$GITHUB_WORKSPACE/dotnet/TestResults"
+            -p:RunAnalyzers=false
+          )
 
           filter="$DOTNET_TEST_FILTER"
           if [[ "$DOTNET_TEST_SHARD" != "full" ]]; then
@@ -217,3 +227,12 @@ jobs:
             args+=(--filter "$filter")
           fi
           dotnet test test/GitHub.Copilot.SDK.Test.csproj "${args[@]}"
+
+      - name: Upload .NET test diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dotnet-test-diagnostics-${{ matrix.os }}-${{ matrix.transport }}-${{ matrix.backend }}-${{ matrix.shard }}-${{ github.run_attempt }}
+          path: dotnet/TestResults/
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/java-sdk-tests.yml
+++ b/.github/workflows/java-sdk-tests.yml
@@ -7,6 +7,11 @@ on:
 permissions:
   contents: read
 
+env:
+  MAVEN_OPTS: >-
+    -Daether.connector.http.retryHandler.count=3
+    -Daether.connector.http.retryHandler.serviceUnavailable=429,502,503
+
 jobs:
   java-sdk-inprocess:
     name: "Java SDK InProcess Tests (${{ matrix.classifier }})"
@@ -121,11 +126,12 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: java-native-publication-linux-arm64-${{ github.run_id }}-${{ github.run_attempt }}
+          name: java-native-publication-linux-arm64-${{ github.run_id }}
           path: |
             java/copilot-native/target/copilot-sdk-java-runtime-${{ steps.build.outputs.version }}-linux-arm64.jar
             java/copilot-native/target/linux-arm64-${{ steps.build.outputs.version }}.sha256
           if-no-files-found: error
+          overwrite: true
           retention-days: 1
 
   java-native-publication-windows:
@@ -178,11 +184,12 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: java-native-publication-win32-x64-${{ github.run_id }}-${{ github.run_attempt }}
+          name: java-native-publication-win32-x64-${{ github.run_id }}
           path: |
             java/copilot-native/target/copilot-sdk-java-runtime-${{ steps.build.outputs.version }}-win32-x64.jar
             java/copilot-native/target/win32-x64-${{ steps.build.outputs.version }}.sha256
           if-no-files-found: error
+          overwrite: true
           retention-days: 1
 
   java-native-publication-windows-arm64:
@@ -235,11 +242,12 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: java-native-publication-win32-arm64-${{ github.run_id }}-${{ github.run_attempt }}
+          name: java-native-publication-win32-arm64-${{ github.run_id }}
           path: |
             java/copilot-native/target/copilot-sdk-java-runtime-${{ steps.build.outputs.version }}-win32-arm64.jar
             java/copilot-native/target/win32-arm64-${{ steps.build.outputs.version }}.sha256
           if-no-files-found: error
+          overwrite: true
           retention-days: 1
 
   java-native-publication-darwin:
@@ -293,11 +301,12 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: java-native-publication-darwin-arm64-${{ github.run_id }}-${{ github.run_attempt }}
+          name: java-native-publication-darwin-arm64-${{ github.run_id }}
           path: |
             java/copilot-native/target/copilot-sdk-java-runtime-${{ steps.build.outputs.version }}-darwin-arm64.jar
             java/copilot-native/target/darwin-arm64-${{ steps.build.outputs.version }}.sha256
           if-no-files-found: error
+          overwrite: true
           retention-days: 1
 
   java-native-publication-assembly:
@@ -333,22 +342,22 @@ jobs:
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: java-native-publication-linux-arm64-${{ github.run_id }}-${{ github.run_attempt }}
+          name: java-native-publication-linux-arm64-${{ github.run_id }}
           path: ${{ github.workspace }}/java/native-publication-input/linux-arm64
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: java-native-publication-win32-x64-${{ github.run_id }}-${{ github.run_attempt }}
+          name: java-native-publication-win32-x64-${{ github.run_id }}
           path: ${{ github.workspace }}/java/native-publication-input/windows
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: java-native-publication-win32-arm64-${{ github.run_id }}-${{ github.run_attempt }}
+          name: java-native-publication-win32-arm64-${{ github.run_id }}
           path: ${{ github.workspace }}/java/native-publication-input/windows-arm64
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: java-native-publication-darwin-arm64-${{ github.run_id }}-${{ github.run_attempt }}
+          name: java-native-publication-darwin-arm64-${{ github.run_id }}
           path: ${{ github.workspace }}/java/native-publication-input/darwin
 
       - name: Verify native inputs and deploy the complete local release

--- a/.github/workflows/nodejs-sdk-tests.yml
+++ b/.github/workflows/nodejs-sdk-tests.yml
@@ -53,6 +53,11 @@ jobs:
         working-directory: ./test/harness
         run: npm ci --ignore-scripts
 
+      - name: Run test harness tests
+        if: runner.os == 'Linux' && matrix.transport == 'default'
+        working-directory: ./test/harness
+        run: npm test
+
       - name: Warm up PowerShell
         if: runner.os == 'Windows'
         run: pwsh.exe -Command "Write-Host 'PowerShell ready'"

--- a/.github/workflows/python-sdk-tests.yml
+++ b/.github/workflows/python-sdk-tests.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install Node.js dependencies (for CLI in tests)
         working-directory: ./nodejs
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --fetch-retries=4 --fetch-retry-mintimeout=10000 --fetch-retry-maxtimeout=60000
 
       - name: Run ruff format check
         run: uv run ruff format --check .
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install test harness dependencies
         working-directory: ./test/harness
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --fetch-retries=4 --fetch-retry-mintimeout=10000 --fetch-retry-maxtimeout=60000
 
       - name: Warm up PowerShell
         if: runner.os == 'Windows'

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ format: format-go format-python format-nodejs format-dotnet format-rust
 lint: lint-go lint-python lint-nodejs lint-dotnet lint-rust
 
 # Run tests for all languages
-test: test-go test-python test-nodejs test-dotnet test-rust test-corrections
+test: test-go test-python test-nodejs test-dotnet test-rust test-harness test-corrections
 
 # Format Go code
 format-go:
@@ -65,6 +65,11 @@ test-python:
 test-nodejs:
     @echo "=== Testing Node.js code ==="
     @cd nodejs && npm test
+
+# Run test harness tests
+test-harness:
+    @echo "=== Testing test harness ==="
+    @cd test/harness && npm test
 
 # Test .NET code
 test-dotnet:
@@ -168,4 +173,3 @@ validate-docs-go:
 validate-docs-cs:
     @echo "=== Validating C# documentation ==="
     @cd scripts/docs-validation && npm run validate:cs
-

--- a/rust/tests/e2e/support.rs
+++ b/rust/tests/e2e/support.rs
@@ -31,6 +31,7 @@ static SHARED_E2E_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| 
         .expect("create shared E2E runtime")
 });
 const SHARED_E2E_CLEANUP_TIMEOUT: Duration = Duration::from_secs(10);
+const PROXY_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub const DEFAULT_TEST_TOKEN: &str = "rust-e2e-token";
 
@@ -1274,7 +1275,7 @@ impl CapiProxy {
             }
         });
         let re = regex::Regex::new(r"Listening: (http://[^\s]+)\s+(\{.*\})$").unwrap();
-        let deadline = Instant::now() + SHARED_E2E_CLEANUP_TIMEOUT;
+        let deadline = Instant::now() + PROXY_STARTUP_TIMEOUT;
         while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
             let line = match line_rx.recv_timeout(remaining) {
                 Ok(Ok(line)) => line,
@@ -1341,7 +1342,7 @@ impl CapiProxy {
 
         kill_and_wait_child(&mut child);
         Err(std::io::Error::other(format!(
-            "timed out after {SHARED_E2E_CLEANUP_TIMEOUT:?} waiting for proxy startup"
+            "timed out after {PROXY_STARTUP_TIMEOUT:?} waiting for proxy startup"
         )))
     }
 

--- a/test/harness/capturingHttpProxy.test.ts
+++ b/test/harness/capturingHttpProxy.test.ts
@@ -10,9 +10,21 @@ describe("Capturing HTTP Proxy", () => {
   let proxy: CapturingHttpProxy;
   let testServer: http.Server;
   let testServerAddress: string;
+  let onHangingRequest: (() => void) | undefined;
+  let onStreamingResponse: (() => void) | undefined;
 
   beforeEach(async () => {
     testServer = http.createServer((req, res) => {
+      if (req.url === "/hang") {
+        onHangingRequest?.();
+        return;
+      }
+      if (req.url === "/stream") {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.write("started");
+        onStreamingResponse?.();
+        return;
+      }
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ message: "Hello", path: req.url }));
     });
@@ -70,5 +82,35 @@ describe("Capturing HTTP Proxy", () => {
         },
       } as CapturedExchange,
     ]);
+  });
+
+  test("stops while a proxied request is still active", async () => {
+    proxy = new CapturingHttpProxy(testServerAddress);
+    const proxyUrl = await proxy.start();
+    const requestStarted = new Promise<void>((resolve) => {
+      onHangingRequest = resolve;
+    });
+    const request = fetch(`${proxyUrl}/hang`).catch(() => undefined);
+    await requestStarted;
+
+    await proxy.stop();
+
+    await request;
+  });
+
+  test("stops while a proxied response is still streaming", async () => {
+    proxy = new CapturingHttpProxy(testServerAddress);
+    const proxyUrl = await proxy.start();
+    const responseStarted = new Promise<void>((resolve) => {
+      onStreamingResponse = resolve;
+    });
+    const responsePromise = fetch(`${proxyUrl}/stream`);
+    await responseStarted;
+    const response = await responsePromise;
+    const body = response.text().catch(() => undefined);
+
+    await proxy.stop();
+
+    await body;
   });
 });

--- a/test/harness/capturingHttpProxy.ts
+++ b/test/harness/capturingHttpProxy.ts
@@ -10,7 +10,10 @@ import https from "https";
  */
 export class CapturingHttpProxy {
   private readonly capturedExchanges: CapturedExchange[] = [];
+  private readonly activeRequests = new Set<http.ClientRequest>();
+  private readonly activeResponses = new Set<http.IncomingMessage>();
   private server?: http.Server;
+  private stopPromise?: Promise<void>;
 
   constructor(private targetUrl: string) {}
 
@@ -90,6 +93,10 @@ export class CapturingHttpProxy {
             res.end();
           },
           onError: (err) => {
+            if (!this.server) {
+              res.destroy();
+              return;
+            }
             console.error("Error in proxying request:", err);
             const endTime = Date.now();
             const formattedError =
@@ -130,9 +137,19 @@ export class CapturingHttpProxy {
   }
 
   async stop(): Promise<void> {
-    if (this.server) {
-      return new Promise((resolve, reject) => {
-        this.server!.close((err) => {
+    if (this.stopPromise) {
+      return this.stopPromise;
+    }
+
+    const server = this.server;
+    if (!server) {
+      return;
+    }
+
+    this.server = undefined;
+    this.stopPromise = (async () => {
+      const closed = new Promise<void>((resolve, reject) => {
+        server.close((err) => {
           if (err) {
             reject(err);
           } else {
@@ -140,14 +157,38 @@ export class CapturingHttpProxy {
           }
         });
       });
-    }
+
+      // server.close() waits for active connections. A replayed streaming request
+      // can otherwise wedge fixture teardown after its test has already passed.
+      server.closeAllConnections();
+      for (const response of this.activeResponses) {
+        response.destroy();
+      }
+      this.activeResponses.clear();
+      for (const request of this.activeRequests) {
+        request.destroy();
+      }
+      this.activeRequests.clear();
+
+      await closed;
+    })();
+    return this.stopPromise;
   }
 
   performRequest(options: PerformRequestOptions): void {
+    if (this.stopPromise) {
+      options.onError(new Error("Proxy is stopping"));
+      return;
+    }
+
     const protocol = options.isHttps ? https : http;
     const upstreamRequest = protocol.request(
       options.requestOptions,
       (upstreamResponse) => {
+        this.activeResponses.add(upstreamResponse);
+        upstreamResponse.once("close", () => {
+          this.activeResponses.delete(upstreamResponse);
+        });
         options.onResponseStart(
           upstreamResponse.statusCode || 500,
           upstreamResponse.headers,
@@ -157,6 +198,10 @@ export class CapturingHttpProxy {
       },
     );
 
+    this.activeRequests.add(upstreamRequest);
+    upstreamRequest.once("close", () => {
+      this.activeRequests.delete(upstreamRequest);
+    });
     upstreamRequest.on("error", options.onError);
 
     if (options.body) {

--- a/test/harness/replayingCapiProxy.test.ts
+++ b/test/harness/replayingCapiProxy.test.ts
@@ -24,13 +24,21 @@ import { ShellConfig } from "./util";
 describe("ReplayingCapiProxy", () => {
   let tempDir: string;
   let workDir: string;
+  let githubActions: string | undefined;
 
   beforeEach(async () => {
+    githubActions = process.env.GITHUB_ACTIONS;
+    delete process.env.GITHUB_ACTIONS;
     tempDir = await mkdtemp(path.join(os.tmpdir(), "capi-proxy-test-"));
     workDir = path.join(tempDir, "work");
   });
 
   afterEach(async () => {
+    if (githubActions === undefined) {
+      delete process.env.GITHUB_ACTIONS;
+    } else {
+      process.env.GITHUB_ACTIONS = githubActions;
+    }
     await rm(tempDir, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## Summary

Analyzed every GitHub Actions run with event `merge_group` in the 48-hour window ending 2026-09-02 14:03 UTC: 165 workflow runs across 55 merge-group commits. Thirty run IDs encountered a blocking failure or cancellation, including five that recovered on rerun.

The largest recurring cluster was silent .NET test hangs: 13 jobs across 12 merge-group runs, usually macOS shard `2b`. The runners frequently died without uploading logs. Other actionable clusters included Rust proxy startup timeouts, transient npm/Maven downloads, and a Java artifact-name bug that made failed-job reruns deterministically fail assembly.

## Changes

- Force the replay proxy to close active inbound connections, upstream requests, and streaming responses so .NET fixture teardown cannot hang after a test passes; retain per-attempt TRX/blame diagnostics without changing timeout budgets.
- Make Java native publication artifacts stable across rerun attempts while allowing a rerun producer to replace its own artifact. Assembly can now combine successful attempt-1 producers with a retried producer.
- Retry Maven Resolver responses for 429/502/503 and npm package fetches with bounded backoff.
- Give the Rust CAPI proxy 30 seconds to start on loaded runners instead of reusing its 10-second cleanup deadline.

## Merge-queue evidence

- .NET hangs/timeouts: 13 jobs / 12 runs, including [33631940159](https://github.com/github/copilot-sdk/actions/runs/33631940159), [33633883917](https://github.com/github/copilot-sdk/actions/runs/33633883917), and [33635168417](https://github.com/github/copilot-sdk/actions/runs/33635168417).
- Java failed-job rerun artifact mismatch: [33634556374](https://github.com/github/copilot-sdk/actions/runs/33634556374).
- Rust proxy/shared-client startup: [33525616900](https://github.com/github/copilot-sdk/actions/runs/33525616900) and [33634503025](https://github.com/github/copilot-sdk/actions/runs/33634503025).
- Package registry failures: [33633883917](https://github.com/github/copilot-sdk/actions/runs/33633883917) and [33638905142](https://github.com/github/copilot-sdk/actions/runs/33638905142).

Cross-SDK rewind capture failures and replay fixture drift were intentionally left out: the evidence points to shared runtime/fixture correctness issues rather than safe CI-level retries, so they should be fixed separately without masking failures.

## Validation

- Parsed all changed workflow YAML.
- Ran `cargo fmt --all -- --check`.
- Ran `cargo check --test e2e --no-default-features --features test-support`.
