### PR TITLE
Fix internal client-session handler codegen

### DIFF
--- a/nodejs/test/client-api-codegen.test.ts
+++ b/nodejs/test/client-api-codegen.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { emitClientSessionApiRegistration as emitGoClientSessionApiRegistration } from "../../scripts/codegen/go.ts";
+import { emitClientSessionApiRegistration as emitPythonClientSessionApiRegistration } from "../../scripts/codegen/python.ts";
+import { emitClientSessionApiRegistration as emitTypeScriptClientSessionApiRegistration } from "../../scripts/codegen/typescript.ts";
+
+const clientSessionSchema: Record<string, unknown> = {
+    mixed: {
+        visible: {
+            rpcMethod: "mixed.visible",
+            params: {
+                type: "object",
+                title: "VisibleRequest",
+                properties: {
+                    sessionId: { type: "string" },
+                },
+                required: ["sessionId"],
+            },
+            result: {
+                type: "object",
+                title: "VisibleResult",
+                properties: {},
+            },
+        },
+        secret: {
+            rpcMethod: "mixed.secret",
+            visibility: "internal",
+            params: {
+                $ref: "#/definitions/InternalRequest",
+            },
+            result: {
+                $ref: "#/definitions/InternalResult",
+            },
+        },
+    },
+    internalOnly: {
+        hidden: {
+            rpcMethod: "internalOnly.hidden",
+            visibility: "internal",
+            params: {
+                $ref: "#/definitions/InternalRequest",
+            },
+            result: {
+                $ref: "#/definitions/InternalResult",
+            },
+        },
+    },
+};
+
+function expectOnlyPublicClientSessionHandlers(code: string): void {
+    expect(code).toContain("mixed.visible");
+    expect(code).not.toContain("mixed.secret");
+    expect(code).not.toContain("internalOnly.hidden");
+    expect(code).not.toContain("InternalRequest");
+    expect(code).not.toContain("InternalResult");
+}
+
+describe("client-session API codegen", () => {
+    it("excludes internal methods from TypeScript handlers", () => {
+        const code = emitTypeScriptClientSessionApiRegistration(clientSessionSchema).join("\n");
+
+        expectOnlyPublicClientSessionHandlers(code);
+        expect(code).not.toContain("InternalOnlyHandler");
+    });
+
+    it("excludes internal methods from Go handlers", () => {
+        const lines: string[] = [];
+        emitGoClientSessionApiRegistration(lines, clientSessionSchema, (name) => name, new Map());
+        const code = lines.join("\n");
+
+        expectOnlyPublicClientSessionHandlers(code);
+        expect(code).not.toContain("InternalOnlyHandler");
+    });
+
+    it("excludes internal methods from Python handlers", () => {
+        const lines: string[] = [];
+        emitPythonClientSessionApiRegistration(lines, clientSessionSchema, (name) => name);
+        const code = lines.join("\n");
+
+        expectOnlyPublicClientSessionHandlers(code);
+        expect(code).not.toContain("InternalOnlyHandler");
+    });
+});

--- a/nodejs/test/client-api-codegen.test.ts
+++ b/nodejs/test/client-api-codegen.test.ts
@@ -47,6 +47,10 @@ const clientSessionSchema: Record<string, unknown> = {
     },
 };
 
+const allInternalClientSessionSchema: Record<string, unknown> = {
+    internalOnly: clientSessionSchema.internalOnly,
+};
+
 function expectOnlyPublicClientSessionHandlers(code: string): void {
     expect(code).toContain("mixed.visible");
     expect(code).not.toContain("mixed.secret");
@@ -58,26 +62,54 @@ function expectOnlyPublicClientSessionHandlers(code: string): void {
 describe("client-session API codegen", () => {
     it("excludes internal methods from TypeScript handlers", () => {
         const code = emitTypeScriptClientSessionApiRegistration(clientSessionSchema).join("\n");
+        const allInternalCode = emitTypeScriptClientSessionApiRegistration(
+            allInternalClientSessionSchema
+        ).join("\n");
 
         expectOnlyPublicClientSessionHandlers(code);
         expect(code).not.toContain("InternalOnlyHandler");
+        expect(allInternalCode).toContain("export interface ClientSessionApiHandlers {");
+        expect(allInternalCode).toContain("export function registerClientSessionApiHandlers(");
+        expect(allInternalCode).not.toContain("InternalOnlyHandler");
     });
 
     it("excludes internal methods from Go handlers", () => {
         const lines: string[] = [];
         emitGoClientSessionApiRegistration(lines, clientSessionSchema, (name) => name, new Map());
         const code = lines.join("\n");
+        const allInternalLines: string[] = [];
+        emitGoClientSessionApiRegistration(
+            allInternalLines,
+            allInternalClientSessionSchema,
+            (name) => name,
+            new Map()
+        );
+        const allInternalCode = allInternalLines.join("\n");
 
         expectOnlyPublicClientSessionHandlers(code);
         expect(code).not.toContain("InternalOnlyHandler");
+        expect(allInternalCode).toContain("type ClientSessionAPIHandlers struct {");
+        expect(allInternalCode).toContain("func RegisterClientSessionAPIHandlers(");
+        expect(allInternalCode).not.toContain("InternalOnlyHandler");
+        expect(allInternalCode).not.toContain("clientSessionHandlerError");
     });
 
     it("excludes internal methods from Python handlers", () => {
         const lines: string[] = [];
         emitPythonClientSessionApiRegistration(lines, clientSessionSchema, (name) => name);
         const code = lines.join("\n");
+        const allInternalLines: string[] = [];
+        emitPythonClientSessionApiRegistration(
+            allInternalLines,
+            allInternalClientSessionSchema,
+            (name) => name
+        );
+        const allInternalCode = allInternalLines.join("\n");
 
         expectOnlyPublicClientSessionHandlers(code);
         expect(code).not.toContain("InternalOnlyHandler");
+        expect(allInternalCode).toContain("class ClientSessionApiHandlers:");
+        expect(allInternalCode).toContain("def register_client_session_api_handlers(");
+        expect(allInternalCode).not.toContain("InternalOnlyHandler");
     });
 });

--- a/scripts/codegen/go.ts
+++ b/scripts/codegen/go.ts
@@ -4268,8 +4268,10 @@ function clientHandlerMethodName(rpcMethod: string): string {
     return toPascalCase(rpcMethod.split(".").at(-1)!);
 }
 
-function emitClientSessionApiRegistration(lines: string[], clientSchema: Record<string, unknown>, resolveType: (name: string) => string, unionInfos: Map<string, GoDiscriminatedUnionInfo>): void {
-    const groups = collectClientGroups(clientSchema);
+export function emitClientSessionApiRegistration(lines: string[], clientSchema: Record<string, unknown>, resolveType: (name: string) => string, unionInfos: Map<string, GoDiscriminatedUnionInfo>): void {
+    const publicClientSchema = filterNodeByVisibility(clientSchema, "public");
+    if (!publicClientSchema) return;
+    const groups = collectClientGroups(publicClientSchema);
 
     for (const { groupName, groupNode, methods } of groups) {
         const interfaceName = clientHandlerInterfaceName(groupName);

--- a/scripts/codegen/go.ts
+++ b/scripts/codegen/go.ts
@@ -3967,7 +3967,10 @@ async function generateRpc(schemaPath?: string): Promise<void> {
     if (generatedTypeCode.includes("time.Time")) {
         imports.push(`"time"`);
     }
-    if (schema.clientSession || schema.clientGlobal) {
+    const publicClientSession = schema.clientSession
+        ? filterNodeByVisibility(schema.clientSession, "public")
+        : null;
+    if (publicClientSession || schema.clientGlobal) {
         imports.push(`"errors"`, `"fmt"`);
     }
     imports.push(`"github.com/github/copilot-sdk/go/internal/jsonrpc2"`);
@@ -4269,8 +4272,7 @@ function clientHandlerMethodName(rpcMethod: string): string {
 }
 
 export function emitClientSessionApiRegistration(lines: string[], clientSchema: Record<string, unknown>, resolveType: (name: string) => string, unionInfos: Map<string, GoDiscriminatedUnionInfo>): void {
-    const publicClientSchema = filterNodeByVisibility(clientSchema, "public");
-    if (!publicClientSchema) return;
+    const publicClientSchema = filterNodeByVisibility(clientSchema, "public") ?? {};
     const groups = collectClientGroups(publicClientSchema);
 
     for (const { groupName, groupNode, methods } of groups) {
@@ -4326,17 +4328,19 @@ export function emitClientSessionApiRegistration(lines: string[], clientSchema: 
     lines.push(`}`);
     lines.push(``);
 
-    lines.push(`func clientSessionHandlerError(err error) *jsonrpc2.Error {`);
-    lines.push(`\tif err == nil {`);
-    lines.push(`\t\treturn nil`);
-    lines.push(`\t}`);
-    lines.push(`\tvar rpcErr *jsonrpc2.Error`);
-    lines.push(`\tif errors.As(err, &rpcErr) {`);
-    lines.push(`\t\treturn rpcErr`);
-    lines.push(`\t}`);
-    lines.push(`\treturn &jsonrpc2.Error{Code: -32603, Message: err.Error()}`);
-    lines.push(`}`);
-    lines.push(``);
+    if (groups.length > 0) {
+        lines.push(`func clientSessionHandlerError(err error) *jsonrpc2.Error {`);
+        lines.push(`\tif err == nil {`);
+        lines.push(`\t\treturn nil`);
+        lines.push(`\t}`);
+        lines.push(`\tvar rpcErr *jsonrpc2.Error`);
+        lines.push(`\tif errors.As(err, &rpcErr) {`);
+        lines.push(`\t\treturn rpcErr`);
+        lines.push(`\t}`);
+        lines.push(`\treturn &jsonrpc2.Error{Code: -32603, Message: err.Error()}`);
+        lines.push(`}`);
+        lines.push(``);
+    }
 
     lines.push(`// RegisterClientSessionAPIHandlers registers handlers for server-to-client session API calls.`);
     lines.push(`func RegisterClientSessionAPIHandlers(client *jsonrpc2.Client, getHandlers func(sessionID string) *ClientSessionAPIHandlers) {`);

--- a/scripts/codegen/python.ts
+++ b/scripts/codegen/python.ts
@@ -3773,12 +3773,14 @@ function clientSessionHandlerMethodName(rpcMethod: string): string {
     return toSnakeCase(parts[parts.length - 1]);
 }
 
-function emitClientSessionApiRegistration(
+export function emitClientSessionApiRegistration(
     lines: string[],
     node: Record<string, unknown>,
     resolveType: (name: string) => string
 ): void {
-    const groups = Object.entries(node).filter(([, value]) => typeof value === "object" && value !== null && !isRpcMethod(value));
+    const publicNode = filterNodeByVisibility(node, "public");
+    if (!publicNode) return;
+    const groups = Object.entries(publicNode).filter(([, value]) => typeof value === "object" && value !== null && !isRpcMethod(value));
 
     for (const [groupName, groupNode] of groups) {
         const handlerName = `${toPascalCase(groupName)}Handler`;

--- a/scripts/codegen/python.ts
+++ b/scripts/codegen/python.ts
@@ -3778,8 +3778,7 @@ export function emitClientSessionApiRegistration(
     node: Record<string, unknown>,
     resolveType: (name: string) => string
 ): void {
-    const publicNode = filterNodeByVisibility(node, "public");
-    if (!publicNode) return;
+    const publicNode = filterNodeByVisibility(node, "public") ?? {};
     const groups = Object.entries(publicNode).filter(([, value]) => typeof value === "object" && value !== null && !isRpcMethod(value));
 
     for (const [groupName, groupNode] of groups) {

--- a/scripts/codegen/typescript.ts
+++ b/scripts/codegen/typescript.ts
@@ -1079,8 +1079,7 @@ function handlerMethodName(rpcMethod: string): string {
  */
 export function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>): string[] {
     const lines: string[] = [];
-    const publicClientSchema = filterNodeByVisibility(clientSchema, "public");
-    if (!publicClientSchema) return lines;
+    const publicClientSchema = filterNodeByVisibility(clientSchema, "public") ?? {};
     const groups = collectClientGroups(publicClientSchema);
 
     // Emit a handler interface per group

--- a/scripts/codegen/typescript.ts
+++ b/scripts/codegen/typescript.ts
@@ -25,6 +25,7 @@ import {
     collectExperimentalOnlyRpcReferencedDefinitionNames,
     collectReachableDefinitionNames,
     collectRpcMethodReferencedDefinitionNames,
+    filterNodeByVisibility,
     findSharedSchemaDefinitions,
     hasSchemaPayload,
     parseExternalSchemaRef,
@@ -1076,15 +1077,17 @@ function handlerMethodName(rpcMethod: string): string {
  * `getHandler` callback that resolves a sessionId to a handler object.
  * Param types include sessionId — handler code can simply ignore it.
  */
-function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>): string[] {
+export function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>): string[] {
     const lines: string[] = [];
-    const groups = collectClientGroups(clientSchema);
+    const publicClientSchema = filterNodeByVisibility(clientSchema, "public");
+    if (!publicClientSchema) return lines;
+    const groups = collectClientGroups(publicClientSchema);
 
     // Emit a handler interface per group
     for (const [groupName, methods] of groups) {
         const interfaceName = toPascalCase(groupName) + "Handler";
-        const groupDeprecated = isNodeFullyDeprecated(clientSchema[groupName] as Record<string, unknown>);
-        const groupExperimental = isNodeFullyExperimental(clientSchema[groupName] as Record<string, unknown>);
+        const groupDeprecated = isNodeFullyDeprecated(publicClientSchema[groupName] as Record<string, unknown>);
+        const groupExperimental = isNodeFullyExperimental(publicClientSchema[groupName] as Record<string, unknown>);
         if (groupDeprecated) {
             lines.push(`/** @deprecated Handler for \`${groupName}\` client session API methods. */`);
         } else if (groupExperimental) {


### PR DESCRIPTION
## Overview

Internal client-session RPC methods were emitted into public TypeScript, Go, and Python handler surfaces. The `@github/copilot@1.0.83-3` schema exposed this bug by adding internal skill-provider callbacks, causing TypeScript codegen to reject the resulting public references to internal types.

## Changes

- Filter client-session API trees to public methods before generating handler interfaces and registration plumbing.
- Preserve existing internal client-global plumbing used by SDK hook dispatch.
- Add cross-language regression coverage for mixed and internal-only client-session handler groups.

## Validation

- Regenerated all SDK outputs against the pinned schema without changes.
- Generated all SDK outputs successfully against `@github/copilot@1.0.83-3`.
- Ran focused codegen tests and Node type checking.