### PR TITLE
Support non-object arguments for external tools

### DIFF
--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -898,9 +898,16 @@ public sealed partial class CopilotSession : IAsyncDisposable
 
             if (arguments is JsonElement incomingJsonArgs)
             {
-                foreach (var prop in incomingJsonArgs.EnumerateObject())
+                if (incomingJsonArgs.ValueKind == JsonValueKind.Object)
                 {
-                    aiFunctionArgs[prop.Name] = prop.Value;
+                    foreach (var prop in incomingJsonArgs.EnumerateObject())
+                    {
+                        aiFunctionArgs[prop.Name] = prop.Value;
+                    }
+                }
+                else
+                {
+                    aiFunctionArgs[GetSingleParameterName(tool)] = incomingJsonArgs;
                 }
             }
 
@@ -940,6 +947,55 @@ public sealed partial class CopilotSession : IAsyncDisposable
             {
                 // Connection already disposed — nothing we can do
             }
+        }
+
+        static string GetSingleParameterName(AIFunction tool)
+        {
+            if (tool.JsonSchema.TryGetProperty("properties", out var properties) &&
+                properties.ValueKind == JsonValueKind.Object)
+            {
+                string? parameterName = null;
+                foreach (var property in properties.EnumerateObject())
+                {
+                    if (parameterName is not null)
+                    {
+                        parameterName = null;
+                        break;
+                    }
+
+                    parameterName = property.Name;
+                }
+
+                if (parameterName is not null)
+                {
+                    return parameterName;
+                }
+
+                if (tool.JsonSchema.TryGetProperty("required", out var required) &&
+                    required.ValueKind == JsonValueKind.Array)
+                {
+                    string? requiredParameterName = null;
+                    foreach (var requiredParameter in required.EnumerateArray())
+                    {
+                        if (requiredParameterName is not null)
+                        {
+                            requiredParameterName = null;
+                            break;
+                        }
+
+                        requiredParameterName = requiredParameter.GetString();
+                    }
+
+                    if (requiredParameterName is not null &&
+                        properties.TryGetProperty(requiredParameterName, out _))
+                    {
+                        return requiredParameterName;
+                    }
+                }
+            }
+
+            throw new ArgumentException(
+                $"Tool '{tool.Name}' received non-object arguments, but its schema does not define exactly one parameter or one required parameter.");
         }
     }
 

--- a/dotnet/test/Unit/ClientSessionLifetimeTests.cs
+++ b/dotnet/test/Unit/ClientSessionLifetimeTests.cs
@@ -12,6 +12,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using GitHub.Copilot.Rpc;
+using Microsoft.Extensions.AI;
 using Xunit;
 
 namespace GitHub.Copilot.Test.Unit;
@@ -663,6 +664,166 @@ public sealed class ClientSessionLifetimeTests
 
         var resumeRequest = Assert.Single(server.Requests, request => request.Method == "session.resume");
         Assert.True(resumeRequest.Params.GetProperty("tools")[0].GetProperty("isTerminal").GetBoolean());
+    }
+
+    [Fact]
+    public async Task ExternalTool_String_Arguments_Bind_To_Single_Function_Parameter()
+    {
+        await using var server = await FakeCopilotServer.StartAsync();
+        await using var client = new CopilotClient(new CopilotClientOptions { Connection = RuntimeConnection.ForUri(server.Url) });
+        string? receivedPatch = null;
+        var tool = CopilotTool.DefineTool(
+            (string patch) =>
+            {
+                receivedPatch = patch;
+                return "applied";
+            },
+            new CopilotToolOptions { OverridesBuiltInTool = true },
+            new AIFunctionFactoryOptions { Name = "apply_patch" });
+        await using var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            Tools = [tool],
+            OnPermissionRequest = PermissionHandler.ApproveAll
+        });
+        server.ClearRequests();
+        using var arguments = JsonDocument.Parse("\"*** Begin Patch\\n*** End Patch\"");
+
+        DispatchEvent(session, new ExternalToolRequestedEvent
+        {
+            Data = new ExternalToolRequestedData
+            {
+                Arguments = arguments.RootElement.Clone(),
+                RequestId = "apply-patch-request",
+                SessionId = session.SessionId,
+                ToolCallId = "apply-patch-call",
+                ToolName = "apply_patch"
+            }
+        });
+
+        var request = await WaitForRequestAsync(server, "session.tools.handlePendingToolCall");
+        Assert.Equal("*** Begin Patch\n*** End Patch", receivedPatch);
+        Assert.False(request.Params.TryGetProperty("error", out _));
+        Assert.Equal("applied", request.Params.GetProperty("result").GetProperty("textResultForLlm").GetString());
+    }
+
+    [Fact]
+    public async Task ExternalTool_String_Arguments_Reject_Ambiguous_Function_Parameters()
+    {
+        await using var server = await FakeCopilotServer.StartAsync();
+        await using var client = new CopilotClient(new CopilotClientOptions { Connection = RuntimeConnection.ForUri(server.Url) });
+        var invoked = false;
+        var tool = CopilotTool.DefineTool(
+            (string patch, string explanation) =>
+            {
+                invoked = true;
+                return "applied";
+            },
+            new CopilotToolOptions { OverridesBuiltInTool = true },
+            new AIFunctionFactoryOptions { Name = "apply_patch" });
+        await using var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            Tools = [tool],
+            OnPermissionRequest = PermissionHandler.ApproveAll
+        });
+        server.ClearRequests();
+        using var arguments = JsonDocument.Parse("\"*** Begin Patch\\n*** End Patch\"");
+
+        DispatchEvent(session, new ExternalToolRequestedEvent
+        {
+            Data = new ExternalToolRequestedData
+            {
+                Arguments = arguments.RootElement.Clone(),
+                RequestId = "ambiguous-apply-patch-request",
+                SessionId = session.SessionId,
+                ToolCallId = "ambiguous-apply-patch-call",
+                ToolName = "apply_patch"
+            }
+        });
+
+        var request = await WaitForRequestAsync(server, "session.tools.handlePendingToolCall");
+        Assert.False(invoked);
+        Assert.Contains("received non-object arguments", request.Params.GetProperty("error").GetString());
+        Assert.False(request.Params.TryGetProperty("result", out _));
+    }
+
+    [Fact]
+    public async Task ExternalTool_Number_Arguments_Bind_To_Single_Function_Parameter()
+    {
+        await using var server = await FakeCopilotServer.StartAsync();
+        await using var client = new CopilotClient(new CopilotClientOptions { Connection = RuntimeConnection.ForUri(server.Url) });
+        int? receivedLine = null;
+        var tool = CopilotTool.DefineTool(
+            (int line) =>
+            {
+                receivedLine = line;
+                return "selected";
+            },
+            factoryOptions: new AIFunctionFactoryOptions { Name = "select_line" });
+        await using var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            Tools = [tool],
+            OnPermissionRequest = PermissionHandler.ApproveAll
+        });
+        server.ClearRequests();
+        using var arguments = JsonDocument.Parse("42");
+
+        DispatchEvent(session, new ExternalToolRequestedEvent
+        {
+            Data = new ExternalToolRequestedData
+            {
+                Arguments = arguments.RootElement.Clone(),
+                RequestId = "select-line-request",
+                SessionId = session.SessionId,
+                ToolCallId = "select-line-call",
+                ToolName = "select_line"
+            }
+        });
+
+        var request = await WaitForRequestAsync(server, "session.tools.handlePendingToolCall");
+        Assert.Equal(42, receivedLine);
+        Assert.False(request.Params.TryGetProperty("error", out _));
+    }
+
+    [Fact]
+    public async Task ExternalTool_String_Arguments_Bind_To_Sole_Required_Function_Parameter()
+    {
+        await using var server = await FakeCopilotServer.StartAsync();
+        await using var client = new CopilotClient(new CopilotClientOptions { Connection = RuntimeConnection.ForUri(server.Url) });
+        string? receivedPatch = null;
+        string? receivedExplanation = null;
+        var tool = CopilotTool.DefineTool(
+            (string patch, string? explanation = null) =>
+            {
+                receivedPatch = patch;
+                receivedExplanation = explanation;
+                return "applied";
+            },
+            new CopilotToolOptions { OverridesBuiltInTool = true },
+            new AIFunctionFactoryOptions { Name = "apply_patch" });
+        await using var session = await client.CreateSessionAsync(new SessionConfig
+        {
+            Tools = [tool],
+            OnPermissionRequest = PermissionHandler.ApproveAll
+        });
+        server.ClearRequests();
+        using var arguments = JsonDocument.Parse("\"*** Begin Patch\\n*** End Patch\"");
+
+        DispatchEvent(session, new ExternalToolRequestedEvent
+        {
+            Data = new ExternalToolRequestedData
+            {
+                Arguments = arguments.RootElement.Clone(),
+                RequestId = "optional-apply-patch-request",
+                SessionId = session.SessionId,
+                ToolCallId = "optional-apply-patch-call",
+                ToolName = "apply_patch"
+            }
+        });
+
+        var request = await WaitForRequestAsync(server, "session.tools.handlePendingToolCall");
+        Assert.Equal("*** Begin Patch\n*** End Patch", receivedPatch);
+        Assert.Null(receivedExplanation);
+        Assert.False(request.Params.TryGetProperty("error", out _));
     }
 
     [Fact]
@@ -1664,6 +1825,10 @@ public sealed class ClientSessionLifetimeTests
                     ["success"] = true
                 },
                 "session.permissions.handlePendingPermissionRequest" => new Dictionary<string, object?>
+                {
+                    ["success"] = true
+                },
+                "session.tools.handlePendingToolCall" => new Dictionary<string, object?>
                 {
                     ["success"] = true
                 },


### PR DESCRIPTION
External tool overrides such as `apply_patch` can receive freeform JSON values, but the .NET SDK previously assumed every invocation root was an object and failed before entering the host handler.

This change preserves named-property expansion for object roots and binds any non-object JSON value to the function's sole schema parameter. When additional parameters are optional, it selects the sole required parameter; ambiguous schemas return a clear tool error instead of guessing. Fake-server coverage exercises string and numeric values, optional parameters, successful responses, and ambiguous rejection.

**Tests**
- `dotnet test dotnet\test\GitHub.Copilot.SDK.Test.csproj --filter "FullyQualifiedName~GitHub.Copilot.Test.Unit.ClientSessionLifetimeTests" --no-restore`

Generated by Copilot