### PR TITLE
Add taskModelSource to SubagentStartedData

### DIFF
--- a/nodejs/src/generated/session-events.ts
+++ b/nodejs/src/generated/session-events.ts
@@ -641,6 +641,18 @@ export type SkillInvokedTrigger =
   /** Skill content loaded as part of another context, such as a configured custom agent or subagent. */
   | "context-load";
 /**
+ * Where the model input for a task-tool sub-agent came from.
+ */
+export type SubagentTaskModelSource =
+  /** The spawning agent supplied the task tool's model argument. */
+  | "task_argument"
+  /** The task omitted a model and the per-sub-agent settings entry supplied a concrete one. */
+  | "subagent_configuration"
+  /** The task omitted a model and the user-defined custom agent's definition supplied one. */
+  | "custom_agent_definition"
+  /** Neither the task call nor structured sub-agent configuration supplied a model. */
+  | "unset";
+/**
  * Binary asset type discriminator. Use "image" for images and "resource" otherwise.
  */
 export type BinaryAssetType =
@@ -6708,6 +6720,10 @@ export interface SubagentStartedData {
    * Whether this sub-agent can be resumed. Currently always false.
    */
   resumable?: boolean;
+  /**
+   * Where the model input for this task-tool sub-agent came from. Absent for sub-agents created through other runtime paths.
+   */
+  taskModelSource?: SubagentTaskModelSource;
   /**
    * Tool call ID of the parent tool invocation that spawned this sub-agent
    */


### PR DESCRIPTION
## Summary

Adds the Node event type for the runtime's new optional `taskModelSource` field on `subagent.started` (github/copilot-agent-runtime#18727). VS Code Agent Host reads it to report where a task-tool sub-agent's model input came from.

| Value | What it tracks |
| --- | --- |
| `task_argument` | The parent agent passed `task.model` |
| `subagent_configuration` | No `task.model`; the per-sub-agent settings entry supplied a concrete model |
| `custom_agent_definition` | No `task.model`; a user-defined custom agent's definition supplied its model |
| `unset` | Neither the task call nor structured configuration supplied a model |

The field is optional. Task-planned launches (including factory agents) populate it; other launch paths leave it absent.

## Dependency status — September 8, 2026

- Runtime PR github/copilot-agent-runtime#18727 merged on September 5.
- CLI `1.0.84-2` is published. Its release schema was checked directly: it contains the optional field and all four enum values.
- **#2572 already regenerates all SDK bindings from this release, including the Node field and enum proposed here.** This hand-edited PR will be redundant once #2572 lands; prefer that generated update rather than duplicating the CLI version bump here.
- SDK main is still pinned to CLI `1.0.83`, so the codegen check on this standalone hand-edit is not expected to pass. Closed at the author's request as superseded by #2572; that generated update remains the dependency for the VS Code consumer.
- Companion microsoft/vscode#334184 still needs a published SDK containing the generated field before its dependency bump and temporary cast removal.

## Original validation

- `tsc --noEmit`
- `vitest run session-event` (26 tests)
- `prettier --check` on the generated file
