### PR TITLE
docs: link runtime prerequisites instead of restating versions

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,8 +19,7 @@ Copilot: In Tokyo it's 75°F and sunny. Great day to be outside!
 Before you begin, make sure you have:
 
 * **GitHub Copilot CLI** installed and authenticated (the Node.js, Python, and .NET SDKs provide the CLI automatically—see [Bundled CLI](./setup/bundled-cli.md). Required for Go, Java, and Rust unless using their application-level CLI bundling features.)
-* Your preferred language runtime:
-  * **Node.js** 20+ or **Python** 3.11+ or **Go** 1.24+ or **Rust** 1.94+ or **Java** 17+ or **.NET** 8.0+
+* Your preferred language runtime, at or above the version its SDK requires. Each SDK states its own floor in the Prerequisites section of its README: [Node.js](../nodejs/README.md#prerequisites), [Python](../python/README.md#prerequisites), [Go](../go/README.md#prerequisites), [Rust](../rust/README.md#prerequisites), [Java](../java/README.md#prerequisites), [.NET](../dotnet/README.md#prerequisites).
 
 Verify the CLI is working:
 


### PR DESCRIPTION
## Summary

The getting-started prerequisites say **Node.js 20+**, but the Node SDK declares:

```json
"engines": { "node": "^20.19.0 || >=22.12.0" }
```

So 20.0-20.18 and all of 21.x are unsupported, and a reader who follows this page onto one of them hits `EBADENGINE` at install time. `nodejs/README.md` already states the real constraint, so the list on this page had simply drifted.

Rather than correcting the number and leaving a second copy to drift again, this points each language at the Prerequisites section of its own README - the same thing `docs/setup/bundled-cli.md` now does. That keeps one source of truth per SDK.

## Verification

* All six targets exist and expose a `## Prerequisites` heading, and the `../<lang>/README.md` paths resolve from `docs/`.
* Current floors, for reference: Node `^20.19.0 || >=22.12.0`, Python `>=3.11`, Go `1.24`, Rust `1.94.0`, Java 17 (JDK 25 recommended), .NET any .NET Standard 2.0-compatible implementation. The removed line also understated .NET, which targets `netstandard2.0` in addition to `net8.0`/`net10.0`.
* Prose only, no code blocks touched, so `docs-validate` is unaffected.