### PR TITLE
docs: fix six broken hook anchor links

### DIFF
--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -22,13 +22,13 @@ flowchart LR
 
 | Hook                                                                | When it fires                       | What you can do                            |
 | ------------------------------------------------------------------- | ----------------------------------- | ------------------------------------------ |
-| [`onSessionStart`](../hooks/session-lifecycle.md#session-start)     | Session begins (new or resumed)     | Inject context, load preferences           |
+| [`onSessionStart`](../hooks/session-lifecycle.md#session-start-hook)     | Session begins (new or resumed)     | Inject context, load preferences           |
 | [`onUserPromptSubmitted`](../hooks/user-prompt-submitted.md)        | User sends a message                | Rewrite prompts, add context, filter input |
 | [`onUserPromptTransformed`](../hooks/user-prompt-transformed.md)    | Runtime builds the model prompt     | Inspect or replace model-facing content    |
 | [`onPreToolUse`](../hooks/pre-tool-use.md)                          | Before a tool executes              | Allow / deny / modify the call             |
 | [`onPostToolUse`](../hooks/post-tool-use.md)                        | After a tool returns (success only) | Transform results, redact secrets, audit   |
 | [`onPostToolUseFailure`](../hooks/post-tool-use.md#failure-variant) | After a tool returns a failure      | Inject retry guidance, log failures        |
-| [`onSessionEnd`](../hooks/session-lifecycle.md#session-end)         | Session ends                        | Clean up, record metrics                   |
+| [`onSessionEnd`](../hooks/session-lifecycle.md#session-end-hook)         | Session ends                        | Clean up, record metrics                   |
 | [`onErrorOccurred`](../hooks/error-handling.md)                     | An error is raised                  | Custom logging, retry logic, alerts        |
 
 All hooks are **optional**—register only the ones you need. Returning `null` (or the language equivalent) from any hook tells the SDK to continue with default behavior.

--- a/docs/hooks/hooks-overview.md
+++ b/docs/hooks/hooks-overview.md
@@ -17,10 +17,10 @@ Hooks allow you to intercept and customize the behavior of Copilot sessions at k
 | [`onPostToolUseFailure`](./post-tool-use.md#failure-variant) | After a tool execution whose result was a failure | Inject retry guidance, log failures |
 | [`onUserPromptSubmitted`](./user-prompt-submitted.md) | When user sends a message | Prompt modification, filtering |
 | [`onUserPromptTransformed`](./user-prompt-transformed.md) | After runtime prompt transformation | Inspect or replace model-facing content |
-| [`onSessionStart`](./session-lifecycle.md#session-start) | Session begins | Add context, configure session |
-| [`onSessionEnd`](./session-lifecycle.md#session-end) | Session ends | Cleanup, analytics |
+| [`onSessionStart`](./session-lifecycle.md#session-start-hook) | Session begins | Add context, configure session |
+| [`onSessionEnd`](./session-lifecycle.md#session-end-hook) | Session ends | Cleanup, analytics |
 | [`onErrorOccurred`](./error-handling.md) | Error happens | Custom error handling |
-| [`onAgentStop`](./session-lifecycle.md#agent-stop) | Top-level agent naturally stops | Validate completion or request another turn |
+| [`onAgentStop`](./session-lifecycle.md#agent-stop-hook) | Top-level agent naturally stops | Validate completion or request another turn |
 
 ## Quick start
 
@@ -266,7 +266,7 @@ const session = await client.createSession({
 * **[User Prompt Submitted Hook](./user-prompt-submitted.md)** - Modify user prompts
 * **[User Prompt Transformed Hook](./user-prompt-transformed.md)** - Replace model-facing prompts
 * **[Session Lifecycle Hooks](./session-lifecycle.md)** - Session start and end
-* **[Agent Stop Hook](./session-lifecycle.md#agent-stop)** - Validate completion before the agent stops
+* **[Agent Stop Hook](./session-lifecycle.md#agent-stop-hook)** - Validate completion before the agent stops
 * **[Error Handling Hook](./error-handling.md)** - Custom error handling
 
 ## See also

--- a/docs/hooks/session-lifecycle.md
+++ b/docs/hooks/session-lifecycle.md
@@ -7,7 +7,7 @@ Session lifecycle hooks let you respond to session start and end events. Use the
 * Track session metrics and analytics
 * Configure session behavior dynamically
 
-## Session start hook {#session-start}
+## Session start hook
 
 The `onSessionStart` hook is called when a session begins (new or resumed).
 
@@ -250,7 +250,7 @@ const session = await client.createSession({
 });
 ```
 
-## Session end hook {#session-end}
+## Session end hook
 
 The `onSessionEnd` hook is called when a session ends.
 
@@ -540,7 +540,7 @@ Session Summary:
 });
 ```
 
-## Agent stop hook {#agent-stop}
+## Agent stop hook
 
 The agent stop hook runs when the top-level agent naturally reaches the end of a turn. It is separate from `onSessionEnd`: the session remains active, and the hook can request another agent turn.
 


### PR DESCRIPTION
## Summary

`docs/hooks/session-lifecycle.md` is the only file in `docs/` that uses the explicit heading-id extension:

```markdown
## Session start hook {#session-start}
```

GitHub-flavored Markdown does not implement that extension, so the braces render as literal text inside the heading and the id is never created. The generated slug is `session-start-hook`, which means every link aimed at `#session-start`, `#session-end` or `#agent-stop` lands at the top of the page instead of the section.

Six links are affected:

* `docs/features/hooks.md` - `onSessionStart`, `onSessionEnd`
* `docs/hooks/hooks-overview.md` - `onSessionStart`, `onSessionEnd`, `onAgentStop` (twice)

This drops the three explicit ids and retargets the links at the generated slugs, matching the other 50 files in `docs/`. It also removes the stray `{#...}` text from the rendered headings.

## Verification

Walked every relative link in `docs/` and resolved each target file and anchor against the headings actually present:

* before: 6 problems, all in these three files
* after: 0 problems across 51 files

Prose and links only, no code blocks touched, so `docs-validate` is unaffected.