### PR TITLE
docs(rust): point dependency examples at the published 1.0 line

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -928,7 +928,7 @@ Enable `bundled-in-process` to additionally embed the native runtime library
 and use `Transport::InProcess`:
 
 ```toml
-github-copilot-sdk = { version = "0.1", features = ["bundled-in-process"] }
+github-copilot-sdk = { version = "1.0", features = ["bundled-in-process"] }
 ```
 
 `CliProgram::Path` and raw `ClientOptions::extra_args` apply only to
@@ -938,7 +938,7 @@ provisioned compatible runtime package with in-process transport.
 For builds that prefer a smaller artifact, disable the `bundled-cli` feature:
 
 ```toml
-github-copilot-sdk = { version = "0.1", default-features = false }
+github-copilot-sdk = { version = "1.0", default-features = false }
 ```
 
 > **You become responsible for supplying the runtime at deployment.** With
@@ -1076,20 +1076,17 @@ Supported: `darwin-arm64`, `darwin-x64`, `linux-x64`, `linux-arm64`, `win32-x64`
 | `derive` | — | `schema_for::<T>()` for generating JSON Schema from Rust types (adds `schemars`). |
 
 ```toml
-# These examples use registry syntax for illustration; until the crate is
-# published, use a path or git dependency instead.
-
 # Default — bundles the Copilot CLI in your binary.
-github-copilot-sdk = "0.1"
+github-copilot-sdk = "1.0"
 
 # Enable the in-process transport and bundle its native runtime library.
-github-copilot-sdk = { version = "0.1", features = ["bundled-in-process"] }
+github-copilot-sdk = { version = "1.0", features = ["bundled-in-process"] }
 
 # Opt out of bundling — supply the CLI explicitly at runtime.
-github-copilot-sdk = { version = "0.1", default-features = false }
+github-copilot-sdk = { version = "1.0", default-features = false }
 
 # Derive JSON Schema for tool parameters (adds to default bundled-cli).
-github-copilot-sdk = { version = "0.1", features = ["derive"] }
+github-copilot-sdk = { version = "1.0", features = ["derive"] }
 ```
 
 ## Development

--- a/rust/README.md
+++ b/rust/README.md
@@ -928,7 +928,7 @@ Enable `bundled-in-process` to additionally embed the native runtime library
 and use `Transport::InProcess`:
 
 ```toml
-github-copilot-sdk = { version = "1.0", features = ["bundled-in-process"] }
+github-copilot-sdk = { version = "1", features = ["bundled-in-process"] }
 ```
 
 `CliProgram::Path` and raw `ClientOptions::extra_args` apply only to
@@ -938,7 +938,7 @@ provisioned compatible runtime package with in-process transport.
 For builds that prefer a smaller artifact, disable the `bundled-cli` feature:
 
 ```toml
-github-copilot-sdk = { version = "1.0", default-features = false }
+github-copilot-sdk = { version = "1", default-features = false }
 ```
 
 > **You become responsible for supplying the runtime at deployment.** With
@@ -1077,16 +1077,16 @@ Supported: `darwin-arm64`, `darwin-x64`, `linux-x64`, `linux-arm64`, `win32-x64`
 
 ```toml
 # Default — bundles the Copilot CLI in your binary.
-github-copilot-sdk = "1.0"
+github-copilot-sdk = "1"
 
 # Enable the in-process transport and bundle its native runtime library.
-github-copilot-sdk = { version = "1.0", features = ["bundled-in-process"] }
+github-copilot-sdk = { version = "1", features = ["bundled-in-process"] }
 
 # Opt out of bundling — supply the CLI explicitly at runtime.
-github-copilot-sdk = { version = "1.0", default-features = false }
+github-copilot-sdk = { version = "1", default-features = false }
 
 # Derive JSON Schema for tool parameters (adds to default bundled-cli).
-github-copilot-sdk = { version = "1.0", features = ["derive"] }
+github-copilot-sdk = { version = "1", features = ["derive"] }
 ```
 
 ## Development


### PR DESCRIPTION
## Summary

`rust/README.md` still pins `version = "0.1"` in every dependency example and says the crate is not published yet. It has been on crates.io since `1.0.0` (2026-06-02); the current stable is `1.0.11`.

`0.1.0` was published 2026-05-06 and predates the feature rename, so it exposes `embedded-cli` rather than `bundled-cli` / `bundled-in-process`. Copying the README's own feature examples fails outright:

```console
$ cargo generate-lockfile     # github-copilot-sdk = { version = "0.1", features = ["bundled-in-process"] }
error: failed to select a version for `github-copilot-sdk`.
```

The bare `github-copilot-sdk = "0.1"` does resolve, but silently to the four-month-old `0.1.0`, which is a pre-1.0 API.

This updates the six examples to `"1.0"` and drops the stale pre-publication caveat.

## Verification

Real resolution, not `cargo add --dry-run` (which reports features "as of v1.0.0" and rejects `bundled-in-process` for that reason even when the requirement is satisfiable):

| Dependency line | `cargo generate-lockfile` |
| --- | --- |
| `{ version = "0.1", features = ["bundled-in-process"] }` | fails to select a version |
| `"0.1"` | resolves to `0.1.0` |
| `{ version = "1.0", features = ["bundled-in-process"] }` | resolves to `1.0.11`, 214 packages locked |

Feature sets from the crates.io API confirm the cause:

* `0.1.0` - `default, derive, embedded-cli, test-support`
* `1.0.11` - `bundled-cli, bundled-in-process, default, derive, test-support`