### PR TITLE
docs(java): fix the installation section structure

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -30,8 +30,6 @@ runtime.
 
 ### Maven
 
-Replace `${copilot.sdk.version}` with the latest release from Maven Central.
-
 ```xml
 <dependency>
     <groupId>com.github</groupId>
@@ -46,9 +44,11 @@ Replace `${copilot.sdk.version}` with the latest release from Maven Central.
 implementation 'com.github:copilot-sdk-java:1.0.13-preview.5'
 ```
 
-#### Snapshot Builds
+### Snapshot builds
 
-Snapshot builds of the next development version are published to Maven Central Snapshots. To use them, add the repository and update the dependency version in your `pom.xml`:
+Snapshot builds of the next development version are published to Maven Central Snapshots. To use them, add the snapshot repository and depend on the development version:
+
+#### Maven
 
 ```xml
 <repositories>
@@ -66,9 +66,7 @@ Snapshot builds of the next development version are published to Maven Central S
 </dependency>
 ```
 
-### Gradle
-
-Replace `${copilot.sdk.version}` with the latest release from Maven Central.
+#### Gradle
 
 ```groovy
 implementation 'com.github:copilot-sdk-java:1.0.14-preview.5-SNAPSHOT'


### PR DESCRIPTION
## Summary

Three problems in `java/README.md` under Installation:

* Two sentences say to replace `${copilot.sdk.version}`, but no snippet contains that placeholder - `scripts/update-documentation-versions.sh` writes concrete versions in at release time.
* The copy above the snapshot Gradle example said to use "the latest release from Maven Central" while the snippet below it is a `-SNAPSHOT`.
* `Snapshot Builds` was nested under `### Gradle` even though it covers both build tools, and the snapshot Gradle example sat back at `###`. The page therefore rendered two sibling "Gradle" installation sections showing different versions.

This promotes the section to `### Snapshot builds` with `#### Maven` and `#### Gradle` underneath, and removes the two stale sentences.

## Anchors

The root `README.md` links to `./java/README.md#maven` and `#gradle`. Both still resolve to the release install sections at the top, because those remain the first headings with those names.

To be explicit about a side effect: this file already repeated the `Maven` and `Gradle` heading names further down, and adding `#### Maven` shifts the later Maven heading from `#maven-1` to `#maven-2`. Nothing links to the suffixed slugs, so no reference breaks. This PR does not try to clean up that pre-existing duplication.

## Release automation is unaffected

No version string is touched, so the updater keeps finding exactly one release and one snapshot example for each build tool. Verified by running the real script against the modified file:

```console
$ scripts/update-documentation-versions.sh 9.9.9-preview.1 9.9.10-preview.1-SNAPSHOT README.md jbang-example.java
$ echo $?
0
```

All four lines were rewritten as expected:

```
    <version>9.9.9-preview.1</version>
implementation 'com.github:copilot-sdk-java:9.9.9-preview.1'
    <version>9.9.10-preview.1-SNAPSHOT</version>
implementation 'com.github:copilot-sdk-java:9.9.10-preview.1-SNAPSHOT'
```

`scripts/test-update-documentation-versions.sh` also still passes; it builds its own fixture, so it is independent of this file either way.