### PR TITLE
python: remove implicit PATH fallback for CLI executable resolution

### DIFF
--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -20,7 +20,6 @@ import ipaddress
 import logging
 import os
 import re
-import shutil
 import subprocess
 import sys
 import threading
@@ -4352,11 +4351,15 @@ class CopilotClient:
         cli_path = conn.path
         assert cli_path is not None  # resolved in __init__
 
-        # Verify CLI exists
+        # Verify the resolved CLI path exists. `cli_path` must already come from
+        # an explicit override, COPILOT_CLI_PATH, or the SDK-managed downloaded
+        # runtime (see `_resolve_runtime_entrypoint`); the SDK never falls back to
+        # searching PATH for an arbitrary system installation.
         if not os.path.exists(cli_path):
-            original_path = cli_path
-            if (cli_path := shutil.which(cli_path)) is None:
-                raise RuntimeError(f"Copilot CLI not found at {original_path}")
+            raise RuntimeError(
+                f"Copilot CLI not found at {cli_path!r}. Set an explicit path, "
+                "COPILOT_CLI_PATH, or ensure the SDK-managed runtime download succeeded."
+            )
 
         # Start with user-provided args, then add SDK-managed args
         args = list(conn.args) + [

--- a/python/test_client.py
+++ b/python/test_client.py
@@ -83,6 +83,25 @@ def test_copilot_cli_path_does_not_require_runtime_bundle(tmp_path):
     assert connection.path == str(explicit)
 
 
+@pytest.mark.asyncio
+async def test_missing_cli_path_does_not_fall_back_to_path_search(tmp_path):
+    """A missing resolved CLI path must fail rather than silently resolving an
+    arbitrary same-named executable found on PATH (see #2524 / commit 05dd60e)."""
+    path_dir = tmp_path / "on_path"
+    path_dir.mkdir()
+    decoy = path_dir / "copilot"
+    decoy.write_text("#!/bin/sh\necho decoy\n")
+    decoy.chmod(0o755)
+
+    missing = tmp_path / "copilot"
+    connection = RuntimeConnection.for_stdio(path=str(missing))
+    client = CopilotClient(connection=connection, env={"PATH": str(path_dir)})
+
+    with patch.dict(os.environ, {"PATH": str(path_dir)}):
+        with pytest.raises(RuntimeError, match="Copilot CLI not found"):
+            await client._start_cli_server()
+
+
 class TestBuiltinPluginDirectories:
     @staticmethod
     async def _start_client(paths=None):


### PR DESCRIPTION
## Summary

Part of #2524 (Consolidate runtime discovery, acquisition, and embedding). Removes the Python SDK's implicit fallback to `PATH`-based executable resolution, satisfying the required outcome:

> Python does not implicitly select an executable through `PATH`; it uses the SDK-managed runtime or an explicitly configured path.

## Background

Commit `05dd60e` (#793) added a `shutil.which(cli_path)` fallback in `CopilotClient._start_cli_server` that runs whenever the resolved `cli_path` does not exist as a file. This let the SDK silently pick up an arbitrary same-named executable from the host `PATH` instead of using the runtime the SDK actually resolved (explicit path > `COPILOT_CLI_PATH` > SDK-managed download, see `_resolve_runtime_entrypoint`). #1934 flagged this explicitly for removal, and #2522/#2524 carry that forward.

I confirmed on latest `main` (`0921029`) and on the in-flight `roji-unify-runtime-artifacts` branch (#2505) that this fallback is unchanged in both — #2505 only changes *how* the runtime is downloaded/verified from GitHub Releases for Python/.NET/Go/Java, not this PATH-search behavior at process start, so this is not duplicating that work.

## What changed

- `python/copilot/client.py`: `_start_cli_server` now raises a clear `RuntimeError` when the resolved `cli_path` doesn't exist, instead of falling back to `shutil.which`. Removed the now-unused `shutil` import.
- `python/test_client.py`: added a regression test that plants a same-named decoy executable on `PATH` and asserts it is never used when the configured path is missing.

## Not in scope here (tracked separately on #2524)

- Runtime acquisition from GitHub Releases for Python/.NET/Go/Java (in-flight in #2505; already release-backed for Java/Rust per #2463).
- Rust (`bundled-in-process` Cargo feature) and Go (`copilot_inprocess` build tag) compile-time in-process embedding choices — see my findings comment on #2524 for why I'm not changing these here and what maintainer input I'm requesting.

## Validation

- `ruff check` / `ruff format --check` on changed files: pass.
- `ty check` on `copilot/client.py`: pass.
- `pytest python/test_client.py python/test_cli_download.py`: same 79 pre-existing environment-only failures as unmodified `main` (fake local CLI binary used for offline testing has no real e2e semantics); all path-resolution tests, including the new regression test, pass with zero new failures.

Closes #2524 once merged (remaining #2524 items tracked in the follow-up comment on that issue).
