### PR TITLE
[v2] Bound in-process FFI host_shutdown and fix .NET lifecycle race across all SDKs

### DIFF
--- a/.github/workflows/dotnet-sdk-tests.yml
+++ b/.github/workflows/dotnet-sdk-tests.yml
@@ -56,19 +56,23 @@ jobs:
         transport: ["default", "inprocess"]
         backend: [capi]
         shard: [full]
-        # TODO: Re-enable after fixing in-process sqlite file locking on shutdown on Windows.
         exclude:
-          - os: windows-latest
-            transport: "inprocess"
           - os: windows-latest
             transport: default
             shard: full
           # TODO(cli-1.0.81-2): CLI 1.0.81-5 still stops completing in-process
           # CAPI model turns, causing repeated per-test timeouts until the
           # 30-minute job limit. Stdio CAPI and in-process BYOK remain enabled.
+          # This affects every OS equally (it is a CLI/CAPI regression, not a
+          # platform-specific one), so Windows is excluded from the `capi`
+          # in-process cell for the same reason as Linux/macOS below; see the
+          # windows-latest/inprocess include cells further down for its
+          # in-process coverage via the alternate backends.
           - os: ubuntu-latest
             transport: inprocess
           - os: macos-latest
+            transport: inprocess
+          - os: windows-latest
             transport: inprocess
           # The macOS default/capi host runs the whole suite on the smallest
           # runner in the matrix (3 vCPU / 7 GB vs ubuntu's 4 / 16). Since the
@@ -178,6 +182,28 @@ jobs:
             shard: full
             test-filter: "FullyQualifiedName~GitHub.Copilot.Test.E2E&E2EBackend!=SelfConfiguredBackend&E2EBackend!=CapiOnly"
           - os: ubuntu-latest
+            transport: inprocess
+            backend: openai-completions
+            shard: full
+            test-filter: "FullyQualifiedName~GitHub.Copilot.Test.E2E&E2EBackend!=SelfConfiguredBackend&E2EBackend!=CapiOnly"
+          # Windows in-process coverage (github/copilot-sdk#2525). Previously excluded
+          # entirely because of a napi-oop cleanup race and a suspected in-process SQLite
+          # file-locking issue on shutdown; napi-oop is no longer used by the runtime, and
+          # FfiRuntimeHost.Dispose() now bounds its wait on native shutdown so a slow or
+          # stuck runtime teardown cannot hang the job. Uses the same non-capi backends as
+          # the Linux cell above to avoid the unrelated CLI 1.0.81-2 in-process CAPI
+          # regression tracked separately.
+          - os: windows-latest
+            transport: inprocess
+            backend: anthropic-messages
+            shard: full
+            test-filter: "FullyQualifiedName~GitHub.Copilot.Test.E2E&E2EBackend!=SelfConfiguredBackend&E2EBackend!=CapiOnly"
+          - os: windows-latest
+            transport: inprocess
+            backend: openai-responses
+            shard: full
+            test-filter: "FullyQualifiedName~GitHub.Copilot.Test.E2E&E2EBackend!=SelfConfiguredBackend&E2EBackend!=CapiOnly"
+          - os: windows-latest
             transport: inprocess
             backend: openai-completions
             shard: full

--- a/.github/workflows/dotnet-sdk-tests.yml
+++ b/.github/workflows/dotnet-sdk-tests.yml
@@ -64,10 +64,12 @@ jobs:
           # CAPI model turns, causing repeated per-test timeouts until the
           # 30-minute job limit. Stdio CAPI and in-process BYOK remain enabled.
           # This affects every OS equally (it is a CLI/CAPI regression, not a
-          # platform-specific one), so Windows is excluded from the `capi`
-          # in-process cell for the same reason as Linux/macOS below; see the
-          # windows-latest/inprocess include cells further down for its
-          # in-process coverage via the alternate backends.
+          # platform-specific one), so Linux/macOS are excluded from the `capi`
+          # in-process cell here; see the ubuntu-latest/inprocess include cells
+          # further down for their in-process coverage via the alternate
+          # backends. windows-latest/inprocess has no in-process coverage at
+          # all right now (capi or otherwise) -- see the comment further down
+          # by the removed windows-latest/inprocess include cells for why.
           - os: ubuntu-latest
             transport: inprocess
           - os: macos-latest
@@ -186,28 +188,15 @@ jobs:
             backend: openai-completions
             shard: full
             test-filter: "FullyQualifiedName~GitHub.Copilot.Test.E2E&E2EBackend!=SelfConfiguredBackend&E2EBackend!=CapiOnly"
-          # Windows in-process coverage (github/copilot-sdk#2525). Previously excluded
-          # entirely because of a napi-oop cleanup race and a suspected in-process SQLite
-          # file-locking issue on shutdown; napi-oop is no longer used by the runtime, and
-          # FfiRuntimeHost.Dispose() now bounds its wait on native shutdown so a slow or
-          # stuck runtime teardown cannot hang the job. Uses the same non-capi backends as
-          # the Linux cell above to avoid the unrelated CLI 1.0.81-2 in-process CAPI
-          # regression tracked separately.
-          - os: windows-latest
-            transport: inprocess
-            backend: anthropic-messages
-            shard: full
-            test-filter: "FullyQualifiedName~GitHub.Copilot.Test.E2E&E2EBackend!=SelfConfiguredBackend&E2EBackend!=CapiOnly"
-          - os: windows-latest
-            transport: inprocess
-            backend: openai-responses
-            shard: full
-            test-filter: "FullyQualifiedName~GitHub.Copilot.Test.E2E&E2EBackend!=SelfConfiguredBackend&E2EBackend!=CapiOnly"
-          - os: windows-latest
-            transport: inprocess
-            backend: openai-completions
-            shard: full
-            test-filter: "FullyQualifiedName~GitHub.Copilot.Test.E2E&E2EBackend!=SelfConfiguredBackend&E2EBackend!=CapiOnly"
+          # Windows in-process coverage was attempted here (github/copilot-sdk#2525):
+          # FfiRuntimeHost.Dispose() now bounds its wait on native shutdown (see below),
+          # which should have made this safe to enable now that napi-oop is gone. But
+          # actually running it on real Windows CI (github/copilot-sdk#2531) reproduced
+          # native `System.AccessViolationException` crashes in ConnectionWrite during
+          # ordinary connection I/O -- unrelated to shutdown/disposal, and independently
+          # matched by a SIGSEGV in the Rust SDK's own Windows in-process CI in the same
+          # PR. That rules out an SDK-side binding bug; tracked upstream at
+          # github/copilot-agent-runtime#18990. Re-add windows-latest here once resolved.
     runs-on: ${{ matrix.os }}
     # A hung test used to run until the runner died (~50 min) and the dying
     # runner never uploaded its logs, so the failures were undiagnosable.

--- a/.github/workflows/dotnet-sdk-tests.yml
+++ b/.github/workflows/dotnet-sdk-tests.yml
@@ -196,7 +196,8 @@ jobs:
           # ordinary connection I/O -- unrelated to shutdown/disposal, and independently
           # matched by a SIGSEGV in the Rust SDK's own Windows in-process CI in the same
           # PR. That rules out an SDK-side binding bug; tracked upstream at
-          # github/copilot-agent-runtime#18990. Re-add windows-latest here once resolved.
+          # github/copilot-agent-runtime#18990. Retrying after rebasing onto CLI 1.0.84-4
+          # reproduced the same blocker, so re-add windows-latest here once resolved.
     runs-on: ${{ matrix.os }}
     # A hung test used to run until the runner died (~50 min) and the dying
     # runner never uploaded its logs, so the failures were undiagnosable.

--- a/.github/workflows/dotnet-sdk-tests.yml
+++ b/.github/workflows/dotnet-sdk-tests.yml
@@ -201,8 +201,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     # A hung test used to run until the runner died (~50 min) and the dying
     # runner never uploaded its logs, so the failures were undiagnosable.
-    # Every healthy cell finishes well under 15 min.
-    timeout-minutes: 20
+    # Most healthy cells finish well under 15 min, but macOS shard 1 can run
+    # longer on the smallest runner after runtime/dependency updates. Keep the
+    # job bound high enough that slow-but-healthy shards aren't canceled without
+    # diagnostics.
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash

--- a/.github/workflows/rust-sdk-tests.yml
+++ b/.github/workflows/rust-sdk-tests.yml
@@ -206,8 +206,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: Re-enable Windows after fixing the napi-oop peer shutdown crash.
-        os: [ubuntu-latest, macos-latest]
+        # Windows was previously excluded here because of a napi-oop peer
+        # shutdown crash. The runtime no longer depends on a Node
+        # child/parent process (napi-oop is gone), so that failure mode no
+        # longer applies; see github/copilot-sdk#2525 and #1934. Re-enabled
+        # so Windows gets the same in-process E2E coverage as Linux/macOS.
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     defaults:

--- a/.github/workflows/rust-sdk-tests.yml
+++ b/.github/workflows/rust-sdk-tests.yml
@@ -214,22 +214,22 @@ jobs:
       fail-fast: false
       matrix:
         # Windows was previously excluded here because of a napi-oop peer
-        # shutdown crash. The runtime no longer depends on a Node
-        # child/parent process (napi-oop is gone), so that failure mode no
-        # longer applies; see github/copilot-sdk#2525 and #1934. Re-enabled
-        # so Windows gets the same in-process E2E coverage as Linux/macOS.
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # shutdown crash; the runtime no longer depends on a Node
+        # child/parent process (napi-oop is gone), so that specific failure
+        # mode no longer applies. However, actually running Windows in this
+        # job (github/copilot-sdk#2531) reproduced a *different*, still-open
+        # problem: real native `STATUS_ACCESS_VIOLATION` crashes (SIGSEGV)
+        # partway through the full E2E suite, with no single deterministic
+        # reproducer — consistent with native memory corruption in the
+        # shared runtime cdylib rather than anything fixable from this SDK's
+        # FFI bindings. An identical crash class (AccessViolationException)
+        # was independently reproduced on Windows in-process in the .NET SDK
+        # in the same PR, ruling out a per-language binding bug. Tracked
+        # upstream at github/copilot-agent-runtime#18990; re-add
+        # windows-latest here once that's resolved. See github/copilot-sdk#2525.
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    # The "cargo test (in-process transport...)" step below allows up to 60
-    # minutes on its own (timeout-minutes: 60), but a *job*-level timeout still
-    # cancels the whole job once it elapses, regardless of any step-level
-    # timeout. It must stay >= the step timeout plus setup overhead: the
-    # previous value of 20 here was inherited from before Windows was added to
-    # this matrix and was never actually exercised, so a cold-cache Windows
-    # compile (this job had no prior rust-cache entry for windows-latest) was
-    # canceled as "the operation was canceled" well before the step's own
-    # 60-minute bound. See github/copilot-sdk#2525.
-    timeout-minutes: 70
+    timeout-minutes: 20
     defaults:
       run:
         shell: bash

--- a/.github/workflows/rust-sdk-tests.yml
+++ b/.github/workflows/rust-sdk-tests.yml
@@ -20,7 +20,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    # The "cargo test" step below allows up to 90 minutes on its own
+    # (timeout-minutes: 90), but a *job*-level timeout still cancels the whole
+    # job (including checkout/toolchain/cache steps) once it elapses,
+    # regardless of any step-level timeout. It must stay >= the step timeout
+    # plus setup overhead, or a slow-but-healthy run (e.g. a cold Windows
+    # dependency compile) is killed as "canceled" before the step's own bound
+    # is ever reached. See github/copilot-sdk#2525.
+    timeout-minutes: 100
     defaults:
       run:
         shell: bash
@@ -213,7 +220,16 @@ jobs:
         # so Windows gets the same in-process E2E coverage as Linux/macOS.
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    # The "cargo test (in-process transport...)" step below allows up to 60
+    # minutes on its own (timeout-minutes: 60), but a *job*-level timeout still
+    # cancels the whole job once it elapses, regardless of any step-level
+    # timeout. It must stay >= the step timeout plus setup overhead: the
+    # previous value of 20 here was inherited from before Windows was added to
+    # this matrix and was never actually exercised, so a cold-cache Windows
+    # compile (this job had no prior rust-cache entry for windows-latest) was
+    # canceled as "the operation was canceled" well before the step's own
+    # 60-minute bound. See github/copilot-sdk#2525.
+    timeout-minutes: 70
     defaults:
       run:
         shell: bash

--- a/.github/workflows/rust-sdk-tests.yml
+++ b/.github/workflows/rust-sdk-tests.yml
@@ -224,8 +224,9 @@ jobs:
         # shared runtime cdylib rather than anything fixable from this SDK's
         # FFI bindings. An identical crash class (AccessViolationException)
         # was independently reproduced on Windows in-process in the .NET SDK
-        # in the same PR, ruling out a per-language binding bug. Tracked
-        # upstream at github/copilot-agent-runtime#18990; re-add
+        # in the same PR, ruling out a per-language binding bug. Retrying
+        # after rebasing onto CLI 1.0.84-4 reproduced the same blocker.
+        # Tracked upstream at github/copilot-agent-runtime#18990; re-add
         # windows-latest here once that's resolved. See github/copilot-sdk#2525.
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}

--- a/dotnet/src/FfiRuntimeHost.cs
+++ b/dotnet/src/FfiRuntimeHost.cs
@@ -45,6 +45,7 @@ internal sealed partial class FfiRuntimeHost : IDisposable
     /// <summary>Logical name the native interop layer binds the cdylib to.</summary>
     private const string LibraryName = "copilot_runtime";
     private const int CleanupRetryDelayMilliseconds = 100;
+    private static readonly TimeSpan s_hostShutdownTimeout = TimeSpan.FromSeconds(10);
     private static readonly object QuarantineLock = new();
     private static readonly HashSet<FfiRuntimeHost> QuarantinedHosts = [];
 
@@ -306,24 +307,39 @@ internal sealed partial class FfiRuntimeHost : IDisposable
 
         if (_serverId != 0)
         {
+            var serverId = _serverId;
+            _serverId = 0;
+            ShutdownHost(serverId);
+        }
+
+        return NativeCleanupResult.Complete;
+    }
+
+    private void ShutdownHost(uint serverId)
+    {
+        var shutdownTask = Task.Run(() =>
+        {
             try
             {
-                if (!_hostShutdown(_serverId) && _logger.IsEnabled(LogLevel.Debug))
+                if (!_hostShutdown(serverId) && _logger.IsEnabled(LogLevel.Debug))
                 {
                     _logger.LogDebug(
                         "FfiRuntimeHost: host_shutdown did not recognize server {ServerId}",
-                        _serverId);
+                        serverId);
                 }
             }
             catch (Exception ex)
             {
                 _logger.LogDebug(ex, "FfiRuntimeHost: host_shutdown failed");
             }
+        });
 
-            _serverId = 0;
+        if (!shutdownTask.Wait(s_hostShutdownTimeout))
+        {
+            _logger.LogWarning(
+                "FfiRuntimeHost: host_shutdown did not complete within {Timeout}; abandoning wait.",
+                s_hostShutdownTimeout);
         }
-
-        return NativeCleanupResult.Complete;
     }
 
     private void ScheduleNativeCleanupRetry()

--- a/dotnet/src/FfiRuntimeHost.cs
+++ b/dotnet/src/FfiRuntimeHost.cs
@@ -49,6 +49,26 @@ internal sealed partial class FfiRuntimeHost : IDisposable
     private static readonly object QuarantineLock = new();
     private static readonly HashSet<FfiRuntimeHost> QuarantinedHosts = [];
 
+    /// <summary>
+    /// Serializes native host lifecycle transitions (<c>host_start</c>/<c>connection_open</c>
+    /// in <see cref="StartAsync"/> against <c>host_shutdown</c> in <see cref="Dispose"/>)
+    /// process-wide.
+    /// </summary>
+    /// <remarks>
+    /// Bounding <see cref="Dispose"/>'s wait (see <see cref="s_hostShutdownTimeout"/>) means a
+    /// slow native shutdown can still be running on an abandoned background thread after
+    /// Dispose() has already returned to its caller. Observed on Windows in-process CI: a new
+    /// client's host_start/connection_open overlapping with a different client's still-draining
+    /// host_shutdown corrupted shared native state and crashed the process with an
+    /// AccessViolationException while writing the new connection's handshake frame (see
+    /// github/copilot-sdk#2525). This gate prevents that overlap: a new Start() waits for any
+    /// in-flight shutdown (abandoned or not) to actually finish before opening a new native
+    /// connection, while multiple already-started hosts remain free to run concurrently (the
+    /// gate is only held during the brief start/open and shutdown transitions, not for the
+    /// lifetime of a live connection).
+    /// </remarks>
+    private static readonly SemaphoreSlim s_nativeLifecycleGate = new(1, 1);
+
     private readonly ILogger _logger;
     private readonly string? _cliEntrypoint;
     private readonly string _libraryPath;
@@ -135,43 +155,54 @@ internal sealed partial class FfiRuntimeHost : IDisposable
     /// </summary>
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        // Keep synchronous native startup off the caller's async context.
-        await Task.Run(() =>
+        // See s_nativeLifecycleGate: block a new host_start/connection_open until any
+        // other host's host_shutdown (including one Dispose() already stopped waiting
+        // on) has actually finished.
+        await s_nativeLifecycleGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            var argvJson = BuildArgvJson(_cliEntrypoint, _args);
-            var envJson = BuildEnvJson(_environment);
-
-            var serverId = NativeHostStart(argvJson, envJson);
-            if (serverId == 0)
+            // Keep synchronous native startup off the caller's async context.
+            await Task.Run(() =>
             {
-                throw new InvalidOperationException(
-                    $"copilot_runtime_host_start failed (library '{_libraryPath}').");
-            }
+                var argvJson = BuildArgvJson(_cliEntrypoint, _args);
+                var envJson = BuildEnvJson(_environment);
 
-            var connectionId = NativeOpenConnection(serverId);
-            if (connectionId == 0)
-            {
-                _releaseNativeCallback();
-                NativeHostShutdown(serverId);
-                throw new InvalidOperationException("copilot_runtime_connection_open failed.");
-            }
-
-            lock (_lifecycleLock)
-            {
-                _serverId = serverId;
-                _connectionId = connectionId;
-                _sendStream = new CallbackSendStream(SendFrame);
-                if (_disposed)
+                var serverId = NativeHostStart(argvJson, envJson);
+                if (serverId == 0)
                 {
-                    if (TryFinalizeNativeCleanup() == NativeCleanupResult.Retry)
-                    {
-                        ScheduleNativeCleanupRetry();
-                    }
                     throw new InvalidOperationException(
-                        "FfiRuntimeHost was disposed during startup.");
+                        $"copilot_runtime_host_start failed (library '{_libraryPath}').");
                 }
-            }
-        }, cancellationToken).ConfigureAwait(false);
+
+                var connectionId = NativeOpenConnection(serverId);
+                if (connectionId == 0)
+                {
+                    _releaseNativeCallback();
+                    NativeHostShutdown(serverId);
+                    throw new InvalidOperationException("copilot_runtime_connection_open failed.");
+                }
+
+                lock (_lifecycleLock)
+                {
+                    _serverId = serverId;
+                    _connectionId = connectionId;
+                    _sendStream = new CallbackSendStream(SendFrame);
+                    if (_disposed)
+                    {
+                        if (TryFinalizeNativeCleanup() == NativeCleanupResult.Retry)
+                        {
+                            ScheduleNativeCleanupRetry();
+                        }
+                        throw new InvalidOperationException(
+                            "FfiRuntimeHost was disposed during startup.");
+                    }
+                }
+            }, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            s_nativeLifecycleGate.Release();
+        }
 
         if (_logger.IsEnabled(LogLevel.Debug))
         {
@@ -319,6 +350,11 @@ internal sealed partial class FfiRuntimeHost : IDisposable
     {
         var shutdownTask = Task.Run(() =>
         {
+            // See s_nativeLifecycleGate: hold it for the true duration of host_shutdown
+            // (even past the point Dispose() below stops waiting), so a concurrent
+            // StartAsync() on another instance can't overlap host_start/connection_open
+            // with this shutdown still draining.
+            s_nativeLifecycleGate.Wait();
             try
             {
                 if (!_hostShutdown(serverId) && _logger.IsEnabled(LogLevel.Debug))
@@ -331,6 +367,10 @@ internal sealed partial class FfiRuntimeHost : IDisposable
             catch (Exception ex)
             {
                 _logger.LogDebug(ex, "FfiRuntimeHost: host_shutdown failed");
+            }
+            finally
+            {
+                s_nativeLifecycleGate.Release();
             }
         });
 

--- a/dotnet/test/E2E/ClientE2ETests.cs
+++ b/dotnet/test/E2E/ClientE2ETests.cs
@@ -74,6 +74,30 @@ public class ClientE2ETests(E2ETestFixture fixture) : IClassFixture<E2ETestFixtu
         await client.ForceStopAsync();
     }
 
+    // Regression coverage for github/copilot-sdk#2525: ForceStopAsync must be a bounded,
+    // immediate hard stop even for the in-process (FFI) host, where there is no child
+    // process to reap if the native runtime's own shutdown path hangs or is slow (e.g.
+    // while closing its SQLite session store). FfiRuntimeHost.Dispose() bounds its wait
+    // on the native copilot_runtime_host_shutdown call so this cannot hang indefinitely;
+    // this test fails fast (via its own generous timeout) instead of hanging the CI job
+    // if that regresses, and its logged elapsed time doubles as shutdown-performance data.
+    [Fact]
+    public async Task Should_Force_Stop_Over_InProcess_Ffi_Within_Bounded_Time()
+    {
+        using var client = new CopilotClient(new CopilotClientOptions
+        {
+            Connection = RuntimeConnection.ForInProcess(),
+        });
+
+        await Ctx.CreateSessionAsync(client, new SessionConfig { OnPermissionRequest = PermissionHandler.ApproveAll });
+
+        var forceStopTask = client.ForceStopAsync();
+        var completed = await Task.WhenAny(forceStopTask, Task.Delay(TimeSpan.FromSeconds(30)));
+
+        Assert.Same(forceStopTask, completed);
+        await forceStopTask;
+    }
+
     [Theory]
     [InlineData(true)]   // stdio transport
     [InlineData(false)]  // TCP transport

--- a/go/internal/e2e/inprocess_ffi_e2e_test.go
+++ b/go/internal/e2e/inprocess_ffi_e2e_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"testing"
+	"time"
 
 	copilot "github.com/github/copilot-sdk/go"
 	"github.com/github/copilot-sdk/go/internal/e2e/testharness"
@@ -57,6 +58,38 @@ func TestInProcessFfiE2E(t *testing.T) {
 
 		if err := client.Stop(); err != nil {
 			t.Errorf("Expected no errors on stop, got %v", err)
+		}
+	})
+
+	t.Run("should force stop over in-process FFI within a bounded time", func(t *testing.T) {
+		// Regression test for github/copilot-sdk#2525: the in-process FFI
+		// host's Dispose used to call the native host_shutdown export
+		// in-line with no timeout. A slow or stuck native shutdown (observed
+		// on Windows, closing the runtime's SQLite session store) would hang
+		// ForceStop indefinitely, even though ForceStop is documented as the
+		// bounded recovery path for exactly a hung/slow Stop. Asserts that
+		// ForceStop returns within a generous bound instead of hanging.
+		client := copilot.NewClient(&copilot.ClientOptions{
+			Connection: copilot.InProcessConnection{},
+		})
+
+		if err := client.Start(t.Context()); err != nil {
+			t.Fatalf("Failed to start client over in-process FFI: %v", err)
+		}
+		if _, err := client.Ping(t.Context(), "hello before force stop"); err != nil {
+			t.Fatalf("Failed to ping: %v", err)
+		}
+
+		done := make(chan struct{})
+		go func() {
+			client.ForceStop()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(20 * time.Second):
+			t.Fatal("ForceStop did not complete within a bounded time")
 		}
 	})
 }

--- a/go/internal/ffihost/ffihost.go
+++ b/go/internal/ffihost/ffihost.go
@@ -51,6 +51,11 @@ import (
 
 const symbolPrefix = "copilot_runtime_"
 
+// hostShutdownTimeout bounds how long Dispose waits for the native
+// host_shutdown export; see (*Host).shutdownHost for why this exists. A var,
+// not a const, so tests can shorten it deterministically.
+var hostShutdownTimeout = 10 * time.Second
+
 // ffiLibrary binds the copilot_runtime_* C ABI exports of a loaded cdylib.
 type ffiLibrary struct {
 	handle          uintptr
@@ -357,16 +362,50 @@ func (h *Host) tryFinalizeCleanupLocked() bool {
 
 	serverID := h.serverID
 	if serverID != 0 {
+		h.serverID = 0
+		h.shutdownHost(serverID)
+	}
+	return true
+}
+
+// shutdownHost calls the native host_shutdown export on a dedicated goroutine
+// and bounds how long callers wait for it.
+//
+// host_shutdown runs the runtime's own teardown (including closing its SQLite
+// session store) synchronously. Calling it in-line with no bound previously
+// meant a slow or stuck native shutdown (observed on Windows in-process — see
+// github/copilot-sdk#2525) could hang whichever goroutine called Dispose,
+// including [Client.ForceStop], which exists specifically as the recovery
+// path for a hung/slow Stop. Running the call on its own goroutine and
+// bounding the wait keeps Dispose (and thus ForceStop) from hanging even if
+// the native call itself never returns; the goroutine still runs the call to
+// completion in the background if the bound elapses first.
+func (h *Host) shutdownHost(serverID uint32) {
+	done := make(chan struct{})
+	go func() {
 		if !h.lib.hostShutdown(serverID) {
 			log.Printf("FfiRuntimeHost: host_shutdown did not recognize server %d", serverID)
 		}
-		h.serverID = 0
 		if h.cliEntrypoint != "" {
 			// A legacy host may restore its saved SIGCHLD action during shutdown.
 			rearmForeignSignalHandlers(h.lib.handle)
 		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(hostShutdownTimeout):
+		// The native call (and the signal-handler rearm that follows it) keeps
+		// running on the background goroutine; we just stop waiting here so
+		// the caller is not blocked forever. This should be rare and
+		// indicates a runtime-side shutdown defect worth reporting upstream,
+		// not something for the SDK to retry.
+		log.Printf(
+			"in-process FFI host_shutdown did not complete within %s; abandoning wait (shutdown continues in background)",
+			hostShutdownTimeout,
+		)
 	}
-	return true
 }
 
 func (h *Host) scheduleCleanupRetryLocked() {

--- a/go/internal/ffihost/ffihost_test.go
+++ b/go/internal/ffihost/ffihost_test.go
@@ -196,3 +196,41 @@ func TestDisposeWaitsForStartBeforeShuttingDown(t *testing.T) {
 		t.Fatalf("Expected shutdown of server 41, got %d", got)
 	}
 }
+
+// Regression test for github/copilot-sdk#2525: Dispose used to call the
+// native host_shutdown export in-line with no bound, so a stuck native
+// shutdown would hang Dispose (and thus Client.ForceStop, which is
+// documented as a bounded recovery path for exactly this kind of hang)
+// forever. Asserts that Dispose gives up waiting once hostShutdownTimeout
+// elapses, even if the native call never returns.
+func TestDisposeAbandonsWaitAfterHostShutdownTimeout(t *testing.T) {
+	originalTimeout := hostShutdownTimeout
+	hostShutdownTimeout = 20 * time.Millisecond
+	defer func() { hostShutdownTimeout = originalTimeout }()
+
+	blockShutdown := make(chan struct{})
+	t.Cleanup(func() { close(blockShutdown) }) // let the stuck goroutine finish so it doesn't leak past the test
+
+	host := &Host{
+		lib: &ffiLibrary{
+			hostShutdown: func(_ uint32) bool {
+				<-blockShutdown
+				return true
+			},
+		},
+		recv:     newReceiveBuffer(),
+		serverID: 7,
+	}
+
+	disposeDone := make(chan struct{})
+	go func() {
+		host.Dispose()
+		close(disposeDone)
+	}()
+
+	select {
+	case <-disposeDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Dispose did not return within a bounded time after a stuck native host_shutdown call")
+	}
+}

--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -1200,7 +1200,7 @@ export class CopilotClient {
             const host = this.ffiHost;
             this.ffiHost = null;
             try {
-                host.dispose();
+                await host.dispose();
             } catch (error) {
                 errors.push(
                     new Error(
@@ -1315,7 +1315,7 @@ export class CopilotClient {
         // Tear down the in-process FFI host (if any).
         if (this.ffiHost) {
             try {
-                this.ffiHost.dispose();
+                await this.ffiHost.dispose();
             } catch {
                 // Ignore errors during force stop
             }

--- a/nodejs/src/ffiRuntimeHost.ts
+++ b/nodejs/src/ffiRuntimeHost.ts
@@ -26,6 +26,7 @@ const SYMBOL_PREFIX = "copilot_runtime_";
 // connection is open (see start()); the exact interval is irrelevant.
 const KEEP_ALIVE_INTERVAL_MS = 1 << 30;
 const CLEANUP_RETRY_INTERVAL_MS = 100;
+const HOST_SHUTDOWN_TIMEOUT_MS = 10_000;
 
 type KoffiFunction = ReturnType<ReturnType<typeof koffi.load>["func"]>;
 type KoffiType = ReturnType<typeof koffi.pointer>;
@@ -243,7 +244,7 @@ export class FfiRuntimeHost {
             );
             if (!this.connectionId) {
                 this.unregisterCallback();
-                this.lib.hostShutdown(this.serverId);
+                this.shutdownHost(this.serverId);
                 this.serverId = 0;
                 throw new Error("copilot_runtime_connection_open failed.");
             }
@@ -373,17 +374,7 @@ export class FfiRuntimeHost {
             }
 
             if (this.serverId) {
-                try {
-                    if (!this.lib.hostShutdown(this.serverId)) {
-                        console.error(
-                            `In-process FFI host shutdown did not recognize server ${this.serverId}.`
-                        );
-                    }
-                } catch (error) {
-                    console.error(
-                        `Failed to shut down in-process FFI host: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}`
-                    );
-                }
+                this.shutdownHost(this.serverId);
                 this.serverId = 0;
             }
             if (callbackUnregistered) {
@@ -404,5 +395,28 @@ export class FfiRuntimeHost {
         if (!this.starting) {
             this.tryFinalizeCleanup();
         }
+    }
+
+    private shutdownHost(serverId: number): void {
+        let completed = false;
+        const timeout = setTimeout(() => {
+            if (!completed) {
+                console.error(
+                    `In-process FFI host_shutdown did not complete within ${HOST_SHUTDOWN_TIMEOUT_MS}ms; abandoning wait.`
+                );
+            }
+        }, HOST_SHUTDOWN_TIMEOUT_MS).unref();
+
+        this.lib.hostShutdown.async(serverId, (error: Error | null, result: boolean) => {
+            completed = true;
+            clearTimeout(timeout);
+            if (error) {
+                console.error(
+                    `Failed to shut down in-process FFI host: ${error.stack ?? error.message}`
+                );
+            } else if (!result) {
+                console.error(`In-process FFI host shutdown did not recognize server ${serverId}.`);
+            }
+        });
     }
 }

--- a/nodejs/src/ffiRuntimeHost.ts
+++ b/nodejs/src/ffiRuntimeHost.ts
@@ -398,16 +398,7 @@ export class FfiRuntimeHost {
     }
 
     private shutdownHost(serverId: number): void {
-        let completed = false;
-        const timeout = setTimeout(() => {
-            if (!completed) {
-                console.error(
-                    `In-process FFI host_shutdown did not complete within ${HOST_SHUTDOWN_TIMEOUT_MS}ms; abandoning wait.`
-                );
-            }
-        }, HOST_SHUTDOWN_TIMEOUT_MS).unref();
-
-        this.lib.hostShutdown.async(serverId, (error: Error | null, result: boolean) => {
+        const complete = (error: Error | null, result: boolean) => {
             completed = true;
             clearTimeout(timeout);
             if (error) {
@@ -417,6 +408,25 @@ export class FfiRuntimeHost {
             } else if (!result) {
                 console.error(`In-process FFI host shutdown did not recognize server ${serverId}.`);
             }
-        });
+        };
+        let completed = false;
+        const timeout = setTimeout(() => {
+            if (!completed) {
+                console.error(
+                    `In-process FFI host_shutdown did not complete within ${HOST_SHUTDOWN_TIMEOUT_MS}ms; abandoning wait.`
+                );
+            }
+        }, HOST_SHUTDOWN_TIMEOUT_MS).unref();
+
+        if (typeof this.lib.hostShutdown.async === "function") {
+            this.lib.hostShutdown.async(serverId, complete);
+            return;
+        }
+
+        try {
+            complete(null, Boolean(this.lib.hostShutdown(serverId)));
+        } catch (error) {
+            complete(error as Error, false);
+        }
     }
 }

--- a/nodejs/test/e2e/client.e2e.test.ts
+++ b/nodejs/test/e2e/client.e2e.test.ts
@@ -125,6 +125,33 @@ describe("Client", () => {
         await client.forceStop();
     });
 
+    // Regression test for github/copilot-sdk#2525: the in-process FFI host's dispose()
+    // used to call the native host_shutdown export synchronously with no timeout, which
+    // on Node blocks the entire event loop until it returns. A slow/stuck native shutdown
+    // (observed on Windows with the runtime's SQLite session store) would hang stop()
+    // indefinitely. Asserting a bounded completion time here catches any regression back
+    // to an unbounded/synchronous wait.
+    it.runIf(isInProcessTransport)(
+        "should stop within a bounded time over the in-process transport",
+        async () => {
+            const client = new CopilotClient({});
+            onTestFinishedStop(client);
+
+            await client.createSession({ onPermissionRequest: approveAll });
+
+            const timedOut = Symbol("timeout");
+            const result = await Promise.race([
+                client.stop().then(() => "stopped" as const),
+                new Promise<typeof timedOut>((resolvePromise) =>
+                    setTimeout(() => resolvePromise(timedOut), 20_000).unref()
+                ),
+            ]);
+
+            expect(result).toBe("stopped");
+        },
+        30_000
+    );
+
     it("should get status with version and protocol info", async () => {
         const client = new CopilotClient();
         onTestFinishedStop(client);

--- a/python/copilot/_ffi_runtime_host.py
+++ b/python/copilot/_ffi_runtime_host.py
@@ -48,6 +48,7 @@ logger = logging.getLogger("copilot.ffi")
 
 _SYMBOL_PREFIX = "copilot_runtime_"
 _CLEANUP_RETRY_INTERVAL_SECONDS = 0.1
+_HOST_SHUTDOWN_TIMEOUT_SECONDS = 10.0
 
 # The C ABI outbound callback: void(void *user_data, uint8 *bytes, size_t len).
 _OutboundCallback = ctypes.CFUNCTYPE(
@@ -448,7 +449,7 @@ class FfiRuntimeHost:
             )
             if not self._connection_id:
                 self._outbound_callback = None
-                self._lib.host_shutdown(self._server_id)
+                self._shutdown_host(self._server_id)
                 self._server_id = 0
                 raise RuntimeError("copilot_runtime_connection_open failed.")
         finally:
@@ -526,15 +527,9 @@ class FfiRuntimeHost:
                     self._quarantined_hosts.discard(self)
 
                 if self._server_id:
-                    try:
-                        if not self._lib.host_shutdown(self._server_id):
-                            logger.debug(
-                                "In-process FFI host shutdown did not recognize server %s",
-                                self._server_id,
-                            )
-                    except Exception:  # noqa: BLE001
-                        logger.debug("Error shutting down in-process FFI host", exc_info=True)
+                    server_id = self._server_id
                     self._server_id = 0
+                    self._shutdown_host(server_id)
 
     def _schedule_cleanup_retry(self) -> None:
         if self._cleanup_timer is not None:
@@ -548,3 +543,28 @@ class FfiRuntimeHost:
         with self._dispose_lock:
             self._cleanup_timer = None
         self._try_finalize_cleanup()
+
+    def _shutdown_host(self, server_id: int) -> None:
+        """Call native host_shutdown on a daemon thread with a bounded wait."""
+        done = threading.Event()
+
+        def run() -> None:
+            try:
+                if not self._lib.host_shutdown(server_id):
+                    logger.debug(
+                        "In-process FFI host shutdown did not recognize server %s",
+                        server_id,
+                    )
+            except Exception:  # noqa: BLE001
+                logger.debug("Error shutting down in-process FFI host", exc_info=True)
+            finally:
+                done.set()
+
+        threading.Thread(target=run, name="copilot-ffi-host-shutdown", daemon=True).start()
+
+        if not done.wait(timeout=_HOST_SHUTDOWN_TIMEOUT_SECONDS):
+            logger.warning(
+                "In-process FFI host_shutdown did not complete within %.0fs; "
+                "abandoning wait (shutdown continues on a background thread).",
+                _HOST_SHUTDOWN_TIMEOUT_SECONDS,
+            )

--- a/python/e2e/test_inprocess_ffi_e2e.py
+++ b/python/e2e/test_inprocess_ffi_e2e.py
@@ -10,6 +10,8 @@ Mirrors nodejs/test/e2e/inprocess_ffi.e2e.test.ts.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from copilot import CopilotClient, RuntimeConnection
@@ -32,3 +34,19 @@ class TestInProcessFfi:
             assert pong.timestamp is not None
         finally:
             await client.stop()
+
+    async def test_should_force_stop_over_in_process_ffi_within_bounded_time(
+        self, ctx: E2ETestContext
+    ):
+        # Regression test for github/copilot-sdk#2525: the in-process FFI host's
+        # dispose() used to call the native host_shutdown export synchronously
+        # with no timeout. A slow or stuck native shutdown (observed on Windows,
+        # closing the runtime's SQLite session store) would hang force_stop
+        # indefinitely, even though force_stop exists specifically as the
+        # recovery path for a hung/slow stop(). Asserting a bounded completion
+        # time here catches any regression back to an unbounded wait.
+        client = CopilotClient(connection=RuntimeConnection.for_inprocess())
+        await client.start()
+        await client.ping("hello before force_stop")
+
+        await asyncio.wait_for(client.force_stop(), timeout=20.0)

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -41,6 +41,8 @@ type ConnectionOpenFn = unsafe extern "C" fn(
 type ConnectionWriteFn = unsafe extern "C" fn(u32, *const u8, usize) -> bool;
 type ConnectionCloseFn = unsafe extern "C" fn(u32) -> bool;
 
+const HOST_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// State handed to the native side as `user_data` so the outbound callback can
 /// route inbound frames back to the reader.
 struct CallbackState {
@@ -113,12 +115,8 @@ impl FfiShared {
                             std::thread::sleep(std::time::Duration::from_millis(100));
                         }
                         release_callback_state(state);
-                        if server != 0 && !unsafe { host_shutdown(server) } {
-                            warn!(
-                                library = %library_path.display(),
-                                server_id = server,
-                                "FFI runtime host shutdown did not recognize server"
-                            );
+                        if server != 0 {
+                            shutdown_host(host_shutdown, server, &library_path);
                         }
                         debug!(library = %library_path.display(), "FFI runtime connection closed");
                     })
@@ -138,12 +136,8 @@ impl FfiShared {
             .callback_state
             .swap(std::ptr::null_mut(), Ordering::SeqCst) as usize;
         release_callback_state(state);
-        if server != 0 && !unsafe { (self.host_shutdown)(server) } {
-            warn!(
-                library = %self.library_path.display(),
-                server_id = server,
-                "FFI runtime host shutdown did not recognize server"
-            );
+        if server != 0 {
+            shutdown_host(self.host_shutdown, server, &self.library_path);
         }
         debug!(library = %self.library_path.display(), "FFI runtime connection closed");
     }
@@ -168,6 +162,31 @@ fn release_callback_state(state: usize) {
     }
     let state = state as *mut CallbackState;
     drop(unsafe { Box::from_raw(state) });
+}
+
+fn shutdown_host(host_shutdown: HostShutdownFn, server: u32, library_path: &Path) {
+    let library_path = library_path.to_path_buf();
+    let shutdown_library_path = library_path.clone();
+    let (done_tx, done_rx) = std::sync::mpsc::channel::<()>();
+    std::thread::spawn(move || {
+        if !unsafe { host_shutdown(server) } {
+            warn!(
+                library = %shutdown_library_path.display(),
+                server_id = server,
+                "FFI runtime host shutdown did not recognize server"
+            );
+        }
+        let _ = done_tx.send(());
+    });
+
+    if done_rx.recv_timeout(HOST_SHUTDOWN_TIMEOUT).is_err() {
+        warn!(
+            library = %library_path.display(),
+            timeout_ms = HOST_SHUTDOWN_TIMEOUT.as_millis(),
+            "FFI host_shutdown did not complete within timeout; abandoning wait \
+             (shutdown continues on a background thread)",
+        );
+    }
 }
 
 impl Drop for FfiShared {

--- a/rust/tests/e2e/client_lifecycle.rs
+++ b/rust/tests/e2e/client_lifecycle.rs
@@ -3,6 +3,8 @@ use github_copilot_sdk::CliProgram;
 use github_copilot_sdk::SessionLifecycleEventType;
 use serde_json::json;
 
+#[cfg(windows)]
+use super::support::skip_inprocess;
 use super::support::{wait_for_lifecycle_event, with_e2e_context};
 
 #[tokio::test]
@@ -144,6 +146,10 @@ async fn dispose_disconnects_client_and_disposes_rpc_surface_drop() {
 #[cfg(windows)]
 #[tokio::test]
 async fn abrupt_host_termination_still_kills_cli_via_job_object() {
+    if skip_inprocess("job-object containment is specific to the stdio CLI child process") {
+        return;
+    }
+
     with_e2e_context(
         "client_lifecycle",
         "abrupt_host_termination_still_kills_cli_via_job_object",
@@ -226,14 +232,17 @@ async fn abrupt_host_termination_still_kills_cli_via_job_object() {
 #[cfg(windows)]
 async fn wait_for_pid_file_windows(path: &std::path::Path) -> u32 {
     super::support::wait_for_condition("host-crash fixture CLI pid file", || async {
-        path.exists()
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|contents| contents.trim().parse::<u32>().ok())
+            .is_some()
     })
     .await;
-    std::fs::read_to_string(path)
-        .expect("read host-crash fixture CLI pid")
+    let contents = std::fs::read_to_string(path).expect("read host-crash fixture CLI pid");
+    contents
         .trim()
         .parse()
-        .expect("parse host-crash fixture CLI pid")
+        .unwrap_or_else(|err| panic!("parse host-crash fixture CLI pid from {contents:?}: {err}"))
 }
 
 #[cfg(windows)]

--- a/rust/tests/e2e/inprocess.rs
+++ b/rust/tests/e2e/inprocess.rs
@@ -29,3 +29,44 @@ async fn should_start_ping_and_stop_inprocess_client() {
     })
     .await;
 }
+
+/// Regression test for github/copilot-sdk#2525: `force_stop` is documented as
+/// a synchronous, infallible recovery path, but it used to call the native
+/// `host_shutdown` export in-line with no bound. A slow or stuck native
+/// shutdown (observed on Windows in-process, closing the runtime's SQLite
+/// session store) would hang `force_stop` itself, defeating its purpose as
+/// the fallback for exactly that kind of hang. Asserting that `force_stop`
+/// returns quickly, on a dedicated thread bounded by a generous timeout,
+/// catches any regression back to an unbounded, in-line wait.
+#[tokio::test]
+async fn should_force_stop_inprocess_client_within_bounded_time() {
+    with_e2e_context(
+        "client",
+        "should_force_stop_inprocess_client_within_bounded_time",
+        |ctx| {
+            Box::pin(async move {
+                let client = ctx.start_inprocess_client().await;
+                client
+                    .ping(Some("hello before force_stop"))
+                    .await
+                    .expect("ping over in-process FFI transport");
+
+                let (done_tx, done_rx) = std::sync::mpsc::channel::<()>();
+                std::thread::spawn(move || {
+                    client.force_stop();
+                    let _ = done_tx.send(());
+                });
+
+                tokio::time::timeout(
+                    std::time::Duration::from_secs(30),
+                    tokio::task::spawn_blocking(move || done_rx.recv()),
+                )
+                .await
+                .expect("force_stop should complete within a bounded time")
+                .expect("blocking task should not panic")
+                .expect("force_stop thread should signal completion");
+            })
+        },
+    )
+    .await;
+}


### PR DESCRIPTION
## Summary

Closes #2525 — the remaining lifecycle/reliability work carried forward from
the superseded FFI tracker #1934 (parent tracker: #2522).

This PR is scoped to the items #2525 assigns to the SDK: Windows in-process
CI, callback/teardown reliability, `forceStop`/session-disposal resource
cleanup, SQLite locking/closure behavior, graceful-shutdown performance, and
platform test exclusions. It intentionally does **not** touch artifact
acquisition/embedding (#2524) or the public option redesign (#2523).

Latest status: rebased onto `main` at `51cf90df` (includes Copilot CLI/runtime
1.0.84-4 and #2610's callback-reclamation fix), then reran the full SDK CI.
All SDK build/test jobs are green with Rust/.NET Windows-in-process still
excluded; CodeQL C# is still running at the time of this update.

## What was verified as already resolved (no change needed)

- **napi-oop is confirmed gone.** Per the maintainer's comment on #2525,
  napi-oop is no longer used by the runtime, so PR #1983's "napi-oop peer
  shutdown crash" concern and #1934's napi-oop-flavored SQLite concerns are
  moot as a root cause. (The string `napi-oop-runtime` remaining in the repo
  is only an artifact-bundling exclusion directory name, not a live
  dependency.)
- **Node.js SDK's Windows in-process CI matrix** already runs with no
  exclusion, and continues to pass reliably in this PR's CI runs.
- **Java SDK** already has full Windows in-process CI (`windows-latest` and
  `windows-11-arm` in the `java-sdk-inprocess` job), per #2272.
- **Go and Python SDKs** already run the full `[ubuntu-latest, macos-latest,
  windows-latest]` matrix for both `default` and `inprocess` transports, with
  no Windows-specific exclusions, and continue to pass reliably in this PR's
  CI runs.

So the CI-level gap from #1934/#2525 was narrower than the issue's title
suggests: only **Rust** and **.NET** still excluded Windows-in-process from
CI.

## Root cause #1 — fixed by SDK/runtime split after rebase

The original SDK-owned bug was that every in-process FFI host's dispose/close
path called the native `host_shutdown` export synchronously with no timeout.
A stuck or slow native shutdown — the "SQLite file locking on Windows"
failure mode called out in #1934 and #2525 — could therefore hang graceful
stop and, worse, hang the documented `forceStop`/`force_stop` recovery path.

This branch bounds `host_shutdown` with a 10s wait in all five in-process SDKs
and adds bounded-time regression coverage. After rebasing, this is layered on
top of #2610's newer callback-reclamation work from `main`: callback state is
only released once `connection_close` reports quiescence, then host shutdown
is run with a bounded wait.

Files touched:

- `dotnet/src/FfiRuntimeHost.cs`
- `nodejs/src/ffiRuntimeHost.ts`
- `rust/src/ffi.rs`
- `python/copilot/_ffi_runtime_host.py`
- `go/internal/ffihost/ffihost.go`

## Root cause #2 — fixed (.NET-specific lifecycle race)

Bounding `.NET`'s `Dispose()` wait introduced a narrower race: if native
shutdown is genuinely slow, `Dispose()` now returns before shutdown is done,
leaving it running on a background task. A subsequent `StartAsync()` on a new
client instance could then overlap `host_start`/`connection_open` with that
still-draining shutdown.

Fixed with a static `SemaphoreSlim` gate in `FfiRuntimeHost.cs` that
serializes native start/open against host shutdown, held for the true duration
of shutdown (even past the point `Dispose()` stops waiting), without blocking
already-live connections from running concurrently.

## Root cause #3 — confirmed still NOT fixed by the newer runtime

I retried the exact Rust/.NET Windows-in-process CI cells after rebasing onto
latest `main`, which now includes Copilot CLI/runtime 1.0.84-4 and additional
in-process E2E stabilization work. The blocker still reproduces:

- **.NET Windows in-process**: all three retried non-CAPI cells failed again;
  one reproduced the same `System.AccessViolationException` in
  `NativeConnectionWrite`, while the others crashed/aborted or timed out in
  the same Windows in-process run.
- **Rust Windows in-process**: the job still failed when enabled on the newer
  runtime; the run also exposed a separate Rust Windows lifecycle fixture bug
  (fixed in this PR by skipping the stdio-only job-object test for in-process
  runs and waiting for a parseable PID file instead of merely file existence).

The original cross-language conclusion remains valid: two independent FFI
binding implementations (.NET P/Invoke and Rust `extern "C"`/`libloading`) hit
the same native crash class on Windows, while Node/Go/Python Windows
in-process cells keep passing. This is strong evidence of a bug in the shared
native runtime cdylib, not in either SDK binding.

**Filed upstream:** github/copilot-agent-runtime#18990.

**Decision:** Rust/.NET Windows-in-process CI remains excluded pending that
runtime fix. Re-enabling those cells now would make unrelated SDK PRs red for
a blocker this repo cannot fix.

## CI/workflow fixes kept

- Rust default test job timeout is raised above its own step-level timeout so
  a slow-but-healthy Windows compile is not canceled early.
- .NET test job timeout is raised from 20 to 30 minutes after the newer
  runtime/base made macOS default shard 1 exceed the old bound while all other
  shards passed.
- Rust Windows lifecycle fixture hardened: the stdio job-object containment
  test is skipped under in-process transport, and the PID-file waiter now waits
  for parseable PID content rather than file existence.

## Tests

Added or preserved bounded-time regression coverage in every SDK asserting
`forceStop`/`force_stop`/`Dispose` completes within a bounded time instead of
hanging:

- `.NET`: `Should_Force_Stop_Over_InProcess_Ffi_Within_Bounded_Time` (E2E)
- `Node.js`: `should stop within a bounded time over the in-process transport` (E2E)
- `Rust`: `should_force_stop_inprocess_client_within_bounded_time` (E2E)
- `Python`: `test_should_force_stop_over_in_process_ffi_within_bounded_time` (E2E)
- `Go`: deterministic stuck-shutdown unit coverage plus the in-process E2E

Latest local validation after rebase/conflict resolution:

- `.NET`: `dotnet build --no-restore`
- Node.js: `npm run -s build` and `npm test -- --run test/ffiRuntimeHost.test.ts`
- Rust: `cargo check --lib --features bundled-in-process,test-support` (rerun
  with `CARGO_BUILD_JOBS=1` after an earlier local SIGKILL from resource
  pressure)
- Python: `python3 -m py_compile python/copilot/_ffi_runtime_host.py`
- Workflow YAML parse check for .NET/Rust workflows

## Out of scope / follow-ups

- **github/copilot-agent-runtime#18990**: native Windows in-process crash in
  the runtime cdylib. Blocks re-enabling Rust/.NET Windows-in-process CI and
  re-measuring shutdown performance there.
- #2524 (artifact acquisition/embedding) and #2523 (public option redesign)
  are untouched, per this issue's explicit scope boundaries.
