### PR TITLE
Add apply_patch override E2E coverage

### DIFF
--- a/dotnet/test/E2E/ToolsE2ETests.cs
+++ b/dotnet/test/E2E/ToolsE2ETests.cs
@@ -7,7 +7,11 @@ using GitHub.Copilot.Test.Harness;
 using Microsoft.Extensions.AI;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Net;
+using System.Net.Http;
+using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,6 +20,9 @@ namespace GitHub.Copilot.Test.E2E;
 
 public partial class ToolsE2ETests(E2ETestFixture fixture, ITestOutputHelper output) : E2ETestBase(fixture, "tools", output)
 {
+    private const string ApplyPatchInput = "*** Begin Patch\n*** End Patch";
+    private const string ApplyPatchResult = "patched by the host";
+
     [Fact]
     public async Task Invokes_Built_In_Tools()
     {
@@ -234,6 +241,91 @@ public partial class ToolsE2ETests(E2ETestFixture fixture, ITestOutputHelper out
             => $"CUSTOM_GREP_RESULT: {query}";
     }
 
+    [Theory]
+    [InlineData("string")]
+    [InlineData("object")]
+    [InlineData("JsonElement")]
+    [InlineData("JsonNode")]
+    [Trait(E2ETestTraits.Backend, E2ETestTraits.SelfConfiguredBackend)]
+    public async Task ApplyPatch_Override_Receives_Freeform_Input_Shapes(string parameterType)
+    {
+        foreach (var useCustomToolCall in new[] { true, false })
+        {
+            object? receivedInput = null;
+            var invocationCount = 0;
+            var handler = new ApplyPatchOverrideRequestHandler(useCustomToolCall);
+            await using var client = Ctx.CreateClient(options: new CopilotClientOptions
+            {
+                Connection = RuntimeConnection.ForStdio(),
+                RequestHandler = handler,
+            });
+            await client.StartAsync();
+
+            string CaptureInput(object input)
+            {
+                receivedInput = input;
+                invocationCount++;
+                return ApplyPatchResult;
+            }
+
+            Delegate applyPatch = parameterType switch
+            {
+                "string" => (string input) => CaptureInput(input),
+                "object" => (object input) => CaptureInput(input),
+                "JsonElement" => (JsonElement input) => CaptureInput(input),
+                "JsonNode" => (JsonNode input) => CaptureInput(input),
+                _ => throw new ArgumentOutOfRangeException(nameof(parameterType)),
+            };
+            var tool = CopilotTool.DefineTool(
+                applyPatch,
+                new CopilotToolOptions
+                {
+                    OverridesBuiltInTool = true,
+                    SkipPermission = true,
+                },
+                new AIFunctionFactoryOptions
+                {
+                    Name = "apply_patch",
+                    Description = "Host-implemented apply_patch",
+                });
+
+            await using var session = await Ctx.CreateSessionAsync(client, new SessionConfig
+            {
+                Model = "gpt-4o-mini",
+                Provider = new ProviderConfig
+                {
+                    Type = "openai",
+                    WireApi = "completions",
+                    BaseUrl = "https://apply-patch.invalid/v1",
+                    ApiKey = "test-key",
+                    ModelId = "gpt-4o-mini",
+                    WireModel = "gpt-4o-mini",
+                },
+                Streaming = true,
+                Tools = [tool],
+                OnPermissionRequest = PermissionHandler.ApproveAll,
+            });
+
+            var message = await session.SendAndWaitAsync(new MessageOptions { Prompt = "Use apply_patch" });
+
+            var input = receivedInput switch
+            {
+                string value => value,
+                JsonElement value => value.GetString(),
+                JsonNode value => value.GetValue<string>(),
+                _ => null,
+            };
+            Assert.Equal(ApplyPatchInput, input);
+            Assert.Equal(1, invocationCount);
+            Assert.Equal("override complete", message?.Data.Content);
+
+            var requests = handler.InferenceRequests;
+            Assert.Equal(2, requests.Count);
+            AssertApplyPatchOverrideAdvertised(requests[0], parameterType);
+            AssertApplyPatchResultReachedModel(requests[1]);
+        }
+    }
+
     [Fact]
     public async Task SkipPermission_Sent_In_Tool_Definition()
     {
@@ -447,5 +539,115 @@ public partial class ToolsE2ETests(E2ETestFixture fixture, ITestOutputHelper out
             excludedToolCalled = true;
             return $"EXCLUDED_{input.ToUpperInvariant()}";
         }
+    }
+
+    private static void AssertApplyPatchOverrideAdvertised(string requestBody, string parameterType)
+    {
+        using var request = JsonDocument.Parse(requestBody);
+        var applyPatchTools = request.RootElement.GetProperty("tools")
+            .EnumerateArray()
+            .Where(tool =>
+                tool.TryGetProperty("function", out var function)
+                    && function.TryGetProperty("name", out var functionName)
+                    && functionName.GetString() == "apply_patch"
+                || tool.TryGetProperty("custom", out var custom)
+                    && custom.TryGetProperty("name", out var customName)
+                    && customName.GetString() == "apply_patch")
+            .ToArray();
+
+        var applyPatch = Assert.Single(applyPatchTools);
+        Assert.Equal("function", applyPatch.GetProperty("type").GetString());
+        var definition = applyPatch.GetProperty("function");
+        Assert.Equal("apply_patch", definition.GetProperty("name").GetString());
+
+        var parameters = definition.GetProperty("parameters");
+        Assert.Equal("object", parameters.GetProperty("type").GetString());
+        var inputSchema = parameters.GetProperty("properties").GetProperty("input");
+        if (parameterType == "string")
+        {
+            Assert.Equal("string", inputSchema.GetProperty("type").GetString());
+        }
+        else
+        {
+            Assert.Equal(JsonValueKind.True, inputSchema.ValueKind);
+        }
+        Assert.Contains(parameters.GetProperty("required").EnumerateArray(), item => item.GetString() == "input");
+    }
+
+    private static void AssertApplyPatchResultReachedModel(string requestBody)
+    {
+        using var request = JsonDocument.Parse(requestBody);
+        var toolResult = Assert.Single(
+            request.RootElement.GetProperty("messages").EnumerateArray(),
+            message =>
+                message.GetProperty("role").GetString() == "tool"
+                && message.GetProperty("tool_call_id").GetString() == "call-1");
+        Assert.Equal(ApplyPatchResult, toolResult.GetProperty("content").GetString());
+    }
+
+    private sealed class ApplyPatchOverrideRequestHandler(bool useCustomToolCall) : CopilotRequestHandler
+    {
+        private const string CustomToolCallResponse =
+            "data: {\"id\":\"chatcmpl-tool\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-4o-mini\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"tool_calls\":[{\"index\":0,\"id\":\"call-1\",\"type\":\"custom\",\"custom\":{\"name\":\"apply_patch\",\"input\":\"*** Begin Patch\\n*** End Patch\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n" +
+            "data: [DONE]\n\n";
+
+        private const string FunctionToolCallResponse =
+            "data: {\"id\":\"chatcmpl-tool\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-4o-mini\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"tool_calls\":[{\"index\":0,\"id\":\"call-1\",\"type\":\"function\",\"function\":{\"name\":\"apply_patch\",\"arguments\":\"{\\\"input\\\":\\\"*** Begin Patch\\\\n*** End Patch\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n" +
+            "data: [DONE]\n\n";
+
+        private const string FinalResponse =
+            "data: {\"id\":\"chatcmpl-final\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-4o-mini\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"override complete\"},\"finish_reason\":null}]}\n\n" +
+            "data: {\"id\":\"chatcmpl-final\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-4o-mini\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n" +
+            "data: [DONE]\n\n";
+
+        private readonly object _lock = new();
+        private readonly List<string> _inferenceRequests = [];
+
+        internal IReadOnlyList<string> InferenceRequests
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return [.. _inferenceRequests];
+                }
+            }
+        }
+
+        protected override async Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, CopilotRequestContext ctx)
+        {
+            var url = request.RequestUri!.ToString();
+            if (!RecordingRequestHandler.IsInferenceUrl(url))
+            {
+                return RecordingRequestHandler.BuildNonInferenceResponse(url);
+            }
+
+            var requestBody = request.Content is null
+                ? string.Empty
+#if NET8_0_OR_GREATER
+                : await request.Content.ReadAsStringAsync(ctx.CancellationToken).ConfigureAwait(false);
+#else
+                : await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
+
+            int requestNumber;
+            lock (_lock)
+            {
+                _inferenceRequests.Add(requestBody);
+                requestNumber = _inferenceRequests.Count;
+            }
+
+            return requestNumber switch
+            {
+                1 => Sse(useCustomToolCall ? CustomToolCallResponse : FunctionToolCallResponse),
+                2 => Sse(FinalResponse),
+                _ => throw new InvalidOperationException($"Unexpected inference request #{requestNumber}."),
+            };
+        }
+
+        private static HttpResponseMessage Sse(string body) => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "text/event-stream"),
+        };
     }
 }


### PR DESCRIPTION
The `apply_patch` built-in is a freeform GPT tool, so an SDK override must handle both OpenAI's raw custom-tool input and the object-shaped function-call compatibility form without bypassing the host `AIFunction`.

This adds a self-configured .NET E2E theory that runs through the real CLI runtime and verifies:

- the built-in descriptor is replaced by the host override
- raw custom-tool strings and `{ "input": ... }` function arguments reach the override
- `string`, `object`, `JsonElement`, and `JsonNode` parameter bindings preserve the patch content
- the host result is returned to the model for turn completion

Generated by Copilot