### PR TITLE
Fix stale Java release preparation

### DIFF
--- a/.github/workflows/java-publish-maven.yml
+++ b/.github/workflows/java-publish-maven.yml
@@ -90,12 +90,13 @@ jobs:
       development_version: ${{ steps.versions.outputs.development_version }}
       release_tag: ${{ steps.release-identity.outputs.release_tag }}
       tag_commit: ${{ steps.release-identity.outputs.tag_commit }}
-      pre_prepare_commit: ${{ steps.pre-prepare.outputs.pre_prepare_commit }}
+      pre_prepare_commit: ${{ steps.update-docs.outputs.pre_prepare_commit }}
       post_prepare_commit: ${{ steps.release-identity.outputs.post_prepare_commit }}
       docs_commit: ${{ steps.update-docs.outputs.docs_commit_sha }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: main
           fetch-depth: 0
           token: ${{ secrets.JAVA_RELEASE_TOKEN }}
 
@@ -150,16 +151,27 @@ jobs:
         run: |
           VERSION="${{ steps.versions.outputs.release_version }}"
           DEV_VERSION="${{ steps.versions.outputs.development_version }}"
-          ./scripts/test-update-documentation-versions.sh
-          ./scripts/update-documentation-versions.sh "$VERSION" "$DEV_VERSION" README.md sdk/jbang-example.java
-          git add README.md sdk/jbang-example.java
-          git commit -m "docs: update version references to ${VERSION}"
-          echo "docs_commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          git push origin main
 
-      - name: Record rollback base
-        id: pre-prepare
-        run: echo "pre_prepare_commit=$(git rev-parse HEAD^)" >> "$GITHUB_OUTPUT"
+          for attempt in 1 2 3; do
+            git fetch origin main
+            git reset --hard origin/main
+            ./scripts/test-update-documentation-versions.sh
+            ./scripts/update-documentation-versions.sh "$VERSION" "$DEV_VERSION" README.md sdk/jbang-example.java
+            git add README.md sdk/jbang-example.java
+            git commit -m "docs: update version references to ${VERSION}"
+
+            if git push origin HEAD:main; then
+              echo "pre_prepare_commit=$(git rev-parse HEAD^)" >> "$GITHUB_OUTPUT"
+              echo "docs_commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+              break
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::main continued to advance while preparing the Java release."
+              exit 1
+            fi
+            echo "main advanced during release preparation; retrying from the latest commit."
+          done
 
       - name: Prepare Release
         run: |

--- a/.github/workflows/java-publish-maven.yml
+++ b/.github/workflows/java-publish-maven.yml
@@ -155,6 +155,13 @@ jobs:
           for attempt in 1 2 3; do
             git fetch origin main
             git reset --hard origin/main
+            if [ -z "${{ inputs.releaseVersion }}" ]; then
+              LIVE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+              if [ "${LIVE_VERSION%-SNAPSHOT}" != "$VERSION" ]; then
+                echo "::error::main advanced from release version $VERSION to ${LIVE_VERSION%-SNAPSHOT}; restart the release with the current version."
+                exit 1
+              fi
+            fi
             ./scripts/test-update-documentation-versions.sh
             ./scripts/update-documentation-versions.sh "$VERSION" "$DEV_VERSION" README.md sdk/jbang-example.java
             git add README.md sdk/jbang-example.java


### PR DESCRIPTION
## Summary

- check out the live `main` branch when preparing Java releases instead of the workflow dispatch SHA
- retry the documentation version commit from the latest remote commit when `main` advances
- record the documentation commit and rollback base only after the push succeeds, avoiding unsafe rollback attempts with empty identities

## Root cause analysis

Actions run 33810120846 failed differently on its two attempts:

1. **Attempt 1, September 3:** the Java job checked out `39c027b0`, pushed documentation commit `70fa5d31`, and created Maven release commit `d6791fcd`. The Maven release plugin then failed when GitHub rejected the `java/v1.0.13-preview.6` tag push with `remote: fatal error in commit_refs`. The guarded rollback succeeded and pushed `18fba144` and `81ffc2a7`, reverting the release and documentation commits.
2. **Attempt 2, September 4:** rerunning the workflow retained the original run SHA, `39c027b0`. The Java workflow used the default `actions/checkout` ref, so it checked out that old commit even though `main` had advanced through the rollback commits and #2507 to `184e504c`. Its new documentation commit `3bdce0b6` was therefore rejected as a non-fast-forward push.
3. The documentation step wrote `docs_commit_sha` before the failed push, which triggered rollback. However, `pre_prepare_commit` was recorded by the following step, which never ran. The rollback received an empty base SHA and failed with `Recorded pre-prepare commit does not exist`.

### Regression provenance

- The latent stale-checkout bug was introduced by #1348 when the Java release workflow was added with a default event-SHA checkout followed by direct pushes to `main`. A rerun after any partial release rollback could therefore start from the original run SHA rather than current `main`.
- #1938 made the Java workflow reusable from the unified publish workflow but preserved the same checkout behavior; it exposed a broader path to the bug but did not introduce it.
- The secondary rollback failure was introduced by #2393, which moved guarded rollback into a separate job while recording `pre_prepare_commit` only after the documentation push.
- #2507 merely advanced `main` between attempts and exposed the stale checkout; it did not break Java.

The original attempt-1 GitHub tag rejection is separate from this workflow regression. This change makes release preparation and reruns safe after that or any similar partial failure.

## Fix

- explicitly check out live `main` for release preparation
- rebuild and retry the documentation commit up to three times if `main` advances
- publish the final documentation commit and its parent as outputs only after the push succeeds

## Validation

- `cd java && ./scripts/test-update-documentation-versions.sh`
- YAML parse check
- actionlint comparison against `main` (no new findings)