### PR TITLE
Add Rust session store identity support

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2573,6 +2573,23 @@ impl Client {
         Ok(serde_json::from_value(value)?)
     }
 
+    /// Set the account identity used to scope persisted session-store operations.
+    ///
+    /// Call this after connecting and before local session-store operations such
+    /// as listing or resuming sessions. Pass `None` to clear the identity, such
+    /// as when the user logs out.
+    pub async fn set_session_store_identity(
+        &self,
+        identity: Option<&SessionStoreIdentity>,
+    ) -> Result<()> {
+        self.call(
+            "sessionStore.setIdentity",
+            Some(serde_json::json!({ "identity": identity })),
+        )
+        .await?;
+        Ok(())
+    }
+
     /// List persisted sessions, optionally filtered by working directory,
     /// repository, or git context.
     pub async fn list_sessions(

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2590,6 +2590,23 @@ impl Client {
         Ok(())
     }
 
+    /// Claim one quarantined legacy local session for the active store identity.
+    ///
+    /// The runtime atomically binds the claim to the identity most recently set
+    /// on this client connection through
+    /// [`set_session_store_identity`](Self::set_session_store_identity). Call
+    /// this only after explicit trusted-host user confirmation for the selected
+    /// session. The runtime rejects missing identities, conflicting ownership,
+    /// and sessions that are not eligible legacy local sessions.
+    pub async fn claim_legacy_session(&self, session_id: &SessionId) -> Result<()> {
+        self.call(
+            "sessionStore.claimLegacySession",
+            Some(serde_json::json!({ "sessionId": session_id })),
+        )
+        .await?;
+        Ok(())
+    }
+
     /// List persisted sessions, optionally filtered by working directory,
     /// repository, or git context.
     pub async fn list_sessions(

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1081,6 +1081,7 @@ impl ExtensionInfo {
 /// Identity used to isolate persisted session-store data by GitHub account.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct SessionStoreIdentity {
     /// Canonical HTTPS origin for GitHub.com or the GitHub Enterprise Server.
     pub authority: String,

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1078,6 +1078,26 @@ impl ExtensionInfo {
     }
 }
 
+/// Identity used to isolate persisted session-store data by GitHub account.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionStoreIdentity {
+    /// Canonical HTTPS origin for GitHub.com or the GitHub Enterprise Server.
+    pub authority: String,
+    /// Positive decimal GitHub account database ID.
+    pub account_id: String,
+}
+
+impl SessionStoreIdentity {
+    /// Create a session-store identity.
+    pub fn new(authority: impl Into<String>, account_id: impl Into<String>) -> Self {
+        Self {
+            authority: authority.into(),
+            account_id: account_id.into(),
+        }
+    }
+}
+
 /// Stable identity for a host/SDK connection that supplies built-in canvases.
 ///
 /// When set on session create or resume, the runtime uses [`id`] verbatim as
@@ -2036,6 +2056,8 @@ pub struct SessionConfig {
     pub enable_host_git_operations: Option<bool>,
     /// When true, enables the session store for this session.
     pub enable_session_store: Option<bool>,
+    /// Identity used to isolate this session's persisted session-store data.
+    pub session_store_identity: Option<SessionStoreIdentity>,
     /// When true, enables skills for this session.
     pub enable_skills: Option<bool>,
     /// **Experimental.** This option is part of an experimental wire-protocol
@@ -2350,6 +2372,7 @@ impl std::fmt::Debug for SessionConfig {
                 &self.enable_host_git_operations,
             )
             .field("enable_session_store", &self.enable_session_store)
+            .field("session_store_identity", &self.session_store_identity)
             .field("enable_skills", &self.enable_skills)
             .field("enable_mcp_apps", &self.enable_mcp_apps)
             .field("skill_directories", &self.skill_directories)
@@ -2478,6 +2501,7 @@ impl Default for SessionConfig {
             enable_file_hooks: None,
             enable_host_git_operations: None,
             enable_session_store: None,
+            session_store_identity: None,
             enable_skills: None,
             embedding_cache_storage: None,
             enable_mcp_apps: None,
@@ -2650,6 +2674,7 @@ impl SessionConfig {
             enable_file_hooks: self.enable_file_hooks,
             enable_host_git_operations: self.enable_host_git_operations,
             enable_session_store: self.enable_session_store,
+            session_store_identity: self.session_store_identity,
             enable_skills: self.enable_skills,
             request_user_input,
             request_permission: permission_active,
@@ -3040,6 +3065,12 @@ impl SessionConfig {
     /// Set [`Self::enable_session_store`].
     pub fn with_enable_session_store(mut self, value: bool) -> Self {
         self.enable_session_store = Some(value);
+        self
+    }
+
+    /// Set the identity used to isolate persisted session-store data.
+    pub fn with_session_store_identity(mut self, identity: SessionStoreIdentity) -> Self {
+        self.session_store_identity = Some(identity);
         self
     }
 
@@ -3487,6 +3518,8 @@ pub struct ResumeSessionConfig {
     pub enable_host_git_operations: Option<bool>,
     /// When true, enables the session store on resume.
     pub enable_session_store: Option<bool>,
+    /// Identity used to isolate the resumed session's persisted session-store data.
+    pub session_store_identity: Option<SessionStoreIdentity>,
     /// When true, enables skills on resume.
     pub enable_skills: Option<bool>,
     /// **Experimental.** This option is part of an experimental wire-protocol
@@ -3721,6 +3754,7 @@ impl std::fmt::Debug for ResumeSessionConfig {
                 &self.enable_host_git_operations,
             )
             .field("enable_session_store", &self.enable_session_store)
+            .field("session_store_identity", &self.session_store_identity)
             .field("enable_skills", &self.enable_skills)
             .field("enable_mcp_apps", &self.enable_mcp_apps)
             .field("skill_directories", &self.skill_directories)
@@ -3893,6 +3927,7 @@ impl ResumeSessionConfig {
             enable_file_hooks: self.enable_file_hooks,
             enable_host_git_operations: self.enable_host_git_operations,
             enable_session_store: self.enable_session_store,
+            session_store_identity: self.session_store_identity,
             enable_skills: self.enable_skills,
             request_user_input,
             request_permission: permission_active,
@@ -4001,6 +4036,7 @@ impl ResumeSessionConfig {
             enable_file_hooks: None,
             enable_host_git_operations: None,
             enable_session_store: None,
+            session_store_identity: None,
             enable_skills: None,
             embedding_cache_storage: None,
             enable_mcp_apps: None,
@@ -4365,6 +4401,12 @@ impl ResumeSessionConfig {
     /// Set [`Self::enable_session_store`].
     pub fn with_enable_session_store(mut self, value: bool) -> Self {
         self.enable_session_store = Some(value);
+        self
+    }
+
+    /// Set the identity used to isolate persisted session-store data on resume.
+    pub fn with_session_store_identity(mut self, identity: SessionStoreIdentity) -> Self {
+        self.session_store_identity = Some(identity);
         self
     }
 
@@ -6239,8 +6281,8 @@ mod tests {
         InfiniteSessionConfig, LargeToolOutputConfig, McpServerConfig, McpStdioServerConfig,
         MemoryConfiguration, NamedProviderConfig, PermissionResponseCapability, ProviderConfig,
         ProviderModelConfig, ReasoningSummary, ResumeSessionConfig, SessionConfig, SessionEvent,
-        SessionId, SystemMessageConfig, Tool, ToolBinaryResult, ToolResult, ToolResultExpanded,
-        ToolResultResponse, ensure_attachment_display_names,
+        SessionId, SessionStoreIdentity, SystemMessageConfig, Tool, ToolBinaryResult, ToolResult,
+        ToolResultExpanded, ToolResultResponse, ensure_attachment_display_names,
     };
     use crate::generated::session_events::TypedSessionEvent;
 
@@ -6526,6 +6568,60 @@ mod tests {
         assert!(!wire.request_mcp_apps);
         let json = serde_json::to_value(&wire).unwrap();
         assert!(json.get("askUserVariant").is_none());
+    }
+
+    #[test]
+    fn session_store_identity_serializes_to_exact_create_and_resume_wire_shape() {
+        let identity = SessionStoreIdentity::new("https://github.com", "123456");
+        assert_eq!(
+            serde_json::to_value(&identity).unwrap(),
+            json!({
+                "authority": "https://github.com",
+                "accountId": "123456"
+            })
+        );
+
+        let (create_wire, _) = SessionConfig::default()
+            .with_session_store_identity(identity.clone())
+            .into_wire(Some(SessionId::from("store-identity-create")))
+            .expect("create config has no duplicate handlers");
+        let create_json = serde_json::to_value(&create_wire).unwrap();
+        assert_eq!(
+            create_json["sessionStoreIdentity"],
+            json!({
+                "authority": "https://github.com",
+                "accountId": "123456"
+            })
+        );
+
+        let (resume_wire, _) = ResumeSessionConfig::new(SessionId::from("store-identity-resume"))
+            .with_session_store_identity(identity)
+            .into_wire()
+            .expect("resume config has no duplicate handlers");
+        let resume_json = serde_json::to_value(&resume_wire).unwrap();
+        assert_eq!(
+            resume_json["sessionStoreIdentity"],
+            json!({
+                "authority": "https://github.com",
+                "accountId": "123456"
+            })
+        );
+    }
+
+    #[test]
+    fn session_store_identity_is_omitted_when_absent() {
+        let (create_wire, _) = SessionConfig::default()
+            .into_wire(Some(SessionId::from("store-identity-create-unset")))
+            .expect("create config has no duplicate handlers");
+        let create_json = serde_json::to_value(&create_wire).unwrap();
+        assert!(create_json.get("sessionStoreIdentity").is_none());
+
+        let (resume_wire, _) =
+            ResumeSessionConfig::new(SessionId::from("store-identity-resume-unset"))
+                .into_wire()
+                .expect("resume config has no duplicate handlers");
+        let resume_json = serde_json::to_value(&resume_wire).unwrap();
+        assert!(resume_json.get("sessionStoreIdentity").is_none());
     }
 
     #[test]

--- a/rust/src/wire.rs
+++ b/rust/src/wire.rs
@@ -29,7 +29,7 @@ use crate::types::{
     CustomAgentConfig, DefaultAgentConfig, ExtensionInfo, GitHubMcpToolConfig,
     InfiniteSessionConfig, LargeToolOutputConfig, McpServerConfig, MemoryConfiguration,
     NamedProviderConfig, ProviderConfig, ProviderModelConfig, SessionId, SessionLimitsConfig,
-    SystemMessageConfig, Tool, ToolSearchConfig,
+    SessionStoreIdentity, SystemMessageConfig, Tool, ToolSearchConfig,
 };
 
 /// Wire representation of a slash command (name + description only). The
@@ -112,6 +112,8 @@ pub(crate) struct SessionCreateWire {
     pub enable_host_git_operations: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enable_session_store: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_store_identity: Option<SessionStoreIdentity>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enable_skills: Option<bool>,
     pub request_user_input: bool,
@@ -273,6 +275,8 @@ pub(crate) struct SessionResumeWire {
     pub enable_host_git_operations: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enable_session_store: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_store_identity: Option<SessionStoreIdentity>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enable_skills: Option<bool>,
     pub request_user_input: bool,

--- a/rust/tests/session_test.rs
+++ b/rust/tests/session_test.rs
@@ -31,7 +31,8 @@ use github_copilot_sdk::types::{
     ElicitationRequest, ElicitationResult, ExitPlanModeData, ExtensionInfo, ManagedSettings,
     ManagedSettingsPermissions, MessageOptions, PermissionDecisionContext,
     PermissionDecisionOutcome, PermissionDecisionSource, PermissionDecisionSurface, RequestId,
-    SessionConfig, SessionId, SetModelOptions, Tool, ToolInvocation, ToolResult,
+    SessionConfig, SessionId, SessionStoreIdentity, SetModelOptions, Tool, ToolInvocation,
+    ToolResult,
 };
 use github_copilot_sdk::{
     AgentMode, Attachment, Client, ContextTier, ErrorKind, MessageSource, ProtocolErrorKind, tool,
@@ -2523,6 +2524,57 @@ async fn list_sessions_returns_typed_metadata() {
     assert_eq!(sessions.len(), 1);
     assert_eq!(sessions[0].session_id, "s1");
     assert_eq!(sessions[0].summary, Some("test session".to_string()));
+}
+
+#[tokio::test]
+async fn set_session_store_identity_sends_exact_wire_shape() {
+    let (client, mut server_read, mut server_write) = make_client();
+    let identity = SessionStoreIdentity::new("https://github.com", "123456");
+
+    let handle = tokio::spawn({
+        let client = client.clone();
+        async move { client.set_session_store_identity(Some(&identity)).await }
+    });
+
+    let request = read_framed(&mut server_read).await;
+    assert_eq!(request["method"], "sessionStore.setIdentity");
+    assert_eq!(
+        request["params"],
+        serde_json::json!({
+            "identity": {
+                "authority": "https://github.com",
+                "accountId": "123456"
+            }
+        })
+    );
+    let response = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": request["id"],
+        "result": {}
+    });
+    write_framed(&mut server_write, &serde_json::to_vec(&response).unwrap()).await;
+    handle.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn set_session_store_identity_sends_null_to_clear() {
+    let (client, mut server_read, mut server_write) = make_client();
+
+    let handle = tokio::spawn({
+        let client = client.clone();
+        async move { client.set_session_store_identity(None).await }
+    });
+
+    let request = read_framed(&mut server_read).await;
+    assert_eq!(request["method"], "sessionStore.setIdentity");
+    assert_eq!(request["params"], serde_json::json!({ "identity": null }));
+    let response = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": request["id"],
+        "result": {}
+    });
+    write_framed(&mut server_write, &serde_json::to_vec(&response).unwrap()).await;
+    handle.await.unwrap().unwrap();
 }
 
 #[tokio::test]

--- a/rust/tests/session_test.rs
+++ b/rust/tests/session_test.rs
@@ -2578,6 +2578,68 @@ async fn set_session_store_identity_sends_null_to_clear() {
 }
 
 #[tokio::test]
+async fn claim_legacy_session_sends_exact_wire_shape() {
+    let (client, mut server_read, mut server_write) = make_client();
+
+    let handle = tokio::spawn({
+        let client = client.clone();
+        async move {
+            client
+                .claim_legacy_session(&SessionId::new("legacy-session"))
+                .await
+        }
+    });
+
+    let request = read_framed(&mut server_read).await;
+    assert_eq!(request["method"], "sessionStore.claimLegacySession");
+    assert_eq!(
+        request["params"],
+        serde_json::json!({ "sessionId": "legacy-session" })
+    );
+    let response = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": request["id"],
+        "result": {}
+    });
+    write_framed(&mut server_write, &serde_json::to_vec(&response).unwrap()).await;
+    handle.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn claim_legacy_session_propagates_rpc_errors() {
+    let (client, mut server_read, mut server_write) = make_client();
+
+    let handle = tokio::spawn({
+        let client = client.clone();
+        async move {
+            client
+                .claim_legacy_session(&SessionId::new("owned-session"))
+                .await
+        }
+    });
+
+    let request = read_framed(&mut server_read).await;
+    assert_eq!(request["method"], "sessionStore.claimLegacySession");
+    let response = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": request["id"],
+        "error": {
+            "code": -32000,
+            "message": "legacy session is not eligible for claim"
+        }
+    });
+    write_framed(&mut server_write, &serde_json::to_vec(&response).unwrap()).await;
+
+    let error = handle.await.unwrap().unwrap_err();
+    assert!(matches!(error.kind(), ErrorKind::Rpc { code: -32000 }));
+    assert!(
+        error
+            .to_string()
+            .contains("legacy session is not eligible for claim")
+    );
+}
+
+#[tokio::test]
 async fn list_sessions_serializes_typed_filter() {
     use github_copilot_sdk::SessionListFilter;
 


### PR DESCRIPTION
## Context

Persisted session history must be scoped to the authoritative GitHub account identity, not only to the local machine or runtime process. This PR provides the Rust SDK portion of a coordinated runtime-and-consumer rollout so hosts can establish that scope before accessing local session history and preserve it when creating or resuming a session.

The identity consists of:

- `authority`: the canonical HTTPS origin for GitHub.com or a GitHub Enterprise Server instance
- `accountId`: the positive decimal authoritative GitHub database ID

It intentionally does not use login names, tokens, local UUIDs, or environment variables as identity transport.

## Summary

- add public, non-exhaustive `SessionStoreIdentity` with Rust fields `authority` and `account_id`
- support optional `sessionStoreIdentity` payloads on session create and resume for compatibility with runtimes that do not yet consume the field
- add `Client::set_session_store_identity` for the server-scoped `sessionStore.setIdentity` set/clear contract
- add `Client::claim_legacy_session` for an explicit, trusted-host-only migration of one selected quarantined legacy local session
- cover exact camelCase serialization, omission when absent, setter/clear requests, claim requests, and claim error propagation

## Integration contract

Consumers should call `Client::set_session_store_identity(Some(&identity))` after connecting and before local session-store operations such as list, metadata lookup, or resume. On an account switch, set the new identity before any subsequent session-store request; on logout, call `Client::set_session_store_identity(None)`.

After explicit user confirmation for one selected legacy session, a trusted host may call `Client::claim_legacy_session(&session_id)`. This invokes `sessionStore.claimLegacySession` with only `{ "sessionId": "..." }`; the runtime atomically binds the claim to the identity already configured on that same client connection. A successful or idempotent same-owner claim returns `{}`. Missing identity, ineligible or missing sessions, conflicting ownership, validation failures, and storage failures are surfaced as JSON-RPC errors.

Claiming is deliberately separate from create/resume, listing, and model-facing RPC namespaces. There is no bulk or automatic claim path. Only after the explicit claim succeeds should the consumer resume the session with the same `SessionStoreIdentity`.

The same identity can be supplied through `SessionConfig::with_session_store_identity` and `ResumeSessionConfig::with_session_store_identity` so create and resume requests carry the account scope explicitly. The identity is create/resume and server-context configuration only; it is not a mutable session update option.

Related runtime and consumer changes are being coordinated in private repositories and are therefore not linked from this public PR.

## Validation

- `cargo +nightly-2026-04-14 fmt --check`
- `cargo test --lib session_store_identity`
- `cargo test --features test-support --test session_test set_session_store_identity`
- `cargo test --features test-support --test session_test claim_legacy_session`
- `cargo clippy --all-features --all-targets -- -D warnings`
- GitHub Rust test, documentation, Clippy, bundled CLI, and CodeQL checks