### PR TITLE
[java] Fix broken LICENSE link in java/README.md

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -623,4 +623,4 @@ Each classifier JAR includes `runtime.node`, `platform.properties`, and `copilot
 
 ## License
 
-MIT — see [LICENSE](sdk/LICENSE) for details.
+MIT — see [LICENSE](../LICENSE) for details.


### PR DESCRIPTION
The **License** section of `java/README.md` links to `sdk/LICENSE`, which resolves to `java/sdk/LICENSE` — a path that does not exist. The link 404s on GitHub.

No java-local `LICENSE` has ever been tracked in this repository, so the link has been dead since it was introduced; the `java/src` → `java/sdk` restructure in #2301 only changed *which* nonexistent path it pointed at (`LICENSE` → `sdk/LICENSE`). This retargets it to the repository-root `../LICENSE`.

## Verification

The only LICENSE files tracked in the repo:

```console
$ git ls-files | grep LICENSE
LICENSE
rust/LICENSE
```

`java/LICENSE` was never tracked, so the pre-restructure link was dead too:

```console
$ git log --oneline --all -- java/LICENSE
                      # (no output)
$ git ls-tree d9a6fabb^ java/ --name-only | grep LICENSE
                      # (no output — java/LICENSE absent before the move as well)
```

Before / after, resolved relative to `java/README.md`:

| Link target | Resolves to | Exists |
| --- | --- | --- |
| `sdk/LICENSE` (before) | `java/sdk/LICENSE` | ❌ |
| `../LICENSE` (after) | `LICENSE` | ✅ |

## Scope

One line in one file. `java/README.md` is the only README that links to a LICENSE file — `nodejs`, `go`, and `dotnet` each render a bare `MIT` under `## License`, and `rust`/`python` have no License section at all — so nothing else is affected.
