### PR TITLE
Make referenced optional Python RPC requests omittable

### DIFF
--- a/docs/features/usage-and-billing.md
+++ b/docs/features/usage-and-billing.md
@@ -1193,11 +1193,10 @@ if (premium) {
 <!-- docs-validate: hidden -->
 ```python
 from copilot import CopilotClient
-from copilot.rpc import AccountGetQuotaRequest
 
 client = CopilotClient()
 
-result = await client.rpc.account.get_quota(AccountGetQuotaRequest())
+result = await client.rpc.account.get_quota()
 premium = result.quota_snapshots.get("premium_interactions")
 
 if premium is not None:
@@ -1209,7 +1208,7 @@ if premium is not None:
 <!-- /docs-validate: hidden -->
 
 ```python
-result = await client.rpc.account.get_quota(AccountGetQuotaRequest())
+result = await client.rpc.account.get_quota()
 premium = result.quota_snapshots.get("premium_interactions")
 
 if premium is not None:

--- a/python/copilot/generated/rpc.py
+++ b/python/copilot/generated/rpc.py
@@ -40622,9 +40622,9 @@ class ServerModelsApi:
     def __init__(self, client: "JsonRpcClient"):
         self._client = client
 
-    async def list(self, params: ModelsListRequest, *, timeout: float | None = None) -> ModelList:
+    async def list(self, params: ModelsListRequest | None = None, *, timeout: float | None = None) -> ModelList:
         "Lists Copilot models available to the authenticated user.\n\nArgs:\n    params: Optional opaque account selection or compatibility GitHub token used to list models.\n\nReturns:\n    List of Copilot models available to the resolved user, including capabilities and billing metadata."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return ModelList.from_dict(_patch_model_capabilities(await self._client.request("models.list", params_dict, **_timeout_kwargs(timeout))))
 
     async def get_built_in_catalog(self, *, timeout: float | None = None) -> BuiltInModelCatalog:
@@ -40648,9 +40648,9 @@ class ServerAccountApi:
     def __init__(self, client: "JsonRpcClient"):
         self._client = client
 
-    async def get_quota(self, params: AccountGetQuotaRequest, *, timeout: float | None = None) -> AccountGetQuotaResult:
+    async def get_quota(self, params: AccountGetQuotaRequest | None = None, *, timeout: float | None = None) -> AccountGetQuotaResult:
         "Gets Copilot quota usage for the current or opaquely selected authenticated user.\n\nArgs:\n    params: Optional opaque account selection or compatibility GitHub token used to look up quota.\n\nReturns:\n    Quota usage snapshots for the resolved user, keyed by quota type."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return AccountGetQuotaResult.from_dict(await self._client.request("account.getQuota", params_dict, **_timeout_kwargs(timeout)))
 
     async def get_current_auth(self, *, timeout: float | None = None) -> AccountGetCurrentAuthResult:
@@ -40805,9 +40805,9 @@ class ServerPluginsMarketplacesApi:
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return MarketplaceBrowseResult.from_dict(await self._client.request("plugins.marketplaces.browse", params_dict, **_timeout_kwargs(timeout)))
 
-    async def refresh(self, params: PluginsMarketplacesRefreshRequest, *, timeout: float | None = None) -> MarketplaceRefreshResult:
+    async def refresh(self, params: PluginsMarketplacesRefreshRequest | None = None, *, timeout: float | None = None) -> MarketplaceRefreshResult:
         "Re-fetches one or all registered marketplace catalogs.\n\nArgs:\n    params: Optional marketplace name; omit to refresh all.\n\nReturns:\n    Result of refreshing one or more marketplace catalogs."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return MarketplaceRefreshResult.from_dict(await self._client.request("plugins.marketplaces.refresh", params_dict, **_timeout_kwargs(timeout)))
 
 
@@ -41028,9 +41028,9 @@ class ServerSessionsApi:
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return RemoteSessionConnectionResult.from_dict(await self._client.request("sessions.connect", params_dict, **_timeout_kwargs(timeout)))
 
-    async def list(self, params: SessionsListRequest, *, timeout: float | None = None) -> SessionList:
+    async def list(self, params: SessionsListRequest | None = None, *, timeout: float | None = None) -> SessionList:
         "Lists sessions, optionally filtered by source and working-directory context. Returned entries are discriminated by `isRemote`: local entries carry only the lightweight `LocalSessionMetadataValue` shape; remote entries carry the full `RemoteSessionMetadataValue` shape (repository, PR number, taskType, etc.).\n\nArgs:\n    params: Optional source filter, metadata-load limit, and context filter applied to the returned sessions.\n\nReturns:\n    Sessions matching the filter, ordered most-recently-modified first."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return SessionList.from_dict(await self._client.request("sessions.list", params_dict, **_timeout_kwargs(timeout)))
 
     async def read_persisted_events(self, params: SessionsReadPersistedEventsRequest, *, timeout: float | None = None) -> EventsReadResult:
@@ -41122,9 +41122,9 @@ class ServerSessionsApi:
         params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
         return RemoteControlStatusResult.from_dict(await self._client.request("sessions.setRemoteControlSteering", params_dict, **_timeout_kwargs(timeout)))
 
-    async def stop_remote_control(self, params: SessionsStopRemoteControlRequest, *, timeout: float | None = None) -> RemoteControlStopResult:
+    async def stop_remote_control(self, params: SessionsStopRemoteControlRequest | None = None, *, timeout: float | None = None) -> RemoteControlStopResult:
         "Stops the remote-control singleton. When `expectedSessionId` is provided and does not match the singleton's current `attachedSessionId`, the stop is rejected with `stopped: false` and the current status is returned unchanged (unless `force` is set, in which case the singleton is unconditionally torn down).\n\nArgs:\n    params: Parameters for stopping the remote-control singleton.\n\nReturns:\n    Outcome of a stopRemoteControl call."
-        params_dict = {k: v for k, v in params.to_dict().items() if v is not None}
+        params_dict = {k: v for k, v in params.to_dict().items() if v is not None} if params is not None else {}
         return RemoteControlStopResult.from_dict(await self._client.request("sessions.stopRemoteControl", params_dict, **_timeout_kwargs(timeout)))
 
     async def get_remote_control_status(self, *, timeout: float | None = None) -> RemoteControlStatusResult:

--- a/python/test_rpc_generated.py
+++ b/python/test_rpc_generated.py
@@ -1,11 +1,15 @@
 """Tests for generated RPC method behavior."""
 
+import inspect
 import json
+from typing import get_type_hints
 from unittest.mock import AsyncMock
 
 import pytest
 
 from copilot.rpc import (
+    AccountGetQuotaRequest,
+    AccountLoginRequest,
     BuiltinToolInputSchemaType,
     CommandsApi,
     CommandsInvokeRequest,
@@ -17,11 +21,40 @@ from copilot.rpc import (
     RemoteControlStatusResult,
     RemoteSessionMetadataValue,
     SandboxConfig,
+    ServerAccountApi,
     SessionList,
     SlashCommandTextResult,
     TaskAgentInfo,
     UIElicitationSchemaType,
 )
+
+
+def test_referenced_optional_request_is_omittable_and_required_request_is_not():
+    quota_params = inspect.signature(ServerAccountApi.get_quota).parameters["params"]
+    login_params = inspect.signature(ServerAccountApi.login).parameters["params"]
+
+    assert get_type_hints(ServerAccountApi.get_quota)["params"] == AccountGetQuotaRequest | None
+    assert quota_params.default is None
+    assert get_type_hints(ServerAccountApi.login)["params"] is AccountLoginRequest
+    assert login_params.default is inspect.Parameter.empty
+
+
+@pytest.mark.asyncio
+async def test_referenced_optional_request_serializes_omitted_and_explicit_params():
+    client = AsyncMock()
+    client.request = AsyncMock(return_value={"quotaSnapshots": {}})
+    api = ServerAccountApi(client)
+
+    await api.get_quota()
+    client.request.assert_awaited_once_with("account.getQuota", {})
+
+    client.request.reset_mock()
+    await api.get_quota(AccountGetQuotaRequest())
+    client.request.assert_awaited_once_with("account.getQuota", {})
+
+    client.request.reset_mock()
+    await api.get_quota(AccountGetQuotaRequest(git_hub_token="github-token"))
+    client.request.assert_awaited_once_with("account.getQuota", {"gitHubToken": "github-token"})
 
 
 def test_sandbox_config_round_trips_allow_bypass_and_omits_when_absent():

--- a/scripts/codegen/python.ts
+++ b/scripts/codegen/python.ts
@@ -1527,9 +1527,9 @@ function pythonResultTypeName(method: RpcMethod, schemaOverride?: JSONSchema7): 
     return getRpcSchemaTypeName(schema, toPascalCase(method.rpcMethod) + "Result");
 }
 
-/** Detect the Zod optional params pattern: `anyOf: [{ not: {} }, { $ref }]` */
+/** Detect the Zod optional params pattern: `anyOf: [{ not: {} }, { $ref }]`, including behind a `$ref`. */
 function isParamsOptional(method: RpcMethod): boolean {
-    const schema = method.params;
+    const schema = resolveSchema(method.params, rpcDefinitions);
     if (!schema?.anyOf) return false;
     return schema.anyOf.some(
         (item) =>


### PR DESCRIPTION
Fixes #1946

## Problem

`account.getQuota` declares its params as a `$ref` to `AccountGetQuotaRequest`, and that referenced definition already carries the optional-request wrapper `anyOf: [{ not: {} }, { ... }]`. The Python generator's optional-params check only inspected the unresolved `$ref`, so it never saw the wrapper and emitted a required parameter:

```python
result = await client.rpc.account.get_quota()
# TypeError: ServerAccountApi.get_quota() missing 1 required positional argument: 'params'
```

Callers had no values to supply, so the only workaround was to pass an empty request object.

## Change

Resolve the params schema before the existing wrapper check, so a wrapper reached through a `$ref` is detected exactly like an inline one.

This corrects the five methods whose requests are declared that way — `models.list`, `account.getQuota`, `plugins.marketplaces.refresh`, `sessions.list`, and `sessions.stopRemoteControl` — and updates the Python quota example that documented the workaround.

The change is limited to that lookup. It adds no dependency and no general schema-validity inference, and it does not alter required requests, required-nullable fields, dataclass defaults, or how a supplied request is serialized. Other language generators are untouched.

## Validation

- `npm run generate:python`, rerun to confirm byte-identical output
- `python/test_rpc_generated.py` — 12 passing; full Python unit suite — 407 passing
- `nodejs` `npm run typecheck`; `shared-codegen`, `typescript-codegen`, `client-api-codegen` — 28 passing
- `ruff check` and `ruff format --check`
- Live A/B against the real Copilot CLI 1.0.83, using wheels built from each tree and installed into separate clean virtual environments outside the repository:
  - Unpatched `main` raised `ServerAccountApi.get_quota() missing 1 required positional argument: 'params'`, matching the report.
  - The patched wheel returned real quota snapshots for `chat`, `completions`, and `premium_interactions`.
  - Controls in both arms: an explicit `AccountGetQuotaRequest()` still succeeded, and required-params `account.login` still rejected omission.
