### PR TITLE
Link docs index section headings to their section index pages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -67,17 +67,17 @@ Detailed API reference for each session hook.
 * [Session Lifecycle](./hooks/session-lifecycle.md): session start and end
 * [Error Handling](./hooks/error-handling.md): custom error handling
 
-### [Troubleshooting](./troubleshooting/debugging.md)
+### [Troubleshooting](./troubleshooting/README.md)
 
 * [Debugging Guide](./troubleshooting/debugging.md): common issues and solutions
 * [MCP Debugging](./troubleshooting/mcp-debugging.md): MCP-specific troubleshooting
 * [Compatibility](./troubleshooting/compatibility.md): SDK vs CLI feature matrix
 
-### [Observability](./observability/opentelemetry.md)
+### [Observability](./observability/README.md)
 
 * [OpenTelemetry Instrumentation](./observability/opentelemetry.md): built-in TelemetryConfig and trace context propagation
 
-### [Integrations](./integrations/microsoft-agent-framework.md)
+### [Integrations](./integrations/README.md)
 
 Guides for using the SDK with other platforms and frameworks.
 


### PR DESCRIPTION
In `docs/README.md`, most section headings link to that section's index page, but three link to an individual article instead. Two of those sections have an index that nothing links to as a result.

| Heading | Linked to | Section index |
| --- | --- | --- |
| Setup | `./setup/README.md` | ✅ |
| Authentication | `./auth/README.md` | ✅ |
| Features | `./features/README.md` | ✅ |
| Hooks Reference | `./hooks/README.md` | ✅ |
| Troubleshooting | `./troubleshooting/debugging.md` | ❌ index exists, unlinked |
| Observability | `./observability/opentelemetry.md` | ❌ index exists |
| Integrations | `./integrations/microsoft-agent-framework.md` | ❌ index exists, unlinked |

`docs/integrations/README.md` and `docs/troubleshooting/README.md` were unreachable — nothing in the repository linked to them:

```console
$ git grep -rn -E 'integrations/README\.md|troubleshooting/README\.md'
                      # (no output, before this change)
```

Both are real index pages, not placeholders — `troubleshooting/README.md` lists all three troubleshooting articles, and `integrations/README.md` lists the integrations guide.

## Verification

All seven section headings now resolve to a file that exists, and the two orphans are linked:

```console
$ git grep -rn -E 'integrations/README\.md|troubleshooting/README\.md'
docs/README.md:70:### [Troubleshooting](./troubleshooting/README.md)
docs/README.md:80:### [Integrations](./integrations/README.md)

$ ls docs/troubleshooting/README.md docs/observability/README.md docs/integrations/README.md
docs/troubleshooting/README.md  docs/observability/README.md  docs/integrations/README.md
```

## Notes

Observability was not orphaned — `docs/features/usage-and-billing.md` links its index — but its heading deviated from the same convention, so it is included here for consistency.

Two things deliberately left alone:

- The **Debug an issue** row in the quick-start table still points at `./troubleshooting/debugging.md`. That table is task-oriented, so linking the article rather than the index looks intentional.
- `docs/developer-docs/secrets.md` is also unlinked, but it documents Actions secrets for maintainers rather than being part of the user-facing navigation.
