### PR TITLE
fix(rust): isolate GitHub token callbacks from request routing

### DIFF
--- a/rust/src/github_token.rs
+++ b/rust/src/github_token.rs
@@ -2,11 +2,15 @@
 
 use std::collections::HashMap;
 use std::future::Future;
+use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, OnceLock, Weak};
 
 use async_trait::async_trait;
+use futures_util::FutureExt;
 use parking_lot::Mutex;
 use serde_json::Value;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 use crate::generated::api_types::{
     GitHubTokenAcquireReason, GitHubTokenAcquireRequest, GitHubTokenAcquireResult,
@@ -124,9 +128,25 @@ where
     }
 }
 
+struct ProviderRegistration {
+    provider: Arc<dyn GitHubTokenProvider>,
+    worker: Option<TokenWorker>,
+}
+
+struct TokenWorker {
+    requests: mpsc::UnboundedSender<JsonRpcRequest>,
+    task: JoinHandle<()>,
+}
+
+impl Drop for TokenWorker {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
 #[derive(Default)]
 struct RegistryState {
-    providers: HashMap<String, Arc<dyn GitHubTokenProvider>>,
+    providers: HashMap<String, ProviderRegistration>,
     session_owners: HashMap<crate::SessionId, String>,
 }
 
@@ -149,10 +169,13 @@ impl GitHubTokenRegistry {
 
     pub(crate) fn register(&self, provider: Arc<dyn GitHubTokenProvider>) -> String {
         let registration_id = uuid::Uuid::new_v4().to_string();
-        self.state
-            .lock()
-            .providers
-            .insert(registration_id.clone(), provider);
+        self.state.lock().providers.insert(
+            registration_id.clone(),
+            ProviderRegistration {
+                provider,
+                worker: None,
+            },
+        );
         registration_id
     }
 
@@ -188,11 +211,43 @@ impl GitHubTokenRegistry {
         state.session_owners.clear();
     }
 
-    pub(crate) async fn dispatch(&self, request: JsonRpcRequest) {
-        let Some(inner) = self.client.get().and_then(Weak::upgrade) else {
+    pub(crate) fn dispatch(&self, request: JsonRpcRequest) {
+        let Some(client) = self.client.get().cloned() else {
             return;
         };
-        let client = Client::from_inner(inner);
+        let registration_id = request
+            .params
+            .as_ref()
+            .and_then(|params| params.get("registrationId"))
+            .and_then(Value::as_str);
+        let mut state = self.state.lock();
+        if let Some(registration) = registration_id.and_then(|id| state.providers.get_mut(id)) {
+            let worker = registration.worker.get_or_insert_with(|| {
+                let provider = registration.provider.clone();
+                let (requests, mut rx) = mpsc::unbounded_channel();
+                let task = tokio::spawn(async move {
+                    // One worker per registration preserves callback order without
+                    // holding up requests for other providers or sessions.
+                    while let Some(request) = rx.recv().await {
+                        Self::handle_request(&client, Some(provider.as_ref()), request).await;
+                    }
+                });
+                TokenWorker { requests, task }
+            });
+            let _ = worker.requests.send(request);
+        } else {
+            // Invalid/retired registrations still receive the normal RPC error.
+            tokio::spawn(async move {
+                Self::handle_request(&client, None, request).await;
+            });
+        }
+    }
+
+    async fn handle_request(
+        client: &Weak<ClientInner>,
+        provider: Option<&dyn GitHubTokenProvider>,
+        request: JsonRpcRequest,
+    ) {
         let params = request
             .params
             .clone()
@@ -201,7 +256,7 @@ impl GitHubTokenRegistry {
             Ok(params) => params,
             Err(error) => {
                 send_error(
-                    &client,
+                    client,
                     request.id,
                     error_codes::INVALID_PARAMS,
                     &format!("invalid params: {error}"),
@@ -210,15 +265,9 @@ impl GitHubTokenRegistry {
                 return;
             }
         };
-        let provider = self
-            .state
-            .lock()
-            .providers
-            .get(&params.registration_id)
-            .cloned();
         let Some(provider) = provider else {
             send_error(
-                &client,
+                client,
                 request.id,
                 error_codes::INTERNAL_ERROR,
                 "unknown GitHub token provider registration",
@@ -232,7 +281,7 @@ impl GitHubTokenRegistry {
             GitHubTokenAcquireReason::Refresh => GitHubTokenRequestReason::Refresh,
             GitHubTokenAcquireReason::Unknown => {
                 send_error(
-                    &client,
+                    client,
                     request.id,
                     error_codes::INVALID_PARAMS,
                     "unknown GitHub token acquisition reason",
@@ -242,17 +291,34 @@ impl GitHubTokenRegistry {
             }
         };
 
-        match provider
-            .get_token(GitHubTokenProviderArgs {
-                host: params.host,
-                session_id: params.session_id,
-                reason,
-            })
-            .await
-        {
+        let result = AssertUnwindSafe(async {
+            provider
+                .get_token(GitHubTokenProviderArgs {
+                    host: params.host,
+                    session_id: params.session_id,
+                    reason,
+                })
+                .await
+        })
+        .catch_unwind()
+        .await;
+        let result = match result {
+            Ok(result) => result,
+            Err(_) => {
+                send_error(
+                    client,
+                    request.id,
+                    error_codes::INTERNAL_ERROR,
+                    "GitHub token provider panicked",
+                )
+                .await;
+                return;
+            }
+        };
+        match result {
             Ok(GitHubTokenProviderResult::Token(token)) => {
                 respond(
-                    &client,
+                    client,
                     request.id,
                     GitHubTokenAcquireResult::Token(token.into_wire()),
                 )
@@ -260,7 +326,7 @@ impl GitHubTokenRegistry {
             }
             Ok(GitHubTokenProviderResult::Cancelled) => {
                 respond(
-                    &client,
+                    client,
                     request.id,
                     GitHubTokenAcquireResult::Cancelled(GitHubTokenAcquireResultCancelled {
                         kind: Default::default(),
@@ -270,7 +336,7 @@ impl GitHubTokenRegistry {
             }
             Err(error) => {
                 send_error(
-                    &client,
+                    client,
                     request.id,
                     error_codes::INTERNAL_ERROR,
                     &format!("GitHub token provider failed: {error}"),
@@ -306,10 +372,13 @@ impl Drop for GitHubTokenRegistration {
     }
 }
 
-async fn respond(client: &Client, request_id: u64, result: GitHubTokenAcquireResult) {
+async fn respond(client: &Weak<ClientInner>, request_id: u64, result: GitHubTokenAcquireResult) {
     match serde_json::to_value(result) {
         Ok(result) => {
-            let _ = client
+            let Some(inner) = client.upgrade() else {
+                return;
+            };
+            let _ = Client::from_inner(inner)
                 .send_response(&JsonRpcResponse {
                     jsonrpc: "2.0".to_string(),
                     id: request_id,
@@ -330,8 +399,11 @@ async fn respond(client: &Client, request_id: u64, result: GitHubTokenAcquireRes
     }
 }
 
-async fn send_error(client: &Client, request_id: u64, code: i32, message: &str) {
-    let _ = client
+async fn send_error(client: &Weak<ClientInner>, request_id: u64, code: i32, message: &str) {
+    let Some(inner) = client.upgrade() else {
+        return;
+    };
+    let _ = Client::from_inner(inner)
         .send_response(&JsonRpcResponse {
             jsonrpc: "2.0".to_string(),
             id: request_id,

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -254,7 +254,7 @@ impl SessionRouter {
                         continue;
                     }
                     if request.method == "gitHubToken.getToken" {
-                        github_token_registry.dispatch(request).await;
+                        github_token_registry.dispatch(request);
                         continue;
                     }
                     // Client-global `llmInference.*` requests carry no routable

--- a/rust/tests/session_test.rs
+++ b/rust/tests/session_test.rs
@@ -653,6 +653,219 @@ async fn github_token_provider_is_mutually_exclusive_and_rolls_back_failed_creat
     assert_eq!(unknown["error"]["code"], -32603);
 }
 
+async fn create_token_test_session(
+    client: &Client,
+    server: &mut FakeServer,
+    provider: Arc<dyn github_copilot_sdk::github_token::GitHubTokenProvider>,
+) -> (github_copilot_sdk::session::Session, String) {
+    let create = tokio::spawn({
+        let client = client.clone();
+        async move {
+            client
+                .create_session(SessionConfig::default().with_github_token_provider(provider))
+                .await
+                .unwrap()
+        }
+    });
+    let request = server.read_request().await;
+    let registration = request["params"]["gitHubTokenProviderRegistrationId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    server
+        .respond(
+            &request,
+            serde_json::json!({"sessionId": requested_session_id(&request)}),
+        )
+        .await;
+    (
+        timeout(TIMEOUT, create).await.unwrap().unwrap(),
+        registration,
+    )
+}
+
+async fn request_test_token(server: &mut FakeServer, id: u64, registration: &str, host: &str) {
+    server
+        .send_request(
+            id,
+            "gitHubToken.getToken",
+            serde_json::json!({
+                "registrationId": registration, "host": host, "reason": "refresh"
+            }),
+        )
+        .await;
+}
+
+#[tokio::test]
+async fn github_token_provider_pending_callback_does_not_block_other_providers() {
+    let (client, read, write) = make_client();
+    let mut server = FakeServer {
+        read,
+        write,
+        session_id: String::new(),
+    };
+    let entered = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let calls = Arc::new(AtomicUsize::new(0));
+    let blocked = Arc::new({
+        let calls = calls.clone();
+        let entered = entered.clone();
+        let release = release.clone();
+        move |_args: GitHubTokenProviderArgs| {
+            let calls = calls.clone();
+            let entered = entered.clone();
+            let release = release.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                entered.notify_one();
+                release.notified().await;
+                Ok(GitHubTokenProviderResult::Cancelled)
+            }
+        }
+    });
+    let (first, first_id) = create_token_test_session(&client, &mut server, blocked).await;
+    let (_second, second_id) = create_token_test_session(
+        &client,
+        &mut server,
+        Arc::new(|_args: GitHubTokenProviderArgs| async {
+            Ok(GitHubTokenProviderResult::Cancelled)
+        }),
+    )
+    .await;
+    request_test_token(&mut server, 910, &first_id, "github.com").await;
+    timeout(TIMEOUT, entered.notified()).await.unwrap();
+    request_test_token(&mut server, 912, &first_id, "github.com").await;
+    request_test_token(&mut server, 911, &second_id, "github.com").await;
+    let response = timeout(TIMEOUT, server.read_response())
+        .await
+        .expect("another provider must not wait for a blocked callback");
+    assert_eq!(response["id"], 911);
+    assert_eq!(response["result"]["kind"], "cancelled");
+    server
+        .send_request(
+            913,
+            "userInput.request",
+            serde_json::json!({
+                "sessionId": first.id(), "question": "Still responsive?"
+            }),
+        )
+        .await;
+    let response = timeout(TIMEOUT, server.read_response()).await.unwrap();
+    assert_eq!(response["id"], 913);
+    assert_eq!(response["result"]["noResponse"], true);
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "same-provider callbacks must stay serialized"
+    );
+    release.notify_one();
+    assert_eq!(
+        timeout(TIMEOUT, server.read_response()).await.unwrap()["id"],
+        910
+    );
+    timeout(TIMEOUT, entered.notified()).await.unwrap();
+    release.notify_one();
+    assert_eq!(
+        timeout(TIMEOUT, server.read_response()).await.unwrap()["id"],
+        912
+    );
+    client.force_stop();
+}
+
+#[tokio::test]
+async fn github_token_provider_panic_returns_error_and_keeps_routing() {
+    let (client, read, write) = make_client();
+    let mut server = FakeServer {
+        read,
+        write,
+        session_id: String::new(),
+    };
+    let (_session, registration) = create_token_test_session(
+        &client,
+        &mut server,
+        Arc::new(|args: GitHubTokenProviderArgs| async move {
+            if args.host == "panic.example" {
+                panic!("private provider failure");
+            }
+            Ok(GitHubTokenProviderResult::Cancelled)
+        }),
+    )
+    .await;
+    request_test_token(&mut server, 920, &registration, "panic.example").await;
+    let response = timeout(TIMEOUT, server.read_response())
+        .await
+        .expect("provider panic must receive an error response");
+    assert_eq!(response["id"], 920);
+    assert_eq!(response["error"]["code"], -32603);
+    assert!(!response.to_string().contains("private provider failure"));
+    request_test_token(&mut server, 921, &registration, "github.com").await;
+    let response = timeout(TIMEOUT, server.read_response()).await.unwrap();
+    assert_eq!(response["id"], 921);
+    assert_eq!(response["result"]["kind"], "cancelled");
+    client.force_stop();
+}
+
+#[tokio::test]
+async fn github_token_provider_pending_callback_is_cancelled_on_retirement() {
+    struct OnDrop(Arc<Notify>);
+    impl Drop for OnDrop {
+        fn drop(&mut self) {
+            self.0.notify_one();
+        }
+    }
+    for action in ["delete", "force_stop", "drop"] {
+        let (client, read, write) = make_client();
+        let mut server = FakeServer {
+            read,
+            write,
+            session_id: String::new(),
+        };
+        let entered = Arc::new(Notify::new());
+        let dropped = Arc::new(Notify::new());
+        let provider = Arc::new({
+            let entered = entered.clone();
+            let dropped = dropped.clone();
+            move |_args: GitHubTokenProviderArgs| {
+                let entered = entered.clone();
+                let dropped = dropped.clone();
+                async move {
+                    let _guard = OnDrop(dropped);
+                    entered.notify_one();
+                    std::future::pending::<()>().await;
+                    Ok(GitHubTokenProviderResult::Cancelled)
+                }
+            }
+        });
+        let (session, registration) =
+            create_token_test_session(&client, &mut server, provider).await;
+        request_test_token(&mut server, 930, &registration, "github.com").await;
+        timeout(TIMEOUT, entered.notified()).await.unwrap();
+        match action {
+            "delete" => {
+                let delete = tokio::spawn({
+                    let client = client.clone();
+                    let session_id = session.id().clone();
+                    async move {
+                        client.delete_session(&session_id).await.unwrap();
+                    }
+                });
+                let request = server.read_request().await;
+                assert_eq!(request["method"], "session.delete");
+                server.respond(&request, serde_json::json!({})).await;
+                timeout(TIMEOUT, delete).await.unwrap().unwrap();
+            }
+            "force_stop" => client.force_stop(),
+            _ => {
+                drop(session);
+                drop(client);
+            }
+        }
+        timeout(TIMEOUT, dropped.notified())
+            .await
+            .unwrap_or_else(|_| panic!("callback survived {action}"));
+    }
+}
+
 fn rand_id() -> u64 {
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     COUNTER.fetch_add(1, Ordering::Relaxed) as u64


### PR DESCRIPTION
Fixes #2424.

A pending GitHub token callback currently holds up the single Rust request-routing loop; a callback panic terminates that loop without replying. Give each token-provider registration a lazy FIFO worker so other providers and session requests can continue while preserving callback order within a registration. Catch callback panics and return an internal RPC error without including the panic payload.

The registration owns and aborts its worker on retirement. Workers retain a weak client reference, so pending callbacks do not keep the client alive. No public API or protocol changes.

Three regression tests exercise blocked-provider isolation (including same-provider FIFO and an unrelated user-input request), panic recovery, and cancellation on session deletion, force-stop, and dropping session/client handles. The blocking and panic tests fail on the base commit.

Validation:
- 234 Rust unit tests and 135 session integration tests passed using in-memory JSON-RPC streams.
- Pinned nightly rustfmt check passed.
- Clippy across all targets with `test-support,bundled-in-process` and the repository's strict warning flags passed.
- `git diff --check` passed.

Validation used `COPILOT_SKIP_CLI_DOWNLOAD=1`; live CLI/provider E2E tests were not run. No new dependencies. Codex assisted with implementation and validation.
