### PR TITLE
Document capi.enableWebSocketResponses as a resume option

### DIFF
--- a/docs/features/session-persistence.md
+++ b/docs/features/session-persistence.md
@@ -243,6 +243,7 @@ When resuming a session, you can optionally reconfigure many settings. This is u
 | `excludedTools` | Disable specific tools |
 | `provider` | Re-provide BYOK credentials (required for BYOK sessions) |
 | `capi.autoTier` | Override the persisted Auto routing preference |
+| `capi.enableWebSocketResponses` | Choose the Responses API transport for the resumed session |
 | `reasoningEffort` | Adjust reasoning effort level |
 | `streaming` | Enable/disable streaming responses |
 | `workingDirectory` | Change the working directory |
@@ -310,6 +311,20 @@ To select the `auto` model and its routing preference in a single call, stage th
 | Java | `new SetModelOptions().setModel("auto").setAutoTier(AutoTier.BALANCE)` | `new SetModelOptions().setModel("auto").setResetAutoTier(true)` |
 
 Node.js, Python, and Rust express all three states in a single value: Node.js and Python because `null`/`None` is distinguishable from an omitted argument, and Rust because `AutoTierPreference::Reset` is a distinct variant of the same option. Go, .NET, and Java have no way to distinguish "reset" from "unset" in one value, so they carry a separate reset flag. Omitting both always means "leave the current preference alone."
+
+### Responses transport on resume
+
+The optional `capi.enableWebSocketResponses` setting chooses the transport for the CAPI Responses API. It defaults to `true`, so the WebSocket transport is used whenever the selected model advertises the `ws:/responses` endpoint. Setting it to `false` falls back to the HTTP transport. In Python, use `capi={"enable_web_socket_responses": False}`.
+
+Supply it on the resume call when you need it. It is worth setting when WebSocket connections fail behind a proxy, and when a resumed session reports `400 input item ID does not belong to this connection`, which is specific to the WebSocket transport.
+
+```typescript
+const session = await client.resumeSession("user-123-task-456", {
+  capi: { enableWebSocketResponses: false },
+});
+```
+
+Setting this to `false` is equivalent to the `COPILOT_CLI_DISABLE_WEBSOCKET_RESPONSES` environment variable, which has the opposite polarity.
 
 ### Example: changing model on resume
 


### PR DESCRIPTION
## Why

Someone resumes a session and it starts returning `400 input item ID does not belong to this connection`, or their proxy refuses WebSocket connections so resume never gets off the ground. Both are transport problems, and the SDK already lets them pick the transport on the resume call. They go to the session persistence guide, read the table of what can be reconfigured on resume, and the option is not there. Nothing in the docs suggests it exists, so the reasonable conclusion is that it does not and the session is lost.

The option is real. The resume config accepts it through the shared base config, every language binding exposes it, and it is covered by tests. Only the documentation was missing, and the table already lists its sibling `capi.autoTier`, which is what makes the omission read as deliberate.

After this change the reader finds the option in the same table they were already looking at, with a short section showing how to pass it.

## What changed

One row in the resume options table, plus a section giving the default, the Python spelling, a resume example, and how it relates to the equivalent environment variable.

## Testing Done

Documentation only, no code paths touched.

The option was absent from the docs before this change and present after:

```
$ git grep -c enableWebSocketResponses d5c9d06d -- docs/
(no output, exit status 1)

$ git grep -c enableWebSocketResponses HEAD -- docs/
HEAD:docs/features/session-persistence.md:3
```

The added example is also compiled by the existing docs validation, so a wrong option name or type would fail the build rather than render quietly.

<details><summary>Raw logs: docs validation (tail)</summary>

```
$ npm run validate:ts
TypeScript:
  ✅ 190 files passed

✅ All documentation code blocks are valid!
```

</details>
