### PR TITLE
Validate the examples that follow an unvalidated language fence

### DIFF
--- a/scripts/docs-validation/extract.ts
+++ b/scripts/docs-validation/extract.ts
@@ -61,6 +61,7 @@ function parseMarkdownCodeBlocks(
   let skipNext = false;
   let wrapAsync = false;
   let inHiddenBlock = false;
+  let inUnvalidatedFence = false;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
@@ -86,13 +87,25 @@ function parseMarkdownCodeBlocks(
     }
 
     // Start of code block
-    if (!inCodeBlock && line.startsWith("```")) {
+    if (!inCodeBlock && !inUnvalidatedFence && line.startsWith("```")) {
       const lang = line.slice(3).trim().toLowerCase();
       if (lang && LANGUAGE_MAP[lang]) {
         inCodeBlock = true;
         currentLang = LANGUAGE_MAP[lang];
         currentCode = [];
         blockStartLine = i + 1; // 1-indexed line number
+      } else {
+        inUnvalidatedFence = true;
+      }
+      continue;
+    }
+
+    // End of a fence whose language has no validator. It still consumes a
+    // pending skip so the directive cannot leak onto a later block.
+    if (inUnvalidatedFence && line.startsWith("```")) {
+      inUnvalidatedFence = false;
+      if (!inHiddenBlock) {
+        skipNext = false;
       }
       continue;
     }


### PR DESCRIPTION
## Why

A maintainer who wraps an example in `<!-- docs-validate: hidden -->` is asking for that example to be type-checked. For three examples in this repository, it silently was not, and nothing reported a problem. The most visible one is the trusted host-bundled block in the plugin directories guide, which carries those markers for exactly that reason.

Closing a hidden block sets a pending skip so the visible copy that follows is not validated twice. A fence whose language has no validator, `rust` among them, was never recognized as a code block at all, so it never consumed that pending skip. The flag survived and the next validated block absorbed it instead.

Rust examples appear in nine feature guides, usually as the last language tab before the next section, so any example following one is exposed. Before this change those three blocks were extracted and discarded. After it they are checked like every other example, and a broken one would fail the build.

## What changed

Fences in languages that have no validator are now tracked and consume a pending skip when they close, so the directive can no longer reach past its intended target.

## Testing Done

Three previously discarded examples are now extracted and validated:

```
auth/authenticate.md:412
features/plugin-directories.md:248
features/session-limits.md:164
```

The two TypeScript ones pass locally. The C# one needs a .NET toolchain I do not have, so CI covers it.

<details><summary>Raw logs: extraction before and after</summary>

```
$ git checkout upstream/main -- scripts/docs-validation/extract.ts
$ (cd scripts/docs-validation && npm run extract) | grep -E "typescript|csharp|Total|Skipped"
  typescript     189
  csharp         56
  Total          394
  Skipped        239

$ git checkout HEAD -- scripts/docs-validation/extract.ts
$ (cd scripts/docs-validation && npm run extract) | grep -E "typescript|csharp|Total|Skipped"
  typescript     191
  csharp         57
  Total          397
  Skipped        236

$ (cd scripts/docs-validation && npm run validate:ts) | tail -6
TypeScript:
  ✅ 191 files passed

✅ All documentation code blocks are valid!
```

</details>
