### PR TITLE
Document per-session plugin directories

### DIFF
--- a/docs/features/plugin-directories.md
+++ b/docs/features/plugin-directories.md
@@ -240,6 +240,51 @@ let client = Client::start(
 
 > The example above uses an stdio runtime connection — the default when the SDK bundles the CLI. If you connect to an external runtime via a URL (`forUri` / `ForUri`), pass `--plugin-dir` to the long-running CLI server when you start it; the SDK does not forward `--plugin-dir` to runtimes it didn't spawn.
 
+## Per-session plugin directories
+
+`--plugin-dir` is a launch argument, so it fixes one plugin set for the CLI process and every session created against it. When sessions need different plugin sets, or when the SDK is connected to a runtime it did not spawn, pass the directories on the session config instead. They travel in the `session.create` and `session.resume` payloads over JSON-RPC rather than as process arguments, so they reach an external runtime the same way the startup option does.
+
+<!-- docs-validate: hidden -->
+```typescript
+import { CopilotClient } from "@github/copilot-sdk";
+
+async function main() {
+  const client = new CopilotClient();
+  await client.start();
+
+  const session = await client.createSession({
+    pluginDirectories: ["./plugins/code-reviewer"],
+  });
+}
+
+main();
+```
+<!-- /docs-validate: hidden -->
+
+```typescript
+import { CopilotClient } from "@github/copilot-sdk";
+
+const client = new CopilotClient();
+await client.start();
+
+const session = await client.createSession({
+  pluginDirectories: ["./plugins/code-reviewer"],
+});
+```
+
+Relative paths resolve against `workingDirectory`, or the runtime working directory when that is unset, so absolute paths are recommended. Entries that do not resolve are logged and skipped rather than failing session creation. The option is an explicit opt-in, which means plugin agents and rules load even when `enableConfigDiscovery` is false. Assets loaded this way sit between project sources and personal or home sources in the session-wide precedence order.
+
+The equivalent option in each SDK is:
+
+| SDK | Session option |
+|---|---|
+| Node.js / TypeScript | `pluginDirectories: string[]` |
+| Python | `plugin_directories=[...]` |
+| Go | `PluginDirectories: []string{...}` |
+| .NET | `PluginDirectories = [...]` |
+| Java | `.setPluginDirectories(List.of(...))` |
+| Rust | `.with_plugin_directories([...])` |
+
 ## Trusted host-bundled plugin directories
 
 Applications that ship their own trusted plugins can register them as a client startup option. The SDK sends the complete ordered set after connecting and verifying the protocol, before `start` returns or any session can be created. Paths must be absolute; leaving the option unset or empty makes no RPC call.

--- a/scripts/docs-validation/extract.ts
+++ b/scripts/docs-validation/extract.ts
@@ -61,6 +61,7 @@ function parseMarkdownCodeBlocks(
   let skipNext = false;
   let wrapAsync = false;
   let inHiddenBlock = false;
+  let inUnvalidatedFence = false;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
@@ -86,13 +87,25 @@ function parseMarkdownCodeBlocks(
     }
 
     // Start of code block
-    if (!inCodeBlock && line.startsWith("```")) {
+    if (!inCodeBlock && !inUnvalidatedFence && line.startsWith("```")) {
       const lang = line.slice(3).trim().toLowerCase();
       if (lang && LANGUAGE_MAP[lang]) {
         inCodeBlock = true;
         currentLang = LANGUAGE_MAP[lang];
         currentCode = [];
         blockStartLine = i + 1; // 1-indexed line number
+      } else {
+        inUnvalidatedFence = true;
+      }
+      continue;
+    }
+
+    // End of a fence whose language has no validator. It still consumes a
+    // pending skip so the directive cannot leak onto a later block.
+    if (inUnvalidatedFence && line.startsWith("```")) {
+      inUnvalidatedFence = false;
+      if (!inHiddenBlock) {
+        skipNext = false;
       }
       continue;
     }


### PR DESCRIPTION
Stacked on https://github.com/github/copilot-sdk/pull/2580, which the added example needs in order to be type-checked. Once that merges this reduces to the documentation commit.

## Why

An SDK application wants one session to load a code-review plugin and another to load nothing, or it connects to a runtime it did not spawn. The reader opens the plugin directories guide and finds two ways to load a plugin: the `--plugin-dir` launch argument, and the trusted host-bundled startup option for plugins the host itself ships. Neither fits. The guide says plainly that loading a plugin directory "makes its extensions visible to every session created by the client", and that the SDK does not forward `--plugin-dir` to runtimes it did not spawn.

So the reader concludes per-session plugin sets are not supported, and reaches for a second client or a wrapper process.

They are supported. The session config takes `pluginDirectories`, it is typed in all six language bindings, and the SDK forwards it on both create and resume. Because it travels in the JSON-RPC payload rather than as a process argument, it also reaches an external runtime. It simply had no entry in its own guide.

After this change the reader finds it beside the two mechanisms they were already comparing.

## What changed

A section covering the per-session option: what it does, how paths resolve, how it interacts with config discovery and precedence, an example, and the spelling in each language.

## Testing Done

Documentation only, no code paths touched.

The option was absent from the guide before this change and present after:

```
$ git grep -c pluginDirectories upstream/main -- docs/features/plugin-directories.md
(no output, exit status 1)

$ git grep -c pluginDirectories HEAD -- docs/features/plugin-directories.md
HEAD:docs/features/plugin-directories.md:3
```

The added example is compiled against the SDK types by the docs validation, so a wrong option name or type fails the build.

<details><summary>Raw logs: docs validation</summary>

```
$ (cd scripts/docs-validation && npm run validate:ts) | tail -6
TypeScript:
  ✅ 192 files passed

✅ All documentation code blocks are valid!
```

</details>
