### PR TITLE
Fix vulnerable SourceLink dependency in .NET SDK

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.2.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.102" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.111" />
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.8" />
     <PackageVersion Include="System.Collections.Immutable" Version="10.0.2" />
     <PackageVersion Include="System.Net.Http.Json" Version="10.0.2" />


### PR DESCRIPTION
The [.NET restore job](https://github.com/github/copilot-sdk/actions/runs/34355250116/job/102478159197?pr=2586) fails because `Microsoft.Build.Tasks.Git` 10.0.102 is affected by [CVE-2026-62900](https://github.com/advisories/GHSA-23fw-v26w-5fgq). Update `Microsoft.SourceLink.GitHub` from 10.0.102 to 10.0.111 to bring in the patched transitive dependency while preserving security warnings as errors.