### PR TITLE
docs: clarify Azure project URL support

### DIFF
--- a/docs/auth/byok.md
+++ b/docs/auth/byok.md
@@ -226,8 +226,8 @@ Anthropic models always use the Anthropic Messages API regardless of this settin
 
 **Azure (`type: "azure"`)**
 * Use for native Azure OpenAI endpoints
-* `baseUrl` should be just the host (e.g., `https://my-resource.openai.azure.com`)
-* Do NOT include `/openai/v1` in the URL—the SDK handles path construction
+* `baseUrl` / `base_url` accepts a resource host or a full project URL, such as `https://<host>/api/projects/hosted-agents-ncus`, with or without a trailing slash.
+* The runtime preserves the project prefix when constructing Azure API paths. For `wireApi: "responses"` with `azure.apiVersion` omitted, the project URL above produces `https://<host>/api/projects/hosted-agents-ncus/openai/v1/responses`. Project URLs require an updated Copilot CLI runtime.
 
 **Anthropic (`type: "anthropic"`)**
 * For direct Anthropic API access
@@ -252,7 +252,7 @@ Use `type: "azure"` for endpoints at `*.openai.azure.com`:
 ```typescript
 provider: {
     type: "azure",
-    baseUrl: "https://my-resource.openai.azure.com",  // Just the host
+    baseUrl: "https://my-resource.openai.azure.com",  // Resource host or full project URL
     apiKey: process.env.AZURE_OPENAI_KEY,
     azure: {
         apiVersion: "2024-10-21",


### PR DESCRIPTION
The BYOK guidance currently requires host-only Azure URLs, excluding project-scoped endpoints. Update the existing Azure notes to describe host or project URLs with optional trailing slashes, show the resulting versionless Responses URL, and note the updated CLI runtime requirement.

Documentation only; no SDK behavior changes.

Related to #2588.