### PR TITLE
Add seven-day Dependabot cooldowns for npm, PyPI, and NuGet

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,6 +3,7 @@ multi-ecosystem-groups:
   all:
     schedule:
       interval: 'weekly'
+# npm, PyPI, and NuGet cooldowns accommodate downstream registry quarantine.
 updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
@@ -21,15 +22,23 @@ updates:
   # Node.js dependencies
   - package-ecosystem: 'npm'
     directory: '/nodejs'
+    cooldown:
+      default-days: 7
+      exclude: ['@github/*']
     multi-ecosystem-group: 'all'
     patterns: ['*']
   - package-ecosystem: 'npm'
     directory: '/test/harness'
+    cooldown:
+      default-days: 7
+      exclude: ['@github/*']
     multi-ecosystem-group: 'all'
     patterns: ['*']
   # Python dependencies
   - package-ecosystem: 'pip'
     directory: '/python'
+    cooldown:
+      default-days: 7
     multi-ecosystem-group: 'all'
     patterns: ['*']
   # Go dependencies
@@ -40,6 +49,8 @@ updates:
   # .NET dependencies
   - package-ecosystem: 'nuget'
     directory: '/dotnet'
+    cooldown:
+      default-days: 7
     multi-ecosystem-group: 'all'
     patterns: ['*']
   # Java dependencies
@@ -59,6 +70,9 @@ updates:
   # Java codegen dependencies
   - package-ecosystem: 'npm'
     directory: '/java/scripts/codegen'
+    cooldown:
+      default-days: 7
+      exclude: ['@github/*']
     schedule:
       interval: 'weekly'
     groups:


### PR DESCRIPTION
New dependency releases can be unavailable in downstream registries during their seven-day quarantine, preventing contributors from installing the SDK or its development dependencies.

Add `cooldown.default-days: 7` to all three npm entries and the PyPI and NuGet entries, with `@github/*` excluded from the npm cooldowns. Existing weekly schedules, grouping, ignore rules, and other ecosystems remain unchanged.

Dependabot security updates bypass cooldowns. Copilot CLI version updates are managed separately and are unaffected.