### PR TITLE
Stabilize Python streaming resume E2E test

### DIFF
--- a/python/e2e/test_streaming_fidelity_e2e.py
+++ b/python/e2e/test_streaming_fidelity_e2e.py
@@ -15,6 +15,20 @@ pytestmark = pytest.mark.asyncio(loop_scope="module")
 RESUME_LOCK_TIMEOUT = 60.0
 
 
+async def _wait_for_session_lock_release(ctx: E2ETestContext, session_id: str) -> None:
+    async def session_lock_is_released() -> bool:
+        result = await ctx.client.rpc.sessions.check_in_use(
+            SessionsCheckInUseRequest(session_ids=[session_id])
+        )
+        return session_id not in result.in_use
+
+    await wait_for_condition(
+        session_lock_is_released,
+        timeout=RESUME_LOCK_TIMEOUT,
+        timeout_message=f"Timed out waiting for session '{session_id}' to release its lock.",
+    )
+
+
 class TestStreamingFidelity:
     async def test_should_produce_delta_events_when_streaming_is_enabled(self, ctx: E2ETestContext):
         session = await ctx.client.create_session(
@@ -77,17 +91,7 @@ class TestStreamingFidelity:
         await session.send_and_wait("What is 3 + 6?")
         await session.disconnect()
 
-        async def session_lock_is_released() -> bool:
-            result = await ctx.client.rpc.sessions.check_in_use(
-                SessionsCheckInUseRequest(session_ids=[session_id])
-            )
-            return session_id not in result.in_use
-
-        await wait_for_condition(
-            session_lock_is_released,
-            timeout=RESUME_LOCK_TIMEOUT,
-            timeout_message=f"Timed out waiting for session '{session_id}' to release its lock.",
-        )
+        await _wait_for_session_lock_release(ctx, session_id)
 
         # Resume using a new client
         github_token = (
@@ -141,6 +145,8 @@ class TestStreamingFidelity:
         await session.send_and_wait("What is 3 + 6?")
         session_id = session.session_id
         await session.disconnect()
+
+        await _wait_for_session_lock_release(ctx, session_id)
 
         # Resume with streaming disabled
         new_client = CopilotClient(

--- a/python/e2e/test_streaming_fidelity_e2e.py
+++ b/python/e2e/test_streaming_fidelity_e2e.py
@@ -5,11 +5,14 @@ import os
 import pytest
 
 from copilot import CopilotClient, RuntimeConnection
+from copilot.rpc import SessionsCheckInUseRequest
 from copilot.session import PermissionHandler
 
-from .testharness import E2ETestContext
+from .testharness import E2ETestContext, wait_for_condition
 
 pytestmark = pytest.mark.asyncio(loop_scope="module")
+
+RESUME_LOCK_TIMEOUT = 60.0
 
 
 class TestStreamingFidelity:
@@ -70,8 +73,21 @@ class TestStreamingFidelity:
         session = await ctx.client.create_session(
             on_permission_request=PermissionHandler.approve_all, streaming=False
         )
+        session_id = session.session_id
         await session.send_and_wait("What is 3 + 6?")
         await session.disconnect()
+
+        async def session_lock_is_released() -> bool:
+            result = await ctx.client.rpc.sessions.check_in_use(
+                SessionsCheckInUseRequest(session_ids=[session_id])
+            )
+            return session_id not in result.in_use
+
+        await wait_for_condition(
+            session_lock_is_released,
+            timeout=RESUME_LOCK_TIMEOUT,
+            timeout_message=f"Timed out waiting for session '{session_id}' to release its lock.",
+        )
 
         # Resume using a new client
         github_token = (
@@ -86,7 +102,7 @@ class TestStreamingFidelity:
 
         try:
             session2 = await new_client.resume_session(
-                session.session_id,
+                session_id,
                 on_permission_request=PermissionHandler.approve_all,
                 streaming=True,
             )


### PR DESCRIPTION
A cold-resume E2E run can race the original CLI's asynchronous cleanup after `session.detach`, causing the second CLI process to resume while the session lock is still held and eventually time out waiting for `session.idle`.

Wait for `sessions.check_in_use` on the original client to confirm the lock is released before creating the cold-resume client. This retains the existing streaming, cross-client resume, and timeout assertions rather than masking the race with a longer timeout.