### PR TITLE
Stabilize Java OAuth lifecycle E2E test

### DIFF
--- a/java/sdk/src/test/java/com/github/copilot/McpOAuthE2ETest.java
+++ b/java/sdk/src/test/java/com/github/copilot/McpOAuthE2ETest.java
@@ -114,9 +114,10 @@ public class McpOAuthE2ETest {
 
     @Test
     void testShouldRequestReplacementTokensAcrossMcpOauthLifecycle() throws Exception {
-        try (var oauthServer = OAuthMcpServer.start(ctx.getRepoRoot())) {
+        try (var oauthServer = OAuthMcpServer.start(ctx.getRepoRoot(), true)) {
             var serverName = "oauth-lifecycle-mcp";
             var observedReasons = new CopyOnWriteArrayList<McpOauthRequestReason>();
+            var observedRequest = new AtomicReference<McpAuthRequest>();
             var refreshCount = new java.util.concurrent.atomic.AtomicInteger();
 
             try (var client = ctx.createClient();
@@ -124,6 +125,7 @@ public class McpOAuthE2ETest {
                             .setOnPermissionRequest(PermissionHandler.APPROVE_ALL)
                             .setOnMcpAuthRequest((request, invocation) -> {
                                 assertNotNull(invocation);
+                                observedRequest.set(request);
                                 observedReasons.add(request.reason());
                                 var result = switch (request.reason()) {
                                     case REFRESH -> {
@@ -150,8 +152,8 @@ public class McpOAuthE2ETest {
                             }).setMcpServers(Map.of(serverName, new McpHttpServerConfig()
                                     .setUrl(oauthServer.url() + "/mcp").setTools(List.of("*")))))
                             .get()) {
-                waitForMcpServerStatus(session, serverName, McpServerStatus.CONNECTED,
-                        new java.util.concurrent.atomic.AtomicReference<>());
+                oauthServer.releaseInitialChallenge();
+                waitForMcpServerStatus(session, serverName, McpServerStatus.CONNECTED, observedRequest);
                 callWhoami(session, serverName, "refresh");
                 callWhoami(session, serverName, "upscope");
                 callWhoami(session, serverName, "reauth");
@@ -306,9 +308,16 @@ public class McpOAuthE2ETest {
 
     private record OAuthMcpServer(Process process, String url) implements AutoCloseable {
         static OAuthMcpServer start(Path repoRoot) throws Exception {
+            return start(repoRoot, false);
+        }
+
+        static OAuthMcpServer start(Path repoRoot, boolean deferInitialChallenge) throws Exception {
             var script = repoRoot.resolve("test").resolve("harness").resolve("test-mcp-oauth-server.mjs");
             var processBuilder = new ProcessBuilder(resolveExecutable("node"), script.toString());
             processBuilder.environment().put("EXPECTED_TOKEN", EXPECTED_TOKEN);
+            if (deferInitialChallenge) {
+                processBuilder.environment().put("DEFER_INITIAL_CHALLENGE", "true");
+            }
             var process = processBuilder.start();
             var stderr = new StringBuilder();
             Thread stderrThread = new Thread(() -> {
@@ -334,6 +343,15 @@ public class McpOAuthE2ETest {
             }
             process.destroyForcibly();
             throw new AssertionError("Timed out waiting for OAuth MCP server: " + stderr);
+        }
+
+        void releaseInitialChallenge() throws Exception {
+            var client = HttpClient.newHttpClient();
+            var response = client.send(
+                    HttpRequest.newBuilder(URI.create(url + "/__release-initial-challenge"))
+                            .timeout(Duration.ofSeconds(10)).POST(HttpRequest.BodyPublishers.noBody()).build(),
+                    HttpResponse.BodyHandlers.discarding());
+            assertEquals(204, response.statusCode());
         }
 
         List<OAuthMcpRequest> requests() throws Exception {

--- a/test/harness/test-mcp-oauth-server.mjs
+++ b/test/harness/test-mcp-oauth-server.mjs
@@ -23,9 +23,16 @@ const PROTECTED_RESOURCE_PATH = "/.well-known/oauth-protected-resource";
 
 export async function startOAuthMcpServer({
   expectedToken = DEFAULT_EXPECTED_TOKEN,
+  deferInitialChallenge = false,
   host = "127.0.0.1",
   port = 0,
 } = {}) {
+  let releaseInitialChallenge = () => {};
+  const initialChallenge = deferInitialChallenge
+    ? new Promise((resolve) => {
+        releaseInitialChallenge = resolve;
+      })
+    : Promise.resolve();
   const requests = [];
   const tokens = {
     initial: expectedToken,
@@ -50,6 +57,13 @@ export async function startOAuthMcpServer({
 
     if (req.method === "GET" && url.pathname === "/__requests") {
       respondJson(res, 200, requests);
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/__release-initial-challenge") {
+      releaseInitialChallenge();
+      res.writeHead(204);
+      res.end();
       return;
     }
 
@@ -92,6 +106,7 @@ export async function startOAuthMcpServer({
 
     const token = parseBearerToken(req.headers.authorization);
     if (!token || !acceptedTokens.has(token)) {
+      await initialChallenge;
       challengeInitial(res, baseUrl);
       return;
     }
@@ -317,6 +332,7 @@ if (
 ) {
   const server = await startOAuthMcpServer({
     expectedToken: process.env.EXPECTED_TOKEN ?? DEFAULT_EXPECTED_TOKEN,
+    deferInitialChallenge: process.env.DEFER_INITIAL_CHALLENGE === "true",
   });
   console.log(`Listening: ${server.url}`);
   process.on("SIGTERM", async () => {


### PR DESCRIPTION
The Java OAuth lifecycle E2E test intermittently misses the initial `mcp.oauth_required` event when the test MCP server challenges authentication before `createSession()` finishes registering event interest.

Add an opt-in first-challenge gate to the test server and release it from the lifecycle scenario only after session creation completes. Existing test-server consumers retain their normal behavior, while the lifecycle test still covers initial, refresh, upscope, and reauthentication token flows.