### PR TITLE
Stabilize Rust and .NET E2E isolation

### DIFF
--- a/dotnet/test/Harness/E2ETestContext.cs
+++ b/dotnet/test/Harness/E2ETestContext.cs
@@ -66,6 +66,13 @@ public sealed class E2ETestContext : IAsyncDisposable
 
         var proxy = new ReplayProxy();
         var proxyUrl = await proxy.StartAsync();
+        // Creating an in-process fixture applies this URL before its first
+        // test-specific configuration is posted, so early runtime requests need
+        // an empty but valid replay state.
+        await proxy.ConfigureAsync(
+            Path.Combine(workDir, "__unconfigured__.yaml"),
+            workDir,
+            "capi");
         await proxy.SetCopilotUserByTokenAsync(DefaultGitHubToken, new CopilotUserConfig(
             Login: "e2e-test-user",
             CopilotPlan: "individual_pro",

--- a/rust/tests/e2e/session_config.rs
+++ b/rust/tests/e2e/session_config.rs
@@ -561,6 +561,9 @@ async fn should_enable_citations_for_anthropic_file_attachments_on_create() {
 
 #[tokio::test]
 async fn should_enable_citations_for_anthropic_file_attachments_on_resume() {
+    if super::support::skip_inprocess("LLM inference providers are process-global in-process") {
+        return;
+    }
     with_e2e_context_no_snapshot(|ctx| {
         Box::pin(async move {
             ctx.set_default_copilot_user();

--- a/rust/tests/e2e/system_message_sections.rs
+++ b/rust/tests/e2e/system_message_sections.rs
@@ -2,12 +2,11 @@ use std::collections::HashMap;
 
 use github_copilot_sdk::{SectionOverride, SystemMessageConfig};
 
-use super::support::assistant_message_content;
+use super::support::{assistant_message_content, with_dedicated_e2e_context};
 
 #[tokio::test]
 async fn should_use_replaced_identity_section_in_response() {
-    super::support::with_shared_e2e_context(
-        &E2E,
+    with_dedicated_e2e_context(
         "system_message_sections",
         "should_use_replaced_identity_section_in_response",
         |ctx| {
@@ -61,8 +60,7 @@ async fn should_use_replaced_identity_section_in_response() {
 
 #[tokio::test]
 async fn should_use_replaced_preamble_section_in_response() {
-    super::support::with_shared_e2e_context(
-        &E2E,
+    with_dedicated_e2e_context(
         "system_message_sections",
         "should_use_replaced_preamble_section_in_response",
         |ctx| {
@@ -113,5 +111,3 @@ async fn should_use_replaced_preamble_section_in_response() {
     )
     .await;
 }
-static E2E: super::support::SharedE2eGroup =
-    super::support::SharedE2eGroup::standard("system_message_sections", 2);


### PR DESCRIPTION
The merge-queue run exposed independent E2E flakes from an unconfigured replay proxy during in-process startup and Rust tests that rely on runtime state not safely shared between clients.

- Initialize every .NET replay proxy with an empty valid configuration before an in-process fixture exposes its URL, preventing early runtime requests from crashing the test host.
- Run the Rust system-message override tests with dedicated contexts rather than a shared client, avoiding the observed timeout on the second test.
- Skip the Rust handler-backed citation-resume scenario in in-process mode, matching the create-session case. The native runtime's process-global inference-provider registration persists after disconnect; remove this workaround once provider lifecycle and per-client isolation are fixed.