### PR TITLE
Publish .NET SDK packages to the internal feed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -296,6 +296,59 @@ jobs:
           dotnet nuget push ./artifacts/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols
           dotnet nuget push ./artifacts/*.snupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
+  publish-dotnet-internal:
+    name: Publish .NET SDK to internal feed
+    needs: publish-dotnet
+    if: github.ref == 'refs/heads/main'
+    environment: cicd
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    env:
+      ADO_RESOURCE: 499b84ac-1321-427f-aa17-267ca6975798
+      FEED_URL: https://pkgs.dev.azure.com/devdiv/_packaging/copilot-canary/nuget/v3/index.json
+    steps:
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+      - name: Download .NET package
+        uses: actions/download-artifact@v8.0.0
+        with:
+          name: dotnet-package
+          path: ./dist
+      - name: Azure Login (OIDC -> id-cpd-ci)
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: "${{ vars.CPD_ID_CLIENT_ID }}" # id-cpd-ci
+          tenant-id: "${{ vars.CPD_ID_TENANT_ID }}"
+          allow-no-subscriptions: true
+      - name: Publish package to internal feed
+        run: |
+          set -euo pipefail
+          if [ "$FEED_URL" != "https://pkgs.dev.azure.com/devdiv/_packaging/copilot-canary/nuget/v3/index.json" ]; then
+            echo "::error::FEED_URL ('$FEED_URL') is not the expected internal feed. Refusing to publish."
+            exit 1
+          fi
+          shopt -s nullglob
+          PACKAGES=(./dist/*.nupkg)
+          if [ "${#PACKAGES[@]}" -ne 1 ]; then
+            echo "::error::Expected one .NET package, found ${#PACKAGES[@]}."
+            exit 1
+          fi
+          TOKEN="$(az account get-access-token --resource "$ADO_RESOURCE" --query accessToken -o tsv)"
+          echo "::add-mask::$TOKEN"
+          dotnet nuget add source "$FEED_URL" --name CopilotInternal
+          # Keep the short-lived token out of NuGet.Config and command-line arguments.
+          export NuGetPackageSourceCredentials_CopilotInternal="Username=azure;Password=$TOKEN;ValidAuthenticationTypes=Basic"
+          # Azure Artifacts does not support .snupkg symbol packages.
+          dotnet nuget push "${PACKAGES[0]}" \
+            --api-key AzureArtifacts \
+            --source CopilotInternal \
+            --skip-duplicate \
+            --no-symbols
+
   publish-rust:
     name: Publish Rust SDK
     if: github.event.inputs.dist-tag != 'unstable'


### PR DESCRIPTION
## Summary

Add a `publish-dotnet-internal` job to mirror `GitHub.Copilot.SDK` to the `copilot-canary` Azure Artifacts NuGet feed alongside the existing internal npm publication.

- Reuse the `dotnet-package` artifact produced by the public publishing job; do not rebuild the package.
- Run after successful public NuGet publication for non-unstable releases from `main`.
- Reuse the existing `cicd` environment, `id-cpd-ci` OIDC identity, and Azure DevOps resource. Pass the short-lived token through NuGet's source-credentials environment variable rather than storing it in a config file or command-line arguments.
- Reject unexpected feed URLs and package counts, skip duplicate package versions, and leave `.snupkg` publication on NuGet.org.

Existing npm publication and public release jobs are unchanged.

## Validation

- Parsed the workflow YAML and checked Bash syntax.
- Confirmed artifact reuse, release gating, OIDC settings, and that all existing jobs are unchanged.
- Exercised nine mocked publication scenarios: a package plus symbols, a path containing spaces, missing packages, symbols only, multiple packages, an incorrect destination, and failures in authentication, source configuration, or publication.
- Live Azure OIDC authentication and internal-feed publication have not been exercised; no publishing workflow was triggered.