### PR TITLE
Fix appended system-message test event subscription race

### DIFF
--- a/dotnet/test/E2E/SessionE2ETests.cs
+++ b/dotnet/test/E2E/SessionE2ETests.cs
@@ -54,19 +54,25 @@ public class SessionE2ETests(E2ETestFixture fixture, ITestOutputHelper output) :
             SystemMessage = new SystemMessageConfig { Mode = SystemMessageMode.Append, Content = systemMessageSuffix }
         });
 
-        await session.SendAsync(new MessageOptions { Prompt = "What is your full name?" });
-        var assistantMessage = await TestHelper.GetFinalAssistantMessageAsync(session);
-        Assert.NotNull(assistantMessage);
-
-        var content = assistantMessage!.Data.Content ?? string.Empty;
-        Assert.Contains("GitHub", content);
-        Assert.Contains("Have a nice day!", content);
+        await AssertAppendedSystemMessageResponseAsync(session, TimeSpan.FromSeconds(120));
 
         var traffic = await Ctx.GetExchangesAsync();
         Assert.NotEmpty(traffic);
         var systemMessage = GetSystemMessage(traffic[0]);
         Assert.Contains("GitHub", systemMessage);
         Assert.Contains(systemMessageSuffix, systemMessage);
+    }
+
+    internal static async Task AssertAppendedSystemMessageResponseAsync(CopilotSession session, TimeSpan timeout)
+    {
+        // Subscribe before sending: session.idle is ephemeral and cannot be recovered from history.
+        var assistantMessage = await session.SendAndWaitAsync(
+            new MessageOptions { Prompt = "What is your full name?" }, timeout);
+        Assert.NotNull(assistantMessage);
+
+        var content = assistantMessage.Data.Content ?? string.Empty;
+        Assert.Contains("GitHub", content);
+        Assert.Contains("Have a nice day!", content);
     }
 
     [Fact]

--- a/dotnet/test/Unit/ClientSessionLifetimeTests.cs
+++ b/dotnet/test/Unit/ClientSessionLifetimeTests.cs
@@ -1717,6 +1717,47 @@ public sealed class ClientSessionLifetimeTests
         Assert.False(request.TryGetProperty("wait", out _));
     }
 
+    [Fact]
+    public async Task Appended_System_Message_Observes_Idle_Before_Send_Reply()
+    {
+        await using var server = await FakeCopilotServer.StartAsync();
+        await using var client = new CopilotClient(new CopilotClientOptions { Connection = RuntimeConnection.ForUri(server.Url) });
+        await using var session = await client.CreateSessionAsync(new SessionConfig());
+        var timeout = TimeSpan.FromSeconds(5);
+        const string content = "I am GitHub Copilot. Have a nice day!";
+        var drained = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscription = session.On<SessionTitleChangedEvent>(_ => drained.TrySetResult());
+        server.BeforeResponseAsync = async (request, cancellationToken) =>
+        {
+            if (request.Method != "session.send")
+            {
+                return;
+            }
+
+            await server.SendSessionEventAsync(session.SessionId, "user.message", new()
+            {
+                ["content"] = request.Params.GetProperty("prompt").GetString()
+            });
+            await server.SendSessionEventAsync(session.SessionId, "assistant.message", new()
+            {
+                ["messageId"] = "appended-system-message",
+                ["content"] = content
+            });
+            await server.SendSessionEventAsync(session.SessionId, "session.idle", new());
+            // Drain the idle notification before replying to session.send.
+            await server.SendSessionEventAsync(session.SessionId, "session.title_changed", new() { ["title"] = "fence" });
+            await drained.Task.WaitAsync(timeout, cancellationToken);
+        };
+
+        await E2E.SessionE2ETests.AssertAppendedSystemMessageResponseAsync(session, timeout);
+
+        var request = Assert.Single(server.Requests, request => request.Method == "session.send");
+        Assert.Equal("What is your full name?", request.Params.GetProperty("prompt").GetString());
+        var history = await session.GetEventsAsync();
+        Assert.DoesNotContain(history, evt => evt is SessionIdleEvent);
+        Assert.Equal(content, Assert.Single(history.OfType<AssistantMessageEvent>()).Data.Content);
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]


### PR DESCRIPTION
## Summary

Fix the response wait in `SessionE2ETests.Should_Create_A_Session_With_Appended_SystemMessage_Config`. It subscribed through `GetFinalAssistantMessageAsync` only after awaiting `SendAsync`. A completed turn can deliver its ephemeral `session.idle` first; durable history then contains the assistant message but cannot supply the missing idle notification.

Use `SendAndWaitAsync` to subscribe before sending. Preserve the original 120-second E2E timeout, prompt, response assertions (`GitHub` and `Have a nice day!`), and captured system-message assertions. No SDK or runtime production code changes.

The deterministic regression drives the E2E test's actual response-wait scenario. It reuses the fake RPC server added in github/copilot-sdk#2635, delivers assistant/idle events, and drains a later event before replying to `session.send`. It also verifies that durable history contains the assistant but no idle event.

## Failure evidence

Observed during validation of github/copilot-agent-runtime#20258: first-attempt CAPI run `34677727987`, job `103512036461`, runtime head `4a585d08bf`, SDK commit `a6f2e56acb5e04af56241146668fe71291304266`. The appended-system-message case timed out at `TestHelper.cs:77/85`, called from `SessionE2ETests.cs:58`; that backend finished with 892 passes, one failure, and four skips.

The original CI event trace was not uploaded, so its exact interleaving is unknown. The following controlled reproductions establish a live test race with the same failure, not retrospective proof of that CI interleaving.

## Validation

- Original replay-backed E2E, with a temporary probe holding `SendAsync`'s return until actual idle delivery: failed with `Timeout waiting for assistant message` after the unchanged 120-second wait. The probe observed one durable assistant message and zero durable idle events.
- Same runtime, capture, and probe with the acknowledged send: passed all original response and system-message assertions. The temporary production probe was removed and removal verified against git.
- Retained fake-RPC regression with original shared-scenario ordering: failed with the same helper timeout. With the fix, the complete `ClientSessionLifetimeTests` and `SessionE2ETests` files passed: 164 tests on `net8.0`, no skips.
- `dotnet format test/GitHub.Copilot.SDK.Test.csproj --no-restore --verify-no-changes` passed.

Local replay validation used the freshly built runtime at dependency-integration commit `44613db704`; toolchain was .NET SDK 10.0.401 with the required .NET 8 runtime. No fixture changes are included.

Ten independent `.NET SDK Tests` workflow runs were dispatched on exact head `34f8036f87aa4e186804066cea00d4f529b78190`, each verified as attempt 1: `34680184778`, `34680186084`, `34680187444`, `34680188695`, `34680189919`, `34680190926`, `34680191987`, `34680193191`, `34680194253`, `34680195312`. These are new workflow runs, not reruns of failed checks.

**The population is incomplete: six workflows succeeded; four hit the macOS default/CAPI shard 1 job limit.** GitHub labels runs `34680184778`, `34680187444`, `34680188695`, and `34680189919` as cancelled, but each affected job's annotation explicitly reports the 20-minute execution limit. They are not manual cancellations or passes, and a timeout alone does not establish an infrastructure failure.

The first timed-out job (`103517319544`) completed setup but never recorded completion of the test step. Its job log returns 404, no diagnostic artifact was retained, and the full workflow archive omits that shard. No individual test can yet be attributed from that evidence.

Both the repaired appended-system-message E2E and its early-idle regression are verified **10/10 passing in the Ubuntu/default/CAPI/full jobs**, using original runner-native result lines, exact first-attempt metadata, and hashed logs. No test failures were found in those selected logs; incidental cache-reservation messages were kept separate. These target-level passes do not clear the four macOS job timeouts or establish ten successful whole workflows. No failed jobs have been rerun.

Exact-head Copilot review `5185720603` recommended approval with no findings and no inline threads. This is automated review clearance, not a formal human approval or completion of the ten-success CI requirement.

_Generated by Copilot_
