### PR TITLE
Fix system-message response test subscription races

### DIFF
--- a/dotnet/test/E2E/SessionE2ETests.cs
+++ b/dotnet/test/E2E/SessionE2ETests.cs
@@ -78,17 +78,23 @@ public class SessionE2ETests(E2ETestFixture fixture, ITestOutputHelper output) :
             SystemMessage = new SystemMessageConfig { Mode = SystemMessageMode.Replace, Content = testSystemMessage }
         });
 
-        await session.SendAsync(new MessageOptions { Prompt = "What is your full name?" });
-        var assistantMessage = await TestHelper.GetFinalAssistantMessageAsync(session);
+        await AssertReplacedSystemMessageResponseAsync(session, TimeSpan.FromSeconds(120));
+
+        var traffic = await Ctx.GetExchangesAsync();
+        Assert.NotEmpty(traffic);
+        Assert.Equal(testSystemMessage, GetSystemMessage(traffic[0]));
+    }
+
+    internal static async Task AssertReplacedSystemMessageResponseAsync(CopilotSession session, TimeSpan timeout)
+    {
+        // Subscribe before sending: the ephemeral idle event cannot be recovered from history.
+        var assistantMessage = await session.SendAndWaitAsync(
+            new MessageOptions { Prompt = "What is your full name?" }, timeout);
         Assert.NotNull(assistantMessage);
 
         var content = assistantMessage!.Data.Content ?? string.Empty;
         Assert.DoesNotContain("GitHub", content);
         Assert.Contains("Testy", content);
-
-        var traffic = await Ctx.GetExchangesAsync();
-        Assert.NotEmpty(traffic);
-        Assert.Equal(testSystemMessage, GetSystemMessage(traffic[0]));
     }
 
     [Fact]

--- a/dotnet/test/E2E/SystemMessageSectionsE2ETests.cs
+++ b/dotnet/test/E2E/SystemMessageSectionsE2ETests.cs
@@ -61,8 +61,13 @@ public class SystemMessageSectionsE2ETests(E2ETestFixture fixture, ITestOutputHe
             }
         });
 
-        await session.SendAsync(new MessageOptions { Prompt = "Who are you?" });
-        var response = await TestHelper.GetFinalAssistantMessageAsync(session);
+        await AssertReplacedPreambleResponseAsync(session, TimeSpan.FromSeconds(120));
+    }
+
+    internal static async Task AssertReplacedPreambleResponseAsync(CopilotSession session, TimeSpan timeout)
+    {
+        // Subscribe before sending: the ephemeral idle event cannot be recovered from history.
+        var response = await session.SendAndWaitAsync(new MessageOptions { Prompt = "Who are you?" }, timeout);
 
         Assert.NotNull(response);
         var content = response.Data.Content.ToLowerInvariant();

--- a/dotnet/test/Unit/ClientSessionLifetimeTests.cs
+++ b/dotnet/test/Unit/ClientSessionLifetimeTests.cs
@@ -1718,6 +1718,77 @@ public sealed class ClientSessionLifetimeTests
     }
 
     [Fact]
+    public async Task Replaced_System_Message_Observes_Idle_Before_Send_Reply()
+    {
+        await using var server = await FakeCopilotServer.StartAsync();
+        await using var client = new CopilotClient(new CopilotClientOptions { Connection = RuntimeConnection.ForUri(server.Url) });
+        await using var session = await client.CreateSessionAsync(new SessionConfig());
+        var timeout = TimeSpan.FromSeconds(5);
+        const string finalContent = "My full name is Testy McTestface.";
+        var drained = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscription = session.On<SessionTitleChangedEvent>(_ => drained.TrySetResult());
+        var idleBeforeReply = false;
+        server.BeforeResponseAsync = async (request, cancellationToken) =>
+        {
+            if (request.Method != "session.send")
+            {
+                return;
+            }
+
+            await server.SendSessionEventAsync(session.SessionId, "user.message", new()
+            {
+                ["content"] = request.Params.GetProperty("prompt").GetString()
+            });
+            await server.SendSessionEventAsync(session.SessionId, "assistant.message", new()
+            {
+                ["messageId"] = "intermediate-message",
+                ["content"] = "I will check before answering."
+            });
+            await server.SendSessionEventAsync(session.SessionId, "tool.execution_start", new()
+            {
+                ["toolCallId"] = "check-name",
+                ["toolName"] = "shell"
+            });
+            await server.SendSessionEventAsync(session.SessionId, "tool.execution_complete", new()
+            {
+                ["toolCallId"] = "check-name",
+                ["success"] = true
+            });
+            await server.SendSessionEventAsync(session.SessionId, "assistant.message", new()
+            {
+                ["messageId"] = "final-message",
+                ["content"] = finalContent
+            });
+            await server.SendSessionEventAsync(session.SessionId, "session.idle", new());
+            // Drain a later event before replying, so idle cannot remain queued for a late subscriber.
+            await server.SendSessionEventAsync(session.SessionId, "session.title_changed", new() { ["title"] = "fence" });
+            await drained.Task.WaitAsync(timeout, cancellationToken);
+            idleBeforeReply = true;
+        };
+
+        try
+        {
+            await E2E.SessionE2ETests.AssertReplacedSystemMessageResponseAsync(session, timeout);
+        }
+        catch (TimeoutException error)
+        {
+            var history = await session.GetEventsAsync();
+            throw new TimeoutException(
+                $"{error.Message}; idle drained before send reply: {idleBeforeReply}; " +
+                $"durable assistant messages: {history.OfType<AssistantMessageEvent>().Count()}; " +
+                $"durable idle events: {history.OfType<SessionIdleEvent>().Count()}", error);
+        }
+
+        Assert.True(idleBeforeReply);
+        var request = Assert.Single(server.Requests, request => request.Method == "session.send");
+        Assert.Equal("What is your full name?", request.Params.GetProperty("prompt").GetString());
+        var events = await session.GetEventsAsync();
+        Assert.DoesNotContain(events, evt => evt is SessionIdleEvent);
+        Assert.Equal(2, events.OfType<AssistantMessageEvent>().Count());
+        Assert.Equal(finalContent, events.OfType<AssistantMessageEvent>().Last().Data.Content);
+    }
+
+    [Fact]
     public async Task Replaced_Preamble_Response_Observes_Idle_Before_Send_Reply()
     {
         await using var server = await FakeCopilotServer.StartAsync();

--- a/dotnet/test/Unit/ClientSessionLifetimeTests.cs
+++ b/dotnet/test/Unit/ClientSessionLifetimeTests.cs
@@ -1717,6 +1717,77 @@ public sealed class ClientSessionLifetimeTests
         Assert.False(request.TryGetProperty("wait", out _));
     }
 
+    [Fact]
+    public async Task Replaced_Preamble_Response_Observes_Idle_Before_Send_Reply()
+    {
+        await using var server = await FakeCopilotServer.StartAsync();
+        await using var client = new CopilotClient(new CopilotClientOptions { Connection = RuntimeConnection.ForUri(server.Url) });
+        await using var session = await client.CreateSessionAsync(new SessionConfig());
+        var timeout = TimeSpan.FromSeconds(5);
+        const string finalContent = "I am Botanica, your gardening assistant.";
+        var drained = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscription = session.On<SessionTitleChangedEvent>(_ => drained.TrySetResult());
+        var idleBeforeReply = false;
+        server.BeforeResponseAsync = async (request, cancellationToken) =>
+        {
+            if (request.Method != "session.send")
+            {
+                return;
+            }
+
+            await server.SendSessionEventAsync(session.SessionId, "user.message", new()
+            {
+                ["content"] = request.Params.GetProperty("prompt").GetString()
+            });
+            await server.SendSessionEventAsync(session.SessionId, "assistant.message", new()
+            {
+                ["messageId"] = "intermediate-message",
+                ["content"] = "I will check before answering."
+            });
+            await server.SendSessionEventAsync(session.SessionId, "tool.execution_start", new()
+            {
+                ["toolCallId"] = "check-section",
+                ["toolName"] = "shell"
+            });
+            await server.SendSessionEventAsync(session.SessionId, "tool.execution_complete", new()
+            {
+                ["toolCallId"] = "check-section",
+                ["success"] = true
+            });
+            await server.SendSessionEventAsync(session.SessionId, "assistant.message", new()
+            {
+                ["messageId"] = "final-message",
+                ["content"] = finalContent
+            });
+            await server.SendSessionEventAsync(session.SessionId, "session.idle", new());
+            // Drain a later event before replying, so the idle cannot remain queued for a late subscriber.
+            await server.SendSessionEventAsync(session.SessionId, "session.title_changed", new() { ["title"] = "fence" });
+            await drained.Task.WaitAsync(timeout, cancellationToken);
+            idleBeforeReply = true;
+        };
+
+        try
+        {
+            await E2E.SystemMessageSectionsE2ETests.AssertReplacedPreambleResponseAsync(session, timeout);
+        }
+        catch (TimeoutException error)
+        {
+            var history = await session.GetEventsAsync();
+            throw new TimeoutException(
+                $"{error.Message}; idle drained before send reply: {idleBeforeReply}; " +
+                $"durable assistant messages: {history.OfType<AssistantMessageEvent>().Count()}; " +
+                $"durable idle events: {history.OfType<SessionIdleEvent>().Count()}", error);
+        }
+
+        Assert.True(idleBeforeReply);
+        var request = Assert.Single(server.Requests, request => request.Method == "session.send");
+        Assert.Equal("Who are you?", request.Params.GetProperty("prompt").GetString());
+        var events = await session.GetEventsAsync();
+        Assert.DoesNotContain(events, evt => evt is SessionIdleEvent);
+        Assert.Equal(2, events.OfType<AssistantMessageEvent>().Count());
+        Assert.Equal(finalContent, events.OfType<AssistantMessageEvent>().Last().Data.Content);
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]


### PR DESCRIPTION
## Summary

Fix two test-only lost-idle races: `SystemMessageSectionsE2ETests.Should_Use_Replaced_Preamble_Section_In_Response` and `SessionE2ETests.Should_Create_A_Session_With_Replaced_SystemMessage_Config`. Both old scenarios awaited `SendAsync` before subscribing through `GetFinalAssistantMessageAsync`. A fast turn can dispatch its assistant messages and ephemeral `session.idle` before that subscription; history can recover assistant content but not idle, leaving the helper waiting until its deadline.

Use the existing public `SendAndWaitAsync` in each response scenario so subscription precedes sending. Preserve final-not-intermediate response semantics and both explicit **120-second** E2E budgets. The preamble's Botanica gardening configuration, `Who are you?` prompt, and response assertions remain unchanged. The replaced-message case retains its replacement configuration, `What is your full name?` prompt, NotNull/Testy/not-GitHub response assertions, nonempty actual exchanges, and exact wire-system-message equality.

Two deterministic real-SDK loopback JSON-RPC regressions in `ClientSessionLifetimeTests` call those same E2E response scenarios. Each sends an intermediate assistant, tool activity, final assistant and idle before the send reply. A later delivered event affirmatively fences dispatch without sleeps. History contains both assistant messages but no idle. The published preamble scenario/regression is byte-identical; the new commit adds only the accepted replaced-case repair. Cumulative scope is **three test files**, with no production SDK, shared `TestHelper`, framework, capture, deadline, retry, skip or concurrency change. The appended-message repair in github/copilot-sdk#2636 remains separate and untouched.

Original motivating occurrences, both attempt 1 with consumed SDK `f45c46fd1812f8bed5b4cbc250f47177c83068f0`:

| Case | Runtime run / job | Actual runtime checkout |
| --- | --- | --- |
| Replaced preamble | github/copilot-agent-runtime run **34694180678**, job **103555442838**, associated with github/copilot-agent-runtime#20370 | Synthetic merge `ba1cd6cbad8d0606d2c3d06b41506a512678f8c3` |
| Replaced system message | github/copilot-agent-runtime run **34694551018**, job **103556281133**, associated with github/copilot-agent-runtime#20299 | Synthetic merge `42e1d40b7fa22a9fcc7740216a2a14c6c386db60` |

Each original leg reported 894 passed, 1 failed, 4 skipped, with `Timeout waiting for assistant message` at `TestHelper.cs:77/85` (preamble caller line 65; replaced-message caller line 82). These are actual consumed checkouts, not assumed runtime PR heads.

**The live test-observation races are deterministically proven; both original CI causes remain UNKNOWN.** Neither occurrence retained an event/RPC trace proving its interleaving. The separate original SDK automatic timeout and runtime publication-permission boundary are preserved below; this repair is not claimed to fix that timeout.

## Validation

- Preserved standalone RED proof for each scenario: the forced early-idle regression failed with `Timeout waiting for assistant message; idle drained before send reply: True; durable assistant messages: 2; durable idle events: 0`, retaining the original helper stack. Each standalone GREEN passed 1/1, followed by its 126-case whole-unit validation. Those evidence seals remain unchanged.
- Combined final source, published as **`9f4b9e59ca7ce0516790ad18afc31f7bfd7ead01`** with sole parent `7509bc154359e26b2aa55a0c6a92bda6ed6ecac6`: whole `ClientSessionLifetimeTests` **127/127**, with named pass records proving both new regressions executed.
- Both complete E2E classes in one normal replay invocation: **40/40** (`SessionE2ETests` 38; `SystemMessageSectionsE2ETests` 2), including both modified cases, unchanged identity, and unchanged appended case. All response assertions and replaced-message actual wire equality executed. No completed-suite failures/skips/cleanup errors.
- Formatting and verification covered all three test files; SDK .NET lint passed; full SDK source build passed **netstandard2.0/net8.0/net10.0**, zero warnings/errors.
- Reused the read-only Linux x64 CLI at runtime `ee6465da61c6b394e40d3b5a2de78a485d500f60`. All **114 build-output digests** were rechecked before/after validation. It was previously staged through the runtime's vendored Bazel and CLI build with documented build-cache reuse; no runtime rebuild or unknown bundle was used for combined validation.
- .NET SDK 10.0.100, net8.0/runtime 8.0.22, normal shared TCP and CAPI replay. `GITHUB_ACTIONS=true` blocks live-CAPI fallback and snapshot writes; `COPILOT_AUTO_UPDATE=false` and `CopilotSkipCliDownload=true` preserve the supplied CLI. This is local Linux replay, not cross-platform/live-CI proof.
- Initial missing-NuGet-assets and missing-`tsx` fixture failures are preserved. The latter affected all 40 selected cases before their bodies and emitted fixture-cleanup `NullReferenceException` diagnostics. Dependencies were restored only after those observed failures; no assertions/source/snapshots were weakened. Subsequent combined suites completed successfully.

The preamble evidence, separate 48-file replaced-candidate seal and 41-file combined-validation seal remain intact. No original `7509` automatic result, historical image-capacity proof, or old source-head proof transfers to the combined commit.

| Final combined SDK head | Independent full-workflow proof |
| --- | --- |
| `9f4b9e59ca7ce0516790ad18afc31f7bfd7ead01` | **0/10 — pending** |

The PR remains **draft** pending at least ten qualifying independent final-head workflow passes and parent review. This publication dispatched, reran and cancelled no CI jobs. The existing release-based .NET workflow is separate from the unpublished fixed-runtime validation branch described below.

_Generated by Copilot_

<!-- ci-loop-sdk2638-original-timeout-and-permission -->
### Original CI failure and validation gates

The original automatic [run 34696477539](https://github.com/github/copilot-sdk/actions/runs/34696477539), attempt 1 on `7509bc154359e26b2aa55a0c6a92bda6ed6ecac6`, did **not** pass. The [macOS default/CAPI shard 1](https://github.com/github/copilot-sdk/actions/runs/34696477539/job/103560736314) exceeded its configured **20-minute execution limit** and was cancelled. The downstream `.NET required` failure reflects that cancellation, not a second test failure. The other 26 configured .NET jobs succeeded, but those automatic results are not independent proof.

The failed shard's log endpoint returned 404 and the run has no diagnostic artifacts. Its exact test, completed case count, and cleanup outcome remain unknown. The annotation identifies the configured limit; the 25-minute start-to-end wall interval does not redefine it. This loop did not cancel or rerun the job, and does not claim the pending combined repair fixes this timeout.

The separate fixed-runtime validation branch is **not published**. GitHub rejected its normal push because the OAuth app lacks `workflow` scope. The validated local runtime commit `390a22f5f48cefee7bfc6687e93c2b071e469215` remains available, but no remote branch exists. Publishing it requires credentials authorized to modify workflows; no alternate-credential or API-write workaround was attempted.

The SDK's existing full .NET workflow remains usable for separate release-based coverage. Its first manual wave will wait for the combined system-message candidate's validation and final pushed SDK SHA. All qualifying proof counts remain **0/10**; no historical image-fixture run or automatic check transfers.

<!-- ci-loop-sdk2638-first-manual-proof-started -->
### Independent manual proof: first workflow did not pass

| Workflow / platforms | Run | SDK commit | Attempt / event | Observed outcome |
| --- | --- | --- | --- | --- |
| .NET SDK Tests / all 27 configured jobs across Ubuntu, macOS, Windows and Alpine ARM64 | [3402 / 34698446440](https://github.com/github/copilot-sdk/actions/runs/34698446440) | `9f4b9e59ca7ce0516790ad18afc31f7bfd7ead01` | 1 / `workflow_dispatch` | **Cancelled:** 26 jobs succeeded; macOS `2b-rpc-q-z` exceeded the job execution limit. **0/10 qualifying full-workflow successes.** |

Job [103565867411](https://github.com/github/copilot-sdk/actions/runs/34698446440/job/103565867411) completed as cancelled on September 12, 2026, at 14:34:27 UTC. Its annotation confirms the **20-minute execution limit**; its 25-minute wall interval is a separate measurement. The original job log returned 404, one fallback failed, and the run has no artifacts. The active build/test/cleanup phase, individual case and cause remain **unknown**. Further proof waves are held; no duplicate dispatch or job rerun was made.

Two original-attempt, source-matched q-z comparison jobs completed in 130 and 165 seconds, each with 109 passes and one skip. They are not proof credits or a tail-latency estimate, and do not justify a generic timeout increase. Existing github/copilot-sdk#2531 changes the general limit alongside production FFI behavior, but no causal link to this failure is established.

The completed original logs were audited: 25 test commands, 27 framework completions, 6,531 passed and 37 skipped, with no unclassified count gaps in those logs. Both repaired E2Es passed all nine expected framework executions. Each new unit regression passed all five eligible framework executions; the existing `NET8_0_OR_GREATER` file guard excludes net472, correcting the earlier six-framework estimate. No affected test was skipped in an eligible execution. These partial passes do not make the cancelled workflow a passing run.

Completed jobs logged the exact SDK checkout. Runtime acquisition remains release-based CLI `1.0.84-5`, not fixed-runtime-source proof. Release checksum enforcement, producer/consumer paths and runner cleanup are recorded; independent runtime binary hashes and globally leak-free cleanup are not claimed. The cancelled shard's execution population and cleanup have not been established.
